### PR TITLE
Introduce AST database

### DIFF
--- a/crates/ra_batch/src/lib.rs
+++ b/crates/ra_batch/src/lib.rs
@@ -16,7 +16,12 @@ use vfs_filter::IncludeRustFiles;
 
 type Result<T> = std::result::Result<T, failure::Error>;
 
-#[salsa::database(ra_db::SourceDatabaseStorage, db::HirDatabaseStorage, db::DefDatabaseStorage)]
+#[salsa::database(
+    ra_db::SourceDatabaseStorage,
+    db::AstDatabaseStorage,
+    db::DefDatabaseStorage,
+    db::HirDatabaseStorage
+)]
 #[derive(Debug)]
 pub struct BatchDatabase {
     runtime: salsa::Runtime<BatchDatabase>,

--- a/crates/ra_hir/src/adt.rs
+++ b/crates/ra_hir/src/adt.rs
@@ -10,7 +10,7 @@ use ra_syntax::{
 };
 
 use crate::{
-    Name, AsName, Struct, Union, Enum, EnumVariant, Crate,
+    Name, AsName, Struct, Union, Enum, EnumVariant, Crate, AstDatabase,
     HirDatabase, HirFileId, StructField, FieldSource,
     type_ref::TypeRef, DefDatabase,
 };
@@ -55,7 +55,10 @@ impl StructData {
         StructData { name, variant_data }
     }
 
-    pub(crate) fn struct_data_query(db: &impl DefDatabase, struct_: Struct) -> Arc<StructData> {
+    pub(crate) fn struct_data_query(
+        db: &(impl DefDatabase + AstDatabase),
+        struct_: Struct,
+    ) -> Arc<StructData> {
         let (_, struct_def) = struct_.source(db);
         Arc::new(StructData::new(&*struct_def))
     }
@@ -68,7 +71,7 @@ fn variants(enum_def: &ast::EnumDef) -> impl Iterator<Item = &ast::EnumVariant> 
 impl EnumVariant {
     pub(crate) fn source_impl(
         &self,
-        db: &impl DefDatabase,
+        db: &(impl DefDatabase + AstDatabase),
     ) -> (HirFileId, TreeArc<ast::EnumVariant>) {
         let (file_id, enum_def) = self.parent.source(db);
         let var = variants(&*enum_def)
@@ -91,7 +94,7 @@ pub struct EnumData {
 }
 
 impl EnumData {
-    pub(crate) fn enum_data_query(db: &impl DefDatabase, e: Enum) -> Arc<EnumData> {
+    pub(crate) fn enum_data_query(db: &(impl DefDatabase + AstDatabase), e: Enum) -> Arc<EnumData> {
         let (_file_id, enum_def) = e.source(db);
         let name = enum_def.name().map(|n| n.as_name());
         let variants = variants(&*enum_def)
@@ -198,7 +201,10 @@ impl VariantDef {
 }
 
 impl StructField {
-    pub(crate) fn source_impl(&self, db: &impl DefDatabase) -> (HirFileId, FieldSource) {
+    pub(crate) fn source_impl(
+        &self,
+        db: &(impl DefDatabase + AstDatabase),
+    ) -> (HirFileId, FieldSource) {
         let var_data = self.parent.variant_data(db);
         let fields = var_data.fields().unwrap();
         let ss;

--- a/crates/ra_hir/src/generics.rs
+++ b/crates/ra_hir/src/generics.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use ra_syntax::ast::{self, NameOwner, TypeParamsOwner, TypeBoundsOwner, DefaultTypeParamOwner};
 
 use crate::{
-    db::{ HirDatabase, DefDatabase},
+    db::{HirDatabase, DefDatabase, AstDatabase},
     Name, AsName, Function, Struct, Union, Enum, Trait, TypeAlias, ImplBlock, Container, path::Path, type_ref::TypeRef, AdtDef
 };
 
@@ -52,7 +52,7 @@ impl_froms!(GenericDef: Function, Struct, Union, Enum, Trait, TypeAlias, ImplBlo
 
 impl GenericParams {
     pub(crate) fn generic_params_query(
-        db: &impl DefDatabase,
+        db: &(impl DefDatabase + AstDatabase),
         def: GenericDef,
     ) -> Arc<GenericParams> {
         let mut generics = GenericParams::default();

--- a/crates/ra_hir/src/impl_block.rs
+++ b/crates/ra_hir/src/impl_block.rs
@@ -8,7 +8,7 @@ use ra_syntax::{
 };
 
 use crate::{
-    Const, TypeAlias, Function, HirFileId,
+    Const, TypeAlias, Function, HirFileId, AstDatabase,
     HirDatabase, DefDatabase, TraitRef,
     type_ref::TypeRef,
     ids::LocationCtx,
@@ -58,7 +58,10 @@ impl ImplBlock {
     }
 
     /// Returns the syntax of the impl block
-    pub fn source(&self, db: &impl DefDatabase) -> (HirFileId, TreeArc<ast::ImplBlock>) {
+    pub fn source(
+        &self,
+        db: &(impl DefDatabase + AstDatabase),
+    ) -> (HirFileId, TreeArc<ast::ImplBlock>) {
         let source_map = db.impls_in_module_with_source_map(self.module).1;
         let (file_id, source) = self.module.definition_source(db);
         (file_id, source_map.get(&source, self.impl_id))
@@ -117,7 +120,7 @@ pub struct ImplData {
 
 impl ImplData {
     pub(crate) fn from_ast(
-        db: &impl DefDatabase,
+        db: &(impl DefDatabase + AstDatabase),
         file_id: HirFileId,
         module: Module,
         node: &ast::ImplBlock,
@@ -187,7 +190,11 @@ pub struct ModuleImplBlocks {
 }
 
 impl ModuleImplBlocks {
-    fn collect(db: &impl DefDatabase, module: Module, source_map: &mut ImplSourceMap) -> Self {
+    fn collect(
+        db: &(impl DefDatabase + AstDatabase),
+        module: Module,
+        source_map: &mut ImplSourceMap,
+    ) -> Self {
         let mut m = ModuleImplBlocks {
             module,
             impls: Arena::default(),
@@ -218,7 +225,7 @@ impl ModuleImplBlocks {
 }
 
 pub(crate) fn impls_in_module_with_source_map_query(
-    db: &impl DefDatabase,
+    db: &(impl DefDatabase + AstDatabase),
     module: Module,
 ) -> (Arc<ModuleImplBlocks>, Arc<ImplSourceMap>) {
     let mut source_map = ImplSourceMap::default();

--- a/crates/ra_hir/src/lang_item.rs
+++ b/crates/ra_hir/src/lang_item.rs
@@ -4,7 +4,7 @@ use rustc_hash::FxHashMap;
 use ra_syntax::{SmolStr, ast::AttrsOwner};
 
 use crate::{
-    Crate, DefDatabase, Enum, Function, HirDatabase, ImplBlock, Module, Static, Struct, Trait
+    Crate, DefDatabase, Enum, Function, HirDatabase, ImplBlock, Module, Static, Struct, Trait, AstDatabase,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -41,7 +41,10 @@ impl LangItems {
     }
 
     /// Salsa query. This will look for lang items in a specific crate.
-    pub(crate) fn lang_items_query(db: &impl DefDatabase, krate: Crate) -> Arc<LangItems> {
+    pub(crate) fn lang_items_query(
+        db: &(impl DefDatabase + AstDatabase),
+        krate: Crate,
+    ) -> Arc<LangItems> {
         let mut lang_items = LangItems { items: FxHashMap::default() };
 
         if let Some(module) = krate.root_module(db) {
@@ -74,7 +77,11 @@ impl LangItems {
         }
     }
 
-    fn collect_lang_items_recursive(&mut self, db: &impl DefDatabase, module: &Module) {
+    fn collect_lang_items_recursive(
+        &mut self,
+        db: &(impl DefDatabase + AstDatabase),
+        module: &Module,
+    ) {
         // Look for impl targets
         let (impl_blocks, source_map) = db.impls_in_module_with_source_map(module.clone());
         let source = module.definition_source(db).1;

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -48,7 +48,7 @@ mod code_model;
 mod marks;
 
 use crate::{
-    db::{HirDatabase, DefDatabase},
+    db::{AstDatabase, DefDatabase, HirDatabase},
     name::{AsName, KnownName},
     source_id::{FileAstId, AstId},
     resolve::Resolver,

--- a/crates/ra_hir/src/mock.rs
+++ b/crates/ra_hir/src/mock.rs
@@ -13,7 +13,12 @@ use crate::{db, diagnostics::DiagnosticSink};
 
 pub const WORKSPACE: SourceRootId = SourceRootId(0);
 
-#[salsa::database(ra_db::SourceDatabaseStorage, db::HirDatabaseStorage, db::DefDatabaseStorage)]
+#[salsa::database(
+    ra_db::SourceDatabaseStorage,
+    db::AstDatabaseStorage,
+    db::DefDatabaseStorage,
+    db::HirDatabaseStorage
+)]
 #[derive(Debug)]
 pub struct MockDatabase {
     events: Mutex<Option<Vec<salsa::Event<MockDatabase>>>>,

--- a/crates/ra_hir/src/nameres.rs
+++ b/crates/ra_hir/src/nameres.rs
@@ -65,7 +65,7 @@ use ra_prof::profile;
 use once_cell::sync::Lazy;
 
 use crate::{
-    ModuleDef, Name, Crate, Module, MacroDef, AsName, BuiltinType,
+    ModuleDef, Name, Crate, Module, MacroDef, AsName, BuiltinType, AstDatabase,
     DefDatabase, Path, PathKind, HirFileId, Trait,
     ids::MacroDefId,
     diagnostics::DiagnosticSink,
@@ -232,7 +232,10 @@ fn or(left: ItemOrMacro, right: ItemOrMacro) -> ItemOrMacro {
 }
 
 impl CrateDefMap {
-    pub(crate) fn crate_def_map_query(db: &impl DefDatabase, krate: Crate) -> Arc<CrateDefMap> {
+    pub(crate) fn crate_def_map_query(
+        db: &(impl DefDatabase + AstDatabase),
+        krate: Crate,
+    ) -> Arc<CrateDefMap> {
         db.check_canceled();
         let _p = profile("crate_def_map_query");
         let def_map = {
@@ -278,7 +281,7 @@ impl CrateDefMap {
 
     pub(crate) fn add_diagnostics(
         &self,
-        db: &impl DefDatabase,
+        db: &(impl DefDatabase + AstDatabase),
         module: CrateModuleId,
         sink: &mut DiagnosticSink,
     ) {
@@ -534,7 +537,7 @@ mod diagnostics {
     use ra_syntax::{AstPtr, ast};
 
     use crate::{
-        AstId, DefDatabase,
+        AstId, DefDatabase, AstDatabase,
         nameres::CrateModuleId,
         diagnostics::{DiagnosticSink, UnresolvedModule}
 };
@@ -551,7 +554,7 @@ mod diagnostics {
     impl DefDiagnostic {
         pub(super) fn add_to(
             &self,
-            db: &impl DefDatabase,
+            db: &(impl DefDatabase + AstDatabase),
             target_module: CrateModuleId,
             sink: &mut DiagnosticSink,
         ) {

--- a/crates/ra_hir/src/nameres/raw.rs
+++ b/crates/ra_hir/src/nameres/raw.rs
@@ -7,7 +7,7 @@ use ra_syntax::{
     ast::{self, NameOwner, AttrsOwner},
 };
 
-use crate::{DefDatabase, Name, AsName, Path, HirFileId, ModuleSource, AstIdMap, FileAstId, Either};
+use crate::{DefDatabase, Name, AsName, Path, HirFileId, ModuleSource, AstIdMap, FileAstId, Either, AstDatabase};
 
 /// `RawItems` is a set of top-level items in a file (except for impls).
 ///
@@ -56,12 +56,15 @@ impl ImportSourceMap {
 }
 
 impl RawItems {
-    pub(crate) fn raw_items_query(db: &impl DefDatabase, file_id: HirFileId) -> Arc<RawItems> {
+    pub(crate) fn raw_items_query(
+        db: &(impl DefDatabase + AstDatabase),
+        file_id: HirFileId,
+    ) -> Arc<RawItems> {
         db.raw_items_with_source_map(file_id).0
     }
 
     pub(crate) fn raw_items_with_source_map_query(
-        db: &impl DefDatabase,
+        db: &(impl DefDatabase + AstDatabase),
         file_id: HirFileId,
     ) -> (Arc<RawItems>, Arc<ImportSourceMap>) {
         let mut collector = RawItemsCollector {

--- a/crates/ra_hir/src/source_id.rs
+++ b/crates/ra_hir/src/source_id.rs
@@ -3,7 +3,7 @@ use std::{marker::PhantomData, sync::Arc, hash::{Hash, Hasher}};
 use ra_arena::{Arena, RawId, impl_arena_id};
 use ra_syntax::{SyntaxNodePtr, TreeArc, SyntaxNode, AstNode, ast};
 
-use crate::{HirFileId, DefDatabase};
+use crate::{HirFileId, AstDatabase};
 
 /// `AstId` points to an AST node in any file.
 ///
@@ -38,7 +38,7 @@ impl<N: AstNode> AstId<N> {
         self.file_id
     }
 
-    pub(crate) fn to_node(&self, db: &impl DefDatabase) -> TreeArc<N> {
+    pub(crate) fn to_node(&self, db: &impl AstDatabase) -> TreeArc<N> {
         let syntax_node = db.ast_id_to_node(self.file_id, self.file_ast_id.raw);
         N::cast(&syntax_node).unwrap().to_owned()
     }
@@ -87,7 +87,7 @@ pub struct AstIdMap {
 }
 
 impl AstIdMap {
-    pub(crate) fn ast_id_map_query(db: &impl DefDatabase, file_id: HirFileId) -> Arc<AstIdMap> {
+    pub(crate) fn ast_id_map_query(db: &impl AstDatabase, file_id: HirFileId) -> Arc<AstIdMap> {
         let map = if let Some(node) = db.parse_or_expand(file_id) {
             AstIdMap::from_source(&*node)
         } else {
@@ -97,7 +97,7 @@ impl AstIdMap {
     }
 
     pub(crate) fn file_item_query(
-        db: &impl DefDatabase,
+        db: &impl AstDatabase,
         file_id: HirFileId,
         ast_id: ErasedFileAstId,
     ) -> TreeArc<SyntaxNode> {

--- a/crates/ra_hir/src/traits.rs
+++ b/crates/ra_hir/src/traits.rs
@@ -5,7 +5,10 @@ use rustc_hash::FxHashMap;
 
 use ra_syntax::ast::{self, NameOwner};
 
-use crate::{Function, Const, TypeAlias, Name, DefDatabase, Trait, ids::LocationCtx, name::AsName, Module};
+use crate::{
+    Function, Const, TypeAlias, Name, DefDatabase, Trait, AstDatabase, Module,
+    ids::LocationCtx, name::AsName,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TraitData {
@@ -15,7 +18,10 @@ pub struct TraitData {
 }
 
 impl TraitData {
-    pub(crate) fn trait_data_query(db: &impl DefDatabase, tr: Trait) -> Arc<TraitData> {
+    pub(crate) fn trait_data_query(
+        db: &(impl DefDatabase + AstDatabase),
+        tr: Trait,
+    ) -> Arc<TraitData> {
         let (file_id, node) = tr.source(db);
         let name = node.name().map(|n| n.as_name());
         let module = tr.module(db);

--- a/crates/ra_hir/src/type_alias.rs
+++ b/crates/ra_hir/src/type_alias.rs
@@ -2,9 +2,12 @@
 
 use std::sync::Arc;
 
-use crate::{TypeAlias, db::DefDatabase, type_ref::TypeRef};
+use crate::{TypeAlias, DefDatabase, AstDatabase, type_ref::TypeRef};
 
-pub(crate) fn type_alias_ref_query(db: &impl DefDatabase, typ: TypeAlias) -> Arc<TypeRef> {
+pub(crate) fn type_alias_ref_query(
+    db: &(impl DefDatabase + AstDatabase),
+    typ: TypeAlias,
+) -> Arc<TypeRef> {
     let (_, node) = typ.source(db);
     Arc::new(TypeRef::from_ast_opt(node.type_ref()))
 }

--- a/crates/ra_ide_api/src/db.rs
+++ b/crates/ra_ide_api/src/db.rs
@@ -14,8 +14,9 @@ use crate::{LineIndex, symbol_index::{self, SymbolsDatabase}};
     ra_db::SourceDatabaseStorage,
     LineIndexDatabaseStorage,
     symbol_index::SymbolsDatabaseStorage,
-    hir::db::HirDatabaseStorage,
-    hir::db::DefDatabaseStorage
+    hir::db::AstDatabaseStorage,
+    hir::db::DefDatabaseStorage,
+    hir::db::HirDatabaseStorage
 )]
 #[derive(Debug)]
 pub(crate) struct RootDatabase {


### PR DESCRIPTION
The idea here is to separate fragile bits which look into the syntax directly from robust bits which are safe across reparses. This uses the new `salsa::requires` featue