### PR TITLE
Pass include_declaration to find_all_refs

### DIFF
--- a/crates/ra_ide_api/src/lib.rs
+++ b/crates/ra_ide_api/src/lib.rs
@@ -313,8 +313,12 @@ impl Analysis {
     }
 
     /// Finds all usages of the reference at point.
-    pub fn find_all_refs(&self, position: FilePosition) -> Cancelable<Vec<(FileId, TextRange)>> {
-        self.with_db(|db| references::find_all_refs(db, position))
+    pub fn find_all_refs(
+        &self,
+        position: FilePosition,
+        include_declaration: bool,
+    ) -> Cancelable<Vec<(FileId, TextRange)>> {
+        self.with_db(|db| references::find_all_refs(db, position, include_declaration))
     }
 
     /// Returns a short text describing element at position.

--- a/crates/ra_lsp_server/src/main_loop/handlers.rs
+++ b/crates/ra_lsp_server/src/main_loop/handlers.rs
@@ -456,7 +456,7 @@ pub fn handle_prepare_rename(
 
     // We support renaming references like handle_rename does.
     // In the future we may want to reject the renaming of things like keywords here too.
-    let refs = world.analysis().find_all_refs(position)?;
+    let refs = world.analysis().find_all_refs(position, true)?;
     let r = match refs.first() {
         Some(r) => r,
         None => return Ok(None),
@@ -500,8 +500,10 @@ pub fn handle_references(
     let file_id = params.text_document.try_conv_with(&world)?;
     let line_index = world.analysis().file_line_index(file_id);
     let offset = params.position.conv_with(&line_index);
+    let include_declaration = params.context.include_declaration;
 
-    let refs = world.analysis().find_all_refs(FilePosition { file_id, offset })?;
+    let refs =
+        world.analysis().find_all_refs(FilePosition { file_id, offset }, include_declaration)?;
 
     Ok(Some(
         refs.into_iter().filter_map(|r| to_location(r.0, r.1, &world, &line_index).ok()).collect(),
@@ -712,7 +714,7 @@ pub fn handle_document_highlight(
     let file_id = params.text_document.try_conv_with(&world)?;
     let line_index = world.analysis().file_line_index(file_id);
 
-    let refs = world.analysis().find_all_refs(params.try_conv_with(&world)?)?;
+    let refs = world.analysis().find_all_refs(params.try_conv_with(&world)?, true)?;
 
     Ok(Some(
         refs.into_iter()


### PR DESCRIPTION
By default include_declaration is `true`. It may be provided in the
textDocument/references.

This fixes #835