### PR TITLE
Parse token trees directy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,6 +1066,7 @@ dependencies = [
 name = "ra_mbe"
 version = "0.1.0"
 dependencies = [
+ "ra_parser 0.1.0",
  "ra_syntax 0.1.0",
  "ra_tt 0.1.0",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crates/ra_mbe/Cargo.toml
+++ b/crates/ra_mbe/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["rust-analyzer developers"]
 
 [dependencies]
 ra_syntax = { path = "../ra_syntax" }
+ra_parser = { path = "../ra_parser" }
 tt = { path = "../ra_tt", package = "ra_tt" }
 
 rustc-hash = "1.0.0"

--- a/crates/ra_mbe/src/lib.rs
+++ b/crates/ra_mbe/src/lib.rs
@@ -24,7 +24,7 @@ use ra_syntax::SmolStr;
 
 pub use tt::{Delimiter, Punct};
 
-pub use crate::syntax_bridge::ast_to_token_tree;
+pub use crate::syntax_bridge::{ast_to_token_tree, token_tree_to_ast_item_list};
 
 /// This struct contains AST for a single `macro_rules` definition. What might
 /// be very confusing is that AST has almost exactly the same shape as

--- a/crates/ra_mbe/src/lib.rs
+++ b/crates/ra_mbe/src/lib.rs
@@ -164,14 +164,18 @@ impl_froms!(TokenTree: Leaf, Subtree);
         crate::MacroRules::parse(&definition_tt).unwrap()
     }
 
-    fn assert_expansion(rules: &MacroRules, invocation: &str, expansion: &str) {
+    fn expand(rules: &MacroRules, invocation: &str) -> tt::Subtree {
         let source_file = ast::SourceFile::parse(invocation);
         let macro_invocation =
             source_file.syntax().descendants().find_map(ast::MacroCall::cast).unwrap();
 
         let (invocation_tt, _) = ast_to_token_tree(macro_invocation.token_tree().unwrap()).unwrap();
 
-        let expanded = rules.expand(&invocation_tt).unwrap();
+        rules.expand(&invocation_tt).unwrap()
+    }
+
+    fn assert_expansion(rules: &MacroRules, invocation: &str, expansion: &str) {
+        let expanded = expand(rules, invocation);
         assert_eq!(expanded.to_string(), expansion);
     }
 
@@ -266,6 +270,59 @@ impl_froms!(TokenTree: Leaf, Subtree);
         assert_expansion(&rules, "foo! { foo, bar }", "mod foo {} mod bar {}");
         assert_expansion(&rules, "foo! { foo# bar }", "fn foo () {} fn bar () {}");
         assert_expansion(&rules, "foo! { Foo,# Bar }", "struct Foo ; struct Bar ;");
+    }
+
+    #[test]
+    fn expand_to_item_list() {
+        let rules = create_rules(
+            "
+            macro_rules! structs {
+                ($($i:ident),*) => {
+                    $(struct $i { field: u32 } )*
+                }
+            }
+            ",
+        );
+        let expansion = expand(&rules, "structs!(Foo, Bar)");
+        let tree = token_tree_to_ast_item_list(&expansion);
+        assert_eq!(
+            tree.syntax().debug_dump().trim(),
+            r#"
+SOURCE_FILE@[0; 40)
+  STRUCT_DEF@[0; 20)
+    STRUCT_KW@[0; 6)
+    NAME@[6; 9)
+      IDENT@[6; 9) "Foo"
+    NAMED_FIELD_DEF_LIST@[9; 20)
+      L_CURLY@[9; 10)
+      NAMED_FIELD_DEF@[10; 19)
+        NAME@[10; 15)
+          IDENT@[10; 15) "field"
+        COLON@[15; 16)
+        PATH_TYPE@[16; 19)
+          PATH@[16; 19)
+            PATH_SEGMENT@[16; 19)
+              NAME_REF@[16; 19)
+                IDENT@[16; 19) "u32"
+      R_CURLY@[19; 20)
+  STRUCT_DEF@[20; 40)
+    STRUCT_KW@[20; 26)
+    NAME@[26; 29)
+      IDENT@[26; 29) "Bar"
+    NAMED_FIELD_DEF_LIST@[29; 40)
+      L_CURLY@[29; 30)
+      NAMED_FIELD_DEF@[30; 39)
+        NAME@[30; 35)
+          IDENT@[30; 35) "field"
+        COLON@[35; 36)
+        PATH_TYPE@[36; 39)
+          PATH@[36; 39)
+            PATH_SEGMENT@[36; 39)
+              NAME_REF@[36; 39)
+                IDENT@[36; 39) "u32"
+      R_CURLY@[39; 40)"#
+                .trim()
+        );
     }
 
 }

--- a/crates/ra_mbe/src/syntax_bridge.rs
+++ b/crates/ra_mbe/src/syntax_bridge.rs
@@ -96,10 +96,10 @@ fn convert_tt(
 }
 
 struct TtTokenSource {
-    tokens: Vec<Tok>,
+    tokens: Vec<TtToken>,
 }
 
-struct Tok {
+struct TtToken {
     kind: SyntaxKind,
     is_joint_to_next: bool,
     text: SmolStr,
@@ -124,7 +124,7 @@ impl TtTokenSource {
     }
     fn convert_leaf(&mut self, leaf: &tt::Leaf) {
         let tok = match leaf {
-            tt::Leaf::Literal(l) => Tok {
+            tt::Leaf::Literal(l) => TtToken {
                 kind: SyntaxKind::INT_NUMBER, // FIXME
                 is_joint_to_next: false,
                 text: l.text.clone(),
@@ -144,11 +144,11 @@ impl TtTokenSource {
                     let s: &str = p.char.encode_utf8(&mut buf);
                     SmolStr::new(s)
                 };
-                Tok { kind, is_joint_to_next: p.spacing == tt::Spacing::Joint, text }
+                TtToken { kind, is_joint_to_next: p.spacing == tt::Spacing::Joint, text }
             }
             tt::Leaf::Ident(ident) => {
                 let kind = SyntaxKind::from_keyword(ident.text.as_str()).unwrap_or(IDENT);
-                Tok { kind, is_joint_to_next: false, text: ident.text.clone() }
+                TtToken { kind, is_joint_to_next: false, text: ident.text.clone() }
             }
         };
         self.tokens.push(tok)
@@ -163,7 +163,7 @@ impl TtTokenSource {
         let idx = closing as usize;
         let kind = kinds[idx];
         let text = &texts[idx..texts.len() - (1 - idx)];
-        let tok = Tok { kind, is_joint_to_next: false, text: SmolStr::new(text) };
+        let tok = TtToken { kind, is_joint_to_next: false, text: SmolStr::new(text) };
         self.tokens.push(tok)
     }
 }
@@ -187,14 +187,14 @@ impl TokenSource for TtTokenSource {
 #[derive(Default)]
 struct TtTreeSink<'a> {
     buf: String,
-    tokens: &'a [Tok],
+    tokens: &'a [TtToken],
     text_pos: TextUnit,
     token_pos: usize,
     inner: SyntaxTreeBuilder,
 }
 
 impl<'a> TtTreeSink<'a> {
-    fn new(tokens: &'a [Tok]) -> TtTreeSink {
+    fn new(tokens: &'a [TtToken]) -> TtTreeSink {
         TtTreeSink {
             buf: String::new(),
             tokens,

--- a/crates/ra_mbe/src/syntax_bridge.rs
+++ b/crates/ra_mbe/src/syntax_bridge.rs
@@ -1,5 +1,6 @@
+use ra_parser::TokenSource;
 use ra_syntax::{
-    AstNode, SyntaxNode, TextRange,
+    AstNode, SyntaxNode, TextRange, SyntaxKind,
     ast, SyntaxKind::*, TextUnit
 };
 
@@ -88,4 +89,24 @@ fn convert_tt(
 
     let res = tt::Subtree { delimiter, token_trees };
     Some(res)
+}
+
+struct TtTokenSource;
+
+impl TtTokenSource {
+    fn new(tt: &tt::Subtree) -> TtTokenSource {
+        unimplemented!()
+    }
+}
+
+impl TokenSource for TtTokenSource {
+    fn token_kind(&self, pos: usize) -> SyntaxKind {
+        unimplemented!()
+    }
+    fn is_token_joint_to_next(&self, pos: usize) -> bool {
+        unimplemented!()
+    }
+    fn is_keyword(&self, pos: usize, kw: &str) -> bool {
+        unimplemented!()
+    }
 }

--- a/crates/ra_mbe/src/syntax_bridge.rs
+++ b/crates/ra_mbe/src/syntax_bridge.rs
@@ -19,6 +19,11 @@ pub fn ast_to_token_tree(ast: &ast::TokenTree) -> Option<(tt::Subtree, TokenMap)
     Some((tt, token_map))
 }
 
+/// Parses the token tree (result of macro expansion) as a sequence of items
+pub fn token_tree_to_ast_item_list(tt: &tt::Subtree) -> ast::SourceFile {
+    unimplemented!()
+}
+
 impl TokenMap {
     pub fn relative_range_of(&self, tt: tt::TokenId) -> Option<TextRange> {
         let idx = tt.0 as usize;

--- a/crates/ra_syntax/src/lib.rs
+++ b/crates/ra_syntax/src/lib.rs
@@ -36,7 +36,7 @@ pub use crate::{
     ast::AstNode,
     syntax_error::{SyntaxError, SyntaxErrorKind, Location},
     syntax_text::SyntaxText,
-    syntax_node::{Direction,  SyntaxNode, WalkEvent, TreeArc},
+    syntax_node::{Direction,  SyntaxNode, WalkEvent, TreeArc, SyntaxTreeBuilder},
     ptr::{SyntaxNodePtr, AstPtr},
     parsing::{tokenize, Token},
 };

--- a/crates/ra_syntax/src/parsing.rs
+++ b/crates/ra_syntax/src/parsing.rs
@@ -2,17 +2,13 @@
 //! incremental reparsing.
 
 mod lexer;
-mod input;
-mod builder;
+mod text_token_source;
+mod text_tree_sink;
 mod reparsing;
 
 use crate::{
     SyntaxError,
     syntax_node::GreenNode,
-    parsing::{
-        builder::TreeBuilder,
-        input::ParserInput,
-    },
 };
 
 pub use self::lexer::{tokenize, Token};
@@ -21,8 +17,8 @@ pub(crate) use self::reparsing::incremental_reparse;
 
 pub(crate) fn parse_text(text: &str) -> (GreenNode, Vec<SyntaxError>) {
     let tokens = tokenize(&text);
-    let token_source = ParserInput::new(text, &tokens);
-    let mut tree_sink = TreeBuilder::new(text, &tokens);
+    let token_source = text_token_source::TextTokenSource::new(text, &tokens);
+    let mut tree_sink = text_tree_sink::TextTreeSink::new(text, &tokens);
     ra_parser::parse(&token_source, &mut tree_sink);
     tree_sink.finish()
 }

--- a/crates/ra_syntax/src/parsing/reparsing.rs
+++ b/crates/ra_syntax/src/parsing/reparsing.rs
@@ -14,8 +14,8 @@ use crate::{
     algo,
     syntax_node::{GreenNode, SyntaxNode},
     parsing::{
-        input::ParserInput,
-        builder::TreeBuilder,
+        text_token_source::TextTokenSource,
+        text_tree_sink::TextTreeSink,
         lexer::{tokenize, Token},
     }
 };
@@ -68,8 +68,8 @@ fn reparse_block<'node>(
     if !is_balanced(&tokens) {
         return None;
     }
-    let token_source = ParserInput::new(&text, &tokens);
-    let mut tree_sink = TreeBuilder::new(&text, &tokens);
+    let token_source = TextTokenSource::new(&text, &tokens);
+    let mut tree_sink = TextTreeSink::new(&text, &tokens);
     reparser.parse(&token_source, &mut tree_sink);
     let (green, new_errors) = tree_sink.finish();
     Some((node, green, new_errors))

--- a/crates/ra_syntax/src/parsing/text_token_source.rs
+++ b/crates/ra_syntax/src/parsing/text_token_source.rs
@@ -5,7 +5,7 @@ use crate::{
     parsing::lexer::Token,
 };
 
-pub(crate) struct ParserInput<'t> {
+pub(crate) struct TextTokenSource<'t> {
     text: &'t str,
     /// start position of each token(expect whitespace and comment)
     /// ```non-rust
@@ -25,7 +25,7 @@ pub(crate) struct ParserInput<'t> {
     tokens: Vec<Token>,
 }
 
-impl<'t> TokenSource for ParserInput<'t> {
+impl<'t> TokenSource for TextTokenSource<'t> {
     fn token_kind(&self, pos: usize) -> SyntaxKind {
         if !(pos < self.tokens.len()) {
             return EOF;
@@ -48,9 +48,9 @@ impl<'t> TokenSource for ParserInput<'t> {
     }
 }
 
-impl<'t> ParserInput<'t> {
+impl<'t> TextTokenSource<'t> {
     /// Generate input from tokens(expect comment and whitespace).
-    pub fn new(text: &'t str, raw_tokens: &'t [Token]) -> ParserInput<'t> {
+    pub fn new(text: &'t str, raw_tokens: &'t [Token]) -> TextTokenSource<'t> {
         let mut tokens = Vec::new();
         let mut start_offsets = Vec::new();
         let mut len = 0.into();
@@ -62,6 +62,6 @@ impl<'t> ParserInput<'t> {
             len += token.len;
         }
 
-        ParserInput { text, start_offsets, tokens }
+        TextTokenSource { text, start_offsets, tokens }
     }
 }

--- a/crates/ra_syntax/src/parsing/text_tree_sink.rs
+++ b/crates/ra_syntax/src/parsing/text_tree_sink.rs
@@ -12,8 +12,8 @@ use crate::{
 
 /// Bridges the parser with our specific syntax tree representation.
 ///
-/// `TreeBuilder` also handles attachment of trivia (whitespace) to nodes.
-pub(crate) struct TreeBuilder<'a> {
+/// `TextTreeSink` also handles attachment of trivia (whitespace) to nodes.
+pub(crate) struct TextTreeSink<'a> {
     text: &'a str,
     tokens: &'a [Token],
     text_pos: TextUnit,
@@ -29,7 +29,7 @@ enum State {
     PendingFinish,
 }
 
-impl<'a> TreeSink for TreeBuilder<'a> {
+impl<'a> TreeSink for TextTreeSink<'a> {
     fn leaf(&mut self, kind: SyntaxKind, n_tokens: u8) {
         match mem::replace(&mut self.state, State::Normal) {
             State::PendingStart => unreachable!(),
@@ -91,9 +91,9 @@ impl<'a> TreeSink for TreeBuilder<'a> {
     }
 }
 
-impl<'a> TreeBuilder<'a> {
-    pub(super) fn new(text: &'a str, tokens: &'a [Token]) -> TreeBuilder<'a> {
-        TreeBuilder {
+impl<'a> TextTreeSink<'a> {
+    pub(super) fn new(text: &'a str, tokens: &'a [Token]) -> TextTreeSink<'a> {
+        TextTreeSink {
             text,
             tokens,
             text_pos: 0.into(),


### PR DESCRIPTION
This takes advantage of the recent macro refactoring to directly parse token stream into a syntax tree.