### PR TITLE
Ignore workspace/didChangeConfiguration notifications.

### DIFF
--- a/crates/ra_lsp_server/src/caps.rs
+++ b/crates/ra_lsp_server/src/caps.rs
@@ -1,8 +1,8 @@
 use lsp_types::{
     CodeActionProviderCapability, CodeLensOptions, CompletionOptions,
-    DocumentOnTypeFormattingOptions, ExecuteCommandOptions, FoldingRangeProviderCapability,
-    GenericCapability, ImplementationProviderCapability, RenameOptions, RenameProviderCapability,
-    ServerCapabilities, SignatureHelpOptions, TextDocumentSyncCapability, TextDocumentSyncKind,
+    DocumentOnTypeFormattingOptions, FoldingRangeProviderCapability, GenericCapability,
+    ImplementationProviderCapability, RenameOptions, RenameProviderCapability, ServerCapabilities,
+    SignatureHelpOptions, TextDocumentSyncCapability, TextDocumentSyncKind,
     TextDocumentSyncOptions, TypeDefinitionProviderCapability,
 };
 
@@ -44,9 +44,7 @@ pub fn server_capabilities() -> ServerCapabilities {
             prepare_provider: Some(true),
         })),
         color_provider: None,
-        execute_command_provider: Some(ExecuteCommandOptions {
-            commands: vec!["apply_code_action".to_string()],
-        }),
+        execute_command_provider: None,
         workspace: None,
     }
 }

--- a/crates/ra_lsp_server/src/main_loop.rs
+++ b/crates/ra_lsp_server/src/main_loop.rs
@@ -431,6 +431,12 @@ fn on_notification(
         }
         Err(not) => not,
     };
+    let not = match not.cast::<req::DidChangeConfiguration>() {
+        Ok(_params) => {
+            return Ok(());
+        }
+        Err(not) => not,
+    };
     log::error!("unhandled notification: {:?}", not);
     Ok(())
 }

--- a/crates/ra_lsp_server/src/req.rs
+++ b/crates/ra_lsp_server/src/req.rs
@@ -5,10 +5,11 @@ use url_serde;
 
 pub use lsp_types::{
     notification::*, request::*, ApplyWorkspaceEditParams, CodeActionParams, CodeLens,
-    CodeLensParams, CompletionParams, CompletionResponse, DocumentOnTypeFormattingParams,
-    DocumentSymbolParams, DocumentSymbolResponse, ExecuteCommandParams, Hover, InitializeResult,
-    MessageType, PublishDiagnosticsParams, ReferenceParams, ShowMessageParams, SignatureHelp,
-    TextDocumentEdit, TextDocumentPositionParams, TextEdit, WorkspaceEdit, WorkspaceSymbolParams,
+    CodeLensParams, CompletionParams, CompletionResponse, DidChangeConfigurationParams,
+    DocumentOnTypeFormattingParams, DocumentSymbolParams, DocumentSymbolResponse,
+    ExecuteCommandParams, Hover, InitializeResult, MessageType, PublishDiagnosticsParams,
+    ReferenceParams, ShowMessageParams, SignatureHelp, TextDocumentEdit,
+    TextDocumentPositionParams, TextEdit, WorkspaceEdit, WorkspaceSymbolParams,
 };
 
 pub enum AnalyzerStatus {}

--- a/crates/ra_lsp_server/src/req.rs
+++ b/crates/ra_lsp_server/src/req.rs
@@ -6,10 +6,10 @@ use url_serde;
 pub use lsp_types::{
     notification::*, request::*, ApplyWorkspaceEditParams, CodeActionParams, CodeLens,
     CodeLensParams, CompletionParams, CompletionResponse, DidChangeConfigurationParams,
-    DocumentOnTypeFormattingParams, DocumentSymbolParams, DocumentSymbolResponse,
-    ExecuteCommandParams, Hover, InitializeResult, MessageType, PublishDiagnosticsParams,
-    ReferenceParams, ShowMessageParams, SignatureHelp, TextDocumentEdit,
-    TextDocumentPositionParams, TextEdit, WorkspaceEdit, WorkspaceSymbolParams,
+    DocumentOnTypeFormattingParams, DocumentSymbolParams, DocumentSymbolResponse, Hover,
+    InitializeResult, MessageType, PublishDiagnosticsParams, ReferenceParams, ShowMessageParams,
+    SignatureHelp, TextDocumentEdit, TextDocumentPositionParams, TextEdit, WorkspaceEdit,
+    WorkspaceSymbolParams,
 };
 
 pub enum AnalyzerStatus {}

--- a/docs/dev/lsp-features.md
+++ b/docs/dev/lsp-features.md
@@ -16,8 +16,6 @@ This list documents LSP features, supported by rust-analyzer.
 - [ ] [workspace/configuration](https://microsoft.github.io/language-server-protocol/specification#workspace_configuration)
 - [x] [workspace/didChangeWatchedFiles](https://microsoft.github.io/language-server-protocol/specification#workspace_didChangeWatchedFiles)
 - [x] [workspace/symbol](https://microsoft.github.io/language-server-protocol/specification#workspace_symbol)
-- [x] [workspace/executeCommand](https://microsoft.github.io/language-server-protocol/specification#workspace_executeCommand)
- - `apply_code_action`
 - [ ] [workspace/applyEdit](https://microsoft.github.io/language-server-protocol/specification#workspace_applyEdit)
 
 ## Text Synchronization


### PR DESCRIPTION
If the client happens to send a `workspace/didChangeConfiguration`
notification, it is nicer if rust-analyzer can just ignore it rather than
crash with an "unhandled notification" error.