### PR TITLE
Fix locked git reference for lsp-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,7 +635,7 @@ dependencies = [
 [[package]]
 name = "lsp-types"
 version = "0.57.0"
-source = "git+https://github.com/matklad/lsp-types?branch=selection-range#6e37d45bcf411c18c22ab29ec155946ff001339e"
+source = "git+https://github.com/matklad/lsp-types?branch=selection-range#6b8b7173ad94bd282d053418af10caf828e726f4"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crates/ra_lsp_server/Cargo.toml
+++ b/crates/ra_lsp_server/Cargo.toml
@@ -15,7 +15,7 @@ crossbeam-channel = "0.3.5"
 flexi_logger = "0.11.0"
 log = "0.4.3"
 url_serde = "0.2.0"
-lsp-types = "0.57.0"
+lsp-types = { version = "0.57.0", features = ["proposed"] }
 rustc-hash = "1.0"
 parking_lot = "0.7.0"
 


### PR DESCRIPTION
@matklad Current master doesn't build for me because it doesn't find the commit from the lockfile. Maybe you force-pushed onto the branch? I think this should fix it.