### PR TITLE
Fix diagnostic fixes showing up everywhere

### DIFF
--- a/crates/ra_lsp_server/src/main_loop/handlers.rs
+++ b/crates/ra_lsp_server/src/main_loop/handlers.rs
@@ -9,7 +9,7 @@ use languageserver_types::{
     WorkspaceEdit, ParameterInformation, SignatureInformation, Hover, HoverContents,
 };
 use ra_analysis::{FileId, FoldKind, Query, RunnableKind, FilePosition};
-use ra_syntax::{TextUnit, text_utils::contains_offset_nonstrict};
+use ra_syntax::{TextUnit, text_utils::{contains_offset_nonstrict, intersect}};
 use rustc_hash::FxHashMap;
 use serde_json::to_value;
 
@@ -618,7 +618,7 @@ pub fn handle_code_action(
         .diagnostics(file_id)?
         .into_iter()
         .filter_map(|d| Some((d.range, d.fix?)))
-        .filter(|(range, _fix)| contains_offset_nonstrict(*range, range.start()))
+        .filter(|(diag_range, _fix)| intersect(*diag_range, range).is_some())
         .map(|(_range, fix)| fix);
 
     let mut res = Vec::new();


### PR DESCRIPTION
The LSP code action request always returned the fixes for all diagnostics anywhere in the file, because of a shadowed variable.


There's no test yet; I wasn't sure where to add it. I tried adding one in `heavy_tests`, but that's a bit uncomfortable because the code action response contains the (random) file paths. I could make it work, but wanted to ask beforehand what you think.