### PR TITLE
Fixes to goto definition

### DIFF
--- a/crates/ra_ide_api/src/goto_definition.rs
+++ b/crates/ra_ide_api/src/goto_definition.rs
@@ -1,6 +1,6 @@
 use ra_db::{FileId, SourceDatabase};
 use ra_syntax::{
-    AstNode, ast::{self, NameOwner},
+    AstNode, ast,
     algo::{find_node_at_offset, visit::{visitor, Visitor}},
     SyntaxNode,
 };
@@ -136,22 +136,18 @@ fn name_definition(
 }
 
 fn named_target(file_id: FileId, node: &SyntaxNode) -> Option<NavigationTarget> {
-    fn to_nav_target<N: NameOwner>(node: &N, file_id: FileId) -> Option<NavigationTarget> {
-        Some(NavigationTarget::from_named(file_id, node))
-    }
-
     visitor()
-        .visit(|n: &ast::StructDef| to_nav_target(n, file_id))
-        .visit(|n: &ast::EnumDef| to_nav_target(n, file_id))
-        .visit(|n: &ast::EnumVariant| to_nav_target(n, file_id))
-        .visit(|n: &ast::FnDef| to_nav_target(n, file_id))
-        .visit(|n: &ast::TypeDef| to_nav_target(n, file_id))
-        .visit(|n: &ast::ConstDef| to_nav_target(n, file_id))
-        .visit(|n: &ast::StaticDef| to_nav_target(n, file_id))
-        .visit(|n: &ast::TraitDef| to_nav_target(n, file_id))
-        .visit(|n: &ast::NamedFieldDef| to_nav_target(n, file_id))
-        .visit(|n: &ast::Module| to_nav_target(n, file_id))
-        .accept(node)?
+        .visit(|node: &ast::StructDef| NavigationTarget::from_named(file_id, node))
+        .visit(|node: &ast::EnumDef| NavigationTarget::from_named(file_id, node))
+        .visit(|node: &ast::EnumVariant| NavigationTarget::from_named(file_id, node))
+        .visit(|node: &ast::FnDef| NavigationTarget::from_named(file_id, node))
+        .visit(|node: &ast::TypeDef| NavigationTarget::from_named(file_id, node))
+        .visit(|node: &ast::ConstDef| NavigationTarget::from_named(file_id, node))
+        .visit(|node: &ast::StaticDef| NavigationTarget::from_named(file_id, node))
+        .visit(|node: &ast::TraitDef| NavigationTarget::from_named(file_id, node))
+        .visit(|node: &ast::NamedFieldDef| NavigationTarget::from_named(file_id, node))
+        .visit(|node: &ast::Module| NavigationTarget::from_named(file_id, node))
+        .accept(node)
 }
 
 #[cfg(test)]

--- a/crates/ra_ide_api/src/navigation_target.rs
+++ b/crates/ra_ide_api/src/navigation_target.rs
@@ -193,7 +193,7 @@ impl NavigationTarget {
             buf.push_str(&format!(" {:?}", focus_range))
         }
         if let Some(container_name) = self.container_name() {
-            buf.push_str(&format!(" {:?}", container_name))
+            buf.push_str(&format!(" {}", container_name))
         }
         buf
     }

--- a/crates/ra_ide_api/src/navigation_target.rs
+++ b/crates/ra_ide_api/src/navigation_target.rs
@@ -67,7 +67,7 @@ impl NavigationTarget {
             name: symbol.name.clone(),
             kind: symbol.ptr.kind(),
             full_range: symbol.ptr.range(),
-            focus_range: None,
+            focus_range: symbol.name_range,
             container_name: symbol.container_name.clone(),
         }
     }

--- a/crates/ra_ide_api/src/navigation_target.rs
+++ b/crates/ra_ide_api/src/navigation_target.rs
@@ -198,7 +198,8 @@ impl NavigationTarget {
         buf
     }
 
-    fn from_named(file_id: FileId, node: &impl ast::NameOwner) -> NavigationTarget {
+    /// Allows `NavigationTarget` to be created from a `NameOwner`
+    pub(crate) fn from_named(file_id: FileId, node: &impl ast::NameOwner) -> NavigationTarget {
         let name = node.name().map(|it| it.text().clone()).unwrap_or_default();
         let focus_range = node.name().map(|it| it.syntax().range());
         NavigationTarget::from_syntax(file_id, name, focus_range, node.syntax())


### PR DESCRIPTION
Previously goto definition would fail when the cursor was over the name of the definition. Now we should properly resolve to a `NavigationTarget` when on top of the name of a definition.

In addition this adds `name_range` field to `FileSymbol`, this further fixes goto_definition and symbol based navigation by allowing the `NavigationTarget` to actually have a `focus_range`, meaning instead of focusing on the start of the `full_range`, we can have the cursor focus on the name.

e.g. goto definition
```rust
fn bar() {
    fn foo() { }
  
   foo<|>();
}
```

Previously this would put the cursor at the start of the FN_DEF:
```rust
fn bar() {
   <|>fn foo() { }
  
   foo();
}
```
Now when using the symbol based resolving, we'll have a proper focus range and instead put the cursor at the start of the name.

```rust
fn bar() {
   fn <|>foo() { }
  
   foo();
}
```

This fixes #877 but doesn't contain the refactoring of the return type for `goto_definition`