### PR TITLE
Detangle symbols

### DIFF
--- a/crates/ra_analysis/src/imp.rs
+++ b/crates/ra_analysis/src/imp.rs
@@ -121,6 +121,7 @@ impl db::RootDatabase {
             name: decl_name.text(),
             range: decl_name.syntax().range(),
             kind: MODULE,
+            ptr: None,
         }])
     }
     /// Returns `Vec` for the same reason as `parent_module`
@@ -158,6 +159,7 @@ impl db::RootDatabase {
                         name: entry.name().to_string().into(),
                         range: entry.ptr().range(),
                         kind: NAME,
+                        ptr: None,
                     });
                     return Ok(Some(rr));
                 };
@@ -185,6 +187,7 @@ impl db::RootDatabase {
                             name,
                             range: TextRange::offset_len(0.into(), 0.into()),
                             kind: MODULE,
+                            ptr: None,
                         };
                         rr.resolves_to.push(symbol);
                         return Ok(Some(rr));

--- a/crates/ra_analysis/src/lib.rs
+++ b/crates/ra_analysis/src/lib.rs
@@ -231,9 +231,9 @@ impl NavigationTarget {
     fn from_symbol(file_id: FileId, symbol: FileSymbol) -> NavigationTarget {
         NavigationTarget {
             name: symbol.name.clone(),
-            kind: symbol.kind.clone(),
+            kind: symbol.ptr.kind(),
             file_id,
-            range: symbol.node_range.clone(),
+            range: symbol.ptr.range(),
         }
     }
     pub fn name(&self) -> &SmolStr {

--- a/crates/ra_analysis/src/lib.rs
+++ b/crates/ra_analysis/src/lib.rs
@@ -1,6 +1,8 @@
-//! ra_analyzer crate is the brain of Rust analyzer. It relies on the `salsa`
-//! crate, which provides and incremental on-demand database of facts.
-
+//! ra_analyzer crate provides "ide-centric" APIs for the rust-analyzer. What
+//! powers this API are the `RootDatabase` struct, which defines a `salsa`
+//! database, and the `ra_hir` crate, where majority of the analysis happens.
+//! However, IDE specific bits of the analysis (most notably completion) happen
+//! in this crate.
 macro_rules! ctry {
     ($expr:expr) => {
         match $expr {
@@ -219,6 +221,11 @@ impl Query {
     }
 }
 
+/// `NavigationTarget` represents and element in the editor's UI whihc you can
+/// click on to navigate to a particular piece of code.
+///
+/// Typically, a `NavigationTarget` corresponds to some element in the source
+/// code, like a function or a struct, but this is not strictly required.
 #[derive(Debug)]
 pub struct NavigationTarget {
     file_id: FileId,

--- a/crates/ra_analysis/src/lib.rs
+++ b/crates/ra_analysis/src/lib.rs
@@ -41,7 +41,7 @@ pub use ra_editor::{
 pub use hir::FnSignatureInfo;
 
 pub use ra_db::{
-    Canceled, Cancelable, FilePosition, FileRange,
+    Canceled, Cancelable, FilePosition, FileRange, LocalSyntaxPtr,
     CrateGraph, CrateId, SourceRootId, FileId, SyntaxDatabase, FilesDatabase
 };
 
@@ -225,6 +225,8 @@ pub struct NavigationTarget {
     name: SmolStr,
     kind: SyntaxKind,
     range: TextRange,
+    // Should be DefId ideally
+    ptr: Option<LocalSyntaxPtr>,
 }
 
 impl NavigationTarget {
@@ -234,6 +236,7 @@ impl NavigationTarget {
             kind: symbol.ptr.kind(),
             file_id,
             range: symbol.ptr.range(),
+            ptr: Some(symbol.ptr.clone()),
         }
     }
     pub fn name(&self) -> &SmolStr {

--- a/crates/ra_analysis/src/symbol_index.rs
+++ b/crates/ra_analysis/src/symbol_index.rs
@@ -5,10 +5,10 @@ use std::{
 
 use fst::{self, Streamer};
 use ra_syntax::{
-    AstNode, SyntaxNodeRef, SourceFileNode, SmolStr, TextRange,
+    SyntaxNodeRef, SourceFileNode, SmolStr, TextRange,
     algo::visit::{visitor, Visitor},
     SyntaxKind::{self, *},
-    ast::{self, NameOwner, DocCommentsOwner},
+    ast::{self, NameOwner},
 };
 use ra_db::{SyntaxDatabase, SourceRootId, FilesDatabase};
 use salsa::ParallelDatabase;
@@ -165,91 +165,7 @@ pub(crate) struct FileSymbol {
     pub(crate) name: SmolStr,
     pub(crate) node_range: TextRange,
     pub(crate) kind: SyntaxKind,
-}
-
-impl FileSymbol {
-    pub(crate) fn docs(&self, file: &SourceFileNode) -> Option<String> {
-        file.syntax()
-            .descendants()
-            .filter(|node| node.kind() == self.kind && node.range() == self.node_range)
-            .filter_map(|node: SyntaxNodeRef| {
-                fn doc_comments<'a, N: DocCommentsOwner<'a>>(node: N) -> Option<String> {
-                    let comments = node.doc_comment_text();
-                    if comments.is_empty() {
-                        None
-                    } else {
-                        Some(comments)
-                    }
-                }
-
-                visitor()
-                    .visit(doc_comments::<ast::FnDef>)
-                    .visit(doc_comments::<ast::StructDef>)
-                    .visit(doc_comments::<ast::EnumDef>)
-                    .visit(doc_comments::<ast::TraitDef>)
-                    .visit(doc_comments::<ast::Module>)
-                    .visit(doc_comments::<ast::TypeDef>)
-                    .visit(doc_comments::<ast::ConstDef>)
-                    .visit(doc_comments::<ast::StaticDef>)
-                    .accept(node)?
-            })
-            .nth(0)
-    }
-    /// Get a description of this node.
-    ///
-    /// e.g. `struct Name`, `enum Name`, `fn Name`
-    pub(crate) fn description(&self, file: &SourceFileNode) -> Option<String> {
-        // TODO: After type inference is done, add type information to improve the output
-        file.syntax()
-            .descendants()
-            .filter(|node| node.kind() == self.kind && node.range() == self.node_range)
-            .filter_map(|node: SyntaxNodeRef| {
-                // TODO: Refactor to be have less repetition
-                visitor()
-                    .visit(|node: ast::FnDef| {
-                        let mut string = "fn ".to_string();
-                        node.name()?.syntax().text().push_to(&mut string);
-                        Some(string)
-                    })
-                    .visit(|node: ast::StructDef| {
-                        let mut string = "struct ".to_string();
-                        node.name()?.syntax().text().push_to(&mut string);
-                        Some(string)
-                    })
-                    .visit(|node: ast::EnumDef| {
-                        let mut string = "enum ".to_string();
-                        node.name()?.syntax().text().push_to(&mut string);
-                        Some(string)
-                    })
-                    .visit(|node: ast::TraitDef| {
-                        let mut string = "trait ".to_string();
-                        node.name()?.syntax().text().push_to(&mut string);
-                        Some(string)
-                    })
-                    .visit(|node: ast::Module| {
-                        let mut string = "mod ".to_string();
-                        node.name()?.syntax().text().push_to(&mut string);
-                        Some(string)
-                    })
-                    .visit(|node: ast::TypeDef| {
-                        let mut string = "type ".to_string();
-                        node.name()?.syntax().text().push_to(&mut string);
-                        Some(string)
-                    })
-                    .visit(|node: ast::ConstDef| {
-                        let mut string = "const ".to_string();
-                        node.name()?.syntax().text().push_to(&mut string);
-                        Some(string)
-                    })
-                    .visit(|node: ast::StaticDef| {
-                        let mut string = "static ".to_string();
-                        node.name()?.syntax().text().push_to(&mut string);
-                        Some(string)
-                    })
-                    .accept(node)?
-            })
-            .nth(0)
-    }
+    _x: (),
 }
 
 fn to_symbol(node: SyntaxNodeRef) -> Option<FileSymbol> {
@@ -259,6 +175,7 @@ fn to_symbol(node: SyntaxNodeRef) -> Option<FileSymbol> {
             name: name.text(),
             node_range: node.syntax().range(),
             kind: node.syntax().kind(),
+            _x: (),
         })
     }
     visitor()

--- a/crates/ra_analysis/tests/tests.rs
+++ b/crates/ra_analysis/tests/tests.rs
@@ -25,7 +25,7 @@ fn approximate_resolve_works_in_items() {
     assert_eq_dbg(
         r#"ReferenceResolution {
             reference_range: [23; 26),
-            resolves_to: [NavigationTarget { file_id: FileId(1), symbol: FileSymbol { name: "Foo", node_range: [0; 11), kind: STRUCT_DEF } }]
+            resolves_to: [NavigationTarget { file_id: FileId(1), name: "Foo", kind: STRUCT_DEF, range: [0; 11), ptr: Some(LocalSyntaxPtr { range: [0; 11), kind: STRUCT_DEF }) }]
         }"#,
         &symbols,
     );
@@ -46,7 +46,7 @@ fn test_resolve_module() {
     assert_eq_dbg(
         r#"ReferenceResolution {
             reference_range: [4; 7),
-            resolves_to: [NavigationTarget { file_id: FileId(2), symbol: FileSymbol { name: "foo", node_range: [0; 0), kind: MODULE } }]
+            resolves_to: [NavigationTarget { file_id: FileId(2), name: "foo", kind: MODULE, range: [0; 0), ptr: None }]
         }"#,
         &symbols,
     );
@@ -64,7 +64,7 @@ fn test_resolve_module() {
     assert_eq_dbg(
         r#"ReferenceResolution {
             reference_range: [4; 7),
-            resolves_to: [NavigationTarget { file_id: FileId(2), symbol: FileSymbol { name: "foo", node_range: [0; 0), kind: MODULE } }]
+            resolves_to: [NavigationTarget { file_id: FileId(2), name: "foo", kind: MODULE, range: [0; 0), ptr: None }]
         }"#,
         &symbols,
     );
@@ -107,7 +107,7 @@ fn test_resolve_parent_module() {
     );
     let symbols = analysis.parent_module(pos).unwrap();
     assert_eq_dbg(
-        r#"[NavigationTarget { file_id: FileId(1), symbol: FileSymbol { name: "foo", node_range: [4; 7), kind: MODULE } }]"#,
+        r#"[NavigationTarget { file_id: FileId(1), name: "foo", kind: MODULE, range: [4; 7), ptr: None }]"#,
         &symbols,
     );
 }
@@ -126,7 +126,7 @@ fn test_resolve_parent_module_for_inline() {
     );
     let symbols = analysis.parent_module(pos).unwrap();
     assert_eq_dbg(
-        r#"[NavigationTarget { file_id: FileId(1), symbol: FileSymbol { name: "bar", node_range: [18; 21), kind: MODULE } }]"#,
+        r#"[NavigationTarget { file_id: FileId(1), name: "bar", kind: MODULE, range: [18; 21), ptr: None }]"#,
         &symbols,
     );
 }

--- a/crates/ra_db/src/syntax_ptr.rs
+++ b/crates/ra_db/src/syntax_ptr.rs
@@ -31,6 +31,10 @@ impl LocalSyntaxPtr {
     pub fn range(self) -> TextRange {
         self.range
     }
+
+    pub fn kind(self) -> SyntaxKind {
+        self.kind
+    }
 }
 
 #[test]

--- a/crates/ra_lsp_server/src/main_loop/handlers.rs
+++ b/crates/ra_lsp_server/src/main_loop/handlers.rs
@@ -190,7 +190,7 @@ pub fn handle_workspace_symbol(
         let mut res = Vec::new();
         for nav in world.analysis().symbol_search(query)? {
             let info = SymbolInformation {
-                name: nav.name().into(),
+                name: nav.name().to_string(),
                 kind: nav.kind().conv(),
                 location: nav.try_conv_with(world)?,
                 container_name: None,


### PR DESCRIPTION
Previously, we used `FileSymbol` both to represent bytes which are stored in the index and as an API of `ra_analysis`. Mixing internal storage format and an API is not a really bright idea, so we introduce `NavigationTarget` to handle API part.