### PR TITLE
Remove call to canonicalize in BatchDatabase::load_cargo

### DIFF
--- a/crates/ra_batch/src/lib.rs
+++ b/crates/ra_batch/src/lib.rs
@@ -95,7 +95,7 @@ impl BatchDatabase {
     }
 
     pub fn load_cargo(root: impl AsRef<Path>) -> Result<(BatchDatabase, Vec<SourceRootId>)> {
-        let root = root.as_ref().canonicalize()?;
+        let root = std::env::current_dir()?.join(root);
         let ws = ProjectWorkspace::discover(root.as_ref())?;
         let mut roots = Vec::new();
         roots.push(root.clone());


### PR DESCRIPTION
Instead of using canonicalize, we now join the given path to
`std::env::current_dir()`, which either replaces the path, if the given path is
absolute, or joins the paths.

This fixes #821.