### PR TITLE
use LSP file system operations

### DIFF
--- a/crates/ra_lsp_server/src/req.rs
+++ b/crates/ra_lsp_server/src/req.rs
@@ -1,6 +1,6 @@
-use serde::{Serialize, Deserialize};
 use languageserver_types::{Location, Position, Range, TextDocumentIdentifier, Url};
 use rustc_hash::FxHashMap;
+use serde::{Deserialize, Serialize};
 use url_serde;
 
 pub use languageserver_types::{
@@ -8,7 +8,7 @@ pub use languageserver_types::{
     CompletionResponse, DocumentOnTypeFormattingParams, DocumentSymbolParams,
     DocumentSymbolResponse, ExecuteCommandParams, Hover, InitializeResult,
     PublishDiagnosticsParams, ReferenceParams, SignatureHelp, TextDocumentEdit,
-    TextDocumentPositionParams, TextEdit, WorkspaceSymbolParams,
+    TextDocumentPositionParams, TextEdit, WorkspaceEdit, WorkspaceSymbolParams,
 };
 
 pub enum SyntaxTree {}
@@ -151,24 +151,8 @@ pub struct Runnable {
 #[serde(rename_all = "camelCase")]
 pub struct SourceChange {
     pub label: String,
-    pub source_file_edits: Vec<TextDocumentEdit>,
-    pub file_system_edits: Vec<FileSystemEdit>,
+    pub workspace_edit: WorkspaceEdit,
     pub cursor_position: Option<TextDocumentPositionParams>,
-}
-
-#[derive(Serialize, Debug)]
-#[serde(tag = "type", rename_all = "camelCase")]
-pub enum FileSystemEdit {
-    CreateFile {
-        #[serde(with = "url_serde")]
-        uri: Url,
-    },
-    MoveFile {
-        #[serde(with = "url_serde")]
-        src: Url,
-        #[serde(with = "url_serde")]
-        dst: Url,
-    },
 }
 
 pub enum InternalFeedback {}

--- a/crates/ra_lsp_server/tests/heavy_tests/main.rs
+++ b/crates/ra_lsp_server/tests/heavy_tests/main.rs
@@ -1,8 +1,12 @@
 mod support;
 
+use languageserver_types::{
+    CodeActionContext, DocumentFormattingParams, FormattingOptions, Position, Range,
+};
+use ra_lsp_server::req::{
+    CodeActionParams, CodeActionRequest, Formatting, Runnables, RunnablesParams,
+};
 use serde_json::json;
-use ra_lsp_server::req::{Runnables, RunnablesParams, CodeActionRequest, CodeActionParams, Formatting};
-use languageserver_types::{Position, Range, CodeActionContext, DocumentFormattingParams, FormattingOptions};
 
 use crate::support::project;
 
@@ -203,14 +207,15 @@ fn main() {}
               "arguments": [
                 {
                   "cursorPosition": null,
-                  "fileSystemEdits": [
-                    {
-                        "type": "createFile",
+                  "workspaceEdit": {
+                    "documentChanges": [
+                      {
+                        "kind": "create",
                         "uri": "file:///[..]/src/bar.rs"
-                    }
-                  ],
-                  "label": "create module",
-                  "sourceFileEdits": []
+                      }
+                    ]
+                  },
+                  "label": "create module"
                 }
               ],
               "command": "ra-lsp.applySourceChange",


### PR DESCRIPTION
implements #131

I've replaced `source_file_edits` and `file_system_edits` with `workspace_edit` because [`WorkspacEdit`](https://docs.rs/languageserver-types/0.53.1/languageserver_types/struct.WorkspaceEdit.html) can represent both.

I only use `document_changes` because `changes` cannot represent file system operations.

But if the client doesn't have the `workspace.workspaceEdit.resourceOperations` capability `WorkspaceEdit` cannot replace the current `FileSystemEdit`. Can we assume that the client will support it?

I also adapted the extension code to make use of the new response type, but only for vscode, i don't know if changes have to be made for the emacs part.