### PR TITLE
Fix #1178

### DIFF
--- a/crates/ra_mbe/src/subtree_source.rs
+++ b/crates/ra_mbe/src/subtree_source.rs
@@ -21,6 +21,7 @@ impl<'a> From<&'a [tt::TokenTree]> for TokenSeq<'a> {
     }
 }
 
+#[derive(Debug)]
 enum DelimToken<'a> {
     Delim(&'a tt::Delimiter, bool),
     Token(&'a tt::TokenTree),
@@ -52,10 +53,10 @@ impl<'a> TokenSeq<'a> {
         }
     }
 
-    fn child_slice(&self) -> &[tt::TokenTree] {
+    fn child_slice(&self, pos: usize) -> &[tt::TokenTree] {
         match self {
-            TokenSeq::Subtree(subtree) => &subtree.token_trees,
-            TokenSeq::Seq(tokens) => &tokens,
+            TokenSeq::Subtree(subtree) => &subtree.token_trees[pos - 1..],
+            TokenSeq::Seq(tokens) => &tokens[pos..],
         }
     }
 }
@@ -114,7 +115,7 @@ impl<'a> SubTreeWalker<'a> {
                     WalkCursor::Token(0, convert_delim(subtree.delimiter, false))
                 }
                 tt::TokenTree::Leaf(leaf) => {
-                    let next_tokens = self.ts.child_slice();
+                    let next_tokens = self.ts.child_slice(0);
                     WalkCursor::Token(0, convert_leaf(&next_tokens, leaf))
                 }
             },
@@ -190,8 +191,8 @@ impl<'a> SubTreeWalker<'a> {
                     WalkCursor::Token(new_idx, convert_delim(subtree.delimiter, backward))
                 }
                 tt::TokenTree::Leaf(leaf) => {
-                    let next_tokens = top.child_slice();
-                    WalkCursor::Token(pos, convert_leaf(&next_tokens[pos..], leaf))
+                    let next_tokens = top.child_slice(pos);
+                    WalkCursor::Token(pos, convert_leaf(&next_tokens, leaf))
                 }
             },
             DelimToken::Delim(delim, is_end) => {

--- a/crates/ra_mbe/src/subtree_source.rs
+++ b/crates/ra_mbe/src/subtree_source.rs
@@ -429,7 +429,12 @@ fn convert_literal(l: &tt::Literal) -> TtToken {
 }
 
 fn convert_ident(ident: &tt::Ident) -> TtToken {
-    let kind = SyntaxKind::from_keyword(ident.text.as_str()).unwrap_or(IDENT);
+    let kind = if let Some('\'') = ident.text.chars().next() {
+        LIFETIME
+    } else {
+        SyntaxKind::from_keyword(ident.text.as_str()).unwrap_or(IDENT)
+    };
+
     TtToken { kind, is_joint_to_next: false, text: ident.text.clone(), n_tokens: 1 }
 }
 


### PR DESCRIPTION
This PR improves / fixes mbe :

1. Fixed a offest bug in `SourceTreeWalker`
2. Handle `*+` matcher properly
3. Add missing separator in rhs macro expansion.
4. Fixed bug in single token with empty delimiter subtree case. It is because the current `mbe_expander` will create an delimiter subtree for each expansion. But in `tt` case, all puncts expansion will be incorrect because of it. 
5. Fixed lifetime bug
6. Add more information on parse_macro fail
7. Add tests for above.

