### PR TITLE
Fix missing empty vars in $repeat while macro expansion

### DIFF
--- a/crates/ra_mbe/src/mbe_expander.rs
+++ b/crates/ra_mbe/src/mbe_expander.rs
@@ -177,6 +177,9 @@ fn collect_vars(subtree: &crate::Subtree) -> Vec<SmolStr> {
             crate::TokenTree::Subtree(subtree) => {
                 res.extend(collect_vars(subtree));
             }
+            crate::TokenTree::Repeat(crate::Repeat { subtree, .. }) => {
+                res.extend(collect_vars(subtree));
+            }
             _ => {}
         }
     }


### PR DESCRIPTION
This PR fixes a bug we forget to collect an empty vars in $repeat patterns.

Related issues: #1240 