### PR TITLE
Change TokenSource to iteration based

### DIFF
--- a/crates/ra_mbe/src/subtree_parser.rs
+++ b/crates/ra_mbe/src/subtree_parser.rs
@@ -68,13 +68,13 @@ impl<'a> Parser<'a> {
 
     fn parse<F>(self, f: F) -> Option<tt::TokenTree>
     where
-        F: FnOnce(&dyn TokenSource, &mut dyn TreeSink),
+        F: FnOnce(&mut dyn TokenSource, &mut dyn TreeSink),
     {
         let buffer = TokenBuffer::new(&self.subtree.token_trees[*self.cur_pos..]);
         let mut src = SubtreeTokenSource::new(&buffer);
         let mut sink = OffsetTokenSink { token_pos: 0, error: false };
 
-        f(&src, &mut sink);
+        f(&mut src, &mut sink);
 
         let r = self.finish(sink.token_pos, &mut src);
         if sink.error {

--- a/crates/ra_mbe/src/syntax_bridge.rs
+++ b/crates/ra_mbe/src/syntax_bridge.rs
@@ -48,9 +48,10 @@ pub fn syntax_node_to_token_tree(node: &SyntaxNode) -> Option<(tt::Subtree, Toke
 /// Parses the token tree (result of macro expansion) to an expression
 pub fn token_tree_to_expr(tt: &tt::Subtree) -> Result<TreeArc<ast::Expr>, ExpandError> {
     let buffer = tt::buffer::TokenBuffer::new(&[tt.clone().into()]);
-    let token_source = SubtreeTokenSource::new(&buffer);
-    let mut tree_sink = TtTreeSink::new(token_source.querier());
-    ra_parser::parse_expr(&token_source, &mut tree_sink);
+    let mut token_source = SubtreeTokenSource::new(&buffer);
+    let querier = token_source.querier();
+    let mut tree_sink = TtTreeSink::new(querier.as_ref());
+    ra_parser::parse_expr(&mut token_source, &mut tree_sink);
     if tree_sink.roots.len() != 1 {
         return Err(ExpandError::ConversionError);
     }
@@ -64,9 +65,10 @@ pub fn token_tree_to_expr(tt: &tt::Subtree) -> Result<TreeArc<ast::Expr>, Expand
 /// Parses the token tree (result of macro expansion) to a Pattern
 pub fn token_tree_to_pat(tt: &tt::Subtree) -> Result<TreeArc<ast::Pat>, ExpandError> {
     let buffer = tt::buffer::TokenBuffer::new(&[tt.clone().into()]);
-    let token_source = SubtreeTokenSource::new(&buffer);
-    let mut tree_sink = TtTreeSink::new(token_source.querier());
-    ra_parser::parse_pat(&token_source, &mut tree_sink);
+    let mut token_source = SubtreeTokenSource::new(&buffer);
+    let querier = token_source.querier();
+    let mut tree_sink = TtTreeSink::new(querier.as_ref());
+    ra_parser::parse_pat(&mut token_source, &mut tree_sink);
     if tree_sink.roots.len() != 1 {
         return Err(ExpandError::ConversionError);
     }
@@ -78,9 +80,10 @@ pub fn token_tree_to_pat(tt: &tt::Subtree) -> Result<TreeArc<ast::Pat>, ExpandEr
 /// Parses the token tree (result of macro expansion) to a Type
 pub fn token_tree_to_ty(tt: &tt::Subtree) -> Result<TreeArc<ast::TypeRef>, ExpandError> {
     let buffer = tt::buffer::TokenBuffer::new(&[tt.clone().into()]);
-    let token_source = SubtreeTokenSource::new(&buffer);
-    let mut tree_sink = TtTreeSink::new(token_source.querier());
-    ra_parser::parse_ty(&token_source, &mut tree_sink);
+    let mut token_source = SubtreeTokenSource::new(&buffer);
+    let querier = token_source.querier();
+    let mut tree_sink = TtTreeSink::new(querier.as_ref());
+    ra_parser::parse_ty(&mut token_source, &mut tree_sink);
     if tree_sink.roots.len() != 1 {
         return Err(ExpandError::ConversionError);
     }
@@ -93,9 +96,10 @@ pub fn token_tree_to_macro_stmts(
     tt: &tt::Subtree,
 ) -> Result<TreeArc<ast::MacroStmts>, ExpandError> {
     let buffer = tt::buffer::TokenBuffer::new(&[tt.clone().into()]);
-    let token_source = SubtreeTokenSource::new(&buffer);
-    let mut tree_sink = TtTreeSink::new(token_source.querier());
-    ra_parser::parse_macro_stmts(&token_source, &mut tree_sink);
+    let mut token_source = SubtreeTokenSource::new(&buffer);
+    let querier = token_source.querier();
+    let mut tree_sink = TtTreeSink::new(querier.as_ref());
+    ra_parser::parse_macro_stmts(&mut token_source, &mut tree_sink);
     if tree_sink.roots.len() != 1 {
         return Err(ExpandError::ConversionError);
     }
@@ -108,9 +112,10 @@ pub fn token_tree_to_macro_items(
     tt: &tt::Subtree,
 ) -> Result<TreeArc<ast::MacroItems>, ExpandError> {
     let buffer = tt::buffer::TokenBuffer::new(&[tt.clone().into()]);
-    let token_source = SubtreeTokenSource::new(&buffer);
-    let mut tree_sink = TtTreeSink::new(token_source.querier());
-    ra_parser::parse_macro_items(&token_source, &mut tree_sink);
+    let mut token_source = SubtreeTokenSource::new(&buffer);
+    let querier = token_source.querier();
+    let mut tree_sink = TtTreeSink::new(querier.as_ref());
+    ra_parser::parse_macro_items(&mut token_source, &mut tree_sink);
     if tree_sink.roots.len() != 1 {
         return Err(ExpandError::ConversionError);
     }
@@ -121,9 +126,10 @@ pub fn token_tree_to_macro_items(
 /// Parses the token tree (result of macro expansion) as a sequence of items
 pub fn token_tree_to_ast_item_list(tt: &tt::Subtree) -> TreeArc<ast::SourceFile> {
     let buffer = tt::buffer::TokenBuffer::new(&[tt.clone().into()]);
-    let token_source = SubtreeTokenSource::new(&buffer);
-    let mut tree_sink = TtTreeSink::new(token_source.querier());
-    ra_parser::parse(&token_source, &mut tree_sink);
+    let mut token_source = SubtreeTokenSource::new(&buffer);
+    let querier = token_source.querier();
+    let mut tree_sink = TtTreeSink::new(querier.as_ref());
+    ra_parser::parse(&mut token_source, &mut tree_sink);
     let syntax = tree_sink.inner.finish();
     ast::SourceFile::cast(&syntax).unwrap().to_owned()
 }

--- a/crates/ra_mbe/src/syntax_bridge.rs
+++ b/crates/ra_mbe/src/syntax_bridge.rs
@@ -58,10 +58,6 @@ where
         return Err(ExpandError::ConversionError);
     }
 
-    if tree_sink.roots.len() != 1 {
-        return Err(ExpandError::ConversionError);
-    }
-
     Ok(tree_sink.inner.finish())
 }
 

--- a/crates/ra_mbe/src/syntax_bridge.rs
+++ b/crates/ra_mbe/src/syntax_bridge.rs
@@ -45,18 +45,29 @@ pub fn syntax_node_to_token_tree(node: &SyntaxNode) -> Option<(tt::Subtree, Toke
 //
 //
 
-/// Parses the token tree (result of macro expansion) to an expression
-pub fn token_tree_to_expr(tt: &tt::Subtree) -> Result<TreeArc<ast::Expr>, ExpandError> {
+fn token_tree_to_syntax_node<F>(tt: &tt::Subtree, f: F) -> Result<TreeArc<SyntaxNode>, ExpandError>
+where
+    F: Fn(&mut ra_parser::TokenSource, &mut ra_parser::TreeSink),
+{
     let buffer = tt::buffer::TokenBuffer::new(&[tt.clone().into()]);
     let mut token_source = SubtreeTokenSource::new(&buffer);
     let querier = token_source.querier();
     let mut tree_sink = TtTreeSink::new(querier.as_ref());
-    ra_parser::parse_expr(&mut token_source, &mut tree_sink);
+    f(&mut token_source, &mut tree_sink);
     if tree_sink.roots.len() != 1 {
         return Err(ExpandError::ConversionError);
     }
 
-    let syntax = tree_sink.inner.finish();
+    if tree_sink.roots.len() != 1 {
+        return Err(ExpandError::ConversionError);
+    }
+
+    Ok(tree_sink.inner.finish())
+}
+
+/// Parses the token tree (result of macro expansion) to an expression
+pub fn token_tree_to_expr(tt: &tt::Subtree) -> Result<TreeArc<ast::Expr>, ExpandError> {
+    let syntax = token_tree_to_syntax_node(tt, ra_parser::parse_expr)?;
     ast::Expr::cast(&syntax)
         .map(|m| m.to_owned())
         .ok_or_else(|| crate::ExpandError::ConversionError)
@@ -64,30 +75,13 @@ pub fn token_tree_to_expr(tt: &tt::Subtree) -> Result<TreeArc<ast::Expr>, Expand
 
 /// Parses the token tree (result of macro expansion) to a Pattern
 pub fn token_tree_to_pat(tt: &tt::Subtree) -> Result<TreeArc<ast::Pat>, ExpandError> {
-    let buffer = tt::buffer::TokenBuffer::new(&[tt.clone().into()]);
-    let mut token_source = SubtreeTokenSource::new(&buffer);
-    let querier = token_source.querier();
-    let mut tree_sink = TtTreeSink::new(querier.as_ref());
-    ra_parser::parse_pat(&mut token_source, &mut tree_sink);
-    if tree_sink.roots.len() != 1 {
-        return Err(ExpandError::ConversionError);
-    }
-
-    let syntax = tree_sink.inner.finish();
+    let syntax = token_tree_to_syntax_node(tt, ra_parser::parse_pat)?;
     ast::Pat::cast(&syntax).map(|m| m.to_owned()).ok_or_else(|| ExpandError::ConversionError)
 }
 
 /// Parses the token tree (result of macro expansion) to a Type
 pub fn token_tree_to_ty(tt: &tt::Subtree) -> Result<TreeArc<ast::TypeRef>, ExpandError> {
-    let buffer = tt::buffer::TokenBuffer::new(&[tt.clone().into()]);
-    let mut token_source = SubtreeTokenSource::new(&buffer);
-    let querier = token_source.querier();
-    let mut tree_sink = TtTreeSink::new(querier.as_ref());
-    ra_parser::parse_ty(&mut token_source, &mut tree_sink);
-    if tree_sink.roots.len() != 1 {
-        return Err(ExpandError::ConversionError);
-    }
-    let syntax = tree_sink.inner.finish();
+    let syntax = token_tree_to_syntax_node(tt, ra_parser::parse_ty)?;
     ast::TypeRef::cast(&syntax).map(|m| m.to_owned()).ok_or_else(|| ExpandError::ConversionError)
 }
 
@@ -95,15 +89,7 @@ pub fn token_tree_to_ty(tt: &tt::Subtree) -> Result<TreeArc<ast::TypeRef>, Expan
 pub fn token_tree_to_macro_stmts(
     tt: &tt::Subtree,
 ) -> Result<TreeArc<ast::MacroStmts>, ExpandError> {
-    let buffer = tt::buffer::TokenBuffer::new(&[tt.clone().into()]);
-    let mut token_source = SubtreeTokenSource::new(&buffer);
-    let querier = token_source.querier();
-    let mut tree_sink = TtTreeSink::new(querier.as_ref());
-    ra_parser::parse_macro_stmts(&mut token_source, &mut tree_sink);
-    if tree_sink.roots.len() != 1 {
-        return Err(ExpandError::ConversionError);
-    }
-    let syntax = tree_sink.inner.finish();
+    let syntax = token_tree_to_syntax_node(tt, ra_parser::parse_macro_stmts)?;
     ast::MacroStmts::cast(&syntax).map(|m| m.to_owned()).ok_or_else(|| ExpandError::ConversionError)
 }
 
@@ -111,26 +97,13 @@ pub fn token_tree_to_macro_stmts(
 pub fn token_tree_to_macro_items(
     tt: &tt::Subtree,
 ) -> Result<TreeArc<ast::MacroItems>, ExpandError> {
-    let buffer = tt::buffer::TokenBuffer::new(&[tt.clone().into()]);
-    let mut token_source = SubtreeTokenSource::new(&buffer);
-    let querier = token_source.querier();
-    let mut tree_sink = TtTreeSink::new(querier.as_ref());
-    ra_parser::parse_macro_items(&mut token_source, &mut tree_sink);
-    if tree_sink.roots.len() != 1 {
-        return Err(ExpandError::ConversionError);
-    }
-    let syntax = tree_sink.inner.finish();
+    let syntax = token_tree_to_syntax_node(tt, ra_parser::parse_macro_items)?;
     ast::MacroItems::cast(&syntax).map(|m| m.to_owned()).ok_or_else(|| ExpandError::ConversionError)
 }
 
 /// Parses the token tree (result of macro expansion) as a sequence of items
 pub fn token_tree_to_ast_item_list(tt: &tt::Subtree) -> TreeArc<ast::SourceFile> {
-    let buffer = tt::buffer::TokenBuffer::new(&[tt.clone().into()]);
-    let mut token_source = SubtreeTokenSource::new(&buffer);
-    let querier = token_source.querier();
-    let mut tree_sink = TtTreeSink::new(querier.as_ref());
-    ra_parser::parse(&mut token_source, &mut tree_sink);
-    let syntax = tree_sink.inner.finish();
+    let syntax = token_tree_to_syntax_node(tt, ra_parser::parse).unwrap();
     ast::SourceFile::cast(&syntax).unwrap().to_owned()
 }
 

--- a/crates/ra_syntax/src/parsing.rs
+++ b/crates/ra_syntax/src/parsing.rs
@@ -17,8 +17,8 @@ pub(crate) use self::reparsing::incremental_reparse;
 
 pub(crate) fn parse_text(text: &str) -> (GreenNode, Vec<SyntaxError>) {
     let tokens = tokenize(&text);
-    let token_source = text_token_source::TextTokenSource::new(text, &tokens);
+    let mut token_source = text_token_source::TextTokenSource::new(text, &tokens);
     let mut tree_sink = text_tree_sink::TextTreeSink::new(text, &tokens);
-    ra_parser::parse(&token_source, &mut tree_sink);
+    ra_parser::parse(&mut token_source, &mut tree_sink);
     tree_sink.finish()
 }

--- a/crates/ra_syntax/src/parsing/reparsing.rs
+++ b/crates/ra_syntax/src/parsing/reparsing.rs
@@ -85,9 +85,9 @@ fn reparse_block<'node>(
     if !is_balanced(&tokens) {
         return None;
     }
-    let token_source = TextTokenSource::new(&text, &tokens);
+    let mut token_source = TextTokenSource::new(&text, &tokens);
     let mut tree_sink = TextTreeSink::new(&text, &tokens);
-    reparser.parse(&token_source, &mut tree_sink);
+    reparser.parse(&mut token_source, &mut tree_sink);
     let (green, new_errors) = tree_sink.finish();
     Some((node.replace_with(green), new_errors, node.range()))
 }

--- a/crates/ra_syntax/src/parsing/text_token_source.rs
+++ b/crates/ra_syntax/src/parsing/text_token_source.rs
@@ -1,7 +1,8 @@
 use ra_parser::TokenSource;
+use ra_parser::Token as PToken;
 
 use crate::{
-    SyntaxKind, SyntaxKind::EOF, TextRange, TextUnit,
+    SyntaxKind::EOF, TextRange, TextUnit,
     parsing::lexer::Token,
 };
 
@@ -23,29 +24,48 @@ pub(crate) struct TextTokenSource<'t> {
     /// ```
     /// tokens: `[struct, Foo, {, }]`
     tokens: Vec<Token>,
+
+    /// Current token and position
+    curr: (PToken, usize),
 }
 
 impl<'t> TokenSource for TextTokenSource<'t> {
-    fn token_kind(&self, pos: usize) -> SyntaxKind {
-        if !(pos < self.tokens.len()) {
-            return EOF;
-        }
-        self.tokens[pos].kind
+    fn current(&self) -> PToken {
+        return self.curr.0;
     }
-    fn is_token_joint_to_next(&self, pos: usize) -> bool {
-        if !(pos + 1 < self.tokens.len()) {
-            return true;
-        }
-        self.start_offsets[pos] + self.tokens[pos].len == self.start_offsets[pos + 1]
+
+    fn lookahead_nth(&self, n: usize) -> PToken {
+        mk_token(self.curr.1 + n, &self.start_offsets, &self.tokens)
     }
-    fn is_keyword(&self, pos: usize, kw: &str) -> bool {
+
+    fn bump(&mut self) {
+        if self.curr.0.kind == EOF {
+            return;
+        }
+
+        let pos = self.curr.1 + 1;
+        self.curr = (mk_token(pos, &self.start_offsets, &self.tokens), pos);
+    }
+
+    fn is_keyword(&self, kw: &str) -> bool {
+        let pos = self.curr.1;
         if !(pos < self.tokens.len()) {
             return false;
         }
         let range = TextRange::offset_len(self.start_offsets[pos], self.tokens[pos].len);
-
         self.text[range] == *kw
     }
+}
+
+fn mk_token(pos: usize, start_offsets: &[TextUnit], tokens: &[Token]) -> PToken {
+    let kind = tokens.get(pos).map(|t| t.kind).unwrap_or(EOF);
+    let is_jointed_to_next = if pos + 1 < start_offsets.len() {
+        start_offsets[pos] + tokens[pos].len == start_offsets[pos + 1]
+    } else {
+        false
+    };
+
+    PToken { kind, is_jointed_to_next }
 }
 
 impl<'t> TextTokenSource<'t> {
@@ -62,6 +82,7 @@ impl<'t> TextTokenSource<'t> {
             len += token.len;
         }
 
-        TextTokenSource { text, start_offsets, tokens }
+        let first = mk_token(0, &start_offsets, &tokens);
+        TextTokenSource { text, start_offsets, tokens, curr: (first, 0) }
     }
 }


### PR DESCRIPTION
This PR change the `TokenSource` trait from random access to be an iteration based trait:
```rust

/// `TokenSource` abstracts the source of the tokens parser operates one.
///
/// Hopefully this will allow us to treat text and token trees in the same way!
pub trait TokenSource {
    fn current(&self) -> Token;

    /// Lookahead n token
    fn lookahead_nth(&self, n: usize) -> Token;

    /// bump cursor to next token
    fn bump(&mut self);

    /// Is the current token a specified keyword?
    fn is_keyword(&self, kw: &str) -> bool;
}

/// `TokenCursor` abstracts the cursor of `TokenSource` operates one.
#[derive(Debug, Copy, Clone, Eq, PartialEq)]
pub struct Token {
    /// What is the current token?
    pub kind: SyntaxKind,

    /// Is the current token joined to the next one (`> >` vs `>>`).
    pub is_jointed_to_next: bool,
}
```

Note that the refactoring based on this new trait will be separated to incoming PRs