### PR TITLE
Cancelled is not Copy

### DIFF
--- a/crates/ra_db/src/lib.rs
+++ b/crates/ra_db/src/lib.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use ra_editor::LineIndex;
 use ra_syntax::{TextUnit, SourceFileNode};
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Canceled;
 
 pub type Cancelable<T> = Result<T, Canceled>;


### PR DESCRIPTION
I'd love to have a backtrace in `Cancelled` to be able to debug "completion is always cancelled" problem. So it probably is a good idea to make `Cancelled` non Copy type, even if it is a ZST in prod.