### PR TITLE
Fix bugs and add error log about macro expansion

### DIFF
--- a/crates/ra_mbe/src/subtree_source.rs
+++ b/crates/ra_mbe/src/subtree_source.rs
@@ -379,8 +379,6 @@ where
 {
     if let Some((m, is_joint_to_next)) = iter.current_punct3(p) {
         if let Some((kind, text)) = match m {
-            ('<', '<', '=') => Some((SHLEQ, "<<=")),
-            ('>', '>', '=') => Some((SHREQ, ">>=")),
             ('.', '.', '.') => Some((DOTDOTDOT, "...")),
             ('.', '.', '=') => Some((DOTDOTEQ, "..=")),
             _ => None,
@@ -391,23 +389,6 @@ where
 
     if let Some((m, is_joint_to_next)) = iter.current_punct2(p) {
         if let Some((kind, text)) = match m {
-            ('<', '<') => Some((SHL, "<<")),
-            ('>', '>') => Some((SHR, ">>")),
-
-            ('|', '|') => Some((PIPEPIPE, "||")),
-            ('&', '&') => Some((AMPAMP, "&&")),
-            ('%', '=') => Some((PERCENTEQ, "%=")),
-            ('*', '=') => Some((STAREQ, "*=")),
-            ('/', '=') => Some((SLASHEQ, "/=")),
-            ('^', '=') => Some((CARETEQ, "^=")),
-
-            ('&', '=') => Some((AMPEQ, "&=")),
-            ('|', '=') => Some((PIPEEQ, "|=")),
-            ('-', '=') => Some((MINUSEQ, "-=")),
-            ('+', '=') => Some((PLUSEQ, "+=")),
-            ('>', '=') => Some((GTEQ, ">=")),
-            ('<', '=') => Some((LTEQ, "<=")),
-
             ('-', '>') => Some((THIN_ARROW, "->")),
             ('!', '=') => Some((NEQ, "!=")),
             ('=', '>') => Some((FAT_ARROW, "=>")),


### PR DESCRIPTION
This PR fixed / add following things:

* Add a fused count which stop recursion of macro expansion in name resolution.
* Add some logs when macro expansion fails
* Add `$crate` meta variable support in mbe, which create a `$crate` ident token in token tree.
* Fixed matching a `$REPEAT` pattern inside a subtree, e.g. `(fn $name:ident {$($i:ident)*} ) => {...}`
* Remove composite-able punct token in syntax node to token conversion. 