### PR TITLE
Dont slow down everyone else's testing (especially the CI) just for Mac OS X

### DIFF
--- a/crates/ra_vfs/tests/vfs.rs
+++ b/crates/ra_vfs/tests/vfs.rs
@@ -83,7 +83,7 @@ fn test_vfs_works() -> std::io::Result<()> {
     }
 
     // rust-analyzer#734: fsevents has a bunch of events still sitting around.
-    process_tasks_in_range(&mut vfs, 0, 7);
+    process_tasks_in_range(&mut vfs, 0, if cfg!(target_os = "macos") { 7 } else { 0 });
     match vfs.commit_changes().as_slice() {
         [] => {}
 


### PR DESCRIPTION
The allowance for up to 7 events, and thus requiring anyone with fewer than 7 events to wait for the 3 second timeout, is only relevant to fsevents (i.e. Mac OS X)