### PR TITLE
Add support of matching literal in mbe

### DIFF
--- a/crates/ra_mbe/src/mbe_expander.rs
+++ b/crates/ra_mbe/src/mbe_expander.rs
@@ -281,7 +281,11 @@ fn match_lhs(pattern: &crate::Subtree, input: &mut TtCursor) -> Result<Bindings,
                         return Err(ExpandError::UnexpectedToken);
                     }
                 }
-                _ => return Err(ExpandError::UnexpectedToken),
+                crate::Leaf::Literal(literal) => {
+                    if input.eat_literal().map(|i| &i.text) != Some(&literal.text) {
+                        return Err(ExpandError::UnexpectedToken);
+                    }
+                }
             },
             crate::TokenTree::Repeat(crate::Repeat { subtree, kind, separator }) => {
                 // Dirty hack to make macro-expansion terminate.

--- a/crates/ra_mbe/src/tests.rs
+++ b/crates/ra_mbe/src/tests.rs
@@ -575,6 +575,20 @@ fn test_tt_to_stmts() {
     );
 }
 
+#[test]
+fn test_match_literal() {
+    let rules = create_rules(
+        r#"
+    macro_rules! foo {
+        ('(') => {
+            fn foo() {}
+        }
+    }
+"#,
+    );
+    assert_expansion(MacroKind::Items, &rules, "foo! ['(']", "fn foo () {}");
+}
+
 // The following tests are port from intellij-rust directly
 // https://github.com/intellij-rust/intellij-rust/blob/c4e9feee4ad46e7953b1948c112533360b6087bb/src/test/kotlin/org/rust/lang/core/macros/RsMacroExpansionTest.kt
 


### PR DESCRIPTION
This PR adds support of matching literal in mbe , which used in our `T` macro :

```rust
macro_rules! foo {
    ('(') => {
        fn foo() {}
    }
}
```