### PR TITLE
Bugs fixes And Improvements of MBE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,6 +1059,7 @@ name = "ra_mbe"
 version = "0.1.0"
 dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ra_parser 0.1.0",
  "ra_syntax 0.1.0",
  "ra_tt 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,6 +1063,7 @@ dependencies = [
  "ra_syntax 0.1.0",
  "ra_tt 0.1.0",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/crates/ra_mbe/Cargo.toml
+++ b/crates/ra_mbe/Cargo.toml
@@ -11,3 +11,4 @@ tt = { path = "../ra_tt", package = "ra_tt" }
 itertools = "0.8.0"
 rustc-hash = "1.0.0"
 smallvec = "0.6.9"
+log = "0.4.5"

--- a/crates/ra_mbe/Cargo.toml
+++ b/crates/ra_mbe/Cargo.toml
@@ -10,3 +10,4 @@ ra_parser = { path = "../ra_parser" }
 tt = { path = "../ra_tt", package = "ra_tt" }
 itertools = "0.8.0"
 rustc-hash = "1.0.0"
+smallvec = "0.6.9"

--- a/crates/ra_mbe/src/mbe_expander.rs
+++ b/crates/ra_mbe/src/mbe_expander.rs
@@ -21,7 +21,10 @@ fn expand_rule(rule: &crate::Rule, input: &tt::Subtree) -> Result<tt::Subtree, E
     if !input.is_eof() {
         return Err(ExpandError::UnexpectedToken);
     }
-    expand_subtree(&rule.rhs, &bindings, &mut Vec::new())
+
+    let mut ctx = ExpandCtx { bindings: &bindings, nesting: Vec::new(), var_expanded: false };
+
+    expand_subtree(&rule.rhs, &mut ctx)
 }
 
 /// The actual algorithm for expansion is not too hard, but is pretty tricky.
@@ -225,7 +228,7 @@ fn match_lhs(pattern: &crate::Subtree, input: &mut TtCursor) -> Result<Bindings,
             crate::TokenTree::Repeat(crate::Repeat { subtree, kind, separator }) => {
                 // Dirty hack to make macro-expansion terminate.
                 // This should be replaced by a propper macro-by-example implementation
-                let mut limit = 128;
+                let mut limit = 65536;
                 let mut counter = 0;
 
                 let mut memento = input.save();
@@ -236,6 +239,7 @@ fn match_lhs(pattern: &crate::Subtree, input: &mut TtCursor) -> Result<Bindings,
                             counter += 1;
                             limit -= 1;
                             if limit == 0 {
+                                log::warn!("match_lhs excced in repeat pattern exceed limit => {:#?}\n{:#?}\n{:#?}\n{:#?}", subtree, input, kind, separator);
                                 break;
                             }
 
@@ -303,15 +307,21 @@ fn match_lhs(pattern: &crate::Subtree, input: &mut TtCursor) -> Result<Bindings,
     Ok(res)
 }
 
+#[derive(Debug)]
+struct ExpandCtx<'a> {
+    bindings: &'a Bindings,
+    nesting: Vec<usize>,
+    var_expanded: bool,
+}
+
 fn expand_subtree(
     template: &crate::Subtree,
-    bindings: &Bindings,
-    nesting: &mut Vec<usize>,
+    ctx: &mut ExpandCtx,
 ) -> Result<tt::Subtree, ExpandError> {
     let token_trees = template
         .token_trees
         .iter()
-        .map(|it| expand_tt(it, bindings, nesting))
+        .map(|it| expand_tt(it, ctx))
         .collect::<Result<Vec<_>, ExpandError>>()?;
 
     Ok(tt::Subtree { token_trees, delimiter: template.delimiter })
@@ -333,26 +343,43 @@ fn reduce_single_token(mut subtree: tt::Subtree) -> tt::TokenTree {
 
 fn expand_tt(
     template: &crate::TokenTree,
-    bindings: &Bindings,
-    nesting: &mut Vec<usize>,
+    ctx: &mut ExpandCtx,
 ) -> Result<tt::TokenTree, ExpandError> {
     let res: tt::TokenTree = match template {
-        crate::TokenTree::Subtree(subtree) => expand_subtree(subtree, bindings, nesting)?.into(),
+        crate::TokenTree::Subtree(subtree) => expand_subtree(subtree, ctx)?.into(),
         crate::TokenTree::Repeat(repeat) => {
             let mut token_trees: Vec<tt::TokenTree> = Vec::new();
-            nesting.push(0);
+            ctx.nesting.push(0);
             // Dirty hack to make macro-expansion terminate.
             // This should be replaced by a propper macro-by-example implementation
-            let mut limit = 128;
+            let mut limit = 65536;
             let mut has_seps = 0;
+            let mut counter = 0;
 
-            while let Ok(t) = expand_subtree(&repeat.subtree, bindings, nesting) {
-                limit -= 1;
-                if limit == 0 {
+            let mut some_var_expanded = false;
+            ctx.var_expanded = false;
+
+            while let Ok(t) = expand_subtree(&repeat.subtree, ctx) {
+                // if no var expaned in the child, we count it as a fail
+                if !ctx.var_expanded {
                     break;
                 }
-                let idx = nesting.pop().unwrap();
-                nesting.push(idx + 1);
+                some_var_expanded = true;
+                ctx.var_expanded = false;
+
+                counter += 1;
+                limit -= 1;
+                if limit == 0 {
+                    log::warn!(
+                        "expand_tt excced in repeat pattern exceed limit => {:#?}\n{:#?}",
+                        template,
+                        ctx
+                    );
+                    break;
+                }
+
+                let idx = ctx.nesting.pop().unwrap();
+                ctx.nesting.push(idx + 1);
                 token_trees.push(reduce_single_token(t).into());
 
                 if let Some(ref sep) = repeat.separator {
@@ -374,10 +401,21 @@ fn expand_tt(
                         }
                     }
                 }
+
+                if let crate::RepeatKind::ZeroOrOne = repeat.kind {
+                    break;
+                }
             }
-            nesting.pop().unwrap();
+
+            ctx.var_expanded = some_var_expanded;
+
+            ctx.nesting.pop().unwrap();
             for _ in 0..has_seps {
                 token_trees.pop();
+            }
+
+            if crate::RepeatKind::OneOrMore == repeat.kind && counter == 0 {
+                return Err(ExpandError::UnexpectedToken);
             }
 
             // Check if it is a singel token subtree without any delimiter
@@ -396,7 +434,8 @@ fn expand_tt(
                     tt::Leaf::from(tt::Ident { text: "$crate".into(), id: TokenId::unspecified() })
                         .into()
                 } else {
-                    let tkn = bindings.get(&v.text, nesting)?.clone();
+                    let tkn = ctx.bindings.get(&v.text, &ctx.nesting)?.clone();
+                    ctx.var_expanded = true;
 
                     if let tt::TokenTree::Subtree(subtree) = tkn {
                         reduce_single_token(subtree)

--- a/crates/ra_mbe/src/subtree_source.rs
+++ b/crates/ra_mbe/src/subtree_source.rs
@@ -212,7 +212,7 @@ impl<'a> SubTreeWalker<'a> {
 }
 
 pub(crate) trait Querier {
-    fn token(&self, uidx: usize) -> (SyntaxKind, SmolStr);
+    fn token(&self, uidx: usize) -> (SyntaxKind, SmolStr, bool);
 }
 
 // A wrapper class for ref cell
@@ -292,9 +292,10 @@ impl<'a> WalkerOwner<'a> {
 }
 
 impl<'a> Querier for WalkerOwner<'a> {
-    fn token(&self, uidx: usize) -> (SyntaxKind, SmolStr) {
-        let tkn = self.get(uidx).unwrap();
-        (tkn.kind, tkn.text)
+    fn token(&self, uidx: usize) -> (SyntaxKind, SmolStr, bool) {
+        self.get(uidx)
+            .map(|tkn| (tkn.kind, tkn.text, tkn.is_joint_to_next))
+            .unwrap_or_else(|| (SyntaxKind::EOF, "".into(), false))
     }
 }
 

--- a/crates/ra_mbe/src/subtree_source.rs
+++ b/crates/ra_mbe/src/subtree_source.rs
@@ -438,14 +438,12 @@ fn convert_delim(d: tt::Delimiter, closing: bool) -> TtToken {
 }
 
 fn convert_literal(l: &tt::Literal) -> TtToken {
-    let kind = classify_literal(&l.text)
-        .map(|tkn| tkn.kind)
-        .or_else(|| match l.text.as_ref() {
-            "true" => Some(SyntaxKind::TRUE_KW),
-            "false" => Some(SyntaxKind::FALSE_KW),
-            _ => None,
-        })
-        .unwrap();
+    let kind =
+        classify_literal(&l.text).map(|tkn| tkn.kind).unwrap_or_else(|| match l.text.as_ref() {
+            "true" => SyntaxKind::TRUE_KW,
+            "false" => SyntaxKind::FALSE_KW,
+            _ => panic!("Fail to convert given literal {:#?}", &l),
+        });
 
     TtToken { kind, is_joint_to_next: false, text: l.text.clone(), n_tokens: 1 }
 }

--- a/crates/ra_mbe/src/syntax_bridge.rs
+++ b/crates/ra_mbe/src/syntax_bridge.rs
@@ -123,6 +123,11 @@ fn convert_tt(
     global_offset: TextUnit,
     tt: &SyntaxNode,
 ) -> Option<tt::Subtree> {
+    // This tree is empty
+    if tt.first_child_or_token().is_none() {
+        return Some(tt::Subtree { token_trees: vec![], delimiter: tt::Delimiter::None });
+    }
+
     let first_child = tt.first_child_or_token()?;
     let last_child = tt.last_child_or_token()?;
     let (delimiter, skip_first) = match (first_child.kind(), last_child.kind()) {
@@ -233,7 +238,16 @@ impl<'a, Q: Querier> TreeSink for TtTreeSink<'a, Q> {
         self.text_pos += TextUnit::of_str(&self.buf);
         let text = SmolStr::new(self.buf.as_str());
         self.buf.clear();
-        self.inner.token(kind, text)
+        self.inner.token(kind, text);
+
+        // // Add a white space to token
+        // let (last_kind, _, last_joint_to_next ) = self.src_querier.token(self.token_pos-n_tokens as usize);
+        // if !last_joint_to_next && last_kind.is_punct() {
+        //     let (cur_kind, _, _ ) = self.src_querier.token(self.token_pos);
+        //     if cur_kind.is_punct() {
+        //         self.inner.token(WHITESPACE, " ".into());
+        //     }
+        // }
     }
 
     fn start_node(&mut self, kind: SyntaxKind) {

--- a/crates/ra_mbe/src/tt_cursor.rs
+++ b/crates/ra_mbe/src/tt_cursor.rs
@@ -7,6 +7,10 @@ pub(crate) struct TtCursor<'a> {
     pos: usize,
 }
 
+pub(crate) struct TtCursorMemento {
+    pos: usize,
+}
+
 impl<'a> TtCursor<'a> {
     pub(crate) fn new(subtree: &'a tt::Subtree) -> TtCursor<'a> {
         TtCursor { subtree, pos: 0 }
@@ -156,5 +160,14 @@ impl<'a> TtCursor<'a> {
         } else {
             Err(ParseError::Expected(format!("`{}`", char)))
         }
+    }
+
+    #[must_use]
+    pub(crate) fn save(&self) -> TtCursorMemento {
+        TtCursorMemento { pos: self.pos }
+    }
+
+    pub(crate) fn rollback(&mut self, memento: TtCursorMemento) {
+        self.pos = memento.pos;
     }
 }

--- a/crates/ra_mbe/src/tt_cursor.rs
+++ b/crates/ra_mbe/src/tt_cursor.rs
@@ -3,7 +3,7 @@ use crate::subtree_parser::Parser;
 use crate::subtree_source::TokenPeek;
 use smallvec::{SmallVec, smallvec};
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub(crate) struct TtCursor<'a> {
     subtree: &'a tt::Subtree,
     pos: usize,

--- a/crates/ra_mbe/src/tt_cursor.rs
+++ b/crates/ra_mbe/src/tt_cursor.rs
@@ -1,5 +1,7 @@
 use crate::ParseError;
 use crate::subtree_parser::Parser;
+use crate::subtree_source::TokenPeek;
+use smallvec::{SmallVec, smallvec};
 
 #[derive(Clone)]
 pub(crate) struct TtCursor<'a> {
@@ -159,6 +161,95 @@ impl<'a> TtCursor<'a> {
             Ok(())
         } else {
             Err(ParseError::Expected(format!("`{}`", char)))
+        }
+    }
+
+    fn eat_punct3(&mut self, p: &tt::Punct) -> Option<SmallVec<[tt::Punct; 3]>> {
+        let sec = self.eat_punct()?.clone();
+        let third = self.eat_punct()?.clone();
+        Some(smallvec![p.clone(), sec, third])
+    }
+
+    fn eat_punct2(&mut self, p: &tt::Punct) -> Option<SmallVec<[tt::Punct; 3]>> {
+        let sec = self.eat_punct()?.clone();
+        Some(smallvec![p.clone(), sec])
+    }
+
+    fn eat_multi_char_punct<'b, I>(
+        &mut self,
+        p: &tt::Punct,
+        iter: &mut TokenPeek<'b, I>,
+    ) -> Option<SmallVec<[tt::Punct; 3]>>
+    where
+        I: Iterator<Item = &'b tt::TokenTree>,
+    {
+        if let Some((m, _)) = iter.current_punct3(p) {
+            if let r @ Some(_) = match m {
+                ('<', '<', '=') | ('>', '>', '=') | ('.', '.', '.') | ('.', '.', '=') => {
+                    self.eat_punct3(p)
+                }
+                _ => None,
+            } {
+                return r;
+            }
+        }
+
+        if let Some((m, _)) = iter.current_punct2(p) {
+            if let r @ Some(_) = match m {
+                ('<', '=')
+                | ('>', '=')
+                | ('+', '=')
+                | ('-', '=')
+                | ('|', '=')
+                | ('&', '=')
+                | ('^', '=')
+                | ('/', '=')
+                | ('*', '=')
+                | ('%', '=')
+                | ('&', '&')
+                | ('|', '|')
+                | ('<', '<')
+                | ('>', '>')
+                | ('-', '>')
+                | ('!', '=')
+                | ('=', '>')
+                | ('=', '=')
+                | ('.', '.')
+                | (':', ':') => self.eat_punct2(p),
+
+                _ => None,
+            } {
+                return r;
+            }
+        }
+
+        None
+    }
+
+    pub(crate) fn eat_seperator(&mut self) -> Option<crate::Separator> {
+        match self.eat()? {
+            tt::TokenTree::Leaf(tt::Leaf::Literal(lit)) => {
+                Some(crate::Separator::Literal(lit.clone()))
+            }
+            tt::TokenTree::Leaf(tt::Leaf::Ident(ident)) => {
+                Some(crate::Separator::Ident(ident.clone()))
+            }
+            tt::TokenTree::Leaf(tt::Leaf::Punct(punct)) => {
+                match punct.char {
+                    '*' | '+' | '?' => return None,
+                    _ => {}
+                };
+
+                // FIXME: The parser is only handle some compositeable punct,
+                // But at this phase, some punct still is jointed.
+                // So we by pass that check here.
+                let mut peekable = TokenPeek::new(self.subtree.token_trees[self.pos..].iter());
+                let puncts = self.eat_multi_char_punct(punct, &mut peekable);
+                let puncts = puncts.unwrap_or_else(|| smallvec![punct.clone()]);
+
+                Some(crate::Separator::Puncts(puncts))
+            }
+            _ => None,
         }
     }
 

--- a/crates/ra_parser/src/grammar.rs
+++ b/crates/ra_parser/src/grammar.rs
@@ -119,7 +119,22 @@ pub(crate) fn meta_item(p: &mut Parser) {
             items::token_tree(p);
             break;
         } else {
-            p.bump();
+            // https://doc.rust-lang.org/reference/attributes.html
+            // https://doc.rust-lang.org/reference/paths.html#simple-paths
+            // The start of an meta must be a simple path
+            match p.current() {
+                IDENT | COLONCOLON | SUPER_KW | SELF_KW | CRATE_KW => p.bump(),
+                EQ => {
+                    p.bump();
+                    match p.current() {
+                        c if c.is_literal() => p.bump(),
+                        TRUE_KW | FALSE_KW => p.bump(),
+                        _ => {}
+                    }
+                    break;
+                }
+                _ => break,
+            }
         }
     }
 


### PR DESCRIPTION
This PR fixed / improve followings things:

* Add `token` `$repeat` separator support: Previously $repeat only support single punct separator. 
* Fixed a bug which expand infinite pattern, see `test_match_group_in_group` 
* Correctly handle +,*,? case of $repeat patterns
* Increase the limit of $repeat patterns (128 => 65536), personally i think we could remove this limit as we seem to fix all major loop bugs
* **Re-enable tt matcher**
* Better meta item parsing.
* Add related tests and add some real world test cases.
* Add more debug information.
