### PR TITLE
Fix missing last token in mbe $repeat parsing

### DIFF
--- a/crates/ra_mbe/src/lib.rs
+++ b/crates/ra_mbe/src/lib.rs
@@ -554,6 +554,30 @@ SOURCE_FILE@[0; 40)
     }
 
     #[test]
+    fn test_last_expr() {
+        let rules = create_rules(
+            r#"
+        macro_rules! vec {
+            ($($item:expr),*) => {
+                {
+                    let mut v = Vec::new();
+                    $(
+                        v.push($item);
+                    )*
+                    v
+                }
+            };
+        }
+"#,
+        );
+        assert_expansion(
+            &rules,
+            "vec!(1,2,3)",
+            "{let mut v = Vec :: new () ; v . push (1) ; v . push (2) ; v . push (3) ; v}",
+        );
+    }
+
+    #[test]
     fn test_ty() {
         let rules = create_rules(
             r#"

--- a/crates/ra_mbe/src/mbe_parser.rs
+++ b/crates/ra_mbe/src/mbe_parser.rs
@@ -91,7 +91,6 @@ fn parse_repeat(p: &mut TtCursor) -> Result<crate::Repeat, ParseError> {
         '?' => crate::RepeatKind::ZeroOrOne,
         _ => return Err(ParseError::Expected(String::from("repeat"))),
     };
-    p.bump();
     Ok(crate::Repeat { subtree, kind, separator })
 }
 


### PR DESCRIPTION
The `mbe parser` incorrectly eat one more token in $repeat parsing, described in #1141.

Remove incorrect token eating, and add related test.