### PR TITLE
WIP auto import in autocomplete

### DIFF
--- a/crates/ra_assists/src/assist_ctx.rs
+++ b/crates/ra_assists/src/assist_ctx.rs
@@ -144,6 +144,10 @@ impl AssistBuilder {
         self.replace(node.range(), replace_with)
     }
 
+    pub(crate) fn set_edit_builder(&mut self, edit: TextEditBuilder) {
+        self.edit = edit;
+    }
+
     #[allow(unused)]
     pub(crate) fn delete(&mut self, range: TextRange) {
         self.edit.delete(range)

--- a/crates/ra_assists/src/auto_import.rs
+++ b/crates/ra_assists/src/auto_import.rs
@@ -1,3 +1,4 @@
+use ra_text_edit::TextEditBuilder;
 use hir::db::HirDatabase;
 
 use ra_syntax::{
@@ -374,7 +375,7 @@ fn best_action_for_target<'b, 'a: 'b>(
     }
 }
 
-fn make_assist(action: &ImportAction, target: &[&ast::PathSegment], edit: &mut AssistBuilder) {
+fn make_assist(action: &ImportAction, target: &[&ast::PathSegment], edit: &mut TextEditBuilder) {
     match action {
         ImportAction::AddNewUse { anchor, add_after_anchor } => {
             make_assist_add_new_use(anchor, *add_after_anchor, target, edit)
@@ -408,7 +409,7 @@ fn make_assist_add_new_use(
     anchor: &Option<&SyntaxNode>,
     after: bool,
     target: &[&ast::PathSegment],
-    edit: &mut AssistBuilder,
+    edit: &mut TextEditBuilder,
 ) {
     if let Some(anchor) = anchor {
         let indent = ra_fmt::leading_indent(anchor);
@@ -437,7 +438,7 @@ fn make_assist_add_in_tree_list(
     tree_list: &ast::UseTreeList,
     target: &[&ast::PathSegment],
     add_self: bool,
-    edit: &mut AssistBuilder,
+    edit: &mut TextEditBuilder,
 ) {
     let last = tree_list.use_trees().last();
     if let Some(last) = last {
@@ -466,7 +467,7 @@ fn make_assist_add_nested_import(
     first_segment_to_split: &Option<&ast::PathSegment>,
     target: &[&ast::PathSegment],
     add_self: bool,
-    edit: &mut AssistBuilder,
+    edit: &mut TextEditBuilder,
 ) {
     let use_tree = path.syntax().ancestors().find_map(ast::UseTree::cast);
     if let Some(use_tree) = use_tree {
@@ -491,7 +492,7 @@ fn make_assist_add_nested_import(
             buf.push_str(", ");
         }
         edit.insert(start, buf);
-        edit.insert(end, "}");
+        edit.insert(end, "}".to_string());
     }
 }
 
@@ -499,7 +500,7 @@ fn apply_auto_import<'a>(
     container: &SyntaxNode,
     path: &ast::Path,
     target: &[&'a ast::PathSegment],
-    edit: &mut AssistBuilder,
+    edit: &mut TextEditBuilder,
 ) {
     let action = best_action_for_target(container, path, target);
     make_assist(&action, target, edit);
@@ -510,6 +511,25 @@ fn apply_auto_import<'a>(
             first.syntax().range().start(),
             last.syntax().range().start(),
         ));
+    }
+}
+
+pub fn auto_import_text_edit<'a>(
+    position: &SyntaxNode,
+    path: &ast::Path,
+    target: &[&'a ast::PathSegment],
+    edit: &mut TextEditBuilder,
+) {
+    let container = position.ancestors().find_map(|n| {
+        if let Some(module) = ast::Module::cast(n) {
+            return module.item_list().map(ast::AstNode::syntax);
+        }
+        ast::SourceFile::cast(n).map(ast::AstNode::syntax)
+    });
+
+    if let Some(container) = container {
+        let action = best_action_for_target(container, path, target);
+        make_assist(&action, target, edit);
     }
 }
 
@@ -531,7 +551,9 @@ pub(crate) fn auto_import(mut ctx: AssistCtx<impl HirDatabase>) -> Option<Assist
                 AssistId("auto_import"),
                 format!("import {} in mod {}", fmt_segments(&segments), name.text()),
                 |edit| {
-                    apply_auto_import(item_list.syntax(), path, &segments, edit);
+                    let mut text_edit = TextEditBuilder::default();
+                    apply_auto_import(item_list.syntax(), path, &segments, &mut text_edit);
+                    edit.set_edit_builder(text_edit);
                 },
             );
         }
@@ -541,7 +563,9 @@ pub(crate) fn auto_import(mut ctx: AssistCtx<impl HirDatabase>) -> Option<Assist
             AssistId("auto_import"),
             format!("import {} in the current file", fmt_segments(&segments)),
             |edit| {
-                apply_auto_import(current_file.syntax(), path, &segments, edit);
+                let mut text_edit = TextEditBuilder::default();
+                apply_auto_import(current_file.syntax(), path, &segments, &mut text_edit);
+                edit.set_edit_builder(text_edit);
             },
         );
     }

--- a/crates/ra_assists/src/auto_import.rs
+++ b/crates/ra_assists/src/auto_import.rs
@@ -1,20 +1,14 @@
 use ra_text_edit::TextEditBuilder;
-use hir::db::HirDatabase;
+use hir::{ self, db::HirDatabase};
 
 use ra_syntax::{
-    ast::{ self, NameOwner }, AstNode, SyntaxNode, Direction, TextRange,
+    ast::{ self, NameOwner }, AstNode, SyntaxNode, Direction, TextRange, SmolStr,
     SyntaxKind::{ PATH, PATH_SEGMENT, COLONCOLON, COMMA }
 };
 use crate::{
     AssistId,
-    assist_ctx::{AssistCtx, Assist, AssistBuilder},
+    assist_ctx::{AssistCtx, Assist},
 };
-
-fn collect_path_segments(path: &ast::Path) -> Option<Vec<&ast::PathSegment>> {
-    let mut v = Vec::new();
-    collect_path_segments_raw(&mut v, path)?;
-    return Some(v);
-}
 
 fn collect_path_segments_raw<'a>(
     segments: &mut Vec<&'a ast::PathSegment>,
@@ -46,59 +40,43 @@ fn collect_path_segments_raw<'a>(
     return Some(segments.len() - oldlen);
 }
 
-fn fmt_segments(segments: &[&ast::PathSegment]) -> String {
+fn fmt_segments(segments: &[SmolStr]) -> String {
     let mut buf = String::new();
     fmt_segments_raw(segments, &mut buf);
     return buf;
 }
 
-fn fmt_segments_raw(segments: &[&ast::PathSegment], buf: &mut String) {
-    let mut first = true;
-    for s in segments {
-        if !first {
-            buf.push_str("::");
-        }
-        match s.kind() {
-            Some(ast::PathSegmentKind::Name(nameref)) => buf.push_str(nameref.text()),
-            Some(ast::PathSegmentKind::SelfKw) => buf.push_str("self"),
-            Some(ast::PathSegmentKind::SuperKw) => buf.push_str("super"),
-            Some(ast::PathSegmentKind::CrateKw) => buf.push_str("crate"),
-            None => {}
-        }
-        first = false;
+fn fmt_segments_raw(segments: &[SmolStr], buf: &mut String) {
+    let mut iter = segments.iter();
+    if let Some(s) = iter.next() {
+        buf.push_str(s);
+    }
+    for s in iter {
+        buf.push_str("::");
+        buf.push_str(s);
     }
 }
 
 // Returns the numeber of common segments.
-fn compare_path_segments(left: &[&ast::PathSegment], right: &[&ast::PathSegment]) -> usize {
+fn compare_path_segments(left: &[SmolStr], right: &[&ast::PathSegment]) -> usize {
     return left.iter().zip(right).filter(|(l, r)| compare_path_segment(l, r)).count();
 }
 
-fn compare_path_segment(a: &ast::PathSegment, b: &ast::PathSegment) -> bool {
-    if let (Some(ka), Some(kb)) = (a.kind(), b.kind()) {
-        match (ka, kb) {
-            (ast::PathSegmentKind::Name(nameref_a), ast::PathSegmentKind::Name(nameref_b)) => {
-                nameref_a.text() == nameref_b.text()
-            }
-            (ast::PathSegmentKind::SelfKw, ast::PathSegmentKind::SelfKw) => true,
-            (ast::PathSegmentKind::SuperKw, ast::PathSegmentKind::SuperKw) => true,
-            (ast::PathSegmentKind::CrateKw, ast::PathSegmentKind::CrateKw) => true,
-            (_, _) => false,
+fn compare_path_segment(a: &SmolStr, b: &ast::PathSegment) -> bool {
+    if let Some(kb) = b.kind() {
+        match kb {
+            ast::PathSegmentKind::Name(nameref_b) => a == nameref_b.text(),
+            ast::PathSegmentKind::SelfKw => a == "self",
+            ast::PathSegmentKind::SuperKw => a == "super",
+            ast::PathSegmentKind::CrateKw => a == "crate",
         }
     } else {
         false
     }
 }
 
-fn compare_path_segment_with_name(a: &ast::PathSegment, b: &ast::Name) -> bool {
-    if let Some(ka) = a.kind() {
-        return match (ka, b) {
-            (ast::PathSegmentKind::Name(nameref_a), _) => nameref_a.text() == b.text(),
-            (_, _) => false,
-        };
-    } else {
-        false
-    }
+fn compare_path_segment_with_name(a: &SmolStr, b: &ast::Name) -> bool {
+    a == b.text()
 }
 
 #[derive(Copy, Clone)]
@@ -190,7 +168,7 @@ fn walk_use_tree_for_best_action<'a>(
     current_path_segments: &mut Vec<&'a ast::PathSegment>, // buffer containing path segments
     current_parent_use_tree_list: Option<&'a ast::UseTreeList>, // will be Some value if we are in a nested import
     current_use_tree: &'a ast::UseTree, // the use tree we are currently examinating
-    target: &[&'a ast::PathSegment],    // the path we want to import
+    target: &[SmolStr],    // the path we want to import
 ) -> ImportAction<'a> {
     // We save the number of segments in the buffer so we can restore the correct segments
     // before returning. Recursive call will add segments so we need to delete them.
@@ -216,7 +194,7 @@ fn walk_use_tree_for_best_action<'a>(
 
     // This can happen only if current_use_tree is a direct child of a UseItem
     if let Some(name) = alias.and_then(ast::NameOwner::name) {
-        if compare_path_segment_with_name(target[0], name) {
+        if compare_path_segment_with_name(&target[0], name) {
             return ImportAction::Nothing;
         }
     }
@@ -345,8 +323,8 @@ fn walk_use_tree_for_best_action<'a>(
 
 fn best_action_for_target<'b, 'a: 'b>(
     container: &'a SyntaxNode,
-    path: &'a ast::Path,
-    target: &'b [&'a ast::PathSegment],
+    anchor: &'a SyntaxNode,
+    target: &'b [SmolStr],
 ) -> ImportAction<'a> {
     let mut storage = Vec::with_capacity(16); // this should be the only allocation
     let best_action = container
@@ -368,14 +346,14 @@ fn best_action_for_target<'b, 'a: 'b>(
                 .children()
                 .find_map(ast::ModuleItem::cast)
                 .map(AstNode::syntax)
-                .or(Some(path.syntax()));
+                .or(Some(anchor));
 
             return ImportAction::add_new_use(anchor, false);
         }
     }
 }
 
-fn make_assist(action: &ImportAction, target: &[&ast::PathSegment], edit: &mut TextEditBuilder) {
+fn make_assist(action: &ImportAction, target: &[SmolStr], edit: &mut TextEditBuilder) {
     match action {
         ImportAction::AddNewUse { anchor, add_after_anchor } => {
             make_assist_add_new_use(anchor, *add_after_anchor, target, edit)
@@ -408,7 +386,7 @@ fn make_assist(action: &ImportAction, target: &[&ast::PathSegment], edit: &mut T
 fn make_assist_add_new_use(
     anchor: &Option<&SyntaxNode>,
     after: bool,
-    target: &[&ast::PathSegment],
+    target: &[SmolStr],
     edit: &mut TextEditBuilder,
 ) {
     if let Some(anchor) = anchor {
@@ -436,7 +414,7 @@ fn make_assist_add_new_use(
 
 fn make_assist_add_in_tree_list(
     tree_list: &ast::UseTreeList,
-    target: &[&ast::PathSegment],
+    target: &[SmolStr],
     add_self: bool,
     edit: &mut TextEditBuilder,
 ) {
@@ -465,7 +443,7 @@ fn make_assist_add_in_tree_list(
 fn make_assist_add_nested_import(
     path: &ast::Path,
     first_segment_to_split: &Option<&ast::PathSegment>,
-    target: &[&ast::PathSegment],
+    target: &[SmolStr],
     add_self: bool,
     edit: &mut TextEditBuilder,
 ) {
@@ -496,28 +474,51 @@ fn make_assist_add_nested_import(
     }
 }
 
-fn apply_auto_import<'a>(
+fn apply_auto_import(
     container: &SyntaxNode,
     path: &ast::Path,
-    target: &[&'a ast::PathSegment],
+    target: &[SmolStr],
     edit: &mut TextEditBuilder,
 ) {
-    let action = best_action_for_target(container, path, target);
+    let action = best_action_for_target(container, path.syntax(), target);
     make_assist(&action, target, edit);
-    if let (Some(first), Some(last)) = (target.first(), target.last()) {
+    if let Some(last) = path.segment() {
         // Here we are assuming the assist will provide a  correct use statement
         // so we can delete the path qualifier
         edit.delete(TextRange::from_to(
-            first.syntax().range().start(),
+            path.syntax().range().start(),
             last.syntax().range().start(),
         ));
     }
 }
 
-pub fn auto_import_text_edit<'a>(
+#[allow(unused)]
+pub fn collect_hir_path_segments(path: &hir::Path) -> Vec<SmolStr> {
+    let mut ps = Vec::<SmolStr>::with_capacity(10);
+    match path.kind {
+        hir::PathKind::Abs => ps.push("".into()),
+        hir::PathKind::Crate => ps.push("crate".into()),
+        hir::PathKind::Plain => {},
+        hir::PathKind::Self_ => ps.push("self".into()),
+        hir::PathKind::Super => ps.push("super".into())
+    }
+    for s in path.segments.iter() {
+        ps.push(s.name.to_smolstr());
+    }
+    ps
+}
+
+// This function produces sequence of text edits into edit
+// to import the target path in the most appropriate scope given
+// the cursor position
+#[allow(unused)]
+pub fn auto_import_text_edit(
+    // Ideally the position of the cursor, used to 
     position: &SyntaxNode,
-    path: &ast::Path,
-    target: &[&'a ast::PathSegment],
+    // The statement to use as anchor (last resort)
+    anchor: &SyntaxNode,
+    // The path to import as a sequence of strings
+    target: &[SmolStr],
     edit: &mut TextEditBuilder,
 ) {
     let container = position.ancestors().find_map(|n| {
@@ -528,7 +529,7 @@ pub fn auto_import_text_edit<'a>(
     });
 
     if let Some(container) = container {
-        let action = best_action_for_target(container, path, target);
+        let action = best_action_for_target(container, anchor, target);
         make_assist(&action, target, edit);
     }
 }
@@ -540,7 +541,8 @@ pub(crate) fn auto_import(mut ctx: AssistCtx<impl HirDatabase>) -> Option<Assist
         return None;
     }
 
-    let segments = collect_path_segments(path)?;
+    let hir_path = hir::Path::from_ast(path)?;
+    let segments = collect_hir_path_segments(&hir_path);
     if segments.len() < 2 {
         return None;
     }

--- a/crates/ra_assists/src/lib.rs
+++ b/crates/ra_assists/src/lib.rs
@@ -98,7 +98,7 @@ mod inline_local_variable;
 mod replace_if_let_with_match;
 mod split_import;
 mod remove_dbg;
-mod auto_import;
+pub mod auto_import;
 mod add_missing_impl_members;
 
 fn all_assists<DB: HirDatabase>() -> &'static [fn(AssistCtx<DB>) -> Option<Assist>] {

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -52,7 +52,7 @@ use crate::{
     db::{HirDatabase, DefDatabase},
     name::{AsName, KnownName},
     source_id::{FileAstId, AstId},
-    resolve::Resolver,
+    resolve::Resolver, resolve::ImportResolver,
 };
 
 pub use self::{

--- a/crates/ra_hir/src/name.rs
+++ b/crates/ra_hir/src/name.rs
@@ -46,6 +46,10 @@ impl Name {
         Name::new(idx.to_string().into())
     }
 
+    pub fn to_smolstr(&self) -> SmolStr {
+        self.text.clone()
+    }
+
     pub(crate) fn as_known_name(&self) -> Option<KnownName> {
         let name = match self.text.as_str() {
             "isize" => KnownName::Isize,

--- a/crates/ra_hir/src/resolve.rs
+++ b/crates/ra_hir/src/resolve.rs
@@ -14,12 +14,8 @@ use crate::{
     generics::GenericParams,
     expr::{scope::{ExprScopes, ScopeId}, PatId},
     impl_block::ImplBlock,
-<<<<<<< HEAD
     path::Path,
     Trait
-=======
-    path::Path, Trait,
->>>>>>> complete_import: add new import resolver infrastructure with some hardcoded importable name.
 };
 
 #[derive(Debug, Clone, Default)]

--- a/crates/ra_hir/src/source_binder.rs
+++ b/crates/ra_hir/src/source_binder.rs
@@ -14,14 +14,19 @@ use ra_syntax::{
     ast::{self, AstNode, NameOwner},
     algo::find_node_at_offset,
     SyntaxKind::*,
+    SmolStr,
 };
 
 use crate::{
     HirDatabase, Function, Struct, Enum, Const, Static, Either, DefWithBody, PerNs, Name,
+<<<<<<< HEAD
     AsName, Module, HirFileId, Crate, Trait, Resolver, Ty,
+=======
+    AsName, Module, HirFileId, Crate, Trait, Resolver, ImportResolver,
+>>>>>>> complete_import: add new import resolver infrastructure with some hardcoded importable name.
     expr::{BodySourceMap, scope::{ScopeId, ExprScopes}},
     ids::LocationCtx,
-    expr, AstId
+    expr, AstId,
 };
 
 /// Locates the module by `FileId`. Picks topmost module in the file.
@@ -170,6 +175,7 @@ fn def_with_body_from_child_node(
 #[derive(Debug)]
 pub struct SourceAnalyzer {
     resolver: Resolver,
+    import_resolver: ImportResolver,
     body_source_map: Option<Arc<BodySourceMap>>,
     infer: Option<Arc<crate::ty::InferenceResult>>,
     scopes: Option<Arc<crate::expr::ExprScopes>>,
@@ -217,6 +223,7 @@ impl SourceAnalyzer {
         offset: Option<TextUnit>,
     ) -> SourceAnalyzer {
         let def_with_body = def_with_body_from_child_node(db, file_id, node);
+        let import_resolver = ImportResolver::new();
         if let Some(def) = def_with_body {
             let source_map = def.body_source_map(db);
             let scopes = db.expr_scopes(def);
@@ -227,6 +234,7 @@ impl SourceAnalyzer {
             let resolver = expr::resolver_for_scope(def.body(db), db, scope);
             SourceAnalyzer {
                 resolver,
+                import_resolver,
                 body_source_map: Some(source_map),
                 infer: Some(def.infer(db)),
                 scopes: Some(scopes),
@@ -237,6 +245,7 @@ impl SourceAnalyzer {
                     .ancestors()
                     .find_map(|node| try_get_resolver_for_node(db, file_id, node))
                     .unwrap_or_default(),
+                import_resolver,
                 body_source_map: None,
                 infer: None,
                 scopes: None,
@@ -321,6 +330,14 @@ impl SourceAnalyzer {
 
     pub fn all_names(&self, db: &impl HirDatabase) -> FxHashMap<Name, PerNs<crate::Resolution>> {
         self.resolver.all_names(db)
+    }
+
+    pub fn all_import_names(
+        &self,
+        db: &impl HirDatabase,
+        name: &Name,
+    ) -> FxHashMap<SmolStr, Vec<SmolStr>> {
+        self.import_resolver.all_names(db, name)
     }
 
     pub fn find_all_refs(&self, pat: &ast::BindPat) -> Vec<ReferenceDescriptor> {

--- a/crates/ra_hir/src/source_binder.rs
+++ b/crates/ra_hir/src/source_binder.rs
@@ -19,11 +19,7 @@ use ra_syntax::{
 
 use crate::{
     HirDatabase, Function, Struct, Enum, Const, Static, Either, DefWithBody, PerNs, Name,
-<<<<<<< HEAD
-    AsName, Module, HirFileId, Crate, Trait, Resolver, Ty,
-=======
-    AsName, Module, HirFileId, Crate, Trait, Resolver, ImportResolver,
->>>>>>> complete_import: add new import resolver infrastructure with some hardcoded importable name.
+    AsName, Module, HirFileId, Crate, Trait, Resolver, Ty, ImportResolver,
     expr::{BodySourceMap, scope::{ScopeId, ExprScopes}},
     ids::LocationCtx,
     expr, AstId,

--- a/crates/ra_ide_api/src/completion/complete_scope.rs
+++ b/crates/ra_ide_api/src/completion/complete_scope.rs
@@ -23,13 +23,23 @@ pub(super) fn complete_scope(acc: &mut Completions, ctx: &CompletionContext) {
                 );
                 builder.finish()
             };
-            CompletionItem::new(
-                CompletionKind::Reference,
-                ctx.source_range(),
-                build_import_label(&name, &path),
-            )
-            .text_edit(edit)
-            .add_to(acc)
+
+            // Hack: copied this check form conv.rs beacause auto import can produce edits
+            // that invalidate assert in conv_with.
+            if edit
+                .as_atoms()
+                .iter()
+                .filter(|atom| !ctx.source_range().is_subrange(&atom.delete))
+                .all(|atom| ctx.source_range().intersection(&atom.delete).is_none())
+            {
+                CompletionItem::new(
+                    CompletionKind::Reference,
+                    ctx.source_range(),
+                    build_import_label(&name, &path),
+                )
+                .text_edit(edit)
+                .add_to(acc);
+            }
         });
     }
 }


### PR DESCRIPTION
Part of #1062
This is a rebase of a work I started about two month ago but I did't have time to finish, so someone else have to complete the job. (I cannot work on this in the foreseeable future)
I don't know if this is good enough to merge or if someone want to take this branch as starting point to do more work.
As discussed in #1062 this works with hardcoded items, at the moment just a few.

Next steps would be:
- hardcode the complete standard library just to have immediately something really useful
- use `fst` crate to fuzzy filter names instead `contains` 
- make the `ImportResolver` do the real work...
- make the `ImportResolver` return real Resolution objects and not simply paths, so we can use
  `add_resolution` fancy stuff 
- filter items by resolution type (in addition to the name) looking at the current position

Just a glimpse of what this PR enables

![completeimport](https://user-images.githubusercontent.com/10089822/56476174-4a89e800-6494-11e9-9d23-5947e2643ad9.gif)