### PR TITLE
Add a test to verify if the generated codes are up-to-date.

### DIFF
--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -77,7 +77,7 @@ pub fn update(path: &Path, contents: &str, verify: bool) -> Result<()> {
     Ok(())
 }
 
-pub fn render_template(template: PathBuf) -> Result<String> {
+pub fn render_template(template: &Path) -> Result<String> {
     let grammar: ron::value::Value = {
         let text = fs::read_to_string(project_root().join(GRAMMAR))?;
         ron::de::from_str(&text)?

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -71,9 +71,9 @@ pub fn update(path: &Path, contents: &str, verify: bool) -> Result<()> {
     Ok(())
 }
 
-pub fn render_template(template: &str, grammarfile: &str) -> Result<String> {
+pub fn render_template(template: &str) -> Result<String> {
     let grammar: ron::value::Value = {
-        let text = fs::read_to_string(grammarfile)?;
+        let text = fs::read_to_string(format!("{}{}", Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap()).parent().unwrap().to_str().unwrap(), "/ra_syntax/src/grammar.ron"))?;
         ron::de::from_str(&text)?
     };
     let template = fs::read_to_string(template)?;

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -8,12 +8,18 @@ extern crate heck;
 use std::{
     collections::HashMap,
     fs,
-    path::Path,
+    path::{Path, PathBuf},
 };
 use itertools::Itertools;
 use heck::{CamelCase, ShoutySnakeCase, SnakeCase};
 
 pub type Result<T> = ::std::result::Result<T, failure::Error>;
+
+const GRAMMAR: &str = "ra_syntax/src/grammar.ron";
+pub const SYNTAX_KINDS: &str = "ra_syntax/src/syntax_kinds/generated.rs";
+pub const SYNTAX_KINDS_TEMPLATE: &str = "ra_syntax/src/syntax_kinds/generated.rs.tera";
+pub const AST: &str = "ra_syntax/src/ast/generated.rs";
+pub const AST_TEMPLATE: &str = "ra_syntax/src/ast/generated.rs.tera";
 
 #[derive(Debug)]
 pub struct Test {
@@ -71,9 +77,9 @@ pub fn update(path: &Path, contents: &str, verify: bool) -> Result<()> {
     Ok(())
 }
 
-pub fn render_template(template: &str) -> Result<String> {
+pub fn render_template(template: PathBuf) -> Result<String> {
     let grammar: ron::value::Value = {
-        let text = fs::read_to_string(format!("{}{}", Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap()).parent().unwrap().to_str().unwrap(), "/ra_syntax/src/grammar.ron"))?;
+        let text = fs::read_to_string(project_root().join(GRAMMAR))?;
         ron::de::from_str(&text)?
     };
     let template = fs::read_to_string(template)?;
@@ -107,4 +113,8 @@ pub fn render_template(template: &str) -> Result<String> {
         }
         Ok(tera::Value::Array(elements))
     }
+}
+
+pub fn project_root() -> PathBuf {
+    Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap()).parent().unwrap().to_path_buf()
 }

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -13,7 +13,7 @@ use std::{
 use itertools::Itertools;
 use heck::{CamelCase, ShoutySnakeCase, SnakeCase};
 
-type Result<T> = ::std::result::Result<T, failure::Error>;
+pub type Result<T> = ::std::result::Result<T, failure::Error>;
 
 #[derive(Debug)]
 pub struct Test {

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -11,15 +11,10 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
 };
-use tools::{Test, collect_tests, render_template, update, Result};
+use tools::{AST, AST_TEMPLATE, Result, SYNTAX_KINDS, SYNTAX_KINDS_TEMPLATE, Test, collect_tests, render_template, update, project_root};
 
 const GRAMMAR_DIR: &str = "./crates/ra_syntax/src/grammar";
 const INLINE_TESTS_DIR: &str = "./crates/ra_syntax/tests/data/parser/inline";
-const GRAMMAR: &str = "./crates/ra_syntax/src/grammar.ron";
-const SYNTAX_KINDS: &str = "./crates/ra_syntax/src/syntax_kinds/generated.rs";
-const SYNTAX_KINDS_TEMPLATE: &str = "./crates/ra_syntax/src/syntax_kinds/generated.rs.tera";
-const AST: &str = "./crates/ra_syntax/src/ast/generated.rs";
-const AST_TEMPLATE: &str = "./crates/ra_syntax/src/ast/generated.rs.tera";
 
 fn main() -> Result<()> {
     let matches = App::new("tasks")
@@ -45,8 +40,8 @@ fn main() -> Result<()> {
 fn run_gen_command(name: &str, verify: bool) -> Result<()> {
     match name {
         "gen-kinds" => {
-            update(Path::new(SYNTAX_KINDS), &render_template(SYNTAX_KINDS_TEMPLATE)?, verify)?;
-            update(Path::new(AST), &render_template(AST_TEMPLATE)?, verify)?;
+            update(&project_root().join(SYNTAX_KINDS), &render_template(project_root().join(SYNTAX_KINDS_TEMPLATE))?, verify)?;
+            update(&project_root().join(AST), &render_template(project_root().join(AST_TEMPLATE))?, verify)?;
         },
         "gen-tests" => {
             gen_tests(verify)?

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -40,8 +40,8 @@ fn main() -> Result<()> {
 fn run_gen_command(name: &str, verify: bool) -> Result<()> {
     match name {
         "gen-kinds" => {
-            update(&project_root().join(SYNTAX_KINDS), &render_template(project_root().join(SYNTAX_KINDS_TEMPLATE))?, verify)?;
-            update(&project_root().join(AST), &render_template(project_root().join(AST_TEMPLATE))?, verify)?;
+            update(&project_root().join(SYNTAX_KINDS), &render_template(&project_root().join(SYNTAX_KINDS_TEMPLATE))?, verify)?;
+            update(&project_root().join(AST), &render_template(&project_root().join(AST_TEMPLATE))?, verify)?;
         },
         "gen-tests" => {
             gen_tests(verify)?

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -11,9 +11,7 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
 };
-use tools::{Test, collect_tests, render_template, update};
-
-type Result<T> = ::std::result::Result<T, failure::Error>;
+use tools::{Test, collect_tests, render_template, update, Result};
 
 const GRAMMAR_DIR: &str = "./crates/ra_syntax/src/grammar";
 const INLINE_TESTS_DIR: &str = "./crates/ra_syntax/tests/data/parser/inline";

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -45,8 +45,8 @@ fn main() -> Result<()> {
 fn run_gen_command(name: &str, verify: bool) -> Result<()> {
     match name {
         "gen-kinds" => {
-            update(Path::new(SYNTAX_KINDS), &render_template(SYNTAX_KINDS_TEMPLATE, GRAMMAR)?, verify)?;
-            update(Path::new(AST), &render_template(AST_TEMPLATE, GRAMMAR)?, verify)?;
+            update(Path::new(SYNTAX_KINDS), &render_template(SYNTAX_KINDS_TEMPLATE)?, verify)?;
+            update(Path::new(AST), &render_template(AST_TEMPLATE)?, verify)?;
         },
         "gen-tests" => {
             gen_tests(verify)?

--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -1,21 +1,17 @@
 extern crate clap;
 #[macro_use]
 extern crate failure;
-extern crate ron;
-extern crate tera;
 extern crate tools;
 extern crate walkdir;
-extern crate heck;
 
 use clap::{App, Arg, SubCommand};
-use heck::{CamelCase, ShoutySnakeCase, SnakeCase};
 use std::{
     collections::HashMap,
     fs,
     path::{Path, PathBuf},
     process::Command,
 };
-use tools::{collect_tests, Test};
+use tools::{Test, collect_tests, render_template, update};
 
 type Result<T> = ::std::result::Result<T, failure::Error>;
 
@@ -51,8 +47,8 @@ fn main() -> Result<()> {
 fn run_gen_command(name: &str, verify: bool) -> Result<()> {
     match name {
         "gen-kinds" => {
-            update(Path::new(SYNTAX_KINDS), &render_template(SYNTAX_KINDS_TEMPLATE)?, verify)?;
-            update(Path::new(AST), &render_template(AST_TEMPLATE)?, verify)?;
+            update(Path::new(SYNTAX_KINDS), &render_template(SYNTAX_KINDS_TEMPLATE, GRAMMAR)?, verify)?;
+            update(Path::new(AST), &render_template(AST_TEMPLATE, GRAMMAR)?, verify)?;
         },
         "gen-tests" => {
             gen_tests(verify)?
@@ -62,58 +58,6 @@ fn run_gen_command(name: &str, verify: bool) -> Result<()> {
     Ok(())
 }
 
-fn update(path: &Path, contents: &str, verify: bool) -> Result<()> {
-    match fs::read_to_string(path) {
-        Ok(ref old_contents) if old_contents == contents => {
-            return Ok(());
-        }
-        _ => (),
-    }
-    if verify {
-        bail!("`{}` is not up-to-date", path.display());
-    }
-    eprintln!("updating {}", path.display());
-    fs::write(path, contents)?;
-    Ok(())
-}
-
-fn render_template(template: &str) -> Result<String> {
-    let grammar: ron::value::Value = {
-        let text = fs::read_to_string(GRAMMAR)?;
-        ron::de::from_str(&text)?
-    };
-    let template = fs::read_to_string(template)?;
-    let mut tera = tera::Tera::default();
-    tera.add_raw_template("grammar", &template)
-        .map_err(|e| format_err!("template error: {:?}", e))?;
-    tera.register_function("concat", Box::new(concat));
-    tera.register_filter("camel", |arg, _| {
-        Ok(arg.as_str().unwrap().to_camel_case().into())
-    });
-    tera.register_filter("snake", |arg, _| {
-        Ok(arg.as_str().unwrap().to_snake_case().into())
-    });
-    tera.register_filter("SCREAM", |arg, _| {
-        Ok(arg.as_str().unwrap().to_shouty_snake_case().into())
-    });
-    let ret = tera
-        .render("grammar", &grammar)
-        .map_err(|e| format_err!("template error: {:?}", e))?;
-    return Ok(ret);
-
-    fn concat(args: HashMap<String, tera::Value>) -> tera::Result<tera::Value> {
-        let mut elements = Vec::new();
-        for &key in ["a", "b", "c"].iter() {
-            let val = match args.get(key) {
-                Some(val) => val,
-                None => continue,
-            };
-            let val = val.as_array().unwrap();
-            elements.extend(val.iter().cloned());
-        }
-        Ok(tera::Value::Array(elements))
-    }
-}
 
 fn gen_tests(verify: bool) -> Result<()> {
     let tests = tests_from_dir(Path::new(GRAMMAR_DIR))?;

--- a/crates/tools/tests/cli.rs
+++ b/crates/tools/tests/cli.rs
@@ -11,6 +11,10 @@ const AST_TEMPLATE: &str = "../ra_syntax/src/ast/generated.rs.tera";
 
 #[test]
 fn verify_template_generation() {
-    update(Path::new(SYNTAX_KINDS), &render_template(SYNTAX_KINDS_TEMPLATE, GRAMMAR).unwrap(), true).unwrap();
-    update(Path::new(AST), &render_template(AST_TEMPLATE, GRAMMAR).unwrap(), true).unwrap();
+    if let Err(error) = update(Path::new(SYNTAX_KINDS), &render_template(SYNTAX_KINDS_TEMPLATE, GRAMMAR).unwrap(), true) {
+        panic!("{}. Please update it by running `cargo gen-kinds`", error);
+    }
+    if let Err(error) = update(Path::new(AST), &render_template(AST_TEMPLATE, GRAMMAR).unwrap(), true) {
+        panic!("{}. Please update it by running `cargo gen-kinds`", error);
+    }
 }

--- a/crates/tools/tests/cli.rs
+++ b/crates/tools/tests/cli.rs
@@ -4,10 +4,10 @@ use tools::{AST, AST_TEMPLATE, SYNTAX_KINDS, SYNTAX_KINDS_TEMPLATE, render_templ
 
 #[test]
 fn verify_template_generation() {
-    if let Err(error) = update(&project_root().join(SYNTAX_KINDS), &render_template(project_root().join(SYNTAX_KINDS_TEMPLATE)).unwrap(), true) {
+    if let Err(error) = update(&project_root().join(SYNTAX_KINDS), &render_template(&project_root().join(SYNTAX_KINDS_TEMPLATE)).unwrap(), true) {
         panic!("{}. Please update it by running `cargo gen-kinds`", error);
     }
-    if let Err(error) = update(&project_root().join(AST), &render_template(project_root().join(AST_TEMPLATE)).unwrap(), true) {
+    if let Err(error) = update(&project_root().join(AST), &render_template(&project_root().join(AST_TEMPLATE)).unwrap(), true) {
         panic!("{}. Please update it by running `cargo gen-kinds`", error);
     }
 }

--- a/crates/tools/tests/cli.rs
+++ b/crates/tools/tests/cli.rs
@@ -1,0 +1,16 @@
+extern crate tools;
+
+use std::path::Path;
+use tools::{render_template, update};
+
+const GRAMMAR: &str = "../ra_syntax/src/grammar.ron";
+const SYNTAX_KINDS: &str = "../ra_syntax/src/syntax_kinds/generated.rs";
+const SYNTAX_KINDS_TEMPLATE: &str = "../ra_syntax/src/syntax_kinds/generated.rs.tera";
+const AST: &str = "../ra_syntax/src/ast/generated.rs";
+const AST_TEMPLATE: &str = "../ra_syntax/src/ast/generated.rs.tera";
+
+#[test]
+fn verify_template_generation() {
+    update(Path::new(SYNTAX_KINDS), &render_template(SYNTAX_KINDS_TEMPLATE, GRAMMAR).unwrap(), true).unwrap();
+    update(Path::new(AST), &render_template(AST_TEMPLATE, GRAMMAR).unwrap(), true).unwrap();
+}

--- a/crates/tools/tests/cli.rs
+++ b/crates/tools/tests/cli.rs
@@ -3,7 +3,6 @@ extern crate tools;
 use std::path::Path;
 use tools::{render_template, update};
 
-const GRAMMAR: &str = "../ra_syntax/src/grammar.ron";
 const SYNTAX_KINDS: &str = "../ra_syntax/src/syntax_kinds/generated.rs";
 const SYNTAX_KINDS_TEMPLATE: &str = "../ra_syntax/src/syntax_kinds/generated.rs.tera";
 const AST: &str = "../ra_syntax/src/ast/generated.rs";
@@ -11,10 +10,10 @@ const AST_TEMPLATE: &str = "../ra_syntax/src/ast/generated.rs.tera";
 
 #[test]
 fn verify_template_generation() {
-    if let Err(error) = update(Path::new(SYNTAX_KINDS), &render_template(SYNTAX_KINDS_TEMPLATE, GRAMMAR).unwrap(), true) {
+    if let Err(error) = update(Path::new(SYNTAX_KINDS), &render_template(SYNTAX_KINDS_TEMPLATE).unwrap(), true) {
         panic!("{}. Please update it by running `cargo gen-kinds`", error);
     }
-    if let Err(error) = update(Path::new(AST), &render_template(AST_TEMPLATE, GRAMMAR).unwrap(), true) {
+    if let Err(error) = update(Path::new(AST), &render_template(AST_TEMPLATE).unwrap(), true) {
         panic!("{}. Please update it by running `cargo gen-kinds`", error);
     }
 }

--- a/crates/tools/tests/cli.rs
+++ b/crates/tools/tests/cli.rs
@@ -1,19 +1,13 @@
 extern crate tools;
 
-use std::path::Path;
-use tools::{render_template, update};
-
-const SYNTAX_KINDS: &str = "../ra_syntax/src/syntax_kinds/generated.rs";
-const SYNTAX_KINDS_TEMPLATE: &str = "../ra_syntax/src/syntax_kinds/generated.rs.tera";
-const AST: &str = "../ra_syntax/src/ast/generated.rs";
-const AST_TEMPLATE: &str = "../ra_syntax/src/ast/generated.rs.tera";
+use tools::{AST, AST_TEMPLATE, SYNTAX_KINDS, SYNTAX_KINDS_TEMPLATE, render_template, update, project_root};
 
 #[test]
 fn verify_template_generation() {
-    if let Err(error) = update(Path::new(SYNTAX_KINDS), &render_template(SYNTAX_KINDS_TEMPLATE).unwrap(), true) {
+    if let Err(error) = update(&project_root().join(SYNTAX_KINDS), &render_template(project_root().join(SYNTAX_KINDS_TEMPLATE)).unwrap(), true) {
         panic!("{}. Please update it by running `cargo gen-kinds`", error);
     }
-    if let Err(error) = update(Path::new(AST), &render_template(AST_TEMPLATE).unwrap(), true) {
+    if let Err(error) = update(&project_root().join(AST), &render_template(project_root().join(AST_TEMPLATE)).unwrap(), true) {
         panic!("{}. Please update it by running `cargo gen-kinds`", error);
     }
 }


### PR DESCRIPTION
This test checks if the generated codes are up-to-date every time during `cargo test`.

I have confirmed that the test works by manually editing the `grammar.ron` file.

Closes #126 

Thanks!