### PR TITLE
Macro expand to

### DIFF
--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex};
 
-use ra_syntax::{SyntaxNode, TreeArc, SourceFile, SmolStr, ast};
+use ra_syntax::{SyntaxNode, TreeArc, SmolStr, ast};
 use ra_db::{SourceDatabase, salsa};
 
 use crate::{
@@ -54,8 +54,8 @@ pub trait DefDatabase: SourceDatabase {
     #[salsa::invoke(crate::ids::macro_expand_query)]
     fn macro_expand(&self, macro_call: ids::MacroCallId) -> Result<Arc<tt::Subtree>, String>;
 
-    #[salsa::invoke(crate::ids::HirFileId::hir_parse_query)]
-    fn hir_parse(&self, file_id: HirFileId) -> TreeArc<SourceFile>;
+    #[salsa::invoke(crate::ids::HirFileId::parse_or_expand_query)]
+    fn parse_or_expand(&self, file_id: HirFileId) -> Option<TreeArc<SyntaxNode>>;
 
     #[salsa::invoke(crate::adt::StructData::struct_data_query)]
     fn struct_data(&self, s: Struct) -> Arc<StructData>;

--- a/crates/ra_hir/src/diagnostics.rs
+++ b/crates/ra_hir/src/diagnostics.rs
@@ -1,6 +1,6 @@
 use std::{fmt, any::Any};
 
-use ra_syntax::{SyntaxNodePtr, TreeArc, AstPtr, TextRange, ast, SyntaxNode, AstNode};
+use ra_syntax::{SyntaxNodePtr, TreeArc, AstPtr, TextRange, ast, SyntaxNode};
 use relative_path::RelativePathBuf;
 
 use crate::{HirFileId, HirDatabase, Name};
@@ -29,8 +29,8 @@ pub trait Diagnostic: Any + Send + Sync + fmt::Debug + 'static {
 
 impl dyn Diagnostic {
     pub fn syntax_node(&self, db: &impl HirDatabase) -> TreeArc<SyntaxNode> {
-        let source_file = db.hir_parse(self.file());
-        self.syntax_node_ptr().to_node(source_file.syntax()).to_owned()
+        let node = db.parse_or_expand(self.file()).unwrap();
+        self.syntax_node_ptr().to_node(&*node).to_owned()
     }
     pub fn downcast_ref<D: Diagnostic>(&self) -> Option<&D> {
         self.as_any().downcast_ref()

--- a/crates/ra_hir/src/expr.rs
+++ b/crates/ra_hir/src/expr.rs
@@ -6,11 +6,11 @@ use rustc_hash::FxHashMap;
 use ra_arena::{Arena, RawId, impl_arena_id, map::ArenaMap};
 use ra_syntax::{
     SyntaxNodePtr, AstPtr, AstNode,
-    ast::{self, LoopBodyOwner, ArgListOwner, NameOwner, LiteralKind,ArrayExprKind, TypeAscriptionOwner}
+    ast::{self, LoopBodyOwner, ArgListOwner, NameOwner, LiteralKind,ArrayExprKind, TypeAscriptionOwner},
 };
 
 use crate::{
-    Path, Name, HirDatabase, Resolver,DefWithBody, Either, HirFileId, MacroCallLoc,
+    Path, Name, HirDatabase, Resolver,DefWithBody, Either, HirFileId, MacroCallLoc, MacroFileKind,
     name::AsName,
     type_ref::{Mutability, TypeRef},
 };
@@ -833,8 +833,11 @@ where
                     if let Some(tt) = self.db.macro_expand(call_id).ok() {
                         if let Some(expr) = mbe::token_tree_to_expr(&tt).ok() {
                             log::debug!("macro expansion {}", expr.syntax().debug_dump());
-                            let old_file_id =
-                                std::mem::replace(&mut self.current_file_id, call_id.into());
+                            let old_file_id = std::mem::replace(
+                                &mut self.current_file_id,
+                                //BUG
+                                call_id.as_file(MacroFileKind::Items),
+                            );
                             let id = self.collect_expr(&expr);
                             self.current_file_id = old_file_id;
                             return id;

--- a/crates/ra_hir/src/expr.rs
+++ b/crates/ra_hir/src/expr.rs
@@ -830,14 +830,11 @@ where
 
                 if let Some(def) = self.resolver.resolve_macro_call(path) {
                     let call_id = MacroCallLoc { def, ast_id }.id(self.db);
-                    if let Some(tt) = self.db.macro_expand(call_id).ok() {
-                        if let Some(expr) = mbe::token_tree_to_expr(&tt).ok() {
+                    let file_id = call_id.as_file(MacroFileKind::Expr);
+                    if let Some(node) = self.db.parse_or_expand(file_id) {
+                        if let Some(expr) = ast::Expr::cast(&*node) {
                             log::debug!("macro expansion {}", expr.syntax().debug_dump());
-                            let old_file_id = std::mem::replace(
-                                &mut self.current_file_id,
-                                //BUG
-                                call_id.as_file(MacroFileKind::Items),
-                            );
+                            let old_file_id = std::mem::replace(&mut self.current_file_id, file_id);
                             let id = self.collect_expr(&expr);
                             self.current_file_id = old_file_id;
                             return id;

--- a/crates/ra_hir/src/ids.rs
+++ b/crates/ra_hir/src/ids.rs
@@ -81,6 +81,9 @@ impl HirFileId {
                     MacroFileKind::Items => {
                         Some(mbe::token_tree_to_ast_item_list(&tt).syntax().to_owned())
                     }
+                    MacroFileKind::Expr => {
+                        mbe::token_tree_to_expr(&tt).ok().map(|it| it.syntax().to_owned())
+                    }
                 }
             }
         }
@@ -102,6 +105,7 @@ struct MacroFile {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum MacroFileKind {
     Items,
+    Expr,
 }
 
 impl From<FileId> for HirFileId {

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -53,6 +53,7 @@ use crate::{
     name::{AsName, KnownName},
     source_id::{FileAstId, AstId},
     resolve::Resolver,
+    ids::MacroFileKind,
 };
 
 pub use self::{

--- a/crates/ra_hir/src/nameres/collector.rs
+++ b/crates/ra_hir/src/nameres/collector.rs
@@ -15,7 +15,7 @@ use crate::{
         diagnostics::DefDiagnostic,
         raw,
     },
-    ids::{AstItemDef, LocationCtx, MacroCallLoc, MacroCallId, MacroDefId},
+    ids::{AstItemDef, LocationCtx, MacroCallLoc, MacroCallId, MacroDefId, MacroFileKind},
     AstId,
 };
 
@@ -371,7 +371,7 @@ where
         self.macro_stack_monitor.increase(macro_def_id);
 
         if !self.macro_stack_monitor.is_poison(macro_def_id) {
-            let file_id: HirFileId = macro_call_id.into();
+            let file_id: HirFileId = macro_call_id.as_file(MacroFileKind::Items);
             let raw_items = self.db.raw_items(file_id);
             ModCollector { def_collector: &mut *self, file_id, module_id, raw_items: &raw_items }
                 .collect(raw_items.items());

--- a/crates/ra_hir/src/nameres/raw.rs
+++ b/crates/ra_hir/src/nameres/raw.rs
@@ -75,8 +75,11 @@ impl RawItems {
             source_ast_id_map: db.ast_id_map(file_id.into()),
             source_map: ImportSourceMap::default(),
         };
-        let source_file = db.hir_parse(file_id);
-        collector.process_module(None, &*source_file);
+        if let Some(node) = db.parse_or_expand(file_id) {
+            if let Some(source_file) = ast::SourceFile::cast(&node) {
+                collector.process_module(None, &*source_file);
+            }
+        }
         (Arc::new(collector.raw_items), Arc::new(collector.source_map))
     }
 

--- a/crates/ra_ide_api/src/change.rs
+++ b/crates/ra_ide_api/src/change.rs
@@ -222,7 +222,7 @@ impl RootDatabase {
 
         self.query(ra_db::ParseQuery).sweep(sweep);
 
-        self.query(hir::db::HirParseQuery).sweep(sweep);
+        self.query(hir::db::ParseOrExpandQuery).sweep(sweep);
         self.query(hir::db::AstIdMapQuery).sweep(sweep);
         self.query(hir::db::AstIdToNodeQuery).sweep(sweep);
 


### PR DESCRIPTION
closes #1264 

The core problem this PR is trying to wrangle is that macros can expand to different stuffs, depending on context. 

That is, `foo!()` on the top-level expands to a list of items, but the same `foo!()` in expression position expands to expression.

Our current `hir_parse(HirFileId) -> TreeArc<SourceFile>` does not really support this. 

So, the plan is to change `hir_parse` to untyped inreface (`TreeArc<Syntaxnode>`), and add `expands_to` field to `MacroCallLoc`, such that the *target* of macro expansion is selected by the calling code and is part of macro id. 

This unfortunately looses some type-safety :( 


Moreover, this doesn't really fix #1264 by itself, because we die due to some other error inside macro expansion: expander fails to produce a tree with a single root, which trips assert inside rowan.