### PR TITLE
WIP: module id is not def id

### DIFF
--- a/crates/ra_db/src/input.rs
+++ b/crates/ra_db/src/input.rs
@@ -160,6 +160,7 @@ pub trait FilesDatabase: salsa::Database {
     /// Contents of the source root.
     #[salsa::input]
     fn source_root(&self, id: SourceRootId) -> Arc<SourceRoot>;
+    fn source_root_crates(&self, id: SourceRootId) -> Arc<Vec<CrateId>>;
     /// The set of "local" (that is, from the current workspace) roots.
     /// Files in local roots are assumed to change frequently.
     #[salsa::input]
@@ -171,6 +172,17 @@ pub trait FilesDatabase: salsa::Database {
     /// The crate graph.
     #[salsa::input]
     fn crate_graph(&self) -> Arc<CrateGraph>;
+}
+
+fn source_root_crates(db: &impl FilesDatabase, id: SourceRootId) -> Arc<Vec<CrateId>> {
+    let root = db.source_root(id);
+    let graph = db.crate_graph();
+    let res = root
+        .files
+        .values()
+        .filter_map(|&it| graph.crate_id_for_crate_root(it))
+        .collect::<Vec<_>>();
+    Arc::new(res)
 }
 
 #[cfg(test)]

--- a/crates/ra_db/src/lib.rs
+++ b/crates/ra_db/src/lib.rs
@@ -13,7 +13,7 @@ pub use crate::{
     cancellation::Canceled,
     input::{
         FilesDatabase, FileId, CrateId, SourceRoot, SourceRootId, CrateGraph, Dependency,
-        FileTextQuery, FileSourceRootQuery, SourceRootQuery, LocalRootsQuery, LibraryRootsQuery, CrateGraphQuery,
+        FileTextQuery, FileSourceRootQuery, SourceRootQuery, SourceRootCratesQuery, LocalRootsQuery, LibraryRootsQuery, CrateGraphQuery,
         FileRelativePathQuery
     },
     loc2id::LocationIntener,

--- a/crates/ra_hir/src/adt.rs
+++ b/crates/ra_hir/src/adt.rs
@@ -13,7 +13,7 @@ use crate::{
     HirDatabase, DefKind,
     SourceItemId,
     type_ref::TypeRef,
-    ids::{StructLoc, EnumLoc},
+    ids::ItemLoc,
 };
 
 impl Struct {
@@ -23,8 +23,8 @@ impl Struct {
         file_id: HirFileId,
         ast: &ast::StructDef,
     ) -> Struct {
-        let loc: StructLoc = StructLoc::from_ast(db, module, file_id, ast);
-        let id = loc.id(db);
+        let loc = ItemLoc::from_ast(db, module, file_id, ast);
+        let id = db.as_ref().structs.loc2id(&loc);
         Struct { id }
     }
 
@@ -40,8 +40,8 @@ impl Enum {
         file_id: HirFileId,
         ast: &ast::EnumDef,
     ) -> Enum {
-        let loc: EnumLoc = EnumLoc::from_ast(db, module, file_id, ast);
-        let id = loc.id(db);
+        let loc = ItemLoc::from_ast(db, module, file_id, ast);
+        let id = db.as_ref().enums.loc2id(&loc);
         Enum { id }
     }
 }

--- a/crates/ra_hir/src/adt.rs
+++ b/crates/ra_hir/src/adt.rs
@@ -3,16 +3,31 @@
 
 use std::sync::Arc;
 
-use ra_syntax::{
-    ast::{self, NameOwner, StructFlavor}
-};
+use ra_syntax::ast::{self, NameOwner, StructFlavor};
 
 use crate::{
-    Name, AsName, Struct, Enum, EnumVariant,
+    Name, AsName, Struct, Enum, EnumVariant, Crate,
     HirDatabase,
     type_ref::TypeRef,
     ids::LocationCtx,
 };
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum AdtDef {
+    Struct(Struct),
+    Enum(Enum),
+}
+impl_froms!(AdtDef: Struct, Enum);
+
+impl AdtDef {
+    pub(crate) fn krate(self, db: &impl HirDatabase) -> Option<Crate> {
+        match self {
+            AdtDef::Struct(s) => s.module(db),
+            AdtDef::Enum(e) => e.module(db),
+        }
+        .krate(db)
+    }
+}
 
 impl Struct {
     pub(crate) fn variant_data(&self, db: &impl HirDatabase) -> Arc<VariantData> {

--- a/crates/ra_hir/src/adt.rs
+++ b/crates/ra_hir/src/adt.rs
@@ -64,9 +64,9 @@ fn get_def_id(
         ..same_file_loc.source_item_id
     };
     let loc = DefLoc {
+        module: same_file_loc.module,
         kind: expected_kind,
         source_item_id,
-        ..*same_file_loc
     };
     loc.id(db)
 }

--- a/crates/ra_hir/src/code_model_api.rs
+++ b/crates/ra_hir/src/code_model_api.rs
@@ -5,7 +5,7 @@ use ra_db::{CrateId, FileId};
 use ra_syntax::{ast::self, TreeArc, SyntaxNode};
 
 use crate::{
-    Name, DefId, Path, PerNs, ScopesWithSyntaxMapping, Ty, HirFileId,
+    Name, Path, PerNs, ScopesWithSyntaxMapping, Ty, HirFileId,
     type_ref::TypeRef,
     nameres::{ModuleScope, lower::ImportId},
     db::HirDatabase,
@@ -62,13 +62,12 @@ pub enum ModuleDef {
     Function(Function),
     Struct(Struct),
     Enum(Enum),
+    // Can't be directly declared, but can be imported.
     EnumVariant(EnumVariant),
     Const(Const),
     Static(Static),
     Trait(Trait),
     Type(Type),
-    // Can't be directly declared, but can be imported.
-    Def(DefId),
 }
 impl_froms!(
     ModuleDef: Module,
@@ -81,12 +80,6 @@ impl_froms!(
     Trait,
     Type
 );
-
-impl From<DefId> for ModuleDef {
-    fn from(it: DefId) -> ModuleDef {
-        ModuleDef::Def(it)
-    }
-}
 
 pub enum ModuleSource {
     SourceFile(TreeArc<ast::SourceFile>),

--- a/crates/ra_hir/src/code_model_api.rs
+++ b/crates/ra_hir/src/code_model_api.rs
@@ -16,7 +16,7 @@ use crate::{
     code_model_impl::def_id_to_ast,
     docs::{Documentation, Docs, docs_from_ast},
     module_tree::ModuleId,
-    ids::{FunctionId, StructId, EnumId, EnumVariantId},
+    ids::{FunctionId, StructId, EnumId, EnumVariantId, AstItemDef},
 };
 
 /// hir::Crate describes a single crate. It's the main interface with which
@@ -197,8 +197,12 @@ pub struct Struct {
 }
 
 impl Struct {
+    pub fn source(&self, db: &impl HirDatabase) -> (HirFileId, TreeArc<ast::StructDef>) {
+        self.id.source(db)
+    }
+
     pub fn module(&self, db: &impl HirDatabase) -> Module {
-        self.id.loc(db).module
+        self.id.module(db)
     }
 
     pub fn name(&self, db: &impl HirDatabase) -> Option<Name> {
@@ -215,10 +219,6 @@ impl Struct {
                 name: it.name.clone(),
             })
             .collect()
-    }
-
-    pub fn source(&self, db: &impl HirDatabase) -> (HirFileId, TreeArc<ast::StructDef>) {
-        self.id.loc(db).source(db)
     }
 
     pub fn generic_params(&self, db: &impl HirDatabase) -> Arc<GenericParams> {
@@ -238,8 +238,12 @@ pub struct Enum {
 }
 
 impl Enum {
+    pub fn source(&self, db: &impl HirDatabase) -> (HirFileId, TreeArc<ast::EnumDef>) {
+        self.id.source(db)
+    }
+
     pub fn module(&self, db: &impl HirDatabase) -> Module {
-        self.id.loc(db).module
+        self.id.module(db)
     }
 
     pub fn name(&self, db: &impl HirDatabase) -> Option<Name> {
@@ -248,10 +252,6 @@ impl Enum {
 
     pub fn variants(&self, db: &impl HirDatabase) -> Vec<(Name, EnumVariant)> {
         db.enum_data(*self).variants.clone()
-    }
-
-    pub fn source(&self, db: &impl HirDatabase) -> (HirFileId, TreeArc<ast::EnumDef>) {
-        self.id.loc(db).source(db)
     }
 
     pub fn generic_params(&self, db: &impl HirDatabase) -> Arc<GenericParams> {
@@ -271,8 +271,11 @@ pub struct EnumVariant {
 }
 
 impl EnumVariant {
+    pub fn source(&self, db: &impl HirDatabase) -> (HirFileId, TreeArc<ast::EnumVariant>) {
+        self.id.source(db)
+    }
     pub fn module(&self, db: &impl HirDatabase) -> Module {
-        self.id.loc(db).module
+        self.id.module(db)
     }
     pub fn parent_enum(&self, db: &impl HirDatabase) -> Enum {
         db.enum_variant_data(*self).parent_enum.clone()
@@ -295,10 +298,6 @@ impl EnumVariant {
                 name: it.name.clone(),
             })
             .collect()
-    }
-
-    pub fn source(&self, db: &impl HirDatabase) -> (HirFileId, TreeArc<ast::EnumVariant>) {
-        self.id.loc(db).source(db)
     }
 }
 
@@ -348,7 +347,11 @@ impl FnSignature {
 
 impl Function {
     pub fn source(&self, db: &impl HirDatabase) -> (HirFileId, TreeArc<ast::FnDef>) {
-        self.id.loc(db).source(db)
+        self.id.source(db)
+    }
+
+    pub fn module(&self, db: &impl HirDatabase) -> Module {
+        self.id.module(db)
     }
 
     pub fn body_syntax_mapping(&self, db: &impl HirDatabase) -> Arc<BodySyntaxMapping> {

--- a/crates/ra_hir/src/code_model_api.rs
+++ b/crates/ra_hir/src/code_model_api.rs
@@ -47,8 +47,6 @@ impl Crate {
 
 #[derive(Debug)]
 pub enum Def {
-    Struct(Struct),
-    Enum(Enum),
     EnumVariant(EnumVariant),
     Const(Const),
     Static(Static),

--- a/crates/ra_hir/src/code_model_api.rs
+++ b/crates/ra_hir/src/code_model_api.rs
@@ -16,7 +16,7 @@ use crate::{
     code_model_impl::def_id_to_ast,
     docs::{Documentation, Docs, docs_from_ast},
     module_tree::ModuleId,
-    ids::{FunctionId, StructId, EnumId, EnumVariantId, AstItemDef},
+    ids::{FunctionId, StructId, EnumId, EnumVariantId, AstItemDef, ConstId, StaticId},
 };
 
 /// hir::Crate describes a single crate. It's the main interface with which
@@ -47,8 +47,6 @@ impl Crate {
 
 #[derive(Debug)]
 pub enum Def {
-    Const(Const),
-    Static(Static),
     Trait(Trait),
     Type(Type),
     Item,
@@ -67,11 +65,21 @@ pub enum ModuleDef {
     Function(Function),
     Struct(Struct),
     Enum(Enum),
-    // Can't be directly declared, but can be imported.
     EnumVariant(EnumVariant),
+    Const(Const),
+    Static(Static),
+    // Can't be directly declared, but can be imported.
     Def(DefId),
 }
-impl_froms!(ModuleDef: Module, Function, Struct, Enum, EnumVariant);
+impl_froms!(
+    ModuleDef: Module,
+    Function,
+    Struct,
+    Enum,
+    EnumVariant,
+    Const,
+    Static
+);
 
 impl From<DefId> for ModuleDef {
     fn from(it: DefId) -> ModuleDef {
@@ -386,18 +394,14 @@ impl Docs for Function {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Const {
-    pub(crate) def_id: DefId,
+    pub(crate) id: ConstId,
 }
 
 impl Const {
-    pub(crate) fn new(def_id: DefId) -> Const {
-        Const { def_id }
-    }
-
     pub fn source(&self, db: &impl HirDatabase) -> (HirFileId, TreeArc<ast::ConstDef>) {
-        def_id_to_ast(db, self.def_id)
+        self.id.source(db)
     }
 }
 
@@ -407,18 +411,14 @@ impl Docs for Const {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Static {
-    pub(crate) def_id: DefId,
+    pub(crate) id: StaticId,
 }
 
 impl Static {
-    pub(crate) fn new(def_id: DefId) -> Static {
-        Static { def_id }
-    }
-
     pub fn source(&self, db: &impl HirDatabase) -> (HirFileId, TreeArc<ast::StaticDef>) {
-        def_id_to_ast(db, self.def_id)
+        self.id.source(db)
     }
 }
 

--- a/crates/ra_hir/src/code_model_api.rs
+++ b/crates/ra_hir/src/code_model_api.rs
@@ -70,30 +70,7 @@ pub enum ModuleDef {
     Enum(Enum),
     Def(DefId),
 }
-//FIXME: change to from
-impl From<Module> for ModuleDef {
-    fn from(it: Module) -> ModuleDef {
-        ModuleDef::Module(it)
-    }
-}
-
-impl From<Function> for ModuleDef {
-    fn from(it: Function) -> ModuleDef {
-        ModuleDef::Function(it)
-    }
-}
-
-impl From<Struct> for ModuleDef {
-    fn from(it: Struct) -> ModuleDef {
-        ModuleDef::Struct(it)
-    }
-}
-
-impl From<Enum> for ModuleDef {
-    fn from(it: Enum) -> ModuleDef {
-        ModuleDef::Enum(it)
-    }
-}
+impl_froms!(ModuleDef: Module, Function, Struct, Enum);
 
 impl From<DefId> for ModuleDef {
     fn from(it: DefId) -> ModuleDef {

--- a/crates/ra_hir/src/code_model_api.rs
+++ b/crates/ra_hir/src/code_model_api.rs
@@ -47,7 +47,6 @@ impl Crate {
 
 #[derive(Debug)]
 pub enum Def {
-    EnumVariant(EnumVariant),
     Const(Const),
     Static(Static),
     Trait(Trait),

--- a/crates/ra_hir/src/code_model_impl.rs
+++ b/crates/ra_hir/src/code_model_impl.rs
@@ -1,18 +1,3 @@
 mod krate; // `crate` is invalid ident :(
 mod module;
 pub(crate) mod function;
-
-use ra_syntax::{AstNode, TreeArc};
-
-use crate::{HirDatabase, DefId, HirFileId};
-
-pub(crate) fn def_id_to_ast<N: AstNode>(
-    db: &impl HirDatabase,
-    def_id: DefId,
-) -> (HirFileId, TreeArc<N>) {
-    let (file_id, syntax) = def_id.source(db);
-    let ast = N::cast(&syntax)
-        .unwrap_or_else(|| panic!("def points to wrong source {:?} {:?}", def_id, syntax))
-        .to_owned();
-    (file_id, ast)
-}

--- a/crates/ra_hir/src/code_model_impl/function.rs
+++ b/crates/ra_hir/src/code_model_impl/function.rs
@@ -9,7 +9,7 @@ use crate::{
     type_ref::{TypeRef, Mutability},
     expr::Body,
     impl_block::ImplBlock,
-    ids::FunctionLoc,
+    ids::ItemLoc,
 };
 
 pub use self::scope::{FnScopes, ScopesWithSyntaxMapping, ScopeEntryWithSyntax};
@@ -21,8 +21,8 @@ impl Function {
         file_id: HirFileId,
         ast: &ast::FnDef,
     ) -> Function {
-        let loc: FunctionLoc = FunctionLoc::from_ast(db, module, file_id, ast);
-        let id = loc.id(db);
+        let loc = ItemLoc::from_ast(db, module, file_id, ast);
+        let id = db.as_ref().fns.loc2id(&loc);
         Function { id }
     }
 

--- a/crates/ra_hir/src/code_model_impl/function.rs
+++ b/crates/ra_hir/src/code_model_impl/function.rs
@@ -30,10 +30,6 @@ impl Function {
         db.body_hir(*self)
     }
 
-    pub(crate) fn module(&self, db: &impl HirDatabase) -> Module {
-        self.id.loc(db).module
-    }
-
     /// The containing impl block, if this is a method.
     pub(crate) fn impl_block(&self, db: &impl HirDatabase) -> Option<ImplBlock> {
         let module_impls = db.impls_in_module(self.module(db));

--- a/crates/ra_hir/src/code_model_impl/function.rs
+++ b/crates/ra_hir/src/code_model_impl/function.rs
@@ -5,27 +5,15 @@ use std::sync::Arc;
 use ra_syntax::ast::{self, NameOwner};
 
 use crate::{
-    HirDatabase, Name, AsName, Function, FnSignature, Module, HirFileId,
+    HirDatabase, Name, AsName, Function, FnSignature,
     type_ref::{TypeRef, Mutability},
     expr::Body,
     impl_block::ImplBlock,
-    ids::ItemLoc,
 };
 
 pub use self::scope::{FnScopes, ScopesWithSyntaxMapping, ScopeEntryWithSyntax};
 
 impl Function {
-    pub(crate) fn from_ast(
-        db: &impl HirDatabase,
-        module: Module,
-        file_id: HirFileId,
-        ast: &ast::FnDef,
-    ) -> Function {
-        let loc = ItemLoc::from_ast(db, module, file_id, ast);
-        let id = db.as_ref().fns.loc2id(&loc);
-        Function { id }
-    }
-
     pub(crate) fn body(&self, db: &impl HirDatabase) -> Arc<Body> {
         db.body_hir(*self)
     }

--- a/crates/ra_hir/src/code_model_impl/function.rs
+++ b/crates/ra_hir/src/code_model_impl/function.rs
@@ -2,41 +2,48 @@ mod scope;
 
 use std::sync::Arc;
 
-use ra_syntax::{TreeArc, ast::{self, NameOwner}};
+use ra_syntax::ast::{self, NameOwner};
 
 use crate::{
-    DefId, HirDatabase, Name, AsName, Function, FnSignature, Module,
+    HirDatabase, Name, AsName, Function, FnSignature, Module, HirFileId,
     type_ref::{TypeRef, Mutability},
     expr::Body,
     impl_block::ImplBlock,
-    code_model_impl::def_id_to_ast,
+    ids::FunctionLoc,
 };
 
 pub use self::scope::{FnScopes, ScopesWithSyntaxMapping, ScopeEntryWithSyntax};
 
 impl Function {
-    pub(crate) fn new(def_id: DefId) -> Function {
-        Function { def_id }
+    pub(crate) fn from_ast(
+        db: &impl HirDatabase,
+        module: Module,
+        file_id: HirFileId,
+        ast: &ast::FnDef,
+    ) -> Function {
+        let loc: FunctionLoc = FunctionLoc::from_ast(db, module, file_id, ast);
+        let id = loc.id(db);
+        Function { id }
     }
 
     pub(crate) fn body(&self, db: &impl HirDatabase) -> Arc<Body> {
-        db.body_hir(self.def_id)
+        db.body_hir(*self)
     }
 
     pub(crate) fn module(&self, db: &impl HirDatabase) -> Module {
-        self.def_id.module(db)
+        self.id.loc(db).module
     }
 
     /// The containing impl block, if this is a method.
     pub(crate) fn impl_block(&self, db: &impl HirDatabase) -> Option<ImplBlock> {
-        self.def_id.impl_block(db)
+        let module_impls = db.impls_in_module(self.module(db));
+        ImplBlock::containing(module_impls, (*self).into())
     }
 }
 
 impl FnSignature {
-    pub(crate) fn fn_signature_query(db: &impl HirDatabase, def_id: DefId) -> Arc<FnSignature> {
-        // FIXME: we're using def_id_to_ast here to avoid returning Cancelable... this is a bit hacky
-        let node: TreeArc<ast::FnDef> = def_id_to_ast(db, def_id).1;
+    pub(crate) fn fn_signature_query(db: &impl HirDatabase, func: Function) -> Arc<FnSignature> {
+        let (_, node) = func.source(db);
         let name = node
             .name()
             .map(|n| n.as_name())

--- a/crates/ra_hir/src/code_model_impl/krate.rs
+++ b/crates/ra_hir/src/code_model_impl/krate.rs
@@ -1,7 +1,7 @@
 use ra_db::CrateId;
 
 use crate::{
-    HirFileId, Crate, CrateDependency, AsName, DefLoc, DefKind, Module, SourceItemId,
+    Crate, CrateDependency, AsName, Module,
     db::HirDatabase,
 };
 
@@ -21,27 +21,13 @@ impl Crate {
             .collect()
     }
     pub(crate) fn root_module_impl(&self, db: &impl HirDatabase) -> Option<Module> {
-        let crate_graph = db.crate_graph();
-        let file_id = crate_graph.crate_root(self.crate_id);
-        let source_root_id = db.file_source_root(file_id);
-        let file_id = HirFileId::from(file_id);
-        let module_tree = db.module_tree(source_root_id);
-        // FIXME: teach module tree about crate roots instead of guessing
-        let source = SourceItemId {
-            file_id,
-            item_id: None,
-        };
-        let module_id = module_tree.find_module_by_source(source)?;
+        let module_tree = db.module_tree(self.crate_id);
+        let module_id = module_tree.modules().next()?;
 
-        let def_loc = DefLoc {
-            kind: DefKind::Module,
-            source_root_id,
+        let module = Module {
+            krate: self.crate_id,
             module_id,
-            source_item_id: module_id.source(&module_tree),
         };
-        let def_id = def_loc.id(db);
-
-        let module = Module::new(def_id);
         Some(module)
     }
 }

--- a/crates/ra_hir/src/code_model_impl/module.rs
+++ b/crates/ra_hir/src/code_model_impl/module.rs
@@ -135,7 +135,7 @@ impl Module {
                         None => PerNs::none(),
                     }
                 }
-                ModuleDef::Function(_) => PerNs::none(),
+                ModuleDef::Function(_) | ModuleDef::Struct(_) => PerNs::none(),
                 ModuleDef::Def(def) => {
                     match def.resolve(db) {
                         Def::Enum(e) => {

--- a/crates/ra_hir/src/code_model_impl/module.rs
+++ b/crates/ra_hir/src/code_model_impl/module.rs
@@ -143,11 +143,11 @@ impl Module {
                         .find(|(n, _variant)| n == &segment.name);
 
                     match matching_variant {
-                        Some((_n, variant)) => PerNs::both(variant.def_id().into(), (*e).into()),
+                        Some((_n, variant)) => PerNs::both(variant.into(), (*e).into()),
                         None => PerNs::none(),
                     }
                 }
-                ModuleDef::Function(_) | ModuleDef::Struct(_) => {
+                ModuleDef::Function(_) | ModuleDef::Struct(_) | ModuleDef::EnumVariant(_) => {
                     // could be an inherent method call in UFCS form
                     // (`Struct::method`), or some other kind of associated
                     // item... Which we currently don't handle (TODO)

--- a/crates/ra_hir/src/code_model_impl/module.rs
+++ b/crates/ra_hir/src/code_model_impl/module.rs
@@ -147,7 +147,11 @@ impl Module {
                         None => PerNs::none(),
                     }
                 }
-                ModuleDef::Function(_) | ModuleDef::Struct(_) | ModuleDef::EnumVariant(_) => {
+                ModuleDef::Function(_)
+                | ModuleDef::Struct(_)
+                | ModuleDef::Const(_)
+                | ModuleDef::Static(_)
+                | ModuleDef::EnumVariant(_) => {
                     // could be an inherent method call in UFCS form
                     // (`Struct::method`), or some other kind of associated
                     // item... Which we currently don't handle (TODO)

--- a/crates/ra_hir/src/code_model_impl/module.rs
+++ b/crates/ra_hir/src/code_model_impl/module.rs
@@ -135,6 +135,7 @@ impl Module {
                         None => PerNs::none(),
                     }
                 }
+                ModuleDef::Function(_) => PerNs::none(),
                 ModuleDef::Def(def) => {
                     match def.resolve(db) {
                         Def::Enum(e) => {

--- a/crates/ra_hir/src/code_model_impl/module.rs
+++ b/crates/ra_hir/src/code_model_impl/module.rs
@@ -147,17 +147,12 @@ impl Module {
                         None => PerNs::none(),
                     }
                 }
-                ModuleDef::Function(_)
-                | ModuleDef::Struct(_)
-                | ModuleDef::Const(_)
-                | ModuleDef::Static(_)
-                | ModuleDef::EnumVariant(_) => {
+                _ => {
                     // could be an inherent method call in UFCS form
                     // (`Struct::method`), or some other kind of associated
                     // item... Which we currently don't handle (TODO)
                     PerNs::none()
                 }
-                ModuleDef::Def(_) => PerNs::none(),
             };
         }
         curr_per_ns

--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -8,7 +8,7 @@ use crate::{
     SourceFileItems, SourceItemId, Crate, Module, HirInterner,
     query_definitions,
     Function, FnSignature, FnScopes,
-    Struct,
+    Struct, Enum,
     macros::MacroExpansion,
     module_tree::ModuleTree,
     nameres::{ItemMap, lower::{LoweredModule, ImportSourceMap}},
@@ -30,10 +30,10 @@ pub trait HirDatabase: SyntaxDatabase + AsRef<HirInterner> {
     fn fn_scopes(&self, func: Function) -> Arc<FnScopes>;
 
     #[salsa::invoke(crate::adt::StructData::struct_data_query)]
-    fn struct_data(&self, struct_: Struct) -> Arc<StructData>;
+    fn struct_data(&self, s: Struct) -> Arc<StructData>;
 
     #[salsa::invoke(crate::adt::EnumData::enum_data_query)]
-    fn enum_data(&self, def_id: DefId) -> Arc<EnumData>;
+    fn enum_data(&self, e: Enum) -> Arc<EnumData>;
 
     #[salsa::invoke(crate::adt::EnumVariantData::enum_variant_data_query)]
     fn enum_variant_data(&self, def_id: DefId) -> Arc<EnumVariantData>;

--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -7,14 +7,14 @@ use crate::{
     DefId, MacroCallId, Name, HirFileId,
     SourceFileItems, SourceItemId, Crate, Module, HirInterner,
     query_definitions,
-    FnSignature, FnScopes,
+    Function, FnSignature, FnScopes,
     macros::MacroExpansion,
     module_tree::ModuleTree,
     nameres::{ItemMap, lower::{LoweredModule, ImportSourceMap}},
-    ty::{InferenceResult, Ty, method_resolution::CrateImplBlocks},
+    ty::{InferenceResult, Ty, method_resolution::CrateImplBlocks, TypableDef},
     adt::{StructData, EnumData, EnumVariantData},
     impl_block::ModuleImplBlocks,
-    generics::GenericParams,
+    generics::{GenericParams, GenericDef},
 };
 
 #[salsa::query_group]
@@ -26,7 +26,7 @@ pub trait HirDatabase: SyntaxDatabase + AsRef<HirInterner> {
     fn expand_macro_invocation(&self, invoc: MacroCallId) -> Option<Arc<MacroExpansion>>;
 
     #[salsa::invoke(query_definitions::fn_scopes)]
-    fn fn_scopes(&self, def_id: DefId) -> Arc<FnScopes>;
+    fn fn_scopes(&self, func: Function) -> Arc<FnScopes>;
 
     #[salsa::invoke(crate::adt::StructData::struct_data_query)]
     fn struct_data(&self, def_id: DefId) -> Arc<StructData>;
@@ -38,10 +38,10 @@ pub trait HirDatabase: SyntaxDatabase + AsRef<HirInterner> {
     fn enum_variant_data(&self, def_id: DefId) -> Arc<EnumVariantData>;
 
     #[salsa::invoke(crate::ty::infer)]
-    fn infer(&self, def_id: DefId) -> Arc<InferenceResult>;
+    fn infer(&self, func: Function) -> Arc<InferenceResult>;
 
     #[salsa::invoke(crate::ty::type_for_def)]
-    fn type_for_def(&self, def_id: DefId) -> Ty;
+    fn type_for_def(&self, def: TypableDef) -> Ty;
 
     #[salsa::invoke(crate::ty::type_for_field)]
     fn type_for_field(&self, def_id: DefId, field: Name) -> Option<Ty>;
@@ -77,14 +77,14 @@ pub trait HirDatabase: SyntaxDatabase + AsRef<HirInterner> {
     fn impls_in_crate(&self, krate: Crate) -> Arc<CrateImplBlocks>;
 
     #[salsa::invoke(crate::expr::body_hir)]
-    fn body_hir(&self, def_id: DefId) -> Arc<crate::expr::Body>;
+    fn body_hir(&self, func: Function) -> Arc<crate::expr::Body>;
 
     #[salsa::invoke(crate::expr::body_syntax_mapping)]
-    fn body_syntax_mapping(&self, def_id: DefId) -> Arc<crate::expr::BodySyntaxMapping>;
+    fn body_syntax_mapping(&self, func: Function) -> Arc<crate::expr::BodySyntaxMapping>;
 
     #[salsa::invoke(crate::generics::GenericParams::generic_params_query)]
-    fn generic_params(&self, def_id: DefId) -> Arc<GenericParams>;
+    fn generic_params(&self, def: GenericDef) -> Arc<GenericParams>;
 
     #[salsa::invoke(crate::FnSignature::fn_signature_query)]
-    fn fn_signature(&self, def_id: DefId) -> Arc<FnSignature>;
+    fn fn_signature(&self, func: Function) -> Arc<FnSignature>;
 }

--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -4,11 +4,11 @@ use ra_syntax::{SyntaxNode, TreeArc, SourceFile};
 use ra_db::{SyntaxDatabase, CrateId, salsa};
 
 use crate::{
-    DefId, MacroCallId, Name, HirFileId,
+    MacroCallId, Name, HirFileId,
     SourceFileItems, SourceItemId, Crate, Module, HirInterner,
     query_definitions,
     Function, FnSignature, FnScopes,
-    Struct, Enum,
+    Struct, Enum, EnumVariant,
     macros::MacroExpansion,
     module_tree::ModuleTree,
     nameres::{ItemMap, lower::{LoweredModule, ImportSourceMap}},
@@ -36,7 +36,7 @@ pub trait HirDatabase: SyntaxDatabase + AsRef<HirInterner> {
     fn enum_data(&self, e: Enum) -> Arc<EnumData>;
 
     #[salsa::invoke(crate::adt::EnumVariantData::enum_variant_data_query)]
-    fn enum_variant_data(&self, def_id: DefId) -> Arc<EnumVariantData>;
+    fn enum_variant_data(&self, var: EnumVariant) -> Arc<EnumVariantData>;
 
     #[salsa::invoke(crate::ty::infer)]
     fn infer(&self, func: Function) -> Arc<InferenceResult>;

--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -8,10 +8,11 @@ use crate::{
     SourceFileItems, SourceItemId, Crate, Module, HirInterner,
     query_definitions,
     Function, FnSignature, FnScopes,
+    Struct,
     macros::MacroExpansion,
     module_tree::ModuleTree,
     nameres::{ItemMap, lower::{LoweredModule, ImportSourceMap}},
-    ty::{InferenceResult, Ty, method_resolution::CrateImplBlocks, TypableDef},
+    ty::{InferenceResult, Ty, method_resolution::CrateImplBlocks, TypableDef, VariantDef},
     adt::{StructData, EnumData, EnumVariantData},
     impl_block::ModuleImplBlocks,
     generics::{GenericParams, GenericDef},
@@ -29,7 +30,7 @@ pub trait HirDatabase: SyntaxDatabase + AsRef<HirInterner> {
     fn fn_scopes(&self, func: Function) -> Arc<FnScopes>;
 
     #[salsa::invoke(crate::adt::StructData::struct_data_query)]
-    fn struct_data(&self, def_id: DefId) -> Arc<StructData>;
+    fn struct_data(&self, struct_: Struct) -> Arc<StructData>;
 
     #[salsa::invoke(crate::adt::EnumData::enum_data_query)]
     fn enum_data(&self, def_id: DefId) -> Arc<EnumData>;
@@ -44,7 +45,7 @@ pub trait HirDatabase: SyntaxDatabase + AsRef<HirInterner> {
     fn type_for_def(&self, def: TypableDef) -> Ty;
 
     #[salsa::invoke(crate::ty::type_for_field)]
-    fn type_for_field(&self, def_id: DefId, field: Name) -> Option<Ty>;
+    fn type_for_field(&self, def: VariantDef, field: Name) -> Option<Ty>;
 
     #[salsa::invoke(query_definitions::file_items)]
     fn file_items(&self, file_id: HirFileId) -> Arc<SourceFileItems>;

--- a/crates/ra_hir/src/expr.rs
+++ b/crates/ra_hir/src/expr.rs
@@ -9,7 +9,11 @@ use ra_syntax::{
     ast::{self, LoopBodyOwner, ArgListOwner, NameOwner, LiteralFlavor}
 };
 
-use crate::{Path, type_ref::{Mutability, TypeRef}, Name, HirDatabase, DefId, Def, name::AsName};
+use crate::{
+    Path, Name, HirDatabase, Function,
+    name::AsName,
+    type_ref::{Mutability, TypeRef},
+};
 use crate::ty::primitive::{UintTy, UncertainIntTy, UncertainFloatTy};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -435,8 +439,8 @@ impl Pat {
 
 // Queries
 
-pub(crate) fn body_hir(db: &impl HirDatabase, def_id: DefId) -> Arc<Body> {
-    Arc::clone(&body_syntax_mapping(db, def_id).body)
+pub(crate) fn body_hir(db: &impl HirDatabase, func: Function) -> Arc<Body> {
+    Arc::clone(&body_syntax_mapping(db, func).body)
 }
 
 struct ExprCollector {
@@ -955,14 +959,8 @@ pub(crate) fn collect_fn_body_syntax(node: &ast::FnDef) -> BodySyntaxMapping {
     collector.into_body_syntax_mapping(params, body)
 }
 
-pub(crate) fn body_syntax_mapping(db: &impl HirDatabase, def_id: DefId) -> Arc<BodySyntaxMapping> {
-    let def = def_id.resolve(db);
-
-    let body_syntax_mapping = match def {
-        Def::Function(f) => collect_fn_body_syntax(&f.source(db).1),
-        // TODO: consts, etc.
-        _ => panic!("Trying to get body for item type without body"),
-    };
-
+pub(crate) fn body_syntax_mapping(db: &impl HirDatabase, func: Function) -> Arc<BodySyntaxMapping> {
+    let (_, fn_def) = func.source(db);
+    let body_syntax_mapping = collect_fn_body_syntax(&fn_def);
     Arc::new(body_syntax_mapping)
 }

--- a/crates/ra_hir/src/generics.rs
+++ b/crates/ra_hir/src/generics.rs
@@ -5,9 +5,9 @@
 
 use std::sync::Arc;
 
-use ra_syntax::ast::{TypeParamList, AstNode, NameOwner};
+use ra_syntax::ast::{self, AstNode, NameOwner, TypeParamsOwner};
 
-use crate::{db::HirDatabase, DefId, Name, AsName};
+use crate::{db::HirDatabase, DefId, Name, AsName, Function};
 
 /// Data about a generic parameter (to a function, struct, impl, ...).
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -22,24 +22,60 @@ pub struct GenericParams {
     pub(crate) params: Vec<GenericParam>,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+pub enum GenericDef {
+    Function(Function),
+    Def(DefId),
+}
+
+impl From<Function> for GenericDef {
+    fn from(func: Function) -> GenericDef {
+        GenericDef::Function(func)
+    }
+}
+
+impl From<DefId> for GenericDef {
+    fn from(def_id: DefId) -> GenericDef {
+        GenericDef::Def(def_id)
+    }
+}
+
 impl GenericParams {
-    pub(crate) fn generic_params_query(db: &impl HirDatabase, def_id: DefId) -> Arc<GenericParams> {
-        let (_file_id, node) = def_id.source(db);
+    pub(crate) fn generic_params_query(
+        db: &impl HirDatabase,
+        def: GenericDef,
+    ) -> Arc<GenericParams> {
         let mut generics = GenericParams::default();
-        if let Some(type_param_list) = node.children().find_map(TypeParamList::cast) {
-            for (idx, type_param) in type_param_list.type_params().enumerate() {
-                let name = type_param
-                    .name()
-                    .map(AsName::as_name)
-                    .unwrap_or_else(Name::missing);
-                let param = GenericParam {
-                    idx: idx as u32,
-                    name,
-                };
-                generics.params.push(param);
+        match def {
+            GenericDef::Function(func) => {
+                let (_, fn_def) = func.source(db);
+                if let Some(type_param_list) = fn_def.type_param_list() {
+                    generics.fill(type_param_list)
+                }
+            }
+            GenericDef::Def(def_id) => {
+                let (_file_id, node) = def_id.source(db);
+                if let Some(type_param_list) = node.children().find_map(ast::TypeParamList::cast) {
+                    generics.fill(type_param_list)
+                }
             }
         }
+
         Arc::new(generics)
+    }
+
+    fn fill(&mut self, params: &ast::TypeParamList) {
+        for (idx, type_param) in params.type_params().enumerate() {
+            let name = type_param
+                .name()
+                .map(AsName::as_name)
+                .unwrap_or_else(Name::missing);
+            let param = GenericParam {
+                idx: idx as u32,
+                name,
+            };
+            self.params.push(param);
+        }
     }
 
     pub(crate) fn find_by_name(&self, name: &Name) -> Option<&GenericParam> {

--- a/crates/ra_hir/src/generics.rs
+++ b/crates/ra_hir/src/generics.rs
@@ -29,24 +29,7 @@ pub enum GenericDef {
     Enum(Enum),
     Def(DefId),
 }
-
-impl From<Function> for GenericDef {
-    fn from(func: Function) -> GenericDef {
-        GenericDef::Function(func)
-    }
-}
-
-impl From<Struct> for GenericDef {
-    fn from(s: Struct) -> GenericDef {
-        GenericDef::Struct(s)
-    }
-}
-
-impl From<Enum> for GenericDef {
-    fn from(e: Enum) -> GenericDef {
-        GenericDef::Enum(e)
-    }
-}
+impl_froms!(GenericDef: Function, Struct, Enum);
 
 impl From<DefId> for GenericDef {
     fn from(def_id: DefId) -> GenericDef {

--- a/crates/ra_hir/src/generics.rs
+++ b/crates/ra_hir/src/generics.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use ra_syntax::ast::{self, AstNode, NameOwner, TypeParamsOwner};
 
-use crate::{db::HirDatabase, DefId, Name, AsName, Function};
+use crate::{db::HirDatabase, DefId, Name, AsName, Function, Struct};
 
 /// Data about a generic parameter (to a function, struct, impl, ...).
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -25,12 +25,19 @@ pub struct GenericParams {
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 pub enum GenericDef {
     Function(Function),
+    Struct(Struct),
     Def(DefId),
 }
 
 impl From<Function> for GenericDef {
     fn from(func: Function) -> GenericDef {
         GenericDef::Function(func)
+    }
+}
+
+impl From<Struct> for GenericDef {
+    fn from(func: Struct) -> GenericDef {
+        GenericDef::Struct(func)
     }
 }
 
@@ -50,6 +57,12 @@ impl GenericParams {
             GenericDef::Function(func) => {
                 let (_, fn_def) = func.source(db);
                 if let Some(type_param_list) = fn_def.type_param_list() {
+                    generics.fill(type_param_list)
+                }
+            }
+            GenericDef::Struct(s) => {
+                let (_, struct_def) = s.source(db);
+                if let Some(type_param_list) = struct_def.type_param_list() {
                     generics.fill(type_param_list)
                 }
             }

--- a/crates/ra_hir/src/ids.rs
+++ b/crates/ra_hir/src/ids.rs
@@ -5,7 +5,7 @@ use ra_syntax::{TreeArc, SyntaxNode, SourceFile, AstNode, ast};
 use ra_arena::{Arena, RawId, impl_arena_id};
 
 use crate::{
-    HirDatabase, Def, Crate,
+    HirDatabase, Def,
     Module, Trait, Type, Static, Const,
 };
 
@@ -283,16 +283,6 @@ impl DefId {
         let loc = self.loc(db);
         let syntax = db.file_item(loc.source_item_id);
         (loc.source_item_id.file_id, syntax)
-    }
-
-    /// For a module, returns that module; for any other def, returns the containing module.
-    pub fn module(self, db: &impl HirDatabase) -> Module {
-        self.loc(db).module
-    }
-
-    /// Returns the containing crate.
-    pub fn krate(&self, db: &impl HirDatabase) -> Option<Crate> {
-        self.module(db).krate(db)
     }
 }
 

--- a/crates/ra_hir/src/ids.rs
+++ b/crates/ra_hir/src/ids.rs
@@ -8,13 +8,12 @@ use ra_syntax::{TreeArc, SyntaxNode, SourceFile, AstNode, ast};
 use ra_arena::{Arena, RawId, ArenaId, impl_arena_id};
 
 use crate::{
-    HirDatabase, Def,
+    HirDatabase,
     Module,
 };
 
 #[derive(Debug, Default)]
 pub struct HirInterner {
-    defs: LocationIntener<DefLoc, DefId>,
     macros: LocationIntener<MacroCallLoc, MacroCallId>,
     fns: LocationIntener<ItemLoc<ast::FnDef>, FunctionId>,
     structs: LocationIntener<ItemLoc<ast::StructDef>, StructId>,
@@ -28,7 +27,15 @@ pub struct HirInterner {
 
 impl HirInterner {
     pub fn len(&self) -> usize {
-        self.defs.len() + self.macros.len()
+        self.macros.len()
+            + self.fns.len()
+            + self.structs.len()
+            + self.enums.len()
+            + self.enum_variants.len()
+            + self.consts.len()
+            + self.statics.len()
+            + self.traits.len()
+            + self.types.len()
     }
 }
 
@@ -296,33 +303,6 @@ impl_arena_id!(TypeId);
 impl AstItemDef<ast::TypeDef> for TypeId {
     fn interner(interner: &HirInterner) -> &LocationIntener<ItemLoc<ast::TypeDef>, Self> {
         &interner.types
-    }
-}
-
-/// Def's are a core concept of hir. A `Def` is an Item (function, module, etc)
-/// in a specific module.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct DefId(RawId);
-impl_arena_id!(DefId);
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct DefLoc {
-    pub(crate) kind: DefKind,
-    pub(crate) module: Module,
-    pub(crate) source_item_id: SourceItemId,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub(crate) enum DefKind {}
-
-impl DefId {
-    pub(crate) fn loc(self, db: &impl AsRef<HirInterner>) -> DefLoc {
-        db.as_ref().defs.id2loc(self)
-    }
-
-    pub fn resolve(self, db: &impl HirDatabase) -> Def {
-        let loc = self.loc(db);
-        match loc.kind {}
     }
 }
 

--- a/crates/ra_hir/src/ids.rs
+++ b/crates/ra_hir/src/ids.rs
@@ -209,7 +209,6 @@ pub struct DefLoc {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum DefKind {
-    Function,
     Struct,
     Enum,
     EnumVariant,
@@ -239,7 +238,6 @@ impl DefId {
     pub fn resolve(self, db: &impl HirDatabase) -> Def {
         let loc = self.loc(db);
         match loc.kind {
-            DefKind::Function => unreachable!(),
             DefKind::Struct => {
                 let struct_def = Struct::new(self);
                 Def::Struct(struct_def)

--- a/crates/ra_hir/src/ids.rs
+++ b/crates/ra_hir/src/ids.rs
@@ -5,7 +5,7 @@ use ra_syntax::{TreeArc, SyntaxNode, SourceFile, AstNode, ast};
 use ra_arena::{Arena, RawId, impl_arena_id};
 
 use crate::{
-    HirDatabase, Def, Struct, Enum, EnumVariant, Crate,
+    HirDatabase, Def, Enum, EnumVariant, Crate,
     Module, Trait, Type, Static, Const,
 };
 
@@ -257,10 +257,7 @@ impl DefId {
     pub fn resolve(self, db: &impl HirDatabase) -> Def {
         let loc = self.loc(db);
         match loc.kind {
-            DefKind::Struct => {
-                let struct_def = Struct::new(self);
-                Def::Struct(struct_def)
-            }
+            DefKind::Struct => unreachable!(),
             DefKind::Enum => Def::Enum(Enum::new(self)),
             DefKind::EnumVariant => Def::EnumVariant(EnumVariant::new(self)),
             DefKind::Const => {

--- a/crates/ra_hir/src/ids.rs
+++ b/crates/ra_hir/src/ids.rs
@@ -13,9 +13,9 @@ use crate::{
 pub struct HirInterner {
     defs: LocationIntener<DefLoc, DefId>,
     macros: LocationIntener<MacroCallLoc, MacroCallId>,
-    fns: LocationIntener<FunctionLoc, FunctionId>,
-    structs: LocationIntener<StructLoc, StructId>,
-    enums: LocationIntener<EnumLoc, EnumId>,
+    pub(crate) fns: LocationIntener<ItemLoc<ast::FnDef>, FunctionId>,
+    pub(crate) structs: LocationIntener<ItemLoc<ast::StructDef>, StructId>,
+    pub(crate) enums: LocationIntener<ItemLoc<ast::EnumDef>, EnumId>,
 }
 
 impl HirInterner {
@@ -182,17 +182,9 @@ impl<N: AstNode> Clone for ItemLoc<N> {
 pub struct FunctionId(RawId);
 impl_arena_id!(FunctionId);
 
-pub(crate) type FunctionLoc = ItemLoc<ast::FnDef>;
-
 impl FunctionId {
-    pub(crate) fn loc(self, db: &impl AsRef<HirInterner>) -> FunctionLoc {
+    pub(crate) fn loc(self, db: &impl AsRef<HirInterner>) -> ItemLoc<ast::FnDef> {
         db.as_ref().fns.id2loc(self)
-    }
-}
-
-impl FunctionLoc {
-    pub(crate) fn id(&self, db: &impl AsRef<HirInterner>) -> FunctionId {
-        db.as_ref().fns.loc2id(&self)
     }
 }
 
@@ -200,17 +192,9 @@ impl FunctionLoc {
 pub struct StructId(RawId);
 impl_arena_id!(StructId);
 
-pub(crate) type StructLoc = ItemLoc<ast::StructDef>;
-
 impl StructId {
-    pub(crate) fn loc(self, db: &impl AsRef<HirInterner>) -> StructLoc {
+    pub(crate) fn loc(self, db: &impl AsRef<HirInterner>) -> ItemLoc<ast::StructDef> {
         db.as_ref().structs.id2loc(self)
-    }
-}
-
-impl StructLoc {
-    pub(crate) fn id(&self, db: &impl AsRef<HirInterner>) -> StructId {
-        db.as_ref().structs.loc2id(&self)
     }
 }
 
@@ -218,17 +202,9 @@ impl StructLoc {
 pub struct EnumId(RawId);
 impl_arena_id!(EnumId);
 
-pub(crate) type EnumLoc = ItemLoc<ast::EnumDef>;
-
 impl EnumId {
-    pub(crate) fn loc(self, db: &impl AsRef<HirInterner>) -> EnumLoc {
+    pub(crate) fn loc(self, db: &impl AsRef<HirInterner>) -> ItemLoc<ast::EnumDef> {
         db.as_ref().enums.id2loc(self)
-    }
-}
-
-impl EnumLoc {
-    pub(crate) fn id(&self, db: &impl AsRef<HirInterner>) -> EnumId {
-        db.as_ref().enums.loc2id(&self)
     }
 }
 

--- a/crates/ra_hir/src/ids.rs
+++ b/crates/ra_hir/src/ids.rs
@@ -15,6 +15,7 @@ pub struct HirInterner {
     macros: LocationIntener<MacroCallLoc, MacroCallId>,
     fns: LocationIntener<FunctionLoc, FunctionId>,
     structs: LocationIntener<StructLoc, StructId>,
+    enums: LocationIntener<EnumLoc, EnumId>,
 }
 
 impl HirInterner {
@@ -210,6 +211,24 @@ impl StructId {
 impl StructLoc {
     pub(crate) fn id(&self, db: &impl AsRef<HirInterner>) -> StructId {
         db.as_ref().structs.loc2id(&self)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct EnumId(RawId);
+impl_arena_id!(EnumId);
+
+pub(crate) type EnumLoc = ItemLoc<ast::EnumDef>;
+
+impl EnumId {
+    pub(crate) fn loc(self, db: &impl AsRef<HirInterner>) -> EnumLoc {
+        db.as_ref().enums.id2loc(self)
+    }
+}
+
+impl EnumLoc {
+    pub(crate) fn id(&self, db: &impl AsRef<HirInterner>) -> EnumId {
+        db.as_ref().enums.loc2id(&self)
     }
 }
 

--- a/crates/ra_hir/src/ids.rs
+++ b/crates/ra_hir/src/ids.rs
@@ -5,7 +5,7 @@ use ra_syntax::{TreeArc, SyntaxNode, SourceFile, AstNode, ast};
 use ra_arena::{Arena, RawId, impl_arena_id};
 
 use crate::{
-    HirDatabase, Def, Enum, EnumVariant, Crate,
+    HirDatabase, Def, EnumVariant, Crate,
     Module, Trait, Type, Static, Const,
 };
 
@@ -247,25 +247,22 @@ pub struct DefLoc {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum DefKind {
-    Struct,
-    Enum,
     EnumVariant,
     Const,
     Static,
     Trait,
     Type,
     Item,
-
-    /// The constructor of a struct. E.g. if we have `struct Foo(usize)`, the
-    /// name `Foo` needs to resolve to different types depending on whether we
-    /// are in the types or values namespace: As a type, `Foo` of course refers
-    /// to the struct `Foo`; as a value, `Foo` is a callable type with signature
-    /// `(usize) -> Foo`. The cleanest approach to handle this seems to be to
-    /// have different defs in the two namespaces.
-    ///
-    /// rustc does the same; note that it even creates a struct constructor if
-    /// the struct isn't a tuple struct (see `CtorKind::Fictive` in rustc).
-    StructCtor,
+    // /// The constructor of a struct. E.g. if we have `struct Foo(usize)`, the
+    // /// name `Foo` needs to resolve to different types depending on whether we
+    // /// are in the types or values namespace: As a type, `Foo` of course refers
+    // /// to the struct `Foo`; as a value, `Foo` is a callable type with signature
+    // /// `(usize) -> Foo`. The cleanest approach to handle this seems to be to
+    // /// have different defs in the two namespaces.
+    // ///
+    // /// rustc does the same; note that it even creates a struct constructor if
+    // /// the struct isn't a tuple struct (see `CtorKind::Fictive` in rustc).
+    // StructCtor,
 }
 
 impl DefId {
@@ -276,8 +273,6 @@ impl DefId {
     pub fn resolve(self, db: &impl HirDatabase) -> Def {
         let loc = self.loc(db);
         match loc.kind {
-            DefKind::Struct => unreachable!(),
-            DefKind::Enum => Def::Enum(Enum::new(self)),
             DefKind::EnumVariant => Def::EnumVariant(EnumVariant::new(self)),
             DefKind::Const => {
                 let def = Const::new(self);
@@ -295,8 +290,6 @@ impl DefId {
                 let def = Type::new(self);
                 Def::Type(def)
             }
-
-            DefKind::StructCtor => Def::Item,
             DefKind::Item => Def::Item,
         }
     }

--- a/crates/ra_hir/src/ids.rs
+++ b/crates/ra_hir/src/ids.rs
@@ -14,6 +14,7 @@ pub struct HirInterner {
     defs: LocationIntener<DefLoc, DefId>,
     macros: LocationIntener<MacroCallLoc, MacroCallId>,
     fns: LocationIntener<FunctionLoc, FunctionId>,
+    structs: LocationIntener<StructLoc, StructId>,
 }
 
 impl HirInterner {
@@ -191,6 +192,24 @@ impl FunctionId {
 impl FunctionLoc {
     pub(crate) fn id(&self, db: &impl AsRef<HirInterner>) -> FunctionId {
         db.as_ref().fns.loc2id(&self)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct StructId(RawId);
+impl_arena_id!(StructId);
+
+pub(crate) type StructLoc = ItemLoc<ast::StructDef>;
+
+impl StructId {
+    pub(crate) fn loc(self, db: &impl AsRef<HirInterner>) -> StructLoc {
+        db.as_ref().structs.id2loc(self)
+    }
+}
+
+impl StructLoc {
+    pub(crate) fn id(&self, db: &impl AsRef<HirInterner>) -> StructId {
+        db.as_ref().structs.loc2id(&self)
     }
 }
 

--- a/crates/ra_hir/src/ids.rs
+++ b/crates/ra_hir/src/ids.rs
@@ -313,19 +313,7 @@ pub struct DefLoc {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub(crate) enum DefKind {
-    Item,
-    // /// The constructor of a struct. E.g. if we have `struct Foo(usize)`, the
-    // /// name `Foo` needs to resolve to different types depending on whether we
-    // /// are in the types or values namespace: As a type, `Foo` of course refers
-    // /// to the struct `Foo`; as a value, `Foo` is a callable type with signature
-    // /// `(usize) -> Foo`. The cleanest approach to handle this seems to be to
-    // /// have different defs in the two namespaces.
-    // ///
-    // /// rustc does the same; note that it even creates a struct constructor if
-    // /// the struct isn't a tuple struct (see `CtorKind::Fictive` in rustc).
-    // StructCtor,
-}
+pub(crate) enum DefKind {}
 
 impl DefId {
     pub(crate) fn loc(self, db: &impl AsRef<HirInterner>) -> DefLoc {
@@ -334,15 +322,7 @@ impl DefId {
 
     pub fn resolve(self, db: &impl HirDatabase) -> Def {
         let loc = self.loc(db);
-        match loc.kind {
-            DefKind::Item => Def::Item,
-        }
-    }
-}
-
-impl DefLoc {
-    pub(crate) fn id(&self, db: &impl AsRef<HirInterner>) -> DefId {
-        db.as_ref().defs.loc2id(&self)
+        match loc.kind {}
     }
 }
 

--- a/crates/ra_hir/src/ids.rs
+++ b/crates/ra_hir/src/ids.rs
@@ -11,6 +11,7 @@ use crate::{
 pub struct HirInterner {
     defs: LocationIntener<DefLoc, DefId>,
     macros: LocationIntener<MacroCallLoc, MacroCallId>,
+    fns: LocationIntener<FunctionLoc, FunctionId>,
 }
 
 impl HirInterner {
@@ -125,6 +126,28 @@ impl MacroCallLoc {
     #[allow(unused)]
     pub(crate) fn id(&self, db: &impl AsRef<HirInterner>) -> MacroCallId {
         db.as_ref().macros.loc2id(&self)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FunctionId(RawId);
+impl_arena_id!(FunctionId);
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct FunctionLoc {
+    pub(crate) module: Module,
+    pub(crate) source_item_id: SourceItemId,
+}
+
+impl FunctionId {
+    pub(crate) fn loc(self, db: &impl AsRef<HirInterner>) -> FunctionLoc {
+        db.as_ref().fns.id2loc(self)
+    }
+}
+
+impl FunctionLoc {
+    pub(crate) fn id(&self, db: &impl AsRef<HirInterner>) -> FunctionId {
+        db.as_ref().fns.loc2id(&self)
     }
 }
 

--- a/crates/ra_hir/src/impl_block.rs
+++ b/crates/ra_hir/src/impl_block.rs
@@ -77,7 +77,9 @@ impl ImplData {
                 .impl_items()
                 .map(|item_node| {
                     let kind = match item_node.kind() {
-                        ast::ImplItemKind::FnDef(..) => DefKind::Function,
+                        ast::ImplItemKind::FnDef(it) => {
+                            return ImplItem::Method(Function::from_ast(db, module, file_id, it));
+                        }
                         ast::ImplItemKind::ConstDef(..) => DefKind::Item,
                         ast::ImplItemKind::TypeDef(..) => DefKind::Item,
                     };
@@ -93,9 +95,7 @@ impl ImplData {
                     };
                     let def_id = def_loc.id(db);
                     match item_node.kind() {
-                        ast::ImplItemKind::FnDef(it) => {
-                            ImplItem::Method(Function::from_ast(db, module, file_id, it))
-                        }
+                        ast::ImplItemKind::FnDef(_) => unreachable!(),
                         ast::ImplItemKind::ConstDef(..) => ImplItem::Const(def_id),
                         ast::ImplItemKind::TypeDef(..) => ImplItem::Type(def_id),
                     }

--- a/crates/ra_hir/src/impl_block.rs
+++ b/crates/ra_hir/src/impl_block.rs
@@ -9,6 +9,7 @@ use crate::{
     Function, HirFileId,
     db::HirDatabase,
     type_ref::TypeRef,
+    ids::LocationCtx,
 };
 
 use crate::code_model_api::{Module, ModuleSource};
@@ -72,13 +73,14 @@ impl ImplData {
     ) -> Self {
         let target_trait = node.target_trait().map(TypeRef::from_ast);
         let target_type = TypeRef::from_ast_opt(node.target_type());
+        let ctx = LocationCtx::new(db, module, file_id);
         let items = if let Some(item_list) = node.item_list() {
             item_list
                 .impl_items()
                 .map(|item_node| {
                     let kind = match item_node.kind() {
                         ast::ImplItemKind::FnDef(it) => {
-                            return ImplItem::Method(Function::from_ast(db, module, file_id, it));
+                            return ImplItem::Method(Function { id: ctx.to_def(it) });
                         }
                         ast::ImplItemKind::ConstDef(..) => DefKind::Item,
                         ast::ImplItemKind::TypeDef(..) => DefKind::Item,

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -5,6 +5,18 @@
 //! to a particular crate instance. That is, it has cfg flags and features
 //! applied. So, the relation between syntax and HIR is many-to-one.
 
+macro_rules! impl_froms {
+    ($e:ident: $($v:ident), *) => {
+        $(
+            impl From<$v> for $e {
+                fn from(it: $v) -> $e {
+                    $e::$v(it)
+                }
+            }
+        )*
+    }
+}
+
 pub mod db;
 #[cfg(test)]
 mod mock;

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -55,10 +55,11 @@ pub use self::{
     ids::{HirFileId, MacroCallId, MacroCallLoc, HirInterner},
     macros::{MacroDef, MacroInput, MacroExpansion},
     nameres::{ItemMap, PerNs, Namespace, Resolution},
-    ty::{Ty, AdtDef},
+    ty::Ty,
     impl_block::{ImplBlock, ImplItem},
     code_model_impl::function::{FnScopes, ScopesWithSyntaxMapping},
-    docs::{Docs, Documentation}
+    docs::{Docs, Documentation},
+    adt::AdtDef,
 };
 
 pub use self::code_model_api::{

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -52,7 +52,7 @@ pub use self::{
 pub use self::code_model_api::{
     Crate, CrateDependency,
     Def,
-    Module, ModuleSource, Problem,
+    Module, ModuleDef, ModuleSource, Problem,
     Struct, Enum, EnumVariant,
     Function, FnSignature, ScopeEntryWithSyntax,
     StructField,

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -43,7 +43,7 @@ pub use self::{
     ids::{HirFileId, DefId, DefLoc, MacroCallId, MacroCallLoc, HirInterner},
     macros::{MacroDef, MacroInput, MacroExpansion},
     nameres::{ItemMap, PerNs, Namespace, Resolution},
-    ty::Ty,
+    ty::{Ty, AdtDef},
     impl_block::{ImplBlock, ImplItem},
     code_model_impl::function::{FnScopes, ScopesWithSyntaxMapping},
     docs::{Docs, Documentation}

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -52,7 +52,7 @@ use crate::{
 pub use self::{
     path::{Path, PathKind},
     name::Name,
-    ids::{HirFileId, DefId, DefLoc, MacroCallId, MacroCallLoc, HirInterner},
+    ids::{HirFileId, MacroCallId, MacroCallLoc, HirInterner},
     macros::{MacroDef, MacroInput, MacroExpansion},
     nameres::{ItemMap, PerNs, Namespace, Resolution},
     ty::{Ty, AdtDef},

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -46,7 +46,7 @@ mod marks;
 use crate::{
     db::HirDatabase,
     name::{AsName, KnownName},
-    ids::{DefKind, SourceItemId, SourceFileItems},
+    ids::{SourceItemId, SourceFileItems},
 };
 
 pub use self::{

--- a/crates/ra_hir/src/nameres/lower.rs
+++ b/crates/ra_hir/src/nameres/lower.rs
@@ -10,7 +10,7 @@ use rustc_hash::FxHashMap;
 use crate::{
     SourceItemId, Path, ModuleSource, HirDatabase, Name, SourceFileItems,
     HirFileId, MacroCallLoc, AsName, PerNs, DefKind, DefLoc, Function,
-    ModuleDef, Module,
+    ModuleDef, Module, Struct,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -147,7 +147,14 @@ impl LoweredModule {
         item: &ast::ModuleItem,
     ) {
         let name = match item.kind() {
-            ast::ModuleItemKind::StructDef(it) => it.name(),
+            ast::ModuleItemKind::StructDef(it) => {
+                if let Some(name) = it.name() {
+                    let s = Struct::from_ast(db, module, file_id, it);
+                    let s: ModuleDef = s.into();
+                    self.declarations.insert(name.as_name(), PerNs::both(s, s));
+                }
+                return;
+            }
             ast::ModuleItemKind::EnumDef(it) => it.name(),
             ast::ModuleItemKind::FnDef(it) => {
                 if let Some(name) = it.name() {

--- a/crates/ra_hir/src/nameres/lower.rs
+++ b/crates/ra_hir/src/nameres/lower.rs
@@ -11,6 +11,7 @@ use crate::{
     SourceItemId, Path, ModuleSource, HirDatabase, Name, SourceFileItems,
     HirFileId, MacroCallLoc, AsName, PerNs, DefKind, DefLoc, Function,
     ModuleDef, Module, Struct, Enum,
+    ids::LocationCtx,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -146,10 +147,11 @@ impl LoweredModule {
         file_items: &SourceFileItems,
         item: &ast::ModuleItem,
     ) {
+        let ctx = LocationCtx::new(db, module, file_id);
         let name = match item.kind() {
             ast::ModuleItemKind::StructDef(it) => {
                 if let Some(name) = it.name() {
-                    let s = Struct::from_ast(db, module, file_id, it);
+                    let s = Struct { id: ctx.to_def(it) };
                     let s: ModuleDef = s.into();
                     self.declarations.insert(name.as_name(), PerNs::both(s, s));
                 }
@@ -157,7 +159,7 @@ impl LoweredModule {
             }
             ast::ModuleItemKind::EnumDef(it) => {
                 if let Some(name) = it.name() {
-                    let e = Enum::from_ast(db, module, file_id, it);
+                    let e = Enum { id: ctx.to_def(it) };
                     let e: ModuleDef = e.into();
                     self.declarations.insert(name.as_name(), PerNs::types(e));
                 }
@@ -165,7 +167,7 @@ impl LoweredModule {
             }
             ast::ModuleItemKind::FnDef(it) => {
                 if let Some(name) = it.name() {
-                    let func = Function::from_ast(db, module, file_id, it);
+                    let func = Function { id: ctx.to_def(it) };
                     self.declarations
                         .insert(name.as_name(), PerNs::values(func.into()));
                 }

--- a/crates/ra_hir/src/query_definitions.rs
+++ b/crates/ra_hir/src/query_definitions.rs
@@ -10,14 +10,14 @@ use ra_syntax::{
 use ra_db::{CrateId};
 
 use crate::{
-    SourceFileItems, SourceItemId, DefId, HirFileId,
-    FnScopes, Module,
+    SourceFileItems, SourceItemId, HirFileId,
+    Function, FnScopes, Module,
     db::HirDatabase,
     nameres::{ItemMap, Resolver},
 };
 
-pub(super) fn fn_scopes(db: &impl HirDatabase, def_id: DefId) -> Arc<FnScopes> {
-    let body = db.body_hir(def_id);
+pub(super) fn fn_scopes(db: &impl HirDatabase, func: Function) -> Arc<FnScopes> {
+    let body = db.body_hir(func);
     let res = FnScopes::new(body);
     Arc::new(res)
 }

--- a/crates/ra_hir/src/query_definitions.rs
+++ b/crates/ra_hir/src/query_definitions.rs
@@ -7,11 +7,11 @@ use rustc_hash::FxHashMap;
 use ra_syntax::{
     AstNode, SyntaxNode, TreeArc,
 };
-use ra_db::SourceRootId;
+use ra_db::{CrateId};
 
 use crate::{
     SourceFileItems, SourceItemId, DefId, HirFileId,
-    FnScopes,
+    FnScopes, Module,
     db::HirDatabase,
     nameres::{ItemMap, Resolver},
 };
@@ -41,15 +41,23 @@ pub(super) fn file_item(
     }
 }
 
-pub(super) fn item_map(db: &impl HirDatabase, source_root: SourceRootId) -> Arc<ItemMap> {
+pub(super) fn item_map(db: &impl HirDatabase, crate_id: CrateId) -> Arc<ItemMap> {
     let start = Instant::now();
-    let module_tree = db.module_tree(source_root);
+    let module_tree = db.module_tree(crate_id);
     let input = module_tree
         .modules()
-        .map(|id| (id, db.lower_module_module(source_root, id)))
+        .map(|module_id| {
+            (
+                module_id,
+                db.lower_module_module(Module {
+                    krate: crate_id,
+                    module_id,
+                }),
+            )
+        })
         .collect::<FxHashMap<_, _>>();
 
-    let resolver = Resolver::new(db, &input, source_root, module_tree);
+    let resolver = Resolver::new(db, &input, crate_id);
     let res = resolver.resolve();
     let elapsed = start.elapsed();
     log::info!("item_map: {:?}", elapsed);

--- a/crates/ra_hir/src/source_binder.rs
+++ b/crates/ra_hir/src/source_binder.rs
@@ -15,6 +15,7 @@ use ra_syntax::{
 use crate::{
     HirDatabase, Function, SourceItemId, ModuleDef,
     AsName, Module,
+    ids::LocationCtx,
 };
 
 /// Locates the module by `FileId`. Picks topmost module in the file.
@@ -116,7 +117,10 @@ pub fn function_from_module(
 ) -> Function {
     let (file_id, _) = module.definition_source(db);
     let file_id = file_id.into();
-    Function::from_ast(db, module, file_id, fn_def)
+    let ctx = LocationCtx::new(db, module, file_id);
+    Function {
+        id: ctx.to_def(fn_def),
+    }
 }
 
 pub fn function_from_child_node(

--- a/crates/ra_hir/src/source_binder.rs
+++ b/crates/ra_hir/src/source_binder.rs
@@ -145,10 +145,10 @@ pub fn macro_symbols(db: &impl HirDatabase, file_id: FileId) -> Vec<(SmolStr, Te
         .iter()
         .filter_map(|(_, it)| it.clone().take_types())
         .filter_map(|it| match it {
-            ModuleDef::Def(it) => Some(it),
+            ModuleDef::Trait(it) => Some(it),
             _ => None,
         })
-        .filter_map(|it| it.loc(db).source_item_id.file_id.as_macro_call_id())
+        .filter_map(|it| it.source(db).0.as_macro_call_id())
     {
         if let Some(exp) = db.expand_macro_invocation(macro_call_id) {
             let loc = macro_call_id.loc(db);

--- a/crates/ra_hir/src/source_binder.rs
+++ b/crates/ra_hir/src/source_binder.rs
@@ -14,7 +14,7 @@ use ra_syntax::{
 
 use crate::{
     HirDatabase, Function, SourceItemId, ModuleDef,
-    DefKind, DefLoc, AsName, Module,
+    AsName, Module,
 };
 
 /// Locates the module by `FileId`. Picks topmost module in the file.
@@ -105,29 +105,18 @@ pub fn function_from_source(
     fn_def: &ast::FnDef,
 ) -> Option<Function> {
     let module = module_from_child_node(db, file_id, fn_def.syntax())?;
-    let res = function_from_module(db, &module, fn_def);
+    let res = function_from_module(db, module, fn_def);
     Some(res)
 }
 
 pub fn function_from_module(
     db: &impl HirDatabase,
-    module: &Module,
+    module: Module,
     fn_def: &ast::FnDef,
 ) -> Function {
     let (file_id, _) = module.definition_source(db);
     let file_id = file_id.into();
-    let file_items = db.file_items(file_id);
-    let item_id = file_items.id_of(file_id, fn_def.syntax());
-    let source_item_id = SourceItemId {
-        file_id,
-        item_id: Some(item_id),
-    };
-    let def_loc = DefLoc {
-        module: module.clone(),
-        kind: DefKind::Function,
-        source_item_id,
-    };
-    Function::new(def_loc.id(db))
+    Function::from_ast(db, module, file_id, fn_def)
 }
 
 pub fn function_from_child_node(

--- a/crates/ra_hir/src/ty.rs
+++ b/crates/ra_hir/src/ty.rs
@@ -696,7 +696,9 @@ impl From<ModuleDef> for Option<TypableDef> {
             ModuleDef::Const(_)
             | ModuleDef::Static(_)
             | ModuleDef::Def(_)
-            | ModuleDef::Module(_) => return None,
+            | ModuleDef::Module(_)
+            | ModuleDef::Trait(_)
+            | ModuleDef::Type(_) => return None,
         };
         Some(res)
     }

--- a/crates/ra_hir/src/ty.rs
+++ b/crates/ra_hir/src/ty.rs
@@ -168,18 +168,7 @@ pub enum AdtDef {
     Struct(Struct),
     Enum(Enum),
 }
-
-impl From<Struct> for AdtDef {
-    fn from(s: Struct) -> AdtDef {
-        AdtDef::Struct(s)
-    }
-}
-
-impl From<Enum> for AdtDef {
-    fn from(e: Enum) -> AdtDef {
-        AdtDef::Enum(e)
-    }
-}
+impl_froms!(AdtDef: Struct, Enum);
 
 impl AdtDef {
     fn krate(self, db: &impl HirDatabase) -> Option<Crate> {
@@ -701,24 +690,7 @@ pub enum TypableDef {
     Enum(Enum),
     Def(DefId),
 }
-
-impl From<Function> for TypableDef {
-    fn from(func: Function) -> TypableDef {
-        TypableDef::Function(func)
-    }
-}
-
-impl From<Struct> for TypableDef {
-    fn from(s: Struct) -> TypableDef {
-        TypableDef::Struct(s)
-    }
-}
-
-impl From<Enum> for TypableDef {
-    fn from(e: Enum) -> TypableDef {
-        TypableDef::Enum(e)
-    }
-}
+impl_froms!(TypableDef: Function, Struct, Enum);
 
 impl From<DefId> for TypableDef {
     fn from(func: DefId) -> TypableDef {
@@ -763,12 +735,7 @@ pub enum VariantDef {
     Struct(Struct),
     Def(DefId), // EnumVariant
 }
-
-impl From<Struct> for VariantDef {
-    fn from(struct_: Struct) -> VariantDef {
-        VariantDef::Struct(struct_)
-    }
-}
+impl_froms!(VariantDef: Struct);
 
 impl From<DefId> for VariantDef {
     fn from(def_id: DefId) -> VariantDef {

--- a/crates/ra_hir/src/ty.rs
+++ b/crates/ra_hir/src/ty.rs
@@ -745,7 +745,6 @@ pub(super) fn type_for_def(db: &impl HirDatabase, def: TypableDef) -> Ty {
         TypableDef::Struct(s) => type_for_struct(db, s),
         TypableDef::Enum(e) => type_for_enum(db, e),
         TypableDef::Def(def_id) => match def_id.resolve(db) {
-            Def::Enum(e) => type_for_enum(db, e),
             Def::EnumVariant(ev) => type_for_enum_variant(db, ev),
             _ => {
                 log::debug!(
@@ -787,10 +786,6 @@ pub(super) fn type_for_field(db: &impl HirDatabase, def: VariantDef, field: Name
                 def_id.module(db),
             ),
             // TODO: unions
-            Def::Enum(_) => {
-                // this can happen in (invalid) code, but enums don't have fields themselves
-                return None;
-            }
             _ => panic!(
                 "trying to get type for field {:?} in non-struct/variant {:?}",
                 field, def_id

--- a/crates/ra_hir/src/ty.rs
+++ b/crates/ra_hir/src/ty.rs
@@ -31,7 +31,7 @@ use rustc_hash::FxHashMap;
 
 use crate::{
     Module, Function, Struct, StructField, Enum, EnumVariant, Path, Name, ImplBlock,
-    FnSignature, FnScopes, ModuleDef, Crate,
+    FnSignature, FnScopes, ModuleDef, AdtDef,
     db::HirDatabase,
     type_ref::{TypeRef, Mutability},
     name::KnownName,
@@ -159,23 +159,6 @@ pub struct Substs(Arc<[Ty]>);
 impl Substs {
     pub fn empty() -> Substs {
         Substs(Arc::new([]))
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum AdtDef {
-    Struct(Struct),
-    Enum(Enum),
-}
-impl_froms!(AdtDef: Struct, Enum);
-
-impl AdtDef {
-    fn krate(self, db: &impl HirDatabase) -> Option<Crate> {
-        match self {
-            AdtDef::Struct(s) => s.module(db),
-            AdtDef::Enum(e) => e.module(db),
-        }
-        .krate(db)
     }
 }
 

--- a/crates/ra_hir/src/ty.rs
+++ b/crates/ra_hir/src/ty.rs
@@ -695,7 +695,6 @@ impl From<ModuleDef> for Option<TypableDef> {
             ModuleDef::EnumVariant(v) => v.into(),
             ModuleDef::Const(_)
             | ModuleDef::Static(_)
-            | ModuleDef::Def(_)
             | ModuleDef::Module(_)
             | ModuleDef::Trait(_)
             | ModuleDef::Type(_) => return None,

--- a/crates/ra_hir/src/ty.rs
+++ b/crates/ra_hir/src/ty.rs
@@ -693,7 +693,10 @@ impl From<ModuleDef> for Option<TypableDef> {
             ModuleDef::Struct(s) => s.into(),
             ModuleDef::Enum(e) => e.into(),
             ModuleDef::EnumVariant(v) => v.into(),
-            ModuleDef::Def(_) | ModuleDef::Module(_) => return None,
+            ModuleDef::Const(_)
+            | ModuleDef::Static(_)
+            | ModuleDef::Def(_)
+            | ModuleDef::Module(_) => return None,
         };
         Some(res)
     }

--- a/crates/ra_hir/src/ty/method_resolution.rs
+++ b/crates/ra_hir/src/ty/method_resolution.rs
@@ -118,11 +118,11 @@ impl Ty {
     // TODO: cache this as a query?
     // - if so, what signature? (TyFingerprint, Name)?
     // - or maybe cache all names and def_ids of methods per fingerprint?
-    pub fn lookup_method(self, db: &impl HirDatabase, name: &Name) -> Option<DefId> {
+    pub fn lookup_method(self, db: &impl HirDatabase, name: &Name) -> Option<Function> {
         self.iterate_methods(db, |f| {
             let sig = f.signature(db);
             if sig.name() == name && sig.has_self_param() {
-                Some(f.def_id())
+                Some(f)
             } else {
                 None
             }

--- a/crates/ra_hir/src/ty/method_resolution.rs
+++ b/crates/ra_hir/src/ty/method_resolution.rs
@@ -7,16 +7,16 @@ use std::sync::Arc;
 use rustc_hash::FxHashMap;
 
 use crate::{
-    HirDatabase, DefId, module_tree::ModuleId, Module, Crate, Name, Function,
+    HirDatabase, module_tree::ModuleId, Module, Crate, Name, Function,
     impl_block::{ImplId, ImplBlock, ImplItem},
-    generics::GenericParams
+    generics::GenericParams,
+    ty::{AdtDef, Ty}
 };
-use super::Ty;
 
 /// This is used as a key for indexing impls.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum TyFingerprint {
-    Adt(DefId),
+    Adt(AdtDef),
     // we'll also want to index impls for primitive types etc.
 }
 

--- a/crates/ra_hir/src/ty/snapshots/tests__infer_struct.snap
+++ b/crates/ra_hir/src/ty/snapshots/tests__infer_struct.snap
@@ -1,19 +1,19 @@
 ---
-created: "2019-01-22T14:45:00.058678600+00:00"
-creator: insta@0.4.0
+created: "2019-01-24T14:51:32.808861856+00:00"
+creator: insta@0.5.2
 expression: "&result"
-source: "crates\\ra_hir\\src\\ty\\tests.rs"
+source: crates/ra_hir/src/ty/tests.rs
 ---
 [72; 154) '{     ...a.c; }': ()
 [82; 83) 'c': [unknown]
-[86; 87) 'C': [unknown]
+[86; 87) 'C': C
 [86; 90) 'C(1)': [unknown]
 [88; 89) '1': i32
-[96; 97) 'B': [unknown]
+[96; 97) 'B': B
 [107; 108) 'a': A
 [114; 133) 'A { b:...C(1) }': A
 [121; 122) 'B': B
-[127; 128) 'C': [unknown]
+[127; 128) 'C': C
 [127; 131) 'C(1)': C
 [129; 130) '1': i32
 [139; 140) 'a': A

--- a/crates/ra_ide_api/src/completion/complete_dot.rs
+++ b/crates/ra_ide_api/src/completion/complete_dot.rs
@@ -1,4 +1,4 @@
-use hir::{Ty, Def, AdtDef};
+use hir::{Ty, AdtDef};
 
 use crate::completion::{CompletionContext, Completions, CompletionItem, CompletionItemKind};
 use crate::completion::completion_item::CompletionKind;
@@ -29,23 +29,21 @@ fn complete_fields(acc: &mut Completions, ctx: &CompletionContext, receiver: Ty)
                 def_id, ref substs, ..
             } => {
                 match def_id {
-                    AdtDef::Struct() => {}
-                    AdtDef::Def(def_id) => match def_id.resolve(ctx.db) {
-                        Def::Struct(s) => {
-                            for field in s.fields(ctx.db) {
-                                CompletionItem::new(
-                                    CompletionKind::Reference,
-                                    ctx.source_range(),
-                                    field.name().to_string(),
-                                )
-                                .kind(CompletionItemKind::Field)
-                                .set_detail(field.ty(ctx.db).map(|ty| ty.subst(substs).to_string()))
-                                .add_to(acc);
-                            }
+                    AdtDef::Struct(s) => {
+                        for field in s.fields(ctx.db) {
+                            CompletionItem::new(
+                                CompletionKind::Reference,
+                                ctx.source_range(),
+                                field.name().to_string(),
+                            )
+                            .kind(CompletionItemKind::Field)
+                            .set_detail(field.ty(ctx.db).map(|ty| ty.subst(substs).to_string()))
+                            .add_to(acc);
                         }
-                        // TODO unions
-                        _ => {}
-                    },
+                    }
+
+                    // TODO unions
+                    AdtDef::Enum(_) => (),
                 }
             }
             Ty::Tuple(fields) => {

--- a/crates/ra_ide_api/src/completion/complete_dot.rs
+++ b/crates/ra_ide_api/src/completion/complete_dot.rs
@@ -1,4 +1,4 @@
-use hir::{Ty, Def};
+use hir::{Ty, Def, AdtDef};
 
 use crate::completion::{CompletionContext, Completions, CompletionItem, CompletionItemKind};
 use crate::completion::completion_item::CompletionKind;
@@ -28,21 +28,24 @@ fn complete_fields(acc: &mut Completions, ctx: &CompletionContext, receiver: Ty)
             Ty::Adt {
                 def_id, ref substs, ..
             } => {
-                match def_id.resolve(ctx.db) {
-                    Def::Struct(s) => {
-                        for field in s.fields(ctx.db) {
-                            CompletionItem::new(
-                                CompletionKind::Reference,
-                                ctx.source_range(),
-                                field.name().to_string(),
-                            )
-                            .kind(CompletionItemKind::Field)
-                            .set_detail(field.ty(ctx.db).map(|ty| ty.subst(substs).to_string()))
-                            .add_to(acc);
+                match def_id {
+                    AdtDef::Struct() => {}
+                    AdtDef::Def(def_id) => match def_id.resolve(ctx.db) {
+                        Def::Struct(s) => {
+                            for field in s.fields(ctx.db) {
+                                CompletionItem::new(
+                                    CompletionKind::Reference,
+                                    ctx.source_range(),
+                                    field.name().to_string(),
+                                )
+                                .kind(CompletionItemKind::Field)
+                                .set_detail(field.ty(ctx.db).map(|ty| ty.subst(substs).to_string()))
+                                .add_to(acc);
+                            }
                         }
-                    }
-                    // TODO unions
-                    _ => {}
+                        // TODO unions
+                        _ => {}
+                    },
                 }
             }
             Ty::Tuple(fields) => {

--- a/crates/ra_ide_api/src/completion/complete_path.rs
+++ b/crates/ra_ide_api/src/completion/complete_path.rs
@@ -13,8 +13,8 @@ pub(super) fn complete_path(acc: &mut Completions, ctx: &CompletionContext) {
         Some(it) => it,
         None => return,
     };
-    match def_id.resolve(ctx.db) {
-        hir::Def::Module(module) => {
+    match def_id {
+        hir::ModuleDef::Module(module) => {
             let module_scope = module.scope(ctx.db);
             for (name, res) in module_scope.entries() {
                 CompletionItem::new(
@@ -26,21 +26,24 @@ pub(super) fn complete_path(acc: &mut Completions, ctx: &CompletionContext) {
                 .add_to(acc);
             }
         }
-        hir::Def::Enum(e) => {
-            e.variants(ctx.db)
-                .into_iter()
-                .for_each(|(variant_name, variant)| {
-                    CompletionItem::new(
-                        CompletionKind::Reference,
-                        ctx.source_range(),
-                        variant_name.to_string(),
-                    )
-                    .kind(CompletionItemKind::EnumVariant)
-                    .set_documentation(variant.docs(ctx.db))
-                    .add_to(acc)
-                });
-        }
-        _ => return,
+
+        hir::ModuleDef::Def(def_id) => match def_id.resolve(ctx.db) {
+            hir::Def::Enum(e) => {
+                e.variants(ctx.db)
+                    .into_iter()
+                    .for_each(|(variant_name, variant)| {
+                        CompletionItem::new(
+                            CompletionKind::Reference,
+                            ctx.source_range(),
+                            variant_name.to_string(),
+                        )
+                        .kind(CompletionItemKind::EnumVariant)
+                        .set_documentation(variant.docs(ctx.db))
+                        .add_to(acc)
+                    });
+            }
+            _ => return,
+        },
     };
 }
 

--- a/crates/ra_ide_api/src/completion/complete_path.rs
+++ b/crates/ra_ide_api/src/completion/complete_path.rs
@@ -44,6 +44,8 @@ pub(super) fn complete_path(acc: &mut Completions, ctx: &CompletionContext) {
             }
             _ => return,
         },
+
+        hir::ModuleDef::Function(_) => return,
     };
 }
 

--- a/crates/ra_ide_api/src/completion/complete_path.rs
+++ b/crates/ra_ide_api/src/completion/complete_path.rs
@@ -43,6 +43,8 @@ pub(super) fn complete_path(acc: &mut Completions, ctx: &CompletionContext) {
         hir::ModuleDef::Function(_)
         | hir::ModuleDef::Struct(_)
         | hir::ModuleDef::Def(_)
+        | hir::ModuleDef::Const(_)
+        | hir::ModuleDef::Static(_)
         | hir::ModuleDef::EnumVariant(_) => return,
     };
 }

--- a/crates/ra_ide_api/src/completion/complete_path.rs
+++ b/crates/ra_ide_api/src/completion/complete_path.rs
@@ -26,26 +26,21 @@ pub(super) fn complete_path(acc: &mut Completions, ctx: &CompletionContext) {
                 .add_to(acc);
             }
         }
-
-        hir::ModuleDef::Def(def_id) => match def_id.resolve(ctx.db) {
-            hir::Def::Enum(e) => {
-                e.variants(ctx.db)
-                    .into_iter()
-                    .for_each(|(variant_name, variant)| {
-                        CompletionItem::new(
-                            CompletionKind::Reference,
-                            ctx.source_range(),
-                            variant_name.to_string(),
-                        )
-                        .kind(CompletionItemKind::EnumVariant)
-                        .set_documentation(variant.docs(ctx.db))
-                        .add_to(acc)
-                    });
-            }
-            _ => return,
-        },
-
-        hir::ModuleDef::Function(_) => return,
+        hir::ModuleDef::Enum(e) => {
+            e.variants(ctx.db)
+                .into_iter()
+                .for_each(|(variant_name, variant)| {
+                    CompletionItem::new(
+                        CompletionKind::Reference,
+                        ctx.source_range(),
+                        variant_name.to_string(),
+                    )
+                    .kind(CompletionItemKind::EnumVariant)
+                    .set_documentation(variant.docs(ctx.db))
+                    .add_to(acc)
+                });
+        }
+        hir::ModuleDef::Function(_) | hir::ModuleDef::Struct(_) | hir::ModuleDef::Def(_) => return,
     };
 }
 

--- a/crates/ra_ide_api/src/completion/complete_path.rs
+++ b/crates/ra_ide_api/src/completion/complete_path.rs
@@ -40,12 +40,7 @@ pub(super) fn complete_path(acc: &mut Completions, ctx: &CompletionContext) {
                     .add_to(acc)
                 });
         }
-        hir::ModuleDef::Function(_)
-        | hir::ModuleDef::Struct(_)
-        | hir::ModuleDef::Def(_)
-        | hir::ModuleDef::Const(_)
-        | hir::ModuleDef::Static(_)
-        | hir::ModuleDef::EnumVariant(_) => return,
+        _ => return,
     };
 }
 

--- a/crates/ra_ide_api/src/completion/complete_path.rs
+++ b/crates/ra_ide_api/src/completion/complete_path.rs
@@ -40,7 +40,10 @@ pub(super) fn complete_path(acc: &mut Completions, ctx: &CompletionContext) {
                     .add_to(acc)
                 });
         }
-        hir::ModuleDef::Function(_) | hir::ModuleDef::Struct(_) | hir::ModuleDef::Def(_) => return,
+        hir::ModuleDef::Function(_)
+        | hir::ModuleDef::Struct(_)
+        | hir::ModuleDef::Def(_)
+        | hir::ModuleDef::EnumVariant(_) => return,
     };
 }
 

--- a/crates/ra_ide_api/src/completion/completion_context.rs
+++ b/crates/ra_ide_api/src/completion/completion_context.rs
@@ -127,7 +127,7 @@ impl<'a> CompletionContext<'a> {
             .ancestors()
             .take_while(|it| it.kind() != SOURCE_FILE && it.kind() != MODULE)
             .find_map(ast::FnDef::cast);
-        match (&self.module, self.function_syntax) {
+        match (self.module, self.function_syntax) {
             (Some(module), Some(fn_def)) => {
                 let function = source_binder::function_from_module(self.db, module, fn_def);
                 self.function = Some(function);

--- a/crates/ra_ide_api/src/completion/completion_item.rs
+++ b/crates/ra_ide_api/src/completion/completion_item.rs
@@ -220,9 +220,9 @@ impl Builder {
         let (kind, docs) = match def {
             hir::ModuleDef::Module(_) => (CompletionItemKind::Module, None),
             hir::ModuleDef::Function(func) => return self.from_function(ctx, func),
+            hir::ModuleDef::Struct(it) => (CompletionItemKind::Struct, it.docs(ctx.db)),
+            hir::ModuleDef::Enum(it) => (CompletionItemKind::Enum, it.docs(ctx.db)),
             hir::ModuleDef::Def(def_id) => match def_id.resolve(ctx.db) {
-                hir::Def::Struct(it) => (CompletionItemKind::Struct, it.docs(ctx.db)),
-                hir::Def::Enum(it) => (CompletionItemKind::Enum, it.docs(ctx.db)),
                 hir::Def::Trait(it) => (CompletionItemKind::Trait, it.docs(ctx.db)),
                 hir::Def::Type(it) => (CompletionItemKind::TypeAlias, it.docs(ctx.db)),
                 hir::Def::Const(it) => (CompletionItemKind::Const, it.docs(ctx.db)),

--- a/crates/ra_ide_api/src/completion/completion_item.rs
+++ b/crates/ra_ide_api/src/completion/completion_item.rs
@@ -227,7 +227,6 @@ impl Builder {
             hir::ModuleDef::Static(it) => (CompletionItemKind::Static, it.docs(ctx.db)),
             hir::ModuleDef::Trait(it) => (CompletionItemKind::Trait, it.docs(ctx.db)),
             hir::ModuleDef::Type(it) => (CompletionItemKind::TypeAlias, it.docs(ctx.db)),
-            hir::ModuleDef::Def(_) => return self,
         };
         self.kind = Some(kind);
         self.documentation = docs;

--- a/crates/ra_ide_api/src/completion/completion_item.rs
+++ b/crates/ra_ide_api/src/completion/completion_item.rs
@@ -1,12 +1,12 @@
-use hir::{Docs, Documentation, PerNs};
-
-use crate::completion::completion_context::CompletionContext;
+use hir::{Docs, Documentation};
 use ra_syntax::{
     ast::{self, AstNode},
     TextRange,
 };
 use ra_text_edit::TextEdit;
 use test_utils::tested_by;
+
+use crate::completion::completion_context::CompletionContext;
 
 /// `CompletionItem` describes a single completion variant in the editor pop-up.
 /// It is basically a POD with various properties. To construct a
@@ -209,41 +209,26 @@ impl Builder {
         ctx: &CompletionContext,
         resolution: &hir::Resolution,
     ) -> Builder {
-        let resolved = resolution.def_id.map(|d| d.resolve(ctx.db));
-        let (kind, docs) = match resolved {
-            PerNs {
-                types: Some(hir::Def::Module(..)),
-                ..
-            } => (CompletionItemKind::Module, None),
-            PerNs {
-                types: Some(hir::Def::Struct(s)),
-                ..
-            } => (CompletionItemKind::Struct, s.docs(ctx.db)),
-            PerNs {
-                types: Some(hir::Def::Enum(e)),
-                ..
-            } => (CompletionItemKind::Enum, e.docs(ctx.db)),
-            PerNs {
-                types: Some(hir::Def::Trait(t)),
-                ..
-            } => (CompletionItemKind::Trait, t.docs(ctx.db)),
-            PerNs {
-                types: Some(hir::Def::Type(t)),
-                ..
-            } => (CompletionItemKind::TypeAlias, t.docs(ctx.db)),
-            PerNs {
-                values: Some(hir::Def::Const(c)),
-                ..
-            } => (CompletionItemKind::Const, c.docs(ctx.db)),
-            PerNs {
-                values: Some(hir::Def::Static(s)),
-                ..
-            } => (CompletionItemKind::Static, s.docs(ctx.db)),
-            PerNs {
-                values: Some(hir::Def::Function(function)),
-                ..
-            } => return self.from_function(ctx, function),
-            _ => return self,
+        let def = resolution
+            .def_id
+            .take_types()
+            .or(resolution.def_id.take_values());
+        let def = match def {
+            None => return self,
+            Some(it) => it,
+        };
+        let (kind, docs) = match def {
+            hir::ModuleDef::Module(_) => (CompletionItemKind::Module, None),
+            hir::ModuleDef::Def(def_id) => match def_id.resolve(ctx.db) {
+                hir::Def::Struct(it) => (CompletionItemKind::Struct, it.docs(ctx.db)),
+                hir::Def::Enum(it) => (CompletionItemKind::Enum, it.docs(ctx.db)),
+                hir::Def::Trait(it) => (CompletionItemKind::Trait, it.docs(ctx.db)),
+                hir::Def::Type(it) => (CompletionItemKind::TypeAlias, it.docs(ctx.db)),
+                hir::Def::Const(it) => (CompletionItemKind::Const, it.docs(ctx.db)),
+                hir::Def::Static(it) => (CompletionItemKind::Static, it.docs(ctx.db)),
+                hir::Def::Function(function) => return self.from_function(ctx, function),
+                _ => return self,
+            },
         };
         self.kind = Some(kind);
         self.documentation = docs;

--- a/crates/ra_ide_api/src/completion/completion_item.rs
+++ b/crates/ra_ide_api/src/completion/completion_item.rs
@@ -219,6 +219,7 @@ impl Builder {
         };
         let (kind, docs) = match def {
             hir::ModuleDef::Module(_) => (CompletionItemKind::Module, None),
+            hir::ModuleDef::Function(func) => return self.from_function(ctx, func),
             hir::ModuleDef::Def(def_id) => match def_id.resolve(ctx.db) {
                 hir::Def::Struct(it) => (CompletionItemKind::Struct, it.docs(ctx.db)),
                 hir::Def::Enum(it) => (CompletionItemKind::Enum, it.docs(ctx.db)),
@@ -226,7 +227,6 @@ impl Builder {
                 hir::Def::Type(it) => (CompletionItemKind::TypeAlias, it.docs(ctx.db)),
                 hir::Def::Const(it) => (CompletionItemKind::Const, it.docs(ctx.db)),
                 hir::Def::Static(it) => (CompletionItemKind::Static, it.docs(ctx.db)),
-                hir::Def::Function(function) => return self.from_function(ctx, function),
                 _ => return self,
             },
         };

--- a/crates/ra_ide_api/src/completion/completion_item.rs
+++ b/crates/ra_ide_api/src/completion/completion_item.rs
@@ -223,11 +223,11 @@ impl Builder {
             hir::ModuleDef::Struct(it) => (CompletionItemKind::Struct, it.docs(ctx.db)),
             hir::ModuleDef::Enum(it) => (CompletionItemKind::Enum, it.docs(ctx.db)),
             hir::ModuleDef::EnumVariant(it) => (CompletionItemKind::EnumVariant, it.docs(ctx.db)),
+            hir::ModuleDef::Const(it) => (CompletionItemKind::Const, it.docs(ctx.db)),
+            hir::ModuleDef::Static(it) => (CompletionItemKind::Static, it.docs(ctx.db)),
             hir::ModuleDef::Def(def_id) => match def_id.resolve(ctx.db) {
                 hir::Def::Trait(it) => (CompletionItemKind::Trait, it.docs(ctx.db)),
                 hir::Def::Type(it) => (CompletionItemKind::TypeAlias, it.docs(ctx.db)),
-                hir::Def::Const(it) => (CompletionItemKind::Const, it.docs(ctx.db)),
-                hir::Def::Static(it) => (CompletionItemKind::Static, it.docs(ctx.db)),
                 _ => return self,
             },
         };

--- a/crates/ra_ide_api/src/completion/completion_item.rs
+++ b/crates/ra_ide_api/src/completion/completion_item.rs
@@ -225,11 +225,9 @@ impl Builder {
             hir::ModuleDef::EnumVariant(it) => (CompletionItemKind::EnumVariant, it.docs(ctx.db)),
             hir::ModuleDef::Const(it) => (CompletionItemKind::Const, it.docs(ctx.db)),
             hir::ModuleDef::Static(it) => (CompletionItemKind::Static, it.docs(ctx.db)),
-            hir::ModuleDef::Def(def_id) => match def_id.resolve(ctx.db) {
-                hir::Def::Trait(it) => (CompletionItemKind::Trait, it.docs(ctx.db)),
-                hir::Def::Type(it) => (CompletionItemKind::TypeAlias, it.docs(ctx.db)),
-                _ => return self,
-            },
+            hir::ModuleDef::Trait(it) => (CompletionItemKind::Trait, it.docs(ctx.db)),
+            hir::ModuleDef::Type(it) => (CompletionItemKind::TypeAlias, it.docs(ctx.db)),
+            hir::ModuleDef::Def(_) => return self,
         };
         self.kind = Some(kind);
         self.documentation = docs;

--- a/crates/ra_ide_api/src/completion/completion_item.rs
+++ b/crates/ra_ide_api/src/completion/completion_item.rs
@@ -222,6 +222,7 @@ impl Builder {
             hir::ModuleDef::Function(func) => return self.from_function(ctx, func),
             hir::ModuleDef::Struct(it) => (CompletionItemKind::Struct, it.docs(ctx.db)),
             hir::ModuleDef::Enum(it) => (CompletionItemKind::Enum, it.docs(ctx.db)),
+            hir::ModuleDef::EnumVariant(it) => (CompletionItemKind::EnumVariant, it.docs(ctx.db)),
             hir::ModuleDef::Def(def_id) => match def_id.resolve(ctx.db) {
                 hir::Def::Trait(it) => (CompletionItemKind::Trait, it.docs(ctx.db)),
                 hir::Def::Type(it) => (CompletionItemKind::TypeAlias, it.docs(ctx.db)),

--- a/crates/ra_ide_api/src/db.rs
+++ b/crates/ra_ide_api/src/db.rs
@@ -72,6 +72,7 @@ salsa::database_storage! {
             fn file_relative_path() for ra_db::FileRelativePathQuery;
             fn file_source_root() for ra_db::FileSourceRootQuery;
             fn source_root() for ra_db::SourceRootQuery;
+            fn source_root_crates() for ra_db::SourceRootCratesQuery;
             fn local_roots() for ra_db::LocalRootsQuery;
             fn library_roots() for ra_db::LibraryRootsQuery;
             fn crate_graph() for ra_db::CrateGraphQuery;

--- a/crates/ra_ide_api/src/goto_definition.rs
+++ b/crates/ra_ide_api/src/goto_definition.rs
@@ -63,13 +63,11 @@ pub(crate) fn reference_definition(
             let infer_result = function.infer(db);
             let syntax_mapping = function.body_syntax_mapping(db);
             let expr = ast::Expr::cast(method_call.syntax()).unwrap();
-            if let Some(def_id) = syntax_mapping
+            if let Some(func) = syntax_mapping
                 .node_expr(expr)
                 .and_then(|it| infer_result.method_resolution(it))
             {
-                if let Some(target) = NavigationTarget::from_def(db, hir::ModuleDef::Def(def_id)) {
-                    return Exact(target);
-                }
+                return Exact(NavigationTarget::from_function(db, func));
             };
         }
     }

--- a/crates/ra_ide_api/src/goto_definition.rs
+++ b/crates/ra_ide_api/src/goto_definition.rs
@@ -67,7 +67,7 @@ pub(crate) fn reference_definition(
                 .node_expr(expr)
                 .and_then(|it| infer_result.method_resolution(it))
             {
-                if let Some(target) = NavigationTarget::from_def(db, def_id.resolve(db)) {
+                if let Some(target) = NavigationTarget::from_def(db, hir::ModuleDef::Def(def_id)) {
                     return Exact(target);
                 }
             };
@@ -84,7 +84,7 @@ pub(crate) fn reference_definition(
         {
             let resolved = module.resolve_path(db, &path);
             if let Some(def_id) = resolved.take_types().or(resolved.take_values()) {
-                if let Some(target) = NavigationTarget::from_def(db, def_id.resolve(db)) {
+                if let Some(target) = NavigationTarget::from_def(db, def_id) {
                     return Exact(target);
                 }
             }

--- a/crates/ra_ide_api/src/navigation_target.rs
+++ b/crates/ra_ide_api/src/navigation_target.rs
@@ -107,7 +107,6 @@ impl NavigationTarget {
         module_def: hir::ModuleDef,
     ) -> Option<NavigationTarget> {
         match module_def {
-            hir::ModuleDef::Def(_) => return None,
             hir::ModuleDef::Module(module) => Some(NavigationTarget::from_module(db, module)),
             hir::ModuleDef::Function(func) => Some(NavigationTarget::from_function(db, func)),
             hir::ModuleDef::Struct(s) => {

--- a/crates/ra_ide_api/src/navigation_target.rs
+++ b/crates/ra_ide_api/src/navigation_target.rs
@@ -114,17 +114,23 @@ impl NavigationTarget {
             hir::ModuleDef::Function(func) => {
                 return Some(NavigationTarget::from_function(db, func));
             }
+            hir::ModuleDef::Struct(s) => {
+                let (file_id, node) = s.source(db);
+                return Some(NavigationTarget::from_named(
+                    file_id.original_file(db),
+                    &*node,
+                ));
+            }
+            hir::ModuleDef::Enum(e) => {
+                let (file_id, node) = e.source(db);
+                return Some(NavigationTarget::from_named(
+                    file_id.original_file(db),
+                    &*node,
+                ));
+            }
         };
 
         let res = match def {
-            Def::Struct(s) => {
-                let (file_id, node) = s.source(db);
-                NavigationTarget::from_named(file_id.original_file(db), &*node)
-            }
-            Def::Enum(e) => {
-                let (file_id, node) = e.source(db);
-                NavigationTarget::from_named(file_id.original_file(db), &*node)
-            }
             Def::EnumVariant(ev) => {
                 let (file_id, node) = ev.source(db);
                 NavigationTarget::from_named(file_id.original_file(db), &*node)

--- a/crates/ra_ide_api/src/navigation_target.rs
+++ b/crates/ra_ide_api/src/navigation_target.rs
@@ -121,6 +121,20 @@ impl NavigationTarget {
                     &*node,
                 ));
             }
+            hir::ModuleDef::Const(s) => {
+                let (file_id, node) = s.source(db);
+                return Some(NavigationTarget::from_named(
+                    file_id.original_file(db),
+                    &*node,
+                ));
+            }
+            hir::ModuleDef::Static(s) => {
+                let (file_id, node) = s.source(db);
+                return Some(NavigationTarget::from_named(
+                    file_id.original_file(db),
+                    &*node,
+                ));
+            }
             hir::ModuleDef::Enum(e) => {
                 let (file_id, node) = e.source(db);
                 return Some(NavigationTarget::from_named(
@@ -143,14 +157,6 @@ impl NavigationTarget {
                 NavigationTarget::from_named(file_id.original_file(db), &*node)
             }
             Def::Type(f) => {
-                let (file_id, node) = f.source(db);
-                NavigationTarget::from_named(file_id.original_file(db), &*node)
-            }
-            Def::Static(f) => {
-                let (file_id, node) = f.source(db);
-                NavigationTarget::from_named(file_id.original_file(db), &*node)
-            }
-            Def::Const(f) => {
                 let (file_id, node) = f.source(db);
                 NavigationTarget::from_named(file_id.original_file(db), &*node)
             }

--- a/crates/ra_ide_api/src/navigation_target.rs
+++ b/crates/ra_ide_api/src/navigation_target.rs
@@ -128,13 +128,16 @@ impl NavigationTarget {
                     &*node,
                 ));
             }
+            hir::ModuleDef::EnumVariant(var) => {
+                let (file_id, node) = var.source(db);
+                return Some(NavigationTarget::from_named(
+                    file_id.original_file(db),
+                    &*node,
+                ));
+            }
         };
 
         let res = match def {
-            Def::EnumVariant(ev) => {
-                let (file_id, node) = ev.source(db);
-                NavigationTarget::from_named(file_id.original_file(db), &*node)
-            }
             Def::Trait(f) => {
                 let (file_id, node) = f.source(db);
                 NavigationTarget::from_named(file_id.original_file(db), &*node)

--- a/crates/ra_ide_api/src/navigation_target.rs
+++ b/crates/ra_ide_api/src/navigation_target.rs
@@ -96,6 +96,11 @@ impl NavigationTarget {
         NavigationTarget::from_module(db, module)
     }
 
+    pub(crate) fn from_function(db: &RootDatabase, func: hir::Function) -> NavigationTarget {
+        let (file_id, fn_def) = func.source(db);
+        NavigationTarget::from_named(file_id.original_file(db), &*fn_def)
+    }
+
     // TODO once Def::Item is gone, this should be able to always return a NavigationTarget
     pub(crate) fn from_def(
         db: &RootDatabase,
@@ -105,6 +110,9 @@ impl NavigationTarget {
             hir::ModuleDef::Def(def_id) => def_id.resolve(db),
             hir::ModuleDef::Module(module) => {
                 return Some(NavigationTarget::from_module(db, module));
+            }
+            hir::ModuleDef::Function(func) => {
+                return Some(NavigationTarget::from_function(db, func));
             }
         };
 
@@ -119,10 +127,6 @@ impl NavigationTarget {
             }
             Def::EnumVariant(ev) => {
                 let (file_id, node) = ev.source(db);
-                NavigationTarget::from_named(file_id.original_file(db), &*node)
-            }
-            Def::Function(f) => {
-                let (file_id, node) = f.source(db);
                 NavigationTarget::from_named(file_id.original_file(db), &*node)
             }
             Def::Trait(f) => {

--- a/crates/ra_ide_api/src/navigation_target.rs
+++ b/crates/ra_ide_api/src/navigation_target.rs
@@ -3,7 +3,7 @@ use ra_syntax::{
     SyntaxNode, AstNode, SmolStr, TextRange, ast,
     SyntaxKind::{self, NAME},
 };
-use hir::{Def, ModuleSource};
+use hir::{ModuleSource};
 
 use crate::{FileSymbol, db::RootDatabase};
 
@@ -106,63 +106,60 @@ impl NavigationTarget {
         db: &RootDatabase,
         module_def: hir::ModuleDef,
     ) -> Option<NavigationTarget> {
-        let def = match module_def {
-            hir::ModuleDef::Def(def_id) => def_id.resolve(db),
-            hir::ModuleDef::Module(module) => {
-                return Some(NavigationTarget::from_module(db, module));
-            }
-            hir::ModuleDef::Function(func) => {
-                return Some(NavigationTarget::from_function(db, func));
-            }
+        match module_def {
+            hir::ModuleDef::Def(_) => return None,
+            hir::ModuleDef::Module(module) => Some(NavigationTarget::from_module(db, module)),
+            hir::ModuleDef::Function(func) => Some(NavigationTarget::from_function(db, func)),
             hir::ModuleDef::Struct(s) => {
                 let (file_id, node) = s.source(db);
-                return Some(NavigationTarget::from_named(
+                Some(NavigationTarget::from_named(
                     file_id.original_file(db),
                     &*node,
-                ));
+                ))
             }
             hir::ModuleDef::Const(s) => {
                 let (file_id, node) = s.source(db);
-                return Some(NavigationTarget::from_named(
+                Some(NavigationTarget::from_named(
                     file_id.original_file(db),
                     &*node,
-                ));
+                ))
             }
             hir::ModuleDef::Static(s) => {
                 let (file_id, node) = s.source(db);
-                return Some(NavigationTarget::from_named(
+                Some(NavigationTarget::from_named(
                     file_id.original_file(db),
                     &*node,
-                ));
+                ))
             }
             hir::ModuleDef::Enum(e) => {
                 let (file_id, node) = e.source(db);
-                return Some(NavigationTarget::from_named(
+                Some(NavigationTarget::from_named(
                     file_id.original_file(db),
                     &*node,
-                ));
+                ))
             }
             hir::ModuleDef::EnumVariant(var) => {
                 let (file_id, node) = var.source(db);
-                return Some(NavigationTarget::from_named(
+                Some(NavigationTarget::from_named(
                     file_id.original_file(db),
                     &*node,
-                ));
+                ))
             }
-        };
-
-        let res = match def {
-            Def::Trait(f) => {
-                let (file_id, node) = f.source(db);
-                NavigationTarget::from_named(file_id.original_file(db), &*node)
+            hir::ModuleDef::Trait(e) => {
+                let (file_id, node) = e.source(db);
+                Some(NavigationTarget::from_named(
+                    file_id.original_file(db),
+                    &*node,
+                ))
             }
-            Def::Type(f) => {
-                let (file_id, node) = f.source(db);
-                NavigationTarget::from_named(file_id.original_file(db), &*node)
+            hir::ModuleDef::Type(e) => {
+                let (file_id, node) = e.source(db);
+                Some(NavigationTarget::from_named(
+                    file_id.original_file(db),
+                    &*node,
+                ))
             }
-            Def::Item => return None,
-        };
-        Some(res)
+        }
     }
 
     #[cfg(test)]

--- a/crates/ra_ide_api/src/rename.rs
+++ b/crates/ra_ide_api/src/rename.rs
@@ -57,7 +57,6 @@ fn rename_mod(
 ) -> Option<SourceChange> {
     let mut source_file_edits = Vec::new();
     let mut file_system_edits = Vec::new();
-
     if let Some(module) = module_from_declaration(db, position.file_id, &ast_module) {
         let (file_id, module_source) = module.definition_source(db);
         match module_source {
@@ -223,11 +222,15 @@ mod tests {
     fn test_rename_mod() {
         let (analysis, position) = analysis_and_position(
             "
-        //- /bar.rs
-        mod fo<|>o;
-        //- /bar/foo.rs
-        // emtpy
-    ",
+            //- /lib.rs
+            mod bar;
+
+            //- /bar.rs
+            mod foo<|>;
+
+            //- /bar/foo.rs
+            // emtpy
+            ",
         );
         let new_name = "foo2";
         let source_change = analysis.rename(position, new_name).unwrap();
@@ -238,11 +241,11 @@ mod tests {
     fn test_rename_mod_in_dir() {
         let (analysis, position) = analysis_and_position(
             "
-        //- /lib.rs
-        mod fo<|>o;
-        //- /foo/mod.rs
-        // emtpy
-    ",
+            //- /lib.rs
+            mod fo<|>o;
+            //- /foo/mod.rs
+            // emtpy
+            ",
         );
         let new_name = "foo2";
         let source_change = analysis.rename(position, new_name).unwrap();

--- a/crates/ra_ide_api/src/snapshots/tests__rename_mod.snap
+++ b/crates/ra_ide_api/src/snapshots/tests__rename_mod.snap
@@ -1,8 +1,8 @@
 ---
-created: "2019-01-22T14:45:00.975229300+00:00"
-creator: insta@0.4.0
+created: "2019-01-24T08:39:53.759318522+00:00"
+creator: insta@0.5.2
 expression: "&source_change"
-source: "crates\\ra_ide_api\\src\\rename.rs"
+source: crates/ra_ide_api/src/rename.rs
 ---
 Some(
     SourceChange {
@@ -10,7 +10,7 @@ Some(
         source_file_edits: [
             SourceFileEdit {
                 file_id: FileId(
-                    1
+                    2
                 ),
                 edit: TextEdit {
                     atoms: [
@@ -25,7 +25,7 @@ Some(
         file_system_edits: [
             MoveFile {
                 src: FileId(
-                    2
+                    3
                 ),
                 dst_source_root: SourceRootId(
                     0

--- a/crates/ra_syntax/src/ast.rs
+++ b/crates/ra_syntax/src/ast.rs
@@ -430,6 +430,13 @@ impl StructDef {
 }
 
 impl EnumVariant {
+    pub fn parent_enum(&self) -> &EnumDef {
+        self.syntax()
+            .parent()
+            .and_then(|it| it.parent())
+            .and_then(EnumDef::cast)
+            .expect("EnumVariants are always nested in Enums")
+    }
     pub fn flavor(&self) -> StructFlavor {
         StructFlavor::from_node(self)
     }

--- a/crates/ra_syntax/src/ast/generated.rs
+++ b/crates/ra_syntax/src/ast/generated.rs
@@ -3229,6 +3229,7 @@ impl ast::VisibilityOwner for TraitDef {}
 impl ast::NameOwner for TraitDef {}
 impl ast::AttrsOwner for TraitDef {}
 impl ast::DocCommentsOwner for TraitDef {}
+impl ast::TypeParamsOwner for TraitDef {}
 impl TraitDef {}
 
 // TrueKw

--- a/crates/ra_syntax/src/grammar.ron
+++ b/crates/ra_syntax/src/grammar.ron
@@ -280,7 +280,7 @@ Grammar(
         ], options: [["variant_list", "EnumVariantList"]] ),
         "EnumVariantList": ( collections: [["variants", "EnumVariant"]] ),
         "EnumVariant": ( traits: ["NameOwner", "DocCommentsOwner"], options: ["Expr"] ),
-        "TraitDef": ( traits: ["VisibilityOwner", "NameOwner", "AttrsOwner", "DocCommentsOwner"] ),
+        "TraitDef": ( traits: ["VisibilityOwner", "NameOwner", "AttrsOwner", "DocCommentsOwner", "TypeParamsOwner"] ),
         "Module": (
             traits: ["VisibilityOwner", "NameOwner", "AttrsOwner", "DocCommentsOwner" ],
             options: [ "ItemList" ]
@@ -489,7 +489,7 @@ Grammar(
         ),
 
         "RefPat": ( options: [ "Pat" ]),
-        "BindPat": ( 
+        "BindPat": (
             options: [ "Pat" ],
             traits: ["NameOwner"]
         ),


### PR DESCRIPTION
This achieves two things:

* makes module_tree & item_map per crate, not per source_root
* begins the refactoring to remove universal `DefId` in favor of having separate ids for each kind of `Def`. Currently, only modules get a differnt ID though. 