### PR TITLE
Add mbe expand limit and poision macro set

### DIFF
--- a/crates/ra_hir/src/ids.rs
+++ b/crates/ra_hir/src/ids.rs
@@ -94,6 +94,13 @@ fn parse_macro(
 
     let macro_rules = db.macro_def(loc.def).ok_or("Fail to find macro definition")?;
     let tt = macro_rules.expand(&macro_arg).map_err(|err| format!("{:?}", err))?;
+
+    // Set a hard limit for the expanded tt
+    let count = tt.count();
+    if count > 65536 {
+        return Err(format!("Total tokens count exceed limit : count = {}", count));
+    }
+
     Ok(mbe::token_tree_to_ast_item_list(&tt))
 }
 

--- a/crates/ra_tt/src/lib.rs
+++ b/crates/ra_tt/src/lib.rs
@@ -153,11 +153,15 @@ impl fmt::Display for Punct {
 impl Subtree {
     /// Count the number of tokens recursively
     pub fn count(&self) -> usize {
-        self.token_trees.iter().fold(self.token_trees.len(), |acc, c| {
-            acc + match c {
+        let children_count = self
+            .token_trees
+            .iter()
+            .map(|c| match c {
                 TokenTree::Subtree(c) => c.count(),
                 _ => 0,
-            }
-        })
+            })
+            .sum::<usize>();
+
+        self.token_trees.len() + children_count
     }
 }

--- a/crates/ra_tt/src/lib.rs
+++ b/crates/ra_tt/src/lib.rs
@@ -149,3 +149,15 @@ impl fmt::Display for Punct {
         fmt::Display::fmt(&self.char, f)
     }
 }
+
+impl Subtree {
+    /// Count the number of tokens recursively
+    pub fn count(&self) -> usize {
+        self.token_trees.iter().fold(self.token_trees.len(), |acc, c| {
+            acc + match c {
+                TokenTree::Subtree(c) => c.count(),
+                _ => 0,
+            }
+        })
+    }
+}


### PR DESCRIPTION
As discussed in Zulip, this PR add a token expansion limit in `parse_macro` and a "poison" macro set in `CrateDefMap` to prevent stack over flow and limit a mbe macro size.

Note:
Right now it only handle a poison macro in a single crate, such that if other crate try to call that macro, the whole process will do again until it became poisoned in that crate.
