### PR TITLE
auto_import: multiple assist actions to select import container 

### DIFF
--- a/crates/ra_assists/src/auto_import.rs
+++ b/crates/ra_assists/src/auto_import.rs
@@ -513,6 +513,10 @@ pub(crate) fn auto_import(mut ctx: AssistCtx<impl HirDatabase>) -> Option<Assist
         return None;
     }
 
+    ctx.add_action(format!("import {} in the current file", fmt_segments(&segments)), |edit| {
+        apply_auto_import(current_file.syntax(), path, &segments, edit);
+    });
+
     for module in path.syntax().ancestors().filter_map(ast::Module::cast) {
         if let (Some(item_list), Some(name)) = (module.item_list(), module.name()) {
             ctx.add_action(
@@ -523,10 +527,6 @@ pub(crate) fn auto_import(mut ctx: AssistCtx<impl HirDatabase>) -> Option<Assist
             );
         }
     }
-
-    ctx.add_action(format!("import {} in the current file", fmt_segments(&segments)), |edit| {
-        apply_auto_import(current_file.syntax(), path, &segments, edit);
-    });
 
     for function in path.syntax().ancestors().filter_map(ast::FnDef::cast) {
         if let (Some(block), Some(name)) = (function.body(), function.name()) {
@@ -805,10 +805,10 @@ mod foo {
     }
 }
     ",
-            // 0 in bar
-            // 1 in foo
-            // 2 in current file
-            0,
+            // 0 in current file
+            // 1 in bar
+            // 2 in foo
+            1,
         );
     }
 
@@ -832,10 +832,10 @@ mod foo {
     }
 }
     ",
-            // 0 in bar
-            // 1 in foo
-            // 2 in current file
-            1,
+            // 0 in current file
+            // 1 in bar
+            // 2 in foo
+            2,
         );
     }
 
@@ -859,10 +859,10 @@ mod foo {
     }
 }
     ",
-            // 0 in bar
-            // 1 in foo
-            // 2 in current file
-            2,
+            // 0 in current file
+            // 1 in bar
+            // 2 in foo
+            0,
         );
     }
 


### PR DESCRIPTION
This make auto_import assist to produce multiple actions to select in which module/function to perform auto import.

For example, if we have:
```
mod foo {
    mod bar {
        fn func1() {
            fn func0 () {
                std::fmt::Debug<|>
            }
        }
    }
}
```
you will see the following actions in this order:
```
import std::fmt::Debug in mod bar
import std::fmt::Debug in mod foo
import std::fmt::Debug in the current file
import std::fmt::Debug in fn func0
import std::fmt::Debug in fn func1
```
The priority here is modules > file > functions.