### PR TITLE
Use name resolution for goto definition

### DIFF
--- a/crates/ra_hir/src/expr.rs
+++ b/crates/ra_hir/src/expr.rs
@@ -762,7 +762,7 @@ pub(crate) fn body_syntax_mapping(
     let def = def_id.resolve(db)?;
 
     let body_syntax_mapping = match def {
-        Def::Function(f) => collect_fn_body_syntax(&f.source(db)),
+        Def::Function(f) => collect_fn_body_syntax(&f.source(db)?.1),
         // TODO: consts, etc.
         _ => panic!("Trying to get body for item type without body"),
     };

--- a/crates/ra_hir/src/ids.rs
+++ b/crates/ra_hir/src/ids.rs
@@ -34,7 +34,7 @@ pub struct HirFileId(HirFileIdRepr);
 impl HirFileId {
     /// For macro-expansion files, returns the file original source file the
     /// expansionoriginated from.
-    pub(crate) fn original_file(self, db: &impl HirDatabase) -> FileId {
+    pub fn original_file(self, db: &impl HirDatabase) -> FileId {
         match self.0 {
             HirFileIdRepr::File(file_id) => file_id,
             HirFileIdRepr::Macro(macro_call_id) => {
@@ -177,6 +177,12 @@ impl DefId {
             DefKind::Item => Def::Item,
         };
         Ok(res)
+    }
+
+    pub(crate) fn source(self, db: &impl HirDatabase) -> (HirFileId, TreePtr<SyntaxNode>) {
+        let loc = self.loc(db);
+        let syntax = db.file_item(loc.source_item_id);
+        (loc.source_item_id.file_id, syntax)
     }
 
     /// For a module, returns that module; for any other def, returns the containing module.

--- a/crates/ra_ide_api/src/completion/complete_path.rs
+++ b/crates/ra_ide_api/src/completion/complete_path.rs
@@ -15,11 +15,11 @@ pub(super) fn complete_path(acc: &mut Completions, ctx: &CompletionContext) -> C
     match def_id.resolve(ctx.db)? {
         hir::Def::Module(module) => {
             let module_scope = module.scope(ctx.db)?;
-            module_scope.entries().for_each(|(name, res)| {
+            for (name, res) in module_scope.entries() {
                 CompletionItem::new(CompletionKind::Reference, name.to_string())
                     .from_resolution(ctx, res)
-                    .add_to(acc)
-            });
+                    .add_to(acc);
+            }
         }
         hir::Def::Enum(e) => {
             e.variants(ctx.db)?

--- a/crates/ra_ide_api/src/lib.rs
+++ b/crates/ra_ide_api/src/lib.rs
@@ -33,7 +33,8 @@ mod syntax_highlighting;
 
 use std::{fmt, sync::Arc};
 
-use ra_syntax::{SmolStr, SourceFile, TreePtr, SyntaxKind, TextRange, TextUnit};
+use hir::{Def, ModuleSource, Name};
+use ra_syntax::{SmolStr, SourceFile, TreePtr, SyntaxKind, SyntaxNode, TextRange, TextUnit, AstNode};
 use ra_text_edit::TextEdit;
 use ra_db::{SyntaxDatabase, FilesDatabase, LocalSyntaxPtr, BaseDatabase};
 use rayon::prelude::*;
@@ -266,6 +267,67 @@ impl NavigationTarget {
             range: symbol.ptr.range(),
             ptr: Some(symbol.ptr.clone()),
         }
+    }
+
+    fn from_syntax(name: Option<Name>, file_id: FileId, node: &SyntaxNode) -> NavigationTarget {
+        NavigationTarget {
+            file_id,
+            name: name.map(|n| n.to_string().into()).unwrap_or("".into()),
+            kind: node.kind(),
+            range: node.range(),
+            ptr: Some(LocalSyntaxPtr::new(node)),
+        }
+    }
+    // TODO once Def::Item is gone, this should be able to always return a NavigationTarget
+    fn from_def(db: &db::RootDatabase, def: Def) -> Cancelable<Option<NavigationTarget>> {
+        Ok(match def {
+            Def::Struct(s) => {
+                let (file_id, node) = s.source(db)?;
+                Some(NavigationTarget::from_syntax(
+                    s.name(db)?,
+                    file_id.original_file(db),
+                    node.syntax(),
+                ))
+            }
+            Def::Enum(e) => {
+                let (file_id, node) = e.source(db)?;
+                Some(NavigationTarget::from_syntax(
+                    e.name(db)?,
+                    file_id.original_file(db),
+                    node.syntax(),
+                ))
+            }
+            Def::EnumVariant(ev) => {
+                let (file_id, node) = ev.source(db)?;
+                Some(NavigationTarget::from_syntax(
+                    ev.name(db)?,
+                    file_id.original_file(db),
+                    node.syntax(),
+                ))
+            }
+            Def::Function(f) => {
+                let (file_id, node) = f.source(db)?;
+                let name = f.signature(db).name().clone();
+                Some(NavigationTarget::from_syntax(
+                    Some(name),
+                    file_id.original_file(db),
+                    node.syntax(),
+                ))
+            }
+            Def::Module(m) => {
+                let (file_id, source) = m.definition_source(db)?;
+                let name = m.name(db)?;
+                match source {
+                    ModuleSource::SourceFile(node) => {
+                        Some(NavigationTarget::from_syntax(name, file_id, node.syntax()))
+                    }
+                    ModuleSource::Module(node) => {
+                        Some(NavigationTarget::from_syntax(name, file_id, node.syntax()))
+                    }
+                }
+            }
+            Def::Item => None,
+        })
     }
 
     pub fn name(&self) -> &SmolStr {


### PR DESCRIPTION
This tries proper name resolution before falling back on the index.

@matklad There was currently no way of getting the location of a `DefId` from outside `ra_hir`. I added something, but it's probably not the best API, maybe you have a better idea?