### PR TITLE
Add type decorators

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -238,6 +238,11 @@
                     "type": "number",
                     "default": null,
                     "description": "Number of syntax trees rust-analyzer keeps in memory"
+                },
+                "rust-analyzer.displayInlayHints": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Display additional type information in the editor"
                 }
             }
         },
@@ -443,6 +448,15 @@
                     "dark": "#D4D4D4",
                     "light": "#000000",
                     "highContrast": "#FFFFFF"
+                }
+            },
+            {
+                "id": "ralsp.inlayHint",
+                "description": "Color for inlay hints",
+                "defaults": {
+                    "dark": "#A0A0A0F0",
+                    "light": "#747474",
+                    "highContrast": "#BEBEBE"
                 }
             }
         ]

--- a/editors/code/src/commands/index.ts
+++ b/editors/code/src/commands/index.ts
@@ -6,6 +6,7 @@ import * as onEnter from './on_enter';
 import * as parentModule from './parent_module';
 import * as runnables from './runnables';
 import * as syntaxTree from './syntaxTree';
+import * as inlayHints from './inlay_hints';
 
 export {
     analyzerStatus,
@@ -15,5 +16,6 @@ export {
     parentModule,
     runnables,
     syntaxTree,
-    onEnter
+    onEnter,
+    inlayHints,
 };

--- a/editors/code/src/commands/index.ts
+++ b/editors/code/src/commands/index.ts
@@ -1,12 +1,12 @@
 import * as analyzerStatus from './analyzer_status';
 import * as applySourceChange from './apply_source_change';
+import * as inlayHints from './inlay_hints';
 import * as joinLines from './join_lines';
 import * as matchingBrace from './matching_brace';
 import * as onEnter from './on_enter';
 import * as parentModule from './parent_module';
 import * as runnables from './runnables';
 import * as syntaxTree from './syntaxTree';
-import * as inlayHints from './inlay_hints';
 
 export {
     analyzerStatus,
@@ -17,5 +17,5 @@ export {
     runnables,
     syntaxTree,
     onEnter,
-    inlayHints,
+    inlayHints
 };

--- a/editors/code/src/commands/inlay_hints.ts
+++ b/editors/code/src/commands/inlay_hints.ts
@@ -1,9 +1,5 @@
 import * as vscode from 'vscode';
-import {
-    Range,
-    TextDocumentChangeEvent,
-    TextEditor
-} from 'vscode';
+import { Range, TextDocumentChangeEvent, TextEditor } from 'vscode';
 import { TextDocumentIdentifier } from 'vscode-languageclient';
 import { Server } from '../server';
 
@@ -29,7 +25,7 @@ export class HintsUpdater {
     public async loadHints(
         editor: vscode.TextEditor | undefined
     ): Promise<void> {
-        if (this.displayHints && editor !== undefined) {
+        if (this.displayHints && editor !== undefined && this.isRustDocument(editor.document)) {
             await this.updateDecorationsFromServer(
                 editor.document.uri.toString(),
                 editor
@@ -61,7 +57,7 @@ export class HintsUpdater {
             return;
         }
         const document = cause == null ? editor.document : cause.document;
-        if (document.languageId !== 'rust') {
+        if (!this.isRustDocument(document)) {
             return;
         }
 
@@ -69,6 +65,10 @@ export class HintsUpdater {
             document.uri.toString(),
             editor
         );
+    }
+
+    private isRustDocument(document: vscode.TextDocument): boolean {
+        return document && document.languageId === 'rust';
     }
 
     private async updateDecorationsFromServer(

--- a/editors/code/src/commands/inlay_hints.ts
+++ b/editors/code/src/commands/inlay_hints.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode';
 import {
     Range,
     TextDocumentChangeEvent,
-    TextDocumentContentChangeEvent,
     TextEditor
 } from 'vscode';
 import { TextDocumentIdentifier } from 'vscode-languageclient';
@@ -66,38 +65,10 @@ export class HintsUpdater {
             return;
         }
 
-        // If the dbg! macro is used in the lsp-server, an endless stream of events with `cause.contentChanges` with the dbg messages.
-        // Should not be a real situation, but better to filter such things out.
-        if (
-            cause !== undefined &&
-            cause.contentChanges.filter(changeEvent =>
-                this.isEventInFile(document.lineCount, changeEvent)
-            ).length === 0
-        ) {
-            return;
-        }
         return await this.updateDecorationsFromServer(
             document.uri.toString(),
             editor
         );
-    }
-
-    private isEventInFile(
-        documentLineCount: number,
-        event: TextDocumentContentChangeEvent
-    ): boolean {
-        const eventText = event.text;
-        if (eventText.length === 0) {
-            return (
-                event.range.start.line <= documentLineCount ||
-                event.range.end.line <= documentLineCount
-            );
-        } else {
-            return (
-                event.range.start.line <= documentLineCount &&
-                event.range.end.line <= documentLineCount
-            );
-        }
     }
 
     private async updateDecorationsFromServer(

--- a/editors/code/src/commands/inlay_hints.ts
+++ b/editors/code/src/commands/inlay_hints.ts
@@ -25,7 +25,11 @@ export class HintsUpdater {
     public async loadHints(
         editor: vscode.TextEditor | undefined
     ): Promise<void> {
-        if (this.displayHints && editor !== undefined && this.isRustDocument(editor.document)) {
+        if (
+            this.displayHints &&
+            editor !== undefined &&
+            this.isRustDocument(editor.document)
+        ) {
             await this.updateDecorationsFromServer(
                 editor.document.uri.toString(),
                 editor

--- a/editors/code/src/commands/inlay_hints.ts
+++ b/editors/code/src/commands/inlay_hints.ts
@@ -1,0 +1,142 @@
+import * as vscode from 'vscode';
+import { DecorationOptions, Range, TextDocumentChangeEvent, TextDocumentContentChangeEvent, TextEditor } from 'vscode';
+import { TextDocumentIdentifier } from 'vscode-languageclient';
+import { Server } from '../server';
+
+interface InlayHintsParams {
+    textDocument: TextDocumentIdentifier;
+}
+
+interface InlayHint {
+    range: Range,
+    kind: string,
+    label: string,
+}
+
+const typeHintDecorationType = vscode.window.createTextEditorDecorationType({
+    after: {
+        color: new vscode.ThemeColor('ralsp.inlayHint'),
+    },
+});
+
+export class HintsUpdater {
+    private currentDecorations = new Map<string, DecorationOptions[]>();
+    private displayHints = true;
+
+    public async loadHints(editor: vscode.TextEditor | undefined): Promise<void> {
+        if (this.displayHints && editor !== undefined) {
+            await this.updateDecorationsFromServer(editor.document.uri.toString(), editor);
+        }
+    }
+
+    public dropHints(document: vscode.TextDocument) {
+        if (this.displayHints) {
+            this.currentDecorations.delete(document.uri.toString());
+        }
+    }
+
+    public async toggleHintsDisplay(displayHints: boolean): Promise<void> {
+        if (this.displayHints !== displayHints) {
+            this.displayHints = displayHints;
+            this.currentDecorations.clear();
+
+            if (displayHints) {
+                return this.updateHints();
+            } else {
+                const editor = vscode.window.activeTextEditor;
+                if (editor != null) {
+                    return editor.setDecorations(typeHintDecorationType, [])
+                }
+            }
+        }
+    }
+
+    public async updateHints(cause?: TextDocumentChangeEvent): Promise<void> {
+        if (!this.displayHints) {
+            return;
+        }
+        const editor = vscode.window.activeTextEditor;
+        if (editor == null) {
+            return;
+        }
+        const document = cause == null ? editor.document : cause.document;
+        if (document.languageId !== 'rust') {
+            return;
+        }
+
+        const documentUri = document.uri.toString();
+        const documentDecorators = this.currentDecorations.get(documentUri) || [];
+
+        if (documentDecorators.length > 0) {
+            // FIXME a dbg! in the handlers.rs of the server causes
+            // an endless storm of events with `cause.contentChanges` with the dbg messages, why?
+            const changesFromFile = cause !== undefined ? cause.contentChanges.filter(changeEvent => this.isEventInFile(document.lineCount, changeEvent)) : [];
+            if (changesFromFile.length === 0) {
+                return;
+            }
+
+            const firstShiftedLine = this.getFirstShiftedLine(changesFromFile);
+            if (firstShiftedLine !== null) {
+                const unchangedDecorations = documentDecorators.filter(decoration => decoration.range.start.line < firstShiftedLine);
+                if (unchangedDecorations.length !== documentDecorators.length) {
+                    await editor.setDecorations(typeHintDecorationType, unchangedDecorations);
+                }
+            }
+        }
+        return await this.updateDecorationsFromServer(documentUri, editor);
+    }
+
+    private isEventInFile(documentLineCount: number, event: TextDocumentContentChangeEvent): boolean {
+        const eventText = event.text;
+        if (eventText.length === 0) {
+            return event.range.start.line <= documentLineCount || event.range.end.line <= documentLineCount;
+        } else {
+            return event.range.start.line <= documentLineCount && event.range.end.line <= documentLineCount;
+        }
+    }
+
+    private getFirstShiftedLine(changeEvents: TextDocumentContentChangeEvent[]): number | null {
+        let topmostUnshiftedLine: number | null = null;
+
+        changeEvents
+            .filter(event => this.isShiftingChange(event))
+            .forEach(event => {
+                const shiftedLineNumber = event.range.start.line;
+                if (topmostUnshiftedLine === null || topmostUnshiftedLine > shiftedLineNumber) {
+                    topmostUnshiftedLine = shiftedLineNumber;
+                }
+            });
+
+        return topmostUnshiftedLine;
+    }
+
+    private isShiftingChange(event: TextDocumentContentChangeEvent) {
+        const eventText = event.text;
+        if (eventText.length === 0) {
+            return !event.range.isSingleLine;
+        } else {
+            return eventText.indexOf('\n') >= 0 || eventText.indexOf('\r') >= 0;
+        }
+    }
+
+    private async updateDecorationsFromServer(documentUri: string, editor: TextEditor): Promise<void> {
+        const newHints = await this.queryHints(documentUri) || [];
+        const newDecorations = newHints.map(hint => (
+            {
+                range: hint.range,
+                renderOptions: { after: { contentText: `: ${hint.label}` } },
+            }
+        ));
+        this.currentDecorations.set(documentUri, newDecorations);
+        return editor.setDecorations(typeHintDecorationType, newDecorations);
+    }
+
+    private async queryHints(documentUri: string): Promise<InlayHint[] | null> {
+        const request: InlayHintsParams = { textDocument: { uri: documentUri } };
+        const client = Server.client;
+        return client.onReady().then(() => client.sendRequest<InlayHint[] | null>(
+            'rust-analyzer/inlayHints',
+            request
+        ));
+    }
+}

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -21,6 +21,7 @@ export class Config {
     public raLspServerPath = RA_LSP_DEBUG || 'ra_lsp_server';
     public showWorkspaceLoadedNotification = true;
     public lruCapacity: null | number = null;
+    public displayInlayHints = true;
     public cargoWatchOptions: CargoWatchOptions = {
         enableOnStartup: 'ask',
         trace: 'off',
@@ -122,6 +123,10 @@ export class Config {
 
         if (config.has('lruCapacity')) {
             this.lruCapacity = config.get('lruCapacity') as number;
+        }
+
+        if (config.has('displayInlayHints')) {
+            this.displayInlayHints = config.get('displayInlayHints') as boolean;
         }
     }
 }

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -152,9 +152,15 @@ export function activate(context: vscode.ExtensionContext) {
     if (Server.config.displayInlayHints) {
         const hintsUpdater = new HintsUpdater();
         hintsUpdater.loadHints(vscode.window.activeTextEditor).then(() => {
-            vscode.window.onDidChangeActiveTextEditor(editor => hintsUpdater.loadHints(editor));
-            vscode.workspace.onDidChangeTextDocument(e => hintsUpdater.updateHints(e));
-            vscode.workspace.onDidChangeConfiguration(_ => hintsUpdater.toggleHintsDisplay(Server.config.displayInlayHints));
+            vscode.window.onDidChangeActiveTextEditor(editor =>
+                hintsUpdater.loadHints(editor)
+            );
+            vscode.workspace.onDidChangeTextDocument(e =>
+                hintsUpdater.updateHints(e)
+            );
+            vscode.workspace.onDidChangeConfiguration(_ =>
+                hintsUpdater.toggleHintsDisplay(Server.config.displayInlayHints)
+            );
         });
     }
 }

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -152,15 +152,15 @@ export function activate(context: vscode.ExtensionContext) {
     if (Server.config.displayInlayHints) {
         const hintsUpdater = new HintsUpdater();
         hintsUpdater.loadHints(vscode.window.activeTextEditor).then(() => {
-            vscode.window.onDidChangeActiveTextEditor(editor =>
+            disposeOnDeactivation(vscode.window.onDidChangeActiveTextEditor(editor =>
                 hintsUpdater.loadHints(editor)
-            );
-            vscode.workspace.onDidChangeTextDocument(e =>
+            ));
+            disposeOnDeactivation(vscode.workspace.onDidChangeTextDocument(e =>
                 hintsUpdater.updateHints(e)
-            );
-            vscode.workspace.onDidChangeConfiguration(_ =>
+            ));
+            disposeOnDeactivation(vscode.workspace.onDidChangeConfiguration(_ =>
                 hintsUpdater.toggleHintsDisplay(Server.config.displayInlayHints)
-            );
+            ));
         });
     }
 }

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -3,6 +3,7 @@ import * as lc from 'vscode-languageclient';
 
 import * as commands from './commands';
 import { CargoWatchProvider } from './commands/cargo_watch';
+import { HintsUpdater } from './commands/inlay_hints';
 import {
     interactivelyStartCargoWatch,
     startCargoWatch
@@ -147,6 +148,16 @@ export function activate(context: vscode.ExtensionContext) {
 
     // Start the language server, finally!
     startServer();
+
+    if (Server.config.displayInlayHints) {
+        const hintsUpdater = new HintsUpdater();
+        hintsUpdater.loadHints(vscode.window.activeTextEditor).then(() => {
+            vscode.window.onDidChangeActiveTextEditor(editor => hintsUpdater.loadHints(editor));
+            vscode.workspace.onDidChangeTextDocument(e => hintsUpdater.updateHints(e));
+            vscode.workspace.onDidCloseTextDocument(document => hintsUpdater.dropHints(document));
+            vscode.workspace.onDidChangeConfiguration(_ => hintsUpdater.toggleHintsDisplay(Server.config.displayInlayHints));
+        });
+    }
 }
 
 export function deactivate(): Thenable<void> {

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -152,15 +152,23 @@ export function activate(context: vscode.ExtensionContext) {
     if (Server.config.displayInlayHints) {
         const hintsUpdater = new HintsUpdater();
         hintsUpdater.loadHints(vscode.window.activeTextEditor).then(() => {
-            disposeOnDeactivation(vscode.window.onDidChangeActiveTextEditor(editor =>
-                hintsUpdater.loadHints(editor)
-            ));
-            disposeOnDeactivation(vscode.workspace.onDidChangeTextDocument(e =>
-                hintsUpdater.updateHints(e)
-            ));
-            disposeOnDeactivation(vscode.workspace.onDidChangeConfiguration(_ =>
-                hintsUpdater.toggleHintsDisplay(Server.config.displayInlayHints)
-            ));
+            disposeOnDeactivation(
+                vscode.window.onDidChangeActiveTextEditor(editor =>
+                    hintsUpdater.loadHints(editor)
+                )
+            );
+            disposeOnDeactivation(
+                vscode.workspace.onDidChangeTextDocument(e =>
+                    hintsUpdater.updateHints(e)
+                )
+            );
+            disposeOnDeactivation(
+                vscode.workspace.onDidChangeConfiguration(_ =>
+                    hintsUpdater.toggleHintsDisplay(
+                        Server.config.displayInlayHints
+                    )
+                )
+            );
         });
     }
 }

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -154,7 +154,6 @@ export function activate(context: vscode.ExtensionContext) {
         hintsUpdater.loadHints(vscode.window.activeTextEditor).then(() => {
             vscode.window.onDidChangeActiveTextEditor(editor => hintsUpdater.loadHints(editor));
             vscode.workspace.onDidChangeTextDocument(e => hintsUpdater.updateHints(e));
-            vscode.workspace.onDidCloseTextDocument(document => hintsUpdater.dropHints(document));
             vscode.workspace.onDidChangeConfiguration(_ => hintsUpdater.toggleHintsDisplay(Server.config.displayInlayHints));
         });
     }


### PR DESCRIPTION
A follow-up of https://github.com/rust-analyzer/rust-analyzer/pull/1549

Now the frontend shows inlay hints as VS Code Decorators:

<img width="666" alt="image" src="https://user-images.githubusercontent.com/2690773/61802687-918fcc80-ae39-11e9-97b0-3195ab467393.png">
<img width="893" alt="image" src="https://user-images.githubusercontent.com/2690773/61802688-93599000-ae39-11e9-8bcb-4512e22aa3ed.png">

A few notes on the implementation:
* I could not find a normal way to run and display the hints for the file that's already open in the VS Code when it starts.
The updating code runs ok, but does not actually show anything. 
Seems like I miss some event that I could add a handler to.
I've also experimented with `setTimeout` and it worked, but this is too ugly.
The hints appear now when a new file is open or when some change is done in the existing file.

* If there's a `dbg!` used in the lsp_server, the frontend starts receiving change events that contain the string from the `dbg!` output.
It should not be the case in a real life, but I've decided to cover this case, just in case.

* For bigger files, ~500 lines, the decorators start to blink, when updated, this does not seem to be very much of a problem for me at this particular stage of the feature development and can be optimized later. In the worst case, those decorators can be turned off in settings.

* Cursor movement is rather non-intuitive on the right edge of the decorator.
Seems like a thing to fix in the VS Code, not in the plugin.