### PR TITLE
WIP: goto defenition inside macro_rules macro

### DIFF
--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -2,9 +2,10 @@ use std::sync::Arc;
 
 use ra_syntax::{SyntaxNode, TreeArc, SourceFile};
 use ra_db::{SourceDatabase, salsa};
+use rustc_hash::FxHashMap;
 
 use crate::{
-    MacroCallId, HirFileId,
+    MacroCallId, HirFileId, Name,
     SourceFileItems, SourceItemId, Crate, Module, HirInterner,
     query_definitions,
     Function, FnSignature, ExprScopes,
@@ -17,12 +18,16 @@ use crate::{
     impl_block::{ModuleImplBlocks, ImplSourceMap},
     generics::{GenericParams, GenericDef},
     ids::SourceFileItemId,
+    macros::MacroDef,
 };
 
 #[salsa::query_group(PersistentHirDatabaseStorage)]
 pub trait PersistentHirDatabase: SourceDatabase + AsRef<HirInterner> {
     #[salsa::invoke(HirFileId::hir_parse)]
     fn hir_parse(&self, file_id: HirFileId) -> TreeArc<SourceFile>;
+
+    #[salsa::invoke(crate::macros::macro_definitions)]
+    fn macro_definitions(&self, module: Module) -> Arc<FxHashMap<Name, MacroDef>>;
 
     #[salsa::invoke(crate::macros::expand_macro_invocation)]
     fn expand_macro_invocation(&self, invoc: MacroCallId) -> Option<Arc<MacroExpansion>>;

--- a/crates/ra_hir/src/macros.rs
+++ b/crates/ra_hir/src/macros.rs
@@ -13,14 +13,16 @@ use ra_syntax::{
     TextRange, TextUnit, SourceFile, AstNode, SyntaxNode, TreeArc, SyntaxNodePtr,
     ast::{self, NameOwner},
 };
+use mbe::MacroRules;
 
 use crate::{MacroCallId, PersistentHirDatabase};
 
 // Hard-coded defs for now :-(
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MacroDef {
     Vec,
     QueryGroup,
+    MacroRules(Arc<MacroRules>),
 }
 
 impl MacroDef {

--- a/crates/ra_hir/src/macros.rs
+++ b/crates/ra_hir/src/macros.rs
@@ -178,7 +178,7 @@ pub(crate) fn expand_macro_invocation(
     if let Some((def, input)) = MacroDef::from_call(macro_call) {
         return def.expand(input).map(Arc::new);
     }
-    let defs = macro_definitions(db, loc.module);
+    let defs = db.macro_definitions(loc.module);
     let def = defs.get(&macro_name(macro_call)?.as_name())?;
     let input = MacroInput::from_ast(macro_call)?;
     def.expand(input).map(Arc::new)

--- a/crates/ra_hir/src/module_tree.rs
+++ b/crates/ra_hir/src/module_tree.rs
@@ -115,7 +115,7 @@ pub struct ModuleTree {
     links: Arena<LinkId, LinkData>,
 }
 
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ModuleData {
     file_id: HirFileId,
     /// Points to `ast::Module`, `None` for the whole file.

--- a/crates/ra_ide_api/src/goto_definition.rs
+++ b/crates/ra_ide_api/src/goto_definition.rs
@@ -270,7 +270,7 @@ mod tests {
     }
 
     #[test]
-    fn goto_defenition_works_for_macros() {
+    fn goto_definition_works_for_macros() {
         check_goto(
             "
             //- /lib.rs

--- a/crates/ra_mbe/src/lib.rs
+++ b/crates/ra_mbe/src/lib.rs
@@ -30,7 +30,7 @@ pub use crate::syntax_bridge::ast_to_token_tree;
 /// be very confusing is that AST has almost exactly the same shape as
 /// `tt::TokenTree`, but there's a crucial difference: in macro rules, `$ident`
 /// and `$()*` have special meaning (see `Var` and `Repeat` data structures)
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct MacroRules {
     pub(crate) rules: Vec<Rule>,
 }
@@ -44,13 +44,13 @@ impl MacroRules {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) struct Rule {
     pub(crate) lhs: Subtree,
     pub(crate) rhs: Subtree,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) enum TokenTree {
     Leaf(Leaf),
     Subtree(Subtree),
@@ -58,7 +58,7 @@ pub(crate) enum TokenTree {
 }
 impl_froms!(TokenTree: Leaf, Subtree, Repeat);
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) enum Leaf {
     Literal(Literal),
     Punct(Punct),
@@ -67,37 +67,37 @@ pub(crate) enum Leaf {
 }
 impl_froms!(Leaf: Literal, Punct, Ident, Var);
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) struct Subtree {
     pub(crate) delimiter: Delimiter,
     pub(crate) token_trees: Vec<TokenTree>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) struct Repeat {
     pub(crate) subtree: Subtree,
     pub(crate) kind: RepeatKind,
     pub(crate) separator: Option<char>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) enum RepeatKind {
     ZeroOrMore,
     OneOrMore,
     ZeroOrOne,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) struct Literal {
     pub(crate) text: SmolStr,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) struct Ident {
     pub(crate) text: SmolStr,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) struct Var {
     pub(crate) text: SmolStr,
     pub(crate) kind: Option<SmolStr>,

--- a/crates/ra_mbe/src/lib.rs
+++ b/crates/ra_mbe/src/lib.rs
@@ -150,14 +150,16 @@ impl_froms!(TokenTree: Leaf, Subtree);
             .find_map(ast::MacroCall::cast)
             .unwrap();
 
-        let definition_tt = ast_to_token_tree(macro_definition.token_tree().unwrap()).unwrap();
-        let invocation_tt = ast_to_token_tree(macro_invocation.token_tree().unwrap()).unwrap();
+        let (definition_tt, _token_map) =
+            ast_to_token_tree(macro_definition.token_tree().unwrap()).unwrap();
+        let (invocation_tt, _token_map) =
+            ast_to_token_tree(macro_invocation.token_tree().unwrap()).unwrap();
         let rules = crate::MacroRules::parse(&definition_tt).unwrap();
         let expansion = rules.expand(&invocation_tt).unwrap();
         assert_eq!(
-        expansion.to_string(),
-        "impl From < Leaf > for TokenTree {fn from (it : Leaf) -> TokenTree {TokenTree :: Leaf (it)}} \
-         impl From < Subtree > for TokenTree {fn from (it : Subtree) -> TokenTree {TokenTree :: Subtree (it)}}"
-    )
+            expansion.to_string(),
+            "impl From < Leaf > for TokenTree {fn from (it : Leaf) -> TokenTree {TokenTree :: Leaf (it)}} \
+             impl From < Subtree > for TokenTree {fn from (it : Subtree) -> TokenTree {TokenTree :: Subtree (it)}}"
+        )
     }
 }

--- a/crates/ra_mbe/src/lib.rs
+++ b/crates/ra_mbe/src/lib.rs
@@ -169,4 +169,71 @@ impl_froms!(TokenTree: Leaf, Subtree);
             Some(TextRange::from_to(23.into(), 32.into())),
         )
     }
+
+    #[test]
+    fn dont_die_on_serde() {
+        let macro_definition = r#"
+macro_rules! tuple_impls {
+    ($($len:expr => ($($n:tt $name:ident)+))+) => {
+        $(
+            impl<$($name),+> Serialize for ($($name,)+)
+            where
+                $($name: Serialize,)+
+            {
+                #[inline]
+                fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                where
+                    S: Serializer,
+                {
+                    let mut tuple = try!(serializer.serialize_tuple($len));
+                    $(
+                        try!(tuple.serialize_element(&self.$n));
+                    )+
+                    tuple.end()
+                }
+            }
+        )+
+    }
+}"#;
+        let macro_invocation = r#"
+tuple_impls! {
+    1 => (0 T0)
+    2 => (0 T0 1 T1)
+    3 => (0 T0 1 T1 2 T2)
+    4 => (0 T0 1 T1 2 T2 3 T3)
+    5 => (0 T0 1 T1 2 T2 3 T3 4 T4)
+    6 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5)
+    7 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6)
+    8 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7)
+    9 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8)
+    10 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9)
+    11 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10)
+    12 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11)
+    13 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12)
+    14 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13)
+    15 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 14 T14)
+    16 => (0 T0 1 T1 2 T2 3 T3 4 T4 5 T5 6 T6 7 T7 8 T8 9 T9 10 T10 11 T11 12 T12 13 T13 14 T14 15 T15)
+}
+"#;
+        let source_file = ast::SourceFile::parse(macro_definition);
+        let macro_definition = source_file
+            .syntax()
+            .descendants()
+            .find_map(ast::MacroCall::cast)
+            .unwrap();
+
+        let source_file = ast::SourceFile::parse(macro_invocation);
+        let macro_invocation = source_file
+            .syntax()
+            .descendants()
+            .find_map(ast::MacroCall::cast)
+            .unwrap();
+
+        let (definition_tt, _) = ast_to_token_tree(macro_definition.token_tree().unwrap()).unwrap();
+        let (invocation_tt, token_map) =
+            ast_to_token_tree(macro_invocation.token_tree().unwrap()).unwrap();
+        let rules = crate::MacroRules::parse(&definition_tt).unwrap();
+        let expansion = rules.expand(&invocation_tt);
+        assert!(expansion.is_some())
+    }
 }

--- a/crates/ra_mbe/src/lib.rs
+++ b/crates/ra_mbe/src/lib.rs
@@ -29,7 +29,7 @@ pub use crate::syntax_bridge::{
     TokenMap, RangesMap,
 };
 
-/// This struct contains AST for a single `macro_rules` defenition. What might
+/// This struct contains AST for a single `macro_rules` definition. What might
 /// be very confusing is that AST has almost exactly the same shape as
 /// `tt::TokenTree`, but there's a crucial difference: in macro rules, `$ident`
 /// and `$()*` have special meaning (see `Var` and `Repeat` data structures)

--- a/crates/ra_mbe/src/mbe_expander.rs
+++ b/crates/ra_mbe/src/mbe_expander.rs
@@ -1,4 +1,4 @@
-/// This module takes a (parsed) defenition of `macro_rules` invocation, a
+/// This module takes a (parsed) definition of `macro_rules` invocation, a
 /// `tt::TokenTree` representing an argument of macro invocation, and produces a
 /// `tt::TokenTree` for the result of the expansion.
 use rustc_hash::FxHashMap;

--- a/crates/ra_mbe/src/mbe_expander.rs
+++ b/crates/ra_mbe/src/mbe_expander.rs
@@ -185,6 +185,7 @@ fn expand_tt(
         crate::TokenTree::Leaf(leaf) => match leaf {
             crate::Leaf::Ident(ident) => tt::Leaf::from(tt::Ident {
                 text: ident.text.clone(),
+                id: tt::TokenId::unspecified(),
             })
             .into(),
             crate::Leaf::Punct(punct) => tt::Leaf::from(punct.clone()).into(),

--- a/crates/ra_mbe/src/mbe_expander.rs
+++ b/crates/ra_mbe/src/mbe_expander.rs
@@ -25,7 +25,7 @@ fn expand_rule(rule: &crate::Rule, input: &tt::Subtree) -> Option<tt::Subtree> {
 ///
 /// The tricky bit is dealing with repetitions (`$()*`). Consider this example:
 ///
-/// ```ignore
+/// ```not_rust
 /// macro_rules! foo {
 ///     ($($ i:ident $($ e:expr),*);*) => {
 ///         $(fn $ i() { $($ e);*; })*
@@ -43,7 +43,7 @@ fn expand_rule(rule: &crate::Rule, input: &tt::Subtree) -> Option<tt::Subtree> {
 ///
 /// For the above example, the bindings would store
 ///
-/// ```ignore
+/// ```not_rust
 /// i -> [foo, bar]
 /// e -> [[1, 2, 3], [4, 5, 6]]
 /// ```

--- a/crates/ra_mbe/src/mbe_parser.rs
+++ b/crates/ra_mbe/src/mbe_parser.rs
@@ -35,7 +35,7 @@ fn parse_subtree(tt: &tt::Subtree) -> Option<crate::Subtree> {
                     }
                 }
                 tt::Leaf::Punct(punct) => crate::Leaf::from(*punct).into(),
-                tt::Leaf::Ident(tt::Ident { text }) => {
+                tt::Leaf::Ident(tt::Ident { text, .. }) => {
                     crate::Leaf::from(crate::Ident { text: text.clone() }).into()
                 }
                 tt::Leaf::Literal(tt::Literal { text }) => {

--- a/crates/ra_mbe/src/syntax_bridge.rs
+++ b/crates/ra_mbe/src/syntax_bridge.rs
@@ -1,10 +1,31 @@
-use ra_syntax::{ast, AstNode, SyntaxNode, SyntaxKind::*};
+use ra_syntax::{ast, TextRange, AstNode, SyntaxNode, SyntaxKind::*};
 
-pub fn ast_to_token_tree(ast: &ast::TokenTree) -> Option<tt::Subtree> {
-    convert_tt(ast.syntax())
+pub fn ast_to_token_tree(ast: &ast::TokenTree) -> Option<(tt::Subtree, TokenMap)> {
+    let mut token_map = TokenMap::default();
+    let sub = convert_tt(ast.syntax(), &mut token_map)?;
+    Some((sub, token_map))
 }
 
-fn convert_tt(tt: &SyntaxNode) -> Option<tt::Subtree> {
+#[derive(Default)]
+pub struct TokenMap {
+    tokens: Vec<TextRange>,
+}
+
+impl TokenMap {
+    fn alloc(&mut self, range: TextRange) -> tt::TokenId {
+        let id = self.tokens.len();
+        let id = id as u32;
+        self.tokens.push(range);
+        tt::TokenId(id)
+    }
+
+    pub fn token_range(&self, id: tt::TokenId) -> Option<TextRange> {
+        let id = id.0 as usize;
+        self.tokens.get(id).map(|&it| it)
+    }
+}
+
+fn convert_tt(tt: &SyntaxNode, token_map: &mut TokenMap) -> Option<tt::Subtree> {
     let first_child = tt.first_child()?;
     let last_child = tt.last_child()?;
     let delimiter = match (first_child.kind(), last_child.kind()) {
@@ -13,6 +34,7 @@ fn convert_tt(tt: &SyntaxNode) -> Option<tt::Subtree> {
         (L_BRACK, R_BRACK) => tt::Delimiter::Bracket,
         _ => return None,
     };
+    let start_offset = tt.range().start();
     let mut token_trees = Vec::new();
     for child in tt.children().skip(1) {
         if child == first_child || child == last_child || child.kind().is_trivia() {
@@ -43,10 +65,11 @@ fn convert_tt(tt: &SyntaxNode) -> Option<tt::Subtree> {
             }
         } else {
             let child: tt::TokenTree = if child.kind() == TOKEN_TREE {
-                convert_tt(child)?.into()
+                convert_tt(child, token_map)?.into()
             } else if child.kind().is_keyword() || child.kind() == IDENT {
                 let text = child.leaf_text().unwrap().clone();
-                tt::Leaf::from(tt::Ident { text }).into()
+                let id = token_map.alloc(child.range() - start_offset);
+                tt::Leaf::from(tt::Ident { text, id }).into()
             } else if child.kind().is_literal() {
                 tt::Leaf::from(tt::Literal {
                     text: child.leaf_text().unwrap().clone(),

--- a/crates/ra_mbe/src/syntax_bridge.rs
+++ b/crates/ra_mbe/src/syntax_bridge.rs
@@ -1,6 +1,6 @@
 use ra_syntax::{ast, TextRange, TextUnit, AstNode, SyntaxNode, SyntaxKind::*, SourceFile, TreeArc};
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, PartialEq, Eq, Hash)]
 pub struct TokenMap {
     tokens: Vec<TextRange>,
 }
@@ -19,10 +19,17 @@ impl TokenMap {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct RangesMap {
     // FIXME: account for cases where single input range maps to many output ranges.
     data: Vec<(TextRange, TextRange)>,
+}
+
+// FIXME: remove this impl
+impl From<Vec<(TextRange, TextRange)>> for RangesMap {
+    fn from(data: Vec<(TextRange, TextRange)>) -> RangesMap {
+        RangesMap { data }
+    }
 }
 
 impl RangesMap {

--- a/crates/ra_syntax/src/ast/generated.rs
+++ b/crates/ra_syntax/src/ast/generated.rs
@@ -1838,6 +1838,7 @@ impl ToOwned for MacroCall {
 }
 
 
+impl ast::NameOwner for MacroCall {}
 impl MacroCall {
     pub fn token_tree(&self) -> Option<&TokenTree> {
         super::child_opt(self)

--- a/crates/ra_syntax/src/grammar.ron
+++ b/crates/ra_syntax/src/grammar.ron
@@ -542,7 +542,10 @@ Grammar(
         "Visibility": (),
         "Name": (),
         "NameRef": (),
-        "MacroCall": ( options: [ "TokenTree", "Path" ] ),
+        "MacroCall": (
+            traits: [ "NameOwner" ],
+            options: [ "TokenTree", "Path" ],
+        ),
         "Attr": ( options: [ ["value", "TokenTree"] ] ),
         "TokenTree": (),
         "TypeParamList": (

--- a/crates/ra_syntax/src/grammar/items.rs
+++ b/crates/ra_syntax/src/grammar/items.rs
@@ -351,7 +351,9 @@ fn macro_call(p: &mut Parser) -> BlockLike {
 
 pub(super) fn macro_call_after_excl(p: &mut Parser) -> BlockLike {
     p.expect(EXCL);
-    p.eat(IDENT);
+    if p.at(IDENT) {
+        name(p);
+    }
     match p.current() {
         L_CURLY => {
             token_tree(p);

--- a/crates/ra_syntax/tests/data/parser/err/0028_macro_2.0.txt
+++ b/crates/ra_syntax/tests/data/parser/err/0028_macro_2.0.txt
@@ -6,7 +6,8 @@ SOURCE_FILE@[0; 349)
           IDENT@[0; 5) "macro"
           err: `expected EXCL`
     WHITESPACE@[5; 6)
-    IDENT@[6; 21) "parse_use_trees"
+    NAME@[6; 21)
+      IDENT@[6; 21) "parse_use_trees"
     TOKEN_TREE@[21; 41)
       L_PAREN@[21; 22)
       DOLLAR@[22; 23)

--- a/crates/ra_syntax/tests/data/parser/inline/ok/0062_mod_contents.txt
+++ b/crates/ra_syntax/tests/data/parser/inline/ok/0062_mod_contents.txt
@@ -19,7 +19,8 @@ SOURCE_FILE@[0; 70)
           IDENT@[12; 23) "macro_rules"
     EXCL@[23; 24)
     WHITESPACE@[24; 25)
-    IDENT@[25; 28) "foo"
+    NAME@[25; 28)
+      IDENT@[25; 28) "foo"
     WHITESPACE@[28; 29)
     TOKEN_TREE@[29; 31)
       L_CURLY@[29; 30)

--- a/crates/ra_syntax/tests/data/parser/inline/ok/0096_no_semi_after_block.txt
+++ b/crates/ra_syntax/tests/data/parser/inline/ok/0096_no_semi_after_block.txt
@@ -92,7 +92,8 @@ SOURCE_FILE@[0; 167)
                 IDENT@[109; 120) "macro_rules"
           EXCL@[120; 121)
           WHITESPACE@[121; 122)
-          IDENT@[122; 126) "test"
+          NAME@[122; 126)
+            IDENT@[122; 126) "test"
           WHITESPACE@[126; 127)
           TOKEN_TREE@[127; 152)
             L_CURLY@[127; 128)

--- a/crates/ra_tt/src/lib.rs
+++ b/crates/ra_tt/src/lib.rs
@@ -18,6 +18,15 @@ use std::fmt;
 
 use smol_str::SmolStr;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TokenId(pub u32);
+
+impl TokenId {
+    pub const fn unspecified() -> TokenId {
+        TokenId(!0)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TokenTree {
     Leaf(Leaf),
@@ -67,6 +76,7 @@ pub enum Spacing {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Ident {
     pub text: SmolStr,
+    pub id: TokenId,
 }
 
 impl fmt::Display for TokenTree {

--- a/crates/ra_tt/src/lib.rs
+++ b/crates/ra_tt/src/lib.rs
@@ -18,14 +18,14 @@ use std::fmt;
 
 use smol_str::SmolStr;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TokenTree {
     Leaf(Leaf),
     Subtree(Subtree),
 }
 impl_froms!(TokenTree: Leaf, Subtree);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Leaf {
     Literal(Literal),
     Punct(Punct),
@@ -33,13 +33,13 @@ pub enum Leaf {
 }
 impl_froms!(Leaf: Literal, Punct, Ident);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Subtree {
     pub delimiter: Delimiter,
     pub token_trees: Vec<TokenTree>,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Delimiter {
     Parenthesis,
     Brace,
@@ -47,7 +47,7 @@ pub enum Delimiter {
     None,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Literal {
     pub text: SmolStr,
 }
@@ -64,7 +64,7 @@ pub enum Spacing {
     Joint,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Ident {
     pub text: SmolStr,
 }

--- a/crates/ra_tt/src/lib.rs
+++ b/crates/ra_tt/src/lib.rs
@@ -18,14 +18,14 @@ use std::fmt;
 
 use smol_str::SmolStr;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TokenTree {
     Leaf(Leaf),
     Subtree(Subtree),
 }
 impl_froms!(TokenTree: Leaf, Subtree);
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Leaf {
     Literal(Literal),
     Punct(Punct),
@@ -33,13 +33,13 @@ pub enum Leaf {
 }
 impl_froms!(Leaf: Literal, Punct, Ident);
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Subtree {
     pub delimiter: Delimiter,
     pub token_trees: Vec<TokenTree>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Delimiter {
     Parenthesis,
     Brace,
@@ -47,24 +47,24 @@ pub enum Delimiter {
     None,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Literal {
     pub text: SmolStr,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Punct {
     pub char: char,
     pub spacing: Spacing,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Spacing {
     Alone,
     Joint,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Ident {
     pub text: SmolStr,
 }


### PR DESCRIPTION
This uses #719 to actually implement a user-visible feature. Goto declaration works inside a macro_rules macro (see [this test](https://github.com/rust-analyzer/rust-analyzer/compare/res-macros?expand=1#diff-8f4f8bcc9043f842964105923c50baffR273)).

That's pretty cool except for the fact that, when I try to actually use this branch, rust-analyzer kills my system by consuming all the ram :)

A most important API change here is that we start assigning ids to TokenStream tokens. 
Now token has not only a value, but an identity as well, which we currently use to map offsets, but which should also work for hygiene.