### PR TITLE
Add `if let`, `while let` and match arm inlay hints

### DIFF
--- a/crates/ra_lsp_server/src/main_loop/handlers.rs
+++ b/crates/ra_lsp_server/src/main_loop/handlers.rs
@@ -900,6 +900,9 @@ pub fn handle_inlay_hints(
                 ra_ide_api::InlayKind::ForExpressionBindingType => {
                     InlayKind::ForExpressionBindingType
                 }
+                ra_ide_api::InlayKind::IfExpressionType => InlayKind::IfExpressionType,
+                ra_ide_api::InlayKind::WhileLetExpressionType => InlayKind::WhileLetExpressionType,
+                ra_ide_api::InlayKind::MatchArmType => InlayKind::MatchArmType,
             },
         })
         .collect())

--- a/crates/ra_lsp_server/src/req.rs
+++ b/crates/ra_lsp_server/src/req.rs
@@ -216,6 +216,9 @@ pub enum InlayKind {
     LetBindingType,
     ClosureParameterType,
     ForExpressionBindingType,
+    IfExpressionType,
+    WhileLetExpressionType,
+    MatchArmType,
 }
 
 #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
<img width="693" alt="image" src="https://user-images.githubusercontent.com/2690773/62013363-152f1d80-b19a-11e9-90ea-07568757baa2.png">

Add more inline hints support.
Looks like `while let` type inference support is missing currently, so the corresponding hint tests lack the actual results.

I've also could not find a good way to distinguish between `a` and `b` pats in the following expressions:
`if let Some(Test { a: None, b: y }) = &test {};`

In this case we don't need to add a hint for first pat (`a: None`), since it's matched against the particular enum variant and need a hint for `y`, since it's a new variable.
But both `a` and `b` are `BIND_PAT` with similar contents, so looks like there's nothing I can check for to find any differences.

I don't display any hints for such cases now, to avoid confusion, but would be nice to know if there's a way to fix this behavior.