### PR TITLE
Install and run `cargo watch` if user agrees

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -168,6 +168,11 @@
                     "default": "ra_lsp_server",
                     "description": "Path to ra_lsp_server executable"
                 },
+                "rust-analyzer.enableCargoWatchOnStartup": {
+                    "type": "boolean",
+                    "default": "true",
+                    "description": "When enabled, ask the user whether to run `cargo watch` on startup"
+                },
                 "rust-analyzer.trace.server": {
                     "type": "string",
                     "scope": "window",

--- a/editors/code/src/commands/runnables.ts
+++ b/editors/code/src/commands/runnables.ts
@@ -33,7 +33,7 @@ interface CargoTaskDefinition extends vscode.TaskDefinition {
     env?: { [key: string]: string };
 }
 
-function createTask(spec: Runnable): vscode.Task {
+export function createTask(spec: Runnable): vscode.Task {
     const TASK_SOURCE = 'Rust';
     const definition: CargoTaskDefinition = {
         type: 'cargo',
@@ -123,3 +123,23 @@ export async function handleSingle(runnable: Runnable) {
 
     return vscode.tasks.executeTask(task);
 }
+
+export const autoCargoWatchTask: vscode.Task = {
+    name: 'cargo watch',
+    source: 'rust-analyzer',
+    definition: {
+        type: "dupa",
+    },
+    execution: new vscode.ShellExecution('cargo', ['watch'], { cwd: '.' }),
+
+    isBackground: true,
+    problemMatchers: ['$rustc-watch'],
+    presentationOptions: {
+        clear: true
+    },
+    // Not yet exposed in the vscode.d.ts
+    runOptions: {
+        runOn: 2 // RunOnOptions.folderOpen, https://github.com/Microsoft/vscode/blob/ea7c31d770e04b51d586b0d3944f3a7feb03afb9/src/vs/workbench/contrib/tasks/common/tasks.ts#L444-L456
+    } as unknown as vscode.RunOptions,
+
+};

--- a/editors/code/src/commands/runnables.ts
+++ b/editors/code/src/commands/runnables.ts
@@ -37,7 +37,7 @@ export function createTask(spec: Runnable): vscode.Task {
     const TASK_SOURCE = 'Rust';
     const definition: CargoTaskDefinition = {
         type: 'cargo',
-        label: 'cargo',
+        label: spec.label,
         command: spec.bin,
         args: spec.args,
         env: spec.env

--- a/editors/code/src/commands/runnables.ts
+++ b/editors/code/src/commands/runnables.ts
@@ -128,7 +128,7 @@ export const autoCargoWatchTask: vscode.Task = {
     name: 'cargo watch',
     source: 'rust-analyzer',
     definition: {
-        type: "dupa",
+        type: 'watch'
     },
     execution: new vscode.ShellExecution('cargo', ['watch'], { cwd: '.' }),
 
@@ -138,8 +138,8 @@ export const autoCargoWatchTask: vscode.Task = {
         clear: true
     },
     // Not yet exposed in the vscode.d.ts
-    runOptions: {
-        runOn: 2 // RunOnOptions.folderOpen, https://github.com/Microsoft/vscode/blob/ea7c31d770e04b51d586b0d3944f3a7feb03afb9/src/vs/workbench/contrib/tasks/common/tasks.ts#L444-L456
-    } as unknown as vscode.RunOptions,
-
+    // https://github.com/Microsoft/vscode/blob/ea7c31d770e04b51d586b0d3944f3a7feb03afb9/src/vs/workbench/contrib/tasks/common/tasks.ts#L444-L456
+    runOptions: ({
+        runOn: 2 // RunOnOptions.folderOpen
+    } as unknown) as vscode.RunOptions
 };

--- a/editors/code/src/commands/runnables.ts
+++ b/editors/code/src/commands/runnables.ts
@@ -153,6 +153,10 @@ export const autoCargoWatchTask: vscode.Task = {
  * that, when accepted, allow us to `cargo install cargo-watch` and then run it.
  */
 export async function interactivelyStartCargoWatch() {
+    if (!Server.config.enableCargoWatchOnStartup) {
+        return;
+    }
+
     const execAsync = util.promisify(exec);
 
     const watch = await vscode.window.showInformationMessage(

--- a/editors/code/src/commands/runnables.ts
+++ b/editors/code/src/commands/runnables.ts
@@ -8,7 +8,6 @@ interface RunnablesParams {
 }
 
 interface Runnable {
-    range: lc.Range;
     label: string;
     bin: string;
     args: string[];

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -9,6 +9,7 @@ export class Config {
     public enableEnhancedTyping = true;
     public raLspServerPath = RA_LSP_DEBUG || 'ra_lsp_server';
     public showWorkspaceLoadedNotification = true;
+    public enableCargoWatchOnStartup = true;
 
     private prevEnhancedTyping: null | boolean = null;
 
@@ -67,6 +68,13 @@ export class Config {
         if (config.has('raLspServerPath')) {
             this.raLspServerPath =
                 RA_LSP_DEBUG || (config.get('raLspServerPath') as string);
+        }
+
+        if (config.has('enableCargoWatchOnStartup')) {
+            this.enableCargoWatchOnStartup = config.get<boolean>(
+                'enableCargoWatchOnStartup',
+                true
+            );
         }
     }
 }

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -92,11 +92,11 @@ export function activate(context: vscode.ExtensionContext) {
     const allNotifications: Iterable<
         [string, lc.GenericNotificationHandler]
     > = [
-            [
-                'rust-analyzer/publishDecorations',
-                notifications.publishDecorations.handle
-            ]
-        ];
+        [
+            'rust-analyzer/publishDecorations',
+            notifications.publishDecorations.handle
+        ]
+    ];
     const syntaxTreeContentProvider = new SyntaxTreeContentProvider();
 
     // The events below are plain old javascript events, triggered and handled by vscode
@@ -146,10 +146,17 @@ async function askToCargoWatch() {
         return;
     }
 
-    const { stderr } = await util.promisify(exec)('cargo watch --version').catch(e => e);
+    const { stderr } = await util
+        .promisify(exec)('cargo watch --version')
+        .catch(e => e);
     if (stderr.includes('no such subcommand: `watch`')) {
-        const msg = 'The `cargo-watch` subcommand is not installed. Install? (takes ~1-2 minutes)';
-        const install = await vscode.window.showInformationMessage(msg, 'yes', 'no');
+        const msg =
+            'The `cargo-watch` subcommand is not installed. Install? (takes ~1-2 minutes)';
+        const install = await vscode.window.showInformationMessage(
+            msg,
+            'yes',
+            'no'
+        );
         if (install === 'no') {
             return;
         }
@@ -160,15 +167,26 @@ async function askToCargoWatch() {
                 if (execution.task.name === label) {
                     disposable.dispose();
                     resolve();
-                };
+                }
             });
         });
 
-        vscode.tasks.executeTask(createTask({ label, bin: 'cargo', args: ['install', 'cargo-watch'], env: {} }));
+        vscode.tasks.executeTask(
+            createTask({
+                label,
+                bin: 'cargo',
+                args: ['install', 'cargo-watch'],
+                env: {}
+            })
+        );
         await taskFinished;
-        const { stderr } = await util.promisify(exec)('cargo watch --version').catch(e => e);
+        const { stderr } = await util
+            .promisify(exec)('cargo watch --version')
+            .catch(e => e);
         if (stderr !== '') {
-            vscode.window.showErrorMessage(`Couldn't install \`cargo-\`watch: ${stderr}`);
+            vscode.window.showErrorMessage(
+                `Couldn't install \`cargo-\`watch: ${stderr}`
+            );
             return;
         }
     }

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -1,4 +1,4 @@
-import { exec, spawn } from 'child_process';
+import { exec } from 'child_process';
 import * as util from 'util';
 import * as vscode from 'vscode';
 import * as lc from 'vscode-languageclient';
@@ -9,7 +9,6 @@ import { SyntaxTreeContentProvider } from './commands/syntaxTree';
 import * as events from './events';
 import * as notifications from './notifications';
 import { Server } from './server';
-import { TextDecoder } from 'util';
 
 export function activate(context: vscode.ExtensionContext) {
     function disposeOnDeactivation(disposable: vscode.Disposable) {


### PR DESCRIPTION
This isn't a glorious patch but hopefully is useful :+1: This introduces a default background `cargo watch` task and (separately from that) asks the user on every startup if they want to run `cargo watch` (installs it if it's not available).

r? @matklad does it fit the what you've been thinking about?