### PR TITLE
cache chalk queries

### DIFF
--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -181,6 +181,26 @@ pub trait HirDatabase: DefDatabase + AstDatabase {
     #[salsa::volatile]
     fn solver(&self, krate: Crate) -> Arc<Mutex<crate::ty::traits::Solver>>;
 
+    #[salsa::invoke(crate::ty::traits::chalk::associated_ty_data_query)]
+    fn associated_ty_data(&self, id: chalk_ir::TypeId) -> Arc<chalk_rust_ir::AssociatedTyDatum>;
+
+    #[salsa::invoke(crate::ty::traits::chalk::trait_datum_query)]
+    fn trait_datum(
+        &self,
+        krate: Crate,
+        trait_id: chalk_ir::TraitId,
+    ) -> Arc<chalk_rust_ir::TraitDatum>;
+
+    #[salsa::invoke(crate::ty::traits::chalk::struct_datum_query)]
+    fn struct_datum(
+        &self,
+        krate: Crate,
+        struct_id: chalk_ir::StructId,
+    ) -> Arc<chalk_rust_ir::StructDatum>;
+
+    #[salsa::invoke(crate::ty::traits::chalk::impl_datum_query)]
+    fn impl_datum(&self, krate: Crate, impl_id: chalk_ir::ImplId) -> Arc<chalk_rust_ir::ImplDatum>;
+
     #[salsa::invoke(crate::ty::traits::implements_query)]
     fn implements(
         &self,

--- a/crates/ra_hir/src/ty/traits.rs
+++ b/crates/ra_hir/src/ty/traits.rs
@@ -12,7 +12,7 @@ use super::{TraitRef, Ty, Canonical, ProjectionTy};
 
 use self::chalk::{ToChalk, from_chalk};
 
-mod chalk;
+pub(crate) mod chalk;
 
 pub(crate) type Solver = chalk_solve::Solver;
 


### PR DESCRIPTION
This gives a significant speedup, because chalk will call these
functions several times even withing a single revision. The only
significant one here is `impl_data`, but I figured it might be good to
cache others just for consistency.

The results I get are:

Before:

from scratch:   16.081457952s
no change:      15.846493ms
trivial change: 352.95592ms
comment change: 361.998408ms
const change:   457.629212ms

After:

from scratch:   14.910610278s
no change:      14.934647ms
trivial change: 85.633023ms
comment change: 96.433023ms
const change:   171.543296ms

Seems like a nice win!