### PR TITLE
Fix resolution of associated method calls across crates

### DIFF
--- a/crates/ra_hir/src/nameres.rs
+++ b/crates/ra_hir/src/nameres.rs
@@ -642,7 +642,11 @@ impl ItemMap {
                         log::debug!("resolving {:?} in other crate", path);
                         let item_map = db.item_map(module.krate);
                         let (def, s) = item_map.resolve_path(db, *module, &path);
-                        return ResolvePathResult::with(def, ReachedFixedPoint::Yes, s);
+                        return ResolvePathResult::with(
+                            def,
+                            ReachedFixedPoint::Yes,
+                            s.map(|s| s + i),
+                        );
                     }
 
                     match self[module.module_id].items.get(&segment.name) {

--- a/crates/ra_hir/src/ty.rs
+++ b/crates/ra_hir/src/ty.rs
@@ -1170,6 +1170,13 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
 
         let (def, remaining_index) = resolved.into_inner();
 
+        log::debug!(
+            "path {:?} resolved to {:?} with remaining index {:?}",
+            path,
+            def,
+            remaining_index
+        );
+
         // if the remaining_index is None, we expect the path
         // to be fully resolved, in this case we continue with
         // the default by attempting to `take_values´ from the resolution.
@@ -1190,6 +1197,8 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
                     // TODO: Keep resolving the segments
                     // if we have more segments to process
                     let segment = &path.segments[remaining_index];
+
+                    log::debug!("looking for path segment: {:?}", segment);
 
                     // Attempt to find an impl_item for the type which has a name matching
                     // the current segment


### PR DESCRIPTION
I think it'll be better to make the path resolution the number of unresolved
segments, not the first unresolved index; then this error could simply not have
happened. But I'll do that separately.