### PR TITLE
Add heavy test for code actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,6 +1075,7 @@ version = "0.1.0"
 dependencies = [
  "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "text_unit 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/crates/ra_lsp_server/tests/heavy_tests/main.rs
+++ b/crates/ra_lsp_server/tests/heavy_tests/main.rs
@@ -2,7 +2,9 @@ mod support;
 
 use serde_json::json;
 
-use ra_lsp_server::req::{Runnables, RunnablesParams};
+use ra_lsp_server::req::{Runnables, RunnablesParams, CodeActionRequest, CodeActionParams};
+
+use languageserver_types::{Position, Range, CodeActionContext};
 
 use crate::support::project;
 
@@ -114,5 +116,62 @@ fn test_eggs() {}
             }
           }
         ])
+    );
+}
+
+#[test]
+fn test_missing_module_code_action() {
+    let server = project(
+        r#"
+//- Cargo.toml
+[package]
+name = "foo"
+version = "0.0.0"
+
+//- src/lib.rs
+mod bar;
+
+fn main() {}
+"#,
+    );
+    server.wait_for_feedback("workspace loaded");
+    let empty_context = || CodeActionContext {
+        diagnostics: Vec::new(),
+        only: None,
+    };
+    server.request::<CodeActionRequest>(
+        CodeActionParams {
+            text_document: server.doc_id("src/lib.rs"),
+            range: Range::new(Position::new(0, 0), Position::new(0, 7)),
+            context: empty_context(),
+        },
+        json!([
+            {
+              "arguments": [
+                {
+                  "cursorPosition": null,
+                  "fileSystemEdits": [
+                    {
+                        "type": "createFile",
+                        "uri": "file:///[..]/src/bar.rs"
+                    }
+                  ],
+                  "label": "create module",
+                  "sourceFileEdits": []
+                }
+              ],
+              "command": "ra-lsp.applySourceChange",
+              "title": "create module"
+            }
+        ]),
+    );
+
+    server.request::<CodeActionRequest>(
+        CodeActionParams {
+            text_document: server.doc_id("src/lib.rs"),
+            range: Range::new(Position::new(2, 0), Position::new(2, 7)),
+            context: empty_context(),
+        },
+        json!([]),
     );
 }

--- a/crates/ra_lsp_server/tests/heavy_tests/main.rs
+++ b/crates/ra_lsp_server/tests/heavy_tests/main.rs
@@ -1,5 +1,7 @@
 mod support;
 
+use serde_json::json;
+
 use ra_lsp_server::req::{Runnables, RunnablesParams};
 
 use crate::support::project;
@@ -21,7 +23,7 @@ fn foo() {
             text_document: server.doc_id("lib.rs"),
             position: None,
         },
-        r#"[
+        json!([
           {
             "args": [ "test", "--", "foo", "--nocapture" ],
             "bin": "cargo",
@@ -51,7 +53,7 @@ fn foo() {
               }
             }
           }
-        ]"#,
+        ]),
     );
 }
 
@@ -78,7 +80,7 @@ fn test_eggs() {}
             text_document: server.doc_id("tests/spam.rs"),
             position: None,
         },
-        r#"[
+        json!([
           {
             "args": [ "test", "--package", "foo", "--test", "spam", "--", "test_eggs", "--nocapture" ],
             "bin": "cargo",
@@ -111,6 +113,6 @@ fn test_eggs() {}
               }
             }
           }
-        ]"#
+        ])
     );
 }

--- a/crates/ra_syntax/src/grammar/items/mod.rs
+++ b/crates/ra_syntax/src/grammar/items/mod.rs
@@ -159,7 +159,7 @@ pub(super) fn maybe_item(p: &mut Parser, flavor: ItemFlavor) -> MaybeItem {
                 MaybeItem::Modifiers
             } else {
                 MaybeItem::None
-            }
+            };
         }
     };
 

--- a/crates/test_utils/Cargo.toml
+++ b/crates/test_utils/Cargo.toml
@@ -8,3 +8,4 @@ authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 difference = "2.0.0"
 itertools = "0.7.8"
 text_unit = "0.1.2"
+serde_json = "1.0.24"


### PR DESCRIPTION
Here's the test for the code actions; I didn't find anything fitting on crates.io ([assert-json-diff](https://crates.io/crates/assert-json-diff) looks kind of nice, but doesn't have anything like the wildcards), so I copied the cargo code as you suggested.