### PR TITLE
Fix .not postfix completion

### DIFF
--- a/crates/ra_ide_api/src/completion/complete_postfix.rs
+++ b/crates/ra_ide_api/src/completion/complete_postfix.rs
@@ -33,7 +33,7 @@ fn postfix_snippet(ctx: &CompletionContext, label: &str, snippet: &str) -> Build
 pub(super) fn complete_postfix(acc: &mut Completions, ctx: &CompletionContext) {
     if let Some(dot_receiver) = ctx.dot_receiver {
         let receiver_text = dot_receiver.syntax().text().to_string();
-        postfix_snippet(ctx, "not", "!not").add_to(acc);
+        postfix_snippet(ctx, "not", &format!("!{}", receiver_text)).add_to(acc);
         postfix_snippet(ctx, "if", &format!("if {} {{$0}}", receiver_text)).add_to(acc);
         postfix_snippet(
             ctx,
@@ -50,8 +50,8 @@ mod tests {
     use crate::completion::completion_item::CompletionKind;
     use crate::completion::completion_item::check_completion;
 
-    fn check_snippet_completion(code: &str, expected_completions: &str) {
-        check_completion(code, expected_completions, CompletionKind::Postfix);
+    fn check_snippet_completion(test_name: &str, code: &str) {
+        check_completion(test_name, code, CompletionKind::Postfix);
     }
 
     #[test]

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__filter_postfix_completion1.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__filter_postfix_completion1.snap
@@ -1,4 +1,4 @@
-Created: 2019-01-21T05:12:32.815475+00:00
+Created: 2019-01-21T21:32:37.509646722+00:00
 Creator: insta@0.1.4
 Source: crates/ra_ide_api/src/completion/completion_item.rs
 
@@ -10,7 +10,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
         detail: None,
         lookup: None,
         insert_text: Some(
-            "!not"
+            "!bar"
         ),
         insert_text_format: Snippet,
         source_range: [76; 76),

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__filter_postfix_completion2.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__filter_postfix_completion2.snap
@@ -1,4 +1,4 @@
-Created: 2019-01-21T05:12:32.816092+00:00
+Created: 2019-01-21T21:32:37.510644822+00:00
 Creator: insta@0.1.4
 Source: crates/ra_ide_api/src/completion/completion_item.rs
 
@@ -10,7 +10,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
         detail: None,
         lookup: None,
         insert_text: Some(
-            "!not"
+            "!bar"
         ),
         insert_text_format: Snippet,
         source_range: [76; 77),

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__filter_postfix_completion3.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__filter_postfix_completion3.snap
@@ -1,4 +1,4 @@
-Created: 2019-01-21T05:19:05.341730+00:00
+Created: 2019-01-21T21:32:37.510629228+00:00
 Creator: insta@0.1.4
 Source: crates/ra_ide_api/src/completion/completion_item.rs
 
@@ -10,7 +10,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
         detail: None,
         lookup: None,
         insert_text: Some(
-            "!not"
+            "!bar"
         ),
         insert_text_format: Snippet,
         source_range: [76; 78),


### PR DESCRIPTION
The postfix snippets are awesome! I don't think the `.not` one is supposed to always replace the receiver by literally `!not` :smile: 