### PR TITLE
Super simple macro support

### DIFF
--- a/crates/ra_analysis/src/lib.rs
+++ b/crates/ra_analysis/src/lib.rs
@@ -14,6 +14,7 @@ mod db;
 mod imp;
 mod completion;
 mod symbol_index;
+mod syntax_highlighting;
 pub mod mock_analysis;
 
 use std::{fmt, sync::Arc};
@@ -340,8 +341,7 @@ impl Analysis {
         Ok(ra_editor::runnables(&file))
     }
     pub fn highlight(&self, file_id: FileId) -> Cancelable<Vec<HighlightedRange>> {
-        let file = self.imp.file_syntax(file_id);
-        Ok(ra_editor::highlight(&file))
+        syntax_highlighting::highlight(&*self.imp.db, file_id)
     }
     pub fn completions(&self, position: FilePosition) -> Cancelable<Option<Vec<CompletionItem>>> {
         self.imp.completions(position)

--- a/crates/ra_analysis/src/syntax_highlighting.rs
+++ b/crates/ra_analysis/src/syntax_highlighting.rs
@@ -1,0 +1,12 @@
+use ra_editor::HighlightedRange;
+use ra_db::SyntaxDatabase;
+
+use crate::{
+    db::RootDatabase,
+    FileId, Cancelable,
+};
+
+pub(crate) fn highlight(db: &RootDatabase, file_id: FileId) -> Cancelable<Vec<HighlightedRange>> {
+    let file = db.source_file(file_id);
+    Ok(ra_editor::highlight(&file))
+}

--- a/crates/ra_analysis/src/syntax_highlighting.rs
+++ b/crates/ra_analysis/src/syntax_highlighting.rs
@@ -7,6 +7,8 @@ use crate::{
 };
 
 pub(crate) fn highlight(db: &RootDatabase, file_id: FileId) -> Cancelable<Vec<HighlightedRange>> {
-    let file = db.source_file(file_id);
-    Ok(ra_editor::highlight(&file))
+    let source_file = db.source_file(file_id);
+    let mut res = ra_editor::highlight(&source_file);
+    for node in source_file.syntax().descendants() {}
+    Ok(res)
 }

--- a/crates/ra_analysis/src/syntax_highlighting.rs
+++ b/crates/ra_analysis/src/syntax_highlighting.rs
@@ -1,3 +1,4 @@
+use ra_syntax::{ast, AstNode, SourceFileNode, TextRange};
 use ra_editor::HighlightedRange;
 use ra_db::SyntaxDatabase;
 
@@ -9,6 +10,112 @@ use crate::{
 pub(crate) fn highlight(db: &RootDatabase, file_id: FileId) -> Cancelable<Vec<HighlightedRange>> {
     let source_file = db.source_file(file_id);
     let mut res = ra_editor::highlight(&source_file);
-    for node in source_file.syntax().descendants() {}
+    for macro_call in source_file
+        .syntax()
+        .descendants()
+        .filter_map(ast::MacroCall::cast)
+    {
+        if let Some(exp) = expand(db, file_id, macro_call) {
+            let mapped_ranges = ra_editor::highlight(exp.source_file())
+                .into_iter()
+                .filter_map(|r| {
+                    let mapped_range = exp.map_range_back(r.range)?;
+                    let res = HighlightedRange {
+                        range: mapped_range,
+                        tag: r.tag,
+                    };
+                    Some(res)
+                });
+            res.extend(mapped_ranges);
+        }
+    }
     Ok(res)
+}
+
+fn expand(
+    _db: &RootDatabase,
+    _file_id: FileId,
+    macro_call: ast::MacroCall,
+) -> Option<MacroExpansion> {
+    let path = macro_call.path()?;
+    if path.qualifier().is_some() {
+        return None;
+    }
+    let name_ref = path.segment()?.name_ref()?;
+    if name_ref.text() != "ctry" {
+        return None;
+    }
+
+    let arg = macro_call.token_tree()?;
+    let text = format!(
+        r"
+        fn dummy() {{
+            match {} {{
+                None => return Ok(None),
+                Some(it) => it,
+            }}
+        }}",
+        arg.syntax().text()
+    );
+    let file = SourceFileNode::parse(&text);
+    let match_expr = file.syntax().descendants().find_map(ast::MatchExpr::cast)?;
+    let match_arg = match_expr.expr()?;
+    let ranges_map = vec![(arg.syntax().range(), match_arg.syntax().range())];
+    let res = MacroExpansion {
+        source_file: file,
+        ranges_map,
+    };
+    Some(res)
+}
+
+struct MacroExpansion {
+    source_file: SourceFileNode,
+    ranges_map: Vec<(TextRange, TextRange)>,
+}
+
+impl MacroExpansion {
+    fn source_file(&self) -> &SourceFileNode {
+        &self.source_file
+    }
+    fn map_range_back(&self, tgt_range: TextRange) -> Option<TextRange> {
+        for (s_range, t_range) in self.ranges_map.iter() {
+            if tgt_range.is_subrange(&t_range) {
+                let tgt_at_zero_range = tgt_range - tgt_range.start();
+                let tgt_range_offset = tgt_range.start() - t_range.start();
+                let src_range = tgt_at_zero_range + tgt_range_offset + s_range.start();
+                return Some(src_range);
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::mock_analysis::single_file;
+    use test_utils::assert_eq_dbg;
+
+    #[test]
+    fn highlights_code_inside_macros() {
+        let (analysis, file_id) = single_file(
+            "
+            fn main() {
+                ctry!({ let x = 92; x});
+            }
+        ",
+        );
+        let highlights = analysis.highlight(file_id).unwrap();
+        assert_eq_dbg(
+            r#"[HighlightedRange { range: [13; 15), tag: "keyword" },
+                HighlightedRange { range: [16; 20), tag: "function" },
+                HighlightedRange { range: [41; 45), tag: "text" },
+                HighlightedRange { range: [49; 52), tag: "keyword" },
+                HighlightedRange { range: [57; 59), tag: "literal" },
+                HighlightedRange { range: [49; 52), tag: "keyword" },
+                HighlightedRange { range: [53; 54), tag: "function" },
+                HighlightedRange { range: [57; 59), tag: "literal" },
+                HighlightedRange { range: [61; 62), tag: "text" }]"#,
+            &highlights,
+        )
+    }
 }

--- a/crates/ra_syntax/src/ast/generated.rs
+++ b/crates/ra_syntax/src/ast/generated.rs
@@ -1877,6 +1877,10 @@ impl<'a> MacroCall<'a> {
     pub fn token_tree(self) -> Option<TokenTree<'a>> {
         super::child_opt(self)
     }
+
+    pub fn path(self) -> Option<Path<'a>> {
+        super::child_opt(self)
+    }
 }
 
 // MatchArm

--- a/crates/ra_syntax/src/ast/generated.rs
+++ b/crates/ra_syntax/src/ast/generated.rs
@@ -1838,6 +1838,47 @@ impl<R: TreeRoot<RaTypes>> LoopExprNode<R> {
 impl<'a> ast::LoopBodyOwner<'a> for LoopExpr<'a> {}
 impl<'a> LoopExpr<'a> {}
 
+// MacroCall
+#[derive(Debug, Clone, Copy,)]
+pub struct MacroCallNode<R: TreeRoot<RaTypes> = OwnedRoot> {
+    pub(crate) syntax: SyntaxNode<R>,
+}
+pub type MacroCall<'a> = MacroCallNode<RefRoot<'a>>;
+
+impl<R1: TreeRoot<RaTypes>, R2: TreeRoot<RaTypes>> PartialEq<MacroCallNode<R1>> for MacroCallNode<R2> {
+    fn eq(&self, other: &MacroCallNode<R1>) -> bool { self.syntax == other.syntax }
+}
+impl<R: TreeRoot<RaTypes>> Eq for MacroCallNode<R> {}
+impl<R: TreeRoot<RaTypes>> Hash for MacroCallNode<R> {
+    fn hash<H: Hasher>(&self, state: &mut H) { self.syntax.hash(state) }
+}
+
+impl<'a> AstNode<'a> for MacroCall<'a> {
+    fn cast(syntax: SyntaxNodeRef<'a>) -> Option<Self> {
+        match syntax.kind() {
+            MACRO_CALL => Some(MacroCall { syntax }),
+            _ => None,
+        }
+    }
+    fn syntax(self) -> SyntaxNodeRef<'a> { self.syntax }
+}
+
+impl<R: TreeRoot<RaTypes>> MacroCallNode<R> {
+    pub fn borrowed(&self) -> MacroCall {
+        MacroCallNode { syntax: self.syntax.borrowed() }
+    }
+    pub fn owned(&self) -> MacroCallNode {
+        MacroCallNode { syntax: self.syntax.owned() }
+    }
+}
+
+
+impl<'a> MacroCall<'a> {
+    pub fn token_tree(self) -> Option<TokenTree<'a>> {
+        super::child_opt(self)
+    }
+}
+
 // MatchArm
 #[derive(Debug, Clone, Copy,)]
 pub struct MatchArmNode<R: TreeRoot<RaTypes> = OwnedRoot> {

--- a/crates/ra_syntax/src/grammar.ron
+++ b/crates/ra_syntax/src/grammar.ron
@@ -484,7 +484,7 @@ Grammar(
 
         "Name": (),
         "NameRef": (),
-        "MacroCall": ( options: [ "TokenTree" ] ),
+        "MacroCall": ( options: [ "TokenTree", "Path" ] ),
         "Attr": ( options: [ ["value", "TokenTree"] ] ),
         "TokenTree": (),
         "TypeParamList": (

--- a/crates/ra_syntax/src/grammar.ron
+++ b/crates/ra_syntax/src/grammar.ron
@@ -484,6 +484,7 @@ Grammar(
 
         "Name": (),
         "NameRef": (),
+        "MacroCall": ( options: [ "TokenTree" ] ),
         "Attr": ( options: [ ["value", "TokenTree"] ] ),
         "TokenTree": (),
         "TypeParamList": (


### PR DESCRIPTION
Super simple support for macros, mostly for figuring out how to fit them into the current architecture. Expansion is hard-coded and string based (mid-term, we should try to copy-paste macro-by-example expander from rustc). 

Ideally, we should handle

* highlighting inside the macro (done)
* extend selection inside the macro 
* completion inside the macro
* indexing structs, produced by the macro