### PR TITLE
Start structured editing API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,8 +903,10 @@ version = "0.1.0"
 name = "ra_assists"
 version = "0.1.0"
 dependencies = [
+ "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "join_to_string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ra_db 0.1.0",
  "ra_fmt 0.1.0",
  "ra_hir 0.1.0",

--- a/crates/ra_assists/Cargo.toml
+++ b/crates/ra_assists/Cargo.toml
@@ -5,8 +5,10 @@ version = "0.1.0"
 authors = ["rust-analyzer developers"]
 
 [dependencies]
+lazy_static = "1.3.0"
 join_to_string = "0.1.3"
 itertools = "0.8.0"
+arrayvec = "0.4.10"
 
 ra_syntax = { path = "../ra_syntax" }
 ra_text_edit = { path = "../ra_text_edit" }

--- a/crates/ra_assists/src/assist_ctx.rs
+++ b/crates/ra_assists/src/assist_ctx.rs
@@ -161,6 +161,10 @@ impl AssistBuilder {
         self.target = Some(target)
     }
 
+    pub(crate) fn text_edit_builder(&mut self) -> &mut TextEditBuilder {
+        &mut self.edit
+    }
+
     fn build(self) -> AssistAction {
         AssistAction {
             edit: self.edit.finish(),

--- a/crates/ra_assists/src/ast_editor.rs
+++ b/crates/ra_assists/src/ast_editor.rs
@@ -1,4 +1,4 @@
-use std::iter;
+use std::{iter, ops::RangeInclusive};
 
 use arrayvec::ArrayVec;
 use ra_text_edit::TextEditBuilder;
@@ -26,6 +26,7 @@ impl<N: AstNode> AstEditor<N> {
         &*self.ast
     }
 
+    #[must_use]
     fn insert_children<'a>(
         &self,
         position: InsertPosition<SyntaxElement<'_>>,
@@ -33,6 +34,46 @@ impl<N: AstNode> AstEditor<N> {
     ) -> TreeArc<N> {
         let new_syntax = self.ast().syntax().insert_children(position, to_insert);
         N::cast(&new_syntax).unwrap().to_owned()
+    }
+
+    #[must_use]
+    fn replace_children<'a>(
+        &self,
+        to_delete: RangeInclusive<SyntaxElement<'_>>,
+        to_insert: impl Iterator<Item = SyntaxElement<'a>>,
+    ) -> TreeArc<N> {
+        let new_syntax = self.ast().syntax().replace_children(to_delete, to_insert);
+        N::cast(&new_syntax).unwrap().to_owned()
+    }
+
+    fn do_make_multiline(&mut self) {
+        let l_curly =
+            match self.ast().syntax().children_with_tokens().find(|it| it.kind() == L_CURLY) {
+                Some(it) => it,
+                None => return,
+            };
+        let sibling = match l_curly.next_sibling_or_token() {
+            Some(it) => it,
+            None => return,
+        };
+        let existing_ws = match sibling.as_token() {
+            None => None,
+            Some(tok) if tok.kind() != WHITESPACE => None,
+            Some(ws) => {
+                if ws.text().contains('\n') {
+                    return;
+                }
+                Some(ws)
+            }
+        };
+
+        let indent = leading_indent(self.ast().syntax()).unwrap_or("");
+        let ws = tokens::WsBuilder::new(&format!("\n{}", indent));
+        let to_insert = iter::once(ws.ws().into());
+        self.ast = match existing_ws {
+            None => self.insert_children(InsertPosition::After(l_curly), to_insert),
+            Some(ws) => self.replace_children(RangeInclusive::new(ws.into(), ws.into()), to_insert),
+        };
     }
 }
 
@@ -42,23 +83,7 @@ impl AstEditor<ast::NamedFieldList> {
     }
 
     pub fn make_multiline(&mut self) {
-        let l_curly = match self.l_curly() {
-            Some(it) => it,
-            None => return,
-        };
-        let sibling = match l_curly.next_sibling_or_token() {
-            Some(it) => it,
-            None => return,
-        };
-        if sibling.as_token().map(|it| it.text().contains('\n')) == Some(true) {
-            return;
-        }
-
-        let ws = tokens::WsBuilder::new(&format!(
-            "\n{}",
-            leading_indent(self.ast().syntax()).unwrap_or("")
-        ));
-        self.ast = self.insert_children(InsertPosition::After(l_curly), iter::once(ws.ws().into()));
+        self.do_make_multiline()
     }
 
     pub fn insert_field(
@@ -132,6 +157,79 @@ impl AstEditor<ast::NamedFieldList> {
     }
 }
 
+impl AstEditor<ast::ItemList> {
+    pub fn make_multiline(&mut self) {
+        self.do_make_multiline()
+    }
+
+    pub fn append_functions<'a>(&mut self, fns: impl Iterator<Item = &'a ast::FnDef>) {
+        fns.for_each(|it| self.append_function(it))
+    }
+
+    pub fn append_function(&mut self, fn_def: &ast::FnDef) {
+        let (indent, position) = match self.ast().impl_items().last() {
+            Some(it) => (
+                leading_indent(it.syntax()).unwrap_or("").to_string(),
+                InsertPosition::After(it.syntax().into()),
+            ),
+            None => match self.l_curly() {
+                Some(it) => (
+                    "    ".to_string() + leading_indent(self.ast().syntax()).unwrap_or(""),
+                    InsertPosition::After(it),
+                ),
+                None => return,
+            },
+        };
+        let ws = tokens::WsBuilder::new(&format!("\n{}", indent));
+        let to_insert: ArrayVec<[SyntaxElement; 2]> =
+            [ws.ws().into(), fn_def.syntax().into()].into();
+        self.ast = self.insert_children(position, to_insert.into_iter());
+    }
+
+    fn l_curly(&self) -> Option<SyntaxElement> {
+        self.ast().syntax().children_with_tokens().find(|it| it.kind() == L_CURLY)
+    }
+}
+
+impl AstEditor<ast::FnDef> {
+    pub fn set_body(&mut self, body: &ast::Block) {
+        let mut to_insert: ArrayVec<[SyntaxElement; 2]> = ArrayVec::new();
+        let old_body_or_semi: SyntaxElement = if let Some(old_body) = self.ast().body() {
+            old_body.syntax().into()
+        } else if let Some(semi) = self.ast().semicolon_token() {
+            to_insert.push(tokens::single_space().into());
+            semi.into()
+        } else {
+            to_insert.push(tokens::single_space().into());
+            to_insert.push(body.syntax().into());
+            self.ast = self.insert_children(InsertPosition::Last, to_insert.into_iter());
+            return;
+        };
+        to_insert.push(body.syntax().into());
+        let replace_range = RangeInclusive::new(old_body_or_semi, old_body_or_semi);
+        self.ast = self.replace_children(replace_range, to_insert.into_iter())
+    }
+
+    pub fn strip_attrs_and_docs(&mut self) {
+        loop {
+            if let Some(start) = self
+                .ast()
+                .syntax()
+                .children_with_tokens()
+                .find(|it| it.kind() == ATTR || it.kind() == COMMENT)
+            {
+                let end = match start.next_sibling_or_token() {
+                    Some(el) if el.kind() == WHITESPACE => el,
+                    Some(_) | None => start,
+                };
+                self.ast = self.replace_children(RangeInclusive::new(start, end), iter::empty());
+            } else {
+                break;
+            }
+        }
+    }
+}
+
 pub struct AstBuilder<N: AstNode> {
     _phantom: std::marker::PhantomData<N>,
 }
@@ -149,6 +247,16 @@ impl AstBuilder<ast::NamedField> {
     }
 }
 
+impl AstBuilder<ast::Block> {
+    fn from_text(text: &str) -> TreeArc<ast::Block> {
+        ast_node_from_file_text(&format!("fn f() {}", text))
+    }
+
+    pub fn single_expr(e: &ast::Expr) -> TreeArc<ast::Block> {
+        Self::from_text(&format!("{{ {} }}", e.syntax()))
+    }
+}
+
 impl AstBuilder<ast::Expr> {
     fn from_text(text: &str) -> TreeArc<ast::Expr> {
         ast_node_from_file_text(&format!("fn f() {{ {}; }}", text))
@@ -156,6 +264,10 @@ impl AstBuilder<ast::Expr> {
 
     pub fn unit() -> TreeArc<ast::Expr> {
         Self::from_text("()")
+    }
+
+    pub fn unimplemented() -> TreeArc<ast::Expr> {
+        Self::from_text("unimplemented!()")
     }
 }
 
@@ -194,6 +306,16 @@ mod tokens {
             .descendants_with_tokens()
             .filter_map(|it| it.as_token())
             .find(|it| it.kind() == WHITESPACE && it.text().as_str() == " ")
+            .unwrap()
+    }
+
+    #[allow(unused)]
+    pub(crate) fn single_newline() -> SyntaxToken<'static> {
+        SOURCE_FILE
+            .syntax()
+            .descendants_with_tokens()
+            .filter_map(|it| it.as_token())
+            .find(|it| it.kind() == WHITESPACE && it.text().as_str() == "\n")
             .unwrap()
     }
 

--- a/crates/ra_assists/src/ast_editor.rs
+++ b/crates/ra_assists/src/ast_editor.rs
@@ -110,13 +110,20 @@ impl AstEditor<ast::NamedFieldList> {
 
         let position = match position {
             InsertPosition::First => after_l_curly!(),
-            InsertPosition::Last => match self.ast().fields().last() {
-                Some(it) => after_field!(it),
-                None => after_l_curly!(),
-            },
+            InsertPosition::Last => {
+                if !is_multiline {
+                    // don't insert comma before curly
+                    to_insert.pop();
+                }
+                match self.ast().fields().last() {
+                    Some(it) => after_field!(it),
+                    None => after_l_curly!(),
+                }
+            }
             InsertPosition::Before(anchor) => InsertPosition::Before(anchor.syntax().into()),
             InsertPosition::After(anchor) => after_field!(anchor),
         };
+
         self.ast = self.insert_children(position, to_insert.iter().cloned());
     }
 

--- a/crates/ra_assists/src/ast_editor.rs
+++ b/crates/ra_assists/src/ast_editor.rs
@@ -331,31 +331,3 @@ mod tokens {
     }
 
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    use ra_syntax::SourceFile;
-
-    #[test]
-    fn structure_editing() {
-        let file = SourceFile::parse(
-            "\
-fn foo() {
-    let s = S {
-        original: 92,
-    }
-}
-",
-        );
-        let field_list = file.syntax().descendants().find_map(ast::NamedFieldList::cast).unwrap();
-        let mut editor = AstEditor::new(field_list);
-
-        let field = AstBuilder::<ast::NamedField>::from_text("first_inserted: 1");
-        editor.append_field(&field);
-        let field = AstBuilder::<ast::NamedField>::from_text("second_inserted: 2");
-        editor.append_field(&field);
-        eprintln!("{}", editor.ast().syntax());
-    }
-}

--- a/crates/ra_assists/src/ast_editor.rs
+++ b/crates/ra_assists/src/ast_editor.rs
@@ -1,0 +1,153 @@
+use arrayvec::ArrayVec;
+use ra_text_edit::{TextEdit, TextEditBuilder};
+use ra_syntax::{AstNode, TreeArc, ast, SyntaxKind::*, SyntaxElement, SourceFile, InsertPosition, Direction};
+
+pub struct AstEditor<N: AstNode> {
+    original_ast: TreeArc<N>,
+    ast: TreeArc<N>,
+}
+
+impl<N: AstNode> AstEditor<N> {
+    pub fn new(node: &N) -> AstEditor<N> {
+        AstEditor { original_ast: node.to_owned(), ast: node.to_owned() }
+    }
+
+    pub fn into_text_edit(self) -> TextEdit {
+        // FIXME: compute a more fine-grained diff here.
+        // If *you* know a nice algorithm to compute diff between two syntax
+        // tree, tell me about it!
+        let mut builder = TextEditBuilder::default();
+        builder.replace(self.original_ast.syntax().range(), self.ast().syntax().text().to_string());
+        builder.finish()
+    }
+
+    pub fn ast(&self) -> &N {
+        &*self.ast
+    }
+}
+
+impl AstEditor<ast::NamedFieldList> {
+    pub fn append_field(&mut self, field: &ast::NamedField) {
+        self.insert_field(InsertPosition::Last, field)
+    }
+
+    pub fn insert_field(
+        &mut self,
+        position: InsertPosition<&'_ ast::NamedField>,
+        field: &ast::NamedField,
+    ) {
+        let mut to_insert: ArrayVec<[SyntaxElement; 2]> =
+            [field.syntax().into(), tokens::comma().into()].into();
+        let position = match position {
+            InsertPosition::First => {
+                let anchor = match self
+                    .ast()
+                    .syntax()
+                    .children_with_tokens()
+                    .find(|it| it.kind() == L_CURLY)
+                {
+                    Some(it) => it,
+                    None => return,
+                };
+                InsertPosition::After(anchor)
+            }
+            InsertPosition::Last => {
+                let anchor = match self
+                    .ast()
+                    .syntax()
+                    .children_with_tokens()
+                    .find(|it| it.kind() == R_CURLY)
+                {
+                    Some(it) => it,
+                    None => return,
+                };
+                InsertPosition::Before(anchor)
+            }
+            InsertPosition::Before(anchor) => InsertPosition::Before(anchor.syntax().into()),
+            InsertPosition::After(anchor) => {
+                if let Some(comma) = anchor
+                    .syntax()
+                    .siblings_with_tokens(Direction::Next)
+                    .find(|it| it.kind() == COMMA)
+                {
+                    InsertPosition::After(comma)
+                } else {
+                    to_insert.insert(0, tokens::comma().into());
+                    InsertPosition::After(anchor.syntax().into())
+                }
+            }
+        };
+        self.ast = insert_children_into_ast(self.ast(), position, to_insert.iter().cloned());
+    }
+}
+
+fn insert_children_into_ast<'a, N: AstNode>(
+    node: &N,
+    position: InsertPosition<SyntaxElement<'_>>,
+    to_insert: impl Iterator<Item = SyntaxElement<'a>>,
+) -> TreeArc<N> {
+    let new_syntax = node.syntax().insert_children(position, to_insert);
+    N::cast(&new_syntax).unwrap().to_owned()
+}
+
+pub struct AstBuilder<N: AstNode> {
+    _phantom: std::marker::PhantomData<N>,
+}
+
+impl AstBuilder<ast::NamedField> {
+    pub fn from_text(text: &str) -> TreeArc<ast::NamedField> {
+        ast_node_from_file_text(&format!("fn f() {{ S {{ {}, }} }}", text))
+    }
+}
+
+fn ast_node_from_file_text<N: AstNode>(text: &str) -> TreeArc<N> {
+    let file = SourceFile::parse(text);
+    let res = file.syntax().descendants().find_map(N::cast).unwrap().to_owned();
+    res
+}
+
+mod tokens {
+    use lazy_static::lazy_static;
+    use ra_syntax::{AstNode, SourceFile, TreeArc, SyntaxToken, SyntaxKind::*};
+
+    lazy_static! {
+        static ref SOURCE_FILE: TreeArc<SourceFile> = SourceFile::parse(",");
+    }
+
+    pub(crate) fn comma() -> SyntaxToken<'static> {
+        SOURCE_FILE
+            .syntax()
+            .descendants_with_tokens()
+            .filter_map(|it| it.as_token())
+            .find(|it| it.kind() == COMMA)
+            .unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ra_syntax::SourceFile;
+
+    #[test]
+    fn structure_editing() {
+        let file = SourceFile::parse(
+            "\
+fn foo() {
+    let s = S {
+        original: 92,
+    }
+}
+",
+        );
+        let field_list = file.syntax().descendants().find_map(ast::NamedFieldList::cast).unwrap();
+        let mut editor = AstEditor::new(field_list);
+
+        let field = AstBuilder::<ast::NamedField>::from_text("first_inserted: 1");
+        editor.append_field(&field);
+        let field = AstBuilder::<ast::NamedField>::from_text("second_inserted: 2");
+        editor.append_field(&field);
+        eprintln!("{}", editor.ast().syntax());
+    }
+}

--- a/crates/ra_assists/src/ast_editor.rs
+++ b/crates/ra_assists/src/ast_editor.rs
@@ -1,6 +1,9 @@
+use std::iter;
+
 use arrayvec::ArrayVec;
-use ra_text_edit::{TextEdit, TextEditBuilder};
+use ra_text_edit::TextEditBuilder;
 use ra_syntax::{AstNode, TreeArc, ast, SyntaxKind::*, SyntaxElement, SourceFile, InsertPosition, Direction};
+use ra_fmt::leading_indent;
 
 pub struct AstEditor<N: AstNode> {
     original_ast: TreeArc<N>,
@@ -12,17 +15,24 @@ impl<N: AstNode> AstEditor<N> {
         AstEditor { original_ast: node.to_owned(), ast: node.to_owned() }
     }
 
-    pub fn into_text_edit(self) -> TextEdit {
+    pub fn into_text_edit(self, builder: &mut TextEditBuilder) {
         // FIXME: compute a more fine-grained diff here.
         // If *you* know a nice algorithm to compute diff between two syntax
         // tree, tell me about it!
-        let mut builder = TextEditBuilder::default();
         builder.replace(self.original_ast.syntax().range(), self.ast().syntax().text().to_string());
-        builder.finish()
     }
 
     pub fn ast(&self) -> &N {
         &*self.ast
+    }
+
+    fn insert_children<'a>(
+        &self,
+        position: InsertPosition<SyntaxElement<'_>>,
+        to_insert: impl Iterator<Item = SyntaxElement<'a>>,
+    ) -> TreeArc<N> {
+        let new_syntax = self.ast().syntax().insert_children(position, to_insert);
+        N::cast(&new_syntax).unwrap().to_owned()
     }
 }
 
@@ -31,41 +41,61 @@ impl AstEditor<ast::NamedFieldList> {
         self.insert_field(InsertPosition::Last, field)
     }
 
+    pub fn make_multiline(&mut self) {
+        let l_curly = match self.l_curly() {
+            Some(it) => it,
+            None => return,
+        };
+        let sibling = match l_curly.next_sibling_or_token() {
+            Some(it) => it,
+            None => return,
+        };
+        if sibling.as_token().map(|it| it.text().contains('\n')) == Some(true) {
+            return;
+        }
+
+        let ws = tokens::WsBuilder::new(&format!(
+            "\n{}",
+            leading_indent(self.ast().syntax()).unwrap_or("")
+        ));
+        self.ast = self.insert_children(InsertPosition::After(l_curly), iter::once(ws.ws().into()));
+    }
+
     pub fn insert_field(
         &mut self,
         position: InsertPosition<&'_ ast::NamedField>,
         field: &ast::NamedField,
     ) {
-        let mut to_insert: ArrayVec<[SyntaxElement; 2]> =
-            [field.syntax().into(), tokens::comma().into()].into();
-        let position = match position {
-            InsertPosition::First => {
-                let anchor = match self
-                    .ast()
-                    .syntax()
-                    .children_with_tokens()
-                    .find(|it| it.kind() == L_CURLY)
-                {
+        let is_multiline = self.ast().syntax().text().contains('\n');
+        let ws;
+        let space = if is_multiline {
+            ws = tokens::WsBuilder::new(&format!(
+                "\n{}    ",
+                leading_indent(self.ast().syntax()).unwrap_or("")
+            ));
+            ws.ws()
+        } else {
+            tokens::single_space()
+        };
+
+        let mut to_insert: ArrayVec<[SyntaxElement; 4]> = ArrayVec::new();
+        to_insert.push(space.into());
+        to_insert.push(field.syntax().into());
+        to_insert.push(tokens::comma().into());
+
+        macro_rules! after_l_curly {
+            () => {{
+                let anchor = match self.l_curly() {
                     Some(it) => it,
                     None => return,
                 };
                 InsertPosition::After(anchor)
-            }
-            InsertPosition::Last => {
-                let anchor = match self
-                    .ast()
-                    .syntax()
-                    .children_with_tokens()
-                    .find(|it| it.kind() == R_CURLY)
-                {
-                    Some(it) => it,
-                    None => return,
-                };
-                InsertPosition::Before(anchor)
-            }
-            InsertPosition::Before(anchor) => InsertPosition::Before(anchor.syntax().into()),
-            InsertPosition::After(anchor) => {
-                if let Some(comma) = anchor
+            }};
+        }
+
+        macro_rules! after_field {
+            ($anchor:expr) => {
+                if let Some(comma) = $anchor
                     .syntax()
                     .siblings_with_tokens(Direction::Next)
                     .find(|it| it.kind() == COMMA)
@@ -73,21 +103,26 @@ impl AstEditor<ast::NamedFieldList> {
                     InsertPosition::After(comma)
                 } else {
                     to_insert.insert(0, tokens::comma().into());
-                    InsertPosition::After(anchor.syntax().into())
+                    InsertPosition::After($anchor.syntax().into())
                 }
-            }
+            };
         };
-        self.ast = insert_children_into_ast(self.ast(), position, to_insert.iter().cloned());
-    }
-}
 
-fn insert_children_into_ast<'a, N: AstNode>(
-    node: &N,
-    position: InsertPosition<SyntaxElement<'_>>,
-    to_insert: impl Iterator<Item = SyntaxElement<'a>>,
-) -> TreeArc<N> {
-    let new_syntax = node.syntax().insert_children(position, to_insert);
-    N::cast(&new_syntax).unwrap().to_owned()
+        let position = match position {
+            InsertPosition::First => after_l_curly!(),
+            InsertPosition::Last => match self.ast().fields().last() {
+                Some(it) => after_field!(it),
+                None => after_l_curly!(),
+            },
+            InsertPosition::Before(anchor) => InsertPosition::Before(anchor.syntax().into()),
+            InsertPosition::After(anchor) => after_field!(anchor),
+        };
+        self.ast = self.insert_children(position, to_insert.iter().cloned());
+    }
+
+    fn l_curly(&self) -> Option<SyntaxElement> {
+        self.ast().syntax().children_with_tokens().find(|it| it.kind() == L_CURLY)
+    }
 }
 
 pub struct AstBuilder<N: AstNode> {
@@ -111,7 +146,7 @@ mod tokens {
     use ra_syntax::{AstNode, SourceFile, TreeArc, SyntaxToken, SyntaxKind::*};
 
     lazy_static! {
-        static ref SOURCE_FILE: TreeArc<SourceFile> = SourceFile::parse(",");
+        static ref SOURCE_FILE: TreeArc<SourceFile> = SourceFile::parse(",\n; ;");
     }
 
     pub(crate) fn comma() -> SyntaxToken<'static> {
@@ -122,6 +157,27 @@ mod tokens {
             .find(|it| it.kind() == COMMA)
             .unwrap()
     }
+
+    pub(crate) fn single_space() -> SyntaxToken<'static> {
+        SOURCE_FILE
+            .syntax()
+            .descendants_with_tokens()
+            .filter_map(|it| it.as_token())
+            .find(|it| it.kind() == WHITESPACE && it.text().as_str() == " ")
+            .unwrap()
+    }
+
+    pub(crate) struct WsBuilder(TreeArc<SourceFile>);
+
+    impl WsBuilder {
+        pub(crate) fn new(text: &str) -> WsBuilder {
+            WsBuilder(SourceFile::parse(text))
+        }
+        pub(crate) fn ws(&self) -> SyntaxToken<'_> {
+            self.0.syntax().first_child_or_token().unwrap().as_token().unwrap()
+        }
+    }
+
 }
 
 #[cfg(test)]

--- a/crates/ra_assists/src/ast_editor.rs
+++ b/crates/ra_assists/src/ast_editor.rs
@@ -137,8 +137,31 @@ pub struct AstBuilder<N: AstNode> {
 }
 
 impl AstBuilder<ast::NamedField> {
-    pub fn from_text(text: &str) -> TreeArc<ast::NamedField> {
+    fn from_text(text: &str) -> TreeArc<ast::NamedField> {
         ast_node_from_file_text(&format!("fn f() {{ S {{ {}, }} }}", text))
+    }
+
+    pub fn from_pieces(name: &ast::NameRef, expr: Option<&ast::Expr>) -> TreeArc<ast::NamedField> {
+        match expr {
+            Some(expr) => Self::from_text(&format!("{}: {}", name.syntax(), expr.syntax())),
+            None => Self::from_text(&name.syntax().to_string()),
+        }
+    }
+}
+
+impl AstBuilder<ast::Expr> {
+    fn from_text(text: &str) -> TreeArc<ast::Expr> {
+        ast_node_from_file_text(&format!("fn f() {{ {}; }}", text))
+    }
+
+    pub fn unit() -> TreeArc<ast::Expr> {
+        Self::from_text("()")
+    }
+}
+
+impl AstBuilder<ast::NameRef> {
+    pub fn new(text: &str) -> TreeArc<ast::NameRef> {
+        ast_node_from_file_text(&format!("fn f() {{ {}; }}", text))
     }
 }
 

--- a/crates/ra_assists/src/fill_struct_fields.rs
+++ b/crates/ra_assists/src/fill_struct_fields.rs
@@ -1,94 +1,53 @@
-use std::fmt::Write;
-
 use hir::{AdtDef, db::HirDatabase};
 
 use ra_syntax::ast::{self, AstNode};
 
-use crate::{AssistCtx, Assist, AssistId};
+use crate::{AssistCtx, Assist, AssistId, ast_editor::{AstEditor, AstBuilder}};
 
 pub(crate) fn fill_struct_fields(mut ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
     let struct_lit = ctx.node_at_offset::<ast::StructLit>()?;
-    let mut fsf = FillStructFields {
-        ctx: &mut ctx,
-        named_field_list: struct_lit.named_field_list()?,
-        struct_fields: vec![],
-        struct_lit,
-    };
-    fsf.evaluate_struct_def_fields()?;
-    if fsf.struct_lit_and_def_have_the_same_number_of_fields() {
-        return None;
-    }
-    fsf.remove_already_included_fields()?;
-    fsf.add_action()?;
-    ctx.build()
-}
+    let named_field_list = struct_lit.named_field_list()?;
 
-struct FillStructFields<'a, 'b: 'a, DB> {
-    ctx: &'a mut AssistCtx<'b, DB>,
-    named_field_list: &'a ast::NamedFieldList,
-    struct_fields: Vec<(String, String)>,
-    struct_lit: &'a ast::StructLit,
-}
-
-impl<DB> FillStructFields<'_, '_, DB>
-where
-    DB: HirDatabase,
-{
-    fn add_action(&mut self) -> Option<()> {
-        let named_field_list = self.named_field_list;
-        let struct_fields_string = self.struct_fields_string()?;
-        let struct_lit = self.struct_lit;
-        self.ctx.add_action(AssistId("fill_struct_fields"), "fill struct fields", |edit| {
-            edit.target(struct_lit.syntax().range());
-            edit.set_cursor(struct_lit.syntax().range().start());
-            edit.replace_node_and_indent(named_field_list.syntax(), struct_fields_string);
-        });
-        Some(())
-    }
-
-    fn struct_lit_and_def_have_the_same_number_of_fields(&self) -> bool {
-        self.named_field_list.fields().count() == self.struct_fields.len()
-    }
-
-    fn evaluate_struct_def_fields(&mut self) -> Option<()> {
-        let analyzer = hir::SourceAnalyzer::new(
-            self.ctx.db,
-            self.ctx.frange.file_id,
-            self.struct_lit.syntax(),
-            None,
-        );
-        let struct_lit_ty = analyzer.type_of(self.ctx.db, self.struct_lit.into())?;
+    // Collect all fields from struct definition
+    let mut fields = {
+        let analyzer =
+            hir::SourceAnalyzer::new(ctx.db, ctx.frange.file_id, struct_lit.syntax(), None);
+        let struct_lit_ty = analyzer.type_of(ctx.db, struct_lit.into())?;
         let struct_def = match struct_lit_ty.as_adt() {
             Some((AdtDef::Struct(s), _)) => s,
             _ => return None,
         };
-        self.struct_fields = struct_def
-            .fields(self.ctx.db)
-            .into_iter()
-            .map(|f| (f.name(self.ctx.db).to_string(), "()".into()))
-            .collect();
-        Some(())
+        struct_def.fields(ctx.db)
+    };
+
+    // Filter out existing fields
+    for ast_field in named_field_list.fields() {
+        let name_from_ast = ast_field.name_ref()?.text().to_string();
+        fields.retain(|field| field.name(ctx.db).to_string() != name_from_ast);
+    }
+    if fields.is_empty() {
+        return None;
     }
 
-    fn remove_already_included_fields(&mut self) -> Option<()> {
-        for ast_field in self.named_field_list.fields() {
-            let expr = ast_field.expr()?.syntax().text().to_string();
-            let name_from_ast = ast_field.name_ref()?.text().to_string();
-            if let Some(idx) = self.struct_fields.iter().position(|(n, _)| n == &name_from_ast) {
-                self.struct_fields[idx] = (name_from_ast, expr);
-            }
-        }
-        Some(())
-    }
+    let db = ctx.db;
+    ctx.add_action(AssistId("fill_struct_fields"), "fill struct fields", |edit| {
+        let mut ast_editor = AstEditor::new(named_field_list);
+        if named_field_list.fields().count() == 0 && fields.len() > 2 {
+            ast_editor.make_multiline();
+        };
 
-    fn struct_fields_string(&mut self) -> Option<String> {
-        let mut buf = String::from("{\n");
-        for (name, expr) in &self.struct_fields {
-            write!(&mut buf, "    {}: {},\n", name, expr).unwrap();
+        for field in fields {
+            let field =
+                AstBuilder::<ast::NamedField>::from_text(&format!("{}: ()", field.name(db)));
+            ast_editor.append_field(&field);
         }
-        buf.push_str("}");
-        Some(buf)
-    }
+
+        edit.target(struct_lit.syntax().range());
+        edit.set_cursor(struct_lit.syntax().range().start());
+
+        ast_editor.into_text_edit(edit.text_edit_builder());
+    });
+    ctx.build()
 }
 
 #[cfg(test)]
@@ -225,11 +184,11 @@ mod tests {
 
             fn main() {
                 let s = <|>S {
+                    c: (1, 2),
+                    e: "foo",
                     a: (),
                     b: (),
-                    c: (1, 2),
                     d: (),
-                    e: "foo",
                 }
             }
             "#,

--- a/crates/ra_assists/src/fill_struct_fields.rs
+++ b/crates/ra_assists/src/fill_struct_fields.rs
@@ -37,8 +37,10 @@ pub(crate) fn fill_struct_fields(mut ctx: AssistCtx<impl HirDatabase>) -> Option
         };
 
         for field in fields {
-            let field =
-                AstBuilder::<ast::NamedField>::from_text(&format!("{}: ()", field.name(db)));
+            let field = AstBuilder::<ast::NamedField>::from_pieces(
+                &AstBuilder::<ast::NameRef>::new(&field.name(db).to_string()),
+                Some(&AstBuilder::<ast::Expr>::unit()),
+            );
             ast_editor.append_field(&field);
         }
 

--- a/crates/ra_assists/src/fill_struct_fields.rs
+++ b/crates/ra_assists/src/fill_struct_fields.rs
@@ -194,4 +194,31 @@ mod tests {
             "#,
         );
     }
+
+    #[test]
+    fn fill_struct_short() {
+        check_assist(
+            fill_struct_fields,
+            r#"
+            struct S {
+                foo: u32,
+                bar: String,
+            }
+
+            fn main() {
+                let s = S {<|> };
+            }
+            "#,
+            r#"
+            struct S {
+                foo: u32,
+                bar: String,
+            }
+
+            fn main() {
+                let s = <|>S { foo: (), bar: () };
+            }
+            "#,
+        );
+    }
 }

--- a/crates/ra_assists/src/lib.rs
+++ b/crates/ra_assists/src/lib.rs
@@ -37,7 +37,7 @@ pub struct AssistAction {
     pub target: Option<TextRange>,
 }
 
-/// Return all the assists applicable at the given position.
+/// Return all the assists eapplicable at the given position.
 ///
 /// Assists are returned in the "unresolved" state, that is only labels are
 /// returned, without actual edits.

--- a/crates/ra_assists/src/lib.rs
+++ b/crates/ra_assists/src/lib.rs
@@ -7,6 +7,7 @@
 
 mod assist_ctx;
 mod marks;
+pub mod ast_editor;
 
 use itertools::Itertools;
 

--- a/crates/ra_ide_api/src/completion/complete_postfix.rs
+++ b/crates/ra_ide_api/src/completion/complete_postfix.rs
@@ -40,7 +40,7 @@ pub(super) fn complete_postfix(acc: &mut Completions, ctx: &CompletionContext) {
             ctx,
             "match",
             "match expr {}",
-            &format!("match {} {{\n${{1:_}} => {{$0\\}},\n}}", receiver_text),
+            &format!("match {} {{\n    ${{1:_}} => {{$0\\}},\n}}", receiver_text),
         )
         .add_to(acc);
         postfix_snippet(

--- a/crates/ra_ide_api/src/completion/snapshots/completion_item__postfix_completion_works_for_trivial_path_expression.snap
+++ b/crates/ra_ide_api/src/completion/snapshots/completion_item__postfix_completion_works_for_trivial_path_expression.snap
@@ -1,6 +1,6 @@
 ---
-created: "2019-02-18T09:22:24.127119709Z"
-creator: insta@0.6.2
+created: "2019-04-22T07:37:13.981826301Z"
+creator: insta@0.7.4
 source: crates/ra_ide_api/src/completion/completion_item.rs
 expression: kind_completions
 ---
@@ -23,7 +23,7 @@ expression: kind_completions
         label: "match",
         source_range: [76; 76),
         delete: [72; 76),
-        insert: "match bar {\n${1:_} => {$0\\},\n}",
+        insert: "match bar {\n    ${1:_} => {$0\\},\n}",
         detail: "match expr {}"
     },
     CompletionItem {

--- a/crates/ra_syntax/src/ast/extensions.rs
+++ b/crates/ra_syntax/src/ast/extensions.rs
@@ -210,6 +210,15 @@ impl ast::EnumVariant {
     }
 }
 
+impl ast::FnDef {
+    pub fn semicolon_token(&self) -> Option<SyntaxToken<'_>> {
+        self.syntax()
+            .last_child_or_token()
+            .and_then(|it| it.as_token())
+            .filter(|it| it.kind() == SEMI)
+    }
+}
+
 impl ast::LetStmt {
     pub fn has_semi(&self) -> bool {
         match self.syntax().last_child_or_token() {

--- a/crates/ra_syntax/src/lib.rs
+++ b/crates/ra_syntax/src/lib.rs
@@ -38,7 +38,7 @@ pub use crate::{
     ast::AstNode,
     syntax_error::{SyntaxError, SyntaxErrorKind, Location},
     syntax_text::SyntaxText,
-    syntax_node::{Direction,  SyntaxNode, WalkEvent, TreeArc, SyntaxTreeBuilder, SyntaxElement, SyntaxToken},
+    syntax_node::{Direction,  SyntaxNode, WalkEvent, TreeArc, SyntaxTreeBuilder, SyntaxElement, SyntaxToken, InsertPosition},
     ptr::{SyntaxNodePtr, AstPtr},
     parsing::{tokenize, classify_literal, Token},
 };

--- a/crates/ra_syntax/src/ptr.rs
+++ b/crates/ra_syntax/src/ptr.rs
@@ -10,7 +10,7 @@ use crate::{
 /// specific node across reparses of the same file.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SyntaxNodePtr {
-    range: TextRange,
+    pub(crate) range: TextRange,
     kind: SyntaxKind,
 }
 

--- a/crates/ra_syntax/src/syntax_node.rs
+++ b/crates/ra_syntax/src/syntax_node.rs
@@ -24,6 +24,7 @@ use crate::{
 pub use rowan::WalkEvent;
 pub(crate) use rowan::{GreenNode, GreenToken};
 
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum InsertPosition<T> {
     First,
     Last,


### PR DESCRIPTION
I think I finally understand how to provide nice, mutable structured editing API on top of red-green trees.

The problem I am trying to solve is that any modification to a particular `SyntaxNode` returns an independent new file. So, if you are editing a struct literal, and add a field, you get back a SourceFile, and you have to find the struct literal inside it yourself! This happens because our trees are immutable, but have parent pointers. 

The main idea here is to introduce `AstEditor<T>` type, which abstracts away that API. So, you create an `AstEditor` for node you want to edit and call various `&mut` taking methods on it. Internally, `AstEditor` stores both the original node and the current node. All edits are applied to the current node, which is replaced by the corresponding node in the new file. In the end, `AstEditor` computes a text edit between old and new nodes.

Note that this also should sole a problem when you create an anchor pointing to a subnode and mutate the parent node, invalidating anchor. Because mutation needs `&mut`, all anchors must be killed before modification. 