### PR TITLE
Include primary span label in VS Code diagnostics

### DIFF
--- a/editors/code/src/test/fixtures/rust-diagnostics/error/E0308.json
+++ b/editors/code/src/test/fixtures/rust-diagnostics/error/E0308.json
@@ -1,0 +1,33 @@
+{
+    "message": "mismatched types",
+    "code": {
+        "code": "E0308",
+        "explanation": "\nThis error occurs when the compiler was unable to infer the concrete type of a\nvariable. It can occur for several cases, the most common of which is a\nmismatch in the expected type that the compiler inferred for a variable's\ninitializing expression, and the actual type explicitly assigned to the\nvariable.\n\nFor example:\n\n```compile_fail,E0308\nlet x: i32 = \"I am not a number!\";\n//     ~~~   ~~~~~~~~~~~~~~~~~~~~\n//      |             |\n//      |    initializing expression;\n//      |    compiler infers type `&str`\n//      |\n//    type `i32` assigned to variable `x`\n```\n"
+    },
+    "level": "error",
+    "spans": [
+        {
+            "file_name": "runtime/compiler_support.rs",
+            "byte_start": 1589,
+            "byte_end": 1594,
+            "line_start": 48,
+            "line_end": 48,
+            "column_start": 65,
+            "column_end": 70,
+            "is_primary": true,
+            "text": [
+                {
+                    "text": "    let layout = alloc::Layout::from_size_align_unchecked(size, align);",
+                    "highlight_start": 65,
+                    "highlight_end": 70
+                }
+            ],
+            "label": "expected usize, found u32",
+            "suggested_replacement": null,
+            "suggestion_applicability": null,
+            "expansion": null
+        }
+    ],
+    "children": [],
+    "rendered": "error[E0308]: mismatched types\n  --> runtime/compiler_support.rs:48:65\n   |\n48 |     let layout = alloc::Layout::from_size_align_unchecked(size, align);\n   |                                                                 ^^^^^ expected usize, found u32\n\n"
+}

--- a/editors/code/src/test/utils/diagnotics/rust.test.ts
+++ b/editors/code/src/test/utils/diagnotics/rust.test.ts
@@ -108,7 +108,10 @@ describe('mapRustDiagnosticToVsCode', () => {
         );
         assert.strictEqual(
             diagnostic.message,
-            'this function takes 2 parameters but 3 parameters were supplied'
+            [
+                'this function takes 2 parameters but 3 parameters were supplied',
+                'expected 2 parameters'
+            ].join('\n')
         );
         assert.strictEqual(diagnostic.code, 'E0061');
         assert.strictEqual(diagnostic.source, 'rustc');
@@ -169,5 +172,29 @@ describe('mapRustDiagnosticToVsCode', () => {
             suggestedFix.applicability,
             SuggestionApplicability.Unspecified
         );
+    });
+
+    it('should map a mismatched type error', () => {
+        const { diagnostic, suggestedFixes } = mapFixtureToVsCode(
+            'error/E0308'
+        );
+
+        assert.strictEqual(
+            diagnostic.severity,
+            vscode.DiagnosticSeverity.Error
+        );
+        assert.strictEqual(
+            diagnostic.message,
+            ['mismatched types', 'expected usize, found u32'].join('\n')
+        );
+        assert.strictEqual(diagnostic.code, 'E0308');
+        assert.strictEqual(diagnostic.source, 'rustc');
+        assert.strictEqual(diagnostic.tags, undefined);
+
+        // No related information
+        assert.deepStrictEqual(diagnostic.relatedInformation, []);
+
+        // There are no suggested fixes
+        assert.strictEqual(suggestedFixes.length, 0);
     });
 });

--- a/editors/code/src/utils/diagnostics/rust.ts
+++ b/editors/code/src/utils/diagnostics/rust.ts
@@ -182,6 +182,7 @@ export function mapRustDiagnosticToVsCode(
     const secondarySpans = rd.spans.filter(s => !s.is_primary);
 
     const severity = mapLevelToSeverity(rd.level);
+    let primarySpanLabel = primarySpan.label;
 
     const vd = new vscode.Diagnostic(location.range, rd.message, severity);
 
@@ -220,7 +221,15 @@ export function mapRustDiagnosticToVsCode(
         }
         if (messageLine) {
             vd.message += `\n${messageLine}`;
+
+            // These secondary messages usually duplicate the content of the
+            // primary span label.
+            primarySpanLabel = undefined;
         }
+    }
+
+    if (primarySpanLabel) {
+        vd.message += `\n${primarySpanLabel}`;
     }
 
     if (isUnusedOrUnnecessary(rd)) {


### PR DESCRIPTION
In most cases the primary label span repeats information found elsewhere in the diagnostic. For example, with E0061:

```json
{
  "message": "this function takes 2 parameters but 3 parameters were supplied",
  "spans": [{"label": "expected 2 parameters"}]
}
```

However, with some mismatched type errors (E0308) the expected type only appears in the primary span's label, e.g.:

```json
{
  "message": "mismatched types",
  "spans": [{"label": "expected usize, found u32"}]
}
```

I initially added the primary span label to the message unconditionally. However, for most error types the child diagnostics repeat the primary span label with more detail. `rustc` also renders the duplicate text but because the span label and child diagnostics appear in visually distinct places it's not as confusing.

This takes a heuristic approach where it will only add the primary span label if there are no child message lines. For most error types the child messages repeat the primary span label with more detail.