### PR TITLE
Use ThemeColor and add support for light themes

### DIFF
--- a/crates/ra_ide_api/src/syntax_highlighting.rs
+++ b/crates/ra_ide_api/src/syntax_highlighting.rs
@@ -1,6 +1,6 @@
 use rustc_hash::FxHashSet;
 
-use ra_syntax::{ast, AstNode, TextRange, Direction, SyntaxKind::*, SyntaxElement, T};
+use ra_syntax::{ast, AstNode, TextRange, Direction, SyntaxKind, SyntaxKind::*, SyntaxElement, T};
 use ra_db::SourceDatabase;
 
 use crate::{FileId, db::RootDatabase};
@@ -9,6 +9,14 @@ use crate::{FileId, db::RootDatabase};
 pub struct HighlightedRange {
     pub range: TextRange,
     pub tag: &'static str,
+}
+
+fn is_control_keyword(kind: SyntaxKind) -> bool {
+    match kind {
+        FOR_KW | LOOP_KW | WHILE_KW | CONTINUE_KW | BREAK_KW | IF_KW | ELSE_KW | MATCH_KW
+        | RETURN_KW => true,
+        _ => false,
+    }
 }
 
 pub(crate) fn highlight(db: &RootDatabase, file_id: FileId) -> Vec<HighlightedRange> {
@@ -29,6 +37,8 @@ pub(crate) fn highlight(db: &RootDatabase, file_id: FileId) -> Vec<HighlightedRa
             NAME => "function",
             INT_NUMBER | FLOAT_NUMBER | CHAR | BYTE => "literal",
             LIFETIME => "parameter",
+            UNSAFE_KW => "unsafe",
+            k if is_control_keyword(k) => "control",
             k if k.is_keyword() => "keyword",
             _ => {
                 if let Some(macro_call) = node.as_node().and_then(ast::MacroCall::cast) {

--- a/crates/ra_ide_api/src/syntax_highlighting.rs
+++ b/crates/ra_ide_api/src/syntax_highlighting.rs
@@ -13,8 +13,15 @@ pub struct HighlightedRange {
 
 fn is_control_keyword(kind: SyntaxKind) -> bool {
     match kind {
-        FOR_KW | LOOP_KW | WHILE_KW | CONTINUE_KW | BREAK_KW | IF_KW | ELSE_KW | MATCH_KW
-        | RETURN_KW => true,
+        T![for]
+        | T![loop]
+        | T![while]
+        | T![continue]
+        | T![break]
+        | T![if]
+        | T![else]
+        | T![match]
+        | T![return] => true,
         _ => false,
     }
 }
@@ -37,8 +44,8 @@ pub(crate) fn highlight(db: &RootDatabase, file_id: FileId) -> Vec<HighlightedRa
             NAME => "function",
             INT_NUMBER | FLOAT_NUMBER | CHAR | BYTE => "literal",
             LIFETIME => "parameter",
-            UNSAFE_KW => "unsafe",
-            k if is_control_keyword(k) => "control",
+            T![unsafe] => "keyword.unsafe",
+            k if is_control_keyword(k) => "keyword.control",
             k if k.is_keyword() => "keyword",
             _ => {
                 if let Some(macro_call) = node.as_node().and_then(ast::MacroCall::cast) {

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -271,19 +271,10 @@
         ],
         "colors": [
             {
-                "id": "ralsp.background",
-                "description": "Background color",
-                "defaults": {
-                    "dark": "#3F3F3F",
-                    "light": "#001080",
-                    "highContrast": "#000000"
-                }
-            },
-            {
                 "id": "ralsp.comment",
                 "description": "Color for comments",
                 "defaults": {
-                    "dark": "#7F9F7F",
+                    "dark": "#6A9955",
                     "light": "#008000",
                     "highContrast": "#7CA668"
                 }
@@ -292,13 +283,31 @@
                 "id": "ralsp.string",
                 "description": "Color for strings",
                 "defaults": {
-                    "dark": "#CC9393",
+                    "dark": "#CE9178",
                     "light": "#A31515",
                     "highContrast": "#CE9178"
                 }
             },
             {
-                "id": "ralsp.unsafe",
+                "id": "ralsp.keyword",
+                "description": "Color for keywords",
+                "defaults": {
+                    "dark": "#569cd6",
+                    "light": "#0000FF",
+                    "highContrast": "#569CD6"
+                }
+            },
+            {
+                "id": "ralsp.keyword.control",
+                "description": "Color for control keywords",
+                "defaults": {
+                    "dark": "#C586C0",
+                    "light": "#AF00DB",
+                    "highContrast": "#C586C0"
+                }
+            },
+            {
+                "id": "ralsp.keyword.unsafe",
                 "description": "Color for unsafe",
                 "defaults": {
                     "dark": "#FF3030",
@@ -307,28 +316,10 @@
                 }
             },
             {
-                "id": "ralsp.keyword",
-                "description": "Color for keywords",
-                "defaults": {
-                    "dark": "#F0DFAF",
-                    "light": "#0000FF",
-                    "highContrast": "#569CD6"
-                }
-            },
-            {
-                "id": "ralsp.control",
-                "description": "Color for control keywords",
-                "defaults": {
-                    "dark": "#CF20FB",
-                    "light": "#AF00DB",
-                    "highContrast": "#C586C0"
-                }
-            },
-            {
                 "id": "ralsp.function",
                 "description": "Color for functions",
                 "defaults": {
-                    "dark": "#93E0E3",
+                    "dark": "#DCDCAA",
                     "light": "#795E26",
                     "highContrast": "#DCDCAA"
                 }
@@ -337,7 +328,7 @@
                 "id": "ralsp.parameter",
                 "description": "Color for parameters",
                 "defaults": {
-                    "dark": "#94BFF3",
+                    "dark": "#9CDCFE",
                     "light": "#001080",
                     "highContrast": "#9CDCFE"
                 }
@@ -355,7 +346,7 @@
                 "id": "ralsp.text",
                 "description": "Color for text",
                 "defaults": {
-                    "dark": "#DCDCCC",
+                    "dark": "#D4D4D4",
                     "light": "#000000",
                     "highContrast": "#FFFFFF"
                 }
@@ -364,7 +355,7 @@
                 "id": "ralsp.attribute",
                 "description": "Color for attributes",
                 "defaults": {
-                    "dark": "#BFEBBF",
+                    "dark": "#9FE9BF",
                     "light": "#1F4B1F",
                     "highContrast": "#108010"
                 }
@@ -373,7 +364,7 @@
                 "id": "ralsp.literal",
                 "description": "Color for literals",
                 "defaults": {
-                    "dark": "#DFAF8F",
+                    "dark": "#BECEA8",
                     "light": "#09885A",
                     "highContrast": "#B5CEA8"
                 }

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -268,6 +268,125 @@
                 },
                 "pattern": "$rustc"
             }
+        ],
+        "colors": [
+            {
+                "id": "ralsp.background",
+                "description": "Background color",
+                "defaults": {
+                    "dark": "#3F3F3F",
+                    "light": "#001080",
+                    "highContrast": "#000000"
+                }
+            },
+            {
+                "id": "ralsp.comment",
+                "description": "Color for comments",
+                "defaults": {
+                    "dark": "#7F9F7F",
+                    "light": "#008000",
+                    "highContrast": "#7CA668"
+                }
+            },
+            {
+                "id": "ralsp.string",
+                "description": "Color for strings",
+                "defaults": {
+                    "dark": "#CC9393",
+                    "light": "#A31515",
+                    "highContrast": "#CE9178"
+                }
+            },
+            {
+                "id": "ralsp.unsafe",
+                "description": "Color for unsafe",
+                "defaults": {
+                    "dark": "#FF3030",
+                    "light": "#FF1010",
+                    "highContrast": "#FF1010"
+                }
+            },
+            {
+                "id": "ralsp.keyword",
+                "description": "Color for keywords",
+                "defaults": {
+                    "dark": "#F0DFAF",
+                    "light": "#0000FF",
+                    "highContrast": "#569CD6"
+                }
+            },
+            {
+                "id": "ralsp.control",
+                "description": "Color for control keywords",
+                "defaults": {
+                    "dark": "#CF20FB",
+                    "light": "#AF00DB",
+                    "highContrast": "#C586C0"
+                }
+            },
+            {
+                "id": "ralsp.function",
+                "description": "Color for functions",
+                "defaults": {
+                    "dark": "#93E0E3",
+                    "light": "#795E26",
+                    "highContrast": "#DCDCAA"
+                }
+            },
+            {
+                "id": "ralsp.parameter",
+                "description": "Color for parameters",
+                "defaults": {
+                    "dark": "#94BFF3",
+                    "light": "#001080",
+                    "highContrast": "#9CDCFE"
+                }
+            },
+            {
+                "id": "ralsp.builtin",
+                "description": "Color for builtins",
+                "defaults": {
+                    "dark": "#DD6718",
+                    "light": "#DD6718",
+                    "highContrast": "#DD6718"
+                }
+            },
+            {
+                "id": "ralsp.text",
+                "description": "Color for text",
+                "defaults": {
+                    "dark": "#DCDCCC",
+                    "light": "#000000",
+                    "highContrast": "#FFFFFF"
+                }
+            },
+            {
+                "id": "ralsp.attribute",
+                "description": "Color for attributes",
+                "defaults": {
+                    "dark": "#BFEBBF",
+                    "light": "#1F4B1F",
+                    "highContrast": "#108010"
+                }
+            },
+            {
+                "id": "ralsp.literal",
+                "description": "Color for literals",
+                "defaults": {
+                    "dark": "#DFAF8F",
+                    "light": "#09885A",
+                    "highContrast": "#B5CEA8"
+                }
+            },
+            {
+                "id": "ralsp.macro",
+                "description": "Color for DFAF8F",
+                "defaults": {
+                    "dark": "#BFEBBF",
+                    "light": "#DD6718",
+                    "highContrast": "#ED7718"
+                }
+            }
         ]
     }
 }

--- a/editors/code/src/highlighting.ts
+++ b/editors/code/src/highlighting.ts
@@ -26,12 +26,11 @@ export class Highlighter {
         const decorations: Iterable<
             [string, vscode.TextEditorDecorationType]
         > = [
-            colorContrib('background'),
             colorContrib('comment'),
             colorContrib('string'),
-            colorContrib('unsafe'),
             colorContrib('keyword'),
-            colorContrib('control'),
+            colorContrib('keyword.control'),
+            colorContrib('keyword.unsafe'),
             colorContrib('function'),
             colorContrib('parameter'),
             colorContrib('builtin'),

--- a/editors/code/src/highlighting.ts
+++ b/editors/code/src/highlighting.ts
@@ -13,23 +13,32 @@ export class Highlighter {
         string,
         vscode.TextEditorDecorationType
     > {
-        const decor = (color: string) =>
-            vscode.window.createTextEditorDecorationType({ color });
+        const colorContrib = (
+            tag: string
+        ): [string, vscode.TextEditorDecorationType] => {
+            const color = new vscode.ThemeColor('ralsp.' + tag);
+            const decor = vscode.window.createTextEditorDecorationType({
+                color
+            });
+            return [tag, decor];
+        };
 
         const decorations: Iterable<
             [string, vscode.TextEditorDecorationType]
         > = [
-            ['background', decor('#3F3F3F')],
-            ['comment', decor('#7F9F7F')],
-            ['string', decor('#CC9393')],
-            ['keyword', decor('#F0DFAF')],
-            ['function', decor('#93E0E3')],
-            ['parameter', decor('#94BFF3')],
-            ['builtin', decor('#DD6718')],
-            ['text', decor('#DCDCCC')],
-            ['attribute', decor('#BFEBBF')],
-            ['literal', decor('#DFAF8F')],
-            ['macro', decor('#DFAF8F')]
+            colorContrib('background'),
+            colorContrib('comment'),
+            colorContrib('string'),
+            colorContrib('unsafe'),
+            colorContrib('keyword'),
+            colorContrib('control'),
+            colorContrib('function'),
+            colorContrib('parameter'),
+            colorContrib('builtin'),
+            colorContrib('text'),
+            colorContrib('attribute'),
+            colorContrib('literal'),
+            colorContrib('macro')
         ];
 
         return new Map<string, vscode.TextEditorDecorationType>(decorations);


### PR DESCRIPTION
Part of #1294.

- switch to `ThemeColor`
- add light and high contrast theme definitions
- highlight control flow keywords and `unsafe`
