### PR TITLE
Implement Find All References and Rename for local variables

### DIFF
--- a/crates/ra_analysis/src/lib.rs
+++ b/crates/ra_analysis/src/lib.rs
@@ -217,6 +217,9 @@ impl Analysis {
         self.imp
             .approximately_resolve_symbol(file_id, offset, token)
     }
+    pub fn find_all_refs(&self, file_id: FileId, offset: TextUnit, token: &JobToken) -> Vec<(FileId, TextRange)> {
+        self.imp.find_all_refs(file_id, offset, token)
+    }
     pub fn parent_module(&self, file_id: FileId) -> Vec<(FileId, FileSymbol)> {
         self.imp.parent_module(file_id)
     }

--- a/crates/ra_editor/src/scope/fn_scope.rs
+++ b/crates/ra_editor/src/scope/fn_scope.rs
@@ -270,7 +270,6 @@ pub fn resolve_local_name<'a>(
         .filter(|entry| shadowed.insert(entry.name()))
         .filter(|entry| entry.name() == name_ref.text())
         .nth(0);
-    eprintln!("ret = {:?}", ret);
     ret
 }
 

--- a/crates/ra_lsp_server/src/caps.rs
+++ b/crates/ra_lsp_server/src/caps.rs
@@ -27,7 +27,7 @@ pub fn server_capabilities() -> ServerCapabilities {
         definition_provider: Some(true),
         type_definition_provider: None,
         implementation_provider: None,
-        references_provider: None,
+        references_provider: Some(true),
         document_highlight_provider: None,
         document_symbol_provider: Some(true),
         workspace_symbol_provider: Some(true),

--- a/crates/ra_lsp_server/src/caps.rs
+++ b/crates/ra_lsp_server/src/caps.rs
@@ -2,7 +2,7 @@ use languageserver_types::{
     CodeActionProviderCapability, CompletionOptions, DocumentOnTypeFormattingOptions,
     ExecuteCommandOptions, FoldingRangeProviderCapability, ServerCapabilities,
     SignatureHelpOptions, TextDocumentSyncCapability, TextDocumentSyncKind,
-    TextDocumentSyncOptions,
+    TextDocumentSyncOptions, RenameProviderCapability, RenameOptions
 };
 
 pub fn server_capabilities() -> ServerCapabilities {
@@ -40,7 +40,9 @@ pub fn server_capabilities() -> ServerCapabilities {
             more_trigger_character: None,
         }),
         folding_range_provider: Some(FoldingRangeProviderCapability::Simple(true)),
-        rename_provider: None,
+        rename_provider: Some(RenameProviderCapability::Options(RenameOptions{
+            prepare_provider: Some(true)
+        })),
         color_provider: None,
         execute_command_provider: Some(ExecuteCommandOptions {
             commands: vec!["apply_code_action".to_string()],

--- a/crates/ra_lsp_server/src/main_loop/handlers.rs
+++ b/crates/ra_lsp_server/src/main_loop/handlers.rs
@@ -460,6 +460,22 @@ pub fn handle_signature_help(
     }
 }
 
+pub fn handle_references(
+    world: ServerWorld,
+    params: req::ReferenceParams,
+    token: JobToken,
+) -> Result<Option<Vec<Location>>> {
+    let file_id = params.text_document.try_conv_with(&world)?;
+    let line_index = world.analysis().file_line_index(file_id);
+    let offset = params.position.conv_with(&line_index);
+
+    let refs = world.analysis().find_all_refs(file_id, offset, &token);
+
+    Ok(Some(refs.into_iter()
+        .filter_map(|r| to_location(r.0, r.1, &world, &line_index).ok())
+        .collect()))
+}
+
 pub fn handle_code_action(
     world: ServerWorld,
     params: req::CodeActionParams,

--- a/crates/ra_lsp_server/src/main_loop/mod.rs
+++ b/crates/ra_lsp_server/src/main_loop/mod.rs
@@ -248,6 +248,7 @@ fn on_request(
         .on::<req::CodeActionRequest>(handlers::handle_code_action)?
         .on::<req::FoldingRangeRequest>(handlers::handle_folding_range)?
         .on::<req::SignatureHelpRequest>(handlers::handle_signature_help)?
+        .on::<req::References>(handlers::handle_references)?
         .finish();
     match req {
         Ok((id, handle)) => {

--- a/crates/ra_lsp_server/src/main_loop/mod.rs
+++ b/crates/ra_lsp_server/src/main_loop/mod.rs
@@ -248,6 +248,7 @@ fn on_request(
         .on::<req::CodeActionRequest>(handlers::handle_code_action)?
         .on::<req::FoldingRangeRequest>(handlers::handle_folding_range)?
         .on::<req::SignatureHelpRequest>(handlers::handle_signature_help)?
+        .on::<req::PrepareRenameRequest>(handlers::handle_prepare_rename)?
         .on::<req::Rename>(handlers::handle_rename)?
         .on::<req::References>(handlers::handle_references)?
         .finish();

--- a/crates/ra_lsp_server/src/main_loop/mod.rs
+++ b/crates/ra_lsp_server/src/main_loop/mod.rs
@@ -248,6 +248,7 @@ fn on_request(
         .on::<req::CodeActionRequest>(handlers::handle_code_action)?
         .on::<req::FoldingRangeRequest>(handlers::handle_folding_range)?
         .on::<req::SignatureHelpRequest>(handlers::handle_signature_help)?
+        .on::<req::Rename>(handlers::handle_rename)?
         .on::<req::References>(handlers::handle_references)?
         .finish();
     match req {

--- a/crates/ra_lsp_server/src/req.rs
+++ b/crates/ra_lsp_server/src/req.rs
@@ -7,7 +7,7 @@ pub use languageserver_types::{
     CompletionResponse, DocumentOnTypeFormattingParams, DocumentSymbolParams,
     DocumentSymbolResponse, ExecuteCommandParams, Hover, InitializeResult,
     PublishDiagnosticsParams, SignatureHelp, TextDocumentEdit, TextDocumentPositionParams,
-    TextEdit, WorkspaceSymbolParams,
+    TextEdit, WorkspaceSymbolParams, ReferenceParams,
 };
 
 pub enum SyntaxTree {}

--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -2074,8 +2074,7 @@
         "semver": {
             "version": "5.5.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-            "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
-            "dev": true
+            "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
         },
         "source-map": {
             "version": "0.6.1",
@@ -2509,9 +2508,9 @@
             }
         },
         "vsce": {
-            "version": "1.51.1",
-            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.51.1.tgz",
-            "integrity": "sha512-Hf2HE9O/MRQHxUUgWHAm7mOkz0K5swuF2smaE/sP7+OWp/5DdIPFwmLEYCCZHxG25l3GBRoO0dAL8S5w//et+g==",
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.52.0.tgz",
+            "integrity": "sha512-k+KYoTx1sacpYf2BHTA7GN82MNSlf2N4EuppFWwtTN/Sh6fWzIJafxxCNBCDK0H+5NDWfRGZheBY8C3/HOE2ZA==",
             "dev": true,
             "requires": {
                 "cheerio": "1.0.0-rc.2",
@@ -2561,10 +2560,11 @@
             "integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg=="
         },
         "vscode-languageclient": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-4.4.2.tgz",
-            "integrity": "sha512-9TUzsg1UM6n1UEyPlWbDf7tK1wJAK7UGFRmGDN8sz4KmbbDiVRh6YicaB/5oRSVTpuV47PdJpYlOl3SJ0RiK1Q==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-5.1.1.tgz",
+            "integrity": "sha512-jMxshi+BPRQFNG8GB00dJv7ldqMda0be26laYYll/udtJuHbog6RqK10GSxHWDN0PgY0b0m5fePyTk3bq8a0TA==",
             "requires": {
+                "semver": "5.5.1",
                 "vscode-languageserver-protocol": "3.13.0"
             }
         },

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -28,7 +28,7 @@
         "singleQuote": true
     },
     "dependencies": {
-        "vscode-languageclient": "^4.4.0"
+        "vscode-languageclient": "^5.1.1"
     },
     "devDependencies": {
         "@types/mocha": "^2.2.42",
@@ -37,7 +37,7 @@
         "tslint": "^5.11.0",
         "tslint-config-prettier": "^1.15.0",
         "typescript": "^2.6.1",
-        "vsce": "^1.51.1",
+        "vsce": "^1.52.0",
         "vscode": "^1.1.21"
     },
     "activationEvents": [


### PR DESCRIPTION
Expose `find_all_refs` in `Analysis`. This currently only works for local variables.

Use this in the LSP to implement find all references and rename.