### PR TITLE
Add impl members assist shold not copy docstrings, attrs and default methods

### DIFF
--- a/crates/ra_assists/src/lib.rs
+++ b/crates/ra_assists/src/lib.rs
@@ -112,6 +112,7 @@ fn all_assists<DB: HirDatabase>() -> &'static [fn(AssistCtx<DB>) -> Option<Assis
         remove_dbg::remove_dbg,
         auto_import::auto_import,
         add_missing_impl_members::add_missing_impl_members,
+        add_missing_impl_members::add_missing_default_members,
     ]
 }
 


### PR DESCRIPTION
1. `add missing impl members` assist should not copy docstrings, attrs and default methods
2. Add `add impl default members` assist

fixed #1022