### PR TITLE
Refactor InputModuleItems

### DIFF
--- a/crates/ra_hir/src/code_model_api.rs
+++ b/crates/ra_hir/src/code_model_api.rs
@@ -7,7 +7,7 @@ use ra_syntax::{ast, TreeArc, SyntaxNode};
 use crate::{
     Name, DefId, Path, PerNs, ScopesWithSyntaxMapping, Ty, HirFileId,
     type_ref::TypeRef,
-    nameres::ModuleScope,
+    nameres::{ModuleScope, lower::LoweredImport},
     db::HirDatabase,
     expr::BodySyntaxMapping,
     ty::InferenceResult,
@@ -94,6 +94,15 @@ impl Module {
         db: &impl HirDatabase,
     ) -> Option<(FileId, TreeArc<ast::Module>)> {
         self.declaration_source_impl(db)
+    }
+
+    /// Returns the syntax of the last path segment corresponding to this import
+    pub fn import_source(
+        &self,
+        db: &impl HirDatabase,
+        import: LoweredImport,
+    ) -> TreeArc<ast::PathSegment> {
+        self.import_source_impl(db, import)
     }
 
     /// Returns the crate this module is part of.

--- a/crates/ra_hir/src/code_model_api.rs
+++ b/crates/ra_hir/src/code_model_api.rs
@@ -7,7 +7,7 @@ use ra_syntax::{ast, TreeArc, SyntaxNode};
 use crate::{
     Name, DefId, Path, PerNs, ScopesWithSyntaxMapping, Ty, HirFileId,
     type_ref::TypeRef,
-    nameres::{ModuleScope, lower::LoweredImport},
+    nameres::{ModuleScope, lower::ImportId},
     db::HirDatabase,
     expr::BodySyntaxMapping,
     ty::InferenceResult,
@@ -100,7 +100,7 @@ impl Module {
     pub fn import_source(
         &self,
         db: &impl HirDatabase,
-        import: LoweredImport,
+        import: ImportId,
     ) -> TreeArc<ast::PathSegment> {
         self.import_source_impl(db, import)
     }

--- a/crates/ra_hir/src/code_model_impl/module.rs
+++ b/crates/ra_hir/src/code_model_impl/module.rs
@@ -5,7 +5,7 @@ use crate::{
     Module, ModuleSource, Problem,
     Crate, DefId, DefLoc, DefKind, Name, Path, PathKind, PerNs, Def,
     module_tree::ModuleId,
-    nameres::{ModuleScope, lower::LoweredImport},
+    nameres::{ModuleScope, lower::ImportId},
     db::HirDatabase,
 };
 
@@ -69,7 +69,7 @@ impl Module {
     pub(crate) fn import_source_impl(
         &self,
         db: &impl HirDatabase,
-        import: LoweredImport,
+        import: ImportId,
     ) -> TreeArc<ast::PathSegment> {
         let loc = self.def_id.loc(db);
         let source_map = db.lower_module_source_map(loc.source_root_id, loc.module_id);

--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -10,7 +10,7 @@ use crate::{
     FnSignature, FnScopes,
     macros::MacroExpansion,
     module_tree::{ModuleId, ModuleTree},
-    nameres::{ItemMap, lower::InputModuleItems},
+    nameres::{ItemMap, lower::{InputModuleItems, LoweredModule, ImportSourceMap}},
     ty::{InferenceResult, Ty, method_resolution::CrateImplBlocks},
     adt::{StructData, EnumData, EnumVariantData},
     impl_block::ModuleImplBlocks,
@@ -64,6 +64,27 @@ pub trait HirDatabase:
         source_root_id: SourceRootId,
         module_id: ModuleId,
     ) -> Arc<InputModuleItems>;
+
+    #[salsa::invoke(crate::nameres::lower::LoweredModule::lower_module_query)]
+    fn lower_module(
+        &self,
+        source_root_id: SourceRootId,
+        module_id: ModuleId,
+    ) -> (Arc<LoweredModule>, Arc<ImportSourceMap>);
+
+    #[salsa::invoke(crate::nameres::lower::LoweredModule::lower_module_module_query)]
+    fn lower_module_module(
+        &self,
+        source_root_id: SourceRootId,
+        module_id: ModuleId,
+    ) -> Arc<LoweredModule>;
+
+    #[salsa::invoke(crate::nameres::lower::LoweredModule::lower_module_source_map_query)]
+    fn lower_module_source_map(
+        &self,
+        source_root_id: SourceRootId,
+        module_id: ModuleId,
+    ) -> Arc<ImportSourceMap>;
 
     #[salsa::invoke(query_definitions::item_map)]
     fn item_map(&self, source_root_id: SourceRootId) -> Arc<ItemMap>;

--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -10,7 +10,7 @@ use crate::{
     FnSignature, FnScopes,
     macros::MacroExpansion,
     module_tree::{ModuleId, ModuleTree},
-    nameres::{ItemMap, lower::{InputModuleItems, LoweredModule, ImportSourceMap}},
+    nameres::{ItemMap, lower::{LoweredModule, ImportSourceMap}},
     ty::{InferenceResult, Ty, method_resolution::CrateImplBlocks},
     adt::{StructData, EnumData, EnumVariantData},
     impl_block::ModuleImplBlocks,
@@ -57,13 +57,6 @@ pub trait HirDatabase:
 
     #[salsa::invoke(crate::module_tree::Submodule::submodules_query)]
     fn submodules(&self, source: SourceItemId) -> Arc<Vec<crate::module_tree::Submodule>>;
-
-    #[salsa::invoke(crate::nameres::lower::InputModuleItems::input_module_items_query)]
-    fn input_module_items(
-        &self,
-        source_root_id: SourceRootId,
-        module_id: ModuleId,
-    ) -> Arc<InputModuleItems>;
 
     #[salsa::invoke(crate::nameres::lower::LoweredModule::lower_module_query)]
     fn lower_module(

--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -10,7 +10,7 @@ use crate::{
     FnSignature, FnScopes,
     macros::MacroExpansion,
     module_tree::{ModuleId, ModuleTree},
-    nameres::{ItemMap, InputModuleItems},
+    nameres::{ItemMap, lower::InputModuleItems},
     ty::{InferenceResult, Ty, method_resolution::CrateImplBlocks},
     adt::{StructData, EnumData, EnumVariantData},
     impl_block::ModuleImplBlocks,
@@ -58,7 +58,7 @@ pub trait HirDatabase:
     #[salsa::invoke(crate::module_tree::Submodule::submodules_query)]
     fn submodules(&self, source: SourceItemId) -> Arc<Vec<crate::module_tree::Submodule>>;
 
-    #[salsa::invoke(query_definitions::input_module_items)]
+    #[salsa::invoke(crate::nameres::lower::InputModuleItems::input_module_items_query)]
     fn input_module_items(
         &self,
         source_root_id: SourceRootId,

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -31,7 +31,7 @@ mod code_model_impl;
 use crate::{
     db::HirDatabase,
     name::{AsName, KnownName},
-    ids::{DefKind, SourceItemId, SourceFileItemId, SourceFileItems},
+    ids::{DefKind, SourceItemId, SourceFileItems},
 };
 
 pub use self::{

--- a/crates/ra_hir/src/mock.rs
+++ b/crates/ra_hir/src/mock.rs
@@ -227,7 +227,9 @@ salsa::database_storage! {
             fn fn_scopes() for db::FnScopesQuery;
             fn file_items() for db::FileItemsQuery;
             fn file_item() for db::FileItemQuery;
-            fn input_module_items() for db::InputModuleItemsQuery;
+            fn lower_module() for db::LowerModuleQuery;
+            fn lower_module_module() for db::LowerModuleModuleQuery;
+            fn lower_module_source_map() for db::LowerModuleSourceMapQuery;
             fn item_map() for db::ItemMapQuery;
             fn submodules() for db::SubmodulesQuery;
             fn infer() for db::InferQuery;

--- a/crates/ra_hir/src/nameres.rs
+++ b/crates/ra_hir/src/nameres.rs
@@ -60,7 +60,7 @@ pub struct Resolution {
     /// None for unresolved
     pub def_id: PerNs<DefId>,
     /// ident by whitch this is imported into local scope.
-    pub import: Option<LoweredImport>,
+    pub import: Option<ImportId>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -154,7 +154,7 @@ pub(crate) struct Resolver<'a, DB> {
     input: &'a FxHashMap<ModuleId, Arc<LoweredModule>>,
     source_root: SourceRootId,
     module_tree: Arc<ModuleTree>,
-    processed_imports: FxHashSet<(ModuleId, LoweredImport)>,
+    processed_imports: FxHashSet<(ModuleId, ImportId)>,
     result: ItemMap,
 }
 
@@ -296,7 +296,7 @@ where
     fn resolve_import(
         &mut self,
         module_id: ModuleId,
-        import_id: LoweredImport,
+        import_id: ImportId,
         import: &ImportData,
     ) -> bool {
         log::debug!("resolving import: {:?}", import);

--- a/crates/ra_hir/src/nameres/lower.rs
+++ b/crates/ra_hir/src/nameres/lower.rs
@@ -1,10 +1,11 @@
 use std::sync::Arc;
 
 use ra_syntax::{
-    TextRange, SyntaxKind, AstNode,
+    TextRange, SyntaxKind, AstNode, SourceFile, TreeArc,
     ast::{self, ModuleItemOwner},
 };
-use ra_db::{FileId, SourceRootId};
+use ra_db::{SourceRootId, LocalSyntaxPtr};
+use ra_arena::{Arena, RawId, impl_arena_id, map::ArenaMap};
 
 use crate::{
     SourceItemId, SourceFileItemId, Path, ModuleSource, HirDatabase, Name, SourceFileItems,
@@ -139,12 +140,12 @@ impl InputModuleItems {
     fn add_use_item(&mut self, file_items: &SourceFileItems, item: &ast::UseItem) {
         let file_item_id = file_items.id_of_unchecked(item.syntax());
         let start_offset = item.syntax().range().start();
-        Path::expand_use_item(item, |path, range| {
-            let kind = match range {
+        Path::expand_use_item(item, |path, segment| {
+            let kind = match segment {
                 None => ImportKind::Glob,
-                Some(range) => ImportKind::Named(NamedImport {
+                Some(segment) => ImportKind::Named(NamedImport {
                     file_item_id,
-                    relative_range: range - start_offset,
+                    relative_range: segment.syntax().range() - start_offset,
                 }),
             };
             self.imports.push(Import { kind, path })
@@ -199,22 +200,194 @@ pub struct NamedImport {
     pub relative_range: TextRange,
 }
 
-impl NamedImport {
-    // FIXME: this is only here for one use-case in completion. Seems like a
-    // pretty gross special case.
-    pub fn range(&self, db: &impl HirDatabase, file_id: FileId) -> TextRange {
-        let source_item_id = SourceItemId {
-            file_id: file_id.into(),
-            item_id: Some(self.file_item_id),
-        };
-        let syntax = db.file_item(source_item_id);
-        let offset = syntax.range().start();
-        self.relative_range + offset
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum ImportKind {
     Glob,
     Named(NamedImport),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct LoweredImport(RawId);
+impl_arena_id!(LoweredImport);
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct ImportData {
+    pub(super) path: Path,
+    pub(super) is_glob: bool,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct LoweredModule {
+    pub(super) items: Vec<ModuleItem>,
+    pub(super) imports: Arena<LoweredImport, ImportData>,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ImportSourceMap {
+    map: ArenaMap<LoweredImport, LocalSyntaxPtr>,
+}
+
+impl ImportSourceMap {
+    fn insert(&mut self, import: LoweredImport, segment: &ast::PathSegment) {
+        self.map
+            .insert(import, LocalSyntaxPtr::new(segment.syntax()))
+    }
+
+    pub fn get(&self, source: &ModuleSource, import: LoweredImport) -> TreeArc<ast::PathSegment> {
+        let file = match source {
+            ModuleSource::SourceFile(file) => &*file,
+            ModuleSource::Module(m) => m.syntax().ancestors().find_map(SourceFile::cast).unwrap(),
+        };
+
+        ast::PathSegment::cast(&self.map[import].resolve(file))
+            .unwrap()
+            .to_owned()
+    }
+}
+
+impl LoweredModule {
+    pub(crate) fn lower_module_module_query(
+        db: &impl HirDatabase,
+        source_root_id: SourceRootId,
+        module_id: ModuleId,
+    ) -> Arc<LoweredModule> {
+        db.lower_module(source_root_id, module_id).0
+    }
+
+    pub(crate) fn lower_module_source_map_query(
+        db: &impl HirDatabase,
+        source_root_id: SourceRootId,
+        module_id: ModuleId,
+    ) -> Arc<ImportSourceMap> {
+        db.lower_module(source_root_id, module_id).1
+    }
+
+    pub(crate) fn lower_module_query(
+        db: &impl HirDatabase,
+        source_root_id: SourceRootId,
+        module_id: ModuleId,
+    ) -> (Arc<LoweredModule>, Arc<ImportSourceMap>) {
+        let module_tree = db.module_tree(source_root_id);
+        let source = module_id.source(&module_tree);
+        let file_id = source.file_id;
+        let source = ModuleSource::from_source_item_id(db, source);
+        let mut source_map = ImportSourceMap::default();
+        let mut res = LoweredModule::default();
+        match source {
+            ModuleSource::SourceFile(it) => res.fill(
+                &mut source_map,
+                db,
+                source_root_id,
+                module_id,
+                file_id,
+                &mut it.items_with_macros(),
+            ),
+            ModuleSource::Module(it) => {
+                if let Some(item_list) = it.item_list() {
+                    res.fill(
+                        &mut source_map,
+                        db,
+                        source_root_id,
+                        module_id,
+                        file_id,
+                        &mut item_list.items_with_macros(),
+                    )
+                }
+            }
+        };
+        (Arc::new(res), Arc::new(source_map))
+    }
+
+    fn fill(
+        &mut self,
+        source_map: &mut ImportSourceMap,
+        db: &impl HirDatabase,
+        source_root_id: SourceRootId,
+        module_id: ModuleId,
+        file_id: HirFileId,
+        items: &mut Iterator<Item = ast::ItemOrMacro>,
+    ) {
+        let file_items = db.file_items(file_id);
+
+        for item in items {
+            match item {
+                ast::ItemOrMacro::Item(it) => {
+                    self.add_item(source_map, file_id, &file_items, it);
+                }
+                ast::ItemOrMacro::Macro(macro_call) => {
+                    let item_id = file_items.id_of_unchecked(macro_call.syntax());
+                    let loc = MacroCallLoc {
+                        source_root_id,
+                        module_id,
+                        source_item_id: SourceItemId {
+                            file_id,
+                            item_id: Some(item_id),
+                        },
+                    };
+                    let id = loc.id(db);
+                    let file_id = HirFileId::from(id);
+                    let file_items = db.file_items(file_id);
+                    //FIXME: expand recursively
+                    for item in db.hir_source_file(file_id).items() {
+                        self.add_item(source_map, file_id, &file_items, item);
+                    }
+                }
+            }
+        }
+    }
+
+    fn add_item(
+        &mut self,
+        source_map: &mut ImportSourceMap,
+        file_id: HirFileId,
+        file_items: &SourceFileItems,
+        item: &ast::ModuleItem,
+    ) -> Option<()> {
+        match item.kind() {
+            ast::ModuleItemKind::StructDef(it) => {
+                self.items.push(ModuleItem::new(file_id, file_items, it)?)
+            }
+            ast::ModuleItemKind::EnumDef(it) => {
+                self.items.push(ModuleItem::new(file_id, file_items, it)?)
+            }
+            ast::ModuleItemKind::FnDef(it) => {
+                self.items.push(ModuleItem::new(file_id, file_items, it)?)
+            }
+            ast::ModuleItemKind::TraitDef(it) => {
+                self.items.push(ModuleItem::new(file_id, file_items, it)?)
+            }
+            ast::ModuleItemKind::TypeDef(it) => {
+                self.items.push(ModuleItem::new(file_id, file_items, it)?)
+            }
+            ast::ModuleItemKind::ImplBlock(_) => {
+                // impls don't define items
+            }
+            ast::ModuleItemKind::UseItem(it) => self.add_use_item(source_map, it),
+            ast::ModuleItemKind::ExternCrateItem(_) => {
+                // TODO
+            }
+            ast::ModuleItemKind::ConstDef(it) => {
+                self.items.push(ModuleItem::new(file_id, file_items, it)?)
+            }
+            ast::ModuleItemKind::StaticDef(it) => {
+                self.items.push(ModuleItem::new(file_id, file_items, it)?)
+            }
+            ast::ModuleItemKind::Module(it) => {
+                self.items.push(ModuleItem::new(file_id, file_items, it)?)
+            }
+        }
+        Some(())
+    }
+
+    fn add_use_item(&mut self, source_map: &mut ImportSourceMap, item: &ast::UseItem) {
+        Path::expand_use_item(item, |path, segment| {
+            let import = self.imports.alloc(ImportData {
+                path,
+                is_glob: segment.is_none(),
+            });
+            if let Some(segment) = segment {
+                source_map.insert(import, segment)
+            }
+        })
+    }
 }

--- a/crates/ra_hir/src/nameres/lower.rs
+++ b/crates/ra_hir/src/nameres/lower.rs
@@ -1,0 +1,200 @@
+use std::sync::Arc;
+
+use ra_syntax::{
+    TextRange, SyntaxKind, AstNode,
+    ast::{self, ModuleItemOwner},
+};
+use ra_db::{FileId, SourceRootId};
+
+use crate::{
+    SourceItemId, SourceFileItemId, Path, ModuleSource, HirDatabase, Name, SourceFileItems,
+    HirFileId, MacroCallLoc, AsName,
+    module_tree::ModuleId
+};
+/// A set of items and imports declared inside a module, without relation to
+/// other modules.
+///
+/// This sits in-between raw syntax and name resolution and allows us to avoid
+/// recomputing name res: if two instance of `InputModuleItems` are the same, we
+/// can avoid redoing name resolution.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct InputModuleItems {
+    pub(crate) items: Vec<ModuleItem>,
+    pub(super) imports: Vec<Import>,
+}
+
+impl InputModuleItems {
+    pub(crate) fn input_module_items_query(
+        db: &impl HirDatabase,
+        source_root_id: SourceRootId,
+        module_id: ModuleId,
+    ) -> Arc<InputModuleItems> {
+        let module_tree = db.module_tree(source_root_id);
+        let source = module_id.source(&module_tree);
+        let file_id = source.file_id;
+        let source = ModuleSource::from_source_item_id(db, source);
+        let file_items = db.file_items(file_id);
+        let fill = |acc: &mut InputModuleItems, items: &mut Iterator<Item = ast::ItemOrMacro>| {
+            for item in items {
+                match item {
+                    ast::ItemOrMacro::Item(it) => {
+                        acc.add_item(file_id, &file_items, it);
+                    }
+                    ast::ItemOrMacro::Macro(macro_call) => {
+                        let item_id = file_items.id_of_unchecked(macro_call.syntax());
+                        let loc = MacroCallLoc {
+                            source_root_id,
+                            module_id,
+                            source_item_id: SourceItemId {
+                                file_id,
+                                item_id: Some(item_id),
+                            },
+                        };
+                        let id = loc.id(db);
+                        let file_id = HirFileId::from(id);
+                        let file_items = db.file_items(file_id);
+                        //FIXME: expand recursively
+                        for item in db.hir_source_file(file_id).items() {
+                            acc.add_item(file_id, &file_items, item);
+                        }
+                    }
+                }
+            }
+        };
+
+        let mut res = InputModuleItems::default();
+        match source {
+            ModuleSource::SourceFile(it) => fill(&mut res, &mut it.items_with_macros()),
+            ModuleSource::Module(it) => {
+                if let Some(item_list) = it.item_list() {
+                    fill(&mut res, &mut item_list.items_with_macros())
+                }
+            }
+        };
+        Arc::new(res)
+    }
+
+    pub(crate) fn add_item(
+        &mut self,
+        file_id: HirFileId,
+        file_items: &SourceFileItems,
+        item: &ast::ModuleItem,
+    ) -> Option<()> {
+        match item.kind() {
+            ast::ModuleItemKind::StructDef(it) => {
+                self.items.push(ModuleItem::new(file_id, file_items, it)?)
+            }
+            ast::ModuleItemKind::EnumDef(it) => {
+                self.items.push(ModuleItem::new(file_id, file_items, it)?)
+            }
+            ast::ModuleItemKind::FnDef(it) => {
+                self.items.push(ModuleItem::new(file_id, file_items, it)?)
+            }
+            ast::ModuleItemKind::TraitDef(it) => {
+                self.items.push(ModuleItem::new(file_id, file_items, it)?)
+            }
+            ast::ModuleItemKind::TypeDef(it) => {
+                self.items.push(ModuleItem::new(file_id, file_items, it)?)
+            }
+            ast::ModuleItemKind::ImplBlock(_) => {
+                // impls don't define items
+            }
+            ast::ModuleItemKind::UseItem(it) => self.add_use_item(file_items, it),
+            ast::ModuleItemKind::ExternCrateItem(_) => {
+                // TODO
+            }
+            ast::ModuleItemKind::ConstDef(it) => {
+                self.items.push(ModuleItem::new(file_id, file_items, it)?)
+            }
+            ast::ModuleItemKind::StaticDef(it) => {
+                self.items.push(ModuleItem::new(file_id, file_items, it)?)
+            }
+            ast::ModuleItemKind::Module(it) => {
+                self.items.push(ModuleItem::new(file_id, file_items, it)?)
+            }
+        }
+        Some(())
+    }
+
+    fn add_use_item(&mut self, file_items: &SourceFileItems, item: &ast::UseItem) {
+        let file_item_id = file_items.id_of_unchecked(item.syntax());
+        let start_offset = item.syntax().range().start();
+        Path::expand_use_item(item, |path, range| {
+            let kind = match range {
+                None => ImportKind::Glob,
+                Some(range) => ImportKind::Named(NamedImport {
+                    file_item_id,
+                    relative_range: range - start_offset,
+                }),
+            };
+            self.imports.push(Import { kind, path })
+        })
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum Vis {
+    // Priv,
+    Other,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct ModuleItem {
+    pub(crate) id: SourceItemId,
+    pub(crate) name: Name,
+    pub(super) kind: SyntaxKind,
+    pub(super) vis: Vis,
+}
+
+impl ModuleItem {
+    fn new(
+        file_id: HirFileId,
+        file_items: &SourceFileItems,
+        item: &impl ast::NameOwner,
+    ) -> Option<ModuleItem> {
+        let name = item.name()?.as_name();
+        let kind = item.syntax().kind();
+        let vis = Vis::Other;
+        let item_id = Some(file_items.id_of_unchecked(item.syntax()));
+        let id = SourceItemId { file_id, item_id };
+        let res = ModuleItem {
+            id,
+            name,
+            kind,
+            vis,
+        };
+        Some(res)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct Import {
+    pub(super) path: Path,
+    pub(super) kind: ImportKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NamedImport {
+    pub file_item_id: SourceFileItemId,
+    pub relative_range: TextRange,
+}
+
+impl NamedImport {
+    // FIXME: this is only here for one use-case in completion. Seems like a
+    // pretty gross special case.
+    pub fn range(&self, db: &impl HirDatabase, file_id: FileId) -> TextRange {
+        let source_item_id = SourceItemId {
+            file_id: file_id.into(),
+            item_id: Some(self.file_item_id),
+        };
+        let syntax = db.file_item(source_item_id);
+        let offset = syntax.range().start();
+        self.relative_range + offset
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum ImportKind {
+    Glob,
+    Named(NamedImport),
+}

--- a/crates/ra_hir/src/query_definitions.rs
+++ b/crates/ra_hir/src/query_definitions.rs
@@ -46,7 +46,7 @@ pub(super) fn item_map(db: &impl HirDatabase, source_root: SourceRootId) -> Arc<
     let module_tree = db.module_tree(source_root);
     let input = module_tree
         .modules()
-        .map(|id| (id, db.input_module_items(source_root, id)))
+        .map(|id| (id, db.lower_module_module(source_root, id)))
         .collect::<FxHashMap<_, _>>();
 
     let resolver = Resolver::new(db, &input, source_root, module_tree);

--- a/crates/ra_hir/src/source_binder.rs
+++ b/crates/ra_hir/src/source_binder.rs
@@ -142,7 +142,7 @@ pub fn macro_symbols(db: &impl HirDatabase, file_id: FileId) -> Vec<(SmolStr, Te
         None => return Vec::new(),
     };
     let loc = module.def_id.loc(db);
-    let items = db.input_module_items(loc.source_root_id, loc.module_id);
+    let items = db.lower_module_module(loc.source_root_id, loc.module_id);
     let mut res = Vec::new();
 
     for macro_call_id in items

--- a/crates/ra_ide_api/src/db.rs
+++ b/crates/ra_ide_api/src/db.rs
@@ -113,7 +113,6 @@ salsa::database_storage! {
             fn fn_scopes() for hir::db::FnScopesQuery;
             fn file_items() for hir::db::FileItemsQuery;
             fn file_item() for hir::db::FileItemQuery;
-            fn input_module_items() for hir::db::InputModuleItemsQuery;
             fn lower_module() for hir::db::LowerModuleQuery;
             fn lower_module_module() for hir::db::LowerModuleModuleQuery;
             fn lower_module_source_map() for hir::db::LowerModuleSourceMapQuery;

--- a/crates/ra_ide_api/src/db.rs
+++ b/crates/ra_ide_api/src/db.rs
@@ -114,6 +114,9 @@ salsa::database_storage! {
             fn file_items() for hir::db::FileItemsQuery;
             fn file_item() for hir::db::FileItemQuery;
             fn input_module_items() for hir::db::InputModuleItemsQuery;
+            fn lower_module() for hir::db::LowerModuleQuery;
+            fn lower_module_module() for hir::db::LowerModuleModuleQuery;
+            fn lower_module_source_map() for hir::db::LowerModuleSourceMapQuery;
             fn item_map() for hir::db::ItemMapQuery;
             fn submodules() for hir::db::SubmodulesQuery;
             fn infer() for hir::db::InferQuery;


### PR DESCRIPTION
The main goal here is to get rid of that `NamedImport::range` hack (used in a single place in the completion) and replace it with something more general. "More general" here is the "source map" pattern which we already use for function body: when collecting module items, we produce two bits of information: the items themselves, and a mapping from items to syntax. We discard the second bit during analysis, to keep salsa happy, but we can use it in the IDE to recover ranges and such .