### PR TITLE
Trait environment

### DIFF
--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -213,18 +213,11 @@ pub trait HirDatabase: DefDatabase + AstDatabase {
     #[salsa::invoke(crate::ty::traits::chalk::impl_datum_query)]
     fn impl_datum(&self, krate: Crate, impl_id: chalk_ir::ImplId) -> Arc<chalk_rust_ir::ImplDatum>;
 
-    #[salsa::invoke(crate::ty::traits::implements_query)]
-    fn implements(
+    #[salsa::invoke(crate::ty::traits::solve_query)]
+    fn solve(
         &self,
         krate: Crate,
-        goal: crate::ty::Canonical<crate::ty::InEnvironment<crate::ty::TraitRef>>,
-    ) -> Option<crate::ty::traits::Solution>;
-
-    #[salsa::invoke(crate::ty::traits::normalize_query)]
-    fn normalize(
-        &self,
-        krate: Crate,
-        goal: crate::ty::Canonical<crate::ty::InEnvironment<crate::ty::ProjectionPredicate>>,
+        goal: crate::ty::Canonical<crate::ty::InEnvironment<crate::ty::Obligation>>,
     ) -> Option<crate::ty::traits::Solution>;
 }
 

--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -217,7 +217,7 @@ pub trait HirDatabase: DefDatabase + AstDatabase {
     fn implements(
         &self,
         krate: Crate,
-        goal: crate::ty::Canonical<crate::ty::TraitRef>,
+        goal: crate::ty::Canonical<crate::ty::InEnvironment<crate::ty::TraitRef>>,
     ) -> Option<crate::ty::traits::Solution>;
 
     #[salsa::invoke(crate::ty::traits::normalize_query)]

--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -224,7 +224,7 @@ pub trait HirDatabase: DefDatabase + AstDatabase {
     fn normalize(
         &self,
         krate: Crate,
-        goal: crate::ty::Canonical<crate::ty::ProjectionPredicate>,
+        goal: crate::ty::Canonical<crate::ty::InEnvironment<crate::ty::ProjectionPredicate>>,
     ) -> Option<crate::ty::traits::Solution>;
 }
 

--- a/crates/ra_hir/src/ty.rs
+++ b/crates/ra_hir/src/ty.rs
@@ -26,7 +26,7 @@ pub(crate) use lower::{
     callable_item_sig, generic_defaults_query, generic_predicates_query, type_for_def,
     type_for_field, TypableDef,
 };
-pub(crate) use traits::ProjectionPredicate;
+pub(crate) use traits::{Environment, InEnvironment, ProjectionPredicate};
 
 /// A type constructor or type name: this might be something like the primitive
 /// type `bool`, a struct like `Vec`, or things like function pointers or

--- a/crates/ra_hir/src/ty.rs
+++ b/crates/ra_hir/src/ty.rs
@@ -26,7 +26,7 @@ pub(crate) use lower::{
     callable_item_sig, generic_defaults_query, generic_predicates_query, type_for_def,
     type_for_field, TypableDef,
 };
-pub(crate) use traits::{Environment, InEnvironment, ProjectionPredicate};
+pub(crate) use traits::{Environment, InEnvironment, Obligation, ProjectionPredicate};
 
 /// A type constructor or type name: this might be something like the primitive
 /// type `bool`, a struct like `Vec`, or things like function pointers or

--- a/crates/ra_hir/src/ty/autoderef.rs
+++ b/crates/ra_hir/src/ty/autoderef.rs
@@ -62,11 +62,13 @@ fn deref_by_trait(
         },
     };
 
-    let in_env = super::traits::InEnvironment { value: projection, environment: env };
+    let obligation = super::Obligation::Projection(projection);
+
+    let in_env = super::traits::InEnvironment { value: obligation, environment: env };
 
     let canonical = super::Canonical { num_vars: 1 + ty.num_vars, value: in_env };
 
-    let solution = db.normalize(krate, canonical)?;
+    let solution = db.solve(krate, canonical)?;
 
     match &solution {
         Solution::Unique(vars) => {

--- a/crates/ra_hir/src/ty/autoderef.rs
+++ b/crates/ra_hir/src/ty/autoderef.rs
@@ -52,6 +52,8 @@ fn deref_by_trait(
 
     // FIXME make the Canonical handling nicer
 
+    let env = super::lower::trait_env(db, resolver);
+
     let projection = super::traits::ProjectionPredicate {
         ty: Ty::Bound(0),
         projection_ty: super::ProjectionTy {
@@ -60,7 +62,9 @@ fn deref_by_trait(
         },
     };
 
-    let canonical = super::Canonical { num_vars: 1 + ty.num_vars, value: projection };
+    let in_env = super::traits::InEnvironment { value: projection, environment: env };
+
+    let canonical = super::Canonical { num_vars: 1 + ty.num_vars, value: in_env };
 
     let solution = db.normalize(krate, canonical)?;
 

--- a/crates/ra_hir/src/ty/infer.rs
+++ b/crates/ra_hir/src/ty/infer.rs
@@ -29,7 +29,8 @@ use test_utils::tested_by;
 use super::{
     autoderef, method_resolution, op, primitive,
     traits::{Guidance, Obligation, ProjectionPredicate, Solution},
-    ApplicationTy, CallableDef, ProjectionTy, Substs, TraitRef, Ty, TypableDef, TypeCtor,
+    ApplicationTy, CallableDef, InEnvironment, ProjectionTy, Substs, TraitRef, Ty, TypableDef,
+    TypeCtor,
 };
 use crate::{
     adt::VariantDef,
@@ -330,7 +331,9 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
         for obligation in obligations {
             match &obligation {
                 Obligation::Trait(tr) => {
-                    let canonicalized = self.canonicalizer().canonicalize_trait_ref(tr.clone());
+                    let env = Arc::new(super::Environment); // FIXME add environment
+                    let in_env = InEnvironment::new(env, tr.clone());
+                    let canonicalized = self.canonicalizer().canonicalize_trait_ref(in_env);
                     let solution = self
                         .db
                         .implements(self.resolver.krate().unwrap(), canonicalized.value.clone());

--- a/crates/ra_hir/src/ty/infer.rs
+++ b/crates/ra_hir/src/ty/infer.rs
@@ -356,7 +356,8 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
                     };
                 }
                 Obligation::Projection(pr) => {
-                    let canonicalized = self.canonicalizer().canonicalize_projection(pr.clone());
+                    let in_env = InEnvironment::new(self.trait_env.clone(), pr.clone());
+                    let canonicalized = self.canonicalizer().canonicalize_projection(in_env);
                     let solution = self
                         .db
                         .normalize(self.resolver.krate().unwrap(), canonicalized.value.clone());

--- a/crates/ra_hir/src/ty/infer/unify.rs
+++ b/crates/ra_hir/src/ty/infer/unify.rs
@@ -129,10 +129,14 @@ where
 
     pub fn canonicalize_projection(
         mut self,
-        projection: ProjectionPredicate,
-    ) -> Canonicalized<ProjectionPredicate> {
-        let result = self.do_canonicalize_projection_predicate(projection);
-        self.into_canonicalized(result)
+        projection: InEnvironment<ProjectionPredicate>,
+    ) -> Canonicalized<InEnvironment<ProjectionPredicate>> {
+        let result = self.do_canonicalize_projection_predicate(projection.value);
+        // FIXME canonicalize env
+        self.into_canonicalized(InEnvironment {
+            value: result,
+            environment: projection.environment,
+        })
     }
 }
 

--- a/crates/ra_hir/src/ty/lower.rs
+++ b/crates/ra_hir/src/ty/lower.rs
@@ -317,6 +317,18 @@ pub(crate) fn type_for_field(db: &impl HirDatabase, field: StructField) -> Ty {
     Ty::from_hir(db, &resolver, type_ref)
 }
 
+pub(crate) fn trait_env(db: &impl HirDatabase, resolver: &Resolver) -> Arc<super::Environment> {
+    let predicates = resolver
+        .where_predicates_in_scope()
+        .map(|pred| {
+            TraitRef::for_where_predicate(db, &resolver, pred)
+                .map_or(GenericPredicate::Error, GenericPredicate::Implemented)
+        })
+        .collect::<Vec<_>>();
+
+    Arc::new(super::Environment { predicates })
+}
+
 /// Resolve the where clause(s) of an item with generics.
 pub(crate) fn generic_predicates_query(
     db: &impl HirDatabase,

--- a/crates/ra_hir/src/ty/method_resolution.rs
+++ b/crates/ra_hir/src/ty/method_resolution.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use arrayvec::ArrayVec;
 use rustc_hash::FxHashMap;
 
-use super::{autoderef, Canonical, TraitRef};
+use super::{autoderef, Canonical, Environment, InEnvironment, TraitRef};
 use crate::{
     generics::HasGenericParams,
     impl_block::{ImplBlock, ImplId, ImplItem},
@@ -209,7 +209,8 @@ fn iterate_trait_method_candidates<T>(
                 let data = m.data(db);
                 if name.map_or(true, |name| data.name() == name) && data.has_self_param() {
                     if !known_implemented {
-                        let trait_ref = canonical_trait_ref(db, t, ty.clone());
+                        let env = Arc::new(super::Environment); // FIXME add environment
+                        let trait_ref = canonical_trait_ref(db, env, t, ty.clone());
                         if db.implements(krate, trait_ref).is_none() {
                             continue 'traits;
                         }
@@ -279,9 +280,10 @@ impl Ty {
 /// for all other parameters, to query Chalk with it.
 fn canonical_trait_ref(
     db: &impl HirDatabase,
+    env: Arc<Environment>,
     trait_: Trait,
     self_ty: Canonical<Ty>,
-) -> Canonical<TraitRef> {
+) -> Canonical<InEnvironment<TraitRef>> {
     let mut substs = Vec::new();
     let generics = trait_.generic_params(db);
     let num_vars = self_ty.num_vars;
@@ -296,6 +298,6 @@ fn canonical_trait_ref(
     );
     Canonical {
         num_vars: substs.len() - 1 + self_ty.num_vars,
-        value: TraitRef { trait_, substs: substs.into() },
+        value: InEnvironment::new(env, TraitRef { trait_, substs: substs.into() }),
     }
 }

--- a/crates/ra_hir/src/ty/tests.rs
+++ b/crates/ra_hir/src/ty/tests.rs
@@ -3010,6 +3010,25 @@ fn test<T>(t: T) { t.foo()<|>; }
     assert_eq!(t, "{unknown}");
 }
 
+#[test]
+fn generic_param_env_deref() {
+    let t = type_at(
+        r#"
+//- /main.rs
+#[lang = "deref"]
+trait Deref {
+    type Target;
+}
+trait Trait {}
+impl<T> Deref for T where T: Trait {
+    type Target = i128;
+}
+fn test<T: Trait>(t: T) { (*t)<|>; }
+"#,
+    );
+    assert_eq!(t, "i128");
+}
+
 fn type_at_pos(db: &MockDatabase, pos: FilePosition) -> String {
     let file = db.parse(pos.file_id).ok().unwrap();
     let expr = algo::find_node_at_offset::<ast::Expr>(file.syntax(), pos.offset).unwrap();

--- a/crates/ra_hir/src/ty/traits.rs
+++ b/crates/ra_hir/src/ty/traits.rs
@@ -134,20 +134,9 @@ pub(crate) fn implements_query(
 pub(crate) fn normalize_query(
     db: &impl HirDatabase,
     krate: Crate,
-    projection: Canonical<ProjectionPredicate>,
+    projection: Canonical<InEnvironment<ProjectionPredicate>>,
 ) -> Option<Solution> {
-    let goal: chalk_ir::Goal = chalk_ir::Normalize {
-        projection: projection.value.projection_ty.to_chalk(db),
-        ty: projection.value.ty.to_chalk(db),
-    }
-    .cast();
-    debug!("goal: {:?}", goal);
-    // FIXME unify with `implements`
-    let env = chalk_ir::Environment::new();
-    let in_env = chalk_ir::InEnvironment::new(&env, goal);
-    let parameter = chalk_ir::ParameterKind::Ty(chalk_ir::UniverseIndex::ROOT);
-    let canonical =
-        chalk_ir::Canonical { value: in_env, binders: vec![parameter; projection.num_vars] };
+    let canonical = projection.to_chalk(db).cast();
     // We currently don't deal with universes (I think / hope they're not yet
     // relevant for our use cases?)
     let u_canonical = chalk_ir::UCanonical { canonical, universes: 1 };

--- a/crates/ra_hir/src/ty/traits.rs
+++ b/crates/ra_hir/src/ty/traits.rs
@@ -72,11 +72,13 @@ fn solve(
 /// fn foo<T: Default>(t: T) {}
 /// ```
 /// we assume that `T: Default`.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct Environment;
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Environment {
+    pub predicates: Vec<GenericPredicate>,
+}
 
 /// Something (usually a goal), along with an environment.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct InEnvironment<T> {
     pub environment: Arc<Environment>,
     pub value: T,

--- a/crates/ra_hir/src/ty/traits/chalk.rs
+++ b/crates/ra_hir/src/ty/traits/chalk.rs
@@ -12,7 +12,7 @@ use chalk_rust_ir::{AssociatedTyDatum, ImplDatum, StructDatum, TraitDatum};
 use ra_db::salsa::{InternId, InternKey};
 use test_utils::tested_by;
 
-use super::ChalkContext;
+use super::{Canonical, ChalkContext};
 use crate::{
     db::HirDatabase,
     generics::GenericDef,
@@ -214,6 +214,60 @@ impl ToChalk for ProjectionTy {
         ProjectionTy {
             associated_ty: from_chalk(db, projection_ty.associated_ty_id),
             parameters: from_chalk(db, projection_ty.parameters),
+        }
+    }
+}
+
+impl<T> ToChalk for Canonical<T>
+where
+    T: ToChalk,
+{
+    type Chalk = chalk_ir::Canonical<T::Chalk>;
+
+    fn to_chalk(self, db: &impl HirDatabase) -> chalk_ir::Canonical<T::Chalk> {
+        let parameter = chalk_ir::ParameterKind::Ty(chalk_ir::UniverseIndex::ROOT);
+        let value = self.value.to_chalk(db);
+        let canonical = chalk_ir::Canonical { value, binders: vec![parameter; self.num_vars] };
+        canonical
+    }
+
+    fn from_chalk(db: &impl HirDatabase, canonical: chalk_ir::Canonical<T::Chalk>) -> Canonical<T> {
+        Canonical { num_vars: canonical.binders.len(), value: from_chalk(db, canonical.value) }
+    }
+}
+
+impl ToChalk for Arc<super::Environment> {
+    type Chalk = Arc<chalk_ir::Environment>;
+
+    fn to_chalk(self, _db: &impl HirDatabase) -> Arc<chalk_ir::Environment> {
+        chalk_ir::Environment::new()
+    }
+
+    fn from_chalk(
+        _db: &impl HirDatabase,
+        _env: Arc<chalk_ir::Environment>,
+    ) -> Arc<super::Environment> {
+        Arc::new(super::Environment)
+    }
+}
+
+impl<T: ToChalk> ToChalk for super::InEnvironment<T> {
+    type Chalk = chalk_ir::InEnvironment<T::Chalk>;
+
+    fn to_chalk(self, db: &impl HirDatabase) -> chalk_ir::InEnvironment<T::Chalk> {
+        chalk_ir::InEnvironment {
+            environment: self.environment.to_chalk(db),
+            goal: self.value.to_chalk(db),
+        }
+    }
+
+    fn from_chalk(
+        db: &impl HirDatabase,
+        in_env: chalk_ir::InEnvironment<T::Chalk>,
+    ) -> super::InEnvironment<T> {
+        super::InEnvironment {
+            environment: from_chalk(db, in_env.environment),
+            value: from_chalk(db, in_env.goal),
         }
     }
 }

--- a/crates/ra_hir/src/ty/traits/chalk.rs
+++ b/crates/ra_hir/src/ty/traits/chalk.rs
@@ -218,6 +218,21 @@ impl ToChalk for ProjectionTy {
     }
 }
 
+impl ToChalk for super::ProjectionPredicate {
+    type Chalk = chalk_ir::Normalize;
+
+    fn to_chalk(self, db: &impl HirDatabase) -> chalk_ir::Normalize {
+        chalk_ir::Normalize {
+            projection: self.projection_ty.to_chalk(db),
+            ty: self.ty.to_chalk(db),
+        }
+    }
+
+    fn from_chalk(_db: &impl HirDatabase, _normalize: chalk_ir::Normalize) -> Self {
+        unimplemented!()
+    }
+}
+
 impl<T> ToChalk for Canonical<T>
 where
     T: ToChalk,

--- a/crates/ra_hir/src/ty/traits/chalk.rs
+++ b/crates/ra_hir/src/ty/traits/chalk.rs
@@ -12,7 +12,7 @@ use chalk_rust_ir::{AssociatedTyDatum, ImplDatum, StructDatum, TraitDatum};
 use ra_db::salsa::{InternId, InternKey};
 use test_utils::tested_by;
 
-use super::{Canonical, ChalkContext};
+use super::{Canonical, ChalkContext, Obligation};
 use crate::{
     db::HirDatabase,
     generics::GenericDef,
@@ -229,6 +229,21 @@ impl ToChalk for super::ProjectionPredicate {
     }
 
     fn from_chalk(_db: &impl HirDatabase, _normalize: chalk_ir::Normalize) -> Self {
+        unimplemented!()
+    }
+}
+
+impl ToChalk for Obligation {
+    type Chalk = chalk_ir::DomainGoal;
+
+    fn to_chalk(self, db: &impl HirDatabase) -> chalk_ir::DomainGoal {
+        match self {
+            Obligation::Trait(tr) => tr.to_chalk(db).cast(),
+            Obligation::Projection(pr) => pr.to_chalk(db).cast(),
+        }
+    }
+
+    fn from_chalk(_db: &impl HirDatabase, _goal: chalk_ir::DomainGoal) -> Self {
         unimplemented!()
     }
 }

--- a/crates/ra_ide_api/src/change.rs
+++ b/crates/ra_ide_api/src/change.rs
@@ -295,8 +295,7 @@ impl RootDatabase {
             hir::db::TraitDatumQuery
             hir::db::StructDatumQuery
             hir::db::ImplDatumQuery
-            hir::db::ImplementsQuery
-            hir::db::NormalizeQuery
+            hir::db::SolveQuery
         ];
         acc.sort_by_key(|it| std::cmp::Reverse(it.1));
         acc


### PR DESCRIPTION
This adds the environment, i.e. the set of `where` clauses in scope, when solving trait goals. That means that e.g. in
```rust
fn foo<T: SomeTrait>(t: T) {}
```
, we are able to complete methods of `SomeTrait` on the `t`. This affects the trait APIs quite a bit (since every method that needs to be able to solve for some trait needs to get this environment somehow), so I thought I'd do it rather sooner than later ;)