### PR TITLE
Global module

### DIFF
--- a/crates/ra_analysis/src/db.rs
+++ b/crates/ra_analysis/src/db.rs
@@ -85,10 +85,10 @@ salsa::database_storage! {
         }
         impl DescriptorDatabase {
             fn module_tree() for ModuleTreeQuery;
-            fn module_descriptor() for SubmodulesQuery;
             fn module_scope() for ModuleScopeQuery;
-            fn fn_syntax() for FnSyntaxQuery;
             fn fn_scopes() for FnScopesQuery;
+            fn _fn_syntax() for FnSyntaxQuery;
+            fn _submodules() for SubmodulesQuery;
         }
     }
 }

--- a/crates/ra_analysis/src/descriptors/function/imp.rs
+++ b/crates/ra_analysis/src/descriptors/function/imp.rs
@@ -15,7 +15,7 @@ pub(crate) fn fn_syntax(db: &impl DescriptorDatabase, fn_id: FnId) -> FnDefNode 
 }
 
 pub(crate) fn fn_scopes(db: &impl DescriptorDatabase, fn_id: FnId) -> Arc<FnScopes> {
-    let syntax = db.fn_syntax(fn_id);
+    let syntax = db._fn_syntax(fn_id);
     let res = FnScopes::new(syntax.borrowed());
     Arc::new(res)
 }

--- a/crates/ra_analysis/src/descriptors/mod.rs
+++ b/crates/ra_analysis/src/descriptors/mod.rs
@@ -20,19 +20,19 @@ use crate::{
 
 salsa::query_group! {
     pub(crate) trait DescriptorDatabase: SyntaxDatabase + IdDatabase {
-        fn module_tree(source_root_id: SourceRootId) -> Cancelable<Arc<ModuleTree>> {
-            type ModuleTreeQuery;
-            use fn module::imp::module_tree;
-        }
-        fn module_scope(source_root_id: SourceRootId, module_id: ModuleId) -> Cancelable<Arc<ModuleScope>> {
-            type ModuleScopeQuery;
-            use fn module::imp::module_scope;
-        }
         fn fn_scopes(fn_id: FnId) -> Arc<FnScopes> {
             type FnScopesQuery;
             use fn function::imp::fn_scopes;
         }
 
+        fn _module_tree(source_root_id: SourceRootId) -> Cancelable<Arc<ModuleTree>> {
+            type ModuleTreeQuery;
+            use fn module::imp::module_tree;
+        }
+        fn _module_scope(source_root_id: SourceRootId, module_id: ModuleId) -> Cancelable<Arc<ModuleScope>> {
+            type ModuleScopeQuery;
+            use fn module::imp::module_scope;
+        }
         fn _fn_syntax(fn_id: FnId) -> FnDefNode {
             type FnSyntaxQuery;
             // Don't retain syntax trees in memory

--- a/crates/ra_analysis/src/descriptors/mod.rs
+++ b/crates/ra_analysis/src/descriptors/mod.rs
@@ -24,23 +24,24 @@ salsa::query_group! {
             type ModuleTreeQuery;
             use fn module::imp::module_tree;
         }
-        fn submodules(source: ModuleSource) -> Cancelable<Arc<Vec<module::imp::Submodule>>> {
-            type SubmodulesQuery;
-            use fn module::imp::submodules;
-        }
         fn module_scope(source_root_id: SourceRootId, module_id: ModuleId) -> Cancelable<Arc<ModuleScope>> {
             type ModuleScopeQuery;
             use fn module::imp::module_scope;
         }
-        fn fn_syntax(fn_id: FnId) -> FnDefNode {
+        fn fn_scopes(fn_id: FnId) -> Arc<FnScopes> {
+            type FnScopesQuery;
+            use fn function::imp::fn_scopes;
+        }
+
+        fn _fn_syntax(fn_id: FnId) -> FnDefNode {
             type FnSyntaxQuery;
             // Don't retain syntax trees in memory
             storage volatile;
             use fn function::imp::fn_syntax;
         }
-        fn fn_scopes(fn_id: FnId) -> Arc<FnScopes> {
-            type FnScopesQuery;
-            use fn function::imp::fn_scopes;
+        fn _submodules(source: ModuleSource) -> Cancelable<Arc<Vec<module::imp::Submodule>>> {
+            type SubmodulesQuery;
+            use fn module::imp::submodules;
         }
     }
 }

--- a/crates/ra_analysis/src/descriptors/module/imp.rs
+++ b/crates/ra_analysis/src/descriptors/module/imp.rs
@@ -155,7 +155,7 @@ fn build_subtree(
         parent,
         children: Vec::new(),
     });
-    for sub in db.submodules(source)?.iter() {
+    for sub in db._submodules(source)?.iter() {
         let link = tree.push_link(LinkData {
             name: sub.name().clone(),
             owner: id,

--- a/crates/ra_analysis/src/descriptors/module/imp.rs
+++ b/crates/ra_analysis/src/descriptors/module/imp.rs
@@ -86,7 +86,7 @@ pub(crate) fn module_scope(
     source_root_id: SourceRootId,
     module_id: ModuleId,
 ) -> Cancelable<Arc<ModuleScope>> {
-    let tree = db.module_tree(source_root_id)?;
+    let tree = db._module_tree(source_root_id)?;
     let source = module_id.source(&tree).resolve(db);
     let res = match source {
         ModuleSourceNode::SourceFile(it) => ModuleScope::new(it.borrowed().items()),

--- a/crates/ra_analysis/src/descriptors/module/mod.rs
+++ b/crates/ra_analysis/src/descriptors/module/mod.rs
@@ -142,7 +142,7 @@ impl crate::loc2id::NumericId for ModuleId {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub(crate) struct LinkId(u32);
+struct LinkId(u32);
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum Problem {
@@ -159,7 +159,7 @@ impl ModuleId {
     pub(crate) fn source(self, tree: &ModuleTree) -> ModuleSource {
         tree.module(self).source
     }
-    pub(crate) fn parent_link(self, tree: &ModuleTree) -> Option<LinkId> {
+    fn parent_link(self, tree: &ModuleTree) -> Option<LinkId> {
         tree.module(self).parent
     }
     pub(crate) fn parent(self, tree: &ModuleTree) -> Option<ModuleId> {
@@ -207,17 +207,13 @@ impl ModuleId {
 }
 
 impl LinkId {
-    pub(crate) fn owner(self, tree: &ModuleTree) -> ModuleId {
+    fn owner(self, tree: &ModuleTree) -> ModuleId {
         tree.link(self).owner
     }
-    pub(crate) fn name(self, tree: &ModuleTree) -> SmolStr {
+    fn name(self, tree: &ModuleTree) -> SmolStr {
         tree.link(self).name.clone()
     }
-    pub(crate) fn bind_source<'a>(
-        self,
-        tree: &ModuleTree,
-        db: &impl SyntaxDatabase,
-    ) -> ast::ModuleNode {
+    fn bind_source<'a>(self, tree: &ModuleTree, db: &impl SyntaxDatabase) -> ast::ModuleNode {
         let owner = self.owner(tree);
         match owner.source(tree).resolve(db) {
             ModuleSourceNode::SourceFile(root) => {

--- a/crates/ra_analysis/src/descriptors/module/mod.rs
+++ b/crates/ra_analysis/src/descriptors/module/mod.rs
@@ -165,15 +165,6 @@ enum ModuleSourceNode {
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
 pub(crate) struct ModuleId(u32);
 
-impl crate::loc2id::NumericId for ModuleId {
-    fn from_u32(id: u32) -> Self {
-        ModuleId(id)
-    }
-    fn to_u32(self) -> u32 {
-        self.0
-    }
-}
-
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 struct LinkId(u32);
 
@@ -189,13 +180,13 @@ pub enum Problem {
 }
 
 impl ModuleId {
-    pub(crate) fn source(self, tree: &ModuleTree) -> ModuleSource {
+    fn source(self, tree: &ModuleTree) -> ModuleSource {
         tree.module(self).source
     }
     fn parent_link(self, tree: &ModuleTree) -> Option<LinkId> {
         tree.module(self).parent
     }
-    pub(crate) fn parent(self, tree: &ModuleTree) -> Option<ModuleId> {
+    fn parent(self, tree: &ModuleTree) -> Option<ModuleId> {
         let link = self.parent_link(tree)?;
         Some(tree.link(link).owner)
     }

--- a/crates/ra_analysis/src/descriptors/module/mod.rs
+++ b/crates/ra_analysis/src/descriptors/module/mod.rs
@@ -146,7 +146,7 @@ pub(crate) struct ModuleTree {
 }
 
 impl ModuleTree {
-    pub(crate) fn modules_for_source(&self, source: ModuleSource) -> Vec<ModuleId> {
+    fn modules_for_source(&self, source: ModuleSource) -> Vec<ModuleId> {
         self.mods
             .iter()
             .enumerate()
@@ -155,7 +155,7 @@ impl ModuleTree {
             .collect()
     }
 
-    pub(crate) fn any_module_for_source(&self, source: ModuleSource) -> Option<ModuleId> {
+    fn any_module_for_source(&self, source: ModuleSource) -> Option<ModuleId> {
         self.modules_for_source(source).pop()
     }
 }
@@ -261,7 +261,7 @@ struct ModuleData {
 }
 
 impl ModuleSource {
-    pub(crate) fn new_inline(file_id: FileId, module: ast::Module) -> ModuleSource {
+    fn new_inline(file_id: FileId, module: ast::Module) -> ModuleSource {
         assert!(!module.has_semi());
         let ptr = SyntaxPtr::new(file_id, module.syntax());
         ModuleSource::Module(ptr)

--- a/crates/ra_analysis/src/descriptors/module/mod.rs
+++ b/crates/ra_analysis/src/descriptors/module/mod.rs
@@ -213,11 +213,7 @@ impl ModuleId {
             .find(|it| it.name == name)?;
         Some(*link.points_to.first()?)
     }
-    fn problems(
-        self,
-        tree: &ModuleTree,
-        db: &impl SyntaxDatabase,
-    ) -> Vec<(SyntaxNode, Problem)> {
+    fn problems(self, tree: &ModuleTree, db: &impl SyntaxDatabase) -> Vec<(SyntaxNode, Problem)> {
         tree.module(self)
             .children
             .iter()

--- a/crates/ra_analysis/src/imp.rs
+++ b/crates/ra_analysis/src/imp.rs
@@ -216,8 +216,8 @@ impl AnalysisImpl {
             .sweep(salsa::SweepStrategy::default().discard_values());
         Ok(query.search(&buf))
     }
-    /// This return `Vec`: a module may be inclucded from several places.
-    /// We don't handle this case yet though, so the Vec has length at most one.
+    /// This return `Vec`: a module may be included from several places. We
+    /// don't handle this case yet though, so the Vec has length at most one.
     pub fn parent_module(&self, position: FilePosition) -> Cancelable<Vec<(FileId, FileSymbol)>> {
         let descr = match ModuleDescriptor::guess_from_position(&*self.db, position)? {
             None => return Ok(Vec::new()),

--- a/crates/ra_analysis/src/loc2id.rs
+++ b/crates/ra_analysis/src/loc2id.rs
@@ -89,10 +89,6 @@ macro_rules! impl_numeric_id {
 pub(crate) struct FnId(u32);
 impl_numeric_id!(FnId);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) struct ModId(u32);
-impl_numeric_id!(ModId);
-
 pub(crate) trait IdDatabase: salsa::Database {
     fn id_maps(&self) -> &IdMaps;
 }

--- a/crates/ra_analysis/src/loc2id.rs
+++ b/crates/ra_analysis/src/loc2id.rs
@@ -72,17 +72,26 @@ pub(crate) trait NumericId: Clone + Eq + Hash {
     fn to_u32(self) -> u32;
 }
 
+macro_rules! impl_numeric_id {
+    ($id:ident) => {
+        impl NumericId for $id {
+            fn from_u32(id: u32) -> Self {
+                $id(id)
+            }
+            fn to_u32(self) -> u32 {
+                self.0
+            }
+        }
+    };
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct FnId(u32);
+impl_numeric_id!(FnId);
 
-impl NumericId for FnId {
-    fn from_u32(id: u32) -> FnId {
-        FnId(id)
-    }
-    fn to_u32(self) -> u32 {
-        self.0
-    }
-}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct ModId(u32);
+impl_numeric_id!(ModId);
 
 pub(crate) trait IdDatabase: salsa::Database {
     fn id_maps(&self) -> &IdMaps;


### PR DESCRIPTION
This series of commits re-introdces `ModuleDescriptor` as one stop shop for all information about a module.