### PR TITLE
Put back unexpanded_macros after resolving

### DIFF
--- a/crates/ra_hir/src/nameres/collector.rs
+++ b/crates/ra_hir/src/nameres/collector.rs
@@ -352,9 +352,12 @@ where
             false
         });
 
+        self.unexpanded_macros = macros;
+
         for (module_id, macro_call_id, macro_def_id) in resolved {
             self.collect_macro_expansion(module_id, macro_call_id, macro_def_id);
         }
+
         res
     }
 


### PR DESCRIPTION
This PR fix a minor bug which miss putting back unexpanded macros after resolving.