### PR TITLE
Add WherePred to allow predicate access in WhereClause

### DIFF
--- a/crates/ra_parser/src/grammar/type_params.rs
+++ b/crates/ra_parser/src/grammar/type_params.rs
@@ -165,7 +165,7 @@ fn where_predicate(p: &mut Parser) {
         LIFETIME => {
             p.bump();
             if p.at(COLON) {
-                lifetime_bounds(p);
+                bounds(p);
             } else {
                 p.error("expected colon");
             }

--- a/crates/ra_syntax/src/ast/generated.rs
+++ b/crates/ra_syntax/src/ast/generated.rs
@@ -4810,7 +4810,48 @@ impl ToOwned for WhereClause {
 }
 
 
-impl WhereClause {}
+impl WhereClause {
+    pub fn predicates(&self) -> impl Iterator<Item = &WherePred> {
+        super::children(self)
+    }
+}
+
+// WherePred
+#[derive(Debug, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct WherePred {
+    pub(crate) syntax: SyntaxNode,
+}
+unsafe impl TransparentNewType for WherePred {
+    type Repr = rowan::SyntaxNode<RaTypes>;
+}
+
+impl AstNode for WherePred {
+    fn cast(syntax: &SyntaxNode) -> Option<&Self> {
+        match syntax.kind() {
+            WHERE_PRED => Some(WherePred::from_repr(syntax.into_repr())),
+            _ => None,
+        }
+    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
+}
+
+impl ToOwned for WherePred {
+    type Owned = TreeArc<WherePred>;
+    fn to_owned(&self) -> TreeArc<WherePred> { TreeArc::cast(self.syntax.to_owned()) }
+}
+
+
+impl ast::TypeBoundsOwner for WherePred {}
+impl WherePred {
+    pub fn type_ref(&self) -> Option<&TypeRef> {
+        super::child_opt(self)
+    }
+
+    pub fn lifetime(&self) -> Option<&Lifetime> {
+        super::child_opt(self)
+    }
+}
 
 // WhileExpr
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/crates/ra_syntax/src/grammar.ron
+++ b/crates/ra_syntax/src/grammar.ron
@@ -595,7 +595,20 @@ Grammar(
                 ["bounds", "TypeBound"],
             ]
         ),
-        "WhereClause": (),
+        "WherePred": (
+            options: [
+                "TypeRef",
+                "Lifetime",
+            ],
+            traits: [
+                "TypeBoundsOwner",
+            ],
+        ),
+        "WhereClause": (
+            collections: [
+                ["predicates", "WherePred"],
+            ],
+        ),
         "ExprStmt": (
             options: [ ["expr", "Expr"] ]
         ),

--- a/crates/ra_syntax/tests/data/parser/inline/ok/0056_where_clause.txt
+++ b/crates/ra_syntax/tests/data/parser/inline/ok/0056_where_clause.txt
@@ -15,11 +15,14 @@ SOURCE_FILE@[0; 116)
         LIFETIME@[18; 20) "'a"
         COLON@[20; 21)
         WHITESPACE@[21; 22)
-        LIFETIME@[22; 24) "'b"
-        WHITESPACE@[24; 25)
-        PLUS@[25; 26)
-        WHITESPACE@[26; 27)
-        LIFETIME@[27; 29) "'c"
+        TYPE_BOUND_LIST@[22; 29)
+          TYPE_BOUND@[22; 24)
+            LIFETIME@[22; 24) "'b"
+          WHITESPACE@[24; 25)
+          PLUS@[25; 26)
+          WHITESPACE@[26; 27)
+          TYPE_BOUND@[27; 29)
+            LIFETIME@[27; 29) "'c"
       COMMA@[29; 30)
       WHITESPACE@[30; 34)
       WHERE_PRED@[34; 59)


### PR DESCRIPTION
Lifetime bounds in where predicates are now also parsed into `TYPE_BOUND_LIST` to allow unified access to bounds.