### PR TITLE
Change enableCargoWatchOnStartup to have three states

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -169,9 +169,19 @@
                     "description": "Path to ra_lsp_server executable"
                 },
                 "rust-analyzer.enableCargoWatchOnStartup": {
-                    "type": "boolean",
-                    "default": "true",
-                    "description": "When enabled, ask the user whether to run `cargo watch` on startup"
+                    "type": "string",
+                    "default": "ask",
+                    "enum": [
+                        "ask",
+                        "enabled",
+                        "disabled"
+                    ],
+                    "enumDescriptions": [
+                        "Asks each time whether to run `cargo watch`",
+                        "`cargo watch` is always started",
+                        "Don't start `cargo watch`"
+                    ],
+                    "description": "Whether to run `cargo watch` on startup"
                 },
                 "rust-analyzer.trace.server": {
                     "type": "string",

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -4,12 +4,14 @@ import { Server } from './server';
 
 const RA_LSP_DEBUG = process.env.__RA_LSP_SERVER_DEBUG;
 
+export type CargoWatchOptions = 'ask' | 'enabled' | 'disabled';
+
 export class Config {
     public highlightingOn = true;
     public enableEnhancedTyping = true;
     public raLspServerPath = RA_LSP_DEBUG || 'ra_lsp_server';
     public showWorkspaceLoadedNotification = true;
-    public enableCargoWatchOnStartup = true;
+    public enableCargoWatchOnStartup: CargoWatchOptions = 'ask';
 
     private prevEnhancedTyping: null | boolean = null;
 
@@ -71,9 +73,9 @@ export class Config {
         }
 
         if (config.has('enableCargoWatchOnStartup')) {
-            this.enableCargoWatchOnStartup = config.get<boolean>(
+            this.enableCargoWatchOnStartup = config.get<CargoWatchOptions>(
                 'enableCargoWatchOnStartup',
-                true
+                'ask'
             );
         }
     }


### PR DESCRIPTION
This fixes #1005.

Defaults to `ask` which prompts users each time whether to start `cargo watch`
or not. `enabled` always starts `cargo watch` and `disabled` does not.