### PR TITLE
Turn ImplBlock into a copy type just containing IDs

### DIFF
--- a/crates/ra_cli/src/analysis_stats.rs
+++ b/crates/ra_cli/src/analysis_stats.rs
@@ -36,10 +36,10 @@ pub fn run(verbose: bool) -> Result<()> {
             }
 
             for impl_block in module.impl_blocks(&db) {
-                for item in impl_block.items() {
+                for item in impl_block.items(&db) {
                     num_decls += 1;
                     match item {
-                        ImplItem::Method(f) => funcs.push(*f),
+                        ImplItem::Method(f) => funcs.push(f),
                         _ => {}
                     }
                 }

--- a/crates/ra_hir/src/code_model_api.rs
+++ b/crates/ra_hir/src/code_model_api.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use relative_path::RelativePathBuf;
-use ra_db::{CrateId, FileId, SourceRootId, Edition};
+use ra_db::{CrateId, SourceRootId, Edition};
 use ra_syntax::{ast::self, TreeArc, SyntaxNode};
 
 use crate::{
@@ -16,7 +16,7 @@ use crate::{
     docs::{Documentation, Docs, docs_from_ast},
     module_tree::ModuleId,
     ids::{FunctionId, StructId, EnumId, AstItemDef, ConstId, StaticId, TraitId, TypeId},
-    impl_block::{ImplId, ImplBlock},
+    impl_block::ImplBlock,
     resolve::Resolver,
 };
 
@@ -107,7 +107,7 @@ impl Module {
     }
 
     /// Returns a node which defines this module. That is, a file or a `mod foo {}` with items.
-    pub fn definition_source(&self, db: &impl PersistentHirDatabase) -> (FileId, ModuleSource) {
+    pub fn definition_source(&self, db: &impl PersistentHirDatabase) -> (HirFileId, ModuleSource) {
         self.definition_source_impl(db)
     }
 
@@ -116,7 +116,7 @@ impl Module {
     pub fn declaration_source(
         &self,
         db: &impl HirDatabase,
-    ) -> Option<(FileId, TreeArc<ast::Module>)> {
+    ) -> Option<(HirFileId, TreeArc<ast::Module>)> {
         self.declaration_source_impl(db)
     }
 
@@ -127,11 +127,6 @@ impl Module {
         import: ImportId,
     ) -> TreeArc<ast::PathSegment> {
         self.import_source_impl(db, import)
-    }
-
-    /// Returns the syntax of the impl block in this module
-    pub fn impl_source(&self, db: &impl HirDatabase, impl_id: ImplId) -> TreeArc<ast::ImplBlock> {
-        self.impl_source_impl(db, impl_id)
     }
 
     /// Returns the crate this module is part of.
@@ -202,7 +197,7 @@ impl Module {
         module_impl_blocks
             .impls
             .iter()
-            .map(|(impl_id, _)| ImplBlock::from_id(module_impl_blocks.clone(), impl_id))
+            .map(|(impl_id, _)| ImplBlock::from_id(self, impl_id))
             .collect()
     }
 }

--- a/crates/ra_hir/src/ids.rs
+++ b/crates/ra_hir/src/ids.rs
@@ -74,7 +74,10 @@ impl HirFileId {
         }
     }
 
-    pub(crate) fn as_original_file(self) -> FileId {
+    /// XXX: this is a temporary function, which should go away when we implement the
+    /// nameresolution+macro expansion combo. Prefer using `original_file` if
+    /// possible.
+    pub fn as_original_file(self) -> FileId {
         match self.0 {
             HirFileIdRepr::File(file_id) => file_id,
             HirFileIdRepr::Macro(_r) => panic!("macro generated file: {:?}", self),

--- a/crates/ra_ide_api/src/impls.rs
+++ b/crates/ra_ide_api/src/impls.rs
@@ -50,8 +50,8 @@ fn impls_for_def(
 
     Some(
         impls
-            .lookup_impl_blocks(db, &ty)
-            .map(|(module, imp)| NavigationTarget::from_impl_block(db, module, &imp))
+            .lookup_impl_blocks(&ty)
+            .map(|imp| NavigationTarget::from_impl_block(db, imp))
             .collect(),
     )
 }
@@ -68,8 +68,8 @@ fn impls_for_trait(
 
     Some(
         impls
-            .lookup_impl_blocks_for_trait(db, &tr)
-            .map(|(module, imp)| NavigationTarget::from_impl_block(db, module, &imp))
+            .lookup_impl_blocks_for_trait(&tr)
+            .map(|imp| NavigationTarget::from_impl_block(db, imp))
             .collect(),
     )
 }

--- a/crates/ra_ide_api/src/navigation_target.rs
+++ b/crates/ra_ide_api/src/navigation_target.rs
@@ -79,6 +79,7 @@ impl NavigationTarget {
 
     pub(crate) fn from_module(db: &RootDatabase, module: hir::Module) -> NavigationTarget {
         let (file_id, source) = module.definition_source(db);
+        let file_id = file_id.as_original_file();
         let name = module.name(db).map(|it| it.to_string().into()).unwrap_or_default();
         match source {
             ModuleSource::SourceFile(node) => {
@@ -93,6 +94,7 @@ impl NavigationTarget {
     pub(crate) fn from_module_to_decl(db: &RootDatabase, module: hir::Module) -> NavigationTarget {
         let name = module.name(db).map(|it| it.to_string().into()).unwrap_or_default();
         if let Some((file_id, source)) = module.declaration_source(db) {
+            let file_id = file_id.as_original_file();
             return NavigationTarget::from_syntax(file_id, name, None, source.syntax());
         }
         NavigationTarget::from_module(db, module)
@@ -151,12 +153,15 @@ impl NavigationTarget {
 
     pub(crate) fn from_impl_block(
         db: &RootDatabase,
-        module: hir::Module,
-        impl_block: &hir::ImplBlock,
+        impl_block: hir::ImplBlock,
     ) -> NavigationTarget {
-        let (file_id, _) = module.definition_source(db);
-        let node = module.impl_source(db, impl_block.id());
-        NavigationTarget::from_syntax(file_id, "impl".into(), None, node.syntax())
+        let (file_id, node) = impl_block.source(db);
+        NavigationTarget::from_syntax(
+            file_id.as_original_file(),
+            "impl".into(),
+            None,
+            node.syntax(),
+        )
     }
 
     #[cfg(test)]

--- a/crates/ra_ide_api/src/references.rs
+++ b/crates/ra_ide_api/src/references.rs
@@ -100,6 +100,7 @@ fn rename_mod(
     if let Some(module) = source_binder::module_from_declaration(db, position.file_id, &ast_module)
     {
         let (file_id, module_source) = module.definition_source(db);
+        let file_id = file_id.as_original_file();
         match module_source {
             ModuleSource::SourceFile(..) => {
                 let mod_path: RelativePathBuf = db.file_relative_path(file_id);


### PR DESCRIPTION
This makes it more like the other code model types.

Also make Module::definition_source/declaration_source return HirFileIds, to
make them more like the other source functions.