### PR TITLE
Refactor find_all_refs to return ReferenceSearchResult

### DIFF
--- a/crates/ra_ide_api/src/lib.rs
+++ b/crates/ra_ide_api/src/lib.rs
@@ -56,6 +56,7 @@ pub use crate::{
     completion::{CompletionItem, CompletionItemKind, InsertTextFormat},
     runnables::{Runnable, RunnableKind},
     navigation_target::NavigationTarget,
+    references::ReferenceSearchResult,
 };
 pub use ra_ide_api_light::{
     Fold, FoldKind, HighlightedRange, Severity, StructureNode, LocalEdit,
@@ -319,7 +320,10 @@ impl Analysis {
     }
 
     /// Finds all usages of the reference at point.
-    pub fn find_all_refs(&self, position: FilePosition) -> Cancelable<Vec<(FileId, TextRange)>> {
+    pub fn find_all_refs(
+        &self,
+        position: FilePosition,
+    ) -> Cancelable<Option<ReferenceSearchResult>> {
         self.with_db(|db| references::find_all_refs(db, position))
     }
 

--- a/crates/ra_ide_api/src/navigation_target.rs
+++ b/crates/ra_ide_api/src/navigation_target.rs
@@ -23,6 +23,12 @@ pub struct NavigationTarget {
 }
 
 impl NavigationTarget {
+    /// When `focus_range` is specified, returns it. otherwise
+    /// returns `full_range`
+    pub fn range(&self) -> TextRange {
+        self.focus_range.unwrap_or(self.full_range)
+    }
+
     pub fn name(&self) -> &SmolStr {
         &self.name
     }
@@ -43,12 +49,16 @@ impl NavigationTarget {
         self.full_range
     }
 
-    /// A "most interesting" range withing the `range_full`.
+    /// A "most interesting" range withing the `full_range`.
     ///
-    /// Typically, `range` is the whole syntax node, including doc comments, and
-    /// `focus_range` is the range of the identifier.
+    /// Typically, `full_range` is the whole syntax node,
+    /// including doc comments, and `focus_range` is the range of the identifier.
     pub fn focus_range(&self) -> Option<TextRange> {
         self.focus_range
+    }
+
+    pub(crate) fn from_bind_pat(file_id: FileId, pat: &ast::BindPat) -> NavigationTarget {
+        NavigationTarget::from_named(file_id, pat)
     }
 
     pub(crate) fn from_symbol(symbol: FileSymbol) -> NavigationTarget {

--- a/crates/ra_ide_api/src/references.rs
+++ b/crates/ra_ide_api/src/references.rs
@@ -46,7 +46,7 @@ impl ReferenceSearchResult {
 // over FileRanges
 impl IntoIterator for ReferenceSearchResult {
     type Item = FileRange;
-    type IntoIter = ::std::vec::IntoIter<FileRange>;
+    type IntoIter = std::vec::IntoIter<FileRange>;
 
     fn into_iter(mut self) -> Self::IntoIter {
         let mut v = Vec::with_capacity(self.len());

--- a/crates/ra_ide_api/tests/test/main.rs
+++ b/crates/ra_ide_api/tests/test/main.rs
@@ -1,7 +1,8 @@
 use insta::assert_debug_snapshot_matches;
 use ra_ide_api::{
     mock_analysis::{single_file, single_file_with_position, MockAnalysis},
-    AnalysisChange, CrateGraph, Edition::Edition2018, FileId, Query, NavigationTarget
+    AnalysisChange, CrateGraph, Edition::Edition2018, Query, NavigationTarget,
+    ReferenceSearchResult,
 };
 use ra_syntax::{TextRange, SmolStr};
 
@@ -44,9 +45,9 @@ fn test_resolve_crate_root() {
     assert_eq!(host.analysis().crate_for(mod_file).unwrap(), vec![crate_id]);
 }
 
-fn get_all_refs(text: &str) -> Vec<(FileId, TextRange)> {
+fn get_all_refs(text: &str) -> ReferenceSearchResult {
     let (analysis, position) = single_file_with_position(text);
-    analysis.find_all_refs(position).unwrap()
+    analysis.find_all_refs(position).unwrap().unwrap()
 }
 
 fn get_symbols_matching(text: &str, query: &str) -> Vec<NavigationTarget> {

--- a/crates/ra_lsp_server/src/conv.rs
+++ b/crates/ra_lsp_server/src/conv.rs
@@ -333,7 +333,7 @@ impl TryConvWith for &NavigationTarget {
     type Output = Location;
     fn try_conv_with(self, world: &ServerWorld) -> Result<Location> {
         let line_index = world.analysis().file_line_index(self.file_id());
-        let range = self.focus_range().unwrap_or(self.full_range());
+        let range = self.range();
         to_location(self.file_id(), range, &world, &line_index)
     }
 }


### PR DESCRIPTION
This refactors `find_all_refs` to return a new `ReferenceSearchResult` based on feedback in #839.

There are few questions/notes regarding the refactor:

1. Introducing `NavigationTarget::from_bind_pat` this simply forwards the call to `NavigationTarget::from_named`, could we just expose `from_named` directly as `pub(crate)` ?
2. Added an utility method `NavigationTarget::range` since there were few places where you would use `self.focus_range.unwrap_or(self.full_range)`
3. Implementing `IntoIterator` for `ReferenceSearchResult`. This turns `ReferenceSearchResult` into an iterator over `FileRanges` and allows previous code to mostly stay as it was based on the order that `find_all_refs` previously had (declaration first and then the references). I'm not sure if there is a way of doing the conversion to `IntoIter` without the allocation of a new vector
4. Is it possible to have a binding without a name? I'm not sure if the `NavigationTarget::from_bind_pat` can cause some edge-cases that previously were ok



This fixes #835.