### PR TITLE
Chalk integration / method resolution fixes

### DIFF
--- a/crates/ra_hir/src/ty/method_resolution.rs
+++ b/crates/ra_hir/src/ty/method_resolution.rs
@@ -185,7 +185,7 @@ fn iterate_trait_method_candidates<T>(
     mut callback: impl FnMut(&Ty, Function) -> Option<T>,
 ) -> Option<T> {
     let krate = resolver.krate()?;
-    'traits: for t in resolver.traits_in_scope() {
+    'traits: for t in resolver.traits_in_scope(db) {
         let data = t.trait_data(db);
         // we'll be lazy about checking whether the type implements the
         // trait, but if we find out it doesn't, we'll skip the rest of the

--- a/crates/ra_hir/src/ty/method_resolution.rs
+++ b/crates/ra_hir/src/ty/method_resolution.rs
@@ -75,11 +75,13 @@ impl CrateImplBlocks {
 
             let target_ty = impl_block.target_ty(db);
 
-            if let Some(tr) = impl_block.target_trait_ref(db) {
-                self.impls_by_trait
-                    .entry(tr.trait_)
-                    .or_insert_with(Vec::new)
-                    .push((module.module_id, impl_id));
+            if impl_block.target_trait(db).is_some() {
+                if let Some(tr) = impl_block.target_trait_ref(db) {
+                    self.impls_by_trait
+                        .entry(tr.trait_)
+                        .or_insert_with(Vec::new)
+                        .push((module.module_id, impl_id));
+                }
             } else {
                 if let Some(target_ty_fp) = TyFingerprint::for_impl(&target_ty) {
                     self.impls

--- a/crates/ra_hir/src/ty/tests.rs
+++ b/crates/ra_hir/src/ty/tests.rs
@@ -2620,22 +2620,22 @@ fn method_resolution_slow() {
     let t = type_at(
         r#"
 //- /main.rs
-trait Send {}
+trait SendX {}
 
-struct S1; impl Send for S1;
-struct S2; impl Send for S2;
+struct S1; impl SendX for S1;
+struct S2; impl SendX for S2;
 struct U1;
 
 trait Trait { fn method(self); }
 
 struct X1<A, B> {}
-impl<A, B> Send for X1<A, B> where A: Send, B: Send {}
+impl<A, B> SendX for X1<A, B> where A: SendX, B: SendX {}
 
 struct S<B, C> {}
 
-trait Fn {}
+trait FnX {}
 
-impl<B, C> Trait for S<B, C> where C: Fn, B: Send {}
+impl<B, C> Trait for S<B, C> where C: FnX, B: SendX {}
 
 fn test() { (S {}).method()<|>; }
 "#,


### PR DESCRIPTION
 - fix impl blocks with unresolved target trait being treated as inherent impls
 - add traits from prelude for method resolution, and deduplicate them
 - blacklist some traits from being considered in where clauses, namely `Send`, `Sync`, `Sized`, and the `Fn` traits. We don't handle these correctly yet for several reasons, and this makes us much less likely to run into cases where Chalk gets very slow (because these usually only happen if there is no solution, and that's more likely to happen for these traits).
 - when there's an errored where clause, return just that one (since it will be always false anyway). This also makes things easier on Chalk ;)