### PR TITLE
vscode problem matcher improvements

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -147,6 +147,7 @@
         },
         "problemPatterns": [
             {
+                "//comment": "named multiline problem patterns are not parsed properly in vscode at the moment, when fixed in vscode replace both \"pattern\": [...] below with \"pattern\": \"$rustc\"",
                 "name": "rustc",
                 "patterns": [
                     {
@@ -171,7 +172,20 @@
                     "relative",
                     "${workspaceRoot}"
                 ],
-                "pattern": "$rustc"
+                "pattern": [
+                    {
+                        "regexp": "^(warning|warn|error)(?:\\[(.*?)\\])?: (.*)$",
+                        "severity": 1,
+                        "code": 2,
+                        "message": 3
+                    },
+                    {
+                        "regexp": "^[\\s->=]*(.*?):(\\d*):(\\d*)\\s*$",
+                        "file": 1,
+                        "line": 2,
+                        "column": 3
+                    }
+                ]
             },
             {
                 "name": "rustc-watch",
@@ -183,7 +197,20 @@
                     "beginsPattern": "^\\[Running ",
                     "endsPattern": "^(\\[Finished running\\]|To learn more, run the command again with --verbose\\.)$"
                 },
-                "pattern": "$rustc"
+                "pattern": [
+                    {
+                        "regexp": "^(warning|warn|error)(?:\\[(.*?)\\])?: (.*)$",
+                        "severity": 1,
+                        "code": 2,
+                        "message": 3
+                    },
+                    {
+                        "regexp": "^[\\s->=]*(.*?):(\\d*):(\\d*)\\s*$",
+                        "file": 1,
+                        "line": 2,
+                        "column": 3
+                    }
+                ]
             }
         ]
     }

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -145,6 +145,25 @@
                 }
             }
         },
+        "problemPatterns": [
+            {
+                "name": "rustc",
+                "patterns": [
+                    {
+                        "regexp": "^(warning|warn|error)(?:\\[(.*?)\\])?: (.*)$",
+                        "severity": 1,
+                        "code": 2,
+                        "message": 3
+                    },
+                    {
+                        "regexp": "^[\\s->=]*(.*?):(\\d*):(\\d*)\\s*$",
+                        "file": 1,
+                        "line": 2,
+                        "column": 3
+                    }
+                ]
+            }
+        ],
         "problemMatchers": [
             {
                 "name": "rustc",
@@ -152,29 +171,19 @@
                     "relative",
                     "${workspaceRoot}"
                 ],
-                "pattern": [
-                    {
-                        "regexp": "^(warning|warn|error)(\\[(.*)\\])?: (.*)$",
-                        "severity": 1,
-                        "message": 4,
-                        "code": 3
-                    },
-                    {
-                        "regexp": "^([\\s->=]*(.*):(\\d*):(\\d*)|.*)$",
-                        "file": 2,
-                        "line": 3,
-                        "column": 4
-                    },
-                    {
-                        "regexp": "^.*$"
-                    },
-                    {
-                        "regexp": "^([\\s->=]*(.*):(\\d*):(\\d*)|.*)$",
-                        "file": 2,
-                        "line": 3,
-                        "column": 4
-                    }
-                ]
+                "pattern": "$rustc"
+            },
+            {
+                "name": "rustc-watch",
+                "fileLocation": [
+                    "relative",
+                    "${workspaceRoot}"
+                ],
+                "background": {
+                    "beginsPattern": "^\\[Running ",
+                    "endsPattern": "^(\\[Finished running\\]|To learn more, run the command again with --verbose\\.)$"
+                },
+                "pattern": "$rustc"
             }
         ]
     }


### PR DESCRIPTION
The problem matcher wasn't working properly and looking at the rustc errors i realized it could be simplified.

I also added a new problem matcher that can be used with https://github.com/passcod/cargo-watch to get the errors in the editor on save. To use it one can create a tasks.json file with:
```json
{
    "version": "2.0.0",
    "tasks": [
        {
            "type": "shell",
            "label": "cargo watch",
            "command": "cargo",
            "isBackground": true,
            "args": [
                "watch",
                "-c"
            ],
            "problemMatcher": [
                "$rustc-watch"
            ]
        }
    ]
}
```
I initially implemented it like this: https://github.com/rust-analyzer/rust-analyzer/commit/cff9f62d321a90c45e622f5304e60a248cbcf4f2 but i think there's a bug in vscode so i worked around it by copying the pattern for both problem matchers. The first commit can be used if https://github.com/Microsoft/vscode/pull/65840 is merged.
