### PR TITLE
Desugar doc comments to `#[doc = "...."]` attributes in `syntax node` to tt conversion

### DIFF
--- a/crates/ra_mbe/src/syntax_bridge.rs
+++ b/crates/ra_mbe/src/syntax_bridge.rs
@@ -135,7 +135,7 @@ fn doc_comment_text(comment: &ast::Comment) -> SmolStr {
 
     // Quote the string
     // Note that `tt::Literal` expect an escaped string
-    let text = format!("\"{}\"", text.escape_default());
+    let text = format!("{:?}", text.escape_default().to_string());
     text.into()
 }
 

--- a/crates/ra_mbe/src/syntax_bridge.rs
+++ b/crates/ra_mbe/src/syntax_bridge.rs
@@ -135,7 +135,7 @@ fn doc_comment_text(comment: &ast::Comment) -> SmolStr {
 
     // Quote the string
     // Note that `tt::Literal` expect an escaped string
-    let text = format!("{:?}", text);
+    let text = format!("\"{}\"", text.escape_default());
     text.into()
 }
 

--- a/crates/ra_mbe/src/tests.rs
+++ b/crates/ra_mbe/src/tests.rs
@@ -888,7 +888,7 @@ fn test_meta_doc_comments() {
                 MultiLines Doc
             */
         }"#,
-        "# [doc = \" Single Line Doc 1\"] # [doc = \" \\n                MultiLines Doc\\n            \"] fn bar () {}",
+        "# [doc = \" Single Line Doc 1\"] # [doc = \" \\\\n                MultiLines Doc\\\\n            \"] fn bar () {}",
     );
 }
 

--- a/crates/ra_mbe/src/tests.rs
+++ b/crates/ra_mbe/src/tests.rs
@@ -868,6 +868,31 @@ fn test_meta() {
 }
 
 #[test]
+fn test_meta_doc_comments() {
+    let rules = create_rules(
+        r#"
+        macro_rules! foo {
+            ($(#[$ i:meta])+) => (
+                $(#[$ i])+
+                fn bar() {}
+            )
+        }
+"#,
+    );
+    assert_expansion(
+        MacroKind::Items,
+        &rules,
+        r#"foo! { 
+            /// Single Line Doc 1
+            /** 
+                MultiLines Doc
+            */
+        }"#,
+        "# [doc = \" Single Line Doc 1\"] # [doc = \" \\n                MultiLines Doc\\n            \"] fn bar () {}",
+    );
+}
+
+#[test]
 fn test_tt_block() {
     let rules = create_rules(
         r#"


### PR DESCRIPTION
As discussed in [Zulip](https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Fwg-rls-2.2E0/topic/MBE.20discussion/near/164446835), this PR desugar doc comments to  `#[doc = "...."]` in `syntax node` to tt conversion. 

Note that after this PR, all obvious mbe bugs in dogfooding are fixed. (i.e. No parsing or expanding mbe error in `env RUST_LOG=ra_hir=WARN target\release\ra_cli.exe analysis-stats`) 🎉