### PR TITLE
Fix hover on the beginning of a nested expression

### DIFF
--- a/crates/ra_ide_api/src/goto_definition.rs
+++ b/crates/ra_ide_api/src/goto_definition.rs
@@ -25,6 +25,7 @@ pub(crate) fn goto_definition(
     None
 }
 
+#[derive(Debug)]
 pub(crate) enum ReferenceResult {
     Exact(NavigationTarget),
     Approximate(Vec<NavigationTarget>),


### PR DESCRIPTION
E.g. in
```
let foo = 1u32;
if true {
   <|>foo;
}
```
the hover shows `()`, the type of the whole if expression, instead of the more
sensible `u32`. The reason for this was that the search for an expression was
slightly left-biased: When on the edge between two tokens, it first looked at
all ancestors of the left token and then of the right token. Instead merge the
ancestors in ascending order, so that we get the smaller of the two possible
expressions.

This might seem rather inconsequential, but emacs-lsp's sideline requests hover for the beginning of each word in the current line, so it tends to hit this a lot :smile: Actually, as I think about this now, another solution might be just making hover right-biased, since if I'm hovering a certain character I really mean that character and not the one to its left...