### PR TITLE
remove parse trees after crate def map is done

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1058,7 +1058,7 @@ dependencies = [
  "ra_syntax 0.1.0",
  "relative-path 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "salsa 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "salsa 0.12.1",
  "test_utils 0.1.0",
 ]
 
@@ -1468,7 +1468,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "salsa"
 version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "derive-new 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1476,14 +1475,13 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "salsa-macros 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "salsa-macros 0.12.1",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "salsa-macros"
 version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2125,8 +2123,6 @@ dependencies = [
 "checksum rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "b96a9549dc8d48f2c283938303c4b5a77aa29bfbc5b54b084fb1630408899a8f"
-"checksum salsa 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6ccd6297ee190727cea6f8c81771b73a79bbfc6e320496775083c44dbff67263"
-"checksum salsa-macros 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b7f1e25ca2b995bdf032946174929d62156ffd57abd7ff88dc6f9bdeb5ac0c59"
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ incremental = true
 debug = true
 
 [patch.'crates-io']
+salsa = { path = "../salsa" }

--- a/crates/ra_hir/src/ids.rs
+++ b/crates/ra_hir/src/ids.rs
@@ -94,6 +94,12 @@ impl HirFileId {
             }
         }
     }
+    pub(crate) fn remove_parse_tree(&self, db: &impl AstDatabase) {
+        match self.0 {
+            HirFileIdRepr::File(file_id) => db.remove_parse(file_id),
+            HirFileIdRepr::Macro(macro_file) => db.remove_parse_macro(macro_file),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/ra_hir/src/nameres/collector.rs
+++ b/crates/ra_hir/src/nameres/collector.rs
@@ -47,6 +47,7 @@ pub(super) fn collect_defs(
         unexpanded_macros: Vec::new(),
         global_macro_scope: FxHashMap::default(),
         macro_stack_monitor: MacroStackMonitor::default(),
+        parsed: vec![],
     };
     collector.collect();
     collector.finish()
@@ -92,6 +93,7 @@ struct DefCollector<DB> {
     /// Some macro use `$tt:tt which mean we have to handle the macro perfectly
     /// To prevent stackoverflow, we add a deep counter here for prevent that.
     macro_stack_monitor: MacroStackMonitor,
+    parsed: Vec<HirFileId>,
 }
 
 impl<'a, DB> DefCollector<&'a DB>
@@ -101,6 +103,7 @@ where
     fn collect(&mut self) {
         let crate_graph = self.db.crate_graph();
         let file_id = crate_graph.crate_root(self.def_map.krate.crate_id());
+        self.parsed.push(file_id.into());
         let raw_items = self.db.raw_items(file_id.into());
         let module_id = self.def_map.root;
         self.def_map.modules[module_id].definition = Some(file_id);
@@ -447,6 +450,7 @@ where
 
         if !self.macro_stack_monitor.is_poison(macro_def_id) {
             let file_id: HirFileId = macro_call_id.as_file(MacroFileKind::Items);
+            self.parsed.push(file_id);
             let raw_items = self.db.raw_items(file_id);
             ModCollector { def_collector: &mut *self, file_id, module_id, raw_items: &raw_items }
                 .collect(raw_items.items());
@@ -459,6 +463,10 @@ where
     }
 
     fn finish(self) -> CrateDefMap {
+        for file_id in self.parsed.iter() {
+            file_id.remove_parse_tree(self.db);
+        }
+
         self.def_map
     }
 }
@@ -511,6 +519,7 @@ where
                 match resolve_submodule(self.def_collector.db, self.file_id, name, is_root) {
                     Ok(file_id) => {
                         let module_id = self.push_child_module(name.clone(), ast_id, Some(file_id));
+                        self.def_collector.parsed.push(file_id.into());
                         let raw_items = self.def_collector.db.raw_items(file_id.into());
                         ModCollector {
                             def_collector: &mut *self.def_collector,
@@ -673,6 +682,7 @@ mod tests {
             unexpanded_macros: Vec::new(),
             global_macro_scope: FxHashMap::default(),
             macro_stack_monitor: monitor,
+            parsed: vec![],
         };
         collector.collect();
         collector.finish()

--- a/crates/ra_ide_api/src/change.rs
+++ b/crates/ra_ide_api/src/change.rs
@@ -208,6 +208,7 @@ impl RootDatabase {
     }
 
     pub(crate) fn maybe_collect_garbage(&mut self) {
+        return;
         if self.last_gc_check.elapsed() > GC_COOLDOWN {
             self.last_gc_check = time::Instant::now();
             let retained_trees = syntax_tree_stats(self).retained;
@@ -221,11 +222,10 @@ impl RootDatabase {
     pub(crate) fn collect_garbage(&mut self) {
         let _p = profile("RootDatabase::collect_garbage");
         self.last_gc = time::Instant::now();
-
+        return;
         let sweep = SweepStrategy::default().discard_values().sweep_all_revisions();
 
         self.query(ra_db::ParseQuery).sweep(sweep);
-
         self.query(hir::db::ParseMacroQuery).sweep(sweep);
         self.query(hir::db::MacroDefQuery).sweep(sweep);
         self.query(hir::db::MacroArgQuery).sweep(sweep);

--- a/crates/ra_ide_api/src/symbol_index.rs
+++ b/crates/ra_ide_api/src/symbol_index.rs
@@ -66,7 +66,7 @@ fn file_symbols(db: &impl SymbolsDatabase, file_id: FileId) -> Arc<SymbolIndex> 
     let source_file = db.parse(file_id).tree;
 
     let symbols = source_file_to_file_symbols(&source_file, file_id);
-
+    db.remove_parse(file_id);
     // FIXME: add macros here
 
     Arc::new(SymbolIndex::new(symbols))


### PR DESCRIPTION
more crazy experiments with taming our memory consumption. 

The idea here is to kill syntax trees as soon as we are done with building the crate def map.

It almost works, except for the fact that `ModuleImplBlocks::collect` looks at the raw syntax