### PR TITLE
Improve type hints behavior

### DIFF
--- a/crates/ra_ide_api/src/inlay_hints.rs
+++ b/crates/ra_ide_api/src/inlay_hints.rs
@@ -216,52 +216,52 @@ fn main() {
         assert_debug_snapshot_matches!(analysis.inlay_hints(file_id).unwrap(), @r#"[
     InlayHint {
         range: [193; 197),
-        kind: LetBindingType,
+        kind: TypeHint,
         label: "i32",
     },
     InlayHint {
         range: [236; 244),
-        kind: LetBindingType,
+        kind: TypeHint,
         label: "i32",
     },
     InlayHint {
         range: [275; 279),
-        kind: LetBindingType,
+        kind: TypeHint,
         label: "&str",
     },
     InlayHint {
         range: [539; 543),
-        kind: LetBindingType,
+        kind: TypeHint,
         label: "(i32, char)",
     },
     InlayHint {
         range: [566; 567),
-        kind: LetBindingType,
+        kind: TypeHint,
         label: "i32",
     },
     InlayHint {
         range: [570; 571),
-        kind: LetBindingType,
+        kind: TypeHint,
         label: "i32",
     },
     InlayHint {
         range: [573; 574),
-        kind: LetBindingType,
+        kind: TypeHint,
         label: "i32",
     },
     InlayHint {
         range: [584; 585),
-        kind: LetBindingType,
+        kind: TypeHint,
         label: "i32",
     },
     InlayHint {
         range: [577; 578),
-        kind: LetBindingType,
+        kind: TypeHint,
         label: "f64",
     },
     InlayHint {
         range: [580; 581),
-        kind: LetBindingType,
+        kind: TypeHint,
         label: "f64",
     },
 ]"#
@@ -283,12 +283,12 @@ fn main() {
         assert_debug_snapshot_matches!(analysis.inlay_hints(file_id).unwrap(), @r#"[
     InlayHint {
         range: [21; 30),
-        kind: LetBindingType,
+        kind: TypeHint,
         label: "i32",
     },
     InlayHint {
         range: [57; 66),
-        kind: ClosureParameterType,
+        kind: TypeHint,
         label: "i32",
     },
 ]"#
@@ -310,12 +310,12 @@ fn main() {
         assert_debug_snapshot_matches!(analysis.inlay_hints(file_id).unwrap(), @r#"[
     InlayHint {
         range: [21; 30),
-        kind: LetBindingType,
+        kind: TypeHint,
         label: "i32",
     },
     InlayHint {
         range: [44; 53),
-        kind: ForExpressionBindingType,
+        kind: TypeHint,
         label: "i32",
     },
 ]"#
@@ -356,27 +356,27 @@ fn main() {
         assert_debug_snapshot_matches!(analysis.inlay_hints(file_id).unwrap(), @r#"[
     InlayHint {
         range: [166; 170),
-        kind: LetBindingType,
+        kind: TypeHint,
         label: "CustomOption<Test>",
     },
     InlayHint {
         range: [334; 338),
-        kind: IfExpressionType,
+        kind: TypeHint,
         label: "&Test",
     },
     InlayHint {
         range: [389; 390),
-        kind: IfExpressionType,
+        kind: TypeHint,
         label: "&CustomOption<u32>",
     },
     InlayHint {
         range: [392; 393),
-        kind: IfExpressionType,
+        kind: TypeHint,
         label: "&u8",
     },
     InlayHint {
         range: [531; 532),
-        kind: IfExpressionType,
+        kind: TypeHint,
         label: "&u32",
     },
 ]"#
@@ -417,7 +417,7 @@ fn main() {
         assert_debug_snapshot_matches!(analysis.inlay_hints(file_id).unwrap(), @r#"[
     InlayHint {
         range: [166; 170),
-        kind: LetBindingType,
+        kind: TypeHint,
         label: "CustomOption<Test>",
     },
 ]"#
@@ -457,23 +457,23 @@ fn main() {
 
         assert_debug_snapshot_matches!(analysis.inlay_hints(file_id).unwrap(), @r#"[
     InlayHint {
-        range: [312; 316),
-        kind: MatchArmType,
+        range: [311; 315),
+        kind: TypeHint,
         label: "Test",
     },
     InlayHint {
-        range: [359; 360),
-        kind: MatchArmType,
+        range: [358; 359),
+        kind: TypeHint,
         label: "CustomOption<u32>",
     },
     InlayHint {
-        range: [362; 363),
-        kind: MatchArmType,
+        range: [361; 362),
+        kind: TypeHint,
         label: "u8",
     },
     InlayHint {
-        range: [485; 486),
-        kind: MatchArmType,
+        range: [484; 485),
+        kind: TypeHint,
         label: "u32",
     },
 ]"#

--- a/crates/ra_lsp_server/src/main_loop/handlers.rs
+++ b/crates/ra_lsp_server/src/main_loop/handlers.rs
@@ -894,14 +894,7 @@ pub fn handle_inlay_hints(
             label: api_type.label.to_string(),
             range: api_type.range.conv_with(&line_index),
             kind: match api_type.kind {
-                ra_ide_api::InlayKind::LetBindingType => InlayKind::LetBindingType,
-                ra_ide_api::InlayKind::ClosureParameterType => InlayKind::ClosureParameterType,
-                ra_ide_api::InlayKind::ForExpressionBindingType => {
-                    InlayKind::ForExpressionBindingType
-                }
-                ra_ide_api::InlayKind::IfExpressionType => InlayKind::IfExpressionType,
-                ra_ide_api::InlayKind::WhileLetExpressionType => InlayKind::WhileLetExpressionType,
-                ra_ide_api::InlayKind::MatchArmType => InlayKind::MatchArmType,
+                ra_ide_api::InlayKind::TypeHint => InlayKind::TypeHint,
             },
         })
         .collect())

--- a/crates/ra_lsp_server/src/req.rs
+++ b/crates/ra_lsp_server/src/req.rs
@@ -213,12 +213,7 @@ pub struct InlayHintsParams {
 
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub enum InlayKind {
-    LetBindingType,
-    ClosureParameterType,
-    ForExpressionBindingType,
-    IfExpressionType,
-    WhileLetExpressionType,
-    MatchArmType,
+    TypeHint,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/editors/code/src/commands/inlay_hints.ts
+++ b/editors/code/src/commands/inlay_hints.ts
@@ -27,14 +27,19 @@ export class HintsUpdater {
         if (this.displayHints) {
             const documentUri = this.getEditorDocumentUri(editor);
             if (documentUri !== null) {
-                const latestDecorations = this.drawnDecorations.get(documentUri);
+                const latestDecorations = this.drawnDecorations.get(
+                    documentUri
+                );
                 if (latestDecorations === undefined) {
                     await this.updateDecorationsFromServer(
                         documentUri,
                         editor!
                     );
                 } else {
-                    await editor!.setDecorations(typeHintDecorationType, latestDecorations);
+                    await editor!.setDecorations(
+                        typeHintDecorationType,
+                        latestDecorations
+                    );
                 }
             }
         }
@@ -48,9 +53,12 @@ export class HintsUpdater {
             if (displayHints) {
                 return this.updateHints();
             } else {
-                const editor = vscode.window.activeTextEditor;
-                if (this.getEditorDocumentUri(editor) !== null) {
-                    return editor!.setDecorations(typeHintDecorationType, []);
+                const currentEditor = vscode.window.activeTextEditor;
+                if (this.getEditorDocumentUri(currentEditor) !== null) {
+                    return currentEditor!.setDecorations(
+                        typeHintDecorationType,
+                        []
+                    );
                 }
             }
         }
@@ -92,7 +100,10 @@ export class HintsUpdater {
 
             this.drawnDecorations.set(documentUri, newDecorations);
 
-            if (this.getEditorDocumentUri(vscode.window.activeTextEditor) === documentUri) {
+            if (
+                this.getEditorDocumentUri(vscode.window.activeTextEditor) ===
+                documentUri
+            ) {
                 return editor.setDecorations(
                     typeHintDecorationType,
                     newDecorations


### PR DESCRIPTION
This PR fixed the following type hints issues:

* Restructures the `InlayKind` enum contents based on the discussion here: https://github.com/rust-analyzer/rust-analyzer/pull/1606#issuecomment-515968055
* Races described in #1639 
* Caches the latest decorations received for each file to show them the next time the file is opened (instead of a new server request)