### PR TITLE
Pass `--all-targets` to `cargo watch`

### DIFF
--- a/editors/code/src/commands/cargo_watch.ts
+++ b/editors/code/src/commands/cargo_watch.ts
@@ -57,7 +57,7 @@ export class CargoWatchProvider implements vscode.Disposable {
             return;
         }
 
-        let args = 'check --message-format json';
+        let args = 'check --all-targets --message-format json';
         if (Server.config.cargoWatchOptions.checkArguments.length > 0) {
             // Excape the double quote string:
             args += ' ' + Server.config.cargoWatchOptions.checkArguments;


### PR DESCRIPTION
A trivial change, but passes the `--all-targets` flag to `cargo watch`. This enables inline diagnostics for the example, bin and test targets. Previously, modifying an example would trigger a change notification for `cargo watch`, but `cargo check` does not actually check these unless either `--all-targets` or `--examples` is specified.