### PR TITLE
Remove superfluous semicolons

### DIFF
--- a/crates/ra_ide_api/src/hover.rs
+++ b/crates/ra_ide_api/src/hover.rs
@@ -550,7 +550,7 @@ The Some variant
     fn test_hover_infer_associated_method_result() {
         let (analysis, position) = single_file_with_position(
             "
-            struct Thing { x: u32 };
+            struct Thing { x: u32 }
 
             impl Thing {
                 fn new() -> Thing {
@@ -616,7 +616,7 @@ The Some variant
     fn test_hover_self() {
         let (analysis, position) = single_file_with_position(
             "
-            struct Thing { x: u32 };
+            struct Thing { x: u32 }
             impl Thing {
                 fn new() -> Self {
                     Self<|> { x: 0 }
@@ -630,7 +630,7 @@ The Some variant
 
         let (analysis, position) = single_file_with_position(
             "
-            struct Thing { x: u32 };
+            struct Thing { x: u32 }
             impl Thing {
                 fn new() -> Self<|> {
                     Self { x: 0 }
@@ -644,7 +644,7 @@ The Some variant
 
         let (analysis, position) = single_file_with_position(
             "
-            enum Thing { A };
+            enum Thing { A }
             impl Thing {
                 pub fn new() -> Self<|> {
                     Thing::A
@@ -658,7 +658,7 @@ The Some variant
 
         let (analysis, position) = single_file_with_position(
             "
-            enum Thing { A };
+            enum Thing { A }
             impl Thing {
                 pub fn thing(a: Self<|>) {
                 }


### PR DESCRIPTION
Doesn't change the result of the test but it does prevent the
syntax tree from rendering.