### PR TITLE
Use `:` as a trigger character for completion

### DIFF
--- a/crates/ra_lsp_server/src/caps.rs
+++ b/crates/ra_lsp_server/src/caps.rs
@@ -19,7 +19,7 @@ pub fn server_capabilities() -> ServerCapabilities {
         hover_provider: Some(true),
         completion_provider: Some(CompletionOptions {
             resolve_provider: None,
-            trigger_characters: None,
+            trigger_characters: Some(vec![":".to_string()]),
         }),
         signature_help_provider: Some(SignatureHelpOptions {
             trigger_characters: Some(vec!["(".to_string(), ",".to_string(), ")".to_string()]),


### PR DESCRIPTION
Note that VSCode asks for completion after *first* `:` as well:

    use crate:

we use hacks to protect against that, and to give completions only
after the second `:`.