### PR TITLE
Fix analyzer extension fail when there are enabled any VIM extension

### DIFF
--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -23,19 +23,23 @@ export function activate(context: vscode.ExtensionContext) {
         const original = (...args: any[]) =>
             vscode.commands.executeCommand(defaultCmd, ...args);
 
-        registerCommand(name, async (...args: any[]) => {
-            const editor = vscode.window.activeTextEditor;
-            if (
-                !editor ||
-                !editor.document ||
-                editor.document.languageId !== 'rust'
-            ) {
-                return await original(...args);
-            }
-            if (!(await f(...args))) {
-                return await original(...args);
-            }
-        });
+        try {
+            registerCommand(name, async (...args: any[]) => {
+                const editor = vscode.window.activeTextEditor;
+                if (
+                    !editor ||
+                    !editor.document ||
+                    editor.document.languageId !== 'rust'
+                ) {
+                    return await original(...args);
+                }
+                if (!(await f(...args))) {
+                    return await original(...args);
+                }
+            });
+        } catch(_) {
+            vscode.window.showWarningMessage('Enhanced typing feature is disabled because of incompatibility with VIM extension');
+        }
     }
 
     // Commands are requests from vscode to the language server


### PR DESCRIPTION
`type` command is allowed only once to be registered and it was built specially for vim mode.
So if user has vim extension enabled, rust-analyzer initialization failes on trying to register own `type` handler.

Unfortunatelly, there are no nice ways to check if command is already registered so the way is to wrap everything with try/catch and notify user about conflict.