### PR TITLE
Associated type basics & Deref support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1079,6 +1079,7 @@ dependencies = [
  "flexi_logger 0.11.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "insta 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "join_to_string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lalrpop-intern 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crates/ra_assists/src/fill_match_arms.rs
+++ b/crates/ra_assists/src/fill_match_arms.rs
@@ -22,7 +22,7 @@ pub(crate) fn fill_match_arms(mut ctx: AssistCtx<impl HirDatabase>) -> Option<As
     let expr = match_expr.expr()?;
     let analyzer = hir::SourceAnalyzer::new(ctx.db, ctx.frange.file_id, expr.syntax(), None);
     let match_expr_ty = analyzer.type_of(ctx.db, expr)?;
-    let enum_def = match_expr_ty.autoderef(ctx.db).find_map(|ty| match ty.as_adt() {
+    let enum_def = analyzer.autoderef(ctx.db, match_expr_ty).find_map(|ty| match ty.as_adt() {
         Some((AdtDef::Enum(e), _)) => Some(e),
         _ => None,
     })?;

--- a/crates/ra_hir/Cargo.toml
+++ b/crates/ra_hir/Cargo.toml
@@ -25,6 +25,7 @@ ra_prof = { path = "../ra_prof" }
 chalk-solve = { git = "https://github.com/flodiebold/chalk.git", branch = "fuel" }
 chalk-rust-ir = { git = "https://github.com/flodiebold/chalk.git", branch = "fuel" }
 chalk-ir = { git = "https://github.com/flodiebold/chalk.git", branch = "fuel" }
+lalrpop-intern = "0.15.1"
 
 [dev-dependencies]
 flexi_logger = "0.11.0"

--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -788,8 +788,7 @@ impl Trait {
                 TraitItem::TypeAlias(t) => Some(*t),
                 _ => None,
             })
-            .filter(|t| t.name(db) == name)
-            .next()
+            .find(|t| t.name(db) == name)
     }
 
     pub(crate) fn trait_data(self, db: &impl DefDatabase) -> Arc<TraitData> {

--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -779,6 +779,19 @@ impl Trait {
         self.trait_data(db).items().to_vec()
     }
 
+    pub fn associated_type_by_name(self, db: &impl DefDatabase, name: Name) -> Option<TypeAlias> {
+        let trait_data = self.trait_data(db);
+        trait_data
+            .items()
+            .iter()
+            .filter_map(|item| match item {
+                TraitItem::TypeAlias(t) => Some(*t),
+                _ => None,
+            })
+            .filter(|t| t.name(db) == name)
+            .next()
+    }
+
     pub(crate) fn trait_data(self, db: &impl DefDatabase) -> Arc<TraitData> {
         db.trait_data(self)
     }
@@ -831,8 +844,12 @@ impl TypeAlias {
         }
     }
 
-    pub fn type_ref(self, db: &impl DefDatabase) -> Arc<TypeRef> {
-        db.type_alias_ref(self)
+    pub fn type_ref(self, db: &impl DefDatabase) -> Option<TypeRef> {
+        db.type_alias_data(self).type_ref.clone()
+    }
+
+    pub fn name(self, db: &impl DefDatabase) -> Name {
+        db.type_alias_data(self).name.clone()
     }
 
     /// Builds a resolver for the type references in this type alias.

--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -185,11 +185,11 @@ pub trait HirDatabase: DefDatabase + AstDatabase {
         goal: crate::ty::Canonical<crate::ty::TraitRef>,
     ) -> Option<crate::ty::traits::Solution>;
 
-    #[salsa::invoke(crate::ty::traits::normalize)]
+    #[salsa::invoke(crate::ty::traits::normalize_query)]
     fn normalize(
         &self,
         krate: Crate,
-        goal: crate::ty::Canonical<crate::ty::traits::ProjectionPredicate>,
+        goal: crate::ty::Canonical<crate::ty::ProjectionPredicate>,
     ) -> Option<crate::ty::traits::Solution>;
 }
 

--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -16,9 +16,8 @@ use crate::{
     adt::{StructData, EnumData},
     impl_block::{ModuleImplBlocks, ImplSourceMap, ImplBlock},
     generics::{GenericParams, GenericDef},
-    type_ref::TypeRef,
     traits::TraitData,
-    lang_item::{LangItems, LangItemTarget},
+    lang_item::{LangItems, LangItemTarget}, type_alias::TypeAliasData,
 };
 
 // This database has access to source code, so queries here are not really
@@ -113,8 +112,8 @@ pub trait DefDatabase: SourceDatabase {
     #[salsa::invoke(crate::FnSignature::fn_signature_query)]
     fn fn_signature(&self, func: Function) -> Arc<FnSignature>;
 
-    #[salsa::invoke(crate::type_alias::type_alias_ref_query)]
-    fn type_alias_ref(&self, typ: TypeAlias) -> Arc<TypeRef>;
+    #[salsa::invoke(crate::type_alias::type_alias_data_query)]
+    fn type_alias_data(&self, typ: TypeAlias) -> Arc<TypeAliasData>;
 
     #[salsa::invoke(crate::ConstSignature::const_signature_query)]
     fn const_signature(&self, konst: Const) -> Arc<ConstSignature>;
@@ -184,6 +183,13 @@ pub trait HirDatabase: DefDatabase + AstDatabase {
         &self,
         krate: Crate,
         goal: crate::ty::Canonical<crate::ty::TraitRef>,
+    ) -> Option<crate::ty::traits::Solution>;
+
+    #[salsa::invoke(crate::ty::traits::normalize)]
+    fn normalize(
+        &self,
+        krate: Crate,
+        goal: crate::ty::Canonical<crate::ty::traits::ProjectionPredicate>,
     ) -> Option<crate::ty::traits::Solution>;
 }
 

--- a/crates/ra_hir/src/lang_item.rs
+++ b/crates/ra_hir/src/lang_item.rs
@@ -4,7 +4,7 @@ use rustc_hash::FxHashMap;
 use ra_syntax::{SmolStr, ast::AttrsOwner};
 
 use crate::{
-    Crate, DefDatabase, Enum, Function, HirDatabase, ImplBlock, Module, Static, Struct, Trait, AstDatabase,
+        Crate, DefDatabase, Enum, Function, HirDatabase, ImplBlock, Module, Static, Struct, Trait, ModuleDef, AstDatabase, HasSource
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -87,23 +87,60 @@ impl LangItems {
         let source = module.definition_source(db).ast;
         for (impl_id, _) in impl_blocks.impls.iter() {
             let impl_block = source_map.get(&source, impl_id);
-            let lang_item_name = impl_block
-                .attrs()
-                .filter_map(|a| a.as_key_value())
-                .filter(|(key, _)| key == "lang")
-                .map(|(_, val)| val)
-                .nth(0);
-            if let Some(lang_item_name) = lang_item_name {
+            if let Some(lang_item_name) = lang_item_name(&*impl_block) {
                 let imp = ImplBlock::from_id(*module, impl_id);
                 self.items.entry(lang_item_name).or_insert_with(|| LangItemTarget::ImplBlock(imp));
             }
         }
 
-        // FIXME we should look for the other lang item targets (traits, structs, ...)
+        // FIXME make this nicer
+        for def in module.declarations(db) {
+            match def {
+                ModuleDef::Trait(trait_) => {
+                    let node = trait_.source(db).ast;
+                    if let Some(lang_item_name) = lang_item_name(&*node) {
+                        self.items.entry(lang_item_name).or_insert(LangItemTarget::Trait(trait_));
+                    }
+                }
+                ModuleDef::Enum(e) => {
+                    let node = e.source(db).ast;
+                    if let Some(lang_item_name) = lang_item_name(&*node) {
+                        self.items.entry(lang_item_name).or_insert(LangItemTarget::Enum(e));
+                    }
+                }
+                ModuleDef::Struct(s) => {
+                    let node = s.source(db).ast;
+                    if let Some(lang_item_name) = lang_item_name(&*node) {
+                        self.items.entry(lang_item_name).or_insert(LangItemTarget::Struct(s));
+                    }
+                }
+                ModuleDef::Function(f) => {
+                    let node = f.source(db).ast;
+                    if let Some(lang_item_name) = lang_item_name(&*node) {
+                        self.items.entry(lang_item_name).or_insert(LangItemTarget::Function(f));
+                    }
+                }
+                ModuleDef::Static(s) => {
+                    let node = s.source(db).ast;
+                    if let Some(lang_item_name) = lang_item_name(&*node) {
+                        self.items.entry(lang_item_name).or_insert(LangItemTarget::Static(s));
+                    }
+                }
+                _ => {}
+            }
+        }
 
         // Look for lang items in the children
         for child in module.children(db) {
             self.collect_lang_items_recursive(db, &child);
         }
     }
+}
+
+fn lang_item_name<T: AttrsOwner>(node: &T) -> Option<SmolStr> {
+    node.attrs()
+        .filter_map(|a| a.as_key_value())
+        .filter(|(key, _)| key == "lang")
+        .map(|(_, val)| val)
+        .nth(0)
 }

--- a/crates/ra_hir/src/name.rs
+++ b/crates/ra_hir/src/name.rs
@@ -46,6 +46,11 @@ impl Name {
         Name::new(idx.to_string().into())
     }
 
+    // Needed for Deref
+    pub(crate) fn target() -> Name {
+        Name::new("Target".into())
+    }
+
     // There's should be no way to extract a string out of `Name`: `Name` in the
     // future, `Name` will include hygiene information, and you can't encode
     // hygiene into a String.

--- a/crates/ra_hir/src/source_binder.rs
+++ b/crates/ra_hir/src/source_binder.rs
@@ -369,6 +369,17 @@ impl SourceAnalyzer {
         )
     }
 
+    pub fn autoderef<'a>(
+        &'a self,
+        db: &'a impl HirDatabase,
+        ty: Ty,
+    ) -> impl Iterator<Item = Ty> + 'a {
+        // There should be no inference vars in types passed here
+        // FIXME check that?
+        let canonical = crate::ty::Canonical { value: ty, num_vars: 0 };
+        crate::ty::autoderef(db, &self.resolver, canonical).map(|canonical| canonical.value)
+    }
+
     #[cfg(test)]
     pub(crate) fn body_source_map(&self) -> Arc<BodySourceMap> {
         self.body_source_map.clone().unwrap()

--- a/crates/ra_hir/src/ty.rs
+++ b/crates/ra_hir/src/ty.rs
@@ -23,6 +23,7 @@ pub(crate) use lower::{TypableDef, type_for_def, type_for_field, callable_item_s
 pub(crate) use infer::{infer_query, InferenceResult, InferTy};
 pub use lower::CallableDef;
 pub(crate) use autoderef::autoderef;
+pub(crate) use traits::ProjectionPredicate;
 
 /// A type constructor or type name: this might be something like the primitive
 /// type `bool`, a struct like `Vec`, or things like function pointers or

--- a/crates/ra_hir/src/ty.rs
+++ b/crates/ra_hir/src/ty.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use std::ops::Deref;
 use std::{fmt, mem};
 
-use crate::{Name, AdtDef, type_ref::Mutability, db::HirDatabase, Trait, GenericParams};
+use crate::{Name, AdtDef, type_ref::Mutability, db::HirDatabase, Trait, GenericParams, TypeAlias};
 use display::{HirDisplay, HirFormatter};
 
 pub(crate) use lower::{TypableDef, type_for_def, type_for_field, callable_item_sig, generic_predicates, generic_defaults};
@@ -97,6 +97,15 @@ pub enum TypeCtor {
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub struct ApplicationTy {
     pub ctor: TypeCtor,
+    pub parameters: Substs,
+}
+
+/// A "projection" type corresponds to an (unnormalized)
+/// projection like `<P0 as Trait<P1..Pn>>::Foo`. Note that the
+/// trait and all its parameters are fully known.
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
+pub struct ProjectionTy {
+    pub associated_ty: TypeAlias,
     pub parameters: Substs,
 }
 

--- a/crates/ra_hir/src/ty.rs
+++ b/crates/ra_hir/src/ty.rs
@@ -22,6 +22,7 @@ use display::{HirDisplay, HirFormatter};
 pub(crate) use lower::{TypableDef, type_for_def, type_for_field, callable_item_sig, generic_predicates, generic_defaults};
 pub(crate) use infer::{infer_query, InferenceResult, InferTy};
 pub use lower::CallableDef;
+pub(crate) use autoderef::autoderef;
 
 /// A type constructor or type name: this might be something like the primitive
 /// type `bool`, a struct like `Vec`, or things like function pointers or
@@ -225,8 +226,8 @@ impl Deref for Substs {
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub struct TraitRef {
     /// FIXME name?
-    trait_: Trait,
-    substs: Substs,
+    pub trait_: Trait,
+    pub substs: Substs,
 }
 
 impl TraitRef {

--- a/crates/ra_hir/src/ty.rs
+++ b/crates/ra_hir/src/ty.rs
@@ -474,6 +474,17 @@ impl Ty {
             _ => None,
         }
     }
+
+    /// Shifts up `Ty::Bound` vars by `n`.
+    pub fn shift_bound_vars(self, n: i32) -> Ty {
+        self.fold(&mut |ty| match ty {
+            Ty::Bound(idx) => {
+                assert!(idx as i32 >= -n);
+                Ty::Bound((idx as i32 + n) as u32)
+            }
+            ty => ty,
+        })
+    }
 }
 
 impl HirDisplay for &Ty {

--- a/crates/ra_hir/src/ty/autoderef.rs
+++ b/crates/ra_hir/src/ty/autoderef.rs
@@ -5,17 +5,67 @@
 
 use std::iter::successors;
 
-use crate::HirDatabase;
-use super::Ty;
+use log::info;
 
-impl Ty {
-    /// Iterates over the possible derefs of `ty`.
-    pub fn autoderef<'a>(self, db: &'a impl HirDatabase) -> impl Iterator<Item = Ty> + 'a {
-        successors(Some(self), move |ty| ty.autoderef_step(db))
+use crate::{HirDatabase, Name, Resolver};
+use super::{traits::Solution, Ty, Canonical};
+
+pub(crate) fn autoderef<'a>(
+    db: &'a impl HirDatabase,
+    resolver: &'a Resolver,
+    ty: Canonical<Ty>,
+) -> impl Iterator<Item = Canonical<Ty>> + 'a {
+    successors(Some(ty), move |ty| deref(db, resolver, ty))
+}
+
+pub(crate) fn deref(
+    db: &impl HirDatabase,
+    resolver: &Resolver,
+    ty: &Canonical<Ty>,
+) -> Option<Canonical<Ty>> {
+    if let Some(derefed) = ty.value.builtin_deref() {
+        Some(Canonical { value: derefed, num_vars: ty.num_vars })
+    } else {
+        deref_by_trait(db, resolver, ty)
     }
+}
 
-    fn autoderef_step(&self, _db: &impl HirDatabase) -> Option<Ty> {
-        // FIXME Deref::deref
-        self.builtin_deref()
+fn deref_by_trait(
+    db: &impl HirDatabase,
+    resolver: &Resolver,
+    ty: &Canonical<Ty>,
+) -> Option<Canonical<Ty>> {
+    let krate = resolver.krate()?;
+    let deref_trait = match db.lang_item(krate, "deref".into())? {
+        crate::lang_item::LangItemTarget::Trait(t) => t,
+        _ => return None,
+    };
+    let target = deref_trait.associated_type_by_name(db, Name::target())?;
+
+    // FIXME we should check that Deref has no type parameters, because we assume it below
+
+    // FIXME make the Canonical handling nicer
+    // TODO shift inference variables in ty
+
+    let projection = super::traits::ProjectionPredicate {
+        ty: Ty::Bound(0),
+        projection_ty: super::ProjectionTy {
+            associated_ty: target,
+            parameters: vec![ty.value.clone()].into(),
+        },
+    };
+
+    let canonical = super::Canonical { num_vars: 1 + ty.num_vars, value: projection };
+
+    let solution = db.normalize(krate, canonical)?;
+
+    match &solution {
+        Solution::Unique(vars) => {
+            Some(Canonical { value: vars.0.value[0].clone(), num_vars: vars.0.num_vars })
+        }
+        Solution::Ambig(_) => {
+            info!("Ambiguous solution for deref: {:?}", solution);
+            None
+        }
     }
 }

--- a/crates/ra_hir/src/ty/autoderef.rs
+++ b/crates/ra_hir/src/ty/autoderef.rs
@@ -10,12 +10,14 @@ use log::{info, warn};
 use crate::{HirDatabase, Name, Resolver, HasGenericParams};
 use super::{traits::Solution, Ty, Canonical};
 
+const AUTODEREF_RECURSION_LIMIT: usize = 10;
+
 pub(crate) fn autoderef<'a>(
     db: &'a impl HirDatabase,
     resolver: &'a Resolver,
     ty: Canonical<Ty>,
 ) -> impl Iterator<Item = Canonical<Ty>> + 'a {
-    successors(Some(ty), move |ty| deref(db, resolver, ty))
+    successors(Some(ty), move |ty| deref(db, resolver, ty)).take(AUTODEREF_RECURSION_LIMIT)
 }
 
 pub(crate) fn deref(

--- a/crates/ra_hir/src/ty/infer.rs
+++ b/crates/ra_hir/src/ty/infer.rs
@@ -1126,10 +1126,12 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
                 let inner_ty = self.infer_expr(*expr, &Expectation::none());
                 match op {
                     UnaryOp::Deref => {
-                        if let Some(derefed_ty) = inner_ty.builtin_deref() {
-                            derefed_ty
+                        let canonicalized = self.canonicalizer().canonicalize_ty(inner_ty);
+                        if let Some(derefed_ty) =
+                            autoderef::deref(self.db, &self.resolver, &canonicalized.value)
+                        {
+                            canonicalized.decanonicalize_ty(derefed_ty.value)
                         } else {
-                            // FIXME Deref::deref
                             Ty::Unknown
                         }
                     }

--- a/crates/ra_hir/src/ty/lower.rs
+++ b/crates/ra_hir/src/ty/lower.rs
@@ -460,7 +460,7 @@ fn type_for_type_alias(db: &impl HirDatabase, t: TypeAlias) -> Ty {
     let resolver = t.resolver(db);
     let type_ref = t.type_ref(db);
     let substs = Substs::identity(&generics);
-    let inner = Ty::from_hir(db, &resolver, &type_ref);
+    let inner = Ty::from_hir(db, &resolver, &type_ref.unwrap_or(TypeRef::Error));
     inner.subst(&substs)
 }
 

--- a/crates/ra_hir/src/ty/method_resolution.rs
+++ b/crates/ra_hir/src/ty/method_resolution.rs
@@ -16,7 +16,7 @@ use crate::{
     generics::HasGenericParams,
     ty::primitive::{UncertainIntTy, UncertainFloatTy}
 };
-use super::{TraitRef, Canonical};
+use super::{TraitRef, Canonical, autoderef};
 
 /// This is used as a key for indexing impls.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -162,8 +162,7 @@ pub(crate) fn iterate_method_candidates<T>(
     // rustc does an autoderef and then autoref again).
 
     let krate = resolver.krate()?;
-    for derefed_ty in ty.value.clone().autoderef(db) {
-        let derefed_ty = Canonical { value: derefed_ty, num_vars: ty.num_vars };
+    for derefed_ty in autoderef::autoderef(db, resolver, ty.clone()) {
         if let Some(result) = iterate_inherent_methods(&derefed_ty, db, name, krate, &mut callback)
         {
             return Some(result);

--- a/crates/ra_hir/src/ty/tests.rs
+++ b/crates/ra_hir/src/ty/tests.rs
@@ -2768,7 +2768,6 @@ fn test(s: Arc<S>) {
 
 #[test]
 fn deref_trait_with_inference_var() {
-    // std::env::set_var("RUST_BACKTRACE", "1");
     let t = type_at(
         r#"
 //- /main.rs

--- a/crates/ra_hir/src/ty/tests.rs
+++ b/crates/ra_hir/src/ty/tests.rs
@@ -2766,6 +2766,37 @@ fn test(s: Arc<S>) {
     assert_eq!(t, "(S, u128)");
 }
 
+#[test]
+fn deref_trait_with_inference_var() {
+    // std::env::set_var("RUST_BACKTRACE", "1");
+    let t = type_at(
+        r#"
+//- /main.rs
+#[lang = "deref"]
+trait Deref {
+    type Target;
+    fn deref(&self) -> &Self::Target;
+}
+
+struct Arc<T>;
+fn new_arc<T>() -> Arc<T> {}
+impl<T> Deref for Arc<T> {
+    type Target = T;
+}
+
+struct S;
+fn foo(a: Arc<S>) {}
+
+fn test() {
+    let a = new_arc();
+    let b = (*a)<|>;
+    foo(a);
+}
+"#,
+    );
+    assert_eq!(t, "S");
+}
+
 fn type_at_pos(db: &MockDatabase, pos: FilePosition) -> String {
     let file = db.parse(pos.file_id).ok().unwrap();
     let expr = algo::find_node_at_offset::<ast::Expr>(file.syntax(), pos.offset).unwrap();

--- a/crates/ra_hir/src/ty/tests.rs
+++ b/crates/ra_hir/src/ty/tests.rs
@@ -2796,6 +2796,31 @@ fn test() {
     assert_eq!(t, "S");
 }
 
+#[test]
+fn deref_trait_infinite_recursion() {
+    let t = type_at(
+        r#"
+//- /main.rs
+#[lang = "deref"]
+trait Deref {
+    type Target;
+    fn deref(&self) -> &Self::Target;
+}
+
+struct S;
+
+impl Deref for S {
+    type Target = S;
+}
+
+fn test(s: S) {
+    s.foo()<|>;
+}
+"#,
+    );
+    assert_eq!(t, "{unknown}");
+}
+
 fn type_at_pos(db: &MockDatabase, pos: FilePosition) -> String {
     let file = db.parse(pos.file_id).ok().unwrap();
     let expr = algo::find_node_at_offset::<ast::Expr>(file.syntax(), pos.offset).unwrap();

--- a/crates/ra_hir/src/ty/tests.rs
+++ b/crates/ra_hir/src/ty/tests.rs
@@ -2737,6 +2737,35 @@ fn main() {
     assert_eq!(t, "Foo");
 }
 
+#[test]
+fn deref_trait() {
+    let t = type_at(
+        r#"
+//- /main.rs
+#[lang = "deref"]
+trait Deref {
+    type Target;
+    fn deref(&self) -> &Self::Target;
+}
+
+struct Arc<T>;
+impl<T> Deref for Arc<T> {
+    type Target = T;
+}
+
+struct S;
+impl S {
+    fn foo(&self) -> u128 {}
+}
+
+fn test(s: Arc<S>) {
+    (*s, s.foo())<|>
+}
+"#,
+    );
+    assert_eq!(t, "(S, u128)");
+}
+
 fn type_at_pos(db: &MockDatabase, pos: FilePosition) -> String {
     let file = db.parse(pos.file_id).ok().unwrap();
     let expr = algo::find_node_at_offset::<ast::Expr>(file.syntax(), pos.offset).unwrap();

--- a/crates/ra_hir/src/ty/traits.rs
+++ b/crates/ra_hir/src/ty/traits.rs
@@ -105,7 +105,7 @@ pub(crate) fn implements_query(
     solution.map(|solution| solution_from_chalk(db, solution))
 }
 
-pub(crate) fn normalize(
+pub(crate) fn normalize_query(
     db: &impl HirDatabase,
     krate: Crate,
     projection: Canonical<ProjectionPredicate>,

--- a/crates/ra_hir/src/ty/traits.rs
+++ b/crates/ra_hir/src/ty/traits.rs
@@ -8,7 +8,7 @@ use chalk_ir::cast::Cast;
 use ra_prof::profile;
 
 use crate::{Crate, Trait, db::HirDatabase, ImplBlock};
-use super::{TraitRef, Ty, Canonical};
+use super::{TraitRef, Ty, Canonical, ProjectionTy};
 
 use self::chalk::{ToChalk, from_chalk};
 
@@ -75,6 +75,13 @@ pub enum Obligation {
     /// Prove that a certain type implements a trait (the type is the `Self` type
     /// parameter to the `TraitRef`).
     Trait(TraitRef),
+    // Projection(ProjectionPredicate),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ProjectionPredicate {
+    projection_ty: ProjectionTy,
+    ty: Ty,
 }
 
 /// Check using Chalk whether trait is implemented for given parameters including `Self` type.
@@ -91,6 +98,30 @@ pub(crate) fn implements_query(
     let parameter = chalk_ir::ParameterKind::Ty(chalk_ir::UniverseIndex::ROOT);
     let canonical =
         chalk_ir::Canonical { value: in_env, binders: vec![parameter; trait_ref.num_vars] };
+    // We currently don't deal with universes (I think / hope they're not yet
+    // relevant for our use cases?)
+    let u_canonical = chalk_ir::UCanonical { canonical, universes: 1 };
+    let solution = solve(db, krate, &u_canonical);
+    solution.map(|solution| solution_from_chalk(db, solution))
+}
+
+pub(crate) fn normalize(
+    db: &impl HirDatabase,
+    krate: Crate,
+    projection: Canonical<ProjectionPredicate>,
+) -> Option<Solution> {
+    let goal: chalk_ir::Goal = chalk_ir::Normalize {
+        projection: projection.value.projection_ty.to_chalk(db),
+        ty: projection.value.ty.to_chalk(db),
+    }
+    .cast();
+    debug!("goal: {:?}", goal);
+    // FIXME unify with `implements`
+    let env = chalk_ir::Environment::new();
+    let in_env = chalk_ir::InEnvironment::new(&env, goal);
+    let parameter = chalk_ir::ParameterKind::Ty(chalk_ir::UniverseIndex::ROOT);
+    let canonical =
+        chalk_ir::Canonical { value: in_env, binders: vec![parameter; projection.num_vars] };
     // We currently don't deal with universes (I think / hope they're not yet
     // relevant for our use cases?)
     let u_canonical = chalk_ir::UCanonical { canonical, universes: 1 };

--- a/crates/ra_hir/src/ty/traits.rs
+++ b/crates/ra_hir/src/ty/traits.rs
@@ -80,8 +80,8 @@ pub enum Obligation {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ProjectionPredicate {
-    projection_ty: ProjectionTy,
-    ty: Ty,
+    pub projection_ty: ProjectionTy,
+    pub ty: Ty,
 }
 
 /// Check using Chalk whether trait is implemented for given parameters including `Self` type.

--- a/crates/ra_hir/src/ty/traits/chalk.rs
+++ b/crates/ra_hir/src/ty/traits/chalk.rs
@@ -273,8 +273,9 @@ where
             id,
             name: lalrpop_intern::intern(&type_alias.name(self.db).to_string()),
             parameter_kinds,
-            bounds: vec![],        // FIXME
-            where_clauses: vec![], // FIXME
+            // FIXME add bounds and where clauses
+            bounds: vec![],
+            where_clauses: vec![],
         };
         Arc::new(datum)
     }
@@ -429,13 +430,12 @@ where
             .filter_map(|t| {
                 let assoc_ty = trait_.associated_type_by_name(self.db, t.name(self.db))?;
                 let ty = self.db.type_for_def(t.into(), crate::Namespace::Types).subst(&bound_vars);
-                debug!("ty = {}", ty.display(self.db));
                 Some(chalk_rust_ir::AssociatedTyValue {
                     impl_id,
                     associated_ty_id: assoc_ty.to_chalk(self.db),
                     value: chalk_ir::Binders {
                         value: chalk_rust_ir::AssociatedTyValueBound { ty: ty.to_chalk(self.db) },
-                        binders: vec![], // FIXME add generic params (generic associated types)
+                        binders: vec![], // we don't support GATs yet
                     },
                 })
             })

--- a/crates/ra_hir/src/type_alias.rs
+++ b/crates/ra_hir/src/type_alias.rs
@@ -2,12 +2,22 @@
 
 use std::sync::Arc;
 
-use crate::{TypeAlias, DefDatabase, AstDatabase, HasSource, type_ref::TypeRef};
+use ra_syntax::ast::NameOwner;
 
-pub(crate) fn type_alias_ref_query(
+use crate::{TypeAlias, db::{DefDatabase, AstDatabase}, type_ref::TypeRef, name::{Name, AsName}, HasSource};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeAliasData {
+    pub(crate) name: Name,
+    pub(crate) type_ref: Option<TypeRef>,
+}
+
+pub(crate) fn type_alias_data_query(
     db: &(impl DefDatabase + AstDatabase),
     typ: TypeAlias,
-) -> Arc<TypeRef> {
+) -> Arc<TypeAliasData> {
     let node = typ.source(db).ast;
-    Arc::new(TypeRef::from_ast_opt(node.type_ref()))
+    let name = node.name().map_or_else(Name::missing, |n| n.as_name());
+    let type_ref = node.type_ref().map(TypeRef::from_ast);
+    Arc::new(TypeAliasData { name, type_ref })
 }

--- a/crates/ra_ide_api/src/completion/complete_dot.rs
+++ b/crates/ra_ide_api/src/completion/complete_dot.rs
@@ -15,7 +15,7 @@ pub(super) fn complete_dot(acc: &mut Completions, ctx: &CompletionContext) {
 }
 
 fn complete_fields(acc: &mut Completions, ctx: &CompletionContext, receiver: Ty) {
-    for receiver in receiver.autoderef(ctx.db) {
+    for receiver in ctx.analyzer.autoderef(ctx.db, receiver) {
         if let Ty::Apply(a_ty) = receiver {
             match a_ty.ctor {
                 TypeCtor::Adt(AdtDef::Struct(s)) => {

--- a/crates/ra_ide_api/src/goto_type_definition.rs
+++ b/crates/ra_ide_api/src/goto_type_definition.rs
@@ -30,7 +30,7 @@ pub(crate) fn goto_type_definition(
         return None;
     };
 
-    let adt_def = ty.autoderef(db).find_map(|ty| ty.as_adt().map(|adt| adt.0))?;
+    let adt_def = analyzer.autoderef(db, ty).find_map(|ty| ty.as_adt().map(|adt| adt.0))?;
 
     let nav = NavigationTarget::from_adt_def(db, adt_def);
     Some(RangeInfo::new(node.range(), vec![nav]))


### PR DESCRIPTION
This adds the necessary Chalk integration to handle associated types and uses it to implement support for `Deref` in the `*` operator and autoderef; so e.g. dot completions through an `Arc` work now.

It doesn't yet implement resolution of associated types in paths, though. Also, there's a big FIXME about handling variables in the solution we get from Chalk correctly.