### PR TITLE
Add new configuration "enableEnhancedTyping" to control registering of "type" command

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -150,6 +150,11 @@
                     "default": true,
                     "description": "Highlight Rust code (overrides built-in syntax highlighting)"
                 },
+                "rust-analyzer.enableEnhancedTyping": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enables enhanced typing. NOTE: If using a VIM extension, you should set this to false"
+                },
                 "rust-analyzer.raLspServerPath": {
                     "type": [
                         "string"

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -29,7 +29,9 @@ export class Config {
         }
 
         if (config.has('enableEnhancedTyping')) {
-            this.enableEnhancedTyping = config.get('enableEnhancedTyping') as boolean;
+            this.enableEnhancedTyping = config.get(
+                'enableEnhancedTyping'
+            ) as boolean;
 
             if (this.prevEnhancedTyping === null) {
                 this.prevEnhancedTyping = this.enableEnhancedTyping;
@@ -40,15 +42,20 @@ export class Config {
 
         if (this.prevEnhancedTyping !== this.enableEnhancedTyping) {
             const reloadAction = 'Reload now';
-            vscode.window.showInformationMessage('Changing enhanced typing setting requires a reload', reloadAction)
+            vscode.window
+                .showInformationMessage(
+                    'Changing enhanced typing setting requires a reload',
+                    reloadAction
+                )
                 .then(selectedAction => {
                     if (selectedAction === reloadAction) {
-                        vscode.commands.executeCommand('workbench.action.reloadWindow');
+                        vscode.commands.executeCommand(
+                            'workbench.action.reloadWindow'
+                        );
                     }
                 });
             this.prevEnhancedTyping = this.enableEnhancedTyping;
         }
-
 
         if (config.has('raLspServerPath')) {
             this.raLspServerPath =

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -6,7 +6,10 @@ const RA_LSP_DEBUG = process.env.__RA_LSP_SERVER_DEBUG;
 
 export class Config {
     public highlightingOn = true;
+    public enableEnhancedTyping = true;
     public raLspServerPath = RA_LSP_DEBUG || 'ra_lsp_server';
+
+    private prevEnhancedTyping: null | boolean = null;
 
     constructor() {
         vscode.workspace.onDidChangeConfiguration(_ =>
@@ -24,6 +27,28 @@ export class Config {
         if (!this.highlightingOn && Server) {
             Server.highlighter.removeHighlights();
         }
+
+        if (config.has('enableEnhancedTyping')) {
+            this.enableEnhancedTyping = config.get('enableEnhancedTyping') as boolean;
+
+            if (this.prevEnhancedTyping === null) {
+                this.prevEnhancedTyping = this.enableEnhancedTyping;
+            }
+        } else if (this.prevEnhancedTyping === null) {
+            this.prevEnhancedTyping = this.enableEnhancedTyping;
+        }
+
+        if (this.prevEnhancedTyping !== this.enableEnhancedTyping) {
+            const reloadAction = 'Reload now';
+            vscode.window.showInformationMessage('Changing enhanced typing setting requires a reload', reloadAction)
+                .then(selectedAction => {
+                    if (selectedAction === reloadAction) {
+                        vscode.commands.executeCommand('workbench.action.reloadWindow');
+                    }
+                });
+            this.prevEnhancedTyping = this.enableEnhancedTyping;
+        }
+
 
         if (config.has('raLspServerPath')) {
             this.raLspServerPath =

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -82,7 +82,9 @@ export function activate(context: vscode.ExtensionContext) {
         }
     );
 
-    overrideCommand('type', commands.onEnter.handle);
+    if (Server.config.enableEnhancedTyping) {
+        overrideCommand('type', commands.onEnter.handle);
+    }
 
     // Notifications are events triggered by the language server
     const allNotifications: Iterable<


### PR DESCRIPTION
This further fixes problems when having a VIM extension (at least vscodevim)
enabled, by not calling `overrideCommand('type', commands.onEnter.handle)` when
enableEnhancedTyping is set to `false`.

The problem is dependent on the order in which extensions are activated, if
rust-analyzer is activated before `vscodevim`, rust-analyzer will register the
`type` command, and when `vscodevim` finally attempts to activate, it will fail
to register the command. This causes `vscodevim` to stop working properly.

This setting allows users to disable the registerCommand `type` in
rust-analyzer, allowing `vscodevim` to work. The setting defaults to `true`.

Currently changing the setting requires reloading of the window.