### PR TITLE
Implement .await completion for futures

### DIFF
--- a/crates/ra_hir/src/source_binder.rs
+++ b/crates/ra_hir/src/source_binder.rs
@@ -7,6 +7,16 @@
 /// purely for "IDE needs".
 use std::sync::Arc;
 
+use ra_db::{FileId, FilePosition};
+use ra_syntax::{
+    algo::find_node_at_offset,
+    ast::{self, AstNode, NameOwner},
+    AstPtr,
+    SyntaxKind::*,
+    SyntaxNode, SyntaxNodePtr, TextRange, TextUnit,
+};
+use rustc_hash::{FxHashMap, FxHashSet};
+
 use crate::{
     expr::{
         self,
@@ -21,15 +31,6 @@ use crate::{
     MacroDef, Module, ModuleDef, Name, Path, PerNs, Resolution, Resolver, Static, Struct, Trait,
     Ty,
 };
-use ra_db::{FileId, FilePosition};
-use ra_syntax::{
-    algo::find_node_at_offset,
-    ast::{self, AstNode, NameOwner},
-    AstPtr,
-    SyntaxKind::*,
-    SyntaxNode, SyntaxNodePtr, TextRange, TextUnit,
-};
-use rustc_hash::{FxHashMap, FxHashSet};
 
 /// Locates the module by `FileId`. Picks topmost module in the file.
 pub fn module_from_file_id(db: &impl HirDatabase, file_id: FileId) -> Option<Module> {

--- a/crates/ra_hir/src/source_binder.rs
+++ b/crates/ra_hir/src/source_binder.rs
@@ -427,9 +427,7 @@ impl SourceAnalyzer {
 
         let std_future_trait =
             match self.resolver.resolve_path_segments(db, &std_future_path).into_fully_resolved() {
-                PerNs { types: Some(Resolution::Def(ModuleDef::Trait(trait_))), .. } => {
-                    trait_
-                }
+                PerNs { types: Some(Resolution::Def(ModuleDef::Trait(trait_))), .. } => trait_,
                 _ => return false,
             };
 

--- a/crates/ra_hir/src/source_binder.rs
+++ b/crates/ra_hir/src/source_binder.rs
@@ -428,20 +428,18 @@ impl SourceAnalyzer {
         let std_future_trait =
             match self.resolver.resolve_path_segments(db, &std_future_path).into_fully_resolved() {
                 PerNs { types: Some(Resolution::Def(ModuleDef::Trait(trait_))), .. } => {
-                    Some(trait_)
+                    trait_
                 }
-                _ => None,
+                _ => return false,
             };
 
-        let krate = self.resolver.krate();
-        if let Some(krate) = krate {
-            if let Some(trait_) = std_future_trait {
-                let canonical_ty = crate::ty::Canonical { value: ty, num_vars: 0 };
-                return implements_trait(&canonical_ty, db, &self.resolver, krate, trait_);
-            }
-        }
+        let krate = match self.resolver.krate() {
+            Some(krate) => krate,
+            _ => return false,
+        };
 
-        false
+        let canonical_ty = crate::ty::Canonical { value: ty, num_vars: 0 };
+        return implements_trait(&canonical_ty, db, &self.resolver, krate, std_future_trait);
     }
 
     #[cfg(test)]

--- a/crates/ra_hir/src/source_binder.rs
+++ b/crates/ra_hir/src/source_binder.rs
@@ -23,6 +23,7 @@ use crate::{
         scope::{ExprScopes, ScopeId},
         BodySourceMap,
     },
+    ty::method_resolution::implements_trait,
     ids::LocationCtx,
     AsName, AstId, Const, Crate, DefWithBody, Either, Enum, Function, HirDatabase, HirFileId,
     MacroDef, Module, Name, Path, PerNs, Resolver, Static, Struct, Trait, Ty,
@@ -407,6 +408,42 @@ impl SourceAnalyzer {
         // FIXME check that?
         let canonical = crate::ty::Canonical { value: ty, num_vars: 0 };
         crate::ty::autoderef(db, &self.resolver, canonical).map(|canonical| canonical.value)
+    }
+
+    /// Checks that particular type `ty` implements `std::future::Future` trait.
+    /// This function is used in `.await` syntax completion.
+    pub fn impls_future(&self, db: &impl HirDatabase, ty: Ty) -> bool {
+        // Search for std::future::Future trait in scope
+        let future_trait = self.resolver.traits_in_scope(db)
+            .into_iter()
+            .filter(|t| {
+                let std = t.module(db).parent(db)
+                    .and_then(|m| m
+                        .name(db)
+                        .and_then(|n| Some(n.to_string() == "std")))
+                    .unwrap_or(false);
+
+                let future = t.module(db).name(db)
+                    .and_then(|n| Some(n.to_string() == "future"))
+                    .unwrap_or(false);
+
+                let future_trait = t.name(db)
+                    .and_then(|n| Some(n.to_string() == "Future"))
+                    .unwrap_or(false);
+
+                std && future && future_trait
+            })
+            .nth(0);
+
+        if let Some(trait_) = future_trait {
+            let krate = self.resolver.krate();
+            if let Some(krate) = krate {
+                let canonical_ty = crate::ty::Canonical { value: ty, num_vars: 0 };
+                return implements_trait(&canonical_ty, db, &self.resolver, krate, trait_);
+            }
+        }
+
+        false
     }
 
     #[cfg(test)]

--- a/crates/ra_hir/src/source_binder.rs
+++ b/crates/ra_hir/src/source_binder.rs
@@ -439,7 +439,7 @@ impl SourceAnalyzer {
         };
 
         let canonical_ty = crate::ty::Canonical { value: ty, num_vars: 0 };
-        return implements_trait(&canonical_ty, db, &self.resolver, krate, std_future_trait);
+        implements_trait(&canonical_ty, db, &self.resolver, krate, std_future_trait)
     }
 
     #[cfg(test)]

--- a/crates/ra_hir/src/source_binder.rs
+++ b/crates/ra_hir/src/source_binder.rs
@@ -23,8 +23,8 @@ use crate::{
         scope::{ExprScopes, ScopeId},
         BodySourceMap,
     },
-    ty::method_resolution::implements_trait,
     ids::LocationCtx,
+    ty::method_resolution::implements_trait,
     AsName, AstId, Const, Crate, DefWithBody, Either, Enum, Function, HirDatabase, HirFileId,
     MacroDef, Module, Name, Path, PerNs, Resolver, Static, Struct, Trait, Ty,
 };
@@ -414,22 +414,25 @@ impl SourceAnalyzer {
     /// This function is used in `.await` syntax completion.
     pub fn impls_future(&self, db: &impl HirDatabase, ty: Ty) -> bool {
         // Search for std::future::Future trait in scope
-        let future_trait = self.resolver.traits_in_scope(db)
+        let future_trait = self
+            .resolver
+            .traits_in_scope(db)
             .into_iter()
             .filter(|t| {
-                let std = t.module(db).parent(db)
-                    .and_then(|m| m
-                        .name(db)
-                        .and_then(|n| Some(n.to_string() == "std")))
+                let std = t
+                    .module(db)
+                    .parent(db)
+                    .and_then(|m| m.name(db).and_then(|n| Some(n.to_string() == "std")))
                     .unwrap_or(false);
 
-                let future = t.module(db).name(db)
+                let future = t
+                    .module(db)
+                    .name(db)
                     .and_then(|n| Some(n.to_string() == "future"))
                     .unwrap_or(false);
 
-                let future_trait = t.name(db)
-                    .and_then(|n| Some(n.to_string() == "Future"))
-                    .unwrap_or(false);
+                let future_trait =
+                    t.name(db).and_then(|n| Some(n.to_string() == "Future")).unwrap_or(false);
 
                 std && future && future_trait
             })

--- a/crates/ra_hir/src/ty/method_resolution.rs
+++ b/crates/ra_hir/src/ty/method_resolution.rs
@@ -15,7 +15,7 @@ use crate::{
     resolve::Resolver,
     traits::TraitItem,
     ty::primitive::{FloatBitness, UncertainFloatTy, UncertainIntTy},
-    ty::{Ty, TypeCtor},
+    ty::{Ty, TypeCtor, traits::Solution},
     Crate, Function, HirDatabase, Module, Name, Trait,
 };
 
@@ -253,6 +253,20 @@ fn iterate_inherent_methods<T>(
         }
     }
     None
+}
+
+pub(crate) fn implements_trait(ty: &Canonical<Ty>, db: &impl HirDatabase, resolver: &Resolver, krate: Crate, trait_: Trait) -> bool {
+    let env = lower::trait_env(db, resolver);
+    let goal = generic_implements_goal(db, env.clone(), trait_, ty.clone());
+    let solution = db.trait_solve(krate, goal);
+
+    if let Some(solution) = solution {
+        if let Solution::Unique(_) = solution {
+            return true
+        }
+    }
+
+    false
 }
 
 impl Ty {

--- a/crates/ra_hir/src/ty/method_resolution.rs
+++ b/crates/ra_hir/src/ty/method_resolution.rs
@@ -15,7 +15,7 @@ use crate::{
     resolve::Resolver,
     traits::TraitItem,
     ty::primitive::{FloatBitness, UncertainFloatTy, UncertainIntTy},
-    ty::{Ty, TypeCtor, traits::Solution},
+    ty::{traits::Solution, Ty, TypeCtor},
     Crate, Function, HirDatabase, Module, Name, Trait,
 };
 
@@ -255,14 +255,20 @@ fn iterate_inherent_methods<T>(
     None
 }
 
-pub(crate) fn implements_trait(ty: &Canonical<Ty>, db: &impl HirDatabase, resolver: &Resolver, krate: Crate, trait_: Trait) -> bool {
+pub(crate) fn implements_trait(
+    ty: &Canonical<Ty>,
+    db: &impl HirDatabase,
+    resolver: &Resolver,
+    krate: Crate,
+    trait_: Trait,
+) -> bool {
     let env = lower::trait_env(db, resolver);
     let goal = generic_implements_goal(db, env.clone(), trait_, ty.clone());
     let solution = db.trait_solve(krate, goal);
 
     if let Some(solution) = solution {
         if let Solution::Unique(_) = solution {
-            return true
+            return true;
         }
     }
 

--- a/crates/ra_hir/src/ty/method_resolution.rs
+++ b/crates/ra_hir/src/ty/method_resolution.rs
@@ -15,7 +15,7 @@ use crate::{
     resolve::Resolver,
     traits::TraitItem,
     ty::primitive::{FloatBitness, UncertainFloatTy, UncertainIntTy},
-    ty::{traits::Solution, Ty, TypeCtor},
+    ty::{Ty, TypeCtor},
     Crate, Function, HirDatabase, Module, Name, Trait,
 };
 

--- a/crates/ra_hir/src/ty/method_resolution.rs
+++ b/crates/ra_hir/src/ty/method_resolution.rs
@@ -266,13 +266,7 @@ pub(crate) fn implements_trait(
     let goal = generic_implements_goal(db, env.clone(), trait_, ty.clone());
     let solution = db.trait_solve(krate, goal);
 
-    if let Some(solution) = solution {
-        if let Solution::Unique(_) = solution {
-            return true;
-        }
-    }
-
-    false
+    solution.is_some()
 }
 
 impl Ty {

--- a/crates/ra_ide_api/src/completion/complete_dot.rs
+++ b/crates/ra_ide_api/src/completion/complete_dot.rs
@@ -425,28 +425,25 @@ mod tests {
         assert_debug_snapshot_matches!(
         do_completion(
             r###"
-            // Mock Future trait from stdlib
-            pub mod std {
-                pub mod future {
-                    #[lang = "future_trait"]
-                    pub trait Future {}
-                }
-            }
-
+            //- /main.rs
             use std::future::*;
             struct A {}
             impl Future for A {}
-
             fn foo(a: A) {
                 a.<|>
+            }
+
+            //- /std/lib.rs
+            pub mod future {
+                pub trait Future {}
             }
             "###, CompletionKind::Keyword),
         @r###"
        ⋮[
        ⋮    CompletionItem {
        ⋮        label: "await",
-       ⋮        source_range: [358; 358),
-       ⋮        delete: [358; 358),
+       ⋮        source_range: [74; 74),
+       ⋮        delete: [74; 74),
        ⋮        insert: "await",
        ⋮        detail: "expr.await",
        ⋮    },

--- a/crates/ra_ide_api/src/completion/complete_dot.rs
+++ b/crates/ra_ide_api/src/completion/complete_dot.rs
@@ -1,13 +1,10 @@
 use hir::{AdtDef, Ty, TypeCtor};
 
-use crate::completion::completion_item::{Builder, CompletionKind};
+use crate::completion::completion_item::CompletionKind;
 use crate::{
     completion::{completion_context::CompletionContext, completion_item::Completions},
     CompletionItem,
 };
-use ra_syntax::ast::AstNode;
-use ra_syntax::TextRange;
-use ra_text_edit::TextEditBuilder;
 use rustc_hash::FxHashSet;
 
 /// Complete dot accesses, i.e. fields or methods (and .await syntax).

--- a/crates/ra_ide_api/src/completion/complete_dot.rs
+++ b/crates/ra_ide_api/src/completion/complete_dot.rs
@@ -1,14 +1,14 @@
 use hir::{AdtDef, Ty, TypeCtor};
 
-use crate::{completion::{
-    completion_context::CompletionContext,
-    completion_item::Completions,
-}, CompletionItem};
+use crate::completion::completion_item::{Builder, CompletionKind};
+use crate::{
+    completion::{completion_context::CompletionContext, completion_item::Completions},
+    CompletionItem,
+};
 use ra_syntax::ast::AstNode;
+use ra_syntax::TextRange;
 use ra_text_edit::TextEditBuilder;
 use rustc_hash::FxHashSet;
-use crate::completion::completion_item::{Builder, CompletionKind};
-use ra_syntax::TextRange;
 
 /// Applies postfix edition but with CompletionKind::Reference
 fn postfix_reference(ctx: &CompletionContext, label: &str, detail: &str, snippet: &str) -> Builder {

--- a/crates/ra_ide_api/src/completion/complete_dot.rs
+++ b/crates/ra_ide_api/src/completion/complete_dot.rs
@@ -37,7 +37,7 @@ pub(super) fn complete_dot(acc: &mut Completions, ctx: &CompletionContext) {
             }
             complete_methods(acc, ctx, receiver_ty.clone());
 
-            // Suggest .await syntax for types that implement std::future::Future
+            // Suggest .await syntax for types that implement Future trait
             if ctx.analyzer.impls_future(ctx.db, receiver_ty) {
                 postfix_reference(ctx, ".await", "expr.await", &format!("{}.await", receiver_text))
                     .add_to(acc);
@@ -441,9 +441,14 @@ mod tests {
     fn test_completion_await_impls_future() {
         assert_debug_snapshot_matches!(
         do_ref_completion(
-            r"
+            r###"
             // Mock Future trait from stdlib
-            pub mod std { pub mod future { pub trait Future {} } }
+            pub mod std {
+                pub mod future {
+                    #[lang = "future_trait"]
+                    pub trait Future {}
+                }
+            }
 
             use std::future::*;
             struct A {}
@@ -452,13 +457,13 @@ mod tests {
             fn foo(a: A) {
                 a.<|>
             }
-            "),
+            "###),
         @r###"
        ⋮[
        ⋮    CompletionItem {
        ⋮        label: ".await",
-       ⋮        source_range: [249; 249),
-       ⋮        delete: [247; 249),
+       ⋮        source_range: [358; 358),
+       ⋮        delete: [356; 358),
        ⋮        insert: "a.await",
        ⋮        detail: "expr.await",
        ⋮    },


### PR DESCRIPTION
Closes #1263 with completion for `.await` syntax for types that are implementing `std::future::Future` trait.

r? @flodiebold 