### PR TITLE
Improvements to emacs inlay hints

### DIFF
--- a/editors/emacs/ra-emacs-lsp.el
+++ b/editors/emacs/ra-emacs-lsp.el
@@ -79,6 +79,10 @@
   :ignore-messages nil
   :server-id 'rust-analyzer))
 
+(defun rust-analyzer--initialized? ()
+  (when-let ((workspace (lsp-find-workspace 'rust-analyzer (buffer-file-name))))
+    (eq 'initialized (lsp--workspace-status workspace))))
+
 (with-eval-after-load 'company-lsp
   ;; company-lsp provides a snippet handler for rust by default that adds () after function calls, which RA does better
   (setq company-lsp--snippet-functions (cl-delete "rust" company-lsp--snippet-functions :key #'car :test #'equal)))
@@ -229,21 +233,22 @@
           (pop-to-buffer buf))))))
 
 ;; inlay hints
-(defun rust-analyzer--update-inlay-hints ()
-  (lsp-send-request-async
-   (lsp-make-request "rust-analyzer/inlayHints"
-                     (list :textDocument (lsp--text-document-identifier)))
-   (lambda (res)
-     (remove-overlays (point-min) (point-max) 'rust-analyzer--inlay-hint t)
-     (dolist (hint res)
-       (-let* (((&hash "range" "label" "kind") hint)
-               ((beg . end) (lsp--range-to-region range))
-               (overlay (make-overlay beg end)))
-         (overlay-put overlay 'rust-analyzer--inlay-hint t)
-         (overlay-put overlay 'evaporate t)
-         (overlay-put overlay 'after-string (propertize (concat ": " label)
-                                                        'font-lock-face 'font-lock-comment-face)))))
-   'tick)
+(defun rust-analyzer--update-inlay-hints (buffer)
+  (if (and (rust-analyzer--initialized?) (eq buffer (current-buffer)))
+    (lsp-send-request-async
+     (lsp-make-request "rust-analyzer/inlayHints"
+                       (list :textDocument (lsp--text-document-identifier)))
+     (lambda (res)
+       (remove-overlays (point-min) (point-max) 'rust-analyzer--inlay-hint t)
+       (dolist (hint res)
+         (-let* (((&hash "range" "label" "kind") hint)
+                 ((beg . end) (lsp--range-to-region range))
+                 (overlay (make-overlay beg end)))
+           (overlay-put overlay 'rust-analyzer--inlay-hint t)
+           (overlay-put overlay 'evaporate t)
+           (overlay-put overlay 'after-string (propertize (concat ": " label)
+                                                          'font-lock-face 'font-lock-comment-face)))))
+     'tick))
   nil)
 
 (defvar-local rust-analyzer--inlay-hints-timer nil)
@@ -252,17 +257,19 @@
   (when rust-analyzer--inlay-hints-timer
     (cancel-timer rust-analyzer--inlay-hints-timer))
   (setq rust-analyzer--inlay-hints-timer
-        (run-with-idle-timer 0.1 nil #'rust-analyzer--update-inlay-hints)))
+        (run-with-idle-timer 0.1 nil #'rust-analyzer--update-inlay-hints (current-buffer))))
 
 (define-minor-mode rust-analyzer-inlay-hints-mode
   "Mode for showing inlay hints."
   nil nil nil
   (cond
    (rust-analyzer-inlay-hints-mode
-    (rust-analyzer--update-inlay-hints)
+    (rust-analyzer--update-inlay-hints (current-buffer))
+    (add-hook 'lsp-after-initialize-hook #'rust-analyzer--inlay-hints-change-handler nil t)
     (add-hook 'after-change-functions #'rust-analyzer--inlay-hints-change-handler nil t))
    (t
     (remove-overlays (point-min) (point-max) 'rust-analyzer--inlay-hint t)
+    (remove-hook 'lsp-after-initialize-hook #'rust-analyzer--inlay-hints-change-handler t)
     (remove-hook 'after-change-functions #'rust-analyzer--inlay-hints-change-handler t))))
 
 


### PR DESCRIPTION
 - only send request if workspace is initialized (emacs-lsp doesn't seem to
   prevent sending requests before the initialized notification is sent)
 - check whether we're still in the correct buffer before sending request