### PR TITLE
Consider unreachable code to be unnecessary in VSC

### DIFF
--- a/editors/code/src/utils/diagnostics/rust.ts
+++ b/editors/code/src/utils/diagnostics/rust.ts
@@ -103,6 +103,7 @@ function isUnusedOrUnnecessary(rd: RustDiagnostic): boolean {
     return [
         'dead_code',
         'unknown_lints',
+        'unreachable_code',
         'unused_attributes',
         'unused_imports',
         'unused_macros',


### PR DESCRIPTION
This adds `unreachable_code` to the list of diagnostic codes we map to `Unnecessary` in Visual Studio Code. This is consistent with what the TypeScript language server does.

Before:
<img width="308" alt="Screen Shot 2019-06-30 at 12 08 56" src="https://user-images.githubusercontent.com/687534/60391416-133d5480-9b31-11e9-86fb-e252739ab3a8.png">

After:
<img width="303" alt="Screen Shot 2019-06-30 at 12 16 49" src="https://user-images.githubusercontent.com/687534/60391418-19333580-9b31-11e9-9eea-850c62eb9a07.png">
