### PR TITLE
Wasm dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,7 +402,6 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -660,15 +659,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "memchr"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "memmap"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "memoffset"
@@ -1975,7 +1965,6 @@ dependencies = [
 "checksum maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
-"checksum memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2ffa2c986de11a9df78620c01eeaaf27d94d3ff02bf81bfcca953102dd0c6ff"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)" = "71646331f2619b1026cc302f87a2b8b648d5c6dd6937846a16cc8ce0f347f432"
 "checksum mio-extras 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "46e73a04c2fa6250b8d802134d56d554a9ec2922bf977777c805ea5def61ce40"

--- a/crates/ra_ide_api/Cargo.toml
+++ b/crates/ra_ide_api/Cargo.toml
@@ -10,7 +10,7 @@ join_to_string = "0.1.3"
 log = "0.4.5"
 relative-path = "0.4.0"
 rayon = "1.0.2"
-fst = "0.3.1"
+fst = { version = "0.3.1", default-features = false }
 rustc-hash = "1.0"
 parking_lot = "0.7.0"
 unicase = "2.2.0"


### PR DESCRIPTION
As a first step towards running RA on WASM (see #1007), this tweaks the dependencies somewhat so that projects built using `wasm-pack` can use `ra_ide_api` as a dependency.

There were two problems:
- use of undeclared type or module `MmapInner`
This error occurred because of the `memmap` crate, as a dependency of `fst`
Solution: specify `default-features = false` for the `fst` package (see https://github.com/BurntSushi/fst/issues/70)

- use of undeclared type or module `imp`
This happened in the `wait-timeout` crate ([which uses `Command` under the hood](https://github.com/alexcrichton/wait-timeout/issues/18)), a dependency of `rusty-fork` which is a dependency of `proptest`.
Solution: move `proptest` to dev-dependencies and add `#[cfg(test)]` to the `test_utils` crate.
**Edit:** Oh, that causes trouble with resolving the import when running the tests. Hmm...