### PR TITLE
More trait infrastructure

### DIFF
--- a/crates/ra_hir/src/code_model_api.rs
+++ b/crates/ra_hir/src/code_model_api.rs
@@ -11,7 +11,7 @@ use crate::{
     expr::{Body, BodySourceMap},
     ty::InferenceResult,
     adt::{EnumVariantId, StructFieldId, VariantDef},
-    generics::GenericParams,
+    generics::HasGenericParams,
     docs::{Documentation, Docs, docs_from_ast},
     ids::{FunctionId, StructId, EnumId, AstItemDef, ConstId, StaticId, TraitId, TypeAliasId},
     impl_block::ImplBlock,
@@ -299,10 +299,6 @@ impl Struct {
             .map(|(id, _)| StructField { parent: (*self).into(), id })
     }
 
-    pub fn generic_params(&self, db: &impl DefDatabase) -> Arc<GenericParams> {
-        db.generic_params((*self).into())
-    }
-
     pub fn ty(&self, db: &impl HirDatabase) -> Ty {
         db.type_for_def((*self).into(), Namespace::Types)
     }
@@ -361,10 +357,6 @@ impl Enum {
             .iter()
             .find(|(_id, data)| data.name.as_ref() == Some(name))
             .map(|(id, _)| EnumVariant { parent: *self, id })
-    }
-
-    pub fn generic_params(&self, db: &impl DefDatabase) -> Arc<GenericParams> {
-        db.generic_params((*self).into())
     }
 
     pub fn ty(&self, db: &impl HirDatabase) -> Ty {
@@ -537,10 +529,6 @@ impl Function {
         db.infer((*self).into())
     }
 
-    pub fn generic_params(&self, db: &impl DefDatabase) -> Arc<GenericParams> {
-        db.generic_params((*self).into())
-    }
-
     /// The containing impl block, if this is a method.
     pub fn impl_block(&self, db: &impl DefDatabase) -> Option<ImplBlock> {
         let module_impls = db.impls_in_module(self.module(db));
@@ -696,10 +684,6 @@ impl Trait {
         self.id.module(db)
     }
 
-    pub fn generic_params(&self, db: &impl DefDatabase) -> Arc<GenericParams> {
-        db.generic_params((*self).into())
-    }
-
     pub fn name(self, db: &impl DefDatabase) -> Option<Name> {
         self.trait_data(db).name().clone()
     }
@@ -735,10 +719,6 @@ pub struct TypeAlias {
 impl TypeAlias {
     pub fn source(&self, db: &impl DefDatabase) -> (HirFileId, TreeArc<ast::TypeAliasDef>) {
         self.id.source(db)
-    }
-
-    pub fn generic_params(&self, db: &impl DefDatabase) -> Arc<GenericParams> {
-        db.generic_params((*self).into())
     }
 
     pub fn module(&self, db: &impl DefDatabase) -> Module {

--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -53,6 +53,9 @@ pub trait DefDatabase: SourceDatabase {
     #[salsa::invoke(crate::traits::TraitData::trait_data_query)]
     fn trait_data(&self, t: Trait) -> Arc<TraitData>;
 
+    #[salsa::invoke(crate::traits::TraitItemsIndex::trait_items_index)]
+    fn trait_items_index(&self, module: Module) -> crate::traits::TraitItemsIndex;
+
     #[salsa::invoke(crate::source_id::AstIdMap::ast_id_map_query)]
     fn ast_id_map(&self, file_id: HirFileId) -> Arc<AstIdMap>;
 
@@ -128,8 +131,8 @@ pub trait HirDatabase: DefDatabase {
     #[salsa::invoke(crate::ty::method_resolution::CrateImplBlocks::impls_in_crate_query)]
     fn impls_in_crate(&self, krate: Crate) -> Arc<CrateImplBlocks>;
 
-    #[salsa::invoke(crate::ty::method_resolution::implements)]
-    fn implements(&self, trait_ref: TraitRef) -> bool;
+    #[salsa::invoke(crate::ty::traits::implements)]
+    fn implements(&self, trait_ref: TraitRef) -> Option<crate::ty::traits::Solution>;
 }
 
 #[test]

--- a/crates/ra_hir/src/generics.rs
+++ b/crates/ra_hir/src/generics.rs
@@ -56,7 +56,11 @@ impl GenericParams {
             GenericDef::Function(it) => generics.fill(&*it.source(db).1, start),
             GenericDef::Struct(it) => generics.fill(&*it.source(db).1, start),
             GenericDef::Enum(it) => generics.fill(&*it.source(db).1, start),
-            GenericDef::Trait(it) => generics.fill(&*it.source(db).1, start),
+            GenericDef::Trait(it) => {
+                // traits get the Self type as an implicit first type parameter
+                generics.params.push(GenericParam { idx: start, name: Name::self_type() });
+                generics.fill(&*it.source(db).1, start + 1);
+            }
             GenericDef::TypeAlias(it) => generics.fill(&*it.source(db).1, start),
             GenericDef::ImplBlock(it) => generics.fill(&*it.source(db).1, start),
         }

--- a/crates/ra_hir/src/generics.rs
+++ b/crates/ra_hir/src/generics.rs
@@ -118,3 +118,16 @@ impl From<Container> for GenericDef {
         }
     }
 }
+
+pub trait HasGenericParams {
+    fn generic_params(self, db: &impl DefDatabase) -> Arc<GenericParams>;
+}
+
+impl<T> HasGenericParams for T
+where
+    T: Into<GenericDef>,
+{
+    fn generic_params(self, db: &impl DefDatabase) -> Arc<GenericParams> {
+        db.generic_params(self.into())
+    }
+}

--- a/crates/ra_hir/src/impl_block.rs
+++ b/crates/ra_hir/src/impl_block.rs
@@ -96,7 +96,7 @@ impl ImplBlock {
         db.generic_params((*self).into())
     }
 
-    pub(crate) fn resolver(&self, db: &impl HirDatabase) -> Resolver {
+    pub(crate) fn resolver(&self, db: &impl DefDatabase) -> Resolver {
         let r = self.module().resolver(db);
         // add generic params, if present
         let p = self.generic_params(db);

--- a/crates/ra_hir/src/impl_block.rs
+++ b/crates/ra_hir/src/impl_block.rs
@@ -84,7 +84,8 @@ impl ImplBlock {
     }
 
     pub fn target_trait_ref(&self, db: &impl HirDatabase) -> Option<TraitRef> {
-        TraitRef::from_hir(db, &self.resolver(db), &self.target_trait(db)?)
+        let target_ty = self.target_ty(db);
+        TraitRef::from_hir(db, &self.resolver(db), &self.target_trait(db)?, Some(target_ty))
     }
 
     pub fn items(&self, db: &impl DefDatabase) -> Vec<ImplItem> {

--- a/crates/ra_hir/src/impl_block.rs
+++ b/crates/ra_hir/src/impl_block.rs
@@ -9,12 +9,13 @@ use ra_syntax::{
 
 use crate::{
     Const, TypeAlias, Function, HirFileId,
-    HirDatabase, DefDatabase,
+    HirDatabase, DefDatabase, TraitRef,
     type_ref::TypeRef,
     ids::LocationCtx,
     resolve::Resolver,
-    ty::Ty, generics::GenericParams,
-    TraitRef, code_model_api::{Module, ModuleSource}
+    ty::Ty,
+    generics::HasGenericParams,
+    code_model_api::{Module, ModuleSource}
 };
 
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -90,10 +91,6 @@ impl ImplBlock {
 
     pub fn items(&self, db: &impl DefDatabase) -> Vec<ImplItem> {
         db.impls_in_module(self.module).impls[self.impl_id].items().to_vec()
-    }
-
-    pub fn generic_params(&self, db: &impl DefDatabase) -> Arc<GenericParams> {
-        db.generic_params((*self).into())
     }
 
     pub(crate) fn resolver(&self, db: &impl DefDatabase) -> Resolver {

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -61,7 +61,7 @@ pub use self::{
     source_id::{AstIdMap, ErasedFileAstId},
     ids::{HirFileId, MacroDefId, MacroCallId, MacroCallLoc},
     nameres::{PerNs, Namespace, ImportId},
-    ty::{Ty, ApplicationTy, TypeCtor, Substs, display::HirDisplay, CallableDef},
+    ty::{Ty, ApplicationTy, TypeCtor, TraitRef, Substs, display::HirDisplay, CallableDef},
     impl_block::{ImplBlock, ImplItem},
     docs::{Docs, Documentation},
     adt::AdtDef,

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -67,6 +67,7 @@ pub use self::{
     adt::AdtDef,
     expr::ExprScopes,
     resolve::Resolution,
+    generics::{GenericParams, GenericParam, HasGenericParams},
     source_binder::{SourceAnalyzer, PathResolution, ScopeEntryWithSyntax},
 };
 

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -78,5 +78,5 @@ pub use self::code_model_api::{
     Function, FnSignature,
     StructField, FieldSource,
     Static, Const, ConstSignature,
-    Trait, TypeAlias,
+    Trait, TypeAlias, Container,
 };

--- a/crates/ra_hir/src/ty.rs
+++ b/crates/ra_hir/src/ty.rs
@@ -5,6 +5,7 @@ mod autoderef;
 pub(crate) mod primitive;
 #[cfg(test)]
 mod tests;
+pub(crate) mod traits;
 pub(crate) mod method_resolution;
 mod op;
 mod lower;
@@ -145,6 +146,10 @@ impl Substs {
         Substs(Arc::new([ty]))
     }
 
+    pub fn prefix(&self, n: usize) -> Substs {
+        Substs(self.0.iter().cloned().take(n).collect::<Vec<_>>().into())
+    }
+
     pub fn iter(&self) -> impl Iterator<Item = &Ty> {
         self.0.iter()
     }
@@ -167,6 +172,12 @@ impl Substs {
             panic!("expected substs of len 1, got {:?}", self);
         }
         &self.0[0]
+    }
+}
+
+impl From<Vec<Ty>> for Substs {
+    fn from(v: Vec<Ty>) -> Self {
+        Substs(v.into())
     }
 }
 

--- a/crates/ra_hir/src/ty/infer.rs
+++ b/crates/ra_hir/src/ty/infer.rs
@@ -20,9 +20,9 @@ use std::sync::Arc;
 use std::mem;
 
 use ena::unify::{InPlaceUnificationTable, UnifyKey, UnifyValue, NoError};
-use ra_arena::map::ArenaMap;
 use rustc_hash::FxHashMap;
 
+use ra_arena::map::ArenaMap;
 use test_utils::tested_by;
 
 use crate::{
@@ -33,15 +33,18 @@ use crate::{
     ImplItem,
     type_ref::{TypeRef, Mutability},
     expr::{Body, Expr, BindingAnnotation, Literal, ExprId, Pat, PatId, UnaryOp, BinaryOp, Statement, FieldPat,Array, self},
-    generics::GenericParams,
+    generics::{GenericParams, HasGenericParams},
     path::{GenericArgs, GenericArg},
     adt::VariantDef,
     resolve::{Resolver, Resolution},
     nameres::Namespace,
-    ty::infer::diagnostics::InferenceDiagnostic,
     diagnostics::DiagnosticSink,
 };
-use super::{Ty, TypableDef, Substs, primitive, op, ApplicationTy, TypeCtor, traits::{ Solution, Obligation, Guidance}, CallableDef, TraitRef};
+use super::{
+    Ty, TypableDef, Substs, primitive, op, ApplicationTy, TypeCtor, CallableDef, TraitRef,
+    traits::{ Solution, Obligation, Guidance},
+};
+use self::diagnostics::InferenceDiagnostic;
 
 /// The entry point of type inference.
 pub fn infer(db: &impl HirDatabase, def: DefWithBody) -> Arc<InferenceResult> {

--- a/crates/ra_hir/src/ty/lower.rs
+++ b/crates/ra_hir/src/ty/lower.rs
@@ -16,8 +16,8 @@ use crate::{
     name::KnownName,
     nameres::Namespace,
     resolve::{Resolver, Resolution},
-    path::{ PathSegment, GenericArg},
-    generics::GenericParams,
+    path::{PathSegment, GenericArg},
+    generics::{GenericParams, HasGenericParams},
     adt::VariantDef, Trait
 };
 use super::{Ty, primitive, FnSig, Substs, TypeCtor, TraitRef};

--- a/crates/ra_hir/src/ty/lower.rs
+++ b/crates/ra_hir/src/ty/lower.rs
@@ -206,6 +206,7 @@ impl TraitRef {
         db: &impl HirDatabase,
         resolver: &Resolver,
         type_ref: &TypeRef,
+        explicit_self_ty: Option<Ty>,
     ) -> Option<Self> {
         let path = match type_ref {
             TypeRef::Path(path) => path,
@@ -215,7 +216,13 @@ impl TraitRef {
             Resolution::Def(ModuleDef::Trait(tr)) => tr,
             _ => return None,
         };
-        let substs = Self::substs_from_path(db, resolver, path, resolved);
+        let mut substs = Self::substs_from_path(db, resolver, path, resolved);
+        if let Some(self_ty) = explicit_self_ty {
+            // FIXME this could be nicer
+            let mut substs_vec = substs.0.to_vec();
+            substs_vec[0] = self_ty;
+            substs.0 = substs_vec.into();
+        }
         Some(TraitRef { trait_: resolved, substs })
     }
 

--- a/crates/ra_hir/src/ty/method_resolution.rs
+++ b/crates/ra_hir/src/ty/method_resolution.rs
@@ -72,9 +72,9 @@ impl CrateImplBlocks {
 
             let target_ty = impl_block.target_ty(db);
 
-            if let Some(tr) = impl_block.target_trait(db) {
+            if let Some(tr) = impl_block.target_trait_ref(db) {
                 self.impls_by_trait
-                    .entry(tr)
+                    .entry(tr.trait_)
                     .or_insert_with(Vec::new)
                     .push((module.module_id, impl_id));
             } else {
@@ -185,6 +185,8 @@ impl Ty {
         //    well (in fact, the 'implements' condition could just be considered a
         //    'where Self: Trait' clause)
         candidates.retain(|(t, _m)| {
+            // FIXME construct substs of the correct length for the trait
+            //  - check in rustc whether it does anything smarter than putting variables for everything
             let trait_ref = TraitRef { trait_: *t, substs: Substs::single(self.clone()) };
             db.implements(trait_ref)
         });

--- a/crates/ra_hir/src/ty/method_resolution.rs
+++ b/crates/ra_hir/src/ty/method_resolution.rs
@@ -233,15 +233,16 @@ impl Ty {
     }
 }
 
+/// This creates Substs for a trait with the given Self type and type variables
+/// for all other parameters. This is kind of a hack since these aren't 'real'
+/// type variables; the resulting trait reference is just used for the
+/// preliminary method candidate check.
 fn fresh_substs_for_trait(db: &impl HirDatabase, tr: Trait, self_ty: Ty) -> Substs {
     let mut substs = Vec::new();
-    let mut counter = 0;
     let generics = tr.generic_params(db);
     substs.push(self_ty);
-    substs.extend(generics.params_including_parent().into_iter().skip(1).map(|_p| {
-        let fresh_var = Ty::Infer(super::infer::InferTy::TypeVar(super::infer::TypeVarId(counter)));
-        counter += 1;
-        fresh_var
-    }));
+    substs.extend(generics.params_including_parent().into_iter().skip(1).enumerate().map(
+        |(i, _p)| Ty::Infer(super::infer::InferTy::TypeVar(super::infer::TypeVarId(i as u32))),
+    ));
     substs.into()
 }

--- a/crates/ra_hir/src/ty/method_resolution.rs
+++ b/crates/ra_hir/src/ty/method_resolution.rs
@@ -10,10 +10,12 @@ use crate::{
     HirDatabase, Module, Crate, Name, Function, Trait,
     impl_block::{ImplId, ImplBlock, ImplItem},
     ty::{Ty, TypeCtor},
-    nameres::CrateModuleId, resolve::Resolver, traits::TraitItem
-
+    nameres::CrateModuleId,
+    resolve::Resolver,
+    traits::TraitItem,
+    generics::HasGenericParams,
 };
-use super::{ TraitRef, Substs};
+use super::{TraitRef, Substs};
 
 /// This is used as a key for indexing impls.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/crates/ra_hir/src/ty/traits.rs
+++ b/crates/ra_hir/src/ty/traits.rs
@@ -1,0 +1,112 @@
+//! Stuff that will probably mostly replaced by Chalk.
+use std::collections::HashMap;
+
+use crate::db::HirDatabase;
+use super::{ TraitRef, Substs, infer::{ TypeVarId, InferTy}, Ty};
+
+// Copied (and simplified) from Chalk
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+/// A (possible) solution for a proposed goal. Usually packaged in a `Result`,
+/// where `Err` represents definite *failure* to prove a goal.
+pub enum Solution {
+    /// The goal indeed holds, and there is a unique value for all existential
+    /// variables.
+    Unique(Substs),
+
+    /// The goal may be provable in multiple ways, but regardless we may have some guidance
+    /// for type inference.
+    Ambig(Guidance),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+/// When a goal holds ambiguously (e.g., because there are multiple possible
+/// solutions), we issue a set of *guidance* back to type inference.
+pub enum Guidance {
+    /// The existential variables *must* have the given values if the goal is
+    /// ever to hold, but that alone isn't enough to guarantee the goal will
+    /// actually hold.
+    Definite(Substs),
+
+    /// There are multiple plausible values for the existentials, but the ones
+    /// here are suggested as the preferred choice heuristically. These should
+    /// be used for inference fallback only.
+    Suggested(Substs),
+
+    /// There's no useful information to feed back to type inference
+    Unknown,
+}
+
+/// Something that needs to be proven (by Chalk) during type checking, e.g. that
+/// a certain type implements a certain trait. Proving the Obligation might
+/// result in additional information about inference variables.
+///
+/// This might be handled by Chalk when we integrate it?
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Obligation {
+    /// Prove that a certain type implements a trait (the type is the `Self` type
+    /// parameter to the `TraitRef`).
+    Trait(TraitRef),
+}
+
+/// Rudimentary check whether an impl exists for a given type and trait; this
+/// will actually be done by chalk.
+pub(crate) fn implements(db: &impl HirDatabase, trait_ref: TraitRef) -> Option<Solution> {
+    // FIXME use all trait impls in the whole crate graph
+    let krate = trait_ref.trait_.module(db).krate(db);
+    let krate = match krate {
+        Some(krate) => krate,
+        None => return None,
+    };
+    let crate_impl_blocks = db.impls_in_crate(krate);
+    let mut impl_blocks = crate_impl_blocks.lookup_impl_blocks_for_trait(&trait_ref.trait_);
+    impl_blocks
+        .find_map(|impl_block| unify_trait_refs(&trait_ref, &impl_block.target_trait_ref(db)?))
+}
+
+pub(super) fn canonicalize(trait_ref: TraitRef) -> (TraitRef, Vec<TypeVarId>) {
+    let mut canonical = HashMap::new(); // mapping uncanonical -> canonical
+    let mut uncanonical = Vec::new(); // mapping canonical -> uncanonical (which is dense)
+    let mut substs = trait_ref.substs.0.to_vec();
+    for ty in &mut substs {
+        ty.walk_mut(&mut |ty| match ty {
+            Ty::Infer(InferTy::TypeVar(tv)) => {
+                let tv: &mut TypeVarId = tv;
+                *tv = *canonical.entry(*tv).or_insert_with(|| {
+                    let i = uncanonical.len();
+                    uncanonical.push(*tv);
+                    TypeVarId(i as u32)
+                });
+            }
+            _ => {}
+        });
+    }
+    (TraitRef { substs: substs.into(), ..trait_ref }, uncanonical)
+}
+
+fn unify_trait_refs(tr1: &TraitRef, tr2: &TraitRef) -> Option<Solution> {
+    if tr1.trait_ != tr2.trait_ {
+        return None;
+    }
+    let mut solution_substs = Vec::new();
+    for (t1, t2) in tr1.substs.0.iter().zip(tr2.substs.0.iter()) {
+        // this is very bad / hacky 'unification' logic, just enough to make the simple tests pass
+        match (t1, t2) {
+            (_, Ty::Infer(InferTy::TypeVar(_))) | (_, Ty::Unknown) | (_, Ty::Param { .. }) => {
+                // type variable (or similar) in the impl, we just assume it works
+            }
+            (Ty::Infer(InferTy::TypeVar(v1)), _) => {
+                // type variable in the query and fixed type in the impl, record its value
+                solution_substs.resize_with(v1.0 as usize + 1, || Ty::Unknown);
+                solution_substs[v1.0 as usize] = t2.clone();
+            }
+            _ => {
+                // check that they're equal (actually we'd have to recurse etc.)
+                if t1 != t2 {
+                    return None;
+                }
+            }
+        }
+    }
+    Some(Solution::Unique(solution_substs.into()))
+}

--- a/crates/ra_ide_api/src/goto_definition.rs
+++ b/crates/ra_ide_api/src/goto_definition.rs
@@ -104,7 +104,7 @@ pub(crate) fn reference_definition(
                     }
                 }
                 hir::PathResolution::AssocItem(assoc) => {
-                    return Exact(NavigationTarget::from_impl_item(db, assoc))
+                    return Exact(NavigationTarget::from_impl_item(db, assoc));
                 }
             }
         }


### PR DESCRIPTION
This adds enough trait infrastructure to be able to make some deductions about type variables when resolving trait methods, while at the same time doing as little as possible that will be later replaced by Chalk :smile: 

E.g. (as the tests show) if we have
```rust
trait Trait<T> { fn method(self) -> T }
impl Trait<u32> for S {}
...
S.method()
```
we can infer that the return type is `u32`. On the other hand the unification logic is so primitive that we can't handle e.g. `impl<T> Trait<T> for S<T>`.

It's all quite hacky, I plan to refactor the parts that will stay, while hopefully the other parts will be replaced soon :slightly_smiling_face: In particular, we need to handle 'containers' (impls and trait defs) more cleanly, and I need to reorganize the method resolution / type inference code...