### PR TITLE
Macro queries

### DIFF
--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -45,6 +45,9 @@ pub trait DefDatabase: SourceDatabase {
     #[salsa::invoke(crate::ids::macro_arg_query)]
     fn macro_arg(&self, macro_call: ids::MacroCallId) -> Option<Arc<tt::Subtree>>;
 
+    #[salsa::invoke(crate::ids::macro_expand_query)]
+    fn macro_expand(&self, macro_call: ids::MacroCallId) -> Result<Arc<tt::Subtree>, String>;
+
     #[salsa::invoke(crate::ids::HirFileId::hir_parse_query)]
     fn hir_parse(&self, file_id: HirFileId) -> TreeArc<SourceFile>;
 

--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -60,7 +60,7 @@ pub trait DefDatabase: SourceDatabase {
     #[salsa::invoke(crate::source_id::AstIdMap::ast_id_map_query)]
     fn ast_id_map(&self, file_id: HirFileId) -> Arc<AstIdMap>;
 
-    #[salsa::invoke(crate::source_id::AstIdMap::ast_id_to_node_query)]
+    #[salsa::invoke(crate::source_id::AstIdMap::file_item_query)]
     fn ast_id_to_node(&self, file_id: HirFileId, ast_id: ErasedFileAstId) -> TreeArc<SyntaxNode>;
 
     #[salsa::invoke(RawItems::raw_items_query)]

--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -42,7 +42,10 @@ pub trait DefDatabase: SourceDatabase {
     #[salsa::invoke(crate::ids::macro_def_query)]
     fn macro_def(&self, macro_id: MacroDefId) -> Option<Arc<mbe::MacroRules>>;
 
-    #[salsa::invoke(HirFileId::hir_parse_query)]
+    #[salsa::invoke(crate::ids::macro_arg_query)]
+    fn macro_arg(&self, macro_call: ids::MacroCallId) -> Option<Arc<tt::Subtree>>;
+
+    #[salsa::invoke(crate::ids::HirFileId::hir_parse_query)]
     fn hir_parse(&self, file_id: HirFileId) -> TreeArc<SourceFile>;
 
     #[salsa::invoke(crate::adt::StructData::struct_data_query)]

--- a/crates/ra_hir/src/ids.rs
+++ b/crates/ra_hir/src/ids.rs
@@ -63,19 +63,22 @@ impl HirFileId {
         match file_id.0 {
             HirFileIdRepr::File(file_id) => db.parse(file_id),
             HirFileIdRepr::Macro(macro_call_id) => {
-                parse_macro(db, macro_call_id).unwrap_or_else(|err| {
-                    // Note:
-                    // The final goal we would like to make all parse_macro success,
-                    // such that the following log will not call anyway.
-                    log::warn!(
-                        "fail on macro_parse: (reason: {}) {}",
-                        err,
-                        macro_call_id.debug_dump(db)
-                    );
+                match db.macro_expand(macro_call_id) {
+                    Ok(tt) => mbe::token_tree_to_ast_item_list(&tt),
+                    Err(err) => {
+                        // Note:
+                        // The final goal we would like to make all parse_macro success,
+                        // such that the following log will not call anyway.
+                        log::warn!(
+                            "fail on macro_parse: (reason: {}) {}",
+                            err,
+                            macro_call_id.debug_dump(db)
+                        );
 
-                    // returning an empty string looks fishy...
-                    SourceFile::parse("")
-                })
+                        // returning an empty string looks fishy...
+                        SourceFile::parse("")
+                    }
+                }
             }
         }
     }
@@ -124,23 +127,21 @@ pub(crate) fn macro_arg_query(db: &impl DefDatabase, id: MacroCallId) -> Option<
     Some(Arc::new(tt))
 }
 
-fn parse_macro(
+pub(crate) fn macro_expand_query(
     db: &impl DefDatabase,
-    macro_call_id: MacroCallId,
-) -> Result<TreeArc<SourceFile>, String> {
-    let loc = macro_call_id.loc(db);
-    let macro_arg = db.macro_arg(macro_call_id).ok_or("Fail to args in to tt::TokenTree")?;
+    id: MacroCallId,
+) -> Result<Arc<tt::Subtree>, String> {
+    let loc = id.loc(db);
+    let macro_arg = db.macro_arg(id).ok_or("Fail to args in to tt::TokenTree")?;
 
     let macro_rules = db.macro_def(loc.def).ok_or("Fail to find macro definition")?;
     let tt = macro_rules.expand(&macro_arg).map_err(|err| format!("{:?}", err))?;
-
     // Set a hard limit for the expanded tt
     let count = tt.count();
     if count > 65536 {
         return Err(format!("Total tokens count exceed limit : count = {}", count));
     }
-
-    Ok(mbe::token_tree_to_ast_item_list(&tt))
+    Ok(Arc::new(tt))
 }
 
 macro_rules! impl_intern_key {

--- a/crates/ra_hir/src/source_id.rs
+++ b/crates/ra_hir/src/source_id.rs
@@ -92,7 +92,7 @@ impl AstIdMap {
         Arc::new(AstIdMap::from_source_file(&source_file))
     }
 
-    pub(crate) fn ast_id_to_node_query(
+    pub(crate) fn file_item_query(
         db: &impl DefDatabase,
         file_id: HirFileId,
         ast_id: ErasedFileAstId,

--- a/crates/ra_syntax/src/grammar.ron
+++ b/crates/ra_syntax/src/grammar.ron
@@ -674,7 +674,7 @@ Grammar(
         "LifetimeArg": (),
 
         "MacroItems": (
-            traits: [ "ModuleItemOwner", "FnDefOwner" ],
+            traits: [ "ModuleItemOwner", "FnDefOwner" ],            
         ),
 
         "MacroStmts" : (


### PR DESCRIPTION
In https://github.com/rust-analyzer/rust-analyzer/pull/1231, I've added aggressive clean up of `ast_id_to_node` query. 

The result of this query is a `SyntaxTree`, and we don't want to retain syntax trees in memory unless absolutely necessary.

Moreover, `SyntaxTree` has identity equality semantics, meaning that we'll get a diffferent syntax tree for a file after every reparse. That means that `ast_id_to_node` query should not genereally be used in HIR, unless it is behind some kind of salsa firewall, like the `raw` module of name resoulution.

However, that PR resulted in the abysmal performance: turns out we were using  ast_id_to_node quite heavily in hir when expanding macros! 

So this PR  installs the more incremental-friendly query structure:

* converting source to token tree is now a query; changing source without affecting token-trees will now preserve macro expansions
* expand macro (tt -> tt) is now a query as well, so we cache macro expansions *before* parsing them into item lists or expressions, which is nice: we can cache expansion without knowing the calling context!

r? @edwin0cheng 