### PR TITLE
Refactor assits

### DIFF
--- a/crates/ra_assists/Cargo.toml
+++ b/crates/ra_assists/Cargo.toml
@@ -13,6 +13,4 @@ ra_text_edit = { path = "../ra_text_edit" }
 ra_fmt = { path = "../ra_fmt" }
 ra_db = { path = "../ra_db" }
 hir = { path = "../ra_hir", package = "ra_hir" }
-
-[dev-dependencies]
 test_utils = { path = "../test_utils" }

--- a/crates/ra_assists/src/add_derive.rs
+++ b/crates/ra_assists/src/add_derive.rs
@@ -5,12 +5,12 @@ use ra_syntax::{
     TextUnit,
 };
 
-use crate::{AssistCtx, Assist};
+use crate::{AssistCtx, Assist, AssistId};
 
 pub(crate) fn add_derive(mut ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
     let nominal = ctx.node_at_offset::<ast::NominalDef>()?;
     let node_start = derive_insertion_offset(nominal)?;
-    ctx.add_action("add `#[derive]`", |edit| {
+    ctx.add_action(AssistId("add_derive"), "add `#[derive]`", |edit| {
         let derive_attr = nominal
             .attrs()
             .filter_map(|x| x.as_call())

--- a/crates/ra_assists/src/add_impl.rs
+++ b/crates/ra_assists/src/add_impl.rs
@@ -5,12 +5,12 @@ use ra_syntax::{
     TextUnit,
 };
 
-use crate::{AssistCtx, Assist};
+use crate::{AssistCtx, Assist, AssistId};
 
 pub(crate) fn add_impl(mut ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
     let nominal = ctx.node_at_offset::<ast::NominalDef>()?;
     let name = nominal.name()?;
-    ctx.add_action("add impl", |edit| {
+    ctx.add_action(AssistId("add_impl"), "add impl", |edit| {
         edit.target(nominal.syntax().range());
         let type_params = nominal.type_param_list();
         let start_offset = nominal.syntax().range().end();

--- a/crates/ra_assists/src/assist_ctx.rs
+++ b/crates/ra_assists/src/assist_ctx.rs
@@ -7,7 +7,7 @@ use ra_syntax::{
 };
 use ra_fmt::{leading_indent, reindent};
 
-use crate::{AssistLabel, AssistAction};
+use crate::{AssistLabel, AssistAction, AssistId};
 
 #[derive(Clone, Debug)]
 pub(crate) enum Assist {
@@ -81,10 +81,11 @@ impl<'a, DB: HirDatabase> AssistCtx<'a, DB> {
 
     pub(crate) fn add_action(
         &mut self,
+        id: AssistId,
         label: impl Into<String>,
         f: impl FnOnce(&mut AssistBuilder),
     ) -> &mut Self {
-        let label = AssistLabel { label: label.into() };
+        let label = AssistLabel { label: label.into(), id };
         match &mut self.assist {
             Assist::Unresolved(labels) => labels.push(label),
             Assist::Resolved(labels_actions) => {

--- a/crates/ra_assists/src/change_visibility.rs
+++ b/crates/ra_assists/src/change_visibility.rs
@@ -5,7 +5,7 @@ use ra_syntax::{
     SyntaxKind::{VISIBILITY, FN_KW, MOD_KW, STRUCT_KW, ENUM_KW, TRAIT_KW, FN_DEF, MODULE, STRUCT_DEF, ENUM_DEF, TRAIT_DEF, IDENT, WHITESPACE, COMMENT, ATTR},
 };
 
-use crate::{AssistCtx, Assist};
+use crate::{AssistCtx, Assist, AssistId};
 
 pub(crate) fn change_visibility(ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
     if let Some(vis) = ctx.node_at_offset::<ast::Visibility>() {
@@ -41,7 +41,7 @@ fn add_vis(mut ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
         (vis_offset(field.syntax()), ident.range())
     };
 
-    ctx.add_action("make pub(crate)", |edit| {
+    ctx.add_action(AssistId("change_visibility"), "make pub(crate)", |edit| {
         edit.target(target);
         edit.insert(offset, "pub(crate) ");
         edit.set_cursor(offset);
@@ -63,7 +63,7 @@ fn vis_offset(node: &SyntaxNode) -> TextUnit {
 
 fn change_vis(mut ctx: AssistCtx<impl HirDatabase>, vis: &ast::Visibility) -> Option<Assist> {
     if vis.syntax().text() == "pub" {
-        ctx.add_action("change to pub(crate)", |edit| {
+        ctx.add_action(AssistId("change_visibility"), "change to pub(crate)", |edit| {
             edit.target(vis.syntax().range());
             edit.replace(vis.syntax().range(), "pub(crate)");
             edit.set_cursor(vis.syntax().range().start())
@@ -72,7 +72,7 @@ fn change_vis(mut ctx: AssistCtx<impl HirDatabase>, vis: &ast::Visibility) -> Op
         return ctx.build();
     }
     if vis.syntax().text() == "pub(crate)" {
-        ctx.add_action("change to pub", |edit| {
+        ctx.add_action(AssistId("change_visibility"), "change to pub", |edit| {
             edit.target(vis.syntax().range());
             edit.replace(vis.syntax().range(), "pub");
             edit.set_cursor(vis.syntax().range().start());

--- a/crates/ra_assists/src/fill_match_arms.rs
+++ b/crates/ra_assists/src/fill_match_arms.rs
@@ -6,7 +6,7 @@ use hir::{
 };
 use ra_syntax::ast::{self, AstNode};
 
-use crate::{AssistCtx, Assist};
+use crate::{AssistCtx, Assist, AssistId};
 
 pub(crate) fn fill_match_arms(mut ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
     let match_expr = ctx.node_at_offset::<ast::MatchExpr>()?;
@@ -37,7 +37,7 @@ pub(crate) fn fill_match_arms(mut ctx: AssistCtx<impl HirDatabase>) -> Option<As
     let enum_name = enum_def.name(ctx.db)?;
     let db = ctx.db;
 
-    ctx.add_action("fill match arms", |edit| {
+    ctx.add_action(AssistId("fill_match_arms"), "fill match arms", |edit| {
         let mut buf = format!("match {} {{\n", expr.syntax().text().to_string());
         let variants = enum_def.variants(db);
         for variant in variants {

--- a/crates/ra_assists/src/flip_comma.rs
+++ b/crates/ra_assists/src/flip_comma.rs
@@ -5,13 +5,13 @@ use ra_syntax::{
     algo::non_trivia_sibling,
 };
 
-use crate::{AssistCtx, Assist};
+use crate::{AssistCtx, Assist, AssistId};
 
 pub(crate) fn flip_comma(mut ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
     let comma = ctx.leaf_at_offset().find(|leaf| leaf.kind() == COMMA)?;
     let prev = non_trivia_sibling(comma, Direction::Prev)?;
     let next = non_trivia_sibling(comma, Direction::Next)?;
-    ctx.add_action("flip comma", |edit| {
+    ctx.add_action(AssistId("flip_comma"), "flip comma", |edit| {
         edit.target(comma.range());
         edit.replace(prev.range(), next.text());
         edit.replace(next.range(), prev.text());

--- a/crates/ra_assists/src/introduce_variable.rs
+++ b/crates/ra_assists/src/introduce_variable.rs
@@ -6,7 +6,7 @@ use ra_syntax::{
     }, SyntaxNode, TextUnit,
 };
 
-use crate::{AssistCtx, Assist};
+use crate::{AssistCtx, Assist, AssistId};
 
 pub(crate) fn introduce_variable(mut ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
     let node = ctx.covering_node();
@@ -19,7 +19,7 @@ pub(crate) fn introduce_variable(mut ctx: AssistCtx<impl HirDatabase>) -> Option
     if indent.kind() != WHITESPACE {
         return None;
     }
-    ctx.add_action("introduce variable", move |edit| {
+    ctx.add_action(AssistId("introduce_variable"), "introduce variable", move |edit| {
         let mut buf = String::new();
 
         let cursor_offset = if wrap_in_block {

--- a/crates/ra_assists/src/lib.rs
+++ b/crates/ra_assists/src/lib.rs
@@ -6,6 +6,7 @@
 //! becomes available.
 
 mod assist_ctx;
+mod marks;
 
 use itertools::Itertools;
 

--- a/crates/ra_assists/src/lib.rs
+++ b/crates/ra_assists/src/lib.rs
@@ -16,10 +16,16 @@ use hir::db::HirDatabase;
 
 pub(crate) use crate::assist_ctx::{AssistCtx, Assist};
 
+/// Unique identifier of the assist, should not be shown to the user
+/// directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AssistId(pub &'static str);
+
 #[derive(Debug, Clone)]
 pub struct AssistLabel {
     /// Short description of the assist, as shown in the UI.
     pub label: String,
+    pub id: AssistId,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/ra_assists/src/lib.rs
+++ b/crates/ra_assists/src/lib.rs
@@ -259,6 +259,17 @@ mod helpers {
         let assist = AssistCtx::with_ctx(&db, frange, true, assist);
         assert!(assist.is_none());
     }
+
+    pub(crate) fn check_assist_range_not_applicable(
+        assist: fn(AssistCtx<MockDatabase>) -> Option<Assist>,
+        before: &str,
+    ) {
+        let (range, before) = extract_range(before);
+        let (db, _source_root, file_id) = MockDatabase::with_single_file(&before);
+        let frange = FileRange { file_id, range };
+        let assist = AssistCtx::with_ctx(&db, frange, true, assist);
+        assert!(assist.is_none());
+    }
 }
 
 #[cfg(test)]
@@ -266,7 +277,7 @@ mod tests {
     use hir::mock::MockDatabase;
     use ra_syntax::TextRange;
     use ra_db::FileRange;
-    use test_utils::{extract_offset};
+    use test_utils::{extract_offset, extract_range};
 
     #[test]
     fn assist_order_field_struct() {
@@ -286,16 +297,15 @@ mod tests {
     fn assist_order_if_expr() {
         let before = "
         pub fn test_some_range(a: int) -> bool {
-            if let 2..6 = 5<|> {
+            if let 2..6 = <|>5<|> {
                 true
             } else {
                 false
             }
         }";
-        let (before_cursor_pos, before) = extract_offset(before);
+        let (range, before) = extract_range(before);
         let (db, _source_root, file_id) = MockDatabase::with_single_file(&before);
-        let frange =
-            FileRange { file_id, range: TextRange::offset_len(before_cursor_pos, 0.into()) };
+        let frange = FileRange { file_id, range };
         let assists = super::assists(&db, frange);
         let mut assists = assists.iter();
 

--- a/crates/ra_assists/src/marks.rs
+++ b/crates/ra_assists/src/marks.rs
@@ -1,0 +1,5 @@
+test_utils::marks!(
+    introduce_var_in_comment_is_not_applicable
+    test_introduce_var_expr_stmt
+    test_introduce_var_last_expr
+);

--- a/crates/ra_assists/src/remove_dbg.rs
+++ b/crates/ra_assists/src/remove_dbg.rs
@@ -6,7 +6,7 @@ use ra_syntax::{
         L_PAREN, R_PAREN, L_CURLY, R_CURLY, L_BRACK, R_BRACK, EXCL
     },
 };
-use crate::{AssistCtx, Assist};
+use crate::{AssistCtx, Assist, AssistId};
 
 pub(crate) fn remove_dbg(mut ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
     let macro_call = ctx.node_at_offset::<ast::MacroCall>()?;
@@ -46,7 +46,7 @@ pub(crate) fn remove_dbg(mut ctx: AssistCtx<impl HirDatabase>) -> Option<Assist>
         macro_args.text().slice(start..end).to_string()
     };
 
-    ctx.add_action("remove dbg!()", |edit| {
+    ctx.add_action(AssistId("remove_dbg"), "remove dbg!()", |edit| {
         edit.target(macro_call.syntax().range());
         edit.replace(macro_range, macro_content);
         edit.set_cursor(cursor_pos);

--- a/crates/ra_assists/src/replace_if_let_with_match.rs
+++ b/crates/ra_assists/src/replace_if_let_with_match.rs
@@ -2,7 +2,7 @@ use ra_syntax::{AstNode, ast};
 use ra_fmt::extract_trivial_expression;
 use hir::db::HirDatabase;
 
-use crate::{AssistCtx, Assist};
+use crate::{AssistCtx, Assist, AssistId};
 
 pub(crate) fn replace_if_let_with_match(mut ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
     let if_expr: &ast::IfExpr = ctx.node_at_offset()?;
@@ -15,7 +15,7 @@ pub(crate) fn replace_if_let_with_match(mut ctx: AssistCtx<impl HirDatabase>) ->
         ast::ElseBranchFlavor::IfExpr(_) => return None,
     };
 
-    ctx.add_action("replace with match", |edit| {
+    ctx.add_action(AssistId("replace_if_let_with_match"), "replace with match", |edit| {
         let match_expr = build_match_expr(expr, pat, then_block, else_block);
         edit.target(if_expr.syntax().range());
         edit.replace_node_and_indent(if_expr.syntax(), match_expr);

--- a/crates/ra_assists/src/split_import.rs
+++ b/crates/ra_assists/src/split_import.rs
@@ -5,7 +5,7 @@ use ra_syntax::{
     algo::generate,
 };
 
-use crate::{AssistCtx, Assist};
+use crate::{AssistCtx, Assist, AssistId};
 
 pub(crate) fn split_import(mut ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
     let colon_colon = ctx.leaf_at_offset().find(|leaf| leaf.kind() == COLONCOLON)?;
@@ -23,7 +23,7 @@ pub(crate) fn split_import(mut ctx: AssistCtx<impl HirDatabase>) -> Option<Assis
         None => top_path.syntax().range().end(),
     };
 
-    ctx.add_action("split import", |edit| {
+    ctx.add_action(AssistId("split_import"), "split import", |edit| {
         edit.target(colon_colon.range());
         edit.insert(l_curly, "{");
         edit.insert(r_curly, "}");

--- a/crates/ra_ide_api/src/assists.rs
+++ b/crates/ra_ide_api/src/assists.rs
@@ -2,20 +2,30 @@ use ra_db::{FileRange, FilePosition};
 
 use crate::{SourceFileEdit, SourceChange, db::RootDatabase};
 
-pub(crate) fn assists(db: &RootDatabase, frange: FileRange) -> Vec<SourceChange> {
+pub use ra_assists::AssistId;
+
+#[derive(Debug)]
+pub struct Assist {
+    pub id: AssistId,
+    pub change: SourceChange,
+}
+
+pub(crate) fn assists(db: &RootDatabase, frange: FileRange) -> Vec<Assist> {
     ra_assists::assists(db, frange)
         .into_iter()
         .map(|(label, action)| {
             let file_id = frange.file_id;
             let file_edit = SourceFileEdit { file_id, edit: action.edit };
-            SourceChange {
+            let id = label.id;
+            let change = SourceChange {
                 label: label.label,
                 source_file_edits: vec![file_edit],
                 file_system_edits: vec![],
                 cursor_position: action
                     .cursor_position
                     .map(|offset| FilePosition { offset, file_id }),
-            }
+            };
+            Assist { id, change }
         })
         .collect()
 }

--- a/crates/ra_ide_api/src/lib.rs
+++ b/crates/ra_ide_api/src/lib.rs
@@ -57,6 +57,7 @@ pub use crate::{
     runnables::{Runnable, RunnableKind},
     navigation_target::NavigationTarget,
     references::ReferenceSearchResult,
+    assists::{Assist, AssistId},
 };
 pub use ra_ide_api_light::{
     Fold, FoldKind, HighlightedRange, Severity, StructureNode, LocalEdit,
@@ -368,7 +369,7 @@ impl Analysis {
 
     /// Computes assists (aks code actons aka intentions) for the given
     /// position.
-    pub fn assists(&self, frange: FileRange) -> Cancelable<Vec<SourceChange>> {
+    pub fn assists(&self, frange: FileRange) -> Cancelable<Vec<Assist>> {
         self.with_db(|db| assists::assists(db, frange))
     }
 

--- a/crates/ra_lsp_server/tests/heavy_tests/main.rs
+++ b/crates/ra_lsp_server/tests/heavy_tests/main.rs
@@ -225,10 +225,12 @@ fn main() {}
             context: empty_context(),
         },
         json!([
-            {
+          {
+            "command": {
               "arguments": [
                 {
                   "cursorPosition": null,
+                  "label": "create module",
                   "workspaceEdit": {
                     "documentChanges": [
                       {
@@ -236,13 +238,14 @@ fn main() {}
                         "uri": "file:///[..]/src/bar.rs"
                       }
                     ]
-                  },
-                  "label": "create module"
+                  }
                 }
               ],
               "command": "rust-analyzer.applySourceChange",
               "title": "create module"
-            }
+            },
+            "title": "create module"
+          }
         ]),
     );
 


### PR DESCRIPTION
* assign unique IDs to assists so that clients could do custom stuff
* specify kinds for assists, 
* make introduce_variable a `refactoring.extract` and make it available only when expression is selected
* introduce marks to assists