### PR TITLE
Mention node.js requirement in readme

### DIFF
--- a/editors/README.md
+++ b/editors/README.md
@@ -1,4 +1,12 @@
-To install experimental VS Code plugin:
+
+Preqrequisites:
+
+In order to build the VS Code plugin, you need to have node.js and npm with
+a minimum version of 10 installed. Please refer to
+[node.js and npm documentation](https://nodejs.org) for installation instructions.
+
+The experimental VS Code plugin can then be built and installed by executing the
+following commands:
 
 ```
 $ git clone https://github.com/rust-analyzer/rust-analyzer.git --depth 1


### PR DESCRIPTION
I tried building rust-analyzer according to the instructions, but it failed with a very non-descriptive error:

> will run: npm ci
> Error: Os { code: 2, kind: NotFound, message: "No such file or directory" }

It took me a while to figure out I had an outdated node version installed, which didn't support `npm ci`. I think mentioning the requirement explicitly might prevent others from running into the same issue.