### PR TITLE
Change default value of highlightingOn to false

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -147,7 +147,7 @@
             "properties": {
                 "rust-analyzer.highlightingOn": {
                     "type": "boolean",
-                    "default": true,
+                    "default": false,
                     "description": "Highlight Rust code (overrides built-in syntax highlighting)"
                 },
                 "rust-analyzer.enableEnhancedTyping": {


### PR DESCRIPTION
This changes the default value for the vscode setting `rust-analyzer.highlightingOn` to `false`. Since currently the highlighting only supports Zenburn, which people may not be using, I think it makes sense to have this feature disabled by default.

This was discussed in #896 