### PR TITLE
Simplify

### DIFF
--- a/crates/ra_analysis/src/completion.rs
+++ b/crates/ra_analysis/src/completion.rs
@@ -58,6 +58,6 @@ fn check_completion(code: &str, expected_completions: &str, kind: CompletionKind
     } else {
         single_file_with_position(code)
     };
-    let completions = completions(&analysis.imp.db, position).unwrap().unwrap();
+    let completions = completions(&analysis.db, position).unwrap().unwrap();
     completions.assert_match(expected_completions, kind);
 }

--- a/crates/ra_analysis/src/imp.rs
+++ b/crates/ra_analysis/src/imp.rs
@@ -9,7 +9,7 @@ use hir::{
     self, FnSignatureInfo, Problem, source_binder,
 };
 use ra_db::{FilesDatabase, SourceRoot, SourceRootId, SyntaxDatabase};
-use ra_editor::{self, find_node_at_offset, LineIndex, LocalEdit, Severity};
+use ra_editor::{self, find_node_at_offset, LocalEdit, Severity};
 use ra_syntax::{
     algo::find_covering_node,
     ast::{self, ArgListOwner, Expr, FnDef, NameOwner},
@@ -139,15 +139,6 @@ impl fmt::Debug for AnalysisImpl {
 }
 
 impl AnalysisImpl {
-    pub fn file_text(&self, file_id: FileId) -> Arc<String> {
-        self.db.file_text(file_id)
-    }
-    pub fn file_syntax(&self, file_id: FileId) -> SourceFileNode {
-        self.db.source_file(file_id)
-    }
-    pub fn file_line_index(&self, file_id: FileId) -> Arc<LineIndex> {
-        self.db.file_lines(file_id)
-    }
     pub(crate) fn module_path(&self, position: FilePosition) -> Cancelable<Option<String>> {
         let descr = match source_binder::module_from_position(&*self.db, position)? {
             None => return Ok(None),
@@ -400,7 +391,7 @@ impl AnalysisImpl {
     }
 
     pub fn assists(&self, frange: FileRange) -> Vec<SourceChange> {
-        let file = self.file_syntax(frange.file_id);
+        let file = self.db.source_file(frange.file_id);
         let offset = frange.range.start();
         let actions = vec![
             ra_editor::flip_comma(&file, offset).map(|f| f()),

--- a/crates/ra_analysis/src/lib.rs
+++ b/crates/ra_analysis/src/lib.rs
@@ -29,7 +29,7 @@ use rayon::prelude::*;
 use relative_path::RelativePathBuf;
 
 use crate::{
-    imp::{AnalysisHostImpl, AnalysisImpl},
+    imp::AnalysisImpl,
     symbol_index::{SymbolIndex, FileSymbol},
 };
 
@@ -153,7 +153,7 @@ impl AnalysisChange {
 /// `AnalysisHost` stores the current state of the world.
 #[derive(Debug, Default)]
 pub struct AnalysisHost {
-    imp: AnalysisHostImpl,
+    db: db::RootDatabase,
 }
 
 impl AnalysisHost {
@@ -161,13 +161,13 @@ impl AnalysisHost {
     /// semantic information.
     pub fn analysis(&self) -> Analysis {
         Analysis {
-            imp: self.imp.analysis(),
+            imp: self.db.analysis(),
         }
     }
     /// Applies changes to the current state of the world. If there are
     /// outstanding snapshots, they will be canceled.
     pub fn apply_change(&mut self, change: AnalysisChange) {
-        self.imp.apply_change(change)
+        self.db.apply_change(change)
     }
 }
 

--- a/crates/ra_analysis/src/lib.rs
+++ b/crates/ra_analysis/src/lib.rs
@@ -357,7 +357,7 @@ impl Analysis {
     }
     /// Fuzzy searches for a symbol.
     pub fn symbol_search(&self, query: Query) -> Cancelable<Vec<NavigationTarget>> {
-        let res = symbol_index::world_symbols(self.db, query)?
+        let res = symbol_index::world_symbols(&*self.db, query)?
             .into_iter()
             .map(|(file_id, symbol)| NavigationTarget { file_id, symbol })
             .collect();

--- a/crates/ra_analysis/src/lib.rs
+++ b/crates/ra_analysis/src/lib.rs
@@ -342,9 +342,7 @@ impl Analysis {
         ra_editor::folding_ranges(&file)
     }
     pub fn symbol_search(&self, query: Query) -> Cancelable<Vec<NavigationTarget>> {
-        let res = self
-            .imp
-            .world_symbols(query)?
+        let res = symbol_index::world_symbols(&*self.imp.db, query)?
             .into_iter()
             .map(|(file_id, symbol)| NavigationTarget { file_id, symbol })
             .collect();


### PR DESCRIPTION
Get rid of `AnalysisImpl` wrapper around salsa database. It was useful before we migrated by salsa, but it's long have been just a useless boilerplate. 