### PR TITLE
Introduce "introduce match"

### DIFF
--- a/crates/ra_ide_api/src/lib.rs
+++ b/crates/ra_ide_api/src/lib.rs
@@ -7,7 +7,7 @@
 //! However, IDE specific bits of the analysis (most notably completion) happen
 //! in this crate.
 //!
-//! The sibling `ra_ide_api_light` handles thouse bits of IDE functionality
+//! The sibling `ra_ide_api_light` handles those bits of IDE functionality
 //! which are restricted to a single file and need only syntax.
 mod db;
 mod imp;
@@ -309,12 +309,12 @@ impl Analysis {
         self.db.line_index(file_id)
     }
 
-    /// Selects the next syntactic nodes encopasing the range.
+    /// Selects the next syntactic nodes encompassing the range.
     pub fn extend_selection(&self, frange: FileRange) -> TextRange {
         extend_selection::extend_selection(&self.db, frange)
     }
 
-    /// Returns position of the mathcing brace (all types of braces are
+    /// Returns position of the matching brace (all types of braces are
     /// supported).
     pub fn matching_brace(&self, file: &SourceFile, offset: TextUnit) -> Option<TextUnit> {
         ra_ide_api_light::matching_brace(file, offset)
@@ -397,7 +397,7 @@ impl Analysis {
         self.with_db(|db| db.find_all_refs(position))
     }
 
-    /// Returns a short text descrbing element at position.
+    /// Returns a short text describing element at position.
     pub fn hover(&self, position: FilePosition) -> Cancelable<Option<RangeInfo<String>>> {
         self.with_db(|db| hover::hover(db, position))
     }

--- a/crates/ra_ide_api_light/src/assists.rs
+++ b/crates/ra_ide_api_light/src/assists.rs
@@ -6,6 +6,7 @@
 mod flip_comma;
 mod add_derive;
 mod add_impl;
+mod introduce_match;
 mod introduce_variable;
 mod change_visibility;
 mod split_import;
@@ -24,6 +25,7 @@ pub use self::{
     flip_comma::flip_comma,
     add_derive::add_derive,
     add_impl::add_impl,
+    introduce_match::introduce_match,
     introduce_variable::introduce_variable,
     change_visibility::change_visibility,
     split_import::split_import,
@@ -37,6 +39,7 @@ pub fn assists(file: &SourceFile, range: TextRange) -> Vec<LocalEdit> {
         flip_comma,
         add_derive,
         add_impl,
+        introduce_match,
         introduce_variable,
         change_visibility,
         split_import,

--- a/crates/ra_ide_api_light/src/assists/introduce_match.rs
+++ b/crates/ra_ide_api_light/src/assists/introduce_match.rs
@@ -1,0 +1,116 @@
+use ra_syntax::TextUnit;
+
+use crate::assists::{AssistCtx, Assist};
+
+pub fn introduce_match<'a>(ctx: AssistCtx) -> Option<Assist> {
+    let expr = ctx.covering_node();
+
+    ctx.build("introduce match", move |edit| {
+        let first_part = format!("match {} {{\n    ", expr.text());
+        let match_expr = format!("{}_ => (),\n}}", first_part);
+        edit.replace_node_and_indent(expr, match_expr.into_boxed_str());
+
+        // FIXME: Set cursor at beginning of first match arm.
+        // The following doesn't work because of re-indentation:
+        //
+        // edit.set_cursor(expr.range().start() + TextUnit::of_str(&first_part));
+        //
+        // Workaround:
+        edit.set_cursor(expr.range().start() + TextUnit::of_str("match "));
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::assists::{check_assist, check_assist_range};
+
+    #[test]
+    fn test_introduce_match_simple() {
+        check_assist(
+            introduce_match,
+            "
+fn foo() {
+    let x = Some(42);
+    x<|>
+}",
+            "
+fn foo() {
+    let x = Some(42);
+    match <|>x {
+        _ => (),
+    }
+}",
+        );
+    }
+
+    #[test]
+    fn test_introduce_match_expr_stmt() {
+        check_assist_range(
+            introduce_match,
+            "
+fn foo() {
+    <|>Some(42).map(|x| x + 1)<|>
+}",
+            "
+fn foo() {
+    match <|>Some(42).map(|x| x + 1) {
+        _ => (),
+    }
+}",
+        );
+    }
+
+    #[test]
+    fn test_introduce_match_part_of_expr_stmt() {
+        check_assist_range(
+            introduce_match,
+            "
+fn foo() {
+    <|>Some(21)<|>.map(|x| x + 21);
+}",
+            "
+fn foo() {
+    match <|>Some(21) {
+        _ => (),
+    }.map(|x| x + 21);
+}",
+        );
+    }
+
+    #[test]
+    fn test_introduce_match_last_expr() {
+        check_assist_range(
+            introduce_match,
+            "
+fn foo() {
+    bar(<|>Ok(42)<|>)
+}",
+    // FIXME: This is the wrong indentation
+            "
+fn foo() {
+    bar(match <|>Ok(42) {
+    _ => (),
+})
+}",
+        );
+    }
+
+    #[test]
+    fn test_introduce_match_last_full_expr() {
+        check_assist_range(
+            introduce_match,
+            "
+fn foo() {
+    <|>bar(1 + 1)<|>
+}",
+            "
+fn foo() {
+    match <|>bar(1 + 1) {
+        _ => (),
+    }
+}",
+        );
+    }
+
+}


### PR DESCRIPTION
Similar to "Introduce variable". This creates a match for the expression
under the cursor.

This is the simplest possible implementation for now, with two FIXMEs and
a lot of ideas that are just waiting to be implemented.

cf. #528