### PR TITLE
WIP: introduce StablePtr infrastructure

### DIFF
--- a/crates/ra_analysis/src/descriptors/module/nameres/mod.rs
+++ b/crates/ra_analysis/src/descriptors/module/nameres/mod.rs
@@ -14,6 +14,8 @@
 //! modifications (that is, typing inside a function shold not change IMIs),
 //! such that the results of name resolution can be preserved unless the module
 //! structure itself is modified.
+mod ptr;
+
 use std::{
     sync::Arc,
     time::Instant,
@@ -126,6 +128,7 @@ pub(crate) fn item_map(
     log::info!("item_map: {:?}", elapsed);
     Ok(Arc::new(res))
 }
+
 
 /// Resolution is basically `DefId` atm, but it should account for stuff like
 /// multiple namespaces, ambiguity and errors.

--- a/crates/ra_analysis/src/descriptors/module/nameres/ptr.rs
+++ b/crates/ra_analysis/src/descriptors/module/nameres/ptr.rs
@@ -1,0 +1,56 @@
+use ra_syntax::{
+    SyntaxKind, SmolStr,
+    ast::{self, AstNode, NameOwner, ModuleItemOwner},
+};
+
+pub(crate) struct InModulePtr<T> {
+    pub(crate) module: u8,
+    pub(crate) inner: T,
+}
+
+
+/// Plays the same role as `LocalSyntaxPtr`, is costlier to resolve, but survies
+/// most reparses.
+pub(crate) struct ItemPtr {
+    // Kind of enclosing item.
+    pub(crate) kind: SyntaxKind,
+    // Name of enclosing item, if any.
+    pub(crate) name: SmolStr,
+    // Nth item with the specified kind and name.
+    pub(crate) index: u8,
+}
+
+pub(crate) struct ImportPtr {
+    pub(crate) index: u16,
+}
+
+
+impl ItemPtr {
+    fn resolve<'a>(&self, items: impl ast::ModuleItemOwner<'a>) -> ast::ModuleItem<'a> {
+        items
+            .items()
+            .filter(|&it| it.syntax().kind() == self.kind && has_name(it, &self.name))
+            .nth(self.index as usize)
+            .unwrap()
+    }
+}
+
+fn has_name(item: ast::ModuleItem, name: &SmolStr) -> bool {
+    let item_name = match item {
+        ast::ModuleItem::StructDef(it) => it.name(),
+        ast::ModuleItem::EnumDef(it) => it.name(),
+        ast::ModuleItem::FnDef(it) => it.name(),
+        ast::ModuleItem::TraitDef(it) => it.name(),
+        ast::ModuleItem::TypeDef(it) => it.name(),
+        ast::ModuleItem::ConstDef(it) => it.name(),
+        ast::ModuleItem::StaticDef(it) => it.name(),
+        ast::ModuleItem::Module(it) => it.name(),
+        ast::ModuleItem::UseItem(_) => return false,
+        ast::ModuleItem::ImplItem(_) => return false,
+        ast::ModuleItem::ExternCrateItem(_) => return false,
+    };
+    match item_name {
+        None => false,
+        Some(n) => &n.text() == name,
+    }
+}


### PR DESCRIPTION
We currently use LocalSyntaxPtr to refer to various syntax nodes. This is problemantic, b/c local ptr stores text offsets, which are invalidated after most of the edits. The idea is to replace `LocalPtr`s with `StablePtr`s,  which look roughly like "the n'th item named foo in this file", which should be stable across reparses. 