### PR TITLE
Add "Run" lens for binary runnables

### DIFF
--- a/crates/ra_lsp_server/src/main_loop/handlers.rs
+++ b/crates/ra_lsp_server/src/main_loop/handlers.rs
@@ -695,7 +695,7 @@ pub fn handle_code_lens(
         let title = match &runnable.kind {
             RunnableKind::Test { .. } | RunnableKind::TestMod { .. } => Some("▶️Run Test"),
             RunnableKind::Bench { .. } => Some("Run Bench"),
-            _ => None,
+            RunnableKind::Bin => Some("️Run"),
         };
 
         if let Some(title) = title {


### PR DESCRIPTION
Add an easy way to launch the different `main` methods from VS Code:

Before:
![image](https://user-images.githubusercontent.com/2690773/61294531-b0111a80-a7de-11e9-856a-eedce52f883f.png)

After:
![image](https://user-images.githubusercontent.com/2690773/61294556-bef7cd00-a7de-11e9-9fbd-cb5076e0b1b6.png)

I've decided to omit the ️`▶️` symbol (as done for benches) since it looks a bit weird to me, but here's the version with it, just to compare:
![image](https://user-images.githubusercontent.com/2690773/61294597-dafb6e80-a7de-11e9-8f08-b513b8902ef5.png)


