### PR TITLE
Where clauses and other Chalk improvements

### DIFF
--- a/crates/ra_hir/src/code_model_api.rs
+++ b/crates/ra_hir/src/code_model_api.rs
@@ -703,6 +703,10 @@ impl Trait {
         TraitRef::for_trait(db, self)
     }
 
+    pub fn is_auto(self, db: &impl DefDatabase) -> bool {
+        self.trait_data(db).is_auto()
+    }
+
     pub(crate) fn resolver(&self, db: &impl DefDatabase) -> Resolver {
         let r = self.module(db).resolver(db);
         // add generic params, if present

--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -11,7 +11,7 @@ use crate::{
     DefWithBody, Trait,
     ids,
     nameres::{Namespace, ImportSourceMap, RawItems, CrateDefMap},
-    ty::{InferenceResult, Ty, method_resolution::CrateImplBlocks, TypableDef, CallableDef, FnSig, TypeCtor},
+    ty::{InferenceResult, Ty, method_resolution::CrateImplBlocks, TypableDef, CallableDef, FnSig, TypeCtor, GenericPredicate},
     adt::{StructData, EnumData},
     impl_block::{ModuleImplBlocks, ImplSourceMap, ImplBlock},
     generics::{GenericParams, GenericDef},
@@ -137,6 +137,9 @@ pub trait HirDatabase: DefDatabase {
 
     #[salsa::invoke(crate::ty::callable_item_sig)]
     fn callable_item_signature(&self, def: CallableDef) -> FnSig;
+
+    #[salsa::invoke(crate::ty::generic_predicates)]
+    fn generic_predicates(&self, def: GenericDef) -> Arc<[GenericPredicate]>;
 
     #[salsa::invoke(crate::expr::body_with_source_map_query)]
     fn body_with_source_map(

--- a/crates/ra_hir/src/impl_block.rs
+++ b/crates/ra_hir/src/impl_block.rs
@@ -93,6 +93,10 @@ impl ImplBlock {
         db.impls_in_module(self.module).impls[self.impl_id].items().to_vec()
     }
 
+    pub fn is_negative(&self, db: &impl DefDatabase) -> bool {
+        db.impls_in_module(self.module).impls[self.impl_id].negative
+    }
+
     pub(crate) fn resolver(&self, db: &impl DefDatabase) -> Resolver {
         let r = self.module().resolver(db);
         // add generic params, if present
@@ -108,6 +112,7 @@ pub struct ImplData {
     target_trait: Option<TypeRef>,
     target_type: TypeRef,
     items: Vec<ImplItem>,
+    negative: bool,
 }
 
 impl ImplData {
@@ -120,6 +125,7 @@ impl ImplData {
         let target_trait = node.target_trait().map(TypeRef::from_ast);
         let target_type = TypeRef::from_ast_opt(node.target_type());
         let ctx = LocationCtx::new(db, module, file_id);
+        let negative = node.is_negative();
         let items = if let Some(item_list) = node.item_list() {
             item_list
                 .impl_items()
@@ -132,7 +138,7 @@ impl ImplData {
         } else {
             Vec::new()
         };
-        ImplData { target_trait, target_type, items }
+        ImplData { target_trait, target_type, items, negative }
     }
 
     pub fn target_trait(&self) -> Option<&TypeRef> {

--- a/crates/ra_hir/src/marks.rs
+++ b/crates/ra_hir/src/marks.rs
@@ -9,4 +9,5 @@ test_utils::marks!(
     glob_across_crates
     std_prelude
     match_ergonomics_ref
+    trait_resolution_on_fn_type
 );

--- a/crates/ra_hir/src/traits.rs
+++ b/crates/ra_hir/src/traits.rs
@@ -11,6 +11,7 @@ use crate::{Function, Const, TypeAlias, Name, DefDatabase, Trait, ids::LocationC
 pub struct TraitData {
     name: Option<Name>,
     items: Vec<TraitItem>,
+    auto: bool,
 }
 
 impl TraitData {
@@ -19,6 +20,7 @@ impl TraitData {
         let name = node.name().map(|n| n.as_name());
         let module = tr.module(db);
         let ctx = LocationCtx::new(db, module, file_id);
+        let auto = node.is_auto();
         let items = if let Some(item_list) = node.item_list() {
             item_list
                 .impl_items()
@@ -31,7 +33,7 @@ impl TraitData {
         } else {
             Vec::new()
         };
-        Arc::new(TraitData { name, items })
+        Arc::new(TraitData { name, items, auto })
     }
 
     pub(crate) fn name(&self) -> &Option<Name> {
@@ -40,6 +42,10 @@ impl TraitData {
 
     pub(crate) fn items(&self) -> &[TraitItem] {
         &self.items
+    }
+
+    pub(crate) fn is_auto(&self) -> bool {
+        self.auto
     }
 }
 

--- a/crates/ra_hir/src/ty/tests.rs
+++ b/crates/ra_hir/src/ty/tests.rs
@@ -2502,6 +2502,21 @@ fn test() { (&S).foo()<|>; }
 }
 
 #[test]
+fn method_resolution_where_clause_for_unknown_trait() {
+    // The blanket impl shouldn't apply because we can't even resolve UnknownTrait
+    let t = type_at(
+        r#"
+//- /main.rs
+trait Trait { fn foo(self) -> u128; }
+struct S;
+impl<T> Trait for T where T: UnknownTrait {}
+fn test() { (&S).foo()<|>; }
+"#,
+    );
+    assert_eq!(t, "{unknown}");
+}
+
+#[test]
 fn method_resolution_where_clause_not_met() {
     // The blanket impl shouldn't apply because we can't prove S: Clone
     let t = type_at(

--- a/crates/ra_hir/src/ty/tests.rs
+++ b/crates/ra_hir/src/ty/tests.rs
@@ -2568,6 +2568,19 @@ fn test() { S2.into()<|>; }
     assert_eq!(t, "S1");
 }
 
+#[test]
+fn method_resolution_encountering_fn_type() {
+    covers!(trait_resolution_on_fn_type);
+    type_at(
+        r#"
+//- /main.rs
+fn foo() {}
+trait FnOnce { fn call(self); }
+fn test() { foo.call()<|>; }
+"#,
+    );
+}
+
 fn type_at_pos(db: &MockDatabase, pos: FilePosition) -> String {
     let file = db.parse(pos.file_id);
     let expr = algo::find_node_at_offset::<ast::Expr>(file.syntax(), pos.offset).unwrap();

--- a/crates/ra_hir/src/ty/traits/chalk.rs
+++ b/crates/ra_hir/src/ty/traits/chalk.rs
@@ -345,11 +345,14 @@ where
             return Vec::new();
         }
         let trait_ = from_chalk(self.db, trait_id);
-        self.db
+        let result: Vec<_> = self
+            .db
             .impls_for_trait(self.krate, trait_)
             .iter()
             .map(|impl_block| impl_block.to_chalk(self.db))
-            .collect()
+            .collect();
+        debug!("impls_for_trait returned {} impls", result.len());
+        result
     }
     fn impl_provided_for(
         &self,

--- a/crates/ra_syntax/src/ast/extensions.rs
+++ b/crates/ra_syntax/src/ast/extensions.rs
@@ -170,6 +170,10 @@ impl ast::ImplBlock {
         let second = types.next();
         (first, second)
     }
+
+    pub fn is_negative(&self) -> bool {
+        self.syntax().children_with_tokens().any(|t| t.kind() == EXCL)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -346,5 +350,11 @@ impl ast::WherePred {
             .children_with_tokens()
             .filter_map(|it| it.as_token())
             .find(|it| it.kind() == LIFETIME)
+    }
+}
+
+impl ast::TraitDef {
+    pub fn is_auto(&self) -> bool {
+        self.syntax().children_with_tokens().any(|t| t.kind() == AUTO_KW)
     }
 }


### PR DESCRIPTION
This adds support for where clauses to the Chalk integration; it also adds FnDef lowering and partly handles auto traits.

One thing I'm not sure about is the error handling -- what do we do if we can't
resolve a trait reference in a where clause? For impls, I think it's clear we
need to disregard the impl for trait solving. I've solved this for now by
introducing an 'unknown trait' that has no impls, so if we encounter an unknown
trait we can use that and basically get a where clause that's always false. (The
alternative would be somehow not returning the impl to Chalk at all, but we
would need to know that we need to do that in `impls_for_trait` already, and we
don't resolve anything there.)

A bit surprisingly, this has almost no impact on the type inference stats for RA, probably because of missing edge cases. Probably impl Trait support and closure support will do more.