### PR TITLE
Add explicit newline preserving tests

### DIFF
--- a/crates/ra_lsp_server/src/markdown.rs
+++ b/crates/ra_lsp_server/src/markdown.rs
@@ -48,4 +48,10 @@ mod tests {
         let comment = " # stay1\n# stay2\n#stay3\nstay4\n#\n #\n   #    \n #\tstay5\n\t#\t";
         assert_eq!(format_docs(comment), comment);
     }
+
+    #[test]
+    fn test_format_docs_preserves_newlines() {
+        let comment = "this\nis\nultiline";
+        assert_eq!(format_docs(comment), comment);
+    }
 }

--- a/crates/ra_syntax/src/ast.rs
+++ b/crates/ra_syntax/src/ast.rs
@@ -122,6 +122,23 @@ fn test_doc_comment_preserves_indents() {
 }
 
 #[test]
+fn test_doc_comment_preserves_newlines() {
+    let file = SourceFile::parse(
+        r#"
+        /// this
+        /// is
+        /// mod
+        /// foo
+        mod foo {}
+        "#,
+    )
+    .ok()
+    .unwrap();
+    let module = file.syntax().descendants().find_map(Module::cast).unwrap();
+    assert_eq!("this\nis\nmod\nfoo", module.doc_comment_text().unwrap());
+}
+
+#[test]
 fn test_where_predicates() {
     fn assert_bound(text: &str, bound: Option<TypeBound>) {
         assert_eq!(text, bound.unwrap().syntax().text().to_string());


### PR DESCRIPTION
I didn't see anything that explicitly called this out so added tests.