### PR TITLE
Add new trait ast::TypeAscriptionOwner

### DIFF
--- a/crates/ra_hir/src/adt.rs
+++ b/crates/ra_hir/src/adt.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use ra_arena::{RawId, Arena, impl_arena_id};
 use ra_syntax::{
     TreeArc,
-    ast::{self, NameOwner, StructFlavor}
+    ast::{self, NameOwner, StructFlavor, TypeAscriptionOwner}
 };
 
 use crate::{
@@ -164,7 +164,7 @@ impl VariantData {
                     .fields()
                     .map(|fd| StructFieldData {
                         name: fd.name().map(|n| n.as_name()).unwrap_or_else(Name::missing),
-                        type_ref: TypeRef::from_ast_opt(fd.type_ref()),
+                        type_ref: TypeRef::from_ast_opt(fd.ascribed_type()),
                     })
                     .collect();
                 VariantDataInner::Struct(fields)

--- a/crates/ra_hir/src/code_model_impl/function.rs
+++ b/crates/ra_hir/src/code_model_impl/function.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use ra_syntax::ast::{self, NameOwner};
+use ra_syntax::ast::{self, NameOwner, TypeAscriptionOwner};
 
 use crate::{
     Name, AsName, Function, FnSignature,
@@ -19,7 +19,7 @@ impl FnSignature {
         let mut has_self_param = false;
         if let Some(param_list) = node.param_list() {
             if let Some(self_param) = param_list.self_param() {
-                let self_type = if let Some(type_ref) = self_param.type_ref() {
+                let self_type = if let Some(type_ref) = self_param.ascribed_type() {
                     TypeRef::from_ast(type_ref)
                 } else {
                     let self_type = TypeRef::Path(Name::self_type().into());
@@ -37,7 +37,7 @@ impl FnSignature {
                 has_self_param = true;
             }
             for param in param_list.params() {
-                let type_ref = TypeRef::from_ast_opt(param.type_ref());
+                let type_ref = TypeRef::from_ast_opt(param.ascribed_type());
                 params.push(type_ref);
             }
         }

--- a/crates/ra_hir/src/code_model_impl/konst.rs
+++ b/crates/ra_hir/src/code_model_impl/konst.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use ra_syntax::ast::{self, NameOwner};
+use ra_syntax::ast::{NameOwner, TypeAscriptionOwner};
 
 use crate::{
     Name, AsName, Const, ConstSignature, Static,
@@ -8,12 +8,9 @@ use crate::{
     PersistentHirDatabase,
 };
 
-fn const_signature_for<N: NameOwner>(
-    node: &N,
-    type_ref: Option<&ast::TypeRef>,
-) -> Arc<ConstSignature> {
+fn const_signature_for<N: NameOwner + TypeAscriptionOwner>(node: &N) -> Arc<ConstSignature> {
     let name = node.name().map(|n| n.as_name()).unwrap_or_else(Name::missing);
-    let type_ref = TypeRef::from_ast_opt(type_ref);
+    let type_ref = TypeRef::from_ast_opt(node.ascribed_type());
     let sig = ConstSignature { name, type_ref };
     Arc::new(sig)
 }
@@ -24,7 +21,7 @@ impl ConstSignature {
         konst: Const,
     ) -> Arc<ConstSignature> {
         let (_, node) = konst.source(db);
-        const_signature_for(&*node, node.type_ref())
+        const_signature_for(&*node)
     }
 
     pub(crate) fn static_signature_query(
@@ -32,6 +29,6 @@ impl ConstSignature {
         konst: Static,
     ) -> Arc<ConstSignature> {
         let (_, node) = konst.source(db);
-        const_signature_for(&*node, node.type_ref())
+        const_signature_for(&*node)
     }
 }

--- a/crates/ra_hir/src/expr.rs
+++ b/crates/ra_hir/src/expr.rs
@@ -6,7 +6,7 @@ use rustc_hash::FxHashMap;
 use ra_arena::{Arena, RawId, impl_arena_id, map::ArenaMap};
 use ra_syntax::{
     SyntaxNodePtr, AstNode,
-    ast::{self, LoopBodyOwner, ArgListOwner, NameOwner, LiteralFlavor}
+    ast::{self, LoopBodyOwner, ArgListOwner, NameOwner, LiteralFlavor, TypeAscriptionOwner}
 };
 
 use crate::{
@@ -709,7 +709,7 @@ impl ExprCollector {
                 if let Some(pl) = e.param_list() {
                     for param in pl.params() {
                         let pat = self.collect_pat_opt(param.pat());
-                        let type_ref = param.type_ref().map(TypeRef::from_ast);
+                        let type_ref = param.ascribed_type().map(TypeRef::from_ast);
                         args.push(pat);
                         arg_types.push(type_ref);
                     }
@@ -790,7 +790,7 @@ impl ExprCollector {
             .map(|s| match s.kind() {
                 ast::StmtKind::LetStmt(stmt) => {
                     let pat = self.collect_pat_opt(stmt.pat());
-                    let type_ref = stmt.type_ref().map(TypeRef::from_ast);
+                    let type_ref = stmt.ascribed_type().map(TypeRef::from_ast);
                     let initializer = stmt.initializer().map(|e| self.collect_expr(e));
                     Statement::Let { pat, type_ref, initializer }
                 }

--- a/crates/ra_hir/src/type_ref.rs
+++ b/crates/ra_hir/src/type_ref.rs
@@ -1,7 +1,7 @@
 //! HIR for references to types. Paths in these are not yet resolved. They can
 //! be directly created from an ast::TypeRef, without further queries.
 
-use ra_syntax::ast;
+use ra_syntax::ast::{self, TypeAscriptionOwner};
 
 use crate::Path;
 
@@ -81,7 +81,7 @@ impl TypeRef {
             FnPointerType(inner) => {
                 let ret_ty = TypeRef::from_ast_opt(inner.ret_type().and_then(|rt| rt.type_ref()));
                 let mut params = if let Some(pl) = inner.param_list() {
-                    pl.params().map(|p| p.type_ref()).map(TypeRef::from_ast_opt).collect()
+                    pl.params().map(|p| p.ascribed_type()).map(TypeRef::from_ast_opt).collect()
                 } else {
                     Vec::new()
                 };

--- a/crates/ra_syntax/src/ast.rs
+++ b/crates/ra_syntax/src/ast.rs
@@ -31,6 +31,12 @@ pub trait AstToken: AstNode {
     }
 }
 
+pub trait TypeAscriptionOwner: AstNode {
+    fn ascribed_type(&self) -> Option<&TypeRef> {
+        child_opt(self)
+    }
+}
+
 pub trait NameOwner: AstNode {
     fn name(&self) -> Option<&Name> {
         child_opt(self)

--- a/crates/ra_syntax/src/ast/generated.rs
+++ b/crates/ra_syntax/src/ast/generated.rs
@@ -629,11 +629,7 @@ impl ast::TypeParamsOwner for ConstDef {}
 impl ast::AttrsOwner for ConstDef {}
 impl ast::DocCommentsOwner for ConstDef {}
 impl ast::TypeAscriptionOwner for ConstDef {}
-impl ConstDef {
-    pub fn type_ref(&self) -> Option<&TypeRef> {
-        super::child_opt(self)
-    }
-}
+impl ConstDef {}
 
 // ContinueExpr
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -1774,10 +1770,6 @@ impl LetStmt {
         super::child_opt(self)
     }
 
-    pub fn type_ref(&self) -> Option<&TypeRef> {
-        super::child_opt(self)
-    }
-
     pub fn initializer(&self) -> Option<&Expr> {
         super::child_opt(self)
     }
@@ -2595,11 +2587,7 @@ impl ast::NameOwner for NamedFieldDef {}
 impl ast::AttrsOwner for NamedFieldDef {}
 impl ast::DocCommentsOwner for NamedFieldDef {}
 impl ast::TypeAscriptionOwner for NamedFieldDef {}
-impl NamedFieldDef {
-    pub fn type_ref(&self) -> Option<&TypeRef> {
-        super::child_opt(self)
-    }
-}
+impl NamedFieldDef {}
 
 // NamedFieldDefList
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -2780,10 +2768,6 @@ impl ToOwned for Param {
 impl ast::TypeAscriptionOwner for Param {}
 impl Param {
     pub fn pat(&self) -> Option<&Pat> {
-        super::child_opt(self)
-    }
-
-    pub fn type_ref(&self) -> Option<&TypeRef> {
         super::child_opt(self)
     }
 }
@@ -3691,10 +3675,6 @@ impl ToOwned for SelfParam {
 
 impl ast::TypeAscriptionOwner for SelfParam {}
 impl SelfParam {
-    pub fn type_ref(&self) -> Option<&TypeRef> {
-        super::child_opt(self)
-    }
-
     pub fn self_kw(&self) -> Option<&SelfKw> {
         super::child_opt(self)
     }
@@ -3826,11 +3806,7 @@ impl ast::TypeParamsOwner for StaticDef {}
 impl ast::AttrsOwner for StaticDef {}
 impl ast::DocCommentsOwner for StaticDef {}
 impl ast::TypeAscriptionOwner for StaticDef {}
-impl StaticDef {
-    pub fn type_ref(&self) -> Option<&TypeRef> {
-        super::child_opt(self)
-    }
-}
+impl StaticDef {}
 
 // Stmt
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/crates/ra_syntax/src/ast/generated.rs
+++ b/crates/ra_syntax/src/ast/generated.rs
@@ -628,6 +628,7 @@ impl ast::NameOwner for ConstDef {}
 impl ast::TypeParamsOwner for ConstDef {}
 impl ast::AttrsOwner for ConstDef {}
 impl ast::DocCommentsOwner for ConstDef {}
+impl ast::TypeAscriptionOwner for ConstDef {}
 impl ConstDef {
     pub fn type_ref(&self) -> Option<&TypeRef> {
         super::child_opt(self)
@@ -1767,6 +1768,7 @@ impl ToOwned for LetStmt {
 }
 
 
+impl ast::TypeAscriptionOwner for LetStmt {}
 impl LetStmt {
     pub fn pat(&self) -> Option<&Pat> {
         super::child_opt(self)
@@ -2592,6 +2594,7 @@ impl ast::VisibilityOwner for NamedFieldDef {}
 impl ast::NameOwner for NamedFieldDef {}
 impl ast::AttrsOwner for NamedFieldDef {}
 impl ast::DocCommentsOwner for NamedFieldDef {}
+impl ast::TypeAscriptionOwner for NamedFieldDef {}
 impl NamedFieldDef {
     pub fn type_ref(&self) -> Option<&TypeRef> {
         super::child_opt(self)
@@ -2774,6 +2777,7 @@ impl ToOwned for Param {
 }
 
 
+impl ast::TypeAscriptionOwner for Param {}
 impl Param {
     pub fn pat(&self) -> Option<&Pat> {
         super::child_opt(self)
@@ -3685,6 +3689,7 @@ impl ToOwned for SelfParam {
 }
 
 
+impl ast::TypeAscriptionOwner for SelfParam {}
 impl SelfParam {
     pub fn type_ref(&self) -> Option<&TypeRef> {
         super::child_opt(self)
@@ -3820,6 +3825,7 @@ impl ast::NameOwner for StaticDef {}
 impl ast::TypeParamsOwner for StaticDef {}
 impl ast::AttrsOwner for StaticDef {}
 impl ast::DocCommentsOwner for StaticDef {}
+impl ast::TypeAscriptionOwner for StaticDef {}
 impl StaticDef {
     pub fn type_ref(&self) -> Option<&TypeRef> {
         super::child_opt(self)

--- a/crates/ra_syntax/src/grammar.ron
+++ b/crates/ra_syntax/src/grammar.ron
@@ -271,7 +271,7 @@ Grammar(
             ]
         ),
         "NamedFieldDefList": (collections: [["fields", "NamedFieldDef"]]),
-        "NamedFieldDef": ( traits: ["VisibilityOwner", "NameOwner", "AttrsOwner", "DocCommentsOwner"], options: ["TypeRef"] ),
+        "NamedFieldDef": ( traits: ["VisibilityOwner", "NameOwner", "AttrsOwner", "DocCommentsOwner", "TypeAscriptionOwner"], options: ["TypeRef"] ),
         "PosFieldDefList": (collections: [["fields", "PosFieldDef"]]),
         "PosFieldDef": ( traits: ["VisibilityOwner", "AttrsOwner"], options: ["TypeRef"]),
         "EnumDef": ( traits: [
@@ -298,7 +298,8 @@ Grammar(
                 "NameOwner",
                 "TypeParamsOwner",
                 "AttrsOwner",
-                "DocCommentsOwner"
+                "DocCommentsOwner",
+                "TypeAscriptionOwner",
             ],
             options: ["TypeRef"]
         ),
@@ -308,7 +309,8 @@ Grammar(
                 "NameOwner",
                 "TypeParamsOwner",
                 "AttrsOwner",
-                "DocCommentsOwner"
+                "DocCommentsOwner",
+                "TypeAscriptionOwner",
             ],
             options: ["TypeRef"]
         ),
@@ -569,11 +571,16 @@ Grammar(
         "ExprStmt": (
             options: [ ["expr", "Expr"] ]
         ),
-        "LetStmt": ( options: [
-            ["pat", "Pat"],
-            ["type_ref", "TypeRef"],
-            ["initializer", "Expr"],
-        ]),
+        "LetStmt": (
+            options: [
+                ["pat", "Pat"],
+                ["type_ref", "TypeRef"],
+                ["initializer", "Expr"],
+            ],
+            traits: [
+                "TypeAscriptionOwner",
+            ]
+        ),
         "Condition": (
             options: [ "Pat", "Expr" ]
         ),
@@ -595,10 +602,18 @@ Grammar(
                 ["params", "Param"]
             ]
         ),
-        "SelfParam": (options: ["TypeRef", "SelfKw"]),
+        "SelfParam": (
+            options: ["TypeRef", "SelfKw"],
+            traits: [
+                "TypeAscriptionOwner",
+            ]
+        ),
         "SelfKw": (),
         "Param": (
             options: [ "Pat", "TypeRef" ],
+            traits: [
+                "TypeAscriptionOwner",
+            ]
         ),
         "UseItem": (
             traits: ["AttrsOwner"],

--- a/crates/ra_syntax/src/grammar.ron
+++ b/crates/ra_syntax/src/grammar.ron
@@ -271,7 +271,15 @@ Grammar(
             ]
         ),
         "NamedFieldDefList": (collections: [["fields", "NamedFieldDef"]]),
-        "NamedFieldDef": ( traits: ["VisibilityOwner", "NameOwner", "AttrsOwner", "DocCommentsOwner", "TypeAscriptionOwner"], options: ["TypeRef"] ),
+        "NamedFieldDef": (
+            traits: [
+                "VisibilityOwner",
+                "NameOwner",
+                "AttrsOwner",
+                "DocCommentsOwner",
+                "TypeAscriptionOwner"
+            ]
+        ),
         "PosFieldDefList": (collections: [["fields", "PosFieldDef"]]),
         "PosFieldDef": ( traits: ["VisibilityOwner", "AttrsOwner"], options: ["TypeRef"]),
         "EnumDef": ( traits: [
@@ -301,7 +309,6 @@ Grammar(
                 "DocCommentsOwner",
                 "TypeAscriptionOwner",
             ],
-            options: ["TypeRef"]
         ),
         "StaticDef": (
             traits: [
@@ -312,7 +319,6 @@ Grammar(
                 "DocCommentsOwner",
                 "TypeAscriptionOwner",
             ],
-            options: ["TypeRef"]
         ),
         "TypeAliasDef": (
             traits: [
@@ -574,7 +580,6 @@ Grammar(
         "LetStmt": (
             options: [
                 ["pat", "Pat"],
-                ["type_ref", "TypeRef"],
                 ["initializer", "Expr"],
             ],
             traits: [
@@ -603,14 +608,14 @@ Grammar(
             ]
         ),
         "SelfParam": (
-            options: ["TypeRef", "SelfKw"],
+            options: ["SelfKw"],
             traits: [
                 "TypeAscriptionOwner",
             ]
         ),
         "SelfKw": (),
         "Param": (
-            options: [ "Pat", "TypeRef" ],
+            options: [ "Pat" ],
             traits: [
                 "TypeAscriptionOwner",
             ]


### PR DESCRIPTION
This trait should be implemented for nodes which have an ascribed type,
e.g. thing : Type. Such as let, const, static, param, named struct fields.

In addition, we update some places where previously we used node + node.type_ref() with `TypeAscriptionOwner` in the trait bounds.