### PR TITLE
Fold blocks of mod items

### DIFF
--- a/crates/ra_ide_api_light/src/folding_ranges.rs
+++ b/crates/ra_ide_api_light/src/folding_ranges.rs
@@ -83,7 +83,11 @@ fn fold_kind(kind: SyntaxKind) -> Option<FoldKind> {
 }
 
 fn has_visibility(node: &SyntaxNode) -> bool {
-    return node.descendants().any(|n| n.kind() == VISIBILITY);
+    use ast::VisibilityOwner;
+
+    return ast::Module::cast(node)
+        .and_then(|m| m.visibility())
+        .is_some();
 }
 
 fn has_newline(node: &SyntaxNode) -> bool {

--- a/crates/ra_lsp_server/src/main_loop/handlers.rs
+++ b/crates/ra_lsp_server/src/main_loop/handlers.rs
@@ -369,6 +369,7 @@ pub fn handle_folding_range(
                 let kind = match fold.kind {
                     FoldKind::Comment => Some(FoldingRangeKind::Comment),
                     FoldKind::Imports => Some(FoldingRangeKind::Imports),
+                    FoldKind::Mods => None,
                     FoldKind::Block => None,
                 };
                 let range = fold.range.conv_with(&line_index);


### PR DESCRIPTION
Fixes #572

As requested, we ignore `mod`s with a visibility specifier.