### PR TITLE
Add HIR for where clauses & ignore impls with where clauses in trait resolution

### DIFF
--- a/crates/ra_hir/src/ty/tests.rs
+++ b/crates/ra_hir/src/ty/tests.rs
@@ -2477,6 +2477,23 @@ fn test() { (&S).foo()<|>; }
     assert_eq!(t, "u128");
 }
 
+#[test]
+fn method_resolution_where_clause_not_met() {
+    // The blanket impl shouldn't apply because we can't prove S: Clone
+    let t = type_at(
+        r#"
+//- /main.rs
+trait Clone {}
+trait Trait { fn foo(self) -> u128; }
+struct S;
+impl S { fn foo(self) -> i8 { 0 } }
+impl<T> Trait for T where T: Clone { fn foo(self) -> u128 { 0 } }
+fn test() { (&S).foo()<|>; }
+"#,
+    );
+    assert_eq!(t, "i8");
+}
+
 fn type_at_pos(db: &MockDatabase, pos: FilePosition) -> String {
     let file = db.parse(pos.file_id);
     let expr = algo::find_node_at_offset::<ast::Expr>(file.syntax(), pos.offset).unwrap();

--- a/crates/ra_hir/src/ty/traits.rs
+++ b/crates/ra_hir/src/ty/traits.rs
@@ -1,8 +1,8 @@
 //! Stuff that will probably mostly replaced by Chalk.
 use std::collections::HashMap;
 
-use crate::db::HirDatabase;
-use super::{ TraitRef, Substs, infer::{ TypeVarId, InferTy}, Ty};
+use crate::{db::HirDatabase, generics::HasGenericParams};
+use super::{TraitRef, Substs, infer::{TypeVarId, InferTy}, Ty};
 
 // Copied (and simplified) from Chalk
 
@@ -59,7 +59,10 @@ pub(crate) fn implements(db: &impl HirDatabase, trait_ref: TraitRef) -> Option<S
         None => return None,
     };
     let crate_impl_blocks = db.impls_in_crate(krate);
-    let mut impl_blocks = crate_impl_blocks.lookup_impl_blocks_for_trait(&trait_ref.trait_);
+    let mut impl_blocks = crate_impl_blocks
+        .lookup_impl_blocks_for_trait(&trait_ref.trait_)
+        // we don't handle where clauses at all, waiting for Chalk for that
+        .filter(|impl_block| impl_block.generic_params(db).where_predicates.is_empty());
     impl_blocks
         .find_map(|impl_block| unify_trait_refs(&trait_ref, &impl_block.target_trait_ref(db)?))
 }


### PR DESCRIPTION
This prevents any `impl<T> Trait for T where ...` from being treated as a
blanket impl while we don't handle where clauses yet.
