### PR TITLE
Fix VSCode cargo-watch functionality on Linux.

### DIFF
--- a/editors/code/src/commands/cargo_watch.ts
+++ b/editors/code/src/commands/cargo_watch.ts
@@ -51,6 +51,10 @@ export class CargoWatchProvider {
             // Excape the double quote string:
             args += ' ' + Server.config.cargoWatchOptions.checkArguments;
         }
+        // Windows handles arguments differently than the unix-likes, so we need to wrap the args in double quotes
+        if (process.platform == "win32") {
+            args = '"' + args + '"';
+        }
 
         // Start the cargo watch with json message
         this.cargoProcess = child_process.spawn(

--- a/editors/code/src/commands/cargo_watch.ts
+++ b/editors/code/src/commands/cargo_watch.ts
@@ -46,12 +46,11 @@ export class CargoWatchProvider {
             'Cargo Watch Trace'
         );
 
-        let args = '"check --message-format json';
+        let args = 'check --message-format json';
         if (Server.config.cargoWatchOptions.checkArguments.length > 0) {
             // Excape the double quote string:
             args += ' ' + Server.config.cargoWatchOptions.checkArguments;
         }
-        args += '"';
 
         // Start the cargo watch with json message
         this.cargoProcess = child_process.spawn(

--- a/editors/code/src/commands/cargo_watch.ts
+++ b/editors/code/src/commands/cargo_watch.ts
@@ -52,7 +52,7 @@ export class CargoWatchProvider {
             args += ' ' + Server.config.cargoWatchOptions.checkArguments;
         }
         // Windows handles arguments differently than the unix-likes, so we need to wrap the args in double quotes
-        if (process.platform == "win32") {
+        if (process.platform === 'win32') {
             args = '"' + args + '"';
         }
 


### PR DESCRIPTION
As of #1079 the VSCode cargo-watch functionality has been broken on
Linux systems.

The cause seems to be that linux takes the added quotes inside process
arguments literally, so it attempts to make cargo-watch run the command
`cargo "check --message-format json"` with the entire quoted part being
treated as a single long subcommand, which cargo doesn't know how to
handle.

Removing the extra quotes solves the issue.

Closes #1096 