### PR TITLE
Fix macro_rules separator parsing.

### DIFF
--- a/crates/ra_mbe/src/lib.rs
+++ b/crates/ra_mbe/src/lib.rs
@@ -161,6 +161,20 @@ impl_froms!(TokenTree: Leaf, Subtree);
     )
     }
 
+    fn assert_expansion(rules: &MacroRules, invocation: &str, expansion: &str) {
+        let source_file = ast::SourceFile::parse(invocation);
+        let macro_invocation = source_file
+            .syntax()
+            .descendants()
+            .find_map(ast::MacroCall::cast)
+            .unwrap();
+
+        let invocation_tt = ast_to_token_tree(macro_invocation.token_tree().unwrap()).unwrap();
+
+        let expaned = rules.expand(&invocation_tt).unwrap();
+        assert_eq!(expaned.to_string(), expansion);
+    }
+
     #[test]
     fn test_fail_match_pattern_by_token() {
         let macro_definition = r#"
@@ -177,10 +191,6 @@ impl_froms!(TokenTree: Leaf, Subtree);
         }
 "#;
 
-        let macro_invocation = r#"
-foo! {   foo }
-"#;
-
         let source_file = ast::SourceFile::parse(macro_definition);
         let macro_definition = source_file
             .syntax()
@@ -188,18 +198,12 @@ foo! {   foo }
             .find_map(ast::MacroCall::cast)
             .unwrap();
 
-        let source_file = ast::SourceFile::parse(macro_invocation);
-        let macro_invocation = source_file
-            .syntax()
-            .descendants()
-            .find_map(ast::MacroCall::cast)
-            .unwrap();
-
         let definition_tt = ast_to_token_tree(macro_definition.token_tree().unwrap()).unwrap();
-        let invocation_tt = ast_to_token_tree(macro_invocation.token_tree().unwrap()).unwrap();
         let rules = crate::MacroRules::parse(&definition_tt).unwrap();
-        let expansion = rules.expand(&invocation_tt).unwrap();
-        assert_eq!(expansion.to_string(), "mod foo {}")
+
+        assert_expansion(&rules, "foo! { foo }", "mod foo {}");
+        assert_expansion(&rules, "foo! { = bar }", "fn bar () {}");
+        assert_expansion(&rules, "foo! { + Baz }", "struct Baz ;");
     }
 
 }

--- a/crates/ra_mbe/src/mbe_parser.rs
+++ b/crates/ra_mbe/src/mbe_parser.rs
@@ -7,7 +7,13 @@ pub(crate) fn parse(tt: &tt::Subtree) -> Option<crate::MacroRules> {
     let mut parser = TtCursor::new(tt);
     let mut rules = Vec::new();
     while !parser.is_eof() {
-        rules.push(parse_rule(&mut parser)?)
+        rules.push(parse_rule(&mut parser)?);
+        if parser.expect_char(';') == None {
+            if !parser.is_eof() {
+                return None;
+            }
+            break;
+        }
     }
     Some(crate::MacroRules { rules })
 }


### PR DESCRIPTION
macro_rules rules are separated by ';' including an optional ';' at the end