### PR TITLE
Optimize parsing a little

### DIFF
--- a/crates/ra_cli/src/analysis_stats.rs
+++ b/crates/ra_cli/src/analysis_stats.rs
@@ -52,6 +52,9 @@ pub fn run(verbose: bool, memory_usage: bool, path: &Path, only: Option<&str>) -
     println!("Total modules found: {}", visited_modules.len());
     println!("Total declarations: {}", num_decls);
     println!("Total functions: {}", funcs.len());
+    println!("Parsing: {:?}, {}", analysis_time.elapsed(), ra_prof::memory_usage());
+
+    let inference_time = Instant::now();
     let bar = indicatif::ProgressBar::with_draw_target(
         funcs.len() as u64,
         indicatif::ProgressDrawTarget::stderr_nohz(),
@@ -112,7 +115,8 @@ pub fn run(verbose: bool, memory_usage: bool, path: &Path, only: Option<&str>) -
         num_exprs_partially_unknown,
         (num_exprs_partially_unknown * 100 / num_exprs)
     );
-    println!("Analysis: {:?}, {}", analysis_time.elapsed(), ra_prof::memory_usage());
+    println!("Inference: {:?}, {}", inference_time.elapsed(), ra_prof::memory_usage());
+    println!("Total: {:?}, {}", analysis_time.elapsed(), ra_prof::memory_usage());
 
     if memory_usage {
         drop(db);

--- a/crates/ra_cli/src/analysis_stats.rs
+++ b/crates/ra_cli/src/analysis_stats.rs
@@ -52,7 +52,7 @@ pub fn run(verbose: bool, memory_usage: bool, path: &Path, only: Option<&str>) -
     println!("Total modules found: {}", visited_modules.len());
     println!("Total declarations: {}", num_decls);
     println!("Total functions: {}", funcs.len());
-    println!("Parsing: {:?}, {}", analysis_time.elapsed(), ra_prof::memory_usage());
+    println!("Item Collection: {:?}, {}", analysis_time.elapsed(), ra_prof::memory_usage());
 
     let inference_time = Instant::now();
     let bar = indicatif::ProgressBar::with_draw_target(


### PR DESCRIPTION
This is the change from https://github.com/rust-analyzer/rust-analyzer/issues/1643#issuecomment-517979911. In the long run we should probably take a different approach, but until then this provides a decent speed-up (10.5s vs 11.5s according to `ra_cli analysis-stats`.

EDIT: Does the profiling part make sense? I'm not sure if all parsing happens before the type inference begins or it's lazy.