### PR TITLE
Add Union to code_model

### DIFF
--- a/crates/ra_hir/src/adt.rs
+++ b/crates/ra_hir/src/adt.rs
@@ -10,7 +10,7 @@ use ra_syntax::{
 };
 
 use crate::{
-    Name, AsName, Struct, Enum, EnumVariant, Crate,
+    Name, AsName, Struct, Union, Enum, EnumVariant, Crate,
     HirDatabase, HirFileId, StructField, FieldSource,
     type_ref::TypeRef, DefDatabase,
 };
@@ -18,14 +18,16 @@ use crate::{
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum AdtDef {
     Struct(Struct),
+    Union(Union),
     Enum(Enum),
 }
-impl_froms!(AdtDef: Struct, Enum);
+impl_froms!(AdtDef: Struct, Union, Enum);
 
 impl AdtDef {
     pub(crate) fn krate(self, db: &impl HirDatabase) -> Option<Crate> {
         match self {
             AdtDef::Struct(s) => s.module(db),
+            AdtDef::Union(s) => s.module(db),
             AdtDef::Enum(e) => e.module(db),
         }
         .krate(db)
@@ -38,6 +40,7 @@ impl Struct {
     }
 }
 
+/// Note that we use `StructData` for unions as well!
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StructData {
     pub(crate) name: Option<Name>,

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -77,7 +77,7 @@ pub use self::code_model_api::{
     Crate, CrateDependency,
     DefWithBody,
     Module, ModuleDef, ModuleSource,
-    Struct, Enum, EnumVariant,
+    Struct, Union, Enum, EnumVariant,
     Function, FnSignature,
     StructField, FieldSource,
     Static, Const, ConstSignature,

--- a/crates/ra_hir/src/nameres/collector.rs
+++ b/crates/ra_hir/src/nameres/collector.rs
@@ -6,7 +6,7 @@ use ra_db::FileId;
 use ra_syntax::ast;
 
 use crate::{
-    Function, Module, Struct, Enum, Const, Static, Trait, TypeAlias,
+    Function, Module, Struct, Union, Enum, Const, Static, Trait, TypeAlias,
     DefDatabase, HirFileId, Name, Path,
     KnownName,
     nameres::{
@@ -493,6 +493,10 @@ where
             raw::DefKind::Function(ast_id) => PerNs::values(def!(Function, ast_id)),
             raw::DefKind::Struct(ast_id) => {
                 let s = def!(Struct, ast_id);
+                PerNs::both(s, s)
+            }
+            raw::DefKind::Union(ast_id) => {
+                let s = def!(Union, ast_id);
                 PerNs::both(s, s)
             }
             raw::DefKind::Enum(ast_id) => PerNs::types(def!(Enum, ast_id)),

--- a/crates/ra_hir/src/nameres/raw.rs
+++ b/crates/ra_hir/src/nameres/raw.rs
@@ -1,7 +1,4 @@
-use std::{
-    sync::Arc,
-    ops::Index,
-};
+use std::{sync::Arc, ops::Index};
 
 use test_utils::tested_by;
 use ra_arena::{Arena, impl_arena_id, RawId, map::ArenaMap};
@@ -10,10 +7,7 @@ use ra_syntax::{
     ast::{self, NameOwner, AttrsOwner},
 };
 
-use crate::{
-    DefDatabase, Name, AsName, Path, HirFileId, ModuleSource,
-    AstIdMap, FileAstId, Either,
-};
+use crate::{DefDatabase, Name, AsName, Path, HirFileId, ModuleSource, AstIdMap, FileAstId, Either};
 
 /// `RawItems` is a set of top-level items in a file (except for impls).
 ///
@@ -161,6 +155,7 @@ pub(super) struct DefData {
 pub(super) enum DefKind {
     Function(FileAstId<ast::FnDef>),
     Struct(FileAstId<ast::StructDef>),
+    Union(FileAstId<ast::StructDef>),
     Enum(FileAstId<ast::EnumDef>),
     Const(FileAstId<ast::ConstDef>),
     Static(FileAstId<ast::StaticDef>),
@@ -215,7 +210,13 @@ impl RawItemsCollector {
                 return;
             }
             ast::ModuleItemKind::StructDef(it) => {
-                (DefKind::Struct(self.source_ast_id_map.ast_id(it)), it.name())
+                let id = self.source_ast_id_map.ast_id(it);
+                let name = it.name();
+                if it.is_union() {
+                    (DefKind::Union(id), name)
+                } else {
+                    (DefKind::Struct(id), name)
+                }
             }
             ast::ModuleItemKind::EnumDef(it) => {
                 (DefKind::Enum(self.source_ast_id_map.ast_id(it)), it.name())

--- a/crates/ra_hir/src/ty.rs
+++ b/crates/ra_hir/src/ty.rs
@@ -536,6 +536,7 @@ impl HirDisplay for ApplicationTy {
             TypeCtor::Adt(def_id) => {
                 let name = match def_id {
                     AdtDef::Struct(s) => s.name(f.db),
+                    AdtDef::Union(u) => u.name(f.db),
                     AdtDef::Enum(e) => e.name(f.db),
                 }
                 .unwrap_or_else(Name::missing);

--- a/crates/ra_hir/src/ty/infer.rs
+++ b/crates/ra_hir/src/ty/infer.rs
@@ -27,13 +27,13 @@ use ra_prof::profile;
 use test_utils::tested_by;
 
 use crate::{
-    Function, StructField, Path, Name,
-    FnSignature, AdtDef,ConstSignature,
-    HirDatabase,
-    DefWithBody,
-    ImplItem,
+    Function, StructField, Path, Name, FnSignature, AdtDef, ConstSignature, HirDatabase,
+    DefWithBody, ImplItem,
     type_ref::{TypeRef, Mutability},
-    expr::{Body, Expr, BindingAnnotation, Literal, ExprId, Pat, PatId, UnaryOp, BinaryOp, Statement, FieldPat,Array, self},
+    expr::{
+        Body, Expr, BindingAnnotation, Literal, ExprId, Pat, PatId, UnaryOp, BinaryOp, Statement,
+        FieldPat, Array, self,
+    },
     generics::{GenericParams, HasGenericParams},
     path::{GenericArgs, GenericArg},
     ModuleDef,
@@ -644,7 +644,8 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
                 let ty = self.insert_type_vars(ty.apply_substs(substs));
                 (ty, Some(var.into()))
             }
-            TypableDef::TypeAlias(_)
+            TypableDef::Union(_)
+            | TypableDef::TypeAlias(_)
             | TypableDef::Function(_)
             | TypableDef::Enum(_)
             | TypableDef::Const(_)
@@ -1407,7 +1408,11 @@ impl Expectation {
 }
 
 mod diagnostics {
-    use crate::{expr::ExprId, diagnostics::{DiagnosticSink, NoSuchField}, HirDatabase, Function};
+    use crate::{
+        expr::ExprId,
+        diagnostics::{DiagnosticSink, NoSuchField},
+        HirDatabase, Function,
+};
 
     #[derive(Debug, PartialEq, Eq, Clone)]
     pub(super) enum InferenceDiagnostic {

--- a/crates/ra_ide_api/src/completion/complete_struct_literal.rs
+++ b/crates/ra_ide_api/src/completion/complete_struct_literal.rs
@@ -20,6 +20,7 @@ pub(super) fn complete_struct_literal(acc: &mut Completions, ctx: &CompletionCon
         }
 
         // FIXME unions
+        AdtDef::Union(_) => (),
         AdtDef::Enum(_) => (),
     };
 }

--- a/crates/ra_ide_api/src/completion/presentation.rs
+++ b/crates/ra_ide_api/src/completion/presentation.rs
@@ -63,6 +63,7 @@ impl Completions {
                 return self.add_function_with_name(ctx, Some(local_name), *func);
             }
             Resolution::Def(Struct(it)) => (CompletionItemKind::Struct, it.docs(ctx.db)),
+            Resolution::Def(Union(it)) => (CompletionItemKind::Struct, it.docs(ctx.db)),
             Resolution::Def(Enum(it)) => (CompletionItemKind::Enum, it.docs(ctx.db)),
             Resolution::Def(EnumVariant(it)) => (CompletionItemKind::EnumVariant, it.docs(ctx.db)),
             Resolution::Def(Const(it)) => (CompletionItemKind::Const, it.docs(ctx.db)),

--- a/crates/ra_ide_api/src/display/navigation_target.rs
+++ b/crates/ra_ide_api/src/display/navigation_target.rs
@@ -154,6 +154,10 @@ impl NavigationTarget {
                 let (file_id, node) = s.source(db);
                 NavigationTarget::from_named(file_id.original_file(db), &*node)
             }
+            hir::AdtDef::Union(s) => {
+                let (file_id, node) = s.source(db);
+                NavigationTarget::from_named(file_id.original_file(db), &*node)
+            }
             hir::AdtDef::Enum(s) => {
                 let (file_id, node) = s.source(db);
                 NavigationTarget::from_named(file_id.original_file(db), &*node)
@@ -166,6 +170,10 @@ impl NavigationTarget {
             hir::ModuleDef::Module(module) => NavigationTarget::from_module(db, module),
             hir::ModuleDef::Function(func) => NavigationTarget::from_function(db, func),
             hir::ModuleDef::Struct(s) => {
+                let (file_id, node) = s.source(db);
+                NavigationTarget::from_named(file_id.original_file(db), &*node)
+            }
+            hir::ModuleDef::Union(s) => {
                 let (file_id, node) = s.source(db);
                 NavigationTarget::from_named(file_id.original_file(db), &*node)
             }

--- a/crates/ra_ide_api/src/syntax_highlighting.rs
+++ b/crates/ra_ide_api/src/syntax_highlighting.rs
@@ -57,6 +57,7 @@ pub(crate) fn highlight(db: &RootDatabase, file_id: FileId) -> Vec<HighlightedRa
                         Some(Def(ModuleDef::Module(_))) => "module",
                         Some(Def(ModuleDef::Function(_))) => "function",
                         Some(Def(ModuleDef::Struct(_))) => "type",
+                        Some(Def(ModuleDef::Union(_))) => "type",
                         Some(Def(ModuleDef::Enum(_))) => "type",
                         Some(Def(ModuleDef::EnumVariant(_))) => "constant",
                         Some(Def(ModuleDef::Const(_))) => "constant",


### PR DESCRIPTION
@flodiebold I am conflicted about two possible implementation approaches:

* we can add a separate `struct Union` to code model
* we can add `fn is_union(&self)` to existing `Struct`

This PR goes with the former approach, because it seems like Unions are sufficiently different in semantics to warrant a separate types. Which is in contrast to Syntax Tree, where both structs and unions share the same node kind, because their syntax is the same. 

What would be the right thing to do here?