### PR TITLE
Add support for container_name in workspace/symbol query

### DIFF
--- a/crates/ra_ide_api/src/navigation_target.rs
+++ b/crates/ra_ide_api/src/navigation_target.rs
@@ -19,11 +19,16 @@ pub struct NavigationTarget {
     kind: SyntaxKind,
     full_range: TextRange,
     focus_range: Option<TextRange>,
+    container_name: Option<SmolStr>,
 }
 
 impl NavigationTarget {
     pub fn name(&self) -> &SmolStr {
         &self.name
+    }
+
+    pub fn container_name(&self) -> Option<&SmolStr> {
+        self.container_name.as_ref()
     }
 
     pub fn kind(&self) -> SyntaxKind {
@@ -53,6 +58,7 @@ impl NavigationTarget {
             kind: symbol.ptr.kind(),
             full_range: symbol.ptr.range(),
             focus_range: None,
+            container_name: symbol.container_name.map(|v| v.clone()),
         }
     }
 
@@ -67,6 +73,7 @@ impl NavigationTarget {
             full_range: ptr.range(),
             focus_range: None,
             kind: NAME,
+            container_name: None,
         }
     }
 
@@ -170,6 +177,9 @@ impl NavigationTarget {
         if let Some(focus_range) = self.focus_range() {
             buf.push_str(&format!(" {:?}", focus_range))
         }
+        if let Some(container_name) = self.container_name() {
+            buf.push_str(&format!(" {:?}", container_name))
+        }
         buf
     }
 
@@ -192,6 +202,7 @@ impl NavigationTarget {
             full_range: node.range(),
             focus_range,
             // ptr: Some(LocalSyntaxPtr::new(node)),
+            container_name: None,
         }
     }
 }

--- a/crates/ra_ide_api/src/navigation_target.rs
+++ b/crates/ra_ide_api/src/navigation_target.rs
@@ -58,7 +58,7 @@ impl NavigationTarget {
             kind: symbol.ptr.kind(),
             full_range: symbol.ptr.range(),
             focus_range: None,
-            container_name: symbol.container_name.map(|v| v.clone()),
+            container_name: symbol.container_name.clone(),
         }
     }
 

--- a/crates/ra_ide_api/src/symbol_index.rs
+++ b/crates/ra_ide_api/src/symbol_index.rs
@@ -228,7 +228,7 @@ fn source_file_to_file_symbols(source_file: &SourceFile, file_id: FileId) -> Vec
         match event {
             WalkEvent::Enter(node) => {
                 if let Some(mut symbol) = to_file_symbol(node, file_id) {
-                    symbol.container_name = stack.last().map(|v: &SmolStr| v.clone());
+                    symbol.container_name = stack.last().cloned();
 
                     stack.push(symbol.name.clone());
                     symbols.push(symbol);

--- a/crates/ra_ide_api/src/symbol_index.rs
+++ b/crates/ra_ide_api/src/symbol_index.rs
@@ -200,16 +200,6 @@ fn is_type(kind: SyntaxKind) -> bool {
     }
 }
 
-fn is_symbol_def(kind: SyntaxKind) -> bool {
-    match kind {
-        FN_DEF | STRUCT_DEF | ENUM_DEF | TRAIT_DEF | MODULE | TYPE_DEF | CONST_DEF | STATIC_DEF => {
-            true
-        }
-
-        _ => false,
-    }
-}
-
 /// The actual data that is stored in the index. It should be as compact as
 /// possible.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -236,7 +226,7 @@ fn source_file_to_file_symbols(source_file: &SourceFile, file_id: FileId) -> Vec
             }
 
             WalkEvent::Leave(node) => {
-                if is_symbol_def(node.kind()) {
+                if to_symbol(node).is_some() {
                     stack.pop();
                 }
             }

--- a/crates/ra_ide_api/tests/test/main.rs
+++ b/crates/ra_ide_api/tests/test/main.rs
@@ -97,51 +97,45 @@ fn test_find_all_refs_for_fn_param() {
 
 #[test]
 fn test_world_symbols_with_no_container() {
-    {
-        let code = r#"
-        enum FooInner { }
-        "#;
+    let code = r#"
+    enum FooInner { }
+    "#;
 
-        let mut symbols = get_symbols_matching(code, "FooInner");
+    let mut symbols = get_symbols_matching(code, "FooInner");
 
-        let s = symbols.pop().unwrap();
+    let s = symbols.pop().unwrap();
 
-        assert_eq!(s.name(), "FooInner");
-        assert!(s.container_name().is_none());
-    }
+    assert_eq!(s.name(), "FooInner");
+    assert!(s.container_name().is_none());
 }
 
 #[test]
 fn test_world_symbols_include_container_name() {
-    {
-        let code = r#"
-    fn foo() {
-        enum FooInner { }
-    }
-        "#;
+    let code = r#"
+fn foo() {
+    enum FooInner { }
+}
+    "#;
 
-        let mut symbols = get_symbols_matching(code, "FooInner");
+    let mut symbols = get_symbols_matching(code, "FooInner");
 
-        let s = symbols.pop().unwrap();
+    let s = symbols.pop().unwrap();
 
-        assert_eq!(s.name(), "FooInner");
-        assert_eq!(s.container_name(), Some(&SmolStr::new("foo")));
-    }
+    assert_eq!(s.name(), "FooInner");
+    assert_eq!(s.container_name(), Some(&SmolStr::new("foo")));
 
-    {
-        let code = r#"
-    mod foo {
-        struct FooInner;
-    }
-        "#;
+    let code = r#"
+mod foo {
+    struct FooInner;
+}
+    "#;
 
-        let mut symbols = get_symbols_matching(code, "FooInner");
+    let mut symbols = get_symbols_matching(code, "FooInner");
 
-        let s = symbols.pop().unwrap();
+    let s = symbols.pop().unwrap();
 
-        assert_eq!(s.name(), "FooInner");
-        assert_eq!(s.container_name(), Some(&SmolStr::new("foo")));
-    }
+    assert_eq!(s.name(), "FooInner");
+    assert_eq!(s.container_name(), Some(&SmolStr::new("foo")));
 }
 
 #[test]

--- a/crates/ra_ide_api/tests/test/main.rs
+++ b/crates/ra_ide_api/tests/test/main.rs
@@ -1,9 +1,9 @@
 use insta::assert_debug_snapshot_matches;
 use ra_ide_api::{
     mock_analysis::{single_file, single_file_with_position, MockAnalysis},
-    AnalysisChange, CrateGraph, FileId, Query,
+    AnalysisChange, CrateGraph, FileId, Query, NavigationTarget,
 };
-use ra_syntax::TextRange;
+use ra_syntax::{TextRange, SmolStr};
 
 #[test]
 fn test_unresolved_module_diagnostic() {
@@ -49,6 +49,11 @@ fn get_all_refs(text: &str) -> Vec<(FileId, TextRange)> {
     analysis.find_all_refs(position).unwrap()
 }
 
+fn get_symbols_matching(text: &str, query: &str) -> Vec<NavigationTarget> {
+    let (analysis, _) = single_file(text);
+    analysis.symbol_search(Query::new(query.into())).unwrap()
+}
+
 #[test]
 fn test_find_all_refs_for_local() {
     let code = r#"
@@ -88,6 +93,55 @@ fn test_find_all_refs_for_fn_param() {
 
     let refs = get_all_refs(code);
     assert_eq!(refs.len(), 2);
+}
+
+#[test]
+fn test_world_symbols_with_no_container() {
+    {
+        let code = r#"
+        enum FooInner { }
+        "#;
+
+        let mut symbols = get_symbols_matching(code, "FooInner");
+
+        let s = symbols.pop().unwrap();
+
+        assert_eq!(s.name(), "FooInner");
+        assert!(s.container_name().is_none());
+    }
+}
+
+#[test]
+fn test_world_symbols_include_container_name() {
+    {
+        let code = r#"
+    fn foo() {
+        enum FooInner { }
+    }
+        "#;
+
+        let mut symbols = get_symbols_matching(code, "FooInner");
+
+        let s = symbols.pop().unwrap();
+
+        assert_eq!(s.name(), "FooInner");
+        assert_eq!(s.container_name(), Some(&SmolStr::new("foo")));
+    }
+
+    {
+        let code = r#"
+    mod foo {
+        struct FooInner;
+    }
+        "#;
+
+        let mut symbols = get_symbols_matching(code, "FooInner");
+
+        let s = symbols.pop().unwrap();
+
+        assert_eq!(s.name(), "FooInner");
+        assert_eq!(s.container_name(), Some(&SmolStr::new("foo")));
+    }
 }
 
 #[test]

--- a/crates/ra_lsp_server/src/main_loop/handlers.rs
+++ b/crates/ra_lsp_server/src/main_loop/handlers.rs
@@ -190,7 +190,7 @@ pub fn handle_workspace_symbol(
                 name: nav.name().to_string(),
                 kind: nav.kind().conv(),
                 location: nav.try_conv_with(world)?,
-                container_name: None,
+                container_name: nav.container_name().map(|v| v.to_string()),
                 deprecated: None,
             };
             res.push(info);


### PR DESCRIPTION
Currently this does not fill in the container_info if a type is defined on the top level in a file. 

e.g. `foo.rs`
```rust
enum Foo { }
```
`Foo` will have None as the container_name, however

```rust
mod foo_mod {
    enum Foo { } 
}
```
`Foo` has `foo_mod` as the container_name. 

This closes #559 