### PR TITLE
Add token_tree_to_xxx functions

### DIFF
--- a/crates/ra_mbe/src/lib.rs
+++ b/crates/ra_mbe/src/lib.rs
@@ -204,7 +204,7 @@ impl_froms!(TokenTree: Leaf, Subtree);
         invocation: &str,
     ) -> ra_syntax::TreeArc<ast::MacroItems> {
         let expanded = expand(rules, invocation);
-        token_tree_to_macro_items(&expanded)
+        token_tree_to_macro_items(&expanded).unwrap()
     }
 
     pub(crate) fn assert_expansion(rules: &MacroRules, invocation: &str, expansion: &str) {
@@ -218,7 +218,10 @@ impl_froms!(TokenTree: Leaf, Subtree);
         let expansion = syntax_node_to_token_tree(expansion.syntax()).unwrap().0;
         let file = token_tree_to_macro_items(&expansion);
 
-        assert_eq!(tree.syntax().debug_dump().trim(), file.syntax().debug_dump().trim());
+        assert_eq!(
+            tree.unwrap().syntax().debug_dump().trim(),
+            file.unwrap().syntax().debug_dump().trim()
+        );
     }
 
     #[test]
@@ -358,7 +361,7 @@ impl_froms!(TokenTree: Leaf, Subtree);
         let expansion = expand(&rules, "structs!(Foo, Bar)");
         let tree = token_tree_to_macro_items(&expansion);
         assert_eq!(
-            tree.syntax().debug_dump().trim(),
+            tree.unwrap().syntax().debug_dump().trim(),
             r#"
 MACRO_ITEMS@[0; 40)
   STRUCT_DEF@[0; 20)
@@ -472,7 +475,7 @@ MACRO_ITEMS@[0; 40)
         let stmts = token_tree_to_macro_stmts(&expanded);
 
         assert_eq!(
-            stmts.syntax().debug_dump().trim(),
+            stmts.unwrap().syntax().debug_dump().trim(),
             r#"MACRO_STMTS@[0; 15)
   LET_STMT@[0; 7)
     LET_KW@[0; 3) "let"

--- a/crates/ra_mbe/src/syntax_bridge.rs
+++ b/crates/ra_mbe/src/syntax_bridge.rs
@@ -5,6 +5,7 @@ use ra_syntax::{
 };
 
 use crate::subtree_source::{SubtreeTokenSource, Querier};
+use crate::ExpandError;
 
 /// Maps `tt::TokenId` to the relative range of the original token.
 #[derive(Default)]
@@ -45,48 +46,54 @@ pub fn syntax_node_to_token_tree(node: &SyntaxNode) -> Option<(tt::Subtree, Toke
 //
 
 /// Parses the token tree (result of macro expansion) to an expression
-pub fn token_tree_to_expr(tt: &tt::Subtree) -> TreeArc<ast::Expr> {
+pub fn token_tree_to_expr(tt: &tt::Subtree) -> Result<TreeArc<ast::Expr>, ExpandError> {
     let token_source = SubtreeTokenSource::new(tt);
     let mut tree_sink = TtTreeSink::new(token_source.querier());
     ra_parser::parse_expr(&token_source, &mut tree_sink);
     let syntax = tree_sink.inner.finish();
-    ast::Expr::cast(&syntax).unwrap().to_owned()
+    ast::Expr::cast(&syntax)
+        .map(|m| m.to_owned())
+        .ok_or_else(|| crate::ExpandError::ConversionError)
 }
 
 /// Parses the token tree (result of macro expansion) to a Pattern
-pub fn token_tree_to_pat(tt: &tt::Subtree) -> TreeArc<ast::Pat> {
+pub fn token_tree_to_pat(tt: &tt::Subtree) -> Result<TreeArc<ast::Pat>, ExpandError> {
     let token_source = SubtreeTokenSource::new(tt);
     let mut tree_sink = TtTreeSink::new(token_source.querier());
     ra_parser::parse_pat(&token_source, &mut tree_sink);
     let syntax = tree_sink.inner.finish();
-    ast::Pat::cast(&syntax).unwrap().to_owned()
+    ast::Pat::cast(&syntax).map(|m| m.to_owned()).ok_or_else(|| ExpandError::ConversionError)
 }
 
 /// Parses the token tree (result of macro expansion) to a Type
-pub fn token_tree_to_ty(tt: &tt::Subtree) -> TreeArc<ast::TypeRef> {
+pub fn token_tree_to_ty(tt: &tt::Subtree) -> Result<TreeArc<ast::TypeRef>, ExpandError> {
     let token_source = SubtreeTokenSource::new(tt);
     let mut tree_sink = TtTreeSink::new(token_source.querier());
     ra_parser::parse_ty(&token_source, &mut tree_sink);
     let syntax = tree_sink.inner.finish();
-    ast::TypeRef::cast(&syntax).unwrap().to_owned()
+    ast::TypeRef::cast(&syntax).map(|m| m.to_owned()).ok_or_else(|| ExpandError::ConversionError)
 }
 
 /// Parses the token tree (result of macro expansion) as a sequence of stmts
-pub fn token_tree_to_macro_stmts(tt: &tt::Subtree) -> TreeArc<ast::MacroStmts> {
+pub fn token_tree_to_macro_stmts(
+    tt: &tt::Subtree,
+) -> Result<TreeArc<ast::MacroStmts>, ExpandError> {
     let token_source = SubtreeTokenSource::new(tt);
     let mut tree_sink = TtTreeSink::new(token_source.querier());
     ra_parser::parse_macro_stmts(&token_source, &mut tree_sink);
     let syntax = tree_sink.inner.finish();
-    ast::MacroStmts::cast(&syntax).unwrap().to_owned()
+    ast::MacroStmts::cast(&syntax).map(|m| m.to_owned()).ok_or_else(|| ExpandError::ConversionError)
 }
 
 /// Parses the token tree (result of macro expansion) as a sequence of items
-pub fn token_tree_to_macro_items(tt: &tt::Subtree) -> TreeArc<ast::MacroItems> {
+pub fn token_tree_to_macro_items(
+    tt: &tt::Subtree,
+) -> Result<TreeArc<ast::MacroItems>, ExpandError> {
     let token_source = SubtreeTokenSource::new(tt);
     let mut tree_sink = TtTreeSink::new(token_source.querier());
     ra_parser::parse_macro_items(&token_source, &mut tree_sink);
     let syntax = tree_sink.inner.finish();
-    ast::MacroItems::cast(&syntax).unwrap().to_owned()
+    ast::MacroItems::cast(&syntax).map(|m| m.to_owned()).ok_or_else(|| ExpandError::ConversionError)
 }
 
 /// Parses the token tree (result of macro expansion) as a sequence of items

--- a/crates/ra_mbe/src/syntax_bridge.rs
+++ b/crates/ra_mbe/src/syntax_bridge.rs
@@ -30,6 +30,29 @@ pub fn syntax_node_to_token_tree(node: &SyntaxNode) -> Option<(tt::Subtree, Toke
     Some((tt, token_map))
 }
 
+// The following items are what `rustc` macro can be parsed into :
+// link: https://github.com/rust-lang/rust/blob/9ebf47851a357faa4cd97f4b1dc7835f6376e639/src/libsyntax/ext/expand.rs#L141
+// * Expr(P<ast::Expr>)
+// * Pat(P<ast::Pat>)
+// * Ty(P<ast::Ty>)
+// * Stmts(SmallVec<[ast::Stmt; 1]>)
+// * Items(SmallVec<[P<ast::Item>; 1]>)
+//
+// * TraitItems(SmallVec<[ast::TraitItem; 1]>)
+// * ImplItems(SmallVec<[ast::ImplItem; 1]>)
+// * ForeignItems(SmallVec<[ast::ForeignItem; 1]>
+//
+//
+
+/// Parses the token tree (result of macro expansion) as a sequence of items
+pub fn token_tree_to_macro_items(tt: &tt::Subtree) -> TreeArc<ast::MacroItems> {
+    let token_source = SubtreeTokenSource::new(tt);
+    let mut tree_sink = TtTreeSink::new(token_source.querier());
+    ra_parser::parse_macro_items(&token_source, &mut tree_sink);
+    let syntax = tree_sink.inner.finish();
+    ast::MacroItems::cast(&syntax).unwrap().to_owned()
+}
+
 /// Parses the token tree (result of macro expansion) as a sequence of items
 pub fn token_tree_to_ast_item_list(tt: &tt::Subtree) -> TreeArc<ast::SourceFile> {
     let token_source = SubtreeTokenSource::new(tt);

--- a/crates/ra_parser/src/grammar.rs
+++ b/crates/ra_parser/src/grammar.rs
@@ -49,6 +49,12 @@ pub(crate) fn root(p: &mut Parser) {
     m.complete(p, SOURCE_FILE);
 }
 
+pub(crate) fn macro_items(p: &mut Parser) {
+    let m = p.start();
+    items::mod_contents(p, false);
+    m.complete(p, MACRO_ITEMS);
+}
+
 pub(crate) fn path(p: &mut Parser) {
     paths::type_path(p);
 }

--- a/crates/ra_parser/src/grammar.rs
+++ b/crates/ra_parser/src/grammar.rs
@@ -55,6 +55,21 @@ pub(crate) fn macro_items(p: &mut Parser) {
     m.complete(p, MACRO_ITEMS);
 }
 
+pub(crate) fn macro_stmts(p: &mut Parser) {
+    let m = p.start();
+
+    while !p.at(EOF) {
+        if p.current() == SEMI {
+            p.bump();
+            continue;
+        }
+
+        expressions::stmt(p, expressions::StmtWithSemi::Optional);
+    }
+
+    m.complete(p, MACRO_STMTS);
+}
+
 pub(crate) fn path(p: &mut Parser) {
     paths::type_path(p);
 }
@@ -72,6 +87,11 @@ pub(crate) fn pattern(p: &mut Parser) {
 }
 
 pub(crate) fn stmt(p: &mut Parser, with_semi: bool) {
+    let with_semi = match with_semi {
+        true => expressions::StmtWithSemi::Yes,
+        false => expressions::StmtWithSemi::No,
+    };
+
     expressions::stmt(p, with_semi)
 }
 

--- a/crates/ra_parser/src/lib.rs
+++ b/crates/ra_parser/src/lib.rs
@@ -102,6 +102,10 @@ pub fn parse_macro_items(token_source: &dyn TokenSource, tree_sink: &mut dyn Tre
     parse_from_tokens(token_source, tree_sink, grammar::macro_items);
 }
 
+pub fn parse_macro_stmts(token_source: &dyn TokenSource, tree_sink: &mut dyn TreeSink) {
+    parse_from_tokens(token_source, tree_sink, grammar::macro_stmts);
+}
+
 /// A parsing function for a specific braced-block.
 pub struct Reparser(fn(&mut parser::Parser));
 

--- a/crates/ra_parser/src/lib.rs
+++ b/crates/ra_parser/src/lib.rs
@@ -98,6 +98,10 @@ pub fn parse_item(token_source: &dyn TokenSource, tree_sink: &mut dyn TreeSink) 
     parse_from_tokens(token_source, tree_sink, grammar::item);
 }
 
+pub fn parse_macro_items(token_source: &dyn TokenSource, tree_sink: &mut dyn TreeSink) {
+    parse_from_tokens(token_source, tree_sink, grammar::macro_items);
+}
+
 /// A parsing function for a specific braced-block.
 pub struct Reparser(fn(&mut parser::Parser));
 

--- a/crates/ra_parser/src/syntax_kind/generated.rs
+++ b/crates/ra_parser/src/syntax_kind/generated.rs
@@ -233,6 +233,8 @@ pub enum SyntaxKind {
     ARG_LIST,
     TYPE_BOUND,
     TYPE_BOUND_LIST,
+    MACRO_ITEMS,
+    MACRO_STMTS,
     // Technical kind so that we can cast from u16 safely
     #[doc(hidden)]
     __LAST,
@@ -592,6 +594,8 @@ impl SyntaxKind {
             ARG_LIST => &SyntaxInfo { name: "ARG_LIST" },
             TYPE_BOUND => &SyntaxInfo { name: "TYPE_BOUND" },
             TYPE_BOUND_LIST => &SyntaxInfo { name: "TYPE_BOUND_LIST" },
+            MACRO_ITEMS => &SyntaxInfo { name: "MACRO_ITEMS" },
+            MACRO_STMTS => &SyntaxInfo { name: "MACRO_STMTS" },
             TOMBSTONE => &SyntaxInfo { name: "TOMBSTONE" },
             EOF => &SyntaxInfo { name: "EOF" },
             __LAST => &SyntaxInfo { name: "__LAST" },

--- a/crates/ra_syntax/src/ast/generated.rs
+++ b/crates/ra_syntax/src/ast/generated.rs
@@ -1770,6 +1770,72 @@ impl MacroCall {
     }
 }
 
+// MacroItems
+#[derive(Debug, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct MacroItems {
+    pub(crate) syntax: SyntaxNode,
+}
+unsafe impl TransparentNewType for MacroItems {
+    type Repr = rowan::SyntaxNode;
+}
+
+impl AstNode for MacroItems {
+    fn cast(syntax: &SyntaxNode) -> Option<&Self> {
+        match syntax.kind() {
+            MACRO_ITEMS => Some(MacroItems::from_repr(syntax.into_repr())),
+            _ => None,
+        }
+    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
+}
+
+impl ToOwned for MacroItems {
+    type Owned = TreeArc<MacroItems>;
+    fn to_owned(&self) -> TreeArc<MacroItems> { TreeArc::cast(self.syntax.to_owned()) }
+}
+
+
+impl ast::ModuleItemOwner for MacroItems {}
+impl ast::FnDefOwner for MacroItems {}
+impl MacroItems {}
+
+// MacroStmts
+#[derive(Debug, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct MacroStmts {
+    pub(crate) syntax: SyntaxNode,
+}
+unsafe impl TransparentNewType for MacroStmts {
+    type Repr = rowan::SyntaxNode;
+}
+
+impl AstNode for MacroStmts {
+    fn cast(syntax: &SyntaxNode) -> Option<&Self> {
+        match syntax.kind() {
+            MACRO_STMTS => Some(MacroStmts::from_repr(syntax.into_repr())),
+            _ => None,
+        }
+    }
+    fn syntax(&self) -> &SyntaxNode { &self.syntax }
+}
+
+impl ToOwned for MacroStmts {
+    type Owned = TreeArc<MacroStmts>;
+    fn to_owned(&self) -> TreeArc<MacroStmts> { TreeArc::cast(self.syntax.to_owned()) }
+}
+
+
+impl MacroStmts {
+    pub fn statements(&self) -> impl Iterator<Item = &Stmt> {
+        super::children(self)
+    }
+
+    pub fn expr(&self) -> Option<&Expr> {
+        super::child_opt(self)
+    }
+}
+
 // MatchArm
 #[derive(Debug, PartialEq, Eq, Hash)]
 #[repr(transparent)]

--- a/crates/ra_syntax/src/grammar.ron
+++ b/crates/ra_syntax/src/grammar.ron
@@ -247,6 +247,10 @@ Grammar(
         "ARG_LIST",
         "TYPE_BOUND",
         "TYPE_BOUND_LIST",
+
+        // macro related
+        "MACRO_ITEMS",
+        "MACRO_STMTS",
     ],
     ast: {
         "SourceFile": (
@@ -668,5 +672,16 @@ Grammar(
         "TypeArg": (options: ["TypeRef"]),
         "AssocTypeArg": (options: ["NameRef", "TypeRef"]),
         "LifetimeArg": (),
+
+        "MacroItems": (
+            traits: [ "ModuleItemOwner", "FnDefOwner" ],            
+        ),
+
+        "MacroStmts" : (
+            options: [ "Expr" ],
+            collections: [
+                ["statements", "Stmt"],
+            ],
+        )
     },
 )


### PR DESCRIPTION
<del>As discus in  PR #1147 , this PR added a `mbe::MacroKind` .
Currently only 2 kind of macro are supported, `SourceFile` and `Block`.</del>

Added following functions for `tt::TokenTree` and `ast::Node` conversion:

* token_tree_to_expr
* token_tree_to_pat
* token_tree_to_ty
* token_tree_to_macro_stmts
* token_tree_to_macro_items

And added two new syntax kind:

* MACRO_ITEMS
* MACRO_STMTS