### PR TITLE
Implement inlay hints for emacs

### DIFF
--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -86,7 +86,7 @@ Installation:
 [ra-emacs-lsp.el](https://github.com/rust-analyzer/rust-analyzer/blob/69ee5c9c5ef212f7911028c9ddf581559e6565c3/editors/emacs/ra-emacs-lsp.el)
 to load path and require it in `init.el`
 * run `lsp` in a rust buffer
-* (Optionally) bind commands like `rust-analyzer-join-lines` or `rust-analyzer-extend-selection` to keys
+* (Optionally) bind commands like `rust-analyzer-join-lines` or `rust-analyzer-extend-selection` to keys, and enable `rust-analyzer-inlay-hints-mode` to get inline type hints
 
 
 ## Vim and NeoVim


### PR DESCRIPTION
I wanted to have the nice type hints in emacs as well :smile: 

![2019-07-27-111718_982x171_scrot](https://user-images.githubusercontent.com/906069/61992560-43104700-b060-11e9-879f-8ad60f71b2e5.png)
