### PR TITLE
Chalk fuel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,9 +141,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "chalk-engine"
 version = "0.9.0"
-source = "git+https://github.com/rust-lang/chalk.git#b92c15327f1d336fec7573c7de323ab247cca386"
+source = "git+https://github.com/flodiebold/chalk.git?branch=fuel#fba97af88ff2e0266db12490e2baf47d17e557e3"
 dependencies = [
- "chalk-macros 0.1.1 (git+https://github.com/rust-lang/chalk.git)",
+ "chalk-macros 0.1.1 (git+https://github.com/flodiebold/chalk.git?branch=fuel)",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "stacker 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -151,17 +151,17 @@ dependencies = [
 [[package]]
 name = "chalk-ir"
 version = "0.1.0"
-source = "git+https://github.com/rust-lang/chalk.git#b92c15327f1d336fec7573c7de323ab247cca386"
+source = "git+https://github.com/flodiebold/chalk.git?branch=fuel#fba97af88ff2e0266db12490e2baf47d17e557e3"
 dependencies = [
- "chalk-engine 0.9.0 (git+https://github.com/rust-lang/chalk.git)",
- "chalk-macros 0.1.1 (git+https://github.com/rust-lang/chalk.git)",
+ "chalk-engine 0.9.0 (git+https://github.com/flodiebold/chalk.git?branch=fuel)",
+ "chalk-macros 0.1.1 (git+https://github.com/flodiebold/chalk.git?branch=fuel)",
  "lalrpop-intern 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "chalk-macros"
 version = "0.1.1"
-source = "git+https://github.com/rust-lang/chalk.git#b92c15327f1d336fec7573c7de323ab247cca386"
+source = "git+https://github.com/flodiebold/chalk.git?branch=fuel#fba97af88ff2e0266db12490e2baf47d17e557e3"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -169,22 +169,22 @@ dependencies = [
 [[package]]
 name = "chalk-rust-ir"
 version = "0.1.0"
-source = "git+https://github.com/rust-lang/chalk.git#b92c15327f1d336fec7573c7de323ab247cca386"
+source = "git+https://github.com/flodiebold/chalk.git?branch=fuel#fba97af88ff2e0266db12490e2baf47d17e557e3"
 dependencies = [
- "chalk-engine 0.9.0 (git+https://github.com/rust-lang/chalk.git)",
- "chalk-ir 0.1.0 (git+https://github.com/rust-lang/chalk.git)",
- "chalk-macros 0.1.1 (git+https://github.com/rust-lang/chalk.git)",
+ "chalk-engine 0.9.0 (git+https://github.com/flodiebold/chalk.git?branch=fuel)",
+ "chalk-ir 0.1.0 (git+https://github.com/flodiebold/chalk.git?branch=fuel)",
+ "chalk-macros 0.1.1 (git+https://github.com/flodiebold/chalk.git?branch=fuel)",
 ]
 
 [[package]]
 name = "chalk-solve"
 version = "0.1.0"
-source = "git+https://github.com/rust-lang/chalk.git#b92c15327f1d336fec7573c7de323ab247cca386"
+source = "git+https://github.com/flodiebold/chalk.git?branch=fuel#fba97af88ff2e0266db12490e2baf47d17e557e3"
 dependencies = [
- "chalk-engine 0.9.0 (git+https://github.com/rust-lang/chalk.git)",
- "chalk-ir 0.1.0 (git+https://github.com/rust-lang/chalk.git)",
- "chalk-macros 0.1.1 (git+https://github.com/rust-lang/chalk.git)",
- "chalk-rust-ir 0.1.0 (git+https://github.com/rust-lang/chalk.git)",
+ "chalk-engine 0.9.0 (git+https://github.com/flodiebold/chalk.git?branch=fuel)",
+ "chalk-ir 0.1.0 (git+https://github.com/flodiebold/chalk.git?branch=fuel)",
+ "chalk-macros 0.1.1 (git+https://github.com/flodiebold/chalk.git?branch=fuel)",
+ "chalk-rust-ir 0.1.0 (git+https://github.com/flodiebold/chalk.git?branch=fuel)",
  "derive-new 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ena 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1109,9 +1109,9 @@ name = "ra_hir"
 version = "0.1.0"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "chalk-ir 0.1.0 (git+https://github.com/rust-lang/chalk.git)",
- "chalk-rust-ir 0.1.0 (git+https://github.com/rust-lang/chalk.git)",
- "chalk-solve 0.1.0 (git+https://github.com/rust-lang/chalk.git)",
+ "chalk-ir 0.1.0 (git+https://github.com/flodiebold/chalk.git?branch=fuel)",
+ "chalk-rust-ir 0.1.0 (git+https://github.com/flodiebold/chalk.git?branch=fuel)",
+ "chalk-solve 0.1.0 (git+https://github.com/flodiebold/chalk.git?branch=fuel)",
  "ena 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flexi_logger 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "insta 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2036,11 +2036,11 @@ dependencies = [
 "checksum cargo_metadata 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "178d62b240c34223f265a4c1e275e37d62da163d421fc8d7f7e3ee340f803c57"
 "checksum cc 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)" = "a0c56216487bb80eec9c4516337b2588a4f2a2290d72a1416d930e4dcdb0c90d"
 "checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
-"checksum chalk-engine 0.9.0 (git+https://github.com/rust-lang/chalk.git)" = "<none>"
-"checksum chalk-ir 0.1.0 (git+https://github.com/rust-lang/chalk.git)" = "<none>"
-"checksum chalk-macros 0.1.1 (git+https://github.com/rust-lang/chalk.git)" = "<none>"
-"checksum chalk-rust-ir 0.1.0 (git+https://github.com/rust-lang/chalk.git)" = "<none>"
-"checksum chalk-solve 0.1.0 (git+https://github.com/rust-lang/chalk.git)" = "<none>"
+"checksum chalk-engine 0.9.0 (git+https://github.com/flodiebold/chalk.git?branch=fuel)" = "<none>"
+"checksum chalk-ir 0.1.0 (git+https://github.com/flodiebold/chalk.git?branch=fuel)" = "<none>"
+"checksum chalk-macros 0.1.1 (git+https://github.com/flodiebold/chalk.git?branch=fuel)" = "<none>"
+"checksum chalk-rust-ir 0.1.0 (git+https://github.com/flodiebold/chalk.git?branch=fuel)" = "<none>"
+"checksum chalk-solve 0.1.0 (git+https://github.com/flodiebold/chalk.git?branch=fuel)" = "<none>"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum ci_info 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e5e881307a989a3a5e20d52a32cc05950e3c2178cccfcc9428271a6cde09f902"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"

--- a/crates/ra_hir/Cargo.toml
+++ b/crates/ra_hir/Cargo.toml
@@ -21,9 +21,9 @@ tt = { path = "../ra_tt", package = "ra_tt" }
 test_utils = { path = "../test_utils" }
 ra_prof = { path = "../ra_prof" }
 
-chalk-solve = { git = "https://github.com/rust-lang/chalk.git" }
-chalk-rust-ir = { git = "https://github.com/rust-lang/chalk.git" }
-chalk-ir = { git = "https://github.com/rust-lang/chalk.git" }
+chalk-solve = { git = "https://github.com/flodiebold/chalk.git", branch = "fuel" }
+chalk-rust-ir = { git = "https://github.com/flodiebold/chalk.git", branch = "fuel" }
+chalk-ir = { git = "https://github.com/flodiebold/chalk.git", branch = "fuel" }
 
 [dev-dependencies]
 flexi_logger = "0.11.0"

--- a/crates/ra_hir/src/ty/infer/unify.rs
+++ b/crates/ra_hir/src/ty/infer/unify.rs
@@ -56,7 +56,12 @@ where
                     self.var_stack.pop();
                     result
                 } else {
-                    let free_var = InferTy::TypeVar(self.ctx.var_unification_table.find(inner));
+                    let root = self.ctx.var_unification_table.find(inner);
+                    let free_var = match tv {
+                        InferTy::TypeVar(_) => InferTy::TypeVar(root),
+                        InferTy::IntVar(_) => InferTy::IntVar(root),
+                        InferTy::FloatVar(_) => InferTy::FloatVar(root),
+                    };
                     let position = self.add(free_var);
                     Ty::Bound(position as u32)
                 }

--- a/crates/ra_hir/src/ty/traits.rs
+++ b/crates/ra_hir/src/ty/traits.rs
@@ -61,7 +61,7 @@ fn solve(
     let context = ChalkContext { db, krate };
     let solver = db.solver(krate);
     debug!("solve goal: {:?}", goal);
-    let solution = solver.lock().unwrap().solve(&context, goal);
+    let solution = solver.lock().unwrap().solve_with_fuel(&context, goal, Some(1000));
     debug!("solve({:?}) => {:?}", goal, solution);
     solution
 }


### PR DESCRIPTION
This switches Chalk to my fuel branch, and limits the fuel for trait solving. This should improve worst-case performance; for example, we can now run `ra_cli analysis-stats` against rustc again. This also fixes a bug found doing that.