### PR TITLE
Add noUnusedLocals to VsCode tsconfig

### DIFF
--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
 
-import { strict } from 'assert';
 import { Server } from './server';
 
 const RA_LSP_DEBUG = process.env.__RA_LSP_SERVER_DEBUG;

--- a/editors/code/tsconfig.json
+++ b/editors/code/tsconfig.json
@@ -6,7 +6,8 @@
         "lib": ["es6"],
         "sourceMap": true,
         "rootDir": "src",
-        "strict": true
+        "strict": true,
+        "noUnusedLocals": true
     },
     "exclude": ["node_modules", ".vscode-test"]
 }


### PR DESCRIPTION
`tslint` doesn't catch this because TypeScript has had this check builtin since 2.9. However, it's disabled by default so right now nothing is checking for unused variables.