### PR TITLE
update README with Rust 1.31

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ Work on the Rust Analyzer is sponsored by
 
 ## Quick Start
 
-Rust analyzer builds on Rust >= 1.30.0 (currently in beta) and uses
-the 2018 edition.
+Rust analyzer builds on Rust >= 1.31.0 and uses the 2018 edition.
 
 ```
 # run tests

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,7 +16,7 @@ High-level architecture constraints:
     It's *obvious* that the code should be shared, but OTOH, all great IDEs started as from-scratch rewrites.
   * Don't hard-code a particular protocol or mode of operation.
     Produce a library which could be used for implementing an LSP server, or for in-process embedding.
-  * As long as possible, stick with stable Rust (NB: we currently use beta for 2018 edition and salsa).
+  * As long as possible, stick with stable Rust.
 
 
 # Current Goals


### PR DESCRIPTION
Update README with Rust 1.31, since Rust 2018 edition is already on stable