### PR TITLE
Reduce dependnecies of ra_vfs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,7 +1128,6 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ra_arena 0.1.0",
  "relative-path 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,7 +1123,6 @@ name = "ra_vfs"
 version = "0.1.0"
 dependencies = [
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "drop_bomb 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "flexi_logger 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,6 @@ dependencies = [
  "relative-path 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_worker 0.1.0",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/crates/ra_vfs/Cargo.toml
+++ b/crates/ra_vfs/Cargo.toml
@@ -11,7 +11,6 @@ rustc-hash = "1.0"
 crossbeam-channel = "0.3.5"
 log = "0.4.6"
 notify = "4.0.9"
-drop_bomb = "0.1.0"
 parking_lot = "0.7.0"
 
 thread_worker = { path = "../thread_worker" }

--- a/crates/ra_vfs/Cargo.toml
+++ b/crates/ra_vfs/Cargo.toml
@@ -15,7 +15,6 @@ drop_bomb = "0.1.0"
 parking_lot = "0.7.0"
 
 thread_worker = { path = "../thread_worker" }
-ra_arena = { path = "../ra_arena" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/ra_vfs/Cargo.toml
+++ b/crates/ra_vfs/Cargo.toml
@@ -13,8 +13,6 @@ log = "0.4.6"
 notify = "4.0.9"
 parking_lot = "0.7.0"
 
-thread_worker = { path = "../thread_worker" }
-
 [dev-dependencies]
 tempfile = "3"
 flexi_logger = "0.10.0"

--- a/crates/ra_vfs/src/lib.rs
+++ b/crates/ra_vfs/src/lib.rs
@@ -25,7 +25,6 @@ use std::{
 };
 
 use crossbeam_channel::Receiver;
-use ra_arena::{impl_arena_id, Arena, RawId};
 use relative_path::{RelativePath, RelativePathBuf};
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -40,8 +39,7 @@ pub use crate::{
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct VfsFile(pub RawId);
-impl_arena_id!(VfsFile);
+pub struct VfsFile(pub u32);
 
 struct VfsFileData {
     root: VfsRoot,
@@ -52,7 +50,7 @@ struct VfsFileData {
 
 pub struct Vfs {
     roots: Arc<Roots>,
-    files: Arena<VfsFile, VfsFileData>,
+    files: Vec<VfsFileData>,
     root2files: FxHashMap<VfsRoot, FxHashSet<VfsFile>>,
     pending_changes: Vec<VfsChange>,
     worker: Worker,
@@ -78,8 +76,7 @@ impl Vfs {
             root2files.insert(root, Default::default());
             worker.sender().send(io::Task::AddRoot { root }).unwrap();
         }
-        let res =
-            Vfs { roots, files: Arena::default(), root2files, worker, pending_changes: Vec::new() };
+        let res = Vfs { roots, files: Vec::new(), root2files, worker, pending_changes: Vec::new() };
         let vfs_roots = res.roots.iter().collect();
         (res, vfs_roots)
     }
@@ -96,8 +93,8 @@ impl Vfs {
     }
 
     pub fn file2path(&self, file: VfsFile) -> PathBuf {
-        let rel_path = &self.files[file].path;
-        let root_path = &self.roots.path(self.files[file].root);
+        let rel_path = &self.file(file).path;
+        let root_path = &self.roots.path(self.file(file).root);
         rel_path.to_path(root_path)
     }
 
@@ -166,11 +163,11 @@ impl Vfs {
                 // been open in the editor, so we need to account for that.
                 let existing = self.root2files[&root]
                     .iter()
-                    .map(|&file| (self.files[file].path.clone(), file))
+                    .map(|&file| (self.file(file).path.clone(), file))
                     .collect::<FxHashMap<_, _>>();
                 for (path, text) in files {
                     if let Some(&file) = existing.get(&path) {
-                        let text = Arc::clone(&self.files[file].text);
+                        let text = Arc::clone(&self.file(file).text);
                         cur_files.push((file, path, text));
                         continue;
                     }
@@ -184,7 +181,7 @@ impl Vfs {
             }
             TaskResult::SingleFile { root, path, text } => {
                 let existing_file = self.find_file(root, &path);
-                if existing_file.map(|file| self.files[file].is_overlayed) == Some(true) {
+                if existing_file.map(|file| self.file(file).is_overlayed) == Some(true) {
                     return;
                 }
                 match (existing_file, text) {
@@ -240,22 +237,23 @@ impl Vfs {
         is_overlayed: bool,
     ) -> VfsFile {
         let data = VfsFileData { root, path, text, is_overlayed };
-        let file = self.files.alloc(data);
+        let file = VfsFile(self.files.len() as u32);
+        self.files.push(data);
         self.root2files.get_mut(&root).unwrap().insert(file);
         file
     }
 
     fn raw_change_file(&mut self, file: VfsFile, new_text: Arc<String>, is_overlayed: bool) {
-        let mut file_data = &mut self.files[file];
+        let mut file_data = &mut self.file_mut(file);
         file_data.text = new_text;
         file_data.is_overlayed = is_overlayed;
     }
 
     fn raw_remove_file(&mut self, file: VfsFile) {
         // FIXME: use arena with removal
-        self.files[file].text = Default::default();
-        self.files[file].path = Default::default();
-        let root = self.files[file].root;
+        self.file_mut(file).text = Default::default();
+        self.file_mut(file).path = Default::default();
+        let root = self.file(file).root;
         let removed = self.root2files.get_mut(&root).unwrap().remove(&file);
         assert!(removed);
     }
@@ -267,7 +265,15 @@ impl Vfs {
     }
 
     fn find_file(&self, root: VfsRoot, path: &RelativePath) -> Option<VfsFile> {
-        self.root2files[&root].iter().map(|&it| it).find(|&file| self.files[file].path == path)
+        self.root2files[&root].iter().map(|&it| it).find(|&file| self.file(file).path == path)
+    }
+
+    fn file(&self, file: VfsFile) -> &VfsFileData {
+        &self.files[file.0 as usize]
+    }
+
+    fn file_mut(&mut self, file: VfsFile) -> &mut VfsFileData {
+        &mut self.files[file.0 as usize]
     }
 }
 

--- a/crates/ra_vfs/src/lib.rs
+++ b/crates/ra_vfs/src/lib.rs
@@ -66,6 +66,14 @@ impl fmt::Debug for Vfs {
     }
 }
 
+#[derive(Debug, Clone)]
+pub enum VfsChange {
+    AddRoot { root: VfsRoot, files: Vec<(VfsFile, RelativePathBuf, Arc<String>)> },
+    AddFile { root: VfsRoot, file: VfsFile, path: RelativePathBuf, text: Arc<String> },
+    RemoveFile { root: VfsRoot, file: VfsFile, path: RelativePathBuf },
+    ChangeFile { file: VfsFile, text: Arc<String> },
+}
+
 impl Vfs {
     pub fn new(roots: Vec<PathBuf>) -> (Vfs, Vec<VfsRoot>) {
         let roots = Arc::new(Roots::new(roots));
@@ -275,12 +283,4 @@ impl Vfs {
     fn file_mut(&mut self, file: VfsFile) -> &mut VfsFileData {
         &mut self.files[file.0 as usize]
     }
-}
-
-#[derive(Debug, Clone)]
-pub enum VfsChange {
-    AddRoot { root: VfsRoot, files: Vec<(VfsFile, RelativePathBuf, Arc<String>)> },
-    AddFile { root: VfsRoot, file: VfsFile, path: RelativePathBuf, text: Arc<String> },
-    RemoveFile { root: VfsRoot, file: VfsFile, path: RelativePathBuf },
-    ChangeFile { file: VfsFile, text: Arc<String> },
 }

--- a/crates/ra_vfs/src/lib.rs
+++ b/crates/ra_vfs/src/lib.rs
@@ -92,7 +92,7 @@ impl Vfs {
 
         for root in roots.iter() {
             root2files.insert(root, Default::default());
-            worker.sender().send(io::Task::AddRoot { root }).unwrap();
+            worker.sender.send(io::Task::AddRoot { root }).unwrap();
         }
         let res = Vfs { roots, files: Vec::new(), root2files, worker, pending_changes: Vec::new() };
         let vfs_roots = res.roots.iter().collect();
@@ -170,7 +170,7 @@ impl Vfs {
     }
 
     pub fn task_receiver(&self) -> &Receiver<VfsTask> {
-        self.worker.receiver()
+        &self.worker.receiver
     }
 
     pub fn handle_task(&mut self, task: VfsTask) {

--- a/crates/ra_vfs/src/roots.rs
+++ b/crates/ra_vfs/src/roots.rs
@@ -1,6 +1,5 @@
 use std::{
     iter,
-    sync::Arc,
     path::{Path, PathBuf},
 };
 
@@ -25,7 +24,7 @@ struct RootData {
 }
 
 pub(crate) struct Roots {
-    roots: Arena<VfsRoot, Arc<RootData>>,
+    roots: Arena<VfsRoot, RootData>,
 }
 
 impl Roots {
@@ -38,9 +37,7 @@ impl Roots {
             let nested_roots =
                 paths[..i].iter().filter_map(|it| rel_path(path, it)).collect::<Vec<_>>();
 
-            let config = Arc::new(RootData::new(path.clone(), nested_roots));
-
-            roots.alloc(config.clone());
+            roots.alloc(RootData::new(path.clone(), nested_roots));
         }
         Roots { roots }
     }


### PR DESCRIPTION
In preparation for moving `ra_vfs` to a separate repo with extensive cross-platform CI, remove dependency on `ra_thread_workder` and `ra_arena`.