### PR TITLE
In `RootConfig::contains`, check against canonicalized version of root path

### DIFF
--- a/crates/ra_vfs/src/lib.rs
+++ b/crates/ra_vfs/src/lib.rs
@@ -72,12 +72,12 @@ impl RootConfig {
         if self.excluded_dirs.iter().any(|it| path.starts_with(it)) {
             return None;
         }
-        let rel_path = path.strip_prefix(&self.root)
+        let rel_path = path
+            .strip_prefix(&self.root)
             .or_else(|err_payload| {
                 self.canonical_root
                     .as_ref()
-                    .map_or(Err(err_payload),
-                            |canonical_root| path.strip_prefix(canonical_root))
+                    .map_or(Err(err_payload), |canonical_root| path.strip_prefix(canonical_root))
             })
             .ok()?;
         let rel_path = RelativePathBuf::from_path(rel_path).ok()?;


### PR DESCRIPTION
In `RootConfig::contains`, check against canonicalized version of root path since OS may hand us data that uses the canonical form rather than the root as specified by the user.

This is a step towards a resolution of issue #734 but does not completely fix the problem there.