### PR TITLE
Initial support for lang items (and str completion)

### DIFF
--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -16,6 +16,7 @@ use crate::{
     generics::{GenericParams, GenericDef},
     type_ref::TypeRef,
     traits::TraitData, Trait, ty::TraitRef,
+    lang_item::LangItems,
     ids
 };
 
@@ -100,6 +101,9 @@ pub trait DefDatabase: SourceDatabase {
 
     #[salsa::invoke(crate::ConstSignature::static_signature_query)]
     fn static_signature(&self, konst: Static) -> Arc<ConstSignature>;
+
+    #[salsa::invoke(crate::lang_item::LangItems::lang_items_query)]
+    fn lang_items(&self, krate: Crate) -> Arc<LangItems>;
 }
 
 #[salsa::query_group(HirDatabaseStorage)]

--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use ra_syntax::{SyntaxNode, TreeArc, SourceFile, ast};
+use ra_syntax::{SyntaxNode, TreeArc, SourceFile, SmolStr, ast};
 use ra_db::{SourceDatabase, salsa};
 
 use crate::{
@@ -16,7 +16,7 @@ use crate::{
     generics::{GenericParams, GenericDef},
     type_ref::TypeRef,
     traits::TraitData, Trait, ty::TraitRef,
-    lang_item::LangItems,
+    lang_item::{LangItems, LangItemTarget},
     ids
 };
 
@@ -104,6 +104,9 @@ pub trait DefDatabase: SourceDatabase {
 
     #[salsa::invoke(crate::lang_item::LangItems::lang_items_query)]
     fn lang_items(&self, krate: Crate) -> Arc<LangItems>;
+
+    #[salsa::invoke(crate::lang_item::LangItems::lang_item_query)]
+    fn lang_item(&self, start_crate: Crate, item: SmolStr) -> Option<LangItemTarget>;
 }
 
 #[salsa::query_group(HirDatabaseStorage)]

--- a/crates/ra_hir/src/lang_item.rs
+++ b/crates/ra_hir/src/lang_item.rs
@@ -1,0 +1,102 @@
+use std::sync::Arc;
+use rustc_hash::FxHashMap;
+
+use ra_syntax::{SmolStr, ast::AttrsOwner};
+
+use crate::{
+    Crate, DefDatabase, Enum, Function, HirDatabase, ImplBlock, Module, Static, Struct, Trait
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LangItemTarget {
+    Enum(Enum),
+    Function(Function),
+    Impl(ImplBlock),
+    Static(Static),
+    Struct(Struct),
+    Trait(Trait),
+}
+
+impl LangItemTarget {
+    pub(crate) fn krate(&self, db: &impl HirDatabase) -> Option<Crate> {
+        match self {
+            LangItemTarget::Enum(e) => e.module(db).krate(db),
+            LangItemTarget::Function(f) => f.module(db).krate(db),
+            LangItemTarget::Impl(i) => i.module().krate(db),
+            LangItemTarget::Static(s) => s.module(db).krate(db),
+            LangItemTarget::Struct(s) => s.module(db).krate(db),
+            LangItemTarget::Trait(t) => t.module(db).krate(db),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LangItems {
+    items: FxHashMap<SmolStr, LangItemTarget>,
+}
+
+impl LangItems {
+    pub fn target<'a>(&'a self, item: &str) -> Option<&'a LangItemTarget> {
+        self.items.get(item)
+    }
+
+    /// Salsa query. This will query a specific crate for lang items.
+    pub(crate) fn lang_items_query(db: &impl DefDatabase, krate: Crate) -> Arc<LangItems> {
+        let mut lang_items = LangItems { items: FxHashMap::default() };
+
+        if let Some(module) = krate.root_module(db) {
+            lang_items.collect_lang_items_recursive(db, &module);
+        }
+
+        Arc::new(lang_items)
+    }
+
+    fn collect_lang_items_recursive(&mut self, db: &impl DefDatabase, module: &Module) {
+        // Look for impl targets
+        let (impl_blocks, source_map) = db.impls_in_module_with_source_map(module.clone());
+        let source = module.definition_source(db).1;
+        for (impl_id, _) in impl_blocks.impls.iter() {
+            let impl_block = source_map.get(&source, impl_id);
+            let lang_item_name = impl_block
+                .attrs()
+                .filter_map(|a| a.as_key_value())
+                .filter(|(key, _)| key == "lang")
+                .map(|(_, val)| val)
+                .nth(0);
+            if let Some(lang_item_name) = lang_item_name {
+                let imp = ImplBlock::from_id(*module, impl_id);
+                self.items.entry(lang_item_name).or_insert(LangItemTarget::Impl(imp));
+            }
+        }
+
+        // FIXME we should look for the other lang item targets (traits, structs, ...)
+
+        // Look for lang items in the children
+        for child in module.children(db) {
+            self.collect_lang_items_recursive(db, &child);
+        }
+    }
+}
+
+/// Look for a lang item, starting from the specified crate and recursively traversing its
+/// dependencies.
+pub(crate) fn lang_item_lookup(
+    db: &impl DefDatabase,
+    start_krate: Crate,
+    item: &str,
+) -> Option<LangItemTarget> {
+    let lang_items = db.lang_items(start_krate);
+    let start_krate_target = lang_items.items.get(item);
+    if start_krate_target.is_some() {
+        start_krate_target.map(|t| *t)
+    } else {
+        for dep in start_krate.dependencies(db) {
+            let dep_krate = dep.krate;
+            let dep_target = lang_item_lookup(db, dep_krate, item);
+            if dep_target.is_some() {
+                return dep_target;
+            }
+        }
+        None
+    }
+}

--- a/crates/ra_hir/src/lang_item.rs
+++ b/crates/ra_hir/src/lang_item.rs
@@ -11,7 +11,7 @@ use crate::{
 pub enum LangItemTarget {
     Enum(Enum),
     Function(Function),
-    Impl(ImplBlock),
+    ImplBlock(ImplBlock),
     Static(Static),
     Struct(Struct),
     Trait(Trait),
@@ -22,7 +22,7 @@ impl LangItemTarget {
         match self {
             LangItemTarget::Enum(e) => e.module(db).krate(db),
             LangItemTarget::Function(f) => f.module(db).krate(db),
-            LangItemTarget::Impl(i) => i.module().krate(db),
+            LangItemTarget::ImplBlock(i) => i.module().krate(db),
             LangItemTarget::Static(s) => s.module(db).krate(db),
             LangItemTarget::Struct(s) => s.module(db).krate(db),
             LangItemTarget::Trait(t) => t.module(db).krate(db),
@@ -65,7 +65,7 @@ impl LangItems {
                 .nth(0);
             if let Some(lang_item_name) = lang_item_name {
                 let imp = ImplBlock::from_id(*module, impl_id);
-                self.items.entry(lang_item_name).or_insert(LangItemTarget::Impl(imp));
+                self.items.entry(lang_item_name).or_insert(LangItemTarget::ImplBlock(imp));
             }
         }
 

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -36,6 +36,7 @@ mod type_ref;
 mod ty;
 mod impl_block;
 mod expr;
+mod lang_item;
 mod generics;
 mod docs;
 mod resolve;

--- a/crates/ra_hir/src/nameres.rs
+++ b/crates/ra_hir/src/nameres.rs
@@ -202,6 +202,10 @@ impl CrateDefMap {
         Arc::new(def_map)
     }
 
+    pub(crate) fn krate(&self) -> Crate {
+        self.krate
+    }
+
     pub(crate) fn root(&self) -> CrateModuleId {
         self.root
     }

--- a/crates/ra_hir/src/resolve.rs
+++ b/crates/ra_hir/src/resolve.rs
@@ -5,13 +5,15 @@ use rustc_hash::FxHashMap;
 
 use crate::{
     ModuleDef,
+    code_model_api::Crate,
     db::HirDatabase,
     name::{Name, KnownName},
     nameres::{PerNs, CrateDefMap, CrateModuleId},
     generics::GenericParams,
     expr::{scope::{ExprScopes, ScopeId}, PatId},
     impl_block::ImplBlock,
-    path::Path, Trait
+    path::Path,
+    Trait
 };
 
 #[derive(Debug, Clone, Default)]
@@ -190,12 +192,16 @@ impl Resolver {
             .flatten()
     }
 
-    pub(crate) fn module(&self) -> Option<(&CrateDefMap, CrateModuleId)> {
+    fn module(&self) -> Option<(&CrateDefMap, CrateModuleId)> {
         self.scopes.iter().rev().find_map(|scope| match scope {
             Scope::ModuleScope(m) => Some((&*m.crate_def_map, m.module_id)),
 
             _ => None,
         })
+    }
+
+    pub(crate) fn krate(&self) -> Option<Crate> {
+        self.module().map(|t| t.0.krate())
     }
 }
 

--- a/crates/ra_hir/src/resolve.rs
+++ b/crates/ra_hir/src/resolve.rs
@@ -190,7 +190,7 @@ impl Resolver {
             .flatten()
     }
 
-    fn module(&self) -> Option<(&CrateDefMap, CrateModuleId)> {
+    pub(crate) fn module(&self) -> Option<(&CrateDefMap, CrateModuleId)> {
         self.scopes.iter().rev().find_map(|scope| match scope {
             Scope::ModuleScope(m) => Some((&*m.crate_def_map, m.module_id)),
 

--- a/crates/ra_hir/src/ty/infer.rs
+++ b/crates/ra_hir/src/ty/infer.rs
@@ -462,7 +462,7 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
         let remaining_index = remaining_index.unwrap_or(path.segments.len());
         let mut actual_def_ty: Option<Ty> = None;
 
-        let krate = resolver.module().map(|t| t.0.krate());
+        let krate = resolver.krate()?;
         // resolve intermediate segments
         for (i, segment) in path.segments[remaining_index..].iter().enumerate() {
             let ty = match resolved {
@@ -504,38 +504,36 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
 
             actual_def_ty = Some(ty.clone());
 
-            let item: crate::ModuleDef = krate.and_then(|k| {
-                ty.iterate_impl_items(self.db, k, |item| {
-                    let matching_def: Option<crate::ModuleDef> = match item {
-                        crate::ImplItem::Method(func) => {
-                            let sig = func.signature(self.db);
-                            if segment.name == *sig.name() {
-                                Some(func.into())
-                            } else {
-                                None
-                            }
+            let item: crate::ModuleDef = ty.iterate_impl_items(self.db, krate, |item| {
+                let matching_def: Option<crate::ModuleDef> = match item {
+                    crate::ImplItem::Method(func) => {
+                        let sig = func.signature(self.db);
+                        if segment.name == *sig.name() {
+                            Some(func.into())
+                        } else {
+                            None
                         }
-
-                        crate::ImplItem::Const(konst) => {
-                            let sig = konst.signature(self.db);
-                            if segment.name == *sig.name() {
-                                Some(konst.into())
-                            } else {
-                                None
-                            }
-                        }
-
-                        // FIXME: Resolve associated types
-                        crate::ImplItem::TypeAlias(_) => None,
-                    };
-                    match matching_def {
-                        Some(_) => {
-                            self.write_assoc_resolution(id, item);
-                            return matching_def;
-                        }
-                        None => None,
                     }
-                })
+
+                    crate::ImplItem::Const(konst) => {
+                        let sig = konst.signature(self.db);
+                        if segment.name == *sig.name() {
+                            Some(konst.into())
+                        } else {
+                            None
+                        }
+                    }
+
+                    // FIXME: Resolve associated types
+                    crate::ImplItem::TypeAlias(_) => None,
+                };
+                match matching_def {
+                    Some(_) => {
+                        self.write_assoc_resolution(id, item);
+                        return matching_def;
+                    }
+                    None => None,
+                }
             })?;
 
             resolved = Resolution::Def(item.into());

--- a/crates/ra_hir/src/ty/method_resolution.rs
+++ b/crates/ra_hir/src/ty/method_resolution.rs
@@ -14,7 +14,6 @@ use crate::{
     resolve::Resolver,
     traits::TraitItem,
     generics::HasGenericParams,
-    lang_item::lang_item_lookup,
     ty::primitive::{UncertainIntTy, UncertainFloatTy}
 };
 use super::{TraitRef, Substs};
@@ -116,15 +115,15 @@ fn def_crate(db: &impl HirDatabase, cur_crate: Crate, ty: &Ty) -> Option<Crate> 
     match ty {
         Ty::Apply(a_ty) => match a_ty.ctor {
             TypeCtor::Adt(def_id) => def_id.krate(db),
-            TypeCtor::Bool => lang_item_lookup(db, cur_crate, "bool")?.krate(db),
-            TypeCtor::Char => lang_item_lookup(db, cur_crate, "char")?.krate(db),
+            TypeCtor::Bool => db.lang_item(cur_crate, "bool".into())?.krate(db),
+            TypeCtor::Char => db.lang_item(cur_crate, "char".into())?.krate(db),
             TypeCtor::Float(UncertainFloatTy::Known(f)) => {
-                lang_item_lookup(db, cur_crate, f.ty_to_string())?.krate(db)
+                db.lang_item(cur_crate, f.ty_to_string().into())?.krate(db)
             }
             TypeCtor::Int(UncertainIntTy::Known(i)) => {
-                lang_item_lookup(db, cur_crate, i.ty_to_string())?.krate(db)
+                db.lang_item(cur_crate, i.ty_to_string().into())?.krate(db)
             }
-            TypeCtor::Str => lang_item_lookup(db, cur_crate, "str")?.krate(db),
+            TypeCtor::Str => db.lang_item(cur_crate, "str".into())?.krate(db),
             _ => None,
         },
         _ => None,

--- a/crates/ra_ide_api/src/completion/complete_path.rs
+++ b/crates/ra_ide_api/src/completion/complete_path.rs
@@ -38,18 +38,21 @@ pub(super) fn complete_path(acc: &mut Completions, ctx: &CompletionContext) {
         }
         hir::ModuleDef::Struct(s) => {
             let ty = s.ty(ctx.db);
-            ty.iterate_impl_items(ctx.db, |item| {
-                match item {
-                    hir::ImplItem::Method(func) => {
-                        let sig = func.signature(ctx.db);
-                        if !sig.has_self_param() {
-                            acc.add_function(ctx, func);
+            let krate = ctx.module.and_then(|m| m.krate(ctx.db));
+            krate.map_or((), |krate| {
+                ty.iterate_impl_items(ctx.db, krate, |item| {
+                    match item {
+                        hir::ImplItem::Method(func) => {
+                            let sig = func.signature(ctx.db);
+                            if !sig.has_self_param() {
+                                acc.add_function(ctx, func);
+                            }
                         }
+                        hir::ImplItem::Const(ct) => acc.add_const(ctx, ct),
+                        hir::ImplItem::TypeAlias(ty) => acc.add_type_alias(ctx, ty),
                     }
-                    hir::ImplItem::Const(ct) => acc.add_const(ctx, ct),
-                    hir::ImplItem::TypeAlias(ty) => acc.add_type_alias(ctx, ty),
-                }
-                None::<()>
+                    None::<()>
+                });
             });
         }
         _ => return,

--- a/crates/ra_ide_api/src/completion/complete_path.rs
+++ b/crates/ra_ide_api/src/completion/complete_path.rs
@@ -39,7 +39,7 @@ pub(super) fn complete_path(acc: &mut Completions, ctx: &CompletionContext) {
         hir::ModuleDef::Struct(s) => {
             let ty = s.ty(ctx.db);
             let krate = ctx.module.and_then(|m| m.krate(ctx.db));
-            krate.map_or((), |krate| {
+            if let Some(krate) = krate {
                 ty.iterate_impl_items(ctx.db, krate, |item| {
                     match item {
                         hir::ImplItem::Method(func) => {
@@ -53,7 +53,7 @@ pub(super) fn complete_path(acc: &mut Completions, ctx: &CompletionContext) {
                     }
                     None::<()>
                 });
-            });
+            }
         }
         _ => return,
     };

--- a/crates/ra_syntax/src/ast/extensions.rs
+++ b/crates/ra_syntax/src/ast/extensions.rs
@@ -65,6 +65,20 @@ impl ast::Attr {
             None
         }
     }
+
+    pub fn as_key_value(&self) -> Option<(SmolStr, SmolStr)> {
+        let tt = self.value()?;
+        let tt_node = tt.syntax();
+        let attr = tt_node.children_with_tokens().nth(1)?;
+        if attr.kind() == IDENT {
+            let key = attr.as_token()?.text().clone();
+            let val_node = tt_node.children_with_tokens().find(|t| t.kind() == STRING)?;
+            let val = val_node.as_token()?.text().trim_start_matches("\"").trim_end_matches("\"");
+            Some((key, SmolStr::new(val)))
+        } else {
+            None
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/ra_syntax/src/ast/generated.rs
+++ b/crates/ra_syntax/src/ast/generated.rs
@@ -1325,6 +1325,7 @@ impl ToOwned for ImplBlock {
 
 
 impl ast::TypeParamsOwner for ImplBlock {}
+impl ast::AttrsOwner for ImplBlock {}
 impl ImplBlock {
     pub fn item_list(&self) -> Option<&ItemList> {
         super::child_opt(self)

--- a/crates/ra_syntax/src/grammar.ron
+++ b/crates/ra_syntax/src/grammar.ron
@@ -341,7 +341,7 @@ Grammar(
             ],
             options: ["TypeRef"]
         ),
-        "ImplBlock": (options: ["ItemList"], traits: ["TypeParamsOwner"]),
+        "ImplBlock": (options: ["ItemList"], traits: ["TypeParamsOwner", "AttrsOwner"]),
 
         "ParenType": (options: ["TypeRef"]),
         "TupleType": ( collections: [["fields", "TypeRef"]] ),


### PR DESCRIPTION
This PR adds partial support for lang items.
For now, the only supported lang items are the ones that target an impl block.

Lang items are now resolved during type inference - this means that `str` completion now works.

Fixes #1139.

(thanks Florian Diebold for the help!)
