### PR TITLE
Remove FnSig from FnDef type

### DIFF
--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -12,7 +12,7 @@ use crate::{
     macros::MacroExpansion,
     module_tree::ModuleTree,
     nameres::{ItemMap, lower::{LoweredModule, ImportSourceMap}},
-    ty::{InferenceResult, Ty, method_resolution::CrateImplBlocks, TypableDef},
+    ty::{InferenceResult, Ty, method_resolution::CrateImplBlocks, TypableDef, CallableDef, FnSig},
     adt::{StructData, EnumData},
     impl_block::{ModuleImplBlocks, ImplSourceMap},
     generics::{GenericParams, GenericDef},
@@ -104,6 +104,9 @@ pub trait HirDatabase: PersistentHirDatabase {
 
     #[salsa::invoke(crate::ty::type_for_field)]
     fn type_for_field(&self, field: StructField) -> Ty;
+
+    #[salsa::invoke(crate::ty::callable_item_sig)]
+    fn callable_item_signature(&self, def: CallableDef) -> FnSig;
 
     #[salsa::invoke(crate::expr::body_with_source_map_query)]
     fn body_with_source_map(

--- a/crates/ra_hir/src/ty.rs
+++ b/crates/ra_hir/src/ty.rs
@@ -304,8 +304,8 @@ impl HirDisplay for Ty {
         match self {
             Ty::Bool => write!(f, "bool")?,
             Ty::Char => write!(f, "char")?,
-            Ty::Int(t) => write!(f, "{}", t.ty_to_string())?,
-            Ty::Float(t) => write!(f, "{}", t.ty_to_string())?,
+            Ty::Int(t) => write!(f, "{}", t)?,
+            Ty::Float(t) => write!(f, "{}", t)?,
             Ty::Str => write!(f, "str")?,
             Ty::Slice(t) | Ty::Array(t) => {
                 write!(f, "[{}]", t.display(f.db))?;

--- a/crates/ra_hir/src/ty/infer.rs
+++ b/crates/ra_hir/src/ty/infer.rs
@@ -725,7 +725,8 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
                 let callee_ty = self.infer_expr(*callee, &Expectation::none());
                 let (param_tys, ret_ty) = match &callee_ty {
                     Ty::FnPtr(sig) => (sig.params().to_vec(), sig.ret().clone()),
-                    Ty::FnDef { substs, sig, .. } => {
+                    Ty::FnDef { substs, def, .. } => {
+                        let sig = self.db.callable_item_signature(*def);
                         let ret_ty = sig.ret().clone().subst(&substs);
                         let param_tys =
                             sig.params().iter().map(|ty| ty.clone().subst(&substs)).collect();
@@ -768,7 +769,8 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
                             (Ty::Unknown, Vec::new(), sig.ret().clone())
                         }
                     }
-                    Ty::FnDef { substs, sig, .. } => {
+                    Ty::FnDef { substs, def, .. } => {
+                        let sig = self.db.callable_item_signature(*def);
                         let ret_ty = sig.ret().clone().subst(&substs);
 
                         if !sig.params().is_empty() {

--- a/crates/ra_hir/src/ty/lower.rs
+++ b/crates/ra_hir/src/ty/lower.rs
@@ -51,12 +51,10 @@ impl Ty {
             }
             TypeRef::Placeholder => Ty::Unknown,
             TypeRef::Fn(params) => {
-                let mut inner_tys =
+                let inner_tys =
                     params.iter().map(|tr| Ty::from_hir(db, resolver, tr)).collect::<Vec<_>>();
-                let return_ty =
-                    inner_tys.pop().expect("TypeRef::Fn should always have at least return type");
-                let sig = FnSig { input: inner_tys, output: return_ty };
-                Ty::FnPtr(Arc::new(sig))
+                let sig = FnSig { params_and_return: inner_tys.into() };
+                Ty::FnPtr(sig)
             }
             TypeRef::Error => Ty::Unknown,
         }
@@ -226,16 +224,20 @@ pub(crate) fn type_for_field(db: &impl HirDatabase, field: StructField) -> Ty {
     Ty::from_hir(db, &resolver, type_ref)
 }
 
+fn fn_sig_for_fn(db: &impl HirDatabase, def: Function) -> FnSig {
+    let signature = def.signature(db);
+    let resolver = def.resolver(db);
+    let params =
+        signature.params().iter().map(|tr| Ty::from_hir(db, &resolver, tr)).collect::<Vec<_>>();
+    let ret = Ty::from_hir(db, &resolver, signature.ret_type());
+    FnSig::from_params_and_return(params, ret)
+}
+
 /// Build the declared type of a function. This should not need to look at the
 /// function body.
 fn type_for_fn(db: &impl HirDatabase, def: Function) -> Ty {
-    let signature = def.signature(db);
-    let resolver = def.resolver(db);
+    let sig = fn_sig_for_fn(db, def);
     let generics = def.generic_params(db);
-    let input =
-        signature.params().iter().map(|tr| Ty::from_hir(db, &resolver, tr)).collect::<Vec<_>>();
-    let output = Ty::from_hir(db, &resolver, signature.ret_type());
-    let sig = Arc::new(FnSig { input, output });
     let substs = make_substs(&generics);
     Ty::FnDef { def: def.into(), sig, substs }
 }
@@ -256,41 +258,59 @@ fn type_for_static(db: &impl HirDatabase, def: Static) -> Ty {
     Ty::from_hir(db, &resolver, signature.type_ref())
 }
 
-/// Build the type of a tuple struct constructor.
-fn type_for_struct_constructor(db: &impl HirDatabase, def: Struct) -> Ty {
+fn fn_sig_for_struct_constructor(db: &impl HirDatabase, def: Struct) -> FnSig {
     let var_data = def.variant_data(db);
     let fields = match var_data.fields() {
         Some(fields) => fields,
-        None => return type_for_struct(db, def), // Unit struct
+        None => panic!("fn_sig_for_struct_constructor called on unit struct"),
     };
     let resolver = def.resolver(db);
-    let generics = def.generic_params(db);
-    let input = fields
+    let params = fields
         .iter()
         .map(|(_, field)| Ty::from_hir(db, &resolver, &field.type_ref))
         .collect::<Vec<_>>();
-    let output = type_for_struct(db, def);
-    let sig = Arc::new(FnSig { input, output });
+    let ret = type_for_struct(db, def);
+    FnSig::from_params_and_return(params, ret)
+}
+
+/// Build the type of a tuple struct constructor.
+fn type_for_struct_constructor(db: &impl HirDatabase, def: Struct) -> Ty {
+    let var_data = def.variant_data(db);
+    if var_data.fields().is_none() {
+        return type_for_struct(db, def); // Unit struct
+    }
+    let sig = fn_sig_for_struct_constructor(db, def);
+    let generics = def.generic_params(db);
     let substs = make_substs(&generics);
     Ty::FnDef { def: def.into(), sig, substs }
+}
+
+fn fn_sig_for_enum_variant_constructor(db: &impl HirDatabase, def: EnumVariant) -> FnSig {
+    let var_data = def.variant_data(db);
+    let fields = match var_data.fields() {
+        Some(fields) => fields,
+        None => panic!("fn_sig_for_enum_variant_constructor called for unit variant"),
+    };
+    let resolver = def.parent_enum(db).resolver(db);
+    let params = fields
+        .iter()
+        .map(|(_, field)| Ty::from_hir(db, &resolver, &field.type_ref))
+        .collect::<Vec<_>>();
+    let generics = def.parent_enum(db).generic_params(db);
+    let substs = make_substs(&generics);
+    let ret = type_for_enum(db, def.parent_enum(db)).subst(&substs);
+    FnSig::from_params_and_return(params, ret)
 }
 
 /// Build the type of a tuple enum variant constructor.
 fn type_for_enum_variant_constructor(db: &impl HirDatabase, def: EnumVariant) -> Ty {
     let var_data = def.variant_data(db);
-    let fields = match var_data.fields() {
-        Some(fields) => fields,
-        None => return type_for_enum(db, def.parent_enum(db)), // Unit variant
-    };
-    let resolver = def.parent_enum(db).resolver(db);
+    if var_data.fields().is_none() {
+        return type_for_enum(db, def.parent_enum(db)); // Unit variant
+    }
+    let sig = fn_sig_for_enum_variant_constructor(db, def);
     let generics = def.parent_enum(db).generic_params(db);
-    let input = fields
-        .iter()
-        .map(|(_, field)| Ty::from_hir(db, &resolver, &field.type_ref))
-        .collect::<Vec<_>>();
     let substs = make_substs(&generics);
-    let output = type_for_enum(db, def.parent_enum(db)).subst(&substs);
-    let sig = Arc::new(FnSig { input, output });
     Ty::FnDef { def: def.into(), sig, substs }
 }
 

--- a/crates/ra_hir/src/ty/primitive.rs
+++ b/crates/ra_hir/src/ty/primitive.rs
@@ -10,14 +10,6 @@ pub enum UncertainIntTy {
 }
 
 impl UncertainIntTy {
-    pub fn ty_to_string(&self) -> &'static str {
-        match *self {
-            UncertainIntTy::Unknown => "{integer}",
-            UncertainIntTy::Signed(ty) => ty.ty_to_string(),
-            UncertainIntTy::Unsigned(ty) => ty.ty_to_string(),
-        }
-    }
-
     pub fn from_name(name: &Name) -> Option<UncertainIntTy> {
         if let Some(ty) = IntTy::from_name(name) {
             Some(UncertainIntTy::Signed(ty))
@@ -29,6 +21,16 @@ impl UncertainIntTy {
     }
 }
 
+impl fmt::Display for UncertainIntTy {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            UncertainIntTy::Unknown => write!(f, "{{integer}}"),
+            UncertainIntTy::Signed(ty) => write!(f, "{}", ty),
+            UncertainIntTy::Unsigned(ty) => write!(f, "{}", ty),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Copy)]
 pub enum UncertainFloatTy {
     Unknown,
@@ -36,18 +38,20 @@ pub enum UncertainFloatTy {
 }
 
 impl UncertainFloatTy {
-    pub fn ty_to_string(&self) -> &'static str {
-        match *self {
-            UncertainFloatTy::Unknown => "{float}",
-            UncertainFloatTy::Known(ty) => ty.ty_to_string(),
-        }
-    }
-
     pub fn from_name(name: &Name) -> Option<UncertainFloatTy> {
         if let Some(ty) = FloatTy::from_name(name) {
             Some(UncertainFloatTy::Known(ty))
         } else {
             None
+        }
+    }
+}
+
+impl fmt::Display for UncertainFloatTy {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            UncertainFloatTy::Unknown => write!(f, "{{float}}"),
+            UncertainFloatTy::Known(ty) => write!(f, "{}", ty),
         }
     }
 }
@@ -70,22 +74,19 @@ impl fmt::Debug for IntTy {
 
 impl fmt::Display for IntTy {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.ty_to_string())
-    }
-}
-
-impl IntTy {
-    pub fn ty_to_string(&self) -> &'static str {
-        match *self {
+        let s = match *self {
             IntTy::Isize => "isize",
             IntTy::I8 => "i8",
             IntTy::I16 => "i16",
             IntTy::I32 => "i32",
             IntTy::I64 => "i64",
             IntTy::I128 => "i128",
-        }
+        };
+        write!(f, "{}", s)
     }
+}
 
+impl IntTy {
     pub fn from_name(name: &Name) -> Option<IntTy> {
         match name.as_known_name()? {
             KnownName::Isize => Some(IntTy::Isize),
@@ -109,18 +110,21 @@ pub enum UintTy {
     U128,
 }
 
-impl UintTy {
-    pub fn ty_to_string(&self) -> &'static str {
-        match *self {
+impl fmt::Display for UintTy {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let s = match *self {
             UintTy::Usize => "usize",
             UintTy::U8 => "u8",
             UintTy::U16 => "u16",
             UintTy::U32 => "u32",
             UintTy::U64 => "u64",
             UintTy::U128 => "u128",
-        }
+        };
+        write!(f, "{}", s)
     }
+}
 
+impl UintTy {
     pub fn from_name(name: &Name) -> Option<UintTy> {
         match name.as_known_name()? {
             KnownName::Usize => Some(UintTy::Usize),
@@ -137,12 +141,6 @@ impl UintTy {
 impl fmt::Debug for UintTy {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(self, f)
-    }
-}
-
-impl fmt::Display for UintTy {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.ty_to_string())
     }
 }
 


### PR DESCRIPTION
It doesn't need to be in there since it's just information from the def. Another
step towards aligning Ty with Chalk's representation.