### PR TITLE
Specify derive feature for serde

### DIFF
--- a/crates/ra_lsp_server/Cargo.toml
+++ b/crates/ra_lsp_server/Cargo.toml
@@ -10,7 +10,7 @@ relative-path = "0.4.0"
 failure = "0.1.4"
 failure_derive = "0.1.4"
 serde_json = "1.0.34"
-serde = "1.0.83"
+serde = { version = "1.0.83", features = ["derive"] }
 crossbeam-channel = "0.3.5"
 flexi_logger = "0.11.0"
 log = "0.4.3"

--- a/crates/ra_project_model/Cargo.toml
+++ b/crates/ra_project_model/Cargo.toml
@@ -17,7 +17,7 @@ cargo_metadata = "0.7.0"
 ra_arena = { path = "../ra_arena" }
 ra_db = { path = "../ra_db" }
 
-serde = "1.0.89"
+serde = { version = "1.0.89", features = ["derive"] }
 serde_json = "1.0.39"
 
 [dev-dependencies]


### PR DESCRIPTION
`ra_project_model` build will fail when no dependencies are using this feature. Reproduced by creating a crate depending on `ra_batch`.