### PR TITLE
Sort vectors for which lookups are frequent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,7 +727,7 @@ dependencies = [
  "relative-path 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "salsa 0.10.0-alpha1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sortedvec 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sortedvec 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "test_utils 0.1.0",
 ]
 
@@ -747,7 +747,7 @@ dependencies = [
  "ra_syntax 0.1.0",
  "relative-path 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sortedvec 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sortedvec 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "test_utils 0.1.0",
 ]
 
@@ -1217,7 +1217,7 @@ dependencies = [
 
 [[package]]
 name = "sortedvec"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1712,7 +1712,7 @@ dependencies = [
 "checksum slug 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b3bc762e6a4b6c6fcaade73e77f9ebc6991b676f88bb2358bddb56560f073373"
 "checksum smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b73ea3738b47563803ef814925e69be00799a8c07420be8b996f8e98fb2336db"
 "checksum smol_str 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9af1035bc5d742ab6b7ab16713e41cc2ffe78cb474f6f43cd696b2d16052007e"
-"checksum sortedvec 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "33fd996bf5673d05c9056c51b8b34dbd85266a3ccde48ef64abc2dd8fed3c442"
+"checksum sortedvec 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a378717ca50d93776db613950bc76fb438644d4cee92a1e701981282b05d650c"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum superslice 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b50b13d42370e0f5fc62eafdd5c2d20065eaf5458dab215ff3e20e63eea96b30"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,6 +727,7 @@ dependencies = [
  "relative-path 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "salsa 0.10.0-alpha1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sortedvec 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "test_utils 0.1.0",
 ]
 
@@ -1212,6 +1213,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "sortedvec"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1705,6 +1711,7 @@ dependencies = [
 "checksum slug 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b3bc762e6a4b6c6fcaade73e77f9ebc6991b676f88bb2358bddb56560f073373"
 "checksum smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b73ea3738b47563803ef814925e69be00799a8c07420be8b996f8e98fb2336db"
 "checksum smol_str 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9af1035bc5d742ab6b7ab16713e41cc2ffe78cb474f6f43cd696b2d16052007e"
+"checksum sortedvec 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "33fd996bf5673d05c9056c51b8b34dbd85266a3ccde48ef64abc2dd8fed3c442"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum superslice 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b50b13d42370e0f5fc62eafdd5c2d20065eaf5458dab215ff3e20e63eea96b30"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,6 +747,7 @@ dependencies = [
  "ra_syntax 0.1.0",
  "relative-path 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sortedvec 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "test_utils 0.1.0",
 ]
 

--- a/crates/ra_db/Cargo.toml
+++ b/crates/ra_db/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 
 [dependencies]
+sortedvec = "0.3"
 relative-path = "0.4.0"
 salsa = "0.10.0-alpha1"
 rustc-hash = "1.0"

--- a/crates/ra_db/Cargo.toml
+++ b/crates/ra_db/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 
 [dependencies]
-sortedvec = "0.3"
+sortedvec = "0.4"
 relative-path = "0.4.0"
 salsa = "0.10.0-alpha1"
 rustc-hash = "1.0"

--- a/crates/ra_db/src/mock.rs
+++ b/crates/ra_db/src/mock.rs
@@ -1,30 +1,31 @@
 use rustc_hash::FxHashSet;
-use relative_path::{RelativePath, RelativePathBuf};
+use sortedvec::def_sorted_vec;
+use relative_path::RelativePathBuf;
 
-use crate::{FileId};
+use crate::FileId;
 
-#[derive(Default, Debug, Clone)]
-pub struct FileMap(Vec<(FileId, RelativePathBuf)>);
+fn key_deriv(v: &(FileId, RelativePathBuf)) -> &str {
+    v.1.as_relative_path().as_str()
+}
+
+def_sorted_vec! {
+    #[derive(Debug, Clone)]
+    pub struct FileMap: (FileId, RelativePathBuf) => &str, key_deriv
+}
 
 impl FileMap {
     pub fn add(&mut self, path: RelativePathBuf) -> FileId {
-        let file_id = FileId((self.0.len() + 1) as u32);
-        self.0.push((file_id, path));
+        let file_id = FileId((self.len() + 1) as u32);
+        self.insert((file_id, path));
         file_id
     }
 
     pub fn files(&self) -> FxHashSet<FileId> {
-        self.iter().map(|(id, _)| id).collect()
+        self.iter().map(|&(id, _)| id).collect()
     }
 
     pub fn file_id(&self, path: &str) -> FileId {
         assert!(path.starts_with('/'));
-        self.iter().find(|(_, p)| p == &path[1..]).unwrap().0
-    }
-
-    fn iter<'a>(&'a self) -> impl Iterator<Item = (FileId, &'a RelativePath)> + 'a {
-        self.0
-            .iter()
-            .map(|(id, path)| (*id, path.as_relative_path()))
+        self.find(&&path[1..]).unwrap().0
     }
 }

--- a/crates/ra_db/src/mock.rs
+++ b/crates/ra_db/src/mock.rs
@@ -1,16 +1,16 @@
 use rustc_hash::FxHashSet;
-use sortedvec::def_sorted_vec;
+use sortedvec::sortedvec;
 use relative_path::RelativePathBuf;
 
 use crate::FileId;
 
-fn key_deriv(v: &(FileId, RelativePathBuf)) -> &str {
-    v.1.as_relative_path().as_str()
-}
-
-def_sorted_vec! {
+sortedvec! {
     #[derive(Debug, Clone)]
-    pub struct FileMap: (FileId, RelativePathBuf) => &str, key_deriv
+    pub struct FileMap {
+        fn key_deriv(v: &(FileId, RelativePathBuf)) -> &str {
+            v.1.as_relative_path().as_str()
+        }
+    }
 }
 
 impl FileMap {

--- a/crates/ra_hir/Cargo.toml
+++ b/crates/ra_hir/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 
 [dependencies]
+sortedvec = "0.3"
 arrayvec = "0.4.10"
 log = "0.4.5"
 relative-path = "0.4.0"

--- a/crates/ra_hir/Cargo.toml
+++ b/crates/ra_hir/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 
 [dependencies]
-sortedvec = "0.3"
+sortedvec = "0.4"
 arrayvec = "0.4.10"
 log = "0.4.5"
 relative-path = "0.4.0"

--- a/crates/ra_hir/src/adt.rs
+++ b/crates/ra_hir/src/adt.rs
@@ -163,11 +163,20 @@ pub struct StructField {
     pub(crate) type_ref: TypeRef,
 }
 
+fn structfield_key_deriv(v: &StructField) -> &str {
+    v.name.as_str()
+}
+
+def_sorted_vec! {
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct StructFieldVec: StructField => &str, structfield_key_deriv
+}
+
 /// Fields of an enum variant or struct
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VariantData {
-    Struct(Vec<StructField>),
-    Tuple(Vec<StructField>),
+    Struct(StructFieldVec),
+    Tuple(StructFieldVec),
     Unit,
 }
 
@@ -230,9 +239,11 @@ impl VariantData {
     }
 
     pub(crate) fn get_field_type_ref(&self, field_name: &Name) -> Option<&TypeRef> {
-        self.fields()
-            .iter()
-            .find(|f| f.name == *field_name)
-            .map(|f| &f.type_ref)
+        match self {
+            VariantData::Struct(fields) | VariantData::Tuple(fields) => {
+                fields.find(&field_name.as_str()).map(|f| &f.type_ref)
+            }
+            _ => None,
+        }
     }
 }

--- a/crates/ra_hir/src/adt.rs
+++ b/crates/ra_hir/src/adt.rs
@@ -1,7 +1,7 @@
 //! This module contains the implementation details of the HIR for ADTs, i.e.
 //! structs and enums (and unions).
 
-use sortedvec::def_sorted_vec;
+use sortedvec::sortedvec;
 use std::sync::Arc;
 
 use ra_syntax::{
@@ -72,13 +72,13 @@ fn get_def_id(
     loc.id(db)
 }
 
-fn variant_key_deriv(v: &(Name, EnumVariant)) -> &str {
-    v.0.as_str()
-}
-
-def_sorted_vec! {
+sortedvec! {
     #[derive(Debug, Clone, PartialEq, Eq)]
-    pub struct VariantVec: (Name, EnumVariant) => &str, variant_key_deriv
+    pub struct VariantVec {
+        fn variant_key_deriv(v: &(Name, EnumVariant)) -> &str {
+            v.0.as_str()
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -163,13 +163,13 @@ pub struct StructField {
     pub(crate) type_ref: TypeRef,
 }
 
-fn structfield_key_deriv(v: &StructField) -> &str {
-    v.name.as_str()
-}
-
-def_sorted_vec! {
+sortedvec! {
     #[derive(Debug, Clone, PartialEq, Eq)]
-    pub struct StructFieldVec: StructField => &str, structfield_key_deriv
+    pub struct StructFieldVec {
+        fn structfield_key_deriv(v: &StructField) -> &str {
+            v.name.as_str()
+        }
+    }
 }
 
 /// Fields of an enum variant or struct

--- a/crates/ra_hir/src/code_model_api.rs
+++ b/crates/ra_hir/src/code_model_api.rs
@@ -11,7 +11,7 @@ use crate::{
     db::HirDatabase,
     expr::BodySyntaxMapping,
     ty::InferenceResult,
-    adt::VariantData,
+    adt::{VariantData, VariantVec},
     generics::GenericParams,
     code_model_impl::def_id_to_ast,
 };
@@ -226,7 +226,7 @@ impl Enum {
         db.enum_data(self.def_id).name.clone()
     }
 
-    pub fn variants(&self, db: &impl HirDatabase) -> Vec<(Name, EnumVariant)> {
+    pub fn variants(&self, db: &impl HirDatabase) -> VariantVec {
         db.enum_data(self.def_id).variants.clone()
     }
 

--- a/crates/ra_hir/src/code_model_impl/module.rs
+++ b/crates/ra_hir/src/code_model_impl/module.rs
@@ -174,10 +174,8 @@ impl Module {
                 }
                 Def::Enum(e) => {
                     // enum variant
-                    let matching_variant = e
-                        .variants(db)
-                        .into_iter()
-                        .find(|(n, _variant)| n == &segment.name);
+                    let variants = e.variants(db);
+                    let matching_variant = variants.find(&segment.name.as_str());
 
                     match matching_variant {
                         Some((_n, variant)) => PerNs::both(variant.def_id(), e.def_id()),

--- a/crates/ra_hir/src/name.rs
+++ b/crates/ra_hir/src/name.rs
@@ -27,6 +27,10 @@ impl Name {
         Name { text }
     }
 
+    pub(crate) fn as_str(&self) -> &str {
+        self.text.as_str()
+    }
+
     pub(crate) fn missing() -> Name {
         Name::new("[missing name]".into())
     }

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__reference_completion.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__reference_completion.snap
@@ -7,7 +7,7 @@ source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
 [
     CompletionItem {
         completion_kind: Reference,
-        label: "Foo",
+        label: "Bar",
         kind: Some(
             EnumVariant
         ),
@@ -21,7 +21,7 @@ source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
     },
     CompletionItem {
         completion_kind: Reference,
-        label: "Bar",
+        label: "Foo",
         kind: Some(
             EnumVariant
         ),


### PR DESCRIPTION
Inspired by [@matklad's comment here](https://github.com/rust-analyzer/rust-analyzer/pull/470#discussion_r246743680). The idea is to introduce a wrapper around `Vec<T>` which maintains an order invariant which allows for much speedier lookups than regular vectors.

Based on the [sortedvec](https://crates.io/crates/sortedvec) crate.

There's lots more places where we could use this, but wanted to see how well this works first.

Very grateful for any feedback as always! 