### PR TITLE
Use --force when installing the VSIX.

### DIFF
--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -158,12 +158,12 @@ fn install_code_extension() -> Result<()> {
     }
     if cfg!(windows) {
         run(
-            r"cmd.exe /c code.cmd --install-extension ./ra-lsp-0.0.1.vsix",
+            r"cmd.exe /c code.cmd --install-extension ./ra-lsp-0.0.1.vsix --force",
             "./editors/code",
         )?;
     } else {
         run(
-            r"code --install-extension ./ra-lsp-0.0.1.vsix",
+            r"code --install-extension ./ra-lsp-0.0.1.vsix --force",
             "./editors/code",
         )?;
     }


### PR DESCRIPTION
This might fix the extension installation, or it might not.

https://github.com/Microsoft/vscode/issues/65897#issuecomment-451749900 says we need to increase the version on every install, but I can't work out why exactly.

@egamma, can you give us some more insight?

bors r+ - It can't do any harm anyway :).