### PR TITLE
Skip Dollars when bump raw  token

### DIFF
--- a/crates/ra_parser/src/parser.rs
+++ b/crates/ra_parser/src/parser.rs
@@ -129,7 +129,15 @@ impl<'t> Parser<'t> {
     /// Advances the parser by one token unconditionally
     /// Mainly use in `token_tree` parsing
     pub(crate) fn bump_raw(&mut self) {
-        let kind = self.token_source.token_kind(self.token_pos);
+        let mut kind = self.token_source.token_kind(self.token_pos);
+
+        // Skip dollars, do_bump will eat these later
+        let mut i = 0;
+        while kind == SyntaxKind::L_DOLLAR || kind == SyntaxKind::R_DOLLAR {
+            kind = self.token_source.token_kind(self.token_pos + i);
+            i += 1;
+        }
+
         if kind == EOF {
             return;
         }


### PR DESCRIPTION
This PR fixed a bug while parsing token_tree, it should skip all L_DOLLAR AND R_DOLLAR.