### PR TITLE
Use npm ci instead of install

### DIFF
--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -150,10 +150,10 @@ fn existing_tests(dir: &Path, ok: bool) -> Result<HashMap<String, (PathBuf, Test
 fn install_code_extension() -> Result<()> {
     run("cargo install --path crates/ra_lsp_server --force", ".")?;
     if cfg!(windows) {
-        run(r"cmd.exe /c npm.cmd install", "./editors/code")?;
+        run(r"cmd.exe /c npm.cmd ci", "./editors/code")?;
         run(r"cmd.exe /c npm.cmd run package", "./editors/code")?;
     } else {
-        run(r"npm install", "./editors/code")?;
+        run(r"npm ci", "./editors/code")?;
         run(r"npm run package", "./editors/code")?;
     }
     if cfg!(windows) {


### PR DESCRIPTION
fix #422

`npm install` is always recreate `package-lock.json`.
So we might use `npm ci` with `install-code`

https://docs.npmjs.com/cli/ci.html#description