### PR TITLE
Fix installing vscode extension on MacOS

### DIFF
--- a/crates/tools/src/main.rs
+++ b/crates/tools/src/main.rs
@@ -17,7 +17,10 @@ fn main() -> Result<()> {
         .subcommand(SubCommand::with_name("fuzz-tests"))
         .get_matches();
     match matches.subcommand_name().expect("Subcommand must be specified") {
-        "install-code" => install_code_extension()?,
+        "install-code" => {
+            setup_environment()?;
+            install_code_extension()?;
+        }
         "gen-tests" => gen_tests(Overwrite)?,
         "gen-syntax" => generate(Overwrite)?,
         "format" => run_rustfmt(Overwrite)?,
@@ -25,6 +28,14 @@ fn main() -> Result<()> {
         "fuzz-tests" => run_fuzzer()?,
         _ => unreachable!(),
     }
+    Ok(())
+}
+
+fn setup_environment() -> Result<()> {
+    if cfg!(target_os = "macos") {
+        vscode_path_helpers::append_vscode_path()?;
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
VSCode often installed in MacOS as `Visual Studio Code.app` package and `code` binary located at `Contents/Resources/app/bin` in package. This path not exists in `$PATH` variable and we can't run `code`.

In previous version of `do_run` function all before space was command and all after - arguments. If path or command has spaces, extracting command breaks. To fix this i extracted command to separated argument of function.

All packages can be placed in system app dir (`/Applications`) or user app dir (`~/Applications`). I created helper function for find app in this directories.

