### PR TITLE
[WIP] Add mbe matchers for expr, ty and patten

### DIFF
--- a/crates/ra_mbe/src/lib.rs
+++ b/crates/ra_mbe/src/lib.rs
@@ -432,4 +432,52 @@ SOURCE_FILE@[0; 40)
         );
         assert_expansion(&rules, "foo! { foo, bar }", "fn foo () {let a = foo ; let b = bar ;}");
     }
+
+    #[test]
+    fn test_expr() {
+        let rules = create_rules(
+            r#"
+        macro_rules! foo {
+            ($ i:expr) => {
+                 fn bar() { $ i; } 
+            }
+        }
+"#,
+        );
+        assert_expansion(
+            &rules,
+            "foo! { 2 + 2 * baz(3).quux() }",
+            "fn bar () {(2 + 2 * baz (3) . quux ()) ;}",
+        );
+    }
+
+    #[test]
+    fn test_ty() {
+        let rules = create_rules(
+            r#"
+        macro_rules! foo {
+            ($ i:ty) => (
+                fn bar() -> $ i { unimplemented!() }
+            )
+        }
+"#,
+        );
+        assert_expansion(
+            &rules,
+            "foo! { Baz<u8> }",
+            "fn bar () -> Baz < u8 > {unimplemented ! ()}",
+        );
+    }
+
+    #[test]
+    fn test_pat() {
+        let rules = create_rules(
+            r#"
+        macro_rules! foo {
+            ($ i:pat) => { fn foo() { let $ i; } }
+        }
+"#,
+        );
+        assert_expansion(&rules, "foo! { (a, b) }", "fn foo () {let (a , b) ;}");
+    }
 }

--- a/crates/ra_mbe/src/mbe_expander.rs
+++ b/crates/ra_mbe/src/mbe_expander.rs
@@ -144,6 +144,19 @@ fn match_lhs(pattern: &crate::Subtree, input: &mut TtCursor) -> Result<Bindings,
                                 input.eat_path().ok_or(ExpandError::UnexpectedToken)?.clone();
                             res.inner.insert(text.clone(), Binding::Simple(path.into()));
                         }
+                        "expr" => {
+                            let expr =
+                                input.eat_expr().ok_or(ExpandError::UnexpectedToken)?.clone();
+                            res.inner.insert(text.clone(), Binding::Simple(expr.into()));
+                        }
+                        "ty" => {
+                            let ty = input.eat_ty().ok_or(ExpandError::UnexpectedToken)?.clone();
+                            res.inner.insert(text.clone(), Binding::Simple(ty.into()));
+                        }
+                        "pat" => {
+                            let pat = input.eat_pat().ok_or(ExpandError::UnexpectedToken)?.clone();
+                            res.inner.insert(text.clone(), Binding::Simple(pat.into()));
+                        }
                         _ => return Err(ExpandError::UnexpectedToken),
                     }
                 }

--- a/crates/ra_mbe/src/subtree_parser.rs
+++ b/crates/ra_mbe/src/subtree_parser.rs
@@ -30,6 +30,31 @@ impl<'a> Parser<'a> {
         self.parse(ra_parser::parse_path)
     }
 
+    pub fn parse_expr(self) -> Option<tt::TokenTree> {
+        let expr = self.parse(ra_parser::parse_expr);
+        expr.map(|mut tt| {
+            // Add a parenthesis for complex expression
+            match tt {
+                tt::TokenTree::Subtree(ref mut subtree) => {
+                    if let tt::Delimiter::None = subtree.delimiter {
+                        subtree.delimiter = tt::Delimiter::Parenthesis;
+                    }
+
+                    tt
+                }
+                _ => tt,
+            }
+        })
+    }
+
+    pub fn parse_ty(self) -> Option<tt::TokenTree> {
+        self.parse(ra_parser::parse_ty)
+    }
+
+    pub fn parse_pat(self) -> Option<tt::TokenTree> {
+        self.parse(ra_parser::parse_pat)
+    }
+
     fn parse<F>(self, f: F) -> Option<tt::TokenTree>
     where
         F: FnOnce(&dyn TokenSource, &mut dyn TreeSink),

--- a/crates/ra_mbe/src/tt_cursor.rs
+++ b/crates/ra_mbe/src/tt_cursor.rs
@@ -84,6 +84,21 @@ impl<'a> TtCursor<'a> {
         parser.parse_path()
     }
 
+    pub(crate) fn eat_expr(&mut self) -> Option<tt::TokenTree> {
+        let parser = Parser::new(&mut self.pos, self.subtree);
+        parser.parse_expr()
+    }
+
+    pub(crate) fn eat_ty(&mut self) -> Option<tt::TokenTree> {
+        let parser = Parser::new(&mut self.pos, self.subtree);
+        parser.parse_ty()
+    }
+
+    pub(crate) fn eat_pat(&mut self) -> Option<tt::TokenTree> {
+        let parser = Parser::new(&mut self.pos, self.subtree);
+        parser.parse_pat()
+    }
+
     pub(crate) fn expect_char(&mut self, char: char) -> Result<(), ParseError> {
         if self.at_char(char) {
             self.bump();

--- a/crates/ra_parser/src/grammar.rs
+++ b/crates/ra_parser/src/grammar.rs
@@ -53,6 +53,18 @@ pub(crate) fn path(p: &mut Parser) {
     paths::type_path(p);
 }
 
+pub(crate) fn expr(p: &mut Parser) {
+    expressions::expr(p);
+}
+
+pub(crate) fn type_(p: &mut Parser) {
+    types::type_(p)
+}
+
+pub(crate) fn pattern(p: &mut Parser) {
+    patterns::pattern(p)
+}
+
 pub(crate) fn reparser(
     node: SyntaxKind,
     first_child: Option<SyntaxKind>,

--- a/crates/ra_parser/src/lib.rs
+++ b/crates/ra_parser/src/lib.rs
@@ -53,20 +53,39 @@ pub trait TreeSink {
     fn error(&mut self, error: ParseError);
 }
 
-/// Parse given tokens into the given sink as a rust file.
-pub fn parse(token_source: &dyn TokenSource, tree_sink: &mut dyn TreeSink) {
+fn parse_from_tokens<F>(token_source: &dyn TokenSource, tree_sink: &mut dyn TreeSink, f: F)
+where
+    F: FnOnce(&mut parser::Parser),
+{
     let mut p = parser::Parser::new(token_source);
-    grammar::root(&mut p);
+    f(&mut p);
     let events = p.finish();
     event::process(tree_sink, events);
 }
 
+/// Parse given tokens into the given sink as a rust file.
+pub fn parse(token_source: &dyn TokenSource, tree_sink: &mut dyn TreeSink) {
+    parse_from_tokens(token_source, tree_sink, grammar::root);
+}
+
 /// Parse given tokens into the given sink as a path
 pub fn parse_path(token_source: &dyn TokenSource, tree_sink: &mut dyn TreeSink) {
-    let mut p = parser::Parser::new(token_source);
-    grammar::path(&mut p);
-    let events = p.finish();
-    event::process(tree_sink, events);
+    parse_from_tokens(token_source, tree_sink, grammar::path);
+}
+
+/// Parse given tokens into the given sink as a expression
+pub fn parse_expr(token_source: &dyn TokenSource, tree_sink: &mut dyn TreeSink) {
+    parse_from_tokens(token_source, tree_sink, grammar::expr);
+}
+
+/// Parse given tokens into the given sink as a ty
+pub fn parse_ty(token_source: &dyn TokenSource, tree_sink: &mut dyn TreeSink) {
+    parse_from_tokens(token_source, tree_sink, grammar::type_);
+}
+
+/// Parse given tokens into the given sink as a pattern
+pub fn parse_pat(token_source: &dyn TokenSource, tree_sink: &mut dyn TreeSink) {
+    parse_from_tokens(token_source, tree_sink, grammar::pattern);
 }
 
 /// A parsing function for a specific braced-block.


### PR DESCRIPTION
Add `expr`, `ty` and `pat` matchers for macro expansion.

According to [the book](https://doc.rust-lang.org/reference/macros-by-example.html), `stmt` matcher is "a Statement without the trailing semicolon". Current parser do not support this kind of statement, so that implementing `stmt` matcher will change the parser code.  I will create another PR for it to minimize this PR size. 