### PR TITLE
The Fall down of failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,7 +1226,7 @@ version = "0.1.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "teraron 0.0.1 (git+https://github.com/mominul/teraron.git?branch=failure)",
+ "teraron 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1681,8 +1681,8 @@ dependencies = [
 
 [[package]]
 name = "teraron"
-version = "0.0.1"
-source = "git+https://github.com/mominul/teraron.git?branch=failure#e421b697309661dfee00b4ca3804bd4de09ce2b7"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ron 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2141,7 +2141,7 @@ dependencies = [
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7dc4738f2e68ed2855de5ac9cdbe05c9216773ecde4739b2f095002ab03a13ef"
 "checksum tera 0.11.20 (registry+https://github.com/rust-lang/crates.io-index)" = "4b505279e19d8f7d24b1a9dc58327c9c36174b1a2c7ebdeac70792d017cb64f3"
-"checksum teraron 0.0.1 (git+https://github.com/mominul/teraron.git?branch=failure)" = "<none>"
+"checksum teraron 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9a447d012fef5c222f4b11a98fcef2a7e347a57f28be9957c5c390ac9a0e41e0"
 "checksum termion 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dde0593aeb8d47accea5392b39350015b5eccb12c0d98044d856983d89548dea"
 "checksum termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72b620c5ea021d75a735c943269bb07d30c9b77d6ac6b236bc8b5c496ef05625"
 "checksum text_unit 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e08bbcb7a3adbda0eb23431206b653bdad3d8dea311e72d36bf2215e27a42579"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,9 +1225,8 @@ name = "ra_tools"
 version = "0.1.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "teraron 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "teraron 0.0.1 (git+https://github.com/mominul/teraron.git?branch=failure)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1683,9 +1682,8 @@ dependencies = [
 [[package]]
 name = "teraron"
 version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/mominul/teraron.git?branch=failure#e421b697309661dfee00b4ca3804bd4de09ce2b7"
 dependencies = [
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ron 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tera 0.11.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2143,7 +2141,7 @@ dependencies = [
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7dc4738f2e68ed2855de5ac9cdbe05c9216773ecde4739b2f095002ab03a13ef"
 "checksum tera 0.11.20 (registry+https://github.com/rust-lang/crates.io-index)" = "4b505279e19d8f7d24b1a9dc58327c9c36174b1a2c7ebdeac70792d017cb64f3"
-"checksum teraron 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0d89ad4617d1dec55331067fadaa041e813479e1779616f3d3ce9308bf46184e"
+"checksum teraron 0.0.1 (git+https://github.com/mominul/teraron.git?branch=failure)" = "<none>"
 "checksum termion 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dde0593aeb8d47accea5392b39350015b5eccb12c0d98044d856983d89548dea"
 "checksum termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72b620c5ea021d75a735c943269bb07d30c9b77d6ac6b236bc8b5c496ef05625"
 "checksum text_unit 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e08bbcb7a3adbda0eb23431206b653bdad3d8dea311e72d36bf2215e27a42579"

--- a/crates/ra_tools/Cargo.toml
+++ b/crates/ra_tools/Cargo.toml
@@ -6,8 +6,7 @@ authors = ["rust-analyzer developers"]
 publish = false
 
 [dependencies]
-teraron = "0.0.1"
+teraron = { git = "https://github.com/mominul/teraron.git", branch = "failure" }
 walkdir = "2.1.3"
 itertools = "0.8.0"
 clap = "2.32.0"
-failure = "0.1.4"

--- a/crates/ra_tools/Cargo.toml
+++ b/crates/ra_tools/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["rust-analyzer developers"]
 publish = false
 
 [dependencies]
-teraron = { git = "https://github.com/mominul/teraron.git", branch = "failure" }
+teraron = "0.1.0"
 walkdir = "2.1.3"
 itertools = "0.8.0"
 clap = "2.32.0"

--- a/crates/ra_tools/src/bin/pre-commit.rs
+++ b/crates/ra_tools/src/bin/pre-commit.rs
@@ -1,7 +1,5 @@
 use std::process::Command;
 
-use failure::bail;
-
 use ra_tools::{Result, run_rustfmt, run, project_root, Overwrite};
 
 fn main() -> Result<()> {
@@ -19,7 +17,10 @@ fn update_staged() -> Result<()> {
         .current_dir(&root)
         .output()?;
     if !output.status.success() {
-        bail!("`git diff --diff-filter=MAR --name-only --cached` exited with {}", output.status);
+        Err(format!(
+            "`git diff --diff-filter=MAR --name-only --cached` exited with {}",
+            output.status
+        ))?;
     }
     for line in String::from_utf8(output.stdout)?.lines() {
         run(&format!("git update-index --add {}", root.join(line).to_string_lossy()), ".")?;

--- a/crates/ra_tools/src/main.rs
+++ b/crates/ra_tools/src/main.rs
@@ -1,6 +1,5 @@
 use clap::{App, SubCommand};
 use core::str;
-use failure::bail;
 use ra_tools::{
     generate, gen_tests, install_format_hook, run, run_with_output, run_rustfmt,
     Overwrite, Result, run_fuzzer, run_clippy,
@@ -64,10 +63,8 @@ fn verify_installed_extensions() -> Result<()> {
         run_with_output(r"code --list-extensions", ".")?
     };
     if !str::from_utf8(&exts.stdout)?.contains("ra-lsp") {
-        bail!(
-            "Could not install the Visual Studio Code extension. Please make sure you \
-             have at least NodeJS 10.x installed and try again."
-        );
+        Err("Could not install the Visual Studio Code extension. Please make sure you \
+             have at least NodeJS 10.x installed and try again.")?;
     }
     Ok(())
 }
@@ -79,7 +76,7 @@ fn fix_path_for_mac() -> Result<()> {
         const ROOT_DIR: &str = "";
         let home_dir = match env::var("HOME") {
             Ok(home) => home,
-            Err(e) => bail!("Failed getting HOME from environment with error: {}.", e),
+            Err(e) => Err(format!("Failed getting HOME from environment with error: {}.", e))?,
         };
 
         [ROOT_DIR, &home_dir]
@@ -93,7 +90,7 @@ fn fix_path_for_mac() -> Result<()> {
     if !vscode_path.is_empty() {
         let vars = match env::var_os("PATH") {
             Some(path) => path,
-            None => bail!("Could not get PATH variable from env."),
+            None => Err("Could not get PATH variable from env.")?,
         };
 
         let mut paths = env::split_paths(&vars).collect::<Vec<_>>();


### PR DESCRIPTION
:grin:
Replaced all the uses of `failure` crate with `std::error::Error`.

Closes #1400 
Depends on rust-analyzer/teraron#1