### PR TITLE
Docs for completion

### DIFF
--- a/crates/ra_hir/src/code_model_api.rs
+++ b/crates/ra_hir/src/code_model_api.rs
@@ -297,6 +297,7 @@ pub struct FnSignature {
     /// True if the first param is `self`. This is relevant to decide whether this
     /// can be called as a method.
     pub(crate) has_self_param: bool,
+    pub(crate) documentation: String,
 }
 
 impl FnSignature {
@@ -316,6 +317,10 @@ impl FnSignature {
     /// can be called as a method.
     pub fn has_self_param(&self) -> bool {
         self.has_self_param
+    }
+
+    pub fn documentation(&self) -> &String {
+        &self.documentation
     }
 }
 

--- a/crates/ra_hir/src/code_model_impl/function.rs
+++ b/crates/ra_hir/src/code_model_impl/function.rs
@@ -2,7 +2,7 @@ mod scope;
 
 use std::sync::Arc;
 
-use ra_syntax::{TreeArc, ast::{self, NameOwner}};
+use ra_syntax::{TreeArc, ast::{self, NameOwner, DocCommentsOwner}};
 
 use crate::{
     DefId, HirDatabase, Name, AsName, Function, FnSignature, Module,
@@ -72,11 +72,15 @@ impl FnSignature {
         } else {
             TypeRef::unit()
         };
+
+        let comments = node.doc_comment_text();
+
         let sig = FnSignature {
             name,
             params,
             ret_type,
             has_self_param,
+            documentation: comments,
         };
         Arc::new(sig)
     }

--- a/crates/ra_hir/src/code_model_impl/function.rs
+++ b/crates/ra_hir/src/code_model_impl/function.rs
@@ -2,7 +2,7 @@ mod scope;
 
 use std::sync::Arc;
 
-use ra_syntax::{TreeArc, ast::{self, NameOwner, DocCommentsOwner}};
+use ra_syntax::{TreeArc, ast::{self, NameOwner}};
 
 use crate::{
     DefId, HirDatabase, Name, AsName, Function, FnSignature, Module,
@@ -73,14 +73,11 @@ impl FnSignature {
             TypeRef::unit()
         };
 
-        let comments = node.doc_comment_text();
-
         let sig = FnSignature {
             name,
             params,
             ret_type,
             has_self_param,
-            documentation: comments,
         };
         Arc::new(sig)
     }

--- a/crates/ra_hir/src/ty/snapshots/tests__bug_484.snap
+++ b/crates/ra_hir/src/ty/snapshots/tests__bug_484.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-21T21:48:20.662863951+00:00
-Creator: insta@0.1.4
-Source: crates/ra_hir/src/ty/tests.rs
-
+---
+created: "2019-01-22T14:44:59.880187500+00:00"
+creator: insta@0.4.0
+expression: "&result"
+source: "crates\\ra_hir\\src\\ty\\tests.rs"
+---
 [11; 37) '{    l... {}; }': ()
 [20; 21) 'x': ()
 [24; 34) 'if true {}': ()

--- a/crates/ra_hir/src/ty/snapshots/tests__bug_585.snap
+++ b/crates/ra_hir/src/ty/snapshots/tests__bug_585.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-21T21:48:20.662863969+00:00
-Creator: insta@0.1.4
-Source: crates/ra_hir/src/ty/tests.rs
-
+---
+created: "2019-01-22T14:44:59.880187500+00:00"
+creator: insta@0.4.0
+expression: "&result"
+source: "crates\\ra_hir\\src\\ty\\tests.rs"
+---
 [11; 89) '{     ...   } }': ()
 [17; 21) 'X {}': [unknown]
 [27; 87) 'match ...     }': ()

--- a/crates/ra_hir/src/ty/snapshots/tests__infer_adt_pattern.snap
+++ b/crates/ra_hir/src/ty/snapshots/tests__infer_adt_pattern.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-21T21:48:20.662935249+00:00
-Creator: insta@0.1.4
-Source: crates/ra_hir/src/ty/tests.rs
-
+---
+created: "2019-01-22T14:44:59.880187500+00:00"
+creator: insta@0.4.0
+expression: "&result"
+source: "crates\\ra_hir\\src\\ty\\tests.rs"
+---
 [68; 262) '{     ...  d; }': ()
 [78; 79) 'e': E
 [82; 95) 'E::A { x: 3 }': E

--- a/crates/ra_hir/src/ty/snapshots/tests__infer_array.snap
+++ b/crates/ra_hir/src/ty/snapshots/tests__infer_array.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-21T21:48:20.662961921+00:00
-Creator: insta@0.1.4
-Source: crates/ra_hir/src/ty/tests.rs
-
+---
+created: "2019-01-22T14:44:59.880187500+00:00"
+creator: insta@0.4.0
+expression: "&result"
+source: "crates\\ra_hir\\src\\ty\\tests.rs"
+---
 [9; 10) 'x': &str
 [18; 19) 'y': isize
 [28; 293) '{     ... []; }': ()

--- a/crates/ra_hir/src/ty/snapshots/tests__infer_backwards.snap
+++ b/crates/ra_hir/src/ty/snapshots/tests__infer_backwards.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-21T21:48:20.662902243+00:00
-Creator: insta@0.1.4
-Source: crates/ra_hir/src/ty/tests.rs
-
+---
+created: "2019-01-22T14:44:59.880187500+00:00"
+creator: insta@0.4.0
+expression: "&result"
+source: "crates\\ra_hir\\src\\ty\\tests.rs"
+---
 [14; 15) 'x': u32
 [22; 24) '{}': ()
 [78; 231) '{     ...t &c }': &mut &f64

--- a/crates/ra_hir/src/ty/snapshots/tests__infer_basics.snap
+++ b/crates/ra_hir/src/ty/snapshots/tests__infer_basics.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-21T21:48:20.662874226+00:00
-Creator: insta@0.1.4
-Source: crates/ra_hir/src/ty/tests.rs
-
+---
+created: "2019-01-22T14:44:59.880187500+00:00"
+creator: insta@0.4.0
+expression: "&result"
+source: "crates\\ra_hir\\src\\ty\\tests.rs"
+---
 [9; 10) 'a': u32
 [17; 18) 'b': isize
 [27; 28) 'c': !

--- a/crates/ra_hir/src/ty/snapshots/tests__infer_binary_op.snap
+++ b/crates/ra_hir/src/ty/snapshots/tests__infer_binary_op.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-21T21:48:20.662972146+00:00
-Creator: insta@0.1.4
-Source: crates/ra_hir/src/ty/tests.rs
-
+---
+created: "2019-01-22T14:44:59.880187500+00:00"
+creator: insta@0.4.0
+expression: "&result"
+source: "crates\\ra_hir\\src\\ty\\tests.rs"
+---
 [6; 7) 'x': bool
 [22; 34) '{     0i32 }': i32
 [28; 32) '0i32': i32

--- a/crates/ra_hir/src/ty/snapshots/tests__infer_enum.snap
+++ b/crates/ra_hir/src/ty/snapshots/tests__infer_enum.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-21T21:48:20.662949719+00:00
-Creator: insta@0.1.4
-Source: crates/ra_hir/src/ty/tests.rs
-
+---
+created: "2019-01-22T14:44:59.880187500+00:00"
+creator: insta@0.4.0
+expression: "&result"
+source: "crates\\ra_hir\\src\\ty\\tests.rs"
+---
 [48; 82) '{   E:...:V2; }': ()
 [52; 70) 'E::V1 ...d: 1 }': E
 [67; 68) '1': u32

--- a/crates/ra_hir/src/ty/snapshots/tests__infer_field_autoderef.snap
+++ b/crates/ra_hir/src/ty/snapshots/tests__infer_field_autoderef.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-21T21:48:20.671554939+00:00
-Creator: insta@0.1.4
-Source: crates/ra_hir/src/ty/tests.rs
-
+---
+created: "2019-01-22T14:44:59.955954900+00:00"
+creator: insta@0.4.0
+expression: "&result"
+source: "crates\\ra_hir\\src\\ty\\tests.rs"
+---
 [44; 45) 'a': A
 [50; 213) '{     ...5.b; }': ()
 [60; 62) 'a1': A

--- a/crates/ra_hir/src/ty/snapshots/tests__infer_function_generics.snap
+++ b/crates/ra_hir/src/ty/snapshots/tests__infer_function_generics.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-21T21:48:20.669112954+00:00
-Creator: insta@0.1.4
-Source: crates/ra_hir/src/ty/tests.rs
-
+---
+created: "2019-01-22T14:44:59.954958500+00:00"
+creator: insta@0.4.0
+expression: "&result"
+source: "crates\\ra_hir\\src\\ty\\tests.rs"
+---
 [10; 11) 't': [unknown]
 [21; 26) '{ t }': [unknown]
 [23; 24) 't': [unknown]

--- a/crates/ra_hir/src/ty/snapshots/tests__infer_generic_chain.snap
+++ b/crates/ra_hir/src/ty/snapshots/tests__infer_generic_chain.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-21T21:48:20.672467086+00:00
-Creator: insta@0.1.4
-Source: crates/ra_hir/src/ty/tests.rs
-
+---
+created: "2019-01-22T14:44:59.961936900+00:00"
+creator: insta@0.4.0
+expression: "&result"
+source: "crates\\ra_hir\\src\\ty\\tests.rs"
+---
 [53; 57) 'self': A<[unknown]>
 [65; 87) '{     ...     }': [unknown]
 [75; 79) 'self': A<[unknown]>

--- a/crates/ra_hir/src/ty/snapshots/tests__infer_generics_in_patterns.snap
+++ b/crates/ra_hir/src/ty/snapshots/tests__infer_generics_in_patterns.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-21T21:48:20.683908196+00:00
-Creator: insta@0.1.4
-Source: crates/ra_hir/src/ty/tests.rs
-
+---
+created: "2019-01-22T14:44:59.970913200+00:00"
+creator: insta@0.4.0
+expression: "&result"
+source: "crates\\ra_hir\\src\\ty\\tests.rs"
+---
 [79; 81) 'a1': A<u32>
 [91; 92) 'o': Option<u64>
 [107; 244) '{     ...  }; }': ()

--- a/crates/ra_hir/src/ty/snapshots/tests__infer_inherent_method.snap
+++ b/crates/ra_hir/src/ty/snapshots/tests__infer_inherent_method.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-21T21:48:20.670255659+00:00
-Creator: insta@0.1.4
-Source: crates/ra_hir/src/ty/tests.rs
-
+---
+created: "2019-01-22T14:44:59.968918800+00:00"
+creator: insta@0.4.0
+expression: "&result"
+source: "crates\\ra_hir\\src\\ty\\tests.rs"
+---
 [32; 36) 'self': A
 [38; 39) 'x': u32
 [53; 55) '{}': ()

--- a/crates/ra_hir/src/ty/snapshots/tests__infer_let.snap
+++ b/crates/ra_hir/src/ty/snapshots/tests__infer_let.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-21T21:48:20.666406651+00:00
-Creator: insta@0.1.4
-Source: crates/ra_hir/src/ty/tests.rs
-
+---
+created: "2019-01-22T14:44:59.963931700+00:00"
+creator: insta@0.4.0
+expression: "&result"
+source: "crates\\ra_hir\\src\\ty\\tests.rs"
+---
 [11; 71) '{     ...= b; }': ()
 [21; 22) 'a': isize
 [25; 31) '1isize': isize

--- a/crates/ra_hir/src/ty/snapshots/tests__infer_literals.snap
+++ b/crates/ra_hir/src/ty/snapshots/tests__infer_literals.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-21T21:48:20.666200994+00:00
-Creator: insta@0.1.4
-Source: crates/ra_hir/src/ty/tests.rs
-
+---
+created: "2019-01-22T14:44:59.974903100+00:00"
+creator: insta@0.4.0
+expression: "&result"
+source: "crates\\ra_hir\\src\\ty\\tests.rs"
+---
 [11; 201) '{     ...o"#; }': ()
 [17; 21) '5i32': i32
 [27; 34) '"hello"': &str

--- a/crates/ra_hir/src/ty/snapshots/tests__infer_paths.snap
+++ b/crates/ra_hir/src/ty/snapshots/tests__infer_paths.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-21T21:48:20.671399345+00:00
-Creator: insta@0.1.4
-Source: crates/ra_hir/src/ty/tests.rs
-
+---
+created: "2019-01-22T14:44:59.975899500+00:00"
+creator: insta@0.4.0
+expression: "&result"
+source: "crates\\ra_hir\\src\\ty\\tests.rs"
+---
 [15; 20) '{ 1 }': u32
 [17; 18) '1': u32
 [48; 53) '{ 1 }': u32

--- a/crates/ra_hir/src/ty/snapshots/tests__infer_pattern.snap
+++ b/crates/ra_hir/src/ty/snapshots/tests__infer_pattern.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-21T21:48:20.677661229+00:00
-Creator: insta@0.1.4
-Source: crates/ra_hir/src/ty/tests.rs
-
+---
+created: "2019-01-22T14:45:00.037734500+00:00"
+creator: insta@0.4.0
+expression: "&result"
+source: "crates\\ra_hir\\src\\ty\\tests.rs"
+---
 [9; 10) 'x': &i32
 [18; 369) '{     ...o_x; }': ()
 [28; 29) 'y': &i32

--- a/crates/ra_hir/src/ty/snapshots/tests__infer_refs.snap
+++ b/crates/ra_hir/src/ty/snapshots/tests__infer_refs.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-21T21:48:20.674183006+00:00
-Creator: insta@0.1.4
-Source: crates/ra_hir/src/ty/tests.rs
-
+---
+created: "2019-01-22T14:45:00.053692600+00:00"
+creator: insta@0.4.0
+expression: "&result"
+source: "crates\\ra_hir\\src\\ty\\tests.rs"
+---
 [9; 10) 'a': &u32
 [18; 19) 'b': &mut u32
 [31; 32) 'c': *const u32

--- a/crates/ra_hir/src/ty/snapshots/tests__infer_self.snap
+++ b/crates/ra_hir/src/ty/snapshots/tests__infer_self.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-21T21:50:17.870325361+00:00
-Creator: insta@0.1.4
-Source: crates/ra_hir/src/ty/tests.rs
-
+---
+created: "2019-01-22T14:45:00.052694700+00:00"
+creator: insta@0.4.0
+expression: "&result"
+source: "crates\\ra_hir\\src\\ty\\tests.rs"
+---
 [34; 38) 'self': &S
 [40; 61) '{     ...     }': ()
 [50; 54) 'self': &S

--- a/crates/ra_hir/src/ty/snapshots/tests__infer_struct.snap
+++ b/crates/ra_hir/src/ty/snapshots/tests__infer_struct.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-21T21:48:20.677495622+00:00
-Creator: insta@0.1.4
-Source: crates/ra_hir/src/ty/tests.rs
-
+---
+created: "2019-01-22T14:45:00.058678600+00:00"
+creator: insta@0.4.0
+expression: "&result"
+source: "crates\\ra_hir\\src\\ty\\tests.rs"
+---
 [72; 154) '{     ...a.c; }': ()
 [82; 83) 'c': [unknown]
 [86; 87) 'C': [unknown]

--- a/crates/ra_hir/src/ty/snapshots/tests__infer_struct_generics.snap
+++ b/crates/ra_hir/src/ty/snapshots/tests__infer_struct_generics.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-21T21:48:20.678274444+00:00
-Creator: insta@0.1.4
-Source: crates/ra_hir/src/ty/tests.rs
-
+---
+created: "2019-01-22T14:45:00.058678600+00:00"
+creator: insta@0.4.0
+expression: "&result"
+source: "crates\\ra_hir\\src\\ty\\tests.rs"
+---
 [36; 38) 'a1': A<u32>
 [48; 49) 'i': i32
 [56; 147) '{     ...3.x; }': ()

--- a/crates/ra_hir/src/ty/snapshots/tests__infer_tuple.snap
+++ b/crates/ra_hir/src/ty/snapshots/tests__infer_tuple.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-21T21:48:20.676903109+00:00
-Creator: insta@0.1.4
-Source: crates/ra_hir/src/ty/tests.rs
-
+---
+created: "2019-01-22T14:45:00.058678600+00:00"
+creator: insta@0.4.0
+expression: "&result"
+source: "crates\\ra_hir\\src\\ty\\tests.rs"
+---
 [9; 10) 'x': &str
 [18; 19) 'y': isize
 [28; 170) '{     ...d"); }': ()

--- a/crates/ra_hir/src/ty/snapshots/tests__infer_unary_op.snap
+++ b/crates/ra_hir/src/ty/snapshots/tests__infer_unary_op.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-21T21:48:20.676213204+00:00
-Creator: insta@0.1.4
-Source: crates/ra_hir/src/ty/tests.rs
-
+---
+created: "2019-01-22T14:45:00.059676600+00:00"
+creator: insta@0.4.0
+expression: "&result"
+source: "crates\\ra_hir\\src\\ty\\tests.rs"
+---
 [27; 28) 'x': SomeType
 [40; 197) '{     ...lo"; }': ()
 [50; 51) 'b': bool

--- a/crates/ra_hir/src/ty/snapshots/tests__no_panic_on_field_of_enum.snap
+++ b/crates/ra_hir/src/ty/snapshots/tests__no_panic_on_field_of_enum.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-21T21:48:20.676654355+00:00
-Creator: insta@0.1.4
-Source: crates/ra_hir/src/ty/tests.rs
-
+---
+created: "2019-01-22T14:45:00.058678600+00:00"
+creator: insta@0.4.0
+expression: "&result"
+source: "crates\\ra_hir\\src\\ty\\tests.rs"
+---
 [20; 21) 'x': X
 [26; 47) '{     ...eld; }': ()
 [32; 33) 'x': X

--- a/crates/ra_ide_api/src/completion/completion_item.rs
+++ b/crates/ra_ide_api/src/completion/completion_item.rs
@@ -15,6 +15,7 @@ pub struct CompletionItem {
     label: String,
     kind: Option<CompletionItemKind>,
     detail: Option<String>,
+    documentation: Option<String>,
     lookup: Option<String>,
     insert_text: Option<String>,
     insert_text_format: InsertTextFormat,
@@ -77,6 +78,7 @@ impl CompletionItem {
             insert_text: None,
             insert_text_format: InsertTextFormat::PlainText,
             detail: None,
+            documentation: None,
             lookup: None,
             kind: None,
             text_edit: None,
@@ -89,6 +91,10 @@ impl CompletionItem {
     /// Short one-line additional information, like a type
     pub fn detail(&self) -> Option<&str> {
         self.detail.as_ref().map(|it| it.as_str())
+    }
+    /// A doc-comment
+    pub fn documentation(&self) -> Option<&str> {
+        self.documentation.as_ref().map(|it| it.as_str())
     }
     /// What string is used for filtering.
     pub fn lookup(&self) -> &str {
@@ -127,6 +133,7 @@ pub(crate) struct Builder {
     insert_text: Option<String>,
     insert_text_format: InsertTextFormat,
     detail: Option<String>,
+    documentation: Option<String>,
     lookup: Option<String>,
     kind: Option<CompletionItemKind>,
     text_edit: Option<TextEdit>,
@@ -142,6 +149,7 @@ impl Builder {
             source_range: self.source_range,
             label: self.label,
             detail: self.detail,
+            documentation: self.documentation,
             insert_text_format: self.insert_text_format,
             lookup: self.lookup,
             kind: self.kind,
@@ -182,6 +190,14 @@ impl Builder {
     }
     pub(crate) fn set_detail(mut self, detail: Option<impl Into<String>>) -> Builder {
         self.detail = detail.map(Into::into);
+        self
+    }
+    #[allow(unused)]
+    pub(crate) fn documentation(self, docs: impl Into<String>) -> Builder {
+        self.set_documentation(Some(docs))
+    }
+    pub(crate) fn set_documentation(mut self, docs: Option<impl Into<String>>) -> Builder {
+        self.documentation = docs.map(Into::into);
         self
     }
     pub(super) fn from_resolution(

--- a/crates/ra_ide_api/src/completion/completion_item.rs
+++ b/crates/ra_ide_api/src/completion/completion_item.rs
@@ -259,9 +259,8 @@ impl Builder {
             }
             self.insert_text_format = InsertTextFormat::Snippet;
         }
-        let sig = function.signature(ctx.db);
-        if !sig.documentation().is_empty() {
-            self.documentation = Some(sig.documentation().clone());
+        if let Some(docs) = function.docs(ctx.db) {
+            self.documentation = Some(docs);
         }
 
         self.kind = Some(CompletionItemKind::Function);

--- a/crates/ra_ide_api/src/completion/completion_item.rs
+++ b/crates/ra_ide_api/src/completion/completion_item.rs
@@ -259,6 +259,11 @@ impl Builder {
             }
             self.insert_text_format = InsertTextFormat::Snippet;
         }
+        let sig = function.signature(ctx.db);
+        if !sig.documentation().is_empty() {
+            self.documentation = Some(sig.documentation().clone());
+        }
+
         self.kind = Some(CompletionItemKind::Function);
         self
     }

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__bindings_from_for.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__bindings_from_for.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.241096+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.858540400+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Reference,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Binding
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: None,
         insert_text_format: PlainText,
@@ -23,6 +26,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Function
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "quux()$0"

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__bindings_from_if_let.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__bindings_from_if_let.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.242456+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.860535200+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Reference,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Binding
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: None,
         insert_text_format: PlainText,
@@ -23,6 +26,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Binding
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: None,
         insert_text_format: PlainText,
@@ -36,6 +40,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Function
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "quux()$0"

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__bindings_from_let.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__bindings_from_let.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.243016+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.871506600+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Reference,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Binding
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: None,
         insert_text_format: PlainText,
@@ -23,6 +26,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Binding
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: None,
         insert_text_format: PlainText,
@@ -36,6 +40,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Function
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "quux($0)"

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__completes_break_and_continue_in_loops1.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__completes_break_and_continue_in_loops1.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.206357+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.620177400+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Keyword,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "if $0 {}"
@@ -25,6 +28,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "match $0 {}"
@@ -40,6 +44,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "while $0 {}"
@@ -55,6 +60,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "loop {$0}"
@@ -70,6 +76,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "continue;"
@@ -85,6 +92,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "break;"
@@ -100,6 +108,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "return $0;"

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__completes_break_and_continue_in_loops2.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__completes_break_and_continue_in_loops2.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.217822+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.699965300+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Keyword,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "if $0 {}"
@@ -25,6 +28,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "match $0 {}"
@@ -40,6 +44,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "while $0 {}"
@@ -55,6 +60,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "loop {$0}"
@@ -70,6 +76,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "return $0;"

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__deeply_nested_use_tree.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__deeply_nested_use_tree.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.217724+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.719911400+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Reference,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Struct
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: None,
         insert_text_format: PlainText,

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__dont_add_semi_after_return_if_not_a_statement.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__dont_add_semi_after_return_if_not_a_statement.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.208392+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.642118600+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Keyword,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "if $0 {}"
@@ -25,6 +28,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "match $0 {}"
@@ -40,6 +44,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "while $0 {}"
@@ -55,6 +60,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "loop {$0}"
@@ -70,6 +76,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "return $0"

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__dont_render_function_parens_if_already_call.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__dont_render_function_parens_if_already_call.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.239872+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.797704900+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Reference,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Function
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: None,
         insert_text_format: PlainText,
@@ -23,6 +26,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Function
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: None,
         insert_text_format: PlainText,

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__dont_render_function_parens_in_use_item.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__dont_render_function_parens_in_use_item.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.239894+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.801693300+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Reference,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Function
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: None,
         insert_text_format: PlainText,

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__dont_show_both_completions_for_shadowing.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__dont_show_both_completions_for_shadowing.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.248606+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.912397100+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Reference,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Binding
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: None,
         insert_text_format: PlainText,
@@ -23,6 +26,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Function
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "foo()$0"

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__filter_postfix_completion1.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__filter_postfix_completion1.snap
@@ -1,13 +1,16 @@
-Created: 2019-01-21T21:32:37.509646722+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.817649800+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Postfix,
         label: "not",
         kind: None,
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "!bar"
@@ -30,6 +33,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
         label: "if",
         kind: None,
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "if bar {$0}"
@@ -52,6 +56,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
         label: "match",
         kind: None,
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "match bar {\n${1:_} => {$0\\},\n}"
@@ -74,6 +79,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
         label: "while",
         kind: None,
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "while bar {\n$0\n}"

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__filter_postfix_completion2.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__filter_postfix_completion2.snap
@@ -1,13 +1,16 @@
-Created: 2019-01-21T21:32:37.510644822+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.820642200+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Postfix,
         label: "not",
         kind: None,
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "!bar"
@@ -30,6 +33,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
         label: "if",
         kind: None,
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "if bar {$0}"
@@ -52,6 +56,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
         label: "match",
         kind: None,
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "match bar {\n${1:_} => {$0\\},\n}"
@@ -74,6 +79,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
         label: "while",
         kind: None,
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "while bar {\n$0\n}"

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__filter_postfix_completion3.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__filter_postfix_completion3.snap
@@ -1,13 +1,16 @@
-Created: 2019-01-21T21:32:37.510629228+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.830614900+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Postfix,
         label: "not",
         kind: None,
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "!bar"
@@ -30,6 +33,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
         label: "if",
         kind: None,
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "if bar {$0}"
@@ -52,6 +56,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
         label: "match",
         kind: None,
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "match bar {\n${1:_} => {$0\\},\n}"
@@ -74,6 +79,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
         label: "while",
         kind: None,
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "while bar {\n$0\n}"

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__inserts_parens_for_function_calls1.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__inserts_parens_for_function_calls1.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.249349+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.932343200+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Reference,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Function
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "no_args()$0"
@@ -25,6 +28,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Function
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "main()$0"

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__inserts_parens_for_function_calls2.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__inserts_parens_for_function_calls2.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.255317+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.995180+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Reference,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Function
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "main()$0"
@@ -25,6 +28,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Function
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "with_args($0)"

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__keywords_in_function1.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__keywords_in_function1.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.207728+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.635137200+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Keyword,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "if $0 {}"
@@ -25,6 +28,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "match $0 {}"
@@ -40,6 +44,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "while $0 {}"
@@ -55,6 +60,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "loop {$0}"
@@ -70,6 +76,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "return;"

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__keywords_in_function2.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__keywords_in_function2.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.207381+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.626162800+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Keyword,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "if $0 {}"
@@ -25,6 +28,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "match $0 {}"
@@ -40,6 +44,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "while $0 {}"
@@ -55,6 +60,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "loop {$0}"
@@ -70,6 +76,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "else {$0}"
@@ -85,6 +92,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "else if $0 {}"
@@ -100,6 +108,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "return;"

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__keywords_in_function3.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__keywords_in_function3.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.211090+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.701959300+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Keyword,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "if $0 {}"
@@ -25,6 +28,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "match $0 {}"
@@ -40,6 +44,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "while $0 {}"
@@ -55,6 +60,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "loop {$0}"
@@ -70,6 +76,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "return $0;"

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__keywords_in_function4.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__keywords_in_function4.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.218272+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.788727100+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Keyword,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "if $0 {}"
@@ -25,6 +28,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "match $0 {}"
@@ -40,6 +44,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "while $0 {}"
@@ -55,6 +60,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "loop {$0}"
@@ -70,6 +76,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "return;"

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__keywords_in_use_stmt1.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__keywords_in_use_stmt1.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.207433+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.626162800+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Keyword,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "crate::"
@@ -25,6 +28,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: None,
         insert_text_format: PlainText,
@@ -38,6 +42,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "super::"

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__keywords_in_use_stmt2.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__keywords_in_use_stmt2.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T09:26:20.872623+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.698966900+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Keyword,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: None,
         insert_text_format: PlainText,
@@ -23,6 +26,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "super::"

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__keywords_in_use_stmt3.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__keywords_in_use_stmt3.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.217815+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.779752+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Keyword,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: None,
         insert_text_format: PlainText,
@@ -23,6 +26,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "super::"

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__last_return_in_block_has_semi1.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__last_return_in_block_has_semi1.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.208669+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.642118600+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Keyword,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "if $0 {}"
@@ -25,6 +28,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "match $0 {}"
@@ -40,6 +44,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "while $0 {}"
@@ -55,6 +60,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "loop {$0}"
@@ -70,6 +76,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "return $0;"

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__last_return_in_block_has_semi2.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__last_return_in_block_has_semi2.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.221138+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.733874300+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Keyword,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "if $0 {}"
@@ -25,6 +28,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "match $0 {}"
@@ -40,6 +44,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "while $0 {}"
@@ -55,6 +60,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "loop {$0}"
@@ -70,6 +76,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "return $0;"

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__method_completion.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__method_completion.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T09:26:20.868112+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.546394900+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Reference,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Method
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "the_method($0)"

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__module_items.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__module_items.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.243581+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.874497400+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Reference,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Function
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "quux()$0"
@@ -25,6 +28,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Struct
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: None,
         insert_text_format: PlainText,
@@ -38,6 +42,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Enum
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: None,
         insert_text_format: PlainText,

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__module_items_in_nested_modules.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__module_items_in_nested_modules.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.244757+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.875495300+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Reference,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Function
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "quux()$0"
@@ -25,6 +28,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Struct
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: None,
         insert_text_format: PlainText,

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__nested_use_tree.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__nested_use_tree.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.222109+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.723900500+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Reference,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Struct
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: None,
         insert_text_format: PlainText,
@@ -23,6 +26,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Module
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: None,
         insert_text_format: PlainText,

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__no_non_self_method.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__no_non_self_method.snap
@@ -1,5 +1,7 @@
-Created: 2019-01-19T11:34:11.702251+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.552379600+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 []

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__no_semi_after_break_continue_in_expr.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__no_semi_after_break_continue_in_expr.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.209867+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.651095300+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Keyword,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "if $0 {}"
@@ -25,6 +28,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "match $0 {}"
@@ -40,6 +44,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "while $0 {}"
@@ -55,6 +60,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "loop {$0}"
@@ -70,6 +76,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "continue"
@@ -85,6 +92,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "break"
@@ -100,6 +108,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Keyword
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "return"

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__no_struct_field_completion_for_method_call.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__no_struct_field_completion_for_method_call.snap
@@ -1,5 +1,7 @@
-Created: 2019-01-19T11:34:11.702201+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.552379600+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 []

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__param_completion_last_param.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__param_completion_last_param.snap
@@ -1,13 +1,16 @@
-Created: 2019-01-20T04:00:48.203211+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.545423800+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Magic,
         label: "file_id: FileId",
         kind: None,
         detail: None,
+        documentation: None,
         lookup: Some(
             "file_id"
         ),

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__param_completion_nth_param.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__param_completion_nth_param.snap
@@ -1,13 +1,16 @@
-Created: 2019-01-20T04:00:48.203236+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.552379600+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Magic,
         label: "file_id: FileId",
         kind: None,
         detail: None,
+        documentation: None,
         lookup: Some(
             "file_id"
         ),

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__param_completion_trait_param.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__param_completion_trait_param.snap
@@ -1,13 +1,16 @@
-Created: 2019-01-20T04:00:48.206552+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.619180200+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Magic,
         label: "file_id: FileId",
         kind: None,
         detail: None,
+        documentation: None,
         lookup: Some(
             "file_id"
         ),

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__reference_completion.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__reference_completion.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T09:26:20.899262+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.717917+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Reference,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             EnumVariant
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: None,
         insert_text_format: PlainText,
@@ -23,6 +26,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             EnumVariant
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: None,
         insert_text_format: PlainText,

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__return_type.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__return_type.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.245820+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.898433800+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Reference,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Struct
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: None,
         insert_text_format: PlainText,
@@ -23,6 +26,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Function
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "x()$0"

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__self_in_methods.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__self_in_methods.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.244260+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.894444600+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Reference,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Binding
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: None,
         insert_text_format: PlainText,

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__snippets_in_expressions.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__snippets_in_expressions.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.252281+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.944312600+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Snippet,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Snippet
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "eprintln!(\"$0 = {:?}\", $0);"
@@ -25,6 +28,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Snippet
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "eprintln!(\"$0 = {:#?}\", $0);"

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__snippets_in_items.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__snippets_in_items.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.253073+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.944312600+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Snippet,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Snippet
         ),
         detail: None,
+        documentation: None,
         lookup: Some(
             "tfn"
         ),
@@ -27,6 +30,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Snippet
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "pub(crate) $0"

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__struct_field_completion.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__struct_field_completion.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T09:26:20.868146+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.545423800+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Reference,
@@ -12,6 +14,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
         detail: Some(
             "u32"
         ),
+        documentation: None,
         lookup: None,
         insert_text: None,
         insert_text_format: PlainText,

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__struct_field_completion_autoderef.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__struct_field_completion_autoderef.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T09:26:20.868561+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.552379600+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Reference,
@@ -12,6 +14,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
         detail: Some(
             "(u32, i32)"
         ),
+        documentation: None,
         lookup: None,
         insert_text: None,
         insert_text_format: PlainText,
@@ -25,6 +28,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Method
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "foo($0)"

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__struct_field_completion_self.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__struct_field_completion_self.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T09:26:20.868333+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.552379600+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Reference,
@@ -12,6 +14,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
         detail: Some(
             "(u32,)"
         ),
+        documentation: None,
         lookup: None,
         insert_text: None,
         insert_text_format: PlainText,
@@ -25,6 +28,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Method
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: Some(
             "foo($0)"

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__use_item_starting_with_crate.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__use_item_starting_with_crate.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T04:00:48.223130+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.761799100+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Reference,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Struct
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: None,
         insert_text_format: PlainText,
@@ -23,6 +26,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Module
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: None,
         insert_text_format: PlainText,

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__use_item_starting_with_self.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__use_item_starting_with_self.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-20T09:26:20.899584+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/completion/completion_item.rs
-
+---
+created: "2019-01-22T14:45:00.780748400+00:00"
+creator: insta@0.4.0
+expression: kind_completions
+source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+---
 [
     CompletionItem {
         completion_kind: Reference,
@@ -10,6 +12,7 @@ Source: crates/ra_ide_api/src/completion/completion_item.rs
             Struct
         ),
         detail: None,
+        documentation: None,
         lookup: None,
         insert_text: None,
         insert_text_format: PlainText,

--- a/crates/ra_ide_api/src/snapshots/tests__highlight_query_group_macro.snap
+++ b/crates/ra_ide_api/src/snapshots/tests__highlight_query_group_macro.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-15T11:15:20.732493641+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/syntax_highlighting.rs
-
+---
+created: "2019-01-22T14:45:01.017117100+00:00"
+creator: insta@0.4.0
+expression: "&highlights"
+source: "crates\\ra_ide_api\\src\\syntax_highlighting.rs"
+---
 [
     HighlightedRange {
         range: [20; 32),

--- a/crates/ra_ide_api/src/snapshots/tests__highlights_code_inside_macros.snap
+++ b/crates/ra_ide_api/src/snapshots/tests__highlights_code_inside_macros.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-15T11:15:20.732523231+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/syntax_highlighting.rs
-
+---
+created: "2019-01-22T14:45:01.043047100+00:00"
+creator: insta@0.4.0
+expression: "&highlights"
+source: "crates\\ra_ide_api\\src\\syntax_highlighting.rs"
+---
 [
     HighlightedRange {
         range: [13; 15),

--- a/crates/ra_ide_api/src/snapshots/tests__rename_mod.snap
+++ b/crates/ra_ide_api/src/snapshots/tests__rename_mod.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-18T08:26:43.427092+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/rename.rs
-
+---
+created: "2019-01-22T14:45:00.975229300+00:00"
+creator: insta@0.4.0
+expression: "&source_change"
+source: "crates\\ra_ide_api\\src\\rename.rs"
+---
 Some(
     SourceChange {
         label: "rename",

--- a/crates/ra_ide_api/src/snapshots/tests__rename_mod_in_dir.snap
+++ b/crates/ra_ide_api/src/snapshots/tests__rename_mod_in_dir.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-18T08:26:43.427095+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/rename.rs
-
+---
+created: "2019-01-22T14:45:00.975229300+00:00"
+creator: insta@0.4.0
+expression: "&source_change"
+source: "crates\\ra_ide_api\\src\\rename.rs"
+---
 Some(
     SourceChange {
         label: "rename",

--- a/crates/ra_ide_api/src/snapshots/tests__runnables.snap
+++ b/crates/ra_ide_api/src/snapshots/tests__runnables.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-15T11:15:20.732460119+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/runnables.rs
-
+---
+created: "2019-01-22T14:45:00.975229300+00:00"
+creator: insta@0.4.0
+expression: "&runnables"
+source: "crates\\ra_ide_api\\src\\runnables.rs"
+---
 [
     Runnable {
         range: [1; 21),

--- a/crates/ra_ide_api/src/snapshots/tests__runnables_module.snap
+++ b/crates/ra_ide_api/src/snapshots/tests__runnables_module.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-15T11:15:20.732460109+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/runnables.rs
-
+---
+created: "2019-01-22T14:45:00.976230700+00:00"
+creator: insta@0.4.0
+expression: "&runnables"
+source: "crates\\ra_ide_api\\src\\runnables.rs"
+---
 [
     Runnable {
         range: [1; 59),

--- a/crates/ra_ide_api/src/snapshots/tests__runnables_multiple_depth_module.snap
+++ b/crates/ra_ide_api/src/snapshots/tests__runnables_multiple_depth_module.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-15T11:15:20.732522773+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/runnables.rs
-
+---
+created: "2019-01-22T14:45:00.979218100+00:00"
+creator: insta@0.4.0
+expression: "&runnables"
+source: "crates\\ra_ide_api\\src\\runnables.rs"
+---
 [
     Runnable {
         range: [41; 115),

--- a/crates/ra_ide_api/src/snapshots/tests__runnables_one_depth_layer_module.snap
+++ b/crates/ra_ide_api/src/snapshots/tests__runnables_one_depth_layer_module.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-15T11:15:20.732480089+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/src/runnables.rs
-
+---
+created: "2019-01-22T14:45:01.016119500+00:00"
+creator: insta@0.4.0
+expression: "&runnables"
+source: "crates\\ra_ide_api\\src\\runnables.rs"
+---
 [
     Runnable {
         range: [23; 85),

--- a/crates/ra_ide_api/tests/test/snapshots/test__unresolved_module_diagnostic.snap
+++ b/crates/ra_ide_api/tests/test/snapshots/test__unresolved_module_diagnostic.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-15T11:15:20.891129945+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api/tests/test/main.rs
-
+---
+created: "2019-01-22T14:45:01.486985900+00:00"
+creator: insta@0.4.0
+expression: "&diagnostics"
+source: "crates\\ra_ide_api\\tests\\test\\main.rs"
+---
 [
     Diagnostic {
         message: "unresolved module",

--- a/crates/ra_ide_api_light/src/snapshots/tests__file_structure.snap
+++ b/crates/ra_ide_api_light/src/snapshots/tests__file_structure.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-15T11:15:21.073862814+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api_light/src/structure.rs
-
+---
+created: "2019-01-22T14:45:01.959724300+00:00"
+creator: insta@0.4.0
+expression: structure
+source: "crates\\ra_ide_api_light\\src\\structure.rs"
+---
 [
     StructureNode {
         parent: None,

--- a/crates/ra_ide_api_light/src/snapshots/tests__highlighting.snap
+++ b/crates/ra_ide_api_light/src/snapshots/tests__highlighting.snap
@@ -1,7 +1,9 @@
-Created: 2019-01-15T11:15:21.073858657+00:00
-Creator: insta@0.1.4
-Source: crates/ra_ide_api_light/src/lib.rs
-
+---
+created: "2019-01-22T14:45:01.959724300+00:00"
+creator: insta@0.4.0
+expression: hls
+source: "crates\\ra_ide_api_light\\src\\lib.rs"
+---
 [
     HighlightedRange {
         range: [1; 11),

--- a/crates/ra_lsp_server/src/conv.rs
+++ b/crates/ra_lsp_server/src/conv.rs
@@ -1,6 +1,6 @@
 use lsp_types::{
-    self, CreateFile, DocumentChangeOperation, DocumentChanges, Location, LocationLink,
-    Position, Range, RenameFile, ResourceOp, SymbolKind, TextDocumentEdit, TextDocumentIdentifier,
+    self, CreateFile, Documentation, DocumentChangeOperation, DocumentChanges, Location, LocationLink,
+    MarkupContent, MarkupKind, Position, Range, RenameFile, ResourceOp, SymbolKind, TextDocumentEdit, TextDocumentIdentifier,
     TextDocumentItem, TextDocumentPositionParams, Url, VersionedTextDocumentIdentifier,
     WorkspaceEdit,
 };
@@ -87,6 +87,13 @@ impl ConvWith for CompletionItem {
             None
         };
 
+        let documentation = self.documentation().map(|value| {
+            Documentation::MarkupContent(MarkupContent {
+                kind: MarkupKind::Markdown,
+                value: value.to_string(),
+            })
+        });
+
         let mut res = lsp_types::CompletionItem {
             label: self.label().to_string(),
             detail: self.detail().map(|it| it.to_string()),
@@ -94,6 +101,7 @@ impl ConvWith for CompletionItem {
             kind: self.kind().map(|it| it.conv()),
             text_edit: Some(text_edit),
             additional_text_edits,
+            documentation: documentation,
             ..Default::default()
         };
         res.insert_text_format = Some(match self.insert_text_format() {


### PR DESCRIPTION
The first commit adds documentation support to CompletionItems.

The second one I am unsure about. Is that the right way to add docs for functions? If so should I do something similar for other `hir` types and CompletionItems?