### PR TITLE
Introduce cargo-watch.check-command option for Code extension

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -203,8 +203,13 @@
                 },
                 "rust-analyzer.cargo-watch.check-arguments": {
                     "type": "string",
-                    "description": "`cargo-watch` check arguments. (e.g: `--features=\"shumway,pdf\"` will run as `cargo watch -x \"check --features=\"shumway,pdf\"\"` )",
+                    "description": "`cargo-watch` arguments. (e.g: `--features=\"shumway,pdf\"` will run as `cargo watch -x \"check --features=\"shumway,pdf\"\"` )",
                     "default": ""
+                },
+                "rust-analyzer.cargo-watch.check-command": {
+                    "type": "string",
+                    "description": "`cargo-watch` command. (e.g: `clippy` will run as `cargo watch -x clippy` )",
+                    "default": "check"                    
                 },
                 "rust-analyzer.trace.server": {
                     "type": "string",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -201,12 +201,12 @@
                     ],
                     "description": "Whether to run `cargo watch` on startup"
                 },
-                "rust-analyzer.cargo-watch.check-arguments": {
+                "rust-analyzer.cargo-watch.command-arguments": {
                     "type": "string",
                     "description": "`cargo-watch` arguments. (e.g: `--features=\"shumway,pdf\"` will run as `cargo watch -x \"check --features=\"shumway,pdf\"\"` )",
                     "default": ""
                 },
-                "rust-analyzer.cargo-watch.check-command": {
+                "rust-analyzer.cargo-watch.command": {
                     "type": "string",
                     "description": "`cargo-watch` command. (e.g: `clippy` will run as `cargo watch -x clippy` )",
                     "default": "check"                    

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -201,7 +201,7 @@
                     ],
                     "description": "Whether to run `cargo watch` on startup"
                 },
-                "rust-analyzer.cargo-watch.command-arguments": {
+                "rust-analyzer.cargo-watch.arguments": {
                     "type": "string",
                     "description": "`cargo-watch` arguments. (e.g: `--features=\"shumway,pdf\"` will run as `cargo watch -x \"check --features=\"shumway,pdf\"\"` )",
                     "default": ""
@@ -209,7 +209,7 @@
                 "rust-analyzer.cargo-watch.command": {
                     "type": "string",
                     "description": "`cargo-watch` command. (e.g: `clippy` will run as `cargo watch -x clippy` )",
-                    "default": "check"                    
+                    "default": "check"
                 },
                 "rust-analyzer.trace.server": {
                     "type": "string",

--- a/editors/code/src/commands/cargo_watch.ts
+++ b/editors/code/src/commands/cargo_watch.ts
@@ -43,7 +43,7 @@ export class CargoWatchProvider implements vscode.Disposable {
         this.diagnosticCollection = vscode.languages.createDiagnosticCollection(
             'rustc'
         );
-        this.statusDisplay = new StatusDisplay();
+        this.statusDisplay = new StatusDisplay(Server.config.cargoWatchOptions.checkCommand);
         this.outputChannel = vscode.window.createOutputChannel(
             'Cargo Watch Trace'
         );
@@ -57,7 +57,9 @@ export class CargoWatchProvider implements vscode.Disposable {
             return;
         }
 
-        let args = 'check --all-targets --message-format json';
+        let command = Server.config.cargoWatchOptions.checkCommand;
+
+        let args = command + ' --all-targets --message-format json';
         if (Server.config.cargoWatchOptions.checkArguments.length > 0) {
             // Excape the double quote string:
             args += ' ' + Server.config.cargoWatchOptions.checkArguments;

--- a/editors/code/src/commands/cargo_watch.ts
+++ b/editors/code/src/commands/cargo_watch.ts
@@ -57,9 +57,7 @@ export class CargoWatchProvider implements vscode.Disposable {
             return;
         }
 
-        let command = Server.config.cargoWatchOptions.checkCommand;
-
-        let args = command + ' --all-targets --message-format json';
+        let args = Server.config.cargoWatchOptions.checkCommand + ' --all-targets --message-format json';
         if (Server.config.cargoWatchOptions.checkArguments.length > 0) {
             // Excape the double quote string:
             args += ' ' + Server.config.cargoWatchOptions.checkArguments;

--- a/editors/code/src/commands/cargo_watch.ts
+++ b/editors/code/src/commands/cargo_watch.ts
@@ -43,7 +43,9 @@ export class CargoWatchProvider implements vscode.Disposable {
         this.diagnosticCollection = vscode.languages.createDiagnosticCollection(
             'rustc'
         );
-        this.statusDisplay = new StatusDisplay(Server.config.cargoWatchOptions.checkCommand);
+        this.statusDisplay = new StatusDisplay(
+            Server.config.cargoWatchOptions.command
+        );
         this.outputChannel = vscode.window.createOutputChannel(
             'Cargo Watch Trace'
         );
@@ -57,10 +59,12 @@ export class CargoWatchProvider implements vscode.Disposable {
             return;
         }
 
-        let args = Server.config.cargoWatchOptions.checkCommand + ' --all-targets --message-format json';
-        if (Server.config.cargoWatchOptions.checkArguments.length > 0) {
+        let args =
+            Server.config.cargoWatchOptions.command +
+            ' --all-targets --message-format json';
+        if (Server.config.cargoWatchOptions.command.length > 0) {
             // Excape the double quote string:
-            args += ' ' + Server.config.cargoWatchOptions.checkArguments;
+            args += ' ' + Server.config.cargoWatchOptions.arguments;
         }
         // Windows handles arguments differently than the unix-likes, so we need to wrap the args in double quotes
         if (process.platform === 'win32') {

--- a/editors/code/src/commands/watch_status.ts
+++ b/editors/code/src/commands/watch_status.ts
@@ -30,7 +30,9 @@ export class StatusDisplay implements vscode.Disposable {
                         this.packageName
                     }] ${this.frame()}`;
                 } else {
-                    this.statusBarItem!.text = `cargo ${this.command} ${this.frame()}`;
+                    this.statusBarItem!.text = `cargo ${
+                        this.command
+                    } ${this.frame()}`;
                 }
             }, 300);
 

--- a/editors/code/src/commands/watch_status.ts
+++ b/editors/code/src/commands/watch_status.ts
@@ -7,13 +7,15 @@ export class StatusDisplay implements vscode.Disposable {
 
     private i = 0;
     private statusBarItem: vscode.StatusBarItem;
+    private command: string;
     private timer?: NodeJS.Timeout;
 
-    constructor() {
+    constructor(command: string) {
         this.statusBarItem = vscode.window.createStatusBarItem(
             vscode.StatusBarAlignment.Left,
             10
         );
+        this.command = command;
         this.statusBarItem.hide();
     }
 
@@ -24,11 +26,11 @@ export class StatusDisplay implements vscode.Disposable {
             this.timer ||
             setInterval(() => {
                 if (this.packageName) {
-                    this.statusBarItem!.text = `cargo check [${
+                    this.statusBarItem!.text = `cargo ${this.command} [${
                         this.packageName
                     }] ${this.frame()}`;
                 } else {
-                    this.statusBarItem!.text = `cargo check ${this.frame()}`;
+                    this.statusBarItem!.text = `cargo ${this.command} ${this.frame()}`;
                 }
             }, 300);
 

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -25,8 +25,8 @@ export class Config {
     public cargoWatchOptions: CargoWatchOptions = {
         enableOnStartup: 'ask',
         trace: 'off',
-        checkArguments: '',
-        checkCommand: ''
+        arguments: '',
+        command: ''
     };
 
     private prevEnhancedTyping: null | boolean = null;
@@ -107,16 +107,16 @@ export class Config {
             );
         }
 
-        if (config.has('cargo-watch.check-arguments')) {
-            this.cargoWatchOptions.checkArguments = config.get<string>(
-                'cargo-watch.check-arguments',
+        if (config.has('cargo-watch.arguments')) {
+            this.cargoWatchOptions.arguments = config.get<string>(
+                'cargo-watch.arguments',
                 ''
             );
         }
 
-        if (config.has('cargo-watch.check-command')) {
-            this.cargoWatchOptions.checkCommand = config.get<string>(
-                'cargo-watch.check-command',
+        if (config.has('cargo-watch.command')) {
+            this.cargoWatchOptions.command = config.get<string>(
+                'cargo-watch.command',
                 ''
             );
         }

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -10,8 +10,8 @@ export type CargoWatchTraceOptions = 'off' | 'error' | 'verbose';
 
 export interface CargoWatchOptions {
     enableOnStartup: CargoWatchStartupOptions;
-    checkArguments: string;
-    checkCommand: string;
+    arguments: string;
+    command: string;
     trace: CargoWatchTraceOptions;
 }
 

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
 import { Server } from './server';
+import { strict } from 'assert';
 
 const RA_LSP_DEBUG = process.env.__RA_LSP_SERVER_DEBUG;
 
@@ -10,6 +11,7 @@ export type CargoWatchTraceOptions = 'off' | 'error' | 'verbose';
 export interface CargoWatchOptions {
     enableOnStartup: CargoWatchStartupOptions;
     checkArguments: string;
+    checkCommand: string;
     trace: CargoWatchTraceOptions;
 }
 
@@ -23,7 +25,8 @@ export class Config {
     public cargoWatchOptions: CargoWatchOptions = {
         enableOnStartup: 'ask',
         trace: 'off',
-        checkArguments: ''
+        checkArguments: '',
+        checkCommand: ''
     };
 
     private prevEnhancedTyping: null | boolean = null;
@@ -110,6 +113,14 @@ export class Config {
                 ''
             );
         }
+
+        if (config.has('cargo-watch.check-command')) {
+            this.cargoWatchOptions.checkCommand = config.get<string>(
+                'cargo-watch.check-command', 
+                ''
+            );
+        }
+
         if (config.has('lruCapacity')) {
             this.lruCapacity = config.get('lruCapacity') as number;
         }

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
-import { Server } from './server';
 import { strict } from 'assert';
+import { Server } from './server';
 
 const RA_LSP_DEBUG = process.env.__RA_LSP_SERVER_DEBUG;
 
@@ -116,7 +116,7 @@ export class Config {
 
         if (config.has('cargo-watch.check-command')) {
             this.cargoWatchOptions.checkCommand = config.get<string>(
-                'cargo-watch.check-command', 
+                'cargo-watch.check-command',
                 ''
             );
         }


### PR DESCRIPTION
By this option you can replace `check` command in `cargo watch` by the something else like `clippy`.