### PR TITLE
Refactor method candidate generation a bit

### DIFF
--- a/crates/ra_hir/src/source_binder.rs
+++ b/crates/ra_hir/src/source_binder.rs
@@ -18,7 +18,7 @@ use ra_syntax::{
 
 use crate::{
     HirDatabase, Function, Struct, Enum, Const, Static, Either, DefWithBody, PerNs, Name,
-    AsName, Module, HirFileId, Crate, Trait, Resolver,
+    AsName, Module, HirFileId, Crate, Trait, Resolver, Ty,
     expr::{BodySourceMap, scope::{ScopeId, ExprScopes}},
     ids::LocationCtx,
     expr, AstId
@@ -341,6 +341,16 @@ impl SourceAnalyzer {
                 range: name_ref.syntax().range(),
             })
             .collect()
+    }
+
+    pub fn iterate_method_candidates<T>(
+        &self,
+        db: &impl HirDatabase,
+        ty: Ty,
+        name: Option<&Name>,
+        callback: impl FnMut(&Ty, Function) -> Option<T>,
+    ) -> Option<T> {
+        ty.iterate_method_candidates(db, &self.resolver, name, callback)
     }
 
     #[cfg(test)]


### PR DESCRIPTION
This fixes the order in which candidates are chosen a bit (not completely though, as the ignored test demonstrates), and makes autoderef work with trait methods.
As a side effect, this also makes completion of trait methods work :)