### PR TITLE
Skip attrs in `ast::Literal::token`

### DIFF
--- a/crates/ra_syntax/src/ast/expr_extensions.rs
+++ b/crates/ra_syntax/src/ast/expr_extensions.rs
@@ -229,8 +229,11 @@ pub enum LiteralKind {
 
 impl ast::Literal {
     pub fn token(&self) -> SyntaxToken {
-        match self.syntax().first_child_or_token().unwrap() {
-            SyntaxElement::Token(token) => token,
+        let elem = self.syntax()
+            .children_with_tokens()
+            .find(|e| e.kind() != ATTR && !e.kind().is_trivia());
+        match elem {
+            Some(SyntaxElement::Token(token)) => token,
             _ => unreachable!(),
         }
     }
@@ -266,6 +269,18 @@ impl ast::Literal {
             _ => unreachable!(),
         }
     }
+}
+
+#[test]
+fn test_literal_with_attr() {
+    let parse = ast::SourceFile::parse(r#"const _: &str = { #[attr] "Hello" };"#);
+    let lit = parse
+        .tree
+        .syntax()
+        .descendants()
+        .find_map(ast::Literal::cast)
+        .unwrap();
+    assert_eq!(lit.token().text(), r#""Hello""#);
 }
 
 impl ast::NamedField {

--- a/crates/ra_syntax/src/ast/expr_extensions.rs
+++ b/crates/ra_syntax/src/ast/expr_extensions.rs
@@ -229,7 +229,8 @@ pub enum LiteralKind {
 
 impl ast::Literal {
     pub fn token(&self) -> SyntaxToken {
-        let elem = self.syntax()
+        let elem = self
+            .syntax()
             .children_with_tokens()
             .find(|e| e.kind() != ATTR && !e.kind().is_trivia());
         match elem {
@@ -274,12 +275,7 @@ impl ast::Literal {
 #[test]
 fn test_literal_with_attr() {
     let parse = ast::SourceFile::parse(r#"const _: &str = { #[attr] "Hello" };"#);
-    let lit = parse
-        .tree
-        .syntax()
-        .descendants()
-        .find_map(ast::Literal::cast)
-        .unwrap();
+    let lit = parse.tree.syntax().descendants().find_map(ast::Literal::cast).unwrap();
     assert_eq!(lit.token().text(), r#""Hello""#);
 }
 


### PR DESCRIPTION
`ast::Literal::token` panics on literals containing attributes. rust-analyzer crashed on the `rust-lang/rust` repository by parsing [a test containing this](https://github.com/rust-lang/rust/blob/9ebf47851a357faa4cd97f4b1dc7835f6376e639/src/test/run-pass/proc-macro/attr-stmt-expr.rs#L22-L25).