### PR TITLE
Try to resolve name refs during highlighting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,7 @@ version = "0.2.0"
 dependencies = [
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flexi_logger 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lsp-types 0.57.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crates/ra_ide_api/src/snapshots/tests__highlighting.snap
+++ b/crates/ra_ide_api/src/snapshots/tests__highlighting.snap
@@ -1,33 +1,145 @@
 ---
-created: "2019-03-23T16:20:31.394314144Z"
-creator: insta@0.7.1
+created: "2019-05-23T12:10:32.628883358Z"
+creator: insta@0.8.1
 source: crates/ra_ide_api/src/syntax_highlighting.rs
 expression: result
 ---
 Ok(
     [
         HighlightedRange {
-            range: [1; 11),
-            tag: "comment"
+            range: [1; 24),
+            tag: "attribute"
         },
         HighlightedRange {
-            range: [12; 14),
+            range: [25; 31),
             tag: "keyword"
         },
         HighlightedRange {
-            range: [15; 19),
+            range: [32; 35),
             tag: "function"
         },
         HighlightedRange {
-            range: [29; 37),
+            range: [42; 45),
+            tag: "keyword"
+        },
+        HighlightedRange {
+            range: [46; 47),
+            tag: "function"
+        },
+        HighlightedRange {
+            range: [49; 52),
+            tag: "text"
+        },
+        HighlightedRange {
+            range: [58; 61),
+            tag: "keyword"
+        },
+        HighlightedRange {
+            range: [62; 63),
+            tag: "function"
+        },
+        HighlightedRange {
+            range: [65; 68),
+            tag: "text"
+        },
+        HighlightedRange {
+            range: [73; 75),
+            tag: "keyword"
+        },
+        HighlightedRange {
+            range: [76; 79),
+            tag: "function"
+        },
+        HighlightedRange {
+            range: [80; 81),
+            tag: "type"
+        },
+        HighlightedRange {
+            range: [80; 81),
+            tag: "function"
+        },
+        HighlightedRange {
+            range: [88; 89),
+            tag: "type"
+        },
+        HighlightedRange {
+            range: [96; 110),
             tag: "macro"
         },
         HighlightedRange {
-            range: [38; 50),
+            range: [117; 127),
+            tag: "comment"
+        },
+        HighlightedRange {
+            range: [128; 130),
+            tag: "keyword"
+        },
+        HighlightedRange {
+            range: [131; 135),
+            tag: "function"
+        },
+        HighlightedRange {
+            range: [145; 153),
+            tag: "macro"
+        },
+        HighlightedRange {
+            range: [154; 166),
             tag: "string"
         },
         HighlightedRange {
-            range: [52; 54),
+            range: [168; 170),
+            tag: "literal"
+        },
+        HighlightedRange {
+            range: [178; 181),
+            tag: "keyword"
+        },
+        HighlightedRange {
+            range: [182; 185),
+            tag: "keyword"
+        },
+        HighlightedRange {
+            range: [186; 189),
+            tag: "macro"
+        },
+        HighlightedRange {
+            range: [197; 200),
+            tag: "macro"
+        },
+        HighlightedRange {
+            range: [192; 195),
+            tag: "text"
+        },
+        HighlightedRange {
+            range: [208; 211),
+            tag: "macro"
+        },
+        HighlightedRange {
+            range: [212; 216),
+            tag: "macro"
+        },
+        HighlightedRange {
+            range: [226; 227),
+            tag: "literal"
+        },
+        HighlightedRange {
+            range: [232; 233),
+            tag: "literal"
+        },
+        HighlightedRange {
+            range: [242; 248),
+            tag: "keyword.unsafe"
+        },
+        HighlightedRange {
+            range: [251; 254),
+            tag: "text"
+        },
+        HighlightedRange {
+            range: [255; 262),
+            tag: "text"
+        },
+        HighlightedRange {
+            range: [263; 264),
             tag: "literal"
         }
     ]

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -371,11 +371,56 @@
             },
             {
                 "id": "ralsp.macro",
-                "description": "Color for DFAF8F",
+                "description": "Color for macros",
                 "defaults": {
                     "dark": "#BFEBBF",
                     "light": "#DD6718",
                     "highContrast": "#ED7718"
+                }
+            },
+            {
+                "id": "ralsp.constant",
+                "description": "Color for constants",
+                "defaults": {
+                    "dark": "#569cd6",
+                    "light": "#267cb6",
+                    "highContrast": "#569cd6"
+                }
+            },
+            {
+                "id": "ralsp.type",
+                "description": "Color for types",
+                "defaults": {
+                    "dark": "#4EC9B0",
+                    "light": "#267F99",
+                    "highContrast": "#4EC9B0"
+                }
+            },
+            {
+                "id": "ralsp.field",
+                "description": "Color for fields",
+                "defaults": {
+                    "dark": "#4EC9B0",
+                    "light": "#267F99",
+                    "highContrast": "#4EC9B0"
+                }
+            },
+            {
+                "id": "ralsp.variable",
+                "description": "Color for variables",
+                "defaults": {
+                    "dark": "#4EC9B0",
+                    "light": "#267F99",
+                    "highContrast": "#4EC9B0"
+                }
+            },
+            {
+                "id": "ralsp.module",
+                "description": "Color for modules",
+                "defaults": {
+                    "dark": "#D4D4D4",
+                    "light": "#000000",
+                    "highContrast": "#FFFFFF"
                 }
             }
         ]

--- a/editors/code/src/highlighting.ts
+++ b/editors/code/src/highlighting.ts
@@ -33,11 +33,16 @@ export class Highlighter {
             colorContrib('keyword.unsafe'),
             colorContrib('function'),
             colorContrib('parameter'),
+            colorContrib('constant'),
+            colorContrib('type'),
             colorContrib('builtin'),
             colorContrib('text'),
             colorContrib('attribute'),
             colorContrib('literal'),
-            colorContrib('macro')
+            colorContrib('macro'),
+            colorContrib('variable'),
+            colorContrib('field'),
+            colorContrib('module')
         ];
 
         return new Map<string, vscode.TextEditorDecorationType>(decorations);


### PR DESCRIPTION
Preview:

![image](https://user-images.githubusercontent.com/308347/58253075-43464a80-7d70-11e9-84cc-e81990f2d3eb.png)

This is probably not the cleanest implementation, but it's not clear to me what parts of `reference_definition` we don't want to run at this point. Also, is the `SourceAnalyzer` cheap enough to construct for each `NameRef`? Not like there's any alternative at this point, though.