### PR TITLE
Feat/jinstall lsp

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -5,6 +5,8 @@ gen-syntax   = "run --package tools --bin tools -- gen-syntax"
 gen-tests    = "run --package tools --bin tools -- gen-tests"
 # Installs ra_lsp_server
 install-lsp = "install --path crates/ra_lsp_server --force"
+# Installs ra_lsp_server with the jemalloc feature
+jinstall-lsp = "install --path crates/ra_lsp_server --force --features jemalloc"
 # Installs the visual studio code extension
 install-code = "run --package tools --bin tools -- install-code"
 # Formats the full repository or installs the git hook to do it automatically.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -178,7 +178,7 @@ VS Code plugin
 
 To try out VS Code extensions, run `cargo install-code`.  This installs both the
 `ra_lsp_server` binary and the VS Code extension. To install only the binary, use
-`cargo install --path crates/ra_lsp_server --force`
+`cargo install-lsp` (shorthand for `cargo install --path crates/ra_lsp_server --force`)
 
 To see logs from the language server, set `RUST_LOG=info` env variable. To see
 all communication between the server and the client, use
@@ -186,12 +186,12 @@ all communication between the server and the client, use
 
 There's `rust-analyzer: status` command which prints common high-level debug
 info. In particular, it prints info about memory usage of various data
-structures, and, if compiled with jemalloc support (`cargo install --features
-jemalloc`), the summary statistic about the heap.
+structures, and, if compiled with jemalloc support (`cargo jinstall-lsp` or 
+`cargo install --path crates/ra_lsp_server --force --features jemalloc`), includes
+ statistic about the heap.
 
 To run tests, just `cargo test`.
 
 To work on the VS Code extension, launch code inside `editors/code` and use `F5` to
 launch/debug. To automatically apply formatter and linter suggestions, use `npm
 run fix`.
-

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -44,7 +44,9 @@
         "vscode": "^1.1.26"
     },
     "activationEvents": [
-        "onLanguage:rust"
+        "onLanguage:rust",
+        "onCommand:rust-analyzer.analyzerStatus",
+        "onCommand:rust-analyzer.collectGarbage"
     ],
     "main": "./out/extension",
     "contributes": {

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -75,35 +75,43 @@
         "commands": [
             {
                 "command": "rust-analyzer.syntaxTree",
-                "title": "rust-analyzer: syntax tree"
+                "title": "Show syntax tree for current file",
+                "category": "Rust Analyzer"
             },
             {
                 "command": "rust-analyzer.extendSelection",
-                "title": "rust-analyzer: extend selection"
+                "title": "Extend selection",
+                "category": "Rust Analyzer"
             },
             {
                 "command": "rust-analyzer.matchingBrace",
-                "title": "rust-analyzer: matching brace"
+                "title": "Find matching brace",
+                "category": "Rust Analyzer"
             },
             {
                 "command": "rust-analyzer.parentModule",
-                "title": "rust-analyzer: parent module"
+                "title": "Locate parent module",
+                "category": "Rust Analyzer"
             },
             {
                 "command": "rust-analyzer.joinLines",
-                "title": "rust-analyzer: join lines"
+                "title": "Join lines",
+                "category": "Rust Analyzer"
             },
             {
                 "command": "rust-analyzer.run",
-                "title": "rust-analyzer: run"
+                "title": "Run",
+                "category": "Rust Analyzer"
             },
             {
                 "command": "rust-analyzer.analyzerStatus",
-                "title": "rust-analyzer: status"
+                "title": "Status",
+                "category": "Rust Analyzer"
             },
             {
                 "command": "rust-analyzer.collectGarbage",
-                "title": "rust-analyzer: run gc"
+                "title": "Run garbage collection",
+                "category": "Rust Analyzer"
             }
         ],
         "keybindings": [


### PR DESCRIPTION
Add `cargo jinstall-lsp` as a shorthand to include jemalloc support

Also activate the extension when the commands are run which is makes sense to activate.

I still need to work out what `Run` actually does to give it a better name, and other extensions through some voodoo magic are able to hide their commands from the command palette before the extension is activated, which would be a better fix.