### PR TITLE
Rename FnScopes and move them below the expr module

### DIFF
--- a/crates/ra_hir/src/code_model_api.rs
+++ b/crates/ra_hir/src/code_model_api.rs
@@ -396,7 +396,7 @@ pub struct Function {
     pub(crate) id: FunctionId,
 }
 
-pub use crate::code_model_impl::function::ScopeEntryWithSyntax;
+pub use crate::expr::ScopeEntryWithSyntax;
 
 /// The declared signature of a function.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -447,7 +447,7 @@ impl Function {
     }
 
     pub fn scopes(&self, db: &impl HirDatabase) -> ScopesWithSyntaxMapping {
-        let scopes = db.fn_scopes(*self);
+        let scopes = db.expr_scopes(*self);
         let syntax_mapping = db.body_syntax_mapping(*self);
         ScopesWithSyntaxMapping {
             scopes,

--- a/crates/ra_hir/src/code_model_impl/function.rs
+++ b/crates/ra_hir/src/code_model_impl/function.rs
@@ -1,5 +1,3 @@
-mod scope;
-
 use std::sync::Arc;
 
 use ra_syntax::ast::{self, NameOwner};
@@ -10,8 +8,6 @@ use crate::{
     expr::Body,
     impl_block::ImplBlock,
 };
-
-pub use self::scope::{FnScopes, ScopesWithSyntaxMapping, ScopeEntryWithSyntax};
 
 impl Function {
     pub(crate) fn body(&self, db: &impl HirDatabase) -> Arc<Body> {

--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -7,7 +7,7 @@ use crate::{
     MacroCallId, HirFileId,
     SourceFileItems, SourceItemId, Crate, Module, HirInterner,
     query_definitions,
-    Function, FnSignature, FnScopes,
+    Function, FnSignature, ExprScopes,
     Struct, Enum, StructField,
     macros::MacroExpansion,
     module_tree::ModuleTree,
@@ -27,8 +27,8 @@ pub trait HirDatabase: SourceDatabase + AsRef<HirInterner> {
     #[salsa::invoke(crate::macros::expand_macro_invocation)]
     fn expand_macro_invocation(&self, invoc: MacroCallId) -> Option<Arc<MacroExpansion>>;
 
-    #[salsa::invoke(query_definitions::fn_scopes)]
-    fn fn_scopes(&self, func: Function) -> Arc<FnScopes>;
+    #[salsa::invoke(query_definitions::expr_scopes)]
+    fn expr_scopes(&self, func: Function) -> Arc<ExprScopes>;
 
     #[salsa::invoke(crate::adt::StructData::struct_data_query)]
     fn struct_data(&self, s: Struct) -> Arc<StructData>;

--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -27,7 +27,7 @@ pub trait HirDatabase: SourceDatabase + AsRef<HirInterner> {
     #[salsa::invoke(crate::macros::expand_macro_invocation)]
     fn expand_macro_invocation(&self, invoc: MacroCallId) -> Option<Arc<MacroExpansion>>;
 
-    #[salsa::invoke(query_definitions::expr_scopes)]
+    #[salsa::invoke(ExprScopes::expr_scopes_query)]
     fn expr_scopes(&self, func: Function) -> Arc<ExprScopes>;
 
     #[salsa::invoke(crate::adt::StructData::struct_data_query)]

--- a/crates/ra_hir/src/expr.rs
+++ b/crates/ra_hir/src/expr.rs
@@ -16,6 +16,10 @@ use crate::{
 };
 use crate::ty::primitive::{UintTy, UncertainIntTy, UncertainFloatTy};
 
+pub use self::scope::{ExprScopes, ScopesWithSyntaxMapping, ScopeEntryWithSyntax};
+
+mod scope;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ExprId(RawId);
 impl_arena_id!(ExprId);

--- a/crates/ra_hir/src/expr/scope.rs
+++ b/crates/ra_hir/src/expr/scope.rs
@@ -16,7 +16,7 @@ pub struct ScopeId(RawId);
 impl_arena_id!(ScopeId);
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct FnScopes {
+pub struct ExprScopes {
     body: Arc<Body>,
     scopes: Arena<ScopeId, ScopeData>,
     scope_for: FxHashMap<ExprId, ScopeId>,
@@ -34,9 +34,9 @@ pub struct ScopeData {
     entries: Vec<ScopeEntry>,
 }
 
-impl FnScopes {
-    pub(crate) fn new(body: Arc<Body>) -> FnScopes {
-        let mut scopes = FnScopes {
+impl ExprScopes {
+    pub(crate) fn new(body: Arc<Body>) -> ExprScopes {
+        let mut scopes = ExprScopes {
             body: body.clone(),
             scopes: Arena::default(),
             scope_for: FxHashMap::default(),
@@ -119,7 +119,7 @@ impl FnScopes {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScopesWithSyntaxMapping {
     pub syntax_mapping: Arc<BodySyntaxMapping>,
-    pub scopes: Arc<FnScopes>,
+    pub scopes: Arc<ExprScopes>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -249,7 +249,7 @@ fn compute_block_scopes(
     statements: &[Statement],
     tail: Option<ExprId>,
     body: &Body,
-    scopes: &mut FnScopes,
+    scopes: &mut ExprScopes,
     mut scope: ScopeId,
 ) {
     for stmt in statements {
@@ -275,7 +275,7 @@ fn compute_block_scopes(
     }
 }
 
-fn compute_expr_scopes(expr: ExprId, body: &Body, scopes: &mut FnScopes, scope: ScopeId) {
+fn compute_expr_scopes(expr: ExprId, body: &Body, scopes: &mut ExprScopes, scope: ScopeId) {
     scopes.set_scope(expr, scope);
     match &body[expr] {
         Expr::Block { statements, tail } => {
@@ -344,7 +344,7 @@ mod tests {
         let marker: &ast::PathExpr = find_node_at_offset(file.syntax(), off).unwrap();
         let fn_def: &ast::FnDef = find_node_at_offset(file.syntax(), off).unwrap();
         let body_hir = expr::collect_fn_body_syntax(fn_def);
-        let scopes = FnScopes::new(Arc::clone(body_hir.body()));
+        let scopes = ExprScopes::new(Arc::clone(body_hir.body()));
         let scopes = ScopesWithSyntaxMapping {
             scopes: Arc::new(scopes),
             syntax_mapping: Arc::new(body_hir),
@@ -444,7 +444,7 @@ mod tests {
         let name_ref: &ast::NameRef = find_node_at_offset(file.syntax(), off).unwrap();
 
         let body_hir = expr::collect_fn_body_syntax(fn_def);
-        let scopes = FnScopes::new(Arc::clone(body_hir.body()));
+        let scopes = ExprScopes::new(Arc::clone(body_hir.body()));
         let scopes = ScopesWithSyntaxMapping {
             scopes: Arc::new(scopes),
             syntax_mapping: Arc::new(body_hir),

--- a/crates/ra_hir/src/expr/scope.rs
+++ b/crates/ra_hir/src/expr/scope.rs
@@ -9,7 +9,11 @@ use ra_syntax::{
 };
 use ra_arena::{Arena, RawId, impl_arena_id};
 
-use crate::{Name, AsName, expr::{PatId, ExprId, Pat, Expr, Body, Statement, BodySyntaxMapping}};
+use crate::{
+    Name, AsName, Function,
+    expr::{PatId, ExprId, Pat, Expr, Body, Statement, BodySyntaxMapping},
+    db::HirDatabase,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ScopeId(RawId);
@@ -35,7 +39,14 @@ pub struct ScopeData {
 }
 
 impl ExprScopes {
-    pub(crate) fn new(body: Arc<Body>) -> ExprScopes {
+    // TODO: This should take something more general than Function
+    pub(crate) fn expr_scopes_query(db: &impl HirDatabase, function: Function) -> Arc<ExprScopes> {
+        let body = db.body_hir(function);
+        let res = ExprScopes::new(body);
+        Arc::new(res)
+    }
+
+    fn new(body: Arc<Body>) -> ExprScopes {
         let mut scopes = ExprScopes {
             body: body.clone(),
             scopes: Arena::default(),

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -57,9 +57,9 @@ pub use self::{
     nameres::{ItemMap, PerNs, Namespace, Resolution},
     ty::Ty,
     impl_block::{ImplBlock, ImplItem},
-    code_model_impl::function::{FnScopes, ScopesWithSyntaxMapping},
     docs::{Docs, Documentation},
     adt::AdtDef,
+    expr::{ExprScopes, ScopesWithSyntaxMapping},
 };
 
 pub use self::code_model_api::{

--- a/crates/ra_hir/src/query_definitions.rs
+++ b/crates/ra_hir/src/query_definitions.rs
@@ -1,18 +1,13 @@
 use std::sync::Arc;
 
-use ra_syntax::{SyntaxNode, TreeArc};
+use ra_syntax::{
+    SyntaxNode, TreeArc,
+};
 
 use crate::{
     SourceFileItems, SourceItemId, HirFileId,
-    Function, ExprScopes,
     db::HirDatabase,
 };
-
-pub(super) fn expr_scopes(db: &impl HirDatabase, func: Function) -> Arc<ExprScopes> {
-    let body = db.body_hir(func);
-    let res = ExprScopes::new(body);
-    Arc::new(res)
-}
 
 pub(super) fn file_items(db: &impl HirDatabase, file_id: HirFileId) -> Arc<SourceFileItems> {
     let source_file = db.hir_parse(file_id);

--- a/crates/ra_hir/src/query_definitions.rs
+++ b/crates/ra_hir/src/query_definitions.rs
@@ -4,13 +4,13 @@ use ra_syntax::{SyntaxNode, TreeArc};
 
 use crate::{
     SourceFileItems, SourceItemId, HirFileId,
-    Function, FnScopes,
+    Function, ExprScopes,
     db::HirDatabase,
 };
 
-pub(super) fn fn_scopes(db: &impl HirDatabase, func: Function) -> Arc<FnScopes> {
+pub(super) fn expr_scopes(db: &impl HirDatabase, func: Function) -> Arc<ExprScopes> {
     let body = db.body_hir(func);
-    let res = FnScopes::new(body);
+    let res = ExprScopes::new(body);
     Arc::new(res)
 }
 

--- a/crates/ra_hir/src/ty.rs
+++ b/crates/ra_hir/src/ty.rs
@@ -34,7 +34,7 @@ use test_utils::tested_by;
 
 use crate::{
     Module, Function, Struct, StructField, Enum, EnumVariant, Path, Name, ImplBlock,
-    FnSignature, FnScopes, ModuleDef, AdtDef,
+    FnSignature, ExprScopes, ModuleDef, AdtDef,
     db::HirDatabase,
     type_ref::{TypeRef, Mutability},
     name::KnownName,
@@ -814,7 +814,7 @@ impl Index<PatId> for InferenceResult {
 struct InferenceContext<'a, D: HirDatabase> {
     db: &'a D,
     body: Arc<Body>,
-    scopes: Arc<FnScopes>,
+    scopes: Arc<ExprScopes>,
     module: Module,
     impl_block: Option<ImplBlock>,
     var_unification_table: InPlaceUnificationTable<TypeVarId>,
@@ -908,7 +908,7 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
     fn new(
         db: &'a D,
         body: Arc<Body>,
-        scopes: Arc<FnScopes>,
+        scopes: Arc<ExprScopes>,
         module: Module,
         impl_block: Option<ImplBlock>,
     ) -> Self {
@@ -1720,7 +1720,7 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
 pub fn infer(db: &impl HirDatabase, func: Function) -> Arc<InferenceResult> {
     db.check_canceled();
     let body = func.body(db);
-    let scopes = db.fn_scopes(func);
+    let scopes = db.expr_scopes(func);
     let module = func.module(db);
     let impl_block = func.impl_block(db);
     let mut ctx = InferenceContext::new(db, body, scopes, module, impl_block);


### PR DESCRIPTION
Extracted from #693 to reduce the diff and make rebasing easier for me :wink: 

The scopes belong to a body, which could be that of a function, but also a constant, static or array size. So this moves them to a submodule of `expr`.

Also move the `expr_scopes` query from `query_definitions` to that module.