### PR TITLE
De-duplicate `cargo watch` diagnostics

### DIFF
--- a/editors/code/src/commands/cargo_watch.ts
+++ b/editors/code/src/commands/cargo_watch.ts
@@ -33,18 +33,6 @@ export function registerCargoWatchProvider(
     return provider;
 }
 
-function areDiagnosticsEqual(
-    left: vscode.Diagnostic,
-    right: vscode.Diagnostic
-): boolean {
-    return (
-        left.source === right.source &&
-        left.severity === right.severity &&
-        left.range.isEqual(right.range) &&
-        left.message === right.message
-    );
-}
-
 export class CargoWatchProvider implements vscode.Disposable {
     private readonly diagnosticCollection: vscode.DiagnosticCollection;
     private readonly statusDisplay: StatusDisplay;
@@ -174,6 +162,18 @@ export class CargoWatchProvider implements vscode.Disposable {
                 return vscode.DiagnosticSeverity.Warning;
             }
             return vscode.DiagnosticSeverity.Information;
+        }
+
+        function areDiagnosticsEqual(
+            left: vscode.Diagnostic,
+            right: vscode.Diagnostic
+        ): boolean {
+            return (
+                left.source === right.source &&
+                left.severity === right.severity &&
+                left.range.isEqual(right.range) &&
+                left.message === right.message
+            );
         }
 
         // Reference:


### PR DESCRIPTION
When building multiple targets (e.g. debug and test) it's common for the shared code to emit a diagnostic for each target. This is due to rust-lang/cargo#1534 and its many duplicates.

While this renders fine in the text view it can be confusing when looking at the error list or count.

This adds an `areDiagnosticsEqual` helper and then only pushes the new diagnostic if we haven't seen it before. This doesn't do a full proper equality; it only looks at the parts of the diagnostic we set. I couldn't find an appropriate helper function in the VSCode API.