### PR TITLE
More precise completion source change control

### DIFF
--- a/crates/ra_ide_api/src/completion/completion_context.rs
+++ b/crates/ra_ide_api/src/completion/completion_context.rs
@@ -73,7 +73,7 @@ impl<'a> CompletionContext<'a> {
         self.source_range
     }
 
-    pub(crate) fn skip_punctuation_source_range(&mut self, punctuation: char) {
+    fn skip_punctuation_source_range(&mut self, punctuation: char) {
         // If leaf contains punctuations, we skip source range to the current offset.
         // Since we need to filter on source range's text with completions.
         if self


### PR DESCRIPTION
The result is as below. 

before:
![image](https://user-images.githubusercontent.com/510012/51483451-083d0600-1dd4-11e9-932b-ca2c61717fb6.png)

after:
![image](https://user-images.githubusercontent.com/510012/51483391-ecd1fb00-1dd3-11e9-8cd4-5166a8887c54.png)

before:
![image](https://user-images.githubusercontent.com/510012/51483467-0f641400-1dd4-11e9-9921-ef21d15cc343.png)

after:
![image](https://user-images.githubusercontent.com/510012/51483433-fb201700-1dd3-11e9-9730-c2a5d3dd5f5a.png)