### PR TITLE
A touch of type-safety

### DIFF
--- a/crates/ra_hir/src/code_model_api.rs
+++ b/crates/ra_hir/src/code_model_api.rs
@@ -4,7 +4,7 @@ use ra_db::{CrateId, SourceRootId, Edition};
 use ra_syntax::{ast::self, TreeArc};
 
 use crate::{
-    Name, ScopesWithSourceMap, Ty, HirFileId, ImportSource,
+    Name, ScopesWithSourceMap, Ty, HirFileId, Either,
     HirDatabase, DefDatabase,
     type_ref::TypeRef,
     nameres::{ModuleScope, Namespace, ImportId, CrateModuleId},
@@ -117,8 +117,14 @@ impl Module {
     }
 
     /// Returns the syntax of the last path segment corresponding to this import
-    pub fn import_source(&self, db: &impl HirDatabase, import: ImportId) -> ImportSource {
-        self.import_source_impl(db, import)
+    pub fn import_source(
+        &self,
+        db: &impl HirDatabase,
+        import: ImportId,
+    ) -> Either<TreeArc<ast::UseTree>, TreeArc<ast::ExternCrateItem>> {
+        let (file_id, source) = self.definition_source(db);
+        let (_, source_map) = db.raw_items_with_source_map(file_id);
+        source_map.get(&source, import)
     }
 
     /// Returns the crate this module is part of.

--- a/crates/ra_hir/src/code_model_impl/module.rs
+++ b/crates/ra_hir/src/code_model_impl/module.rs
@@ -3,9 +3,9 @@ use ra_syntax::{ast, TreeArc};
 
 use crate::{
     Module, ModuleSource, Name, AstId,
-    nameres::{CrateModuleId, ImportId},
+    nameres::CrateModuleId,
     HirDatabase, DefDatabase,
-    HirFileId, ImportSource,
+    HirFileId,
 };
 
 impl ModuleSource {
@@ -66,16 +66,6 @@ impl Module {
         let decl = def_map[self.module_id].declaration?;
         let ast = decl.to_node(db);
         Some((decl.file_id(), ast))
-    }
-
-    pub(crate) fn import_source_impl(
-        &self,
-        db: &impl HirDatabase,
-        import: ImportId,
-    ) -> ImportSource {
-        let (file_id, source) = self.definition_source(db);
-        let (_, source_map) = db.raw_items_with_source_map(file_id);
-        source_map.get(&source, import)
     }
 
     pub(crate) fn crate_root_impl(&self, db: &impl DefDatabase) -> Module {

--- a/crates/ra_hir/src/either.rs
+++ b/crates/ra_hir/src/either.rs
@@ -1,0 +1,18 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Either<A, B> {
+    A(A),
+    B(B),
+}
+
+impl<A, B> Either<A, B> {
+    pub fn map<U, V, F1, F2>(self, f1: F1, f2: F2) -> Either<U, V>
+    where
+        F1: FnOnce(A) -> U,
+        F2: FnOnce(B) -> V,
+    {
+        match self {
+            Either::A(a) => Either::A(f1(a)),
+            Either::B(b) => Either::B(f2(b)),
+        }
+    }
+}

--- a/crates/ra_hir/src/either.rs
+++ b/crates/ra_hir/src/either.rs
@@ -5,6 +5,16 @@ pub enum Either<A, B> {
 }
 
 impl<A, B> Either<A, B> {
+    pub fn either<R, F1, F2>(self, f1: F1, f2: F2) -> R
+    where
+        F1: FnOnce(A) -> R,
+        F2: FnOnce(B) -> R,
+    {
+        match self {
+            Either::A(a) => f1(a),
+            Either::B(b) => f2(b),
+        }
+    }
     pub fn map<U, V, F1, F2>(self, f1: F1, f2: F2) -> Either<U, V>
     where
         F1: FnOnce(A) -> U,

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -17,6 +17,8 @@ macro_rules! impl_froms {
     }
 }
 
+mod either;
+
 pub mod db;
 #[macro_use]
 pub mod mock;
@@ -52,11 +54,12 @@ use crate::{
 };
 
 pub use self::{
+    either::Either,
     path::{Path, PathKind},
     name::Name,
     source_id::{AstIdMap, ErasedFileAstId},
     ids::{HirFileId, MacroDefId, MacroCallId, MacroCallLoc},
-    nameres::{PerNs, Namespace, ImportId, ImportSource},
+    nameres::{PerNs, Namespace, ImportId},
     ty::{Ty, ApplicationTy, TypeCtor, Substs, display::HirDisplay},
     impl_block::{ImplBlock, ImplItem},
     docs::{Docs, Documentation},

--- a/crates/ra_hir/src/nameres.rs
+++ b/crates/ra_hir/src/nameres.rs
@@ -75,7 +75,7 @@ pub(crate) use self::raw::{RawItems, ImportSourceMap};
 
 pub use self::{
     per_ns::{PerNs, Namespace},
-    raw::{ImportId, ImportSource},
+    raw::ImportId,
 };
 
 /// Contans all top-level defs from a macro-expanded crate

--- a/crates/ra_hir/src/ty/tests.rs
+++ b/crates/ra_hir/src/ty/tests.rs
@@ -2324,7 +2324,7 @@ fn infer(content: &str) -> String {
 
         for (pat, ty) in inference_result.type_of_pat.iter() {
             let syntax_ptr = match body_source_map.pat_syntax(pat) {
-                Some(sp) => sp,
+                Some(sp) => sp.either(|it| it.syntax_node_ptr(), |it| it.syntax_node_ptr()),
                 None => continue,
             };
             types.push((syntax_ptr, ty));

--- a/crates/ra_ide_api/src/completion/complete_path.rs
+++ b/crates/ra_ide_api/src/completion/complete_path.rs
@@ -1,4 +1,4 @@
-use hir::Resolution;
+use hir::{Resolution, Either};
 use ra_syntax::AstNode;
 use test_utils::tested_by;
 
@@ -19,10 +19,8 @@ pub(super) fn complete_path(acc: &mut Completions, ctx: &CompletionContext) {
             for (name, res) in module_scope.entries() {
                 if Some(module) == ctx.module {
                     if let Some(import) = res.import {
-                        if let hir::ImportSource::UseTree(tree) =
-                            module.import_source(ctx.db, import)
-                        {
-                            if tree.syntax().range().contains_inclusive(ctx.offset) {
+                        if let Either::A(use_tree) = module.import_source(ctx.db, import) {
+                            if use_tree.syntax().range().contains_inclusive(ctx.offset) {
                                 // for `use self::foo<|>`, don't suggest `foo` as a completion
                                 tested_by!(dont_complete_current_use);
                                 continue;

--- a/crates/ra_ide_api/src/goto_definition.rs
+++ b/crates/ra_ide_api/src/goto_definition.rs
@@ -113,6 +113,7 @@ pub(crate) fn reference_definition(
                 let ptr = source_map.pat_syntax(pat).expect("pattern not found in syntax mapping");
                 let name =
                     path.as_ident().cloned().expect("local binding from a multi-segment path");
+                let ptr = ptr.either(|it| it.into(), |it| it.into());
                 let nav = NavigationTarget::from_scope_entry(file_id, name, ptr);
                 return Exact(nav);
             }


### PR DESCRIPTION
Note that we intentionally don't use `Either` from crates.io: I like A/B naming more then left/rigth, I feel like we might need Either3 with C at some point, and I'd love the ability to write inherent impls