### PR TITLE
Use closing paren as a trigger character

### DIFF
--- a/crates/ra_lsp_server/src/caps.rs
+++ b/crates/ra_lsp_server/src/caps.rs
@@ -22,7 +22,7 @@ pub fn server_capabilities() -> ServerCapabilities {
             trigger_characters: None,
         }),
         signature_help_provider: Some(SignatureHelpOptions {
-            trigger_characters: Some(vec!["(".to_string(), ",".to_string()]),
+            trigger_characters: Some(vec!["(".to_string(), ",".to_string(), ")".to_string()]),
         }),
         definition_provider: Some(true),
         type_definition_provider: None,


### PR DESCRIPTION
This seems counter-intuitive based on the concept of "trigger character" but it provides a better function signature experience.