### PR TITLE
Don't execute cargo watch when information message is dismissed

### DIFF
--- a/editors/code/src/commands/runnables.ts
+++ b/editors/code/src/commands/runnables.ts
@@ -163,7 +163,7 @@ export async function interactivelyStartCargoWatch() {
             'yes',
             'no'
         );
-        if (watch === 'no') {
+        if (watch !== 'yes') {
             return;
         }
     }
@@ -180,7 +180,7 @@ export async function interactivelyStartCargoWatch() {
             'yes',
             'no'
         );
-        if (install === 'no') {
+        if (install !== 'yes') {
             return;
         }
 


### PR DESCRIPTION
I think most information messages on `VSCode` have such behavior.