### PR TITLE
Refactor to allow for multiple assists 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -921,6 +921,7 @@ version = "0.1.0"
 name = "ra_assists"
 version = "0.1.0"
 dependencies = [
+ "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "join_to_string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ra_db 0.1.0",
  "ra_fmt 0.1.0",

--- a/crates/ra_assists/Cargo.toml
+++ b/crates/ra_assists/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["rust-analyzer developers"]
 
 [dependencies]
 join_to_string = "0.1.3"
+itertools = "0.8.0"
 
 ra_syntax = { path = "../ra_syntax" }
 ra_text_edit = { path = "../ra_text_edit" }

--- a/crates/ra_assists/src/add_derive.rs
+++ b/crates/ra_assists/src/add_derive.rs
@@ -7,10 +7,10 @@ use ra_syntax::{
 
 use crate::{AssistCtx, Assist};
 
-pub(crate) fn add_derive(ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
+pub(crate) fn add_derive(mut ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
     let nominal = ctx.node_at_offset::<ast::NominalDef>()?;
     let node_start = derive_insertion_offset(nominal)?;
-    ctx.build("add `#[derive]`", |edit| {
+    ctx.add_action("add `#[derive]`", |edit| {
         let derive_attr = nominal
             .attrs()
             .filter_map(|x| x.as_call())
@@ -26,7 +26,9 @@ pub(crate) fn add_derive(ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
         };
         edit.target(nominal.syntax().range());
         edit.set_cursor(offset)
-    })
+    });
+
+    ctx.build()
 }
 
 // Insert `derive` after doc comments.

--- a/crates/ra_assists/src/add_impl.rs
+++ b/crates/ra_assists/src/add_impl.rs
@@ -7,10 +7,10 @@ use ra_syntax::{
 
 use crate::{AssistCtx, Assist};
 
-pub(crate) fn add_impl(ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
+pub(crate) fn add_impl(mut ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
     let nominal = ctx.node_at_offset::<ast::NominalDef>()?;
     let name = nominal.name()?;
-    ctx.build("add impl", |edit| {
+    ctx.add_action("add impl", |edit| {
         edit.target(nominal.syntax().range());
         let type_params = nominal.type_param_list();
         let start_offset = nominal.syntax().range().end();
@@ -32,7 +32,9 @@ pub(crate) fn add_impl(ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
         edit.set_cursor(start_offset + TextUnit::of_str(&buf));
         buf.push_str("\n}");
         edit.insert(start_offset, buf);
-    })
+    });
+
+    ctx.build()
 }
 
 #[cfg(test)]

--- a/crates/ra_assists/src/auto_import.rs
+++ b/crates/ra_assists/src/auto_import.rs
@@ -480,7 +480,7 @@ fn make_assist_add_nested_import(
     }
 }
 
-pub(crate) fn auto_import(ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
+pub(crate) fn auto_import(mut ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
     let node = ctx.covering_node();
     let current_file = node.ancestors().find_map(ast::SourceFile::cast)?;
 
@@ -495,7 +495,7 @@ pub(crate) fn auto_import(ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
         return None;
     }
 
-    ctx.build(format!("import {} in the current file", fmt_segments(&segments)), |edit| {
+    ctx.add_action(format!("import {} in the current file", fmt_segments(&segments)), |edit| {
         let action = best_action_for_target(current_file.syntax(), path, &segments);
         make_assist(&action, segments.as_slice(), edit);
         if let Some(last_segment) = path.segment() {
@@ -506,7 +506,9 @@ pub(crate) fn auto_import(ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
                 last_segment.syntax().range().start(),
             ));
         }
-    })
+    });
+
+    ctx.build()
 }
 
 #[cfg(test)]

--- a/crates/ra_assists/src/fill_match_arms.rs
+++ b/crates/ra_assists/src/fill_match_arms.rs
@@ -8,7 +8,7 @@ use ra_syntax::ast::{self, AstNode};
 
 use crate::{AssistCtx, Assist};
 
-pub(crate) fn fill_match_arms(ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
+pub(crate) fn fill_match_arms(mut ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
     let match_expr = ctx.node_at_offset::<ast::MatchExpr>()?;
 
     // We already have some match arms, so we don't provide any assists.
@@ -33,7 +33,7 @@ pub(crate) fn fill_match_arms(ctx: AssistCtx<impl HirDatabase>) -> Option<Assist
     let enum_name = enum_def.name(ctx.db)?;
     let db = ctx.db;
 
-    ctx.build("fill match arms", |edit| {
+    ctx.add_action("fill match arms", |edit| {
         let mut buf = format!("match {} {{\n", expr.syntax().text().to_string());
         let variants = enum_def.variants(db);
         for variant in variants {
@@ -68,7 +68,9 @@ pub(crate) fn fill_match_arms(ctx: AssistCtx<impl HirDatabase>) -> Option<Assist
         edit.target(match_expr.syntax().range());
         edit.set_cursor(expr.syntax().range().start());
         edit.replace_node_and_indent(match_expr.syntax(), buf);
-    })
+    });
+
+    ctx.build()
 }
 
 #[cfg(test)]

--- a/crates/ra_assists/src/flip_comma.rs
+++ b/crates/ra_assists/src/flip_comma.rs
@@ -6,15 +6,17 @@ use ra_syntax::{
 
 use crate::{AssistCtx, Assist, non_trivia_sibling};
 
-pub(crate) fn flip_comma(ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
+pub(crate) fn flip_comma(mut ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
     let comma = ctx.leaf_at_offset().find(|leaf| leaf.kind() == COMMA)?;
     let prev = non_trivia_sibling(comma, Direction::Prev)?;
     let next = non_trivia_sibling(comma, Direction::Next)?;
-    ctx.build("flip comma", |edit| {
+    ctx.add_action("flip comma", |edit| {
         edit.target(comma.range());
         edit.replace(prev.range(), next.text());
         edit.replace(next.range(), prev.text());
-    })
+    });
+
+    ctx.build()
 }
 
 #[cfg(test)]

--- a/crates/ra_assists/src/introduce_variable.rs
+++ b/crates/ra_assists/src/introduce_variable.rs
@@ -8,7 +8,7 @@ use ra_syntax::{
 
 use crate::{AssistCtx, Assist};
 
-pub(crate) fn introduce_variable(ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
+pub(crate) fn introduce_variable(mut ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
     let node = ctx.covering_node();
     if !valid_covering_node(node) {
         return None;
@@ -19,7 +19,7 @@ pub(crate) fn introduce_variable(ctx: AssistCtx<impl HirDatabase>) -> Option<Ass
     if indent.kind() != WHITESPACE {
         return None;
     }
-    ctx.build("introduce variable", move |edit| {
+    ctx.add_action("introduce variable", move |edit| {
         let mut buf = String::new();
 
         let cursor_offset = if wrap_in_block {
@@ -68,7 +68,9 @@ pub(crate) fn introduce_variable(ctx: AssistCtx<impl HirDatabase>) -> Option<Ass
             }
         }
         edit.set_cursor(anchor_stmt.range().start() + cursor_offset);
-    })
+    });
+
+    ctx.build()
 }
 
 fn valid_covering_node(node: &SyntaxNode) -> bool {

--- a/crates/ra_assists/src/remove_dbg.rs
+++ b/crates/ra_assists/src/remove_dbg.rs
@@ -8,7 +8,7 @@ use ra_syntax::{
 };
 use crate::{AssistCtx, Assist};
 
-pub(crate) fn remove_dbg(ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
+pub(crate) fn remove_dbg(mut ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
     let macro_call = ctx.node_at_offset::<ast::MacroCall>()?;
 
     if !is_valid_macrocall(macro_call, "dbg")? {
@@ -46,11 +46,13 @@ pub(crate) fn remove_dbg(ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
         macro_args.text().slice(start..end).to_string()
     };
 
-    ctx.build("remove dbg!()", |edit| {
+    ctx.add_action("remove dbg!()", |edit| {
         edit.target(macro_call.syntax().range());
         edit.replace(macro_range, macro_content);
         edit.set_cursor(cursor_pos);
-    })
+    });
+
+    ctx.build()
 }
 
 /// Verifies that the given macro_call actually matches the given name

--- a/crates/ra_assists/src/split_import.rs
+++ b/crates/ra_assists/src/split_import.rs
@@ -7,7 +7,7 @@ use ra_syntax::{
 
 use crate::{AssistCtx, Assist};
 
-pub(crate) fn split_import(ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
+pub(crate) fn split_import(mut ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
     let colon_colon = ctx.leaf_at_offset().find(|leaf| leaf.kind() == COLONCOLON)?;
     let path = colon_colon.parent().and_then(ast::Path::cast)?;
     let top_path = generate(Some(path), |it| it.parent_path()).last()?;
@@ -23,12 +23,14 @@ pub(crate) fn split_import(ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
         None => top_path.syntax().range().end(),
     };
 
-    ctx.build("split import", |edit| {
+    ctx.add_action("split import", |edit| {
         edit.target(colon_colon.range());
         edit.insert(l_curly, "{");
         edit.insert(r_curly, "}");
         edit.set_cursor(l_curly + TextUnit::of_str("{"));
-    })
+    });
+
+    ctx.build()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This is necessary to allow assist "providers" (which currently are simple free function) to produce multiple assists. I'm not sure this is the best possible refactoring tough.