### PR TITLE
Add trait obligations for where clauses when calling functions/methods

### DIFF
--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -163,10 +163,10 @@ pub trait HirDatabase: DefDatabase + AstDatabase {
     #[salsa::invoke(crate::ty::callable_item_sig)]
     fn callable_item_signature(&self, def: CallableDef) -> FnSig;
 
-    #[salsa::invoke(crate::ty::generic_predicates)]
+    #[salsa::invoke(crate::ty::generic_predicates_query)]
     fn generic_predicates(&self, def: GenericDef) -> Arc<[GenericPredicate]>;
 
-    #[salsa::invoke(crate::ty::generic_defaults)]
+    #[salsa::invoke(crate::ty::generic_defaults_query)]
     fn generic_defaults(&self, def: GenericDef) -> Substs;
 
     #[salsa::invoke(crate::expr::body_with_source_map_query)]

--- a/crates/ra_hir/src/resolve.rs
+++ b/crates/ra_hir/src/resolve.rs
@@ -221,6 +221,18 @@ impl Resolver {
     pub(crate) fn krate(&self) -> Option<Crate> {
         self.module().map(|t| t.0.krate())
     }
+
+    pub(crate) fn where_predicates_in_scope<'a>(
+        &'a self,
+    ) -> impl Iterator<Item = &'a crate::generics::WherePredicate> + 'a {
+        self.scopes
+            .iter()
+            .filter_map(|scope| match scope {
+                Scope::GenericParams(params) => Some(params),
+                _ => None,
+            })
+            .flat_map(|params| params.where_predicates.iter())
+    }
 }
 
 impl Resolver {

--- a/crates/ra_hir/src/ty.rs
+++ b/crates/ra_hir/src/ty.rs
@@ -23,8 +23,8 @@ pub(crate) use autoderef::autoderef;
 pub(crate) use infer::{infer_query, InferTy, InferenceResult};
 pub use lower::CallableDef;
 pub(crate) use lower::{
-    callable_item_sig, generic_defaults, generic_predicates, type_for_def, type_for_field,
-    TypableDef,
+    callable_item_sig, generic_defaults_query, generic_predicates_query, type_for_def,
+    type_for_field, TypableDef,
 };
 pub(crate) use traits::ProjectionPredicate;
 

--- a/crates/ra_hir/src/ty/infer.rs
+++ b/crates/ra_hir/src/ty/infer.rs
@@ -849,8 +849,19 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
     fn register_obligations_for_call(&mut self, callable_ty: &Ty) {
         if let Ty::Apply(a_ty) = callable_ty {
             if let TypeCtor::FnDef(def) = a_ty.ctor {
+                let generic_predicates = self.db.generic_predicates(match def {
+                    // TODO add helper function
+                    CallableDef::Function(f) => f.into(),
+                    CallableDef::Struct(s) => s.into(),
+                    CallableDef::EnumVariant(_e) => unimplemented!(),
+                });
+                for predicate in generic_predicates.iter() {
+                    let predicate = predicate.clone().subst(&a_ty.parameters);
+                    if let Some(obligation) = Obligation::from_predicate(predicate) {
+                        self.obligations.push(obligation);
+                    }
+                }
                 // add obligation for trait implementation, if this is a trait method
-                // FIXME also register obligations from where clauses from the trait or impl and method
                 match def {
                     CallableDef::Function(f) => {
                         if let Some(trait_) = f.parent_trait(self.db) {
@@ -992,7 +1003,7 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
                         (Vec::new(), Ty::Unknown)
                     }
                 };
-                // FIXME register obligations from where clauses from the function
+                self.register_obligations_for_call(&callee_ty);
                 let param_iter = param_tys.into_iter().chain(repeat(Ty::Unknown));
                 for (arg, param) in args.iter().zip(param_iter) {
                     self.infer_expr(*arg, &Expectation::has_type(param));

--- a/crates/ra_hir/src/ty/infer.rs
+++ b/crates/ra_hir/src/ty/infer.rs
@@ -849,12 +849,7 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
     fn register_obligations_for_call(&mut self, callable_ty: &Ty) {
         if let Ty::Apply(a_ty) = callable_ty {
             if let TypeCtor::FnDef(def) = a_ty.ctor {
-                let generic_predicates = self.db.generic_predicates(match def {
-                    // TODO add helper function
-                    CallableDef::Function(f) => f.into(),
-                    CallableDef::Struct(s) => s.into(),
-                    CallableDef::EnumVariant(_e) => unimplemented!(),
-                });
+                let generic_predicates = self.db.generic_predicates(def.into());
                 for predicate in generic_predicates.iter() {
                     let predicate = predicate.clone().subst(&a_ty.parameters);
                     if let Some(obligation) = Obligation::from_predicate(predicate) {

--- a/crates/ra_hir/src/ty/lower.rs
+++ b/crates/ra_hir/src/ty/lower.rs
@@ -318,15 +318,13 @@ pub(crate) fn type_for_field(db: &impl HirDatabase, field: StructField) -> Ty {
 }
 
 /// Resolve the where clause(s) of an item with generics.
-pub(crate) fn generic_predicates(
+pub(crate) fn generic_predicates_query(
     db: &impl HirDatabase,
     def: GenericDef,
 ) -> Arc<[GenericPredicate]> {
     let resolver = def.resolver(db);
-    let generic_params = def.generic_params(db);
-    let predicates = generic_params
-        .where_predicates
-        .iter()
+    let predicates = resolver
+        .where_predicates_in_scope()
         .map(|pred| {
             TraitRef::for_where_predicate(db, &resolver, pred)
                 .map_or(GenericPredicate::Error, GenericPredicate::Implemented)
@@ -336,7 +334,7 @@ pub(crate) fn generic_predicates(
 }
 
 /// Resolve the default type params from generics
-pub(crate) fn generic_defaults(db: &impl HirDatabase, def: GenericDef) -> Substs {
+pub(crate) fn generic_defaults_query(db: &impl HirDatabase, def: GenericDef) -> Substs {
     let resolver = def.resolver(db);
     let generic_params = def.generic_params(db);
 

--- a/crates/ra_hir/src/ty/lower.rs
+++ b/crates/ra_hir/src/ty/lower.rs
@@ -509,3 +509,13 @@ pub enum CallableDef {
     EnumVariant(EnumVariant),
 }
 impl_froms!(CallableDef: Function, Struct, EnumVariant);
+
+impl From<CallableDef> for GenericDef {
+    fn from(def: CallableDef) -> GenericDef {
+        match def {
+            CallableDef::Function(f) => f.into(),
+            CallableDef::Struct(s) => s.into(),
+            CallableDef::EnumVariant(e) => e.into(),
+        }
+    }
+}

--- a/crates/ra_hir/src/ty/traits.rs
+++ b/crates/ra_hir/src/ty/traits.rs
@@ -7,7 +7,7 @@ use parking_lot::Mutex;
 use ra_prof::profile;
 use rustc_hash::FxHashSet;
 
-use super::{Canonical, ProjectionTy, TraitRef, Ty};
+use super::{Canonical, GenericPredicate, ProjectionTy, TraitRef, Ty};
 use crate::{db::HirDatabase, Crate, ImplBlock, Trait};
 
 use self::chalk::{from_chalk, ToChalk};
@@ -76,6 +76,15 @@ pub enum Obligation {
     /// parameter to the `TraitRef`).
     Trait(TraitRef),
     // Projection(ProjectionPredicate),
+}
+
+impl Obligation {
+    pub fn from_predicate(predicate: GenericPredicate) -> Option<Obligation> {
+        match predicate {
+            GenericPredicate::Implemented(trait_ref) => Some(Obligation::Trait(trait_ref)),
+            GenericPredicate::Error => None,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/crates/ra_hir/src/ty/traits/chalk.rs
+++ b/crates/ra_hir/src/ty/traits/chalk.rs
@@ -428,11 +428,7 @@ pub(crate) fn struct_datum_query(
                 CallableDef::Struct(s) => s.module(db).krate(db),
                 CallableDef::EnumVariant(v) => v.parent_enum(db).module(db).krate(db),
             } != Some(krate);
-            let generic_def: GenericDef = match callable {
-                CallableDef::Function(f) => f.into(),
-                CallableDef::Struct(s) => s.into(),
-                CallableDef::EnumVariant(v) => v.parent_enum(db).into(),
-            };
+            let generic_def: GenericDef = callable.into();
             let generic_params = generic_def.generic_params(db);
             let bound_vars = Substs::bound_vars(&generic_params);
             let where_clauses = convert_where_clauses(db, generic_def, &bound_vars);


### PR DESCRIPTION
E.g. if we call `foo<T: Into<u32>>(x)`, that adds an obligation that `x: Into<u32>`, etc., which sometimes allows type inference to make further progress.