### PR TITLE
cleanup cancellation

### DIFF
--- a/crates/gen_lsp_server/src/stdio.rs
+++ b/crates/gen_lsp_server/src/stdio.rs
@@ -27,9 +27,7 @@ pub fn stdio_transport() -> (Receiver<RawMessage>, Sender<RawMessage>, Threads) 
                 _ => false,
             };
 
-            if let Err(_) = reader_sender.send(msg) {
-                break;
-            }
+            reader_sender.send(msg).unwrap();
 
             if is_exit {
                 break;


### PR DESCRIPTION
Now that we explicitelly exit the reading loop on exit notification,
we can assume that the sender is always alive