### PR TITLE
Work around for issue in vscode reporting a failure in request

### DIFF
--- a/crates/gen_lsp_server/src/msg.rs
+++ b/crates/gen_lsp_server/src/msg.rs
@@ -120,11 +120,6 @@ impl RawResponse {
         let error = RawResponseError { code, message, data: None };
         RawResponse { id, result: None, error: Some(error) }
     }
-    /// Returns an "empty" RawResponse
-    /// Empty response still has a value `()` in its `result` field.
-    pub fn empty(id: u64) -> RawResponse {
-        RawResponse { id, result: Some(to_value(&()).unwrap()), error: None }
-    }
 }
 
 impl RawNotification {

--- a/crates/gen_lsp_server/src/msg.rs
+++ b/crates/gen_lsp_server/src/msg.rs
@@ -120,6 +120,11 @@ impl RawResponse {
         let error = RawResponseError { code, message, data: None };
         RawResponse { id, result: None, error: Some(error) }
     }
+    /// Returns an "empty" RawResponse
+    /// Empty response still has a value `()` in its `result` field.
+    pub fn empty(id: u64) -> RawResponse {
+        RawResponse { id, result: Some(to_value(&()).unwrap()), error: None }
+    }
 }
 
 impl RawNotification {

--- a/crates/ra_lsp_server/src/main_loop.rs
+++ b/crates/ra_lsp_server/src/main_loop.rs
@@ -425,8 +425,11 @@ impl<'a> PoolDispatcher<'a> {
                                     //     ErrorCode::ContentModified as i32,
                                     //     "content modified".to_string(),
                                     // )
-                                    RawResponse::empty(id)
-
+                                    RawResponse {
+                                        id,
+                                        result: Some(serde_json::to_value(&()).unwrap()),
+                                        error: None,
+                                    }
                                 } else {
                                     RawResponse::err(
                                         id,

--- a/crates/ra_lsp_server/src/main_loop.rs
+++ b/crates/ra_lsp_server/src/main_loop.rs
@@ -416,11 +416,17 @@ impl<'a> PoolDispatcher<'a> {
                             }
                             Err(e) => {
                                 if is_canceled(&e) {
-                                    RawResponse::err(
-                                        id,
-                                        ErrorCode::ContentModified as i32,
-                                        "content modified".to_string(),
-                                    )
+                                    // FIXME: When https://github.com/Microsoft/vscode-languageserver-node/issues/457
+                                    // gets fixed, we can return the proper response.
+                                    // This works around the issue where "content modified" error would continuously
+                                    // show an message pop-up in VsCode
+                                    // RawResponse::err(
+                                    //     id,
+                                    //     ErrorCode::ContentModified as i32,
+                                    //     "content modified".to_string(),
+                                    // )
+                                    RawResponse::empty(id)
+
                                 } else {
                                     RawResponse::err(
                                         id,


### PR DESCRIPTION
vscode would report "A request has failed" when it got "Content modified"
message and this would cause a pop-up to appear. This works around the issue by
returning an "empty" response that vscode can ignore.