### PR TITLE
derive Hash for ra_hir::ModuleDef

### DIFF
--- a/crates/ra_hir/src/code_model_api.rs
+++ b/crates/ra_hir/src/code_model_api.rs
@@ -69,7 +69,7 @@ pub struct Module {
 }
 
 /// The defs which can be visible in the module.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ModuleDef {
     Module(Module),
     Function(Function),


### PR DESCRIPTION
I wanted to use `HashSet` but it seems like `Hash` derive is missing for no reason.