### PR TITLE
remove hard-coded support for ctry macro

### DIFF
--- a/crates/ra_ide_api/src/extend_selection.rs
+++ b/crates/ra_ide_api/src/extend_selection.rs
@@ -47,11 +47,11 @@ mod tests {
         let (analysis, frange) = single_file_with_range(
             "
             fn main() {
-                ctry!(foo(|x| <|>x<|>));
+                vec![foo(|x| <|>x<|>)];
             }
         ",
         );
         let r = analysis.extend_selection(frange).unwrap();
-        assert_eq!(r, TextRange::from_to(51.into(), 56.into()));
+        assert_eq!(r, TextRange::from_to(50.into(), 55.into()));
     }
 }

--- a/crates/ra_ide_api/src/snapshots/tests__highlight_query_group_macro.snap
+++ b/crates/ra_ide_api/src/snapshots/tests__highlight_query_group_macro.snap
@@ -1,8 +1,8 @@
 ---
-created: "2019-01-22T14:45:01.017117100+00:00"
-creator: insta@0.4.0
+created: "2019-02-01T07:52:15.689836752+00:00"
+creator: insta@0.5.3
 expression: "&highlights"
-source: "crates\\ra_ide_api\\src\\syntax_highlighting.rs"
+source: crates/ra_ide_api/src/syntax_highlighting.rs
 ---
 [
     HighlightedRange {

--- a/crates/ra_ide_api/src/snapshots/tests__highlights_code_inside_macros.snap
+++ b/crates/ra_ide_api/src/snapshots/tests__highlights_code_inside_macros.snap
@@ -1,8 +1,8 @@
 ---
-created: "2019-01-22T14:45:01.043047100+00:00"
-creator: insta@0.4.0
+created: "2019-02-01T07:46:59.130146403+00:00"
+creator: insta@0.5.3
 expression: "&highlights"
-source: "crates\\ra_ide_api\\src\\syntax_highlighting.rs"
+source: crates/ra_ide_api/src/syntax_highlighting.rs
 ---
 [
     HighlightedRange {
@@ -14,59 +14,31 @@ source: "crates\\ra_ide_api\\src\\syntax_highlighting.rs"
         tag: "function"
     },
     HighlightedRange {
-        range: [41; 46),
+        range: [41; 45),
         tag: "macro"
     },
     HighlightedRange {
-        range: [49; 52),
+        range: [48; 51),
         tag: "keyword"
     },
     HighlightedRange {
-        range: [57; 59),
+        range: [56; 58),
         tag: "literal"
     },
     HighlightedRange {
-        range: [82; 86),
-        tag: "macro"
-    },
-    HighlightedRange {
-        range: [89; 92),
+        range: [48; 51),
         tag: "keyword"
     },
     HighlightedRange {
-        range: [97; 99),
-        tag: "literal"
-    },
-    HighlightedRange {
-        range: [49; 52),
-        tag: "keyword"
-    },
-    HighlightedRange {
-        range: [53; 54),
+        range: [52; 53),
         tag: "function"
     },
     HighlightedRange {
-        range: [57; 59),
+        range: [56; 58),
         tag: "literal"
     },
     HighlightedRange {
-        range: [61; 62),
-        tag: "text"
-    },
-    HighlightedRange {
-        range: [89; 92),
-        tag: "keyword"
-    },
-    HighlightedRange {
-        range: [93; 94),
-        tag: "function"
-    },
-    HighlightedRange {
-        range: [97; 99),
-        tag: "literal"
-    },
-    HighlightedRange {
-        range: [101; 102),
+        range: [60; 61),
         tag: "text"
     }
 ]

--- a/crates/ra_ide_api/src/syntax_highlighting.rs
+++ b/crates/ra_ide_api/src/syntax_highlighting.rs
@@ -42,7 +42,6 @@ mod tests {
         let (analysis, file_id) = single_file(
             "
             fn main() {
-                ctry!({ let x = 92; x});
                 vec![{ let x = 92; x}];
             }
             ",


### PR DESCRIPTION
It was used mainly to prevent HirFileId infra from bitroting, but the
`vec![]` macro can serve that just as well!