### PR TITLE
Cleanup grammar generation

### DIFF
--- a/crates/ra_syntax/src/ast/generated.rs
+++ b/crates/ra_syntax/src/ast/generated.rs
@@ -81,7 +81,8 @@ impl<'a> AstNode<'a> for Attr<'a> {
     fn syntax(self) -> SyntaxNodeRef<'a> { self.syntax }
 }
 
-impl<'a> Attr<'a> {pub fn value(self) -> Option<TokenTree<'a>> {
+impl<'a> Attr<'a> {
+    pub fn value(self) -> Option<TokenTree<'a>> {
         super::child_opt(self)
     }
 }
@@ -143,7 +144,8 @@ impl<'a> Block<'a> {
     pub fn statements(self) -> impl Iterator<Item = Stmt<'a>> + 'a {
         super::children(self)
     }
-pub fn expr(self) -> Option<Expr<'a>> {
+
+    pub fn expr(self) -> Option<Expr<'a>> {
         super::child_opt(self)
     }
 }
@@ -164,7 +166,8 @@ impl<'a> AstNode<'a> for BlockExpr<'a> {
     fn syntax(self) -> SyntaxNodeRef<'a> { self.syntax }
 }
 
-impl<'a> BlockExpr<'a> {pub fn block(self) -> Option<Block<'a>> {
+impl<'a> BlockExpr<'a> {
+    pub fn block(self) -> Option<Block<'a>> {
         super::child_opt(self)
     }
 }
@@ -204,7 +207,8 @@ impl<'a> AstNode<'a> for CallExpr<'a> {
 }
 
 impl<'a> ast::ArgListOwner<'a> for CallExpr<'a> {}
-impl<'a> CallExpr<'a> {pub fn expr(self) -> Option<Expr<'a>> {
+impl<'a> CallExpr<'a> {
+    pub fn expr(self) -> Option<Expr<'a>> {
         super::child_opt(self)
     }
 }
@@ -243,10 +247,12 @@ impl<'a> AstNode<'a> for Condition<'a> {
     fn syntax(self) -> SyntaxNodeRef<'a> { self.syntax }
 }
 
-impl<'a> Condition<'a> {pub fn pat(self) -> Option<Pat<'a>> {
+impl<'a> Condition<'a> {
+    pub fn pat(self) -> Option<Pat<'a>> {
         super::child_opt(self)
     }
-pub fn expr(self) -> Option<Expr<'a>> {
+
+    pub fn expr(self) -> Option<Expr<'a>> {
         super::child_opt(self)
     }
 }
@@ -460,7 +466,8 @@ impl<'a> AstNode<'a> for ExprStmt<'a> {
     fn syntax(self) -> SyntaxNodeRef<'a> { self.syntax }
 }
 
-impl<'a> ExprStmt<'a> {pub fn expr(self) -> Option<Expr<'a>> {
+impl<'a> ExprStmt<'a> {
+    pub fn expr(self) -> Option<Expr<'a>> {
         super::child_opt(self)
     }
 }
@@ -538,13 +545,16 @@ impl<'a> AstNode<'a> for FnDef<'a> {
 impl<'a> ast::NameOwner<'a> for FnDef<'a> {}
 impl<'a> ast::TypeParamsOwner<'a> for FnDef<'a> {}
 impl<'a> ast::AttrsOwner<'a> for FnDef<'a> {}
-impl<'a> FnDef<'a> {pub fn param_list(self) -> Option<ParamList<'a>> {
+impl<'a> FnDef<'a> {
+    pub fn param_list(self) -> Option<ParamList<'a>> {
         super::child_opt(self)
     }
-pub fn body(self) -> Option<Block<'a>> {
+
+    pub fn body(self) -> Option<Block<'a>> {
         super::child_opt(self)
     }
-pub fn ret_type(self) -> Option<RetType<'a>> {
+
+    pub fn ret_type(self) -> Option<RetType<'a>> {
         super::child_opt(self)
     }
 }
@@ -584,10 +594,12 @@ impl<'a> AstNode<'a> for ForExpr<'a> {
 }
 
 impl<'a> ast::LoopBodyOwner<'a> for ForExpr<'a> {}
-impl<'a> ForExpr<'a> {pub fn pat(self) -> Option<Pat<'a>> {
+impl<'a> ForExpr<'a> {
+    pub fn pat(self) -> Option<Pat<'a>> {
         super::child_opt(self)
     }
-pub fn iterable(self) -> Option<Expr<'a>> {
+
+    pub fn iterable(self) -> Option<Expr<'a>> {
         super::child_opt(self)
     }
 }
@@ -626,7 +638,8 @@ impl<'a> AstNode<'a> for IfExpr<'a> {
     fn syntax(self) -> SyntaxNodeRef<'a> { self.syntax }
 }
 
-impl<'a> IfExpr<'a> {pub fn condition(self) -> Option<Condition<'a>> {
+impl<'a> IfExpr<'a> {
+    pub fn condition(self) -> Option<Condition<'a>> {
         super::child_opt(self)
     }
 }
@@ -739,10 +752,12 @@ impl<'a> AstNode<'a> for LambdaExpr<'a> {
     fn syntax(self) -> SyntaxNodeRef<'a> { self.syntax }
 }
 
-impl<'a> LambdaExpr<'a> {pub fn param_list(self) -> Option<ParamList<'a>> {
+impl<'a> LambdaExpr<'a> {
+    pub fn param_list(self) -> Option<ParamList<'a>> {
         super::child_opt(self)
     }
-pub fn body(self) -> Option<Expr<'a>> {
+
+    pub fn body(self) -> Option<Expr<'a>> {
         super::child_opt(self)
     }
 }
@@ -763,10 +778,12 @@ impl<'a> AstNode<'a> for LetStmt<'a> {
     fn syntax(self) -> SyntaxNodeRef<'a> { self.syntax }
 }
 
-impl<'a> LetStmt<'a> {pub fn pat(self) -> Option<Pat<'a>> {
+impl<'a> LetStmt<'a> {
+    pub fn pat(self) -> Option<Pat<'a>> {
         super::child_opt(self)
     }
-pub fn initializer(self) -> Option<Expr<'a>> {
+
+    pub fn initializer(self) -> Option<Expr<'a>> {
         super::child_opt(self)
     }
 }
@@ -805,7 +822,8 @@ impl<'a> AstNode<'a> for LifetimeParam<'a> {
     fn syntax(self) -> SyntaxNodeRef<'a> { self.syntax }
 }
 
-impl<'a> LifetimeParam<'a> {pub fn lifetime(self) -> Option<Lifetime<'a>> {
+impl<'a> LifetimeParam<'a> {
+    pub fn lifetime(self) -> Option<Lifetime<'a>> {
         super::child_opt(self)
     }
 }
@@ -867,10 +885,12 @@ impl<'a> MatchArm<'a> {
     pub fn pats(self) -> impl Iterator<Item = Pat<'a>> + 'a {
         super::children(self)
     }
-pub fn guard(self) -> Option<MatchGuard<'a>> {
+
+    pub fn guard(self) -> Option<MatchGuard<'a>> {
         super::child_opt(self)
     }
-pub fn expr(self) -> Option<Expr<'a>> {
+
+    pub fn expr(self) -> Option<Expr<'a>> {
         super::child_opt(self)
     }
 }
@@ -913,10 +933,12 @@ impl<'a> AstNode<'a> for MatchExpr<'a> {
     fn syntax(self) -> SyntaxNodeRef<'a> { self.syntax }
 }
 
-impl<'a> MatchExpr<'a> {pub fn expr(self) -> Option<Expr<'a>> {
+impl<'a> MatchExpr<'a> {
+    pub fn expr(self) -> Option<Expr<'a>> {
         super::child_opt(self)
     }
-pub fn match_arm_list(self) -> Option<MatchArmList<'a>> {
+
+    pub fn match_arm_list(self) -> Option<MatchArmList<'a>> {
         super::child_opt(self)
     }
 }
@@ -956,7 +978,8 @@ impl<'a> AstNode<'a> for MethodCallExpr<'a> {
 }
 
 impl<'a> ast::ArgListOwner<'a> for MethodCallExpr<'a> {}
-impl<'a> MethodCallExpr<'a> {pub fn expr(self) -> Option<Expr<'a>> {
+impl<'a> MethodCallExpr<'a> {
+    pub fn expr(self) -> Option<Expr<'a>> {
         super::child_opt(self)
     }
 }
@@ -979,7 +1002,8 @@ impl<'a> AstNode<'a> for Module<'a> {
 
 impl<'a> ast::NameOwner<'a> for Module<'a> {}
 impl<'a> ast::AttrsOwner<'a> for Module<'a> {}
-impl<'a> Module<'a> {pub fn item_list(self) -> Option<ItemList<'a>> {
+impl<'a> Module<'a> {
+    pub fn item_list(self) -> Option<ItemList<'a>> {
         super::child_opt(self)
     }
 }
@@ -1190,7 +1214,8 @@ impl<'a> AstNode<'a> for Param<'a> {
     fn syntax(self) -> SyntaxNodeRef<'a> { self.syntax }
 }
 
-impl<'a> Param<'a> {pub fn pat(self) -> Option<Pat<'a>> {
+impl<'a> Param<'a> {
+    pub fn pat(self) -> Option<Pat<'a>> {
         super::child_opt(self)
     }
 }
@@ -1215,7 +1240,8 @@ impl<'a> ParamList<'a> {
     pub fn params(self) -> impl Iterator<Item = Param<'a>> + 'a {
         super::children(self)
     }
-pub fn self_param(self) -> Option<SelfParam<'a>> {
+
+    pub fn self_param(self) -> Option<SelfParam<'a>> {
         super::child_opt(self)
     }
 }
@@ -1321,7 +1347,8 @@ impl<'a> AstNode<'a> for Path<'a> {
     fn syntax(self) -> SyntaxNodeRef<'a> { self.syntax }
 }
 
-impl<'a> Path<'a> {pub fn segment(self) -> Option<PathSegment<'a>> {
+impl<'a> Path<'a> {
+    pub fn segment(self) -> Option<PathSegment<'a>> {
         super::child_opt(self)
     }
 }
@@ -1378,7 +1405,8 @@ impl<'a> AstNode<'a> for PathSegment<'a> {
     fn syntax(self) -> SyntaxNodeRef<'a> { self.syntax }
 }
 
-impl<'a> PathSegment<'a> {pub fn name_ref(self) -> Option<NameRef<'a>> {
+impl<'a> PathSegment<'a> {
+    pub fn name_ref(self) -> Option<NameRef<'a>> {
         super::child_opt(self)
     }
 }
@@ -2052,7 +2080,8 @@ impl<'a> AstNode<'a> for UseItem<'a> {
     fn syntax(self) -> SyntaxNodeRef<'a> { self.syntax }
 }
 
-impl<'a> UseItem<'a> {pub fn use_tree(self) -> Option<UseTree<'a>> {
+impl<'a> UseItem<'a> {
+    pub fn use_tree(self) -> Option<UseTree<'a>> {
         super::child_opt(self)
     }
 }
@@ -2073,10 +2102,12 @@ impl<'a> AstNode<'a> for UseTree<'a> {
     fn syntax(self) -> SyntaxNodeRef<'a> { self.syntax }
 }
 
-impl<'a> UseTree<'a> {pub fn path(self) -> Option<Path<'a>> {
+impl<'a> UseTree<'a> {
+    pub fn path(self) -> Option<Path<'a>> {
         super::child_opt(self)
     }
-pub fn use_tree_list(self) -> Option<UseTreeList<'a>> {
+
+    pub fn use_tree_list(self) -> Option<UseTreeList<'a>> {
         super::child_opt(self)
     }
 }
@@ -2138,7 +2169,8 @@ impl<'a> AstNode<'a> for WhileExpr<'a> {
 }
 
 impl<'a> ast::LoopBodyOwner<'a> for WhileExpr<'a> {}
-impl<'a> WhileExpr<'a> {pub fn condition(self) -> Option<Condition<'a>> {
+impl<'a> WhileExpr<'a> {
+    pub fn condition(self) -> Option<Condition<'a>> {
         super::child_opt(self)
     }
 }

--- a/crates/ra_syntax/src/ast/generated.rs.tera
+++ b/crates/ra_syntax/src/ast/generated.rs.tera
@@ -77,8 +77,7 @@ impl<'a> {{ node }}<'a> {
 {%- else -%}
 {%- set method_name = m.0 -%}
 {%- set ChildName = m.1 %}
-{%- endif -%}
-
+{%- endif %}
     pub fn {{ method_name }}(self) -> Option<{{ ChildName }}<'a>> {
         super::child_opt(self)
     }


### PR DESCRIPTION
https://github.com/rust-analyzer/rust-analyzer/blob/31c8ebb743572ef07ac4ca77ddd17eddbcf4b24c/crates/ra_syntax/src/ast/generated.rs#L207-L210
Needed an additional newline before the `pub fn`.

Removing `-` for #114.
Runnning `cargo gen-kinds` to update grammar.