### PR TITLE
WIP: introduce hir::Name

### DIFF
--- a/crates/ra_db/src/lib.rs
+++ b/crates/ra_db/src/lib.rs
@@ -14,7 +14,7 @@ pub use crate::{
     cancelation::{Canceled, Cancelable},
     syntax_ptr::LocalSyntaxPtr,
     input::{
-        FilesDatabase, FileId, CrateId, SourceRoot, SourceRootId, CrateGraph,
+        FilesDatabase, FileId, CrateId, SourceRoot, SourceRootId, CrateGraph, Dependency,
         FileTextQuery, FileSourceRootQuery, SourceRootQuery, LocalRootsQuery, LibraryRootsQuery, CrateGraphQuery,
         FileRelativePathQuery
     },

--- a/crates/ra_hir/src/krate.rs
+++ b/crates/ra_hir/src/krate.rs
@@ -1,7 +1,6 @@
-use ra_syntax::SmolStr;
 pub use ra_db::CrateId;
 
-use crate::{HirDatabase, Module, Cancelable};
+use crate::{HirDatabase, Module, Cancelable, Name, AsName};
 
 /// hir::Crate describes a single crate. It's the main inteface with which
 /// crate's dependencies interact. Mostly, it should be just a proxy for the
@@ -14,7 +13,7 @@ pub struct Crate {
 #[derive(Debug)]
 pub struct CrateDependency {
     pub krate: Crate,
-    pub name: SmolStr,
+    pub name: Name,
 }
 
 impl Crate {
@@ -27,7 +26,7 @@ impl Crate {
             .dependencies(self.crate_id)
             .map(|dep| {
                 let krate = Crate::new(dep.crate_id());
-                let name = dep.name.clone();
+                let name = dep.as_name();
                 CrateDependency { krate, name }
             })
             .collect()

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -38,7 +38,7 @@ use ra_db::{LocationIntener, SourceRootId, FileId, Cancelable};
 use crate::{
     db::HirDatabase,
     arena::{Arena, Id},
-    name::AsName,
+    name::{AsName, KnownName},
 };
 
 pub use self::{

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -22,6 +22,7 @@ mod path;
 mod arena;
 pub mod source_binder;
 
+mod name;
 mod krate;
 mod module;
 mod function;
@@ -37,10 +38,12 @@ use ra_db::{LocationIntener, SourceRootId, FileId, Cancelable};
 use crate::{
     db::HirDatabase,
     arena::{Arena, Id},
+    name::AsName,
 };
 
 pub use self::{
     path::{Path, PathKind},
+    name::Name,
     krate::Crate,
     module::{Module, ModuleId, Problem, nameres::{ItemMap, PerNs, Namespace}, ModuleScope, Resolution},
     function::{Function, FnScopes},

--- a/crates/ra_hir/src/module/nameres/tests.rs
+++ b/crates/ra_hir/src/module/nameres/tests.rs
@@ -9,6 +9,7 @@ use crate::{
     self as hir,
     db::HirDatabase,
     mock::MockDatabase,
+    Name,
 };
 
 fn item_map(fixture: &str) -> (Arc<hir::ItemMap>, hir::ModuleId) {
@@ -38,7 +39,7 @@ fn item_map_smoke_test() {
         pub struct Baz;
     ",
     );
-    let name = SmolStr::from("Baz");
+    let name = Name::new(SmolStr::from("Baz"));
     let resolution = &item_map.per_module[&module_id].items[&name];
     assert!(resolution.def_id.take_types().is_some());
 }
@@ -57,7 +58,7 @@ fn test_self() {
             pub struct Baz;
         ",
     );
-    let name = SmolStr::from("Baz");
+    let name = Name::new(SmolStr::from("Baz"));
     let resolution = &item_map.per_module[&module_id].items[&name];
     assert!(resolution.def_id.take_types().is_some());
 }
@@ -90,7 +91,7 @@ fn item_map_across_crates() {
     let module_id = module.module_id;
     let item_map = db.item_map(source_root).unwrap();
 
-    let name = SmolStr::from("Baz");
+    let name = Name::new(SmolStr::from("Baz"));
     let resolution = &item_map.per_module[&module_id].items[&name];
     assert!(resolution.def_id.take_types().is_some());
 }

--- a/crates/ra_hir/src/name.rs
+++ b/crates/ra_hir/src/name.rs
@@ -5,7 +5,7 @@ use ra_syntax::{ast, SmolStr};
 /// `Name` is a wrapper around string, which is used in hir for both references
 /// and declarations. In theory, names should also carry hygene info, but we are
 /// not there yet!
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Name {
     text: SmolStr,
 }
@@ -13,6 +13,12 @@ pub struct Name {
 impl fmt::Display for Name {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&self.text, f)
+    }
+}
+
+impl fmt::Debug for Name {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.text, f)
     }
 }
 
@@ -38,13 +44,7 @@ impl Name {
         Some(name)
     }
 
-    #[cfg(not(test))]
     fn new(text: SmolStr) -> Name {
-        Name { text }
-    }
-
-    #[cfg(test)]
-    pub(crate) fn new(text: SmolStr) -> Name {
         Name { text }
     }
 }

--- a/crates/ra_hir/src/name.rs
+++ b/crates/ra_hir/src/name.rs
@@ -17,9 +17,25 @@ impl fmt::Display for Name {
 }
 
 impl Name {
-    // TODO: get rid of this?
-    pub(crate) fn as_str(&self) -> &str {
-        self.text.as_str()
+    pub(crate) fn as_known_name(&self) -> Option<KnownName> {
+        let name = match self.text.as_str() {
+            "isize" => KnownName::Isize,
+            "i8" => KnownName::I8,
+            "i16" => KnownName::I16,
+            "i32" => KnownName::I32,
+            "i64" => KnownName::I64,
+            "i128" => KnownName::I128,
+            "usize" => KnownName::Usize,
+            "u8" => KnownName::U8,
+            "u16" => KnownName::U16,
+            "u32" => KnownName::U32,
+            "u64" => KnownName::U64,
+            "u128" => KnownName::U128,
+            "f32" => KnownName::F32,
+            "f64" => KnownName::F64,
+            _ => return None,
+        };
+        Some(name)
     }
 
     #[cfg(not(test))]
@@ -53,4 +69,29 @@ impl AsName for ra_db::Dependency {
     fn as_name(&self) -> Name {
         Name::new(self.name.clone())
     }
+}
+
+// Ideally, should be replaced with
+// ```
+// const ISIZE: Name = Name::new("isize")
+// ```
+// but const-fn is not that powerful yet.
+#[derive(Debug)]
+pub(crate) enum KnownName {
+    Isize,
+    I8,
+    I16,
+    I32,
+    I64,
+    I128,
+
+    Usize,
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
+
+    F32,
+    F64,
 }

--- a/crates/ra_hir/src/name.rs
+++ b/crates/ra_hir/src/name.rs
@@ -1,0 +1,56 @@
+use std::fmt;
+
+use ra_syntax::{ast, SmolStr};
+
+/// `Name` is a wrapper around string, which is used in hir for both references
+/// and declarations. In theory, names should also carry hygene info, but we are
+/// not there yet!
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Name {
+    text: SmolStr,
+}
+
+impl fmt::Display for Name {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.text, f)
+    }
+}
+
+impl Name {
+    // TODO: get rid of this?
+    pub(crate) fn as_str(&self) -> &str {
+        self.text.as_str()
+    }
+
+    #[cfg(not(test))]
+    fn new(text: SmolStr) -> Name {
+        Name { text }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new(text: SmolStr) -> Name {
+        Name { text }
+    }
+}
+
+pub(crate) trait AsName {
+    fn as_name(&self) -> Name;
+}
+
+impl AsName for ast::NameRef<'_> {
+    fn as_name(&self) -> Name {
+        Name::new(self.text())
+    }
+}
+
+impl AsName for ast::Name<'_> {
+    fn as_name(&self) -> Name {
+        Name::new(self.text())
+    }
+}
+
+impl AsName for ra_db::Dependency {
+    fn as_name(&self) -> Name {
+        Name::new(self.name.clone())
+    }
+}

--- a/crates/ra_hir/src/query_definitions.rs
+++ b/crates/ra_hir/src/query_definitions.rs
@@ -11,7 +11,7 @@ use ra_syntax::{
 use ra_db::{SourceRootId, FileId, Cancelable,};
 
 use crate::{
-    SourceFileItems, SourceItemId, DefKind, Function, DefId,
+    SourceFileItems, SourceItemId, DefKind, Function, DefId, Name, AsName,
     db::HirDatabase,
     function::{FnScopes, FnId},
     module::{
@@ -130,14 +130,14 @@ pub(crate) fn submodules(
 
 pub(crate) fn modules<'a>(
     root: impl ast::ModuleItemOwner<'a>,
-) -> impl Iterator<Item = (SmolStr, ast::Module<'a>)> {
+) -> impl Iterator<Item = (Name, ast::Module<'a>)> {
     root.items()
         .filter_map(|item| match item {
             ast::ModuleItem::Module(m) => Some(m),
             _ => None,
         })
         .filter_map(|module| {
-            let name = module.name()?.text();
+            let name = module.name()?.as_name();
             Some((name, module))
         })
 }

--- a/crates/ra_hir/src/ty.rs
+++ b/crates/ra_hir/src/ty.rs
@@ -179,13 +179,13 @@ impl Ty {
         module: &Module,
         path: &Path,
     ) -> Cancelable<Self> {
-        if path.is_ident() {
-            let name = &path.segments[0];
-            if let Some(int_ty) = primitive::IntTy::from_string(&name) {
+        if let Some(name) = path.as_ident() {
+            let name = name.as_str(); // :-(
+            if let Some(int_ty) = primitive::IntTy::from_string(name) {
                 return Ok(Ty::Int(int_ty));
-            } else if let Some(uint_ty) = primitive::UintTy::from_string(&name) {
+            } else if let Some(uint_ty) = primitive::UintTy::from_string(name) {
                 return Ok(Ty::Uint(uint_ty));
-            } else if let Some(float_ty) = primitive::FloatTy::from_string(&name) {
+            } else if let Some(float_ty) = primitive::FloatTy::from_string(name) {
                 return Ok(Ty::Float(float_ty));
             }
         }

--- a/crates/ra_hir/src/ty.rs
+++ b/crates/ra_hir/src/ty.rs
@@ -95,7 +95,7 @@ pub enum Ty {
     Tuple(Vec<Ty>),
 
     // The projection of an associated type.  For example,
-    // `<T as Trait<..>>::N`.
+    // `<T as Trait<..>>::N`.pub
     // Projection(ProjectionTy),
 
     // Opaque (`impl Trait`) type found in a return type.
@@ -180,12 +180,11 @@ impl Ty {
         path: &Path,
     ) -> Cancelable<Self> {
         if let Some(name) = path.as_ident() {
-            let name = name.as_str(); // :-(
-            if let Some(int_ty) = primitive::IntTy::from_string(name) {
+            if let Some(int_ty) = primitive::IntTy::from_name(name) {
                 return Ok(Ty::Int(int_ty));
-            } else if let Some(uint_ty) = primitive::UintTy::from_string(name) {
+            } else if let Some(uint_ty) = primitive::UintTy::from_name(name) {
                 return Ok(Ty::Uint(uint_ty));
-            } else if let Some(float_ty) = primitive::FloatTy::from_string(name) {
+            } else if let Some(float_ty) = primitive::FloatTy::from_name(name) {
                 return Ok(Ty::Float(float_ty));
             }
         }

--- a/crates/ra_hir/src/ty/primitive.rs
+++ b/crates/ra_hir/src/ty/primitive.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+use crate::{Name, KnownName};
+
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub enum IntTy {
     Isize,
@@ -34,14 +36,14 @@ impl IntTy {
         }
     }
 
-    pub fn from_string(s: &str) -> Option<IntTy> {
-        match s {
-            "isize" => Some(IntTy::Isize),
-            "i8" => Some(IntTy::I8),
-            "i16" => Some(IntTy::I16),
-            "i32" => Some(IntTy::I32),
-            "i64" => Some(IntTy::I64),
-            "i128" => Some(IntTy::I128),
+    pub fn from_name(name: &Name) -> Option<IntTy> {
+        match name.as_known_name()? {
+            KnownName::Isize => Some(IntTy::Isize),
+            KnownName::I8 => Some(IntTy::I8),
+            KnownName::I16 => Some(IntTy::I16),
+            KnownName::I32 => Some(IntTy::I32),
+            KnownName::I64 => Some(IntTy::I64),
+            KnownName::I128 => Some(IntTy::I128),
             _ => None,
         }
     }
@@ -69,14 +71,14 @@ impl UintTy {
         }
     }
 
-    pub fn from_string(s: &str) -> Option<UintTy> {
-        match s {
-            "usize" => Some(UintTy::Usize),
-            "u8" => Some(UintTy::U8),
-            "u16" => Some(UintTy::U16),
-            "u32" => Some(UintTy::U32),
-            "u64" => Some(UintTy::U64),
-            "u128" => Some(UintTy::U128),
+    pub fn from_name(name: &Name) -> Option<UintTy> {
+        match name.as_known_name()? {
+            KnownName::Usize => Some(UintTy::Usize),
+            KnownName::U8 => Some(UintTy::U8),
+            KnownName::U16 => Some(UintTy::U16),
+            KnownName::U32 => Some(UintTy::U32),
+            KnownName::U64 => Some(UintTy::U64),
+            KnownName::U128 => Some(UintTy::U128),
             _ => None,
         }
     }
@@ -120,10 +122,10 @@ impl FloatTy {
         }
     }
 
-    pub fn from_string(s: &str) -> Option<FloatTy> {
-        match s {
-            "f32" => Some(FloatTy::F32),
-            "f64" => Some(FloatTy::F64),
+    pub fn from_name(name: &Name) -> Option<FloatTy> {
+        match name.as_known_name()? {
+            KnownName::F32 => Some(FloatTy::F32),
+            KnownName::F64 => Some(FloatTy::F64),
             _ => None,
         }
     }


### PR DESCRIPTION
Currently we are using `SmolStr` throughout the hir as a name, but that is really suboptimal choice: we'll probably want some kind of interning in the future, and we'll definitely need to add hygene info to names. This PR aims to replace strings with a slightly more abstract `Name` type. 