### PR TITLE
Add a simple detail indicating type of resolution

### DIFF
--- a/crates/ra_ide_api/src/completion/completion_item.rs
+++ b/crates/ra_ide_api/src/completion/completion_item.rs
@@ -204,6 +204,7 @@ impl Builder {
         self.documentation = docs.map(Into::into);
         self
     }
+
     pub(super) fn from_resolution(
         mut self,
         ctx: &CompletionContext,
@@ -214,19 +215,34 @@ impl Builder {
             None => return self,
             Some(it) => it,
         };
-        let (kind, docs) = match def {
-            hir::ModuleDef::Module(it) => (CompletionItemKind::Module, it.docs(ctx.db)),
+        let (kind, docs, detail) = match def {
+            hir::ModuleDef::Module(it) => {
+                (CompletionItemKind::Module, it.docs(ctx.db), Some("mod"))
+            }
             hir::ModuleDef::Function(func) => return self.from_function(ctx, func),
-            hir::ModuleDef::Struct(it) => (CompletionItemKind::Struct, it.docs(ctx.db)),
-            hir::ModuleDef::Enum(it) => (CompletionItemKind::Enum, it.docs(ctx.db)),
-            hir::ModuleDef::EnumVariant(it) => (CompletionItemKind::EnumVariant, it.docs(ctx.db)),
-            hir::ModuleDef::Const(it) => (CompletionItemKind::Const, it.docs(ctx.db)),
-            hir::ModuleDef::Static(it) => (CompletionItemKind::Static, it.docs(ctx.db)),
-            hir::ModuleDef::Trait(it) => (CompletionItemKind::Trait, it.docs(ctx.db)),
-            hir::ModuleDef::Type(it) => (CompletionItemKind::TypeAlias, it.docs(ctx.db)),
+            hir::ModuleDef::Struct(it) => {
+                (CompletionItemKind::Struct, it.docs(ctx.db), Some("struct"))
+            }
+            hir::ModuleDef::Enum(it) => (CompletionItemKind::Enum, it.docs(ctx.db), Some("enum")),
+            hir::ModuleDef::EnumVariant(it) => {
+                (CompletionItemKind::EnumVariant, it.docs(ctx.db), None)
+            }
+            hir::ModuleDef::Const(it) => {
+                (CompletionItemKind::Const, it.docs(ctx.db), Some("const"))
+            }
+            hir::ModuleDef::Static(it) => {
+                (CompletionItemKind::Static, it.docs(ctx.db), Some("static"))
+            }
+            hir::ModuleDef::Trait(it) => {
+                (CompletionItemKind::Trait, it.docs(ctx.db), Some("trait"))
+            }
+            hir::ModuleDef::Type(it) => {
+                (CompletionItemKind::TypeAlias, it.docs(ctx.db), Some("type"))
+            }
         };
         self.kind = Some(kind);
         self.documentation = docs;
+        self.detail = detail.map(|it| it.into());
 
         self
     }

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__deeply_nested_use_tree.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__deeply_nested_use_tree.snap
@@ -1,8 +1,8 @@
 ---
-created: "2019-01-22T14:45:00.719911400+00:00"
-creator: insta@0.4.0
+created: "2019-01-25T20:32:41.085195800+00:00"
+creator: insta@0.5.2
 expression: kind_completions
-source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+source: crates/ra_ide_api/src/completion/completion_item.rs
 ---
 [
     CompletionItem {
@@ -11,7 +11,9 @@ source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
         kind: Some(
             Struct
         ),
-        detail: None,
+        detail: Some(
+            "struct"
+        ),
         documentation: None,
         lookup: None,
         insert_text: None,

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__mod_with_docs.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__mod_with_docs.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-01-25T17:49:28.949186500+00:00"
+created: "2019-01-25T20:32:41.088188900+00:00"
 creator: insta@0.5.2
 expression: kind_completions
 source: crates/ra_ide_api/src/completion/completion_item.rs
@@ -11,7 +11,9 @@ source: crates/ra_ide_api/src/completion/completion_item.rs
         kind: Some(
             Module
         ),
-        detail: None,
+        detail: Some(
+            "mod"
+        ),
         documentation: Some(
             Documentation(
                 "Some simple\ndocs describing `mod my`."

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__module_items.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__module_items.snap
@@ -1,6 +1,6 @@
 ---
-created: "2019-01-23T07:42:59.657718+00:00"
-creator: insta@0.4.0
+created: "2019-01-25T20:32:41.100156700+00:00"
+creator: insta@0.5.2
 expression: kind_completions
 source: crates/ra_ide_api/src/completion/completion_item.rs
 ---
@@ -29,7 +29,9 @@ source: crates/ra_ide_api/src/completion/completion_item.rs
         kind: Some(
             Struct
         ),
-        detail: None,
+        detail: Some(
+            "struct"
+        ),
         documentation: None,
         lookup: None,
         insert_text: None,
@@ -43,7 +45,9 @@ source: crates/ra_ide_api/src/completion/completion_item.rs
         kind: Some(
             Enum
         ),
-        detail: None,
+        detail: Some(
+            "enum"
+        ),
         documentation: None,
         lookup: None,
         insert_text: None,

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__module_items_in_nested_modules.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__module_items_in_nested_modules.snap
@@ -1,6 +1,6 @@
 ---
-created: "2019-01-23T07:42:59.657837+00:00"
-creator: insta@0.4.0
+created: "2019-01-25T20:32:41.101154300+00:00"
+creator: insta@0.5.2
 expression: kind_completions
 source: crates/ra_ide_api/src/completion/completion_item.rs
 ---
@@ -29,7 +29,9 @@ source: crates/ra_ide_api/src/completion/completion_item.rs
         kind: Some(
             Struct
         ),
-        detail: None,
+        detail: Some(
+            "struct"
+        ),
         documentation: None,
         lookup: None,
         insert_text: None,

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__nested_use_tree.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__nested_use_tree.snap
@@ -1,8 +1,8 @@
 ---
-created: "2019-01-22T14:45:00.723900500+00:00"
-creator: insta@0.4.0
+created: "2019-01-25T20:32:41.088188900+00:00"
+creator: insta@0.5.2
 expression: kind_completions
-source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+source: crates/ra_ide_api/src/completion/completion_item.rs
 ---
 [
     CompletionItem {
@@ -11,7 +11,9 @@ source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
         kind: Some(
             Struct
         ),
-        detail: None,
+        detail: Some(
+            "struct"
+        ),
         documentation: None,
         lookup: None,
         insert_text: None,
@@ -25,7 +27,9 @@ source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
         kind: Some(
             Module
         ),
-        detail: None,
+        detail: Some(
+            "mod"
+        ),
         documentation: None,
         lookup: None,
         insert_text: None,

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__return_type.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__return_type.snap
@@ -1,6 +1,6 @@
 ---
-created: "2019-01-23T05:27:32.421411+00:00"
-creator: insta@0.4.0
+created: "2019-01-25T20:32:41.105143500+00:00"
+creator: insta@0.5.2
 expression: kind_completions
 source: crates/ra_ide_api/src/completion/completion_item.rs
 ---
@@ -11,7 +11,9 @@ source: crates/ra_ide_api/src/completion/completion_item.rs
         kind: Some(
             Struct
         ),
-        detail: None,
+        detail: Some(
+            "struct"
+        ),
         documentation: None,
         lookup: None,
         insert_text: None,

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__use_item_starting_with_crate.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__use_item_starting_with_crate.snap
@@ -1,8 +1,8 @@
 ---
-created: "2019-01-22T14:45:00.761799100+00:00"
-creator: insta@0.4.0
+created: "2019-01-25T20:32:41.092177700+00:00"
+creator: insta@0.5.2
 expression: kind_completions
-source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+source: crates/ra_ide_api/src/completion/completion_item.rs
 ---
 [
     CompletionItem {
@@ -11,7 +11,9 @@ source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
         kind: Some(
             Struct
         ),
-        detail: None,
+        detail: Some(
+            "struct"
+        ),
         documentation: None,
         lookup: None,
         insert_text: None,
@@ -25,7 +27,9 @@ source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
         kind: Some(
             Module
         ),
-        detail: None,
+        detail: Some(
+            "mod"
+        ),
         documentation: None,
         lookup: None,
         insert_text: None,

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__use_item_starting_with_self.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__use_item_starting_with_self.snap
@@ -1,8 +1,8 @@
 ---
-created: "2019-01-22T14:45:00.780748400+00:00"
-creator: insta@0.4.0
+created: "2019-01-25T20:32:41.092177700+00:00"
+creator: insta@0.5.2
 expression: kind_completions
-source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
+source: crates/ra_ide_api/src/completion/completion_item.rs
 ---
 [
     CompletionItem {
@@ -11,7 +11,9 @@ source: "crates\\ra_ide_api\\src\\completion\\completion_item.rs"
         kind: Some(
             Struct
         ),
-        detail: None,
+        detail: Some(
+            "struct"
+        ),
         documentation: None,
         lookup: None,
         insert_text: None,


### PR DESCRIPTION
This may be a bit of personal preference (and is somewhat addressed by the icons in vscode if you know what those are off the top of your head) but I find adding the kind from resolution makes the experience a bit more clear.