### PR TITLE
Add .vscode/settings.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ crates/*/target
 .idea/*
 *.log
 *.iml
+.vscode/settings.json


### PR DESCRIPTION
#566 removed `.vscode` from .gitignore

I want this because I usually use `formatOnSave`, but until our rustfmt integration properly supports rustfmt.toml, this only leads to spurious diffs, so I disable it in this repository. 

We can always remove this later if we have any settings we are desperate to set.