### PR TITLE
Parse unsafe async / const unsafe fns properly

### DIFF
--- a/crates/ra_parser/src/grammar/items.rs
+++ b/crates/ra_parser/src/grammar/items.rs
@@ -79,19 +79,22 @@ pub(super) fn maybe_item(p: &mut Parser, m: Marker, flavor: ItemFlavor) -> Resul
     let mut has_mods = false;
 
     // modifiers
-    // test_err async_without_semicolon
-    // fn foo() { let _ = async {} }
     has_mods |= p.eat(CONST_KW);
-    if p.at(ASYNC_KW) && p.nth(1) != L_CURLY && p.nth(1) != MOVE_KW && p.nth(1) != PIPE {
-        p.eat(ASYNC_KW);
-        has_mods = true;
-    }
+
     // test_err unsafe_block_in_mod
     // fn foo(){} unsafe { } fn bar(){}
     if p.at(UNSAFE_KW) && p.nth(1) != L_CURLY {
         p.eat(UNSAFE_KW);
         has_mods = true;
     }
+
+    // test_err async_without_semicolon
+    // fn foo() { let _ = async {} }
+    if p.at(ASYNC_KW) && p.nth(1) != L_CURLY && p.nth(1) != MOVE_KW && p.nth(1) != PIPE {
+        p.eat(ASYNC_KW);
+        has_mods = true;
+    }
+
     if p.at(EXTERN_KW) {
         has_mods = true;
         abi(p);
@@ -124,6 +127,14 @@ pub(super) fn maybe_item(p: &mut Parser, m: Marker, flavor: ItemFlavor) -> Resul
 
         // test unsafe_fn
         // unsafe fn foo() {}
+
+        // test combined_fns
+        // unsafe async fn foo() {}
+        // const unsafe fn bar() {}
+
+        // test_err wrong_order_fns
+        // async unsafe fn foo() {}
+        // unsafe const fn bar() {}
         FN_KW => {
             fn_def(p, flavor);
             m.complete(p, FN_DEF);

--- a/crates/ra_syntax/tests/data/parser/inline/err/0010_wrong_order_fns.rs
+++ b/crates/ra_syntax/tests/data/parser/inline/err/0010_wrong_order_fns.rs
@@ -1,0 +1,2 @@
+async unsafe fn foo() {}
+unsafe const fn bar() {}

--- a/crates/ra_syntax/tests/data/parser/inline/err/0010_wrong_order_fns.txt
+++ b/crates/ra_syntax/tests/data/parser/inline/err/0010_wrong_order_fns.txt
@@ -1,0 +1,39 @@
+SOURCE_FILE@[0; 50)
+  ERROR@[0; 5)
+    ASYNC_KW@[0; 5) "async"
+    err: `expected fn, trait or impl`
+  WHITESPACE@[5; 6) " "
+  FN_DEF@[6; 24)
+    UNSAFE_KW@[6; 12) "unsafe"
+    WHITESPACE@[12; 13) " "
+    FN_KW@[13; 15) "fn"
+    WHITESPACE@[15; 16) " "
+    NAME@[16; 19)
+      IDENT@[16; 19) "foo"
+    PARAM_LIST@[19; 21)
+      L_PAREN@[19; 20) "("
+      R_PAREN@[20; 21) ")"
+    WHITESPACE@[21; 22) " "
+    BLOCK@[22; 24)
+      L_CURLY@[22; 23) "{"
+      R_CURLY@[23; 24) "}"
+  WHITESPACE@[24; 25) "\n"
+  ERROR@[25; 31)
+    UNSAFE_KW@[25; 31) "unsafe"
+    err: `expected fn, trait or impl`
+  WHITESPACE@[31; 32) " "
+  FN_DEF@[32; 49)
+    CONST_KW@[32; 37) "const"
+    WHITESPACE@[37; 38) " "
+    FN_KW@[38; 40) "fn"
+    WHITESPACE@[40; 41) " "
+    NAME@[41; 44)
+      IDENT@[41; 44) "bar"
+    PARAM_LIST@[44; 46)
+      L_PAREN@[44; 45) "("
+      R_PAREN@[45; 46) ")"
+    WHITESPACE@[46; 47) " "
+    BLOCK@[47; 49)
+      L_CURLY@[47; 48) "{"
+      R_CURLY@[48; 49) "}"
+  WHITESPACE@[49; 50) "\n"

--- a/crates/ra_syntax/tests/data/parser/inline/ok/0128_combined_fns.rs
+++ b/crates/ra_syntax/tests/data/parser/inline/ok/0128_combined_fns.rs
@@ -1,0 +1,2 @@
+unsafe async fn foo() {}
+const unsafe fn bar() {}

--- a/crates/ra_syntax/tests/data/parser/inline/ok/0128_combined_fns.txt
+++ b/crates/ra_syntax/tests/data/parser/inline/ok/0128_combined_fns.txt
@@ -1,0 +1,35 @@
+SOURCE_FILE@[0; 50)
+  FN_DEF@[0; 24)
+    UNSAFE_KW@[0; 6) "unsafe"
+    WHITESPACE@[6; 7) " "
+    ASYNC_KW@[7; 12) "async"
+    WHITESPACE@[12; 13) " "
+    FN_KW@[13; 15) "fn"
+    WHITESPACE@[15; 16) " "
+    NAME@[16; 19)
+      IDENT@[16; 19) "foo"
+    PARAM_LIST@[19; 21)
+      L_PAREN@[19; 20) "("
+      R_PAREN@[20; 21) ")"
+    WHITESPACE@[21; 22) " "
+    BLOCK@[22; 24)
+      L_CURLY@[22; 23) "{"
+      R_CURLY@[23; 24) "}"
+  WHITESPACE@[24; 25) "\n"
+  FN_DEF@[25; 49)
+    CONST_KW@[25; 30) "const"
+    WHITESPACE@[30; 31) " "
+    UNSAFE_KW@[31; 37) "unsafe"
+    WHITESPACE@[37; 38) " "
+    FN_KW@[38; 40) "fn"
+    WHITESPACE@[40; 41) " "
+    NAME@[41; 44)
+      IDENT@[41; 44) "bar"
+    PARAM_LIST@[44; 46)
+      L_PAREN@[44; 45) "("
+      R_PAREN@[45; 46) ")"
+    WHITESPACE@[46; 47) " "
+    BLOCK@[47; 49)
+      L_CURLY@[47; 48) "{"
+      R_CURLY@[48; 49) "}"
+  WHITESPACE@[49; 50) "\n"


### PR DESCRIPTION
Also adds tests that `unsafe async fn` as well as `const unsafe fn` parse properly and that these keywords in the reversed order cause parse errors.

[Playground link to verify that this is the correct order.](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2018&gist=7850b8d92579de31c38f835f76afa4ce)

Closes #1086.
