### PR TITLE
cancel salsa's validation

### DIFF
--- a/crates/ra_ide_api/src/db.rs
+++ b/crates/ra_ide_api/src/db.rs
@@ -31,6 +31,11 @@ impl salsa::Database for RootDatabase {
     fn on_propagated_panic(&self) -> ! {
         Canceled::throw()
     }
+    fn salsa_event(&self, event: impl Fn() -> salsa::Event<RootDatabase>) {
+        if let salsa::EventKind::DidValidateMemoizedValue { .. } = event().kind {
+            self.check_canceled();
+        }
+    }
 }
 
 impl Default for RootDatabase {


### PR DESCRIPTION
This small fix should improve rust-analyzer resopnsivness for
real-time operations like onEnter handling.

Turns out, salsa's validation can take hundreds of milliseconds, and,
in case no changes were made, it won't be triggering any queries.

Because we check for cancellation in queries, that means that
validation is not cancellable!

What this PR does is injecting check_canceled checks into validation,
by using salsa's event API, which wasn't meant to be used like this,
but, hey, it works!

Here's the onEnter handling before and after this change:

https://youtu.be/7-ffPzgvH7o