### PR TITLE
handle expanding of words in comments at the beginning or end of line

### DIFF
--- a/crates/ra_editor/src/extend_selection.rs
+++ b/crates/ra_editor/src/extend_selection.rs
@@ -48,8 +48,8 @@ fn extend_single_word_in_comment(leaf: SyntaxNodeRef, offset: TextUnit) -> Optio
     let cursor_position: u32 = (offset - leaf.range().start()).into();
 
     let (before, after) = text.split_at(cursor_position as usize);
-    let start_idx = before.rfind(char::is_whitespace)? as u32;
-    let end_idx = after.find(char::is_whitespace)? as u32;
+    let start_idx = before.rfind(char::is_whitespace).unwrap_or(0) as u32;
+    let end_idx = after.find(char::is_whitespace).unwrap_or(after.len()) as u32;
 
     let from: TextUnit = (start_idx + 1).into();
     let to: TextUnit = (cursor_position + end_idx).into();
@@ -184,7 +184,7 @@ fn bar(){}
 
 // fn foo(){}
     "#,
-            &["// 1 + 1", "// fn foo() {\n// 1 + 1\n// }"],
+            &["1", "// 1 + 1", "// fn foo() {\n// 1 + 1\n// }"],
         );
 
         do_check(


### PR DESCRIPTION
After fixing #140 i realized that the logic to determine word boundaries was not correct. It would only consider a word something surrounded by whitespaces in the line, but not newlines before and after the line. This means that one of the tests has changed, but i think that's what was intended.