### PR TITLE
Add .gitattributes for fix Windows Line-ending problem in `generated_grammar_is_fresh`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+crates/ra_syntax/tests/data/** -text


### PR DESCRIPTION
Although https://github.com/rust-analyzer/rust-analyzer/issues/937 is marked as `Closed` . But it should work without setting `core.autocrlf` to `false` by this PR.