### PR TITLE
Update vsce to 1.64.0

### DIFF
--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -39,7 +39,8 @@
         "@types/seedrandom": {
             "version": "2.4.28",
             "resolved": "https://registry.npmjs.org/@types/seedrandom/-/seedrandom-2.4.28.tgz",
-            "integrity": "sha512-SMA+fUwULwK7sd/ZJicUztiPs8F1yCPwF3O23Z9uQ32ME5Ha0NmDK9+QTsYE4O2tHXChzXomSWWeIhCnoN1LqA=="
+            "integrity": "sha512-SMA+fUwULwK7sd/ZJicUztiPs8F1yCPwF3O23Z9uQ32ME5Ha0NmDK9+QTsYE4O2tHXChzXomSWWeIhCnoN1LqA==",
+            "dev": true
         },
         "agent-base": {
             "version": "4.2.1",
@@ -112,6 +113,18 @@
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
             "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
             "dev": true
+        },
+        "azure-devops-node-api": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.2.0.tgz",
+            "integrity": "sha512-pMfGJ6gAQ7LRKTHgiRF+8iaUUeGAI0c8puLaqHLc7B8AR7W6GJLozK9RFeUHFjEGybC9/EB3r67WPd7e46zQ8w==",
+            "dev": true,
+            "requires": {
+                "os": "0.1.1",
+                "tunnel": "0.0.4",
+                "typed-rest-client": "1.2.0",
+                "underscore": "1.8.3"
+            }
         },
         "balanced-match": {
             "version": "1.0.0",
@@ -287,6 +300,12 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
             "integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE=",
+            "dev": true
+        },
+        "didyoumean": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.1.tgz",
+            "integrity": "sha1-6S7f2tplN9SE1zwBcv0eugxJdv8=",
             "dev": true
         },
         "diff": {
@@ -805,6 +824,12 @@
                 "wrappy": "1"
             }
         },
+        "os": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
+            "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M=",
+            "dev": true
+        },
         "os-homedir": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
@@ -887,12 +912,6 @@
             "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
             "dev": true
         },
-        "q": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-            "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-            "dev": true
-        },
         "qs": {
             "version": "6.5.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -915,9 +934,9 @@
             }
         },
         "readable-stream": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
-            "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+            "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
             "dev": true,
             "requires": {
                 "inherits": "^2.0.3",
@@ -1177,21 +1196,13 @@
             "dev": true
         },
         "typed-rest-client": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.9.0.tgz",
-            "integrity": "sha1-92jMDcP06VDwbgSCXDaz54NKofI=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
+            "integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
             "dev": true,
             "requires": {
                 "tunnel": "0.0.4",
                 "underscore": "1.8.3"
-            },
-            "dependencies": {
-                "underscore": {
-                    "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-                    "dev": true
-                }
             }
         },
         "typescript": {
@@ -1207,9 +1218,9 @@
             "dev": true
         },
         "underscore": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-            "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+            "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
             "dev": true
         },
         "uri-js": {
@@ -1261,15 +1272,17 @@
             }
         },
         "vsce": {
-            "version": "1.59.0",
-            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.59.0.tgz",
-            "integrity": "sha512-tkB97885k5ce25Brbe9AZTCAXAkBh7oa5EOzY0BCJQ51W/mfRaQuCluCd9gZpWdgiU4AbPvwxtoVKKsenlSt8w==",
+            "version": "1.64.0",
+            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.64.0.tgz",
+            "integrity": "sha512-t3R7QTe2nAXQZs2kD+nA8GjdlX8pAQlnzxaNTG2976i5cyQ8r+ZsMNa/f9PDt7bhjcQM+u/fL+LkNuw+hwoy2A==",
             "dev": true,
             "requires": {
+                "azure-devops-node-api": "^7.2.0",
                 "chalk": "^2.4.2",
                 "cheerio": "^1.0.0-rc.1",
                 "commander": "^2.8.1",
                 "denodeify": "^1.2.1",
+                "didyoumean": "^1.2.1",
                 "glob": "^7.0.6",
                 "lodash": "^4.17.10",
                 "markdown-it": "^8.3.1",
@@ -1280,8 +1293,8 @@
                 "read": "^1.0.7",
                 "semver": "^5.1.0",
                 "tmp": "0.0.29",
+                "typed-rest-client": "1.2.0",
                 "url-join": "^1.1.0",
-                "vso-node-api": "6.1.2-preview",
                 "yauzl": "^2.3.1",
                 "yazl": "^2.2.2"
             }
@@ -1337,18 +1350,6 @@
             "requires": {
                 "http-proxy-agent": "^2.1.0",
                 "https-proxy-agent": "^2.2.1"
-            }
-        },
-        "vso-node-api": {
-            "version": "6.1.2-preview",
-            "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-6.1.2-preview.tgz",
-            "integrity": "sha1-qrNUbfJFHs2JTgcbuZtd8Zxfp48=",
-            "dev": true,
-            "requires": {
-                "q": "^1.0.1",
-                "tunnel": "0.0.4",
-                "typed-rest-client": "^0.9.0",
-                "underscore": "^1.8.3"
             }
         },
         "wrappy": {

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -44,7 +44,7 @@
         "tslint": "^5.16.0",
         "tslint-config-prettier": "^1.18.0",
         "typescript": "^3.4.4",
-        "vsce": "^1.59.0",
+        "vsce": "^1.64.0",
         "vscode": "^1.1.33"
     },
     "activationEvents": [


### PR DESCRIPTION
Gets rid of the annoying warning asking you to run `npm install -g vsce` on `cargo install`.