### PR TITLE
Add mbe stmt matcher

### DIFF
--- a/crates/ra_mbe/src/lib.rs
+++ b/crates/ra_mbe/src/lib.rs
@@ -582,4 +582,19 @@ SOURCE_FILE@[0; 40)
         );
         assert_expansion(&rules, "foo! { (a, b) }", "fn foo () {let (a , b) ;}");
     }
+
+    #[test]
+    fn test_stmt() {
+        let rules = create_rules(
+            r#"
+        macro_rules! foo {
+            ($ i:stmt) => (
+                fn bar() { $ i; }
+            )
+        }
+"#,
+        );
+        assert_expansion(&rules, "foo! { 2 }", "fn bar () {2 ;}");
+        assert_expansion(&rules, "foo! { let a = 0 }", "fn bar () {let a = 0 ;}");
+    }
 }

--- a/crates/ra_mbe/src/mbe_expander.rs
+++ b/crates/ra_mbe/src/mbe_expander.rs
@@ -157,6 +157,10 @@ fn match_lhs(pattern: &crate::Subtree, input: &mut TtCursor) -> Result<Bindings,
                             let pat = input.eat_pat().ok_or(ExpandError::UnexpectedToken)?.clone();
                             res.inner.insert(text.clone(), Binding::Simple(pat.into()));
                         }
+                        "stmt" => {
+                            let pat = input.eat_stmt().ok_or(ExpandError::UnexpectedToken)?.clone();
+                            res.inner.insert(text.clone(), Binding::Simple(pat.into()));
+                        }
                         _ => return Err(ExpandError::UnexpectedToken),
                     }
                 }

--- a/crates/ra_mbe/src/subtree_parser.rs
+++ b/crates/ra_mbe/src/subtree_parser.rs
@@ -42,6 +42,10 @@ impl<'a> Parser<'a> {
         self.parse(ra_parser::parse_pat)
     }
 
+    pub fn parse_stmt(self) -> Option<tt::TokenTree> {
+        self.parse(|src, sink| ra_parser::parse_stmt(src, sink, false))
+    }
+
     fn parse<F>(self, f: F) -> Option<tt::TokenTree>
     where
         F: FnOnce(&dyn TokenSource, &mut dyn TreeSink),

--- a/crates/ra_mbe/src/tt_cursor.rs
+++ b/crates/ra_mbe/src/tt_cursor.rs
@@ -99,6 +99,11 @@ impl<'a> TtCursor<'a> {
         parser.parse_pat()
     }
 
+    pub(crate) fn eat_stmt(&mut self) -> Option<tt::TokenTree> {
+        let parser = Parser::new(&mut self.pos, self.subtree);
+        parser.parse_stmt()
+    }
+
     pub(crate) fn expect_char(&mut self, char: char) -> Result<(), ParseError> {
         if self.at_char(char) {
             self.bump();

--- a/crates/ra_parser/src/grammar.rs
+++ b/crates/ra_parser/src/grammar.rs
@@ -65,6 +65,10 @@ pub(crate) fn pattern(p: &mut Parser) {
     patterns::pattern(p)
 }
 
+pub(crate) fn stmt(p: &mut Parser, with_semi: bool) {
+    expressions::stmt(p, with_semi)
+}
+
 pub(crate) fn reparser(
     node: SyntaxKind,
     first_child: Option<SyntaxKind>,

--- a/crates/ra_parser/src/lib.rs
+++ b/crates/ra_parser/src/lib.rs
@@ -88,6 +88,11 @@ pub fn parse_pat(token_source: &dyn TokenSource, tree_sink: &mut dyn TreeSink) {
     parse_from_tokens(token_source, tree_sink, grammar::pattern);
 }
 
+/// Parse given tokens into the given sink as a statement
+pub fn parse_stmt(token_source: &dyn TokenSource, tree_sink: &mut dyn TreeSink, with_semi: bool) {
+    parse_from_tokens(token_source, tree_sink, |p| grammar::stmt(p, with_semi));
+}
+
 /// A parsing function for a specific braced-block.
 pub struct Reparser(fn(&mut parser::Parser));
 


### PR DESCRIPTION
Add `stmt` matcher in `ra_mbe` , and added corresponding `stmt()` parser in `ra_syntax`. 
This PR also help PR #1148 for `MarcoKind::Items` parsing.

Note: 
* According [the book](https://doc.rust-lang.org/reference/macros-by-example.html), mbe `stmt` matcher will only match statement without the trailing semicolon 
* `item` is a valid statement.



