### PR TITLE
Increase Chalk solver max_size back to 4

### DIFF
--- a/crates/ra_hir/src/ty/traits.rs
+++ b/crates/ra_hir/src/ty/traits.rs
@@ -17,7 +17,7 @@ pub(crate) type Solver = chalk_solve::Solver;
 /// This controls the maximum size of types Chalk considers. If we set this too
 /// high, we can run into slow edge cases; if we set it too low, Chalk won't
 /// find some solutions.
-const CHALK_SOLVER_MAX_SIZE: usize = 2;
+const CHALK_SOLVER_MAX_SIZE: usize = 4;
 
 #[derive(Debug, Copy, Clone)]
 struct ChalkContext<'a, DB> {


### PR DESCRIPTION
Reducing it to 2 was just a failed attempt to see whether that would help fix
some slow cases; in fact, it can create new slow cases by replacing concrete
types by variables.