### PR TITLE
Improve filtering of file roots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,6 +1088,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ra_arena 0.1.0",
  "ra_db 0.1.0",
+ "relative-path 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crates/ra_batch/src/lib.rs
+++ b/crates/ra_batch/src/lib.rs
@@ -1,5 +1,7 @@
+mod vfs_filter;
+
 use std::sync::Arc;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::collections::HashSet;
 
 use rustc_hash::FxHashMap;
@@ -9,7 +11,8 @@ use ra_db::{
 };
 use ra_hir::{db, HirInterner};
 use ra_project_model::ProjectWorkspace;
-use ra_vfs::{Vfs, VfsChange, RootEntry, Filter, RelativePath};
+use ra_vfs::{Vfs, VfsChange};
+use vfs_filter::IncludeRustFiles;
 
 type Result<T> = std::result::Result<T, failure::Error>;
 
@@ -41,30 +44,6 @@ fn vfs_file_to_id(f: ra_vfs::VfsFile) -> FileId {
 }
 fn vfs_root_to_id(r: ra_vfs::VfsRoot) -> SourceRootId {
     SourceRootId(r.0.into())
-}
-
-struct IncludeRustFiles;
-
-impl IncludeRustFiles {
-    fn to_entry(path: PathBuf) -> RootEntry {
-        RootEntry::new(path, Box::new(Self {}))
-    }
-}
-
-impl Filter for IncludeRustFiles {
-    fn include_dir(&self, dir_path: &RelativePath) -> bool {
-        const IGNORED_FOLDERS: &[&str] = &["node_modules", "target", ".git"];
-
-        let is_ignored = dir_path.components().any(|c| IGNORED_FOLDERS.contains(&c.as_str()));
-
-        let hidden = dir_path.components().any(|c| c.as_str().starts_with("."));
-
-        !is_ignored && !hidden
-    }
-
-    fn include_file(&self, file_path: &RelativePath) -> bool {
-        file_path.extension() == Some("rs")
-    }
 }
 
 impl BatchDatabase {
@@ -122,9 +101,8 @@ impl BatchDatabase {
         let root = std::env::current_dir()?.join(root);
         let ws = ProjectWorkspace::discover(root.as_ref())?;
         let mut roots = Vec::new();
-        roots.push(root.clone());
-        roots.extend(ws.to_roots());
-        let roots = roots.into_iter().map(IncludeRustFiles::to_entry).collect::<Vec<_>>();
+        roots.push(IncludeRustFiles::member(root.clone()));
+        roots.extend(IncludeRustFiles::from_roots(ws.to_roots()));
         let (mut vfs, roots) = Vfs::new(roots);
         let mut load = |path: &Path| {
             let vfs_file = vfs.load(path);

--- a/crates/ra_batch/src/vfs_filter.rs
+++ b/crates/ra_batch/src/vfs_filter.rs
@@ -1,0 +1,59 @@
+use std::path::PathBuf;
+use ra_project_model::ProjectRoot;
+use ra_vfs::{RootEntry, Filter, RelativePath};
+
+pub struct IncludeRustFiles {
+    /// Is a member of the current workspace
+    is_member: bool,
+}
+
+impl IncludeRustFiles {
+    pub fn from_roots<R>(roots: R) -> impl Iterator<Item = RootEntry>
+    where
+        R: IntoIterator<Item = ProjectRoot>,
+    {
+        roots.into_iter().map(IncludeRustFiles::from_root)
+    }
+
+    pub fn from_root(root: ProjectRoot) -> RootEntry {
+        let is_member = root.is_member();
+        IncludeRustFiles::into_entry(root.into_path(), is_member)
+    }
+
+    #[allow(unused)]
+    pub fn external(path: PathBuf) -> RootEntry {
+        IncludeRustFiles::into_entry(path, false)
+    }
+
+    pub fn member(path: PathBuf) -> RootEntry {
+        IncludeRustFiles::into_entry(path, true)
+    }
+
+    fn into_entry(path: PathBuf, is_member: bool) -> RootEntry {
+        RootEntry::new(path, Box::new(Self { is_member }))
+    }
+}
+
+impl Filter for IncludeRustFiles {
+    fn include_dir(&self, dir_path: &RelativePath) -> bool {
+        const COMMON_IGNORED_DIRS: &[&str] = &["node_modules", "target", ".git"];
+        const EXTERNAL_IGNORED_DIRS: &[&str] = &["examples", "tests", "benches"];
+
+        let is_ignored = if self.is_member {
+            dir_path.components().any(|c| COMMON_IGNORED_DIRS.contains(&c.as_str()))
+        } else {
+            dir_path.components().any(|c| {
+                let path = c.as_str();
+                COMMON_IGNORED_DIRS.contains(&path) || EXTERNAL_IGNORED_DIRS.contains(&path)
+            })
+        };
+
+        let hidden = dir_path.components().any(|c| c.as_str().starts_with("."));
+
+        !is_ignored && !hidden
+    }
+
+    fn include_file(&self, file_path: &RelativePath) -> bool {
+        file_path.extension() == Some("rs")
+    }
+}

--- a/crates/ra_lsp_server/src/lib.rs
+++ b/crates/ra_lsp_server/src/lib.rs
@@ -4,6 +4,7 @@ mod conv;
 mod main_loop;
 mod markdown;
 mod project_model;
+mod vfs_filter;
 pub mod req;
 pub mod init;
 mod server_world;

--- a/crates/ra_lsp_server/src/server_world.rs
+++ b/crates/ra_lsp_server/src/server_world.rs
@@ -8,13 +8,14 @@ use ra_ide_api::{
     Analysis, AnalysisChange, AnalysisHost, CrateGraph, FileId, LibraryData,
     SourceRootId
 };
-use ra_vfs::{Vfs, VfsChange, VfsFile, VfsRoot, RootEntry, Filter};
-use relative_path::{RelativePath, RelativePathBuf};
+use ra_vfs::{Vfs, VfsChange, VfsFile, VfsRoot};
+use relative_path::RelativePathBuf;
 use parking_lot::RwLock;
 use failure::format_err;
 
 use crate::{
     project_model::ProjectWorkspace,
+    vfs_filter::IncludeRustFiles,
     Result,
 };
 
@@ -33,40 +34,15 @@ pub struct ServerWorld {
     pub vfs: Arc<RwLock<Vfs>>,
 }
 
-struct IncludeRustFiles;
-
-impl IncludeRustFiles {
-    fn to_entry(path: PathBuf) -> RootEntry {
-        RootEntry::new(path, Box::new(Self {}))
-    }
-}
-
-impl Filter for IncludeRustFiles {
-    fn include_dir(&self, dir_path: &RelativePath) -> bool {
-        const IGNORED_FOLDERS: &[&str] = &["node_modules", "target", ".git"];
-
-        let is_ignored = dir_path.components().any(|c| IGNORED_FOLDERS.contains(&c.as_str()));
-
-        let hidden = dir_path.components().any(|c| c.as_str().starts_with("."));
-
-        !is_ignored && !hidden
-    }
-
-    fn include_file(&self, file_path: &RelativePath) -> bool {
-        file_path.extension() == Some("rs")
-    }
-}
-
 impl ServerWorldState {
     pub fn new(root: PathBuf, workspaces: Vec<ProjectWorkspace>) -> ServerWorldState {
         let mut change = AnalysisChange::new();
 
         let mut roots = Vec::new();
-        roots.push(root.clone());
+        roots.push(IncludeRustFiles::member(root.clone()));
         for ws in workspaces.iter() {
-            roots.extend(ws.to_roots());
+            roots.extend(IncludeRustFiles::from_roots(ws.to_roots()));
         }
-        let roots = roots.into_iter().map(IncludeRustFiles::to_entry).collect::<Vec<_>>();
 
         let (mut vfs, roots) = Vfs::new(roots);
         let roots_to_scan = roots.len();

--- a/crates/ra_lsp_server/src/vfs_filter.rs
+++ b/crates/ra_lsp_server/src/vfs_filter.rs
@@ -1,0 +1,59 @@
+use std::path::PathBuf;
+use ra_project_model::ProjectRoot;
+use ra_vfs::{RootEntry, Filter, RelativePath};
+
+pub struct IncludeRustFiles {
+    /// Is a member of the current workspace
+    is_member: bool,
+}
+
+impl IncludeRustFiles {
+    pub fn from_roots<R>(roots: R) -> impl Iterator<Item = RootEntry>
+    where
+        R: IntoIterator<Item = ProjectRoot>,
+    {
+        roots.into_iter().map(IncludeRustFiles::from_root)
+    }
+
+    pub fn from_root(root: ProjectRoot) -> RootEntry {
+        let is_member = root.is_member();
+        IncludeRustFiles::into_entry(root.into_path(), is_member)
+    }
+
+    #[allow(unused)]
+    pub fn external(path: PathBuf) -> RootEntry {
+        IncludeRustFiles::into_entry(path, false)
+    }
+
+    pub fn member(path: PathBuf) -> RootEntry {
+        IncludeRustFiles::into_entry(path, true)
+    }
+
+    fn into_entry(path: PathBuf, is_member: bool) -> RootEntry {
+        RootEntry::new(path, Box::new(Self { is_member }))
+    }
+}
+
+impl Filter for IncludeRustFiles {
+    fn include_dir(&self, dir_path: &RelativePath) -> bool {
+        const COMMON_IGNORED_DIRS: &[&str] = &["node_modules", "target", ".git"];
+        const EXTERNAL_IGNORED_DIRS: &[&str] = &["examples", "tests", "benches"];
+
+        let is_ignored = if self.is_member {
+            dir_path.components().any(|c| COMMON_IGNORED_DIRS.contains(&c.as_str()))
+        } else {
+            dir_path.components().any(|c| {
+                let path = c.as_str();
+                COMMON_IGNORED_DIRS.contains(&path) || EXTERNAL_IGNORED_DIRS.contains(&path)
+            })
+        };
+
+        let hidden = dir_path.components().any(|c| c.as_str().starts_with("."));
+
+        !is_ignored && !hidden
+    }
+
+    fn include_file(&self, file_path: &RelativePath) -> bool {
+        file_path.extension() == Some("rs")
+    }
+}

--- a/crates/ra_project_model/Cargo.toml
+++ b/crates/ra_project_model/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["rust-analyzer developers"]
 [dependencies]
 log = "0.4.5"
 rustc-hash = "1.0"
+relative-path = "0.4.0"
 
 failure = "0.1.4"
 


### PR DESCRIPTION
`ProjectWorkspace::to_roots` now returns a new `ProjectRoot` which contains
information regarding whether or not the given path is part of the current
workspace or an external dependency. This information can then be used in
`ra_batch` and `ra_lsp_server` to implement more advanced filtering. This allows
us to filter some unnecessary folders from external dependencies such as tests,
examples and benches.

Relates to discussion in #869 