### PR TITLE
Prelude & Edition 2015 import resolution

### DIFF
--- a/crates/ra_db/src/input.rs
+++ b/crates/ra_db/src/input.rs
@@ -119,6 +119,10 @@ impl CrateGraph {
         self.arena[&crate_id].file_id
     }
 
+    pub fn edition(&self, crate_id: CrateId) -> Edition {
+        self.arena[&crate_id].edition
+    }
+
     // TODO: this only finds one crate with the given root; we could have multiple
     pub fn crate_id_for_crate_root(&self, file_id: FileId) -> Option<CrateId> {
         let (&crate_id, _) = self.arena.iter().find(|(_crate_id, data)| data.file_id == file_id)?;

--- a/crates/ra_db/src/input.rs
+++ b/crates/ra_db/src/input.rs
@@ -56,15 +56,22 @@ pub struct CyclicDependencies;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CrateId(pub u32);
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Edition {
+    Edition2018,
+    Edition2015,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct CrateData {
     file_id: FileId,
+    edition: Edition,
     dependencies: Vec<Dependency>,
 }
 
 impl CrateData {
-    fn new(file_id: FileId) -> CrateData {
-        CrateData { file_id, dependencies: Vec::new() }
+    fn new(file_id: FileId, edition: Edition) -> CrateData {
+        CrateData { file_id, edition, dependencies: Vec::new() }
     }
 
     fn add_dep(&mut self, name: SmolStr, crate_id: CrateId) {
@@ -85,9 +92,9 @@ impl Dependency {
 }
 
 impl CrateGraph {
-    pub fn add_crate_root(&mut self, file_id: FileId) -> CrateId {
+    pub fn add_crate_root(&mut self, file_id: FileId, edition: Edition) -> CrateId {
         let crate_id = CrateId(self.arena.len() as u32);
-        let prev = self.arena.insert(crate_id, CrateData::new(file_id));
+        let prev = self.arena.insert(crate_id, CrateData::new(file_id, edition));
         assert!(prev.is_none());
         crate_id
     }
@@ -159,14 +166,14 @@ impl CrateGraph {
 
 #[cfg(test)]
 mod tests {
-    use super::{CrateGraph, FileId, SmolStr};
+    use super::{CrateGraph, FileId, SmolStr, Edition::Edition2018};
 
     #[test]
-    fn it_should_painc_because_of_cycle_dependencies() {
+    fn it_should_panic_because_of_cycle_dependencies() {
         let mut graph = CrateGraph::default();
-        let crate1 = graph.add_crate_root(FileId(1u32));
-        let crate2 = graph.add_crate_root(FileId(2u32));
-        let crate3 = graph.add_crate_root(FileId(3u32));
+        let crate1 = graph.add_crate_root(FileId(1u32), Edition2018);
+        let crate2 = graph.add_crate_root(FileId(2u32), Edition2018);
+        let crate3 = graph.add_crate_root(FileId(3u32), Edition2018);
         assert!(graph.add_dep(crate1, SmolStr::new("crate2"), crate2).is_ok());
         assert!(graph.add_dep(crate2, SmolStr::new("crate3"), crate3).is_ok());
         assert!(graph.add_dep(crate3, SmolStr::new("crate1"), crate1).is_err());
@@ -175,9 +182,9 @@ mod tests {
     #[test]
     fn it_works() {
         let mut graph = CrateGraph::default();
-        let crate1 = graph.add_crate_root(FileId(1u32));
-        let crate2 = graph.add_crate_root(FileId(2u32));
-        let crate3 = graph.add_crate_root(FileId(3u32));
+        let crate1 = graph.add_crate_root(FileId(1u32), Edition2018);
+        let crate2 = graph.add_crate_root(FileId(2u32), Edition2018);
+        let crate3 = graph.add_crate_root(FileId(3u32), Edition2018);
         assert!(graph.add_dep(crate1, SmolStr::new("crate2"), crate2).is_ok());
         assert!(graph.add_dep(crate2, SmolStr::new("crate3"), crate3).is_ok());
     }

--- a/crates/ra_db/src/input.rs
+++ b/crates/ra_db/src/input.rs
@@ -62,6 +62,15 @@ pub enum Edition {
     Edition2015,
 }
 
+impl Edition {
+    pub fn from_string(s: &str) -> Edition {
+        match s {
+            "2015" => Edition::Edition2015,
+            "2018" | _ => Edition::Edition2018,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct CrateData {
     file_id: FileId,

--- a/crates/ra_db/src/lib.rs
+++ b/crates/ra_db/src/lib.rs
@@ -14,7 +14,7 @@ pub use ::salsa as salsa;
 pub use crate::{
     cancellation::Canceled,
     input::{
-        FileId, CrateId, SourceRoot, SourceRootId, CrateGraph, Dependency,
+        FileId, CrateId, SourceRoot, SourceRootId, CrateGraph, Dependency, Edition,
     },
     loc2id::LocationIntener,
 };

--- a/crates/ra_hir/src/code_model_api.rs
+++ b/crates/ra_hir/src/code_model_api.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use relative_path::RelativePathBuf;
-use ra_db::{CrateId, FileId, SourceRootId};
+use ra_db::{CrateId, FileId, SourceRootId, Edition};
 use ra_syntax::{ast::self, TreeArc, SyntaxNode};
 
 use crate::{
@@ -38,11 +38,18 @@ impl Crate {
     pub fn crate_id(&self) -> CrateId {
         self.crate_id
     }
+
     pub fn dependencies(&self, db: &impl PersistentHirDatabase) -> Vec<CrateDependency> {
         self.dependencies_impl(db)
     }
+
     pub fn root_module(&self, db: &impl PersistentHirDatabase) -> Option<Module> {
         self.root_module_impl(db)
+    }
+
+    pub fn edition(&self, db: &impl PersistentHirDatabase) -> Edition {
+        let crate_graph = db.crate_graph();
+        crate_graph.edition(self.crate_id)
     }
 
     // TODO: should this be in source_binder?

--- a/crates/ra_hir/src/marks.rs
+++ b/crates/ra_hir/src/marks.rs
@@ -6,4 +6,5 @@ test_utils::marks!(
     type_var_resolves_to_int_var
     glob_enum
     glob_across_crates
+    std_prelude
 );

--- a/crates/ra_hir/src/mock.rs
+++ b/crates/ra_hir/src/mock.rs
@@ -3,6 +3,7 @@ use std::{sync::Arc, panic};
 use parking_lot::Mutex;
 use ra_db::{
     FilePosition, FileId, CrateGraph, SourceRoot, SourceRootId, SourceDatabase, salsa,
+    Edition,
 };
 use relative_path::RelativePathBuf;
 use test_utils::{parse_fixture, CURSOR_MARKER, extract_offset};
@@ -60,7 +61,7 @@ impl MockDatabase {
         let mut crate_graph = CrateGraph::default();
         for (crate_name, (crate_root, _)) in graph.0.iter() {
             let crate_root = self.file_id_of(&crate_root);
-            let crate_id = crate_graph.add_crate_root(crate_root);
+            let crate_id = crate_graph.add_crate_root(crate_root, Edition::Edition2018);
             ids.insert(crate_name, crate_id);
         }
         for (crate_name, (_, deps)) in graph.0.iter() {
@@ -144,7 +145,7 @@ impl MockDatabase {
 
         if is_crate_root {
             let mut crate_graph = CrateGraph::default();
-            crate_graph.add_crate_root(file_id);
+            crate_graph.add_crate_root(file_id, Edition::Edition2018);
             self.set_crate_graph(Arc::new(crate_graph));
         }
         file_id

--- a/crates/ra_hir/src/mock.rs
+++ b/crates/ra_hir/src/mock.rs
@@ -59,12 +59,12 @@ impl MockDatabase {
     pub fn set_crate_graph_from_fixture(&mut self, graph: CrateGraphFixture) {
         let mut ids = FxHashMap::default();
         let mut crate_graph = CrateGraph::default();
-        for (crate_name, (crate_root, _)) in graph.0.iter() {
+        for (crate_name, (crate_root, edition, _)) in graph.0.iter() {
             let crate_root = self.file_id_of(&crate_root);
-            let crate_id = crate_graph.add_crate_root(crate_root, Edition::Edition2018);
+            let crate_id = crate_graph.add_crate_root(crate_root, *edition);
             ids.insert(crate_name, crate_id);
         }
-        for (crate_name, (_, deps)) in graph.0.iter() {
+        for (crate_name, (_, _, deps)) in graph.0.iter() {
             let from = ids[crate_name];
             for dep in deps {
                 let to = ids[dep];
@@ -233,16 +233,19 @@ impl MockDatabase {
 }
 
 #[derive(Default)]
-pub struct CrateGraphFixture(pub FxHashMap<String, (String, Vec<String>)>);
+pub struct CrateGraphFixture(pub FxHashMap<String, (String, Edition, Vec<String>)>);
 
 #[macro_export]
 macro_rules! crate_graph {
-    ($($crate_name:literal: ($crate_path:literal, [$($dep:literal),*]),)*) => {{
+    ($($crate_name:literal: ($crate_path:literal, $($edition:literal,)? [$($dep:literal),*]),)*) => {{
         let mut res = $crate::mock::CrateGraphFixture::default();
         $(
+            #[allow(unused_mut, unused_assignments)]
+            let mut edition = ra_db::Edition::Edition2018;
+            $(edition = ra_db::Edition::from_string($edition);)?
             res.0.insert(
                 $crate_name.to_string(),
-                ($crate_path.to_string(), vec![$($dep.to_string()),*])
+                ($crate_path.to_string(), edition, vec![$($dep.to_string()),*])
             );
         )*
         res

--- a/crates/ra_hir/src/nameres.rs
+++ b/crates/ra_hir/src/nameres.rs
@@ -40,7 +40,7 @@ pub struct ItemMap {
     /// The prelude module for this crate. This either comes from an import
     /// marked with the `prelude_import` attribute, or (in the normal case) from
     /// a dependency (`std` or `core`).
-    prelude: Option<Module>,
+    pub(crate) prelude: Option<Module>,
     pub(crate) extern_prelude: FxHashMap<Name, ModuleDef>,
     per_module: ArenaMap<ModuleId, ModuleScope>,
 }

--- a/crates/ra_hir/src/nameres/lower.rs
+++ b/crates/ra_hir/src/nameres/lower.rs
@@ -8,7 +8,7 @@ use ra_arena::{Arena, RawId, impl_arena_id, map::ArenaMap};
 use rustc_hash::FxHashMap;
 
 use crate::{
-    SourceItemId, Path, PathKind, ModuleSource, Name,
+    SourceItemId, Path, ModuleSource, Name,
     HirFileId, MacroCallLoc, AsName, PerNs, Function,
     ModuleDef, Module, Struct, Enum, Const, Static, Trait, Type,
     ids::LocationCtx, PersistentHirDatabase,
@@ -180,13 +180,8 @@ impl LoweredModule {
                 self.add_use_item(source_map, it);
             }
             ast::ModuleItemKind::ExternCrateItem(it) => {
-                // Lower `extern crate x` to `use ::x`. This is kind of cheating
-                // and only works if we always interpret absolute paths in the
-                // 2018 style; otherwise `::x` could also refer to a module in
-                // the crate root.
                 if let Some(name_ref) = it.name_ref() {
-                    let mut path = Path::from_name_ref(name_ref);
-                    path.kind = PathKind::Abs;
+                    let path = Path::from_name_ref(name_ref);
                     let alias = it.alias().and_then(|a| a.name()).map(AsName::as_name);
                     self.imports.alloc(ImportData {
                         path,

--- a/crates/ra_hir/src/nameres/tests.rs
+++ b/crates/ra_hir/src/nameres/tests.rs
@@ -267,7 +267,6 @@ fn glob_across_crates() {
 
 #[test]
 fn edition_2015_imports() {
-    use ra_db::{CrateGraph, Edition};
     let mut db = MockDatabase::with_files(
         "
         //- /main.rs
@@ -285,16 +284,11 @@ fn edition_2015_imports() {
         struct FromLib;
     ",
     );
-    let main_id = db.file_id_of("/main.rs");
-    let lib_id = db.file_id_of("/lib.rs");
+    db.set_crate_graph_from_fixture(crate_graph! {
+        "main": ("/main.rs", "2015", ["other_crate"]),
+        "other_crate": ("/lib.rs", "2018", []),
+    });
     let foo_id = db.file_id_of("/foo.rs");
-
-    let mut crate_graph = CrateGraph::default();
-    let main_crate = crate_graph.add_crate_root(main_id, Edition::Edition2015);
-    let lib_crate = crate_graph.add_crate_root(lib_id, Edition::Edition2018);
-    crate_graph.add_dep(main_crate, "other_crate".into(), lib_crate).unwrap();
-
-    db.set_crate_graph(Arc::new(crate_graph));
 
     let module = crate::source_binder::module_from_file_id(&db, foo_id).unwrap();
     let krate = module.krate(&db).unwrap();

--- a/crates/ra_ide_api/src/completion/complete_scope.rs
+++ b/crates/ra_ide_api/src/completion/complete_scope.rs
@@ -4,7 +4,7 @@ pub(super) fn complete_scope(acc: &mut Completions, ctx: &CompletionContext) {
     if !ctx.is_trivial_path {
         return;
     }
-    let names = ctx.resolver.all_names();
+    let names = ctx.resolver.all_names(ctx.db);
 
     names.into_iter().for_each(|(name, res)| {
         CompletionItem::new(CompletionKind::Reference, ctx.source_range(), name.to_string())
@@ -164,5 +164,24 @@ mod tests {
     #[test]
     fn completes_self_in_methods() {
         check_reference_completion("self_in_methods", r"impl S { fn foo(&self) { <|> } }")
+    }
+
+    #[test]
+    fn completes_prelude() {
+        check_reference_completion(
+            "completes_prelude",
+            "
+            //- /main.rs
+            fn foo() { let x: <|> }
+
+            //- /std/lib.rs
+            #[prelude_import]
+            use prelude::*;
+
+            mod prelude {
+                struct Option;
+            }
+            ",
+        );
     }
 }

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__completes_prelude.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__completes_prelude.snap
@@ -1,0 +1,54 @@
+---
+created: "2019-02-13T19:52:43.734834624Z"
+creator: insta@0.6.2
+source: crates/ra_ide_api/src/completion/completion_item.rs
+expression: kind_completions
+---
+[
+    CompletionItem {
+        completion_kind: Reference,
+        label: "Option",
+        kind: Some(
+            Struct
+        ),
+        detail: None,
+        documentation: None,
+        lookup: None,
+        insert_text: None,
+        insert_text_format: PlainText,
+        source_range: [18; 18),
+        text_edit: None
+    },
+    CompletionItem {
+        completion_kind: Reference,
+        label: "foo",
+        kind: Some(
+            Function
+        ),
+        detail: Some(
+            "fn foo()"
+        ),
+        documentation: None,
+        lookup: None,
+        insert_text: Some(
+            "foo()$0"
+        ),
+        insert_text_format: Snippet,
+        source_range: [18; 18),
+        text_edit: None
+    },
+    CompletionItem {
+        completion_kind: Reference,
+        label: "std",
+        kind: Some(
+            Module
+        ),
+        detail: None,
+        documentation: None,
+        lookup: None,
+        insert_text: None,
+        insert_text_format: PlainText,
+        source_range: [18; 18),
+        text_edit: None
+    }
+]

--- a/crates/ra_ide_api/src/lib.rs
+++ b/crates/ra_ide_api/src/lib.rs
@@ -62,7 +62,8 @@ pub use ra_ide_api_light::{
     LineIndex, LineCol, translate_offset_with_edit,
 };
 pub use ra_db::{
-    Canceled, CrateGraph, CrateId, FileId, FilePosition, FileRange, SourceRootId
+    Canceled, CrateGraph, CrateId, FileId, FilePosition, FileRange, SourceRootId,
+    Edition
 };
 pub use hir::Documentation;
 

--- a/crates/ra_ide_api/src/mock_analysis.rs
+++ b/crates/ra_ide_api/src/mock_analysis.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use relative_path::RelativePathBuf;
 use test_utils::{extract_offset, extract_range, parse_fixture, CURSOR_MARKER};
 
-use crate::{Analysis, AnalysisChange, AnalysisHost, CrateGraph, FileId, FilePosition, FileRange, SourceRootId};
+use crate::{Analysis, AnalysisChange, AnalysisHost, CrateGraph, FileId, FilePosition, FileRange, SourceRootId, Edition::Edition2018};
 
 /// Mock analysis is used in test to bootstrap an AnalysisHost/Analysis
 /// from a set of in-memory files.
@@ -89,9 +89,9 @@ impl MockAnalysis {
             let path = RelativePathBuf::from_path(&path[1..]).unwrap();
             let file_id = FileId(i as u32 + 1);
             if path == "/lib.rs" || path == "/main.rs" {
-                root_crate = Some(crate_graph.add_crate_root(file_id));
+                root_crate = Some(crate_graph.add_crate_root(file_id, Edition2018));
             } else if path.ends_with("/lib.rs") {
-                let other_crate = crate_graph.add_crate_root(file_id);
+                let other_crate = crate_graph.add_crate_root(file_id, Edition2018);
                 let crate_name = path.parent().unwrap().file_name().unwrap();
                 if let Some(root_crate) = root_crate {
                     crate_graph.add_dep(root_crate, crate_name.into(), other_crate).unwrap();

--- a/crates/ra_ide_api/tests/test/main.rs
+++ b/crates/ra_ide_api/tests/test/main.rs
@@ -1,7 +1,7 @@
 use insta::assert_debug_snapshot_matches;
 use ra_ide_api::{
     mock_analysis::{single_file, single_file_with_position, MockAnalysis},
-    AnalysisChange, CrateGraph, FileId, Query, NavigationTarget,
+    AnalysisChange, CrateGraph, Edition::Edition2018, FileId, Query, NavigationTarget
 };
 use ra_syntax::{TextRange, SmolStr};
 
@@ -36,7 +36,7 @@ fn test_resolve_crate_root() {
     assert!(host.analysis().crate_for(mod_file).unwrap().is_empty());
 
     let mut crate_graph = CrateGraph::default();
-    let crate_id = crate_graph.add_crate_root(root_file);
+    let crate_id = crate_graph.add_crate_root(root_file, Edition2018);
     let mut change = AnalysisChange::new();
     change.set_crate_graph(crate_graph);
     host.apply_change(change);

--- a/crates/ra_project_model/src/cargo_workspace.rs
+++ b/crates/ra_project_model/src/cargo_workspace.rs
@@ -35,6 +35,7 @@ struct PackageData {
     targets: Vec<Target>,
     is_member: bool,
     dependencies: Vec<PackageDependency>,
+    edition: String,
 }
 
 #[derive(Debug, Clone)]
@@ -83,6 +84,9 @@ impl Package {
     }
     pub fn root(self, ws: &CargoWorkspace) -> &Path {
         ws.packages[self].manifest.parent().unwrap()
+    }
+    pub fn edition(self, ws: &CargoWorkspace) -> &str {
+        &ws.packages[self].edition
     }
     pub fn targets<'a>(self, ws: &'a CargoWorkspace) -> impl Iterator<Item = Target> + 'a {
         ws.packages[self].targets.iter().cloned()
@@ -135,6 +139,7 @@ impl CargoWorkspace {
                 manifest: meta_pkg.manifest_path.clone(),
                 targets: Vec::new(),
                 is_member,
+                edition: meta_pkg.edition,
                 dependencies: Vec::new(),
             });
             let pkg_data = &mut packages[pkg];

--- a/crates/ra_project_model/src/cargo_workspace.rs
+++ b/crates/ra_project_model/src/cargo_workspace.rs
@@ -4,6 +4,7 @@ use cargo_metadata::{MetadataCommand, CargoOpt};
 use ra_arena::{Arena, RawId, impl_arena_id};
 use rustc_hash::FxHashMap;
 use failure::format_err;
+use ra_db::Edition;
 
 use crate::Result;
 
@@ -35,7 +36,7 @@ struct PackageData {
     targets: Vec<Target>,
     is_member: bool,
     dependencies: Vec<PackageDependency>,
-    edition: String,
+    edition: Edition,
 }
 
 #[derive(Debug, Clone)]
@@ -85,8 +86,8 @@ impl Package {
     pub fn root(self, ws: &CargoWorkspace) -> &Path {
         ws.packages[self].manifest.parent().unwrap()
     }
-    pub fn edition(self, ws: &CargoWorkspace) -> &str {
-        &ws.packages[self].edition
+    pub fn edition(self, ws: &CargoWorkspace) -> Edition {
+        ws.packages[self].edition
     }
     pub fn targets<'a>(self, ws: &'a CargoWorkspace) -> impl Iterator<Item = Target> + 'a {
         ws.packages[self].targets.iter().cloned()
@@ -139,7 +140,7 @@ impl CargoWorkspace {
                 manifest: meta_pkg.manifest_path.clone(),
                 targets: Vec::new(),
                 is_member,
-                edition: meta_pkg.edition,
+                edition: Edition::from_string(&meta_pkg.edition),
                 dependencies: Vec::new(),
             });
             let pkg_data = &mut packages[pkg];

--- a/crates/ra_project_model/src/lib.rs
+++ b/crates/ra_project_model/src/lib.rs
@@ -63,11 +63,7 @@ impl ProjectWorkspace {
             for tgt in pkg.targets(&self.cargo) {
                 let root = tgt.root(&self.cargo);
                 if let Some(file_id) = load(root) {
-                    let edition = if pkg.edition(&self.cargo) == "2015" {
-                        Edition::Edition2015
-                    } else {
-                        Edition::Edition2018
-                    };
+                    let edition = pkg.edition(&self.cargo);
                     let crate_id = crate_graph.add_crate_root(file_id, edition);
                     if tgt.kind(&self.cargo) == TargetKind::Lib {
                         lib_tgt = Some(crate_id);

--- a/crates/ra_syntax/src/ast/generated.rs
+++ b/crates/ra_syntax/src/ast/generated.rs
@@ -4210,6 +4210,7 @@ impl ToOwned for UseItem {
 }
 
 
+impl ast::AttrsOwner for UseItem {}
 impl UseItem {
     pub fn use_tree(&self) -> Option<&UseTree> {
         super::child_opt(self)

--- a/crates/ra_syntax/src/grammar.ron
+++ b/crates/ra_syntax/src/grammar.ron
@@ -596,7 +596,8 @@ Grammar(
             options: [ "Pat", "TypeRef" ],
         ),
         "UseItem": (
-            options: [ "UseTree" ]
+            traits: ["AttrsOwner"],
+            options: [ "UseTree" ],
         ),
         "UseTree": (
             options: [ "Path", "UseTreeList", "Alias" ]


### PR DESCRIPTION
I implemented the prelude import, but it turned out to be useless without being able to resolve any of the imports in the prelude :sweat_smile: So I had to add some edition handling and handle 2015-style imports (at least the simplified scheme proposed in rust-lang/rust#57745). So now finally `Option` resolves :smile: 

One remaining problem is that we don't actually know the edition for sysroot crates. They're currently hardcoded to 2015, but there's already a bunch of PRs upgrading the editions of various rustc crates, so we'll have to detect the edition somehow, or just change the hardcoding to 2018 later, I guess...

~Also currently missing is completion for prelude names, though that shouldn't be hard to add. And `Vec` still doesn't resolve, so I need to look into that.~