### PR TITLE
WIP: Support tracing lsp requests.

### DIFF
--- a/crates/ra_lsp_server/src/main.rs
+++ b/crates/ra_lsp_server/src/main.rs
@@ -27,7 +27,7 @@ fn main() -> Result<()> {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct InitializationOptions {
-    publish_decorations: bool,
+    highlighting_on: bool,
 }
 
 fn main_inner() -> Result<()> {
@@ -45,7 +45,7 @@ fn main_inner() -> Result<()> {
             let publish_decorations = params
                 .initialization_options
                 .and_then(|v| InitializationOptions::deserialize(v).ok())
-                .map(|it| it.publish_decorations)
+                .map(|it| it.highlighting_on)
                 == Some(true);
             ra_lsp_server::main_loop(false, root, publish_decorations, r, s)
         },

--- a/crates/ra_lsp_server/src/main.rs
+++ b/crates/ra_lsp_server/src/main.rs
@@ -27,7 +27,10 @@ fn main() -> Result<()> {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct InitializationOptions {
-    highlighting_on: bool,
+    // Whether the client supports our custom highlighting publishing decorations.
+    // This is different to the highlightingOn setting, which is whether the client
+    // wants highlighting to be used or sent.
+    publish_decorations: Option<bool>,
 }
 
 fn main_inner() -> Result<()> {
@@ -42,12 +45,12 @@ fn main_inner() -> Result<()> {
                 .root_uri
                 .and_then(|it| it.to_file_path().ok())
                 .unwrap_or(cwd);
-            let publish_decorations = params
+            let supports_decorations = params
                 .initialization_options
                 .and_then(|v| InitializationOptions::deserialize(v).ok())
-                .map(|it| it.highlighting_on)
+                .and_then(|it| it.publish_decorations)
                 == Some(true);
-            ra_lsp_server::main_loop(false, root, publish_decorations, r, s)
+            ra_lsp_server::main_loop(false, root, supports_decorations, r, s)
         },
     )?;
     log::info!("shutting down IO...");

--- a/crates/ra_lsp_server/src/main.rs
+++ b/crates/ra_lsp_server/src/main.rs
@@ -28,8 +28,8 @@ fn main() -> Result<()> {
 #[serde(rename_all = "camelCase")]
 struct InitializationOptions {
     // Whether the client supports our custom highlighting publishing decorations.
-    // This is different to the highlightingOn setting, which is whether the client
-    // wants highlighting to be used or sent.
+    // This is different to the highlightingOn setting, which is whether the user
+    // wants our custom highlighting to be used.
     publish_decorations: Option<bool>,
 }
 

--- a/crates/ra_lsp_server/src/main_loop.rs
+++ b/crates/ra_lsp_server/src/main_loop.rs
@@ -53,7 +53,7 @@ enum Task {
 pub fn main_loop(
     internal_mode: bool,
     ws_root: PathBuf,
-    publish_decorations: bool,
+    supports_decorations: bool,
     msg_receiver: &Receiver<RawMessage>,
     msg_sender: &Sender<RawMessage>,
 ) -> Result<()> {
@@ -82,7 +82,7 @@ pub fn main_loop(
     let mut subs = Subscriptions::new();
     let main_res = main_loop_inner(
         internal_mode,
-        publish_decorations,
+        supports_decorations,
         &pool,
         msg_sender,
         msg_receiver,
@@ -111,7 +111,7 @@ pub fn main_loop(
 
 fn main_loop_inner(
     internal_mode: bool,
-    publish_decorations: bool,
+    supports_decorations: bool,
     pool: &ThreadPool,
     msg_sender: &Sender<RawMessage>,
     msg_receiver: &Receiver<RawMessage>,
@@ -201,7 +201,7 @@ fn main_loop_inner(
             update_file_notifications_on_threadpool(
                 pool,
                 state.snapshot(),
-                publish_decorations,
+                supports_decorations,
                 task_sender.clone(),
                 subs.subscriptions(),
             )

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -131,6 +131,17 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Highlight Rust code (overrides built-in syntax highlighting)"
+                },
+                "ra-lsp.trace.server": {
+                    "type": "string",
+                    "scope": "window",
+                    "enum": [
+                        "off",
+                        "messages",
+                        "verbose"
+                    ],
+                    "default": "off",
+                    "description": "Trace requests to the ra-lsp server"
                 }
             }
         },

--- a/editors/code/src/server.ts
+++ b/editors/code/src/server.ts
@@ -22,7 +22,7 @@ export class Server {
         const clientOptions: lc.LanguageClientOptions = {
             documentSelector: [{ scheme: 'file', language: 'rust' }],
             initializationOptions: {
-                publishDecorations: true,
+                publishDecorations: true
             }
         };
 
@@ -32,6 +32,30 @@ export class Server {
             serverOptions,
             clientOptions
         );
+        // HACK: This is an awful way of filtering out the decorations notifications
+        // However, pending proper support, this is the most effecitve approach
+        // Proper support for this would entail a change to vscode-languageclient to allow not notifying on certain messages
+        // Or the ability to disable the serverside component of highlighting (but this means that to do tracing we need to disable hihlighting)
+        // This also requires considering our settings strategy, which is work which needs doing
+        // @ts-ignore The tracer is private to vscode-languageclient, but we need access to it to not log publishDecorations requests
+        Server.client._tracer = {
+            log: (messageOrDataObject: string | any, data?: string) => {
+                if (typeof messageOrDataObject === 'string') {
+                    if (
+                        messageOrDataObject.includes('m/publishDecorations') ||
+                        messageOrDataObject.includes('m/decorationsRequest')
+                    ) {
+                        // Don't log publish decorations requests
+                    } else {
+                        // @ts-ignore This is just a utility function
+                        Server.client.logTrace(messageOrDataObject, data);
+                    }
+                } else {
+                    // @ts-ignore
+                    Server.client.logObjectTrace(messageOrDataObject);
+                }
+            }
+        };
         Server.client.onReady().then(() => {
             for (const [type, handler] of notificationHandlers) {
                 Server.client.onNotification(type, handler);


### PR DESCRIPTION
EDIT: We need to work out a better way to handle settings before this can be merged. Help wanted

TODO: Debug why decorations are sent even when highlightingOn is disabled
This makes the log volume so high its impossible to work with anyway.
(Continuation of #84 [#99 only disabled using it, not making sure we don't send it]).

These logs can be used in https://microsoft.github.io/language-server-protocol/inspector/