### PR TITLE
Removes `*/` from block doc comments

### DIFF
--- a/crates/ra_syntax/src/ast.rs
+++ b/crates/ra_syntax/src/ast.rs
@@ -181,10 +181,7 @@ fn test_doc_comment_multi_line_block_strips_suffix() {
     .ok()
     .unwrap();
     let module = file.syntax().descendants().find_map(Module::cast).unwrap();
-    assert_eq!(
-        "        this\n        is\n        mod foo\n       ",
-        module.doc_comment_text().unwrap()
-    );
+    assert_eq!("        this\n        is\n        mod foo", module.doc_comment_text().unwrap());
 }
 
 #[test]

--- a/crates/ra_syntax/src/ast.rs
+++ b/crates/ra_syntax/src/ast.rs
@@ -139,6 +139,55 @@ fn test_doc_comment_preserves_newlines() {
 }
 
 #[test]
+fn test_doc_comment_single_line_block_strips_suffix() {
+    let file = SourceFile::parse(
+        r#"
+        /** this is mod foo*/
+        mod foo {}
+        "#,
+    )
+    .ok()
+    .unwrap();
+    let module = file.syntax().descendants().find_map(Module::cast).unwrap();
+    assert_eq!("this is mod foo", module.doc_comment_text().unwrap());
+}
+
+#[test]
+fn test_doc_comment_single_line_block_strips_suffix_whitespace() {
+    let file = SourceFile::parse(
+        r#"
+        /** this is mod foo */
+        mod foo {}
+        "#,
+    )
+    .ok()
+    .unwrap();
+    let module = file.syntax().descendants().find_map(Module::cast).unwrap();
+    assert_eq!("this is mod foo", module.doc_comment_text().unwrap());
+}
+
+#[test]
+fn test_doc_comment_multi_line_block_strips_suffix() {
+    let file = SourceFile::parse(
+        r#"
+        /**
+        this
+        is
+        mod foo
+        */
+        mod foo {}
+        "#,
+    )
+    .ok()
+    .unwrap();
+    let module = file.syntax().descendants().find_map(Module::cast).unwrap();
+    assert_eq!(
+        "        this\n        is\n        mod foo\n       ",
+        module.doc_comment_text().unwrap()
+    );
+}
+
+#[test]
 fn test_where_predicates() {
     fn assert_bound(text: &str, bound: Option<TypeBound>) {
         assert_eq!(text, bound.unwrap().syntax().text().to_string());

--- a/crates/ra_syntax/src/ast/traits.rs
+++ b/crates/ra_syntax/src/ast/traits.rs
@@ -115,8 +115,8 @@ pub trait DocCommentsOwner: AstNode {
     }
 
     /// Returns the textual content of a doc comment block as a single string.
-    /// That is, strips leading `///` or trailing `*/` (+ optional 1 character of whitespace in either direction)
-    /// and joins lines.
+    /// That is, strips leading `///` (+ optional 1 character of whitespace),
+    /// trailing `*/`, trailing whitespace and then joins the lines.
     fn doc_comment_text(&self) -> Option<String> {
         let mut has_comments = false;
         let docs = self
@@ -137,17 +137,12 @@ pub trait DocCommentsOwner: AstNode {
                     };
 
                 let end = if comment.kind().shape.is_block() && line.ends_with("*/") {
-                    // FIXME: Use `nth_back` here once stable
-                    if line.chars().rev().nth(2).map(|c| c.is_whitespace()).unwrap_or(false) {
-                        line.len() - 3
-                    } else {
-                        line.len() - 2
-                    }
+                    line.len() - 2
                 } else {
                     line.len()
                 };
 
-                line[pos..end].to_owned()
+                line[pos..end].trim_end().to_owned()
             })
             .join("\n");
 


### PR DESCRIPTION
The trailing `/` was annoying me on hover.