### PR TITLE
Run VS Code tests on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ before_cache:
 
 matrix:
     include:
-        - os: linux
+        - name: "Rust Tests"
+          os: linux
           dist: xenial
           language: rust
           rust: stable
@@ -18,7 +19,8 @@ matrix:
           env:
               - RUSTFLAGS="-D warnings", CARGO_INCREMENTAL=0
 
-        - os: linux
+        - name: "Rust Docs"
+          os: linux
           if: branch = master AND type = push
           before_script:
               - DEPLOY_DOCS=1
@@ -29,11 +31,22 @@ matrix:
           env:
               - RUSTFLAGS="-D warnings", CARGO_INCREMENTAL=0
 
-        - language: node_js
+        - name: "VS Code Tests"
+          os: linux
+          language: node_js
+          dist: xenial
           node_js: node
-          before_script: false
+          services:
+            - xvfb
+          before_install: cd editors/code
+          install:
+            - npm install
+            - npm run vscode:prepublish
           script:
-              - cd editors/code && npm ci && npm run travis
+            - npm ci
+            - npm run travis
+          env:
+            - CXX="g++-4.9", CC="gcc-4.9"
 
 branches:
     only:

--- a/editors/code/.prettierignore
+++ b/editors/code/.prettierignore
@@ -1,0 +1,2 @@
+node_modules/
+.vscode-test/

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -25,7 +25,7 @@
         "lint": "tslint --project .",
         "test": "node node_modules/vscode/bin/test",
         "prettier": "prettier **/*.{json,ts}",
-        "travis": "npm run compile && npm run lint && npm run prettier -- --list-different"
+        "travis": "npm run compile && npm run test && npm run lint && npm run prettier -- --list-different"
     },
     "prettier": {
         "tabWidth": 4,


### PR DESCRIPTION
This is actually much faster than I expected; it takes about 13 seconds to download VS Code and run the unit tests. This means the VS Code tests are still significantly faster than the Rust ones.

If this ends up being unreliable we can always remove it later or move it to a separate optional job.

We also need to ignore the `.vscode-test` directory when running `prettier` or it will get upset about some temporary JSON files VS Code creates.

cc @killercup 