### PR TITLE
Temporarily disable tt matcher

### DIFF
--- a/crates/ra_mbe/src/lib.rs
+++ b/crates/ra_mbe/src/lib.rs
@@ -763,29 +763,29 @@ MACRO_ITEMS@[0; 40)
         );
     }
 
-    #[test]
-    fn test_tt_block() {
-        let rules = create_rules(
-            r#"
-        macro_rules! foo {
-            ($ i:tt) => { fn foo() $ i }
-        }
-"#,
-        );
-        assert_expansion(&rules, r#"foo! { { 1; } }"#, r#"fn foo () {1 ;}"#);
-    }
+    //     #[test]
+    //     fn test_tt_block() {
+    //         let rules = create_rules(
+    //             r#"
+    //         macro_rules! foo {
+    //             ($ i:tt) => { fn foo() $ i }
+    //         }
+    // "#,
+    //         );
+    //         assert_expansion(&rules, r#"foo! { { 1; } }"#, r#"fn foo () {1 ;}"#);
+    //     }
 
-    #[test]
-    fn test_tt_group() {
-        let rules = create_rules(
-            r#"
-        macro_rules! foo {
-             ($($ i:tt)*) => { $($ i)* }
-        }
-"#,
-        );
-        assert_expansion(&rules, r#"foo! { fn foo() {} }"#, r#"fn foo () {}"#);
-    }
+    //     #[test]
+    //     fn test_tt_group() {
+    //         let rules = create_rules(
+    //             r#"
+    //         macro_rules! foo {
+    //              ($($ i:tt)*) => { $($ i)* }
+    //         }
+    // "#,
+    //         );
+    //         assert_expansion(&rules, r#"foo! { fn foo() {} }"#, r#"fn foo () {}"#);
+    //     }
 
     #[test]
     fn test_lifetime() {

--- a/crates/ra_mbe/src/mbe_expander.rs
+++ b/crates/ra_mbe/src/mbe_expander.rs
@@ -171,10 +171,14 @@ fn match_lhs(pattern: &crate::Subtree, input: &mut TtCursor) -> Result<Bindings,
                                 input.eat_meta().ok_or(ExpandError::UnexpectedToken)?.clone();
                             res.inner.insert(text.clone(), Binding::Simple(meta.into()));
                         }
-                        "tt" => {
-                            let token = input.eat().ok_or(ExpandError::UnexpectedToken)?.clone();
-                            res.inner.insert(text.clone(), Binding::Simple(token.into()));
-                        }
+                        // FIXME:
+                        // Enable followiing code when everything is fixed
+                        // At least we can dogfood itself to not stackoverflow
+                        //
+                        // "tt" => {
+                        //     let token = input.eat().ok_or(ExpandError::UnexpectedToken)?.clone();
+                        //     res.inner.insert(text.clone(), Binding::Simple(token.into()));
+                        // }
                         "item" => {
                             let item =
                                 input.eat_item().ok_or(ExpandError::UnexpectedToken)?.clone();


### PR DESCRIPTION
Temporarily fix for #1170 by disable the `tt` matcher. The reason for that is normally a `$($tt:tt))* wildcard matcher will be added for recurisve macro. If we have any bugs in macro expansion, the macro will infinite expanding recursively. 

Let me add a fused system and add more test in later PR and then re-enable this one