### PR TITLE
Fix handling of generics in tuple variants and refactor a bit

### DIFF
--- a/crates/ra_hir/src/generics.rs
+++ b/crates/ra_hir/src/generics.rs
@@ -87,4 +87,17 @@ impl GenericParams {
         let parent_count = self.count_parent_params();
         parent_count + self.params.len()
     }
+
+    fn for_each_param<'a>(&'a self, f: &mut impl FnMut(&'a GenericParam)) {
+        if let Some(parent) = &self.parent_params {
+            parent.for_each_param(f);
+        }
+        self.params.iter().for_each(f);
+    }
+
+    pub fn params_including_parent(&self) -> Vec<&GenericParam> {
+        let mut vec = Vec::with_capacity(self.count_params_including_parent());
+        self.for_each_param(&mut |p| vec.push(p));
+        vec
+    }
 }

--- a/crates/ra_hir/src/ty.rs
+++ b/crates/ra_hir/src/ty.rs
@@ -443,7 +443,7 @@ impl Ty {
         for _ in supplied_params..def_generics.count_params_including_parent() {
             substs.push(Ty::Unknown);
         }
-        assert_eq!(substs.len(), def_generics.params.len());
+        assert_eq!(substs.len(), def_generics.count_params_including_parent());
         Substs(substs.into())
     }
 
@@ -1374,6 +1374,7 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
         for _ in supplied_params..parent_param_count + param_count {
             substs.push(Ty::Unknown);
         }
+        assert_eq!(substs.len(), parent_param_count + param_count);
         Substs(substs.into())
     }
 

--- a/crates/ra_hir/src/ty/snapshots/tests__infer_struct.snap
+++ b/crates/ra_hir/src/ty/snapshots/tests__infer_struct.snap
@@ -1,19 +1,19 @@
 ---
-created: "2019-02-17T16:16:58.863630956Z"
+created: "2019-02-20T21:31:12.910924715Z"
 creator: insta@0.6.2
 source: crates/ra_hir/src/ty/tests.rs
 expression: "&result"
 ---
 [72; 154) '{     ...a.c; }': ()
 [82; 83) 'c': C
-[86; 87) 'C': fn C(usize) -> C
+[86; 87) 'C': C(usize) -> C
 [86; 90) 'C(1)': C
 [88; 89) '1': usize
 [96; 97) 'B': B
 [107; 108) 'a': A
 [114; 133) 'A { b:...C(1) }': A
 [121; 122) 'B': B
-[127; 128) 'C': fn C(usize) -> C
+[127; 128) 'C': C(usize) -> C
 [127; 131) 'C(1)': C
 [129; 130) '1': usize
 [139; 140) 'a': A

--- a/crates/ra_hir/src/ty/snapshots/tests__infer_tuple_struct_generics.snap
+++ b/crates/ra_hir/src/ty/snapshots/tests__infer_tuple_struct_generics.snap
@@ -1,0 +1,23 @@
+---
+created: "2019-02-20T21:31:12.911275141Z"
+creator: insta@0.6.2
+source: crates/ra_hir/src/ty/tests.rs
+expression: "&result"
+---
+[77; 185) '{     ...one; }': ()
+[83; 84) 'A': A<i32>(T) -> A<T>
+[83; 88) 'A(42)': A<i32>
+[85; 87) '42': i32
+[94; 95) 'A': A<u128>(T) -> A<T>
+[94; 103) 'A(42u128)': A<u128>
+[96; 102) '42u128': u128
+[109; 113) 'Some': Some<&str>(T) -> Option<T>
+[109; 118) 'Some("x")': Option<&str>
+[114; 117) '"x"': &str
+[124; 136) 'Option::Some': Some<&str>(T) -> Option<T>
+[124; 141) 'Option...e("x")': Option<&str>
+[137; 140) '"x"': &str
+[147; 151) 'None': Option<[unknown]>
+[161; 162) 'x': Option<i64>
+[178; 182) 'None': Option<i64>
+

--- a/crates/ra_hir/src/ty/tests.rs
+++ b/crates/ra_hir/src/ty/tests.rs
@@ -466,6 +466,27 @@ fn test(a1: A<u32>, i: i32) {
 }
 
 #[test]
+fn infer_tuple_struct_generics() {
+    check_inference(
+        "infer_tuple_struct_generics",
+        r#"
+struct A<T>(T);
+enum Option<T> { Some(T), None };
+use Option::*;
+
+fn test() {
+    A(42);
+    A(42u128);
+    Some("x");
+    Option::Some("x");
+    None;
+    let x: Option<i64> = None;
+}
+"#,
+    );
+}
+
+#[test]
 fn infer_generics_in_patterns() {
     check_inference(
         "infer_generics_in_patterns",

--- a/crates/ra_ide_api/src/hover.rs
+++ b/crates/ra_ide_api/src/hover.rs
@@ -164,6 +164,23 @@ mod tests {
     }
 
     #[test]
+    fn hover_some() {
+        let (analysis, position) = single_file_with_position(
+            "
+            enum Option<T> { Some(T) }
+            use Option::Some;
+
+            fn main() {
+                So<|>me(12);
+            }
+            ",
+        );
+        let hover = analysis.hover(position).unwrap().unwrap();
+        // not the nicest way to show it currently
+        assert_eq!(hover.info, "Some<i32>(T) -> Option<T>");
+    }
+
+    #[test]
     fn hover_for_local_variable() {
         let (analysis, position) = single_file_with_position("fn func(foo: i32) { fo<|>o; }");
         let hover = analysis.hover(position).unwrap().unwrap();


### PR DESCRIPTION
(The problem was that we created separate substitutions for the return value, so we lost the connection between the type arguments in the constructor call and the type arguments of the result.)

Also make them display a tiny bit nicer.

Fixes #860.