### PR TITLE
Drop support for old extendSelection API

### DIFF
--- a/crates/ra_lsp_server/src/main_loop.rs
+++ b/crates/ra_lsp_server/src/main_loop.rs
@@ -346,7 +346,6 @@ fn on_request(
         })?
         .on::<req::AnalyzerStatus>(handlers::handle_analyzer_status)?
         .on::<req::SyntaxTree>(handlers::handle_syntax_tree)?
-        .on::<req::ExtendSelection>(handlers::handle_extend_selection)?
         .on::<req::OnTypeFormatting>(handlers::handle_on_type_formatting)?
         .on::<req::DocumentSymbolRequest>(handlers::handle_document_symbol)?
         .on::<req::WorkspaceSymbol>(handlers::handle_workspace_symbol)?

--- a/crates/ra_lsp_server/src/main_loop/handlers.rs
+++ b/crates/ra_lsp_server/src/main_loop/handlers.rs
@@ -9,7 +9,7 @@ use lsp_types::{
     TextEdit, WorkspaceEdit,
 };
 use ra_ide_api::{
-    AssistId, Cancelable, FileId, FilePosition, FileRange, FoldKind, Query, Runnable, RunnableKind,
+    AssistId, FileId, FilePosition, FileRange, FoldKind, Query, Runnable, RunnableKind,
 };
 use ra_prof::profile;
 use ra_syntax::{AstNode, SyntaxKind, TextRange, TextUnit};
@@ -43,27 +43,6 @@ pub fn handle_syntax_tree(world: WorldSnapshot, params: req::SyntaxTreeParams) -
     let text_range = params.range.map(|p| p.conv_with(&line_index));
     let res = world.analysis().syntax_tree(id, text_range)?;
     Ok(res)
-}
-
-// FIXME: drop this API
-pub fn handle_extend_selection(
-    world: WorldSnapshot,
-    params: req::ExtendSelectionParams,
-) -> Result<req::ExtendSelectionResult> {
-    log::error!(
-        "extend selection is deprecated and will be removed soon,
-         use the new selection range API in LSP",
-    );
-    let file_id = params.text_document.try_conv_with(&world)?;
-    let line_index = world.analysis().file_line_index(file_id)?;
-    let selections = params
-        .selections
-        .into_iter()
-        .map_conv_with(&line_index)
-        .map(|range| FileRange { file_id, range })
-        .map(|frange| world.analysis().extend_selection(frange).map(|it| it.conv_with(&line_index)))
-        .collect::<Cancelable<Vec<_>>>()?;
-    Ok(req::ExtendSelectionResult { selections })
 }
 
 pub fn handle_selection_range(

--- a/crates/ra_lsp_server/src/req.rs
+++ b/crates/ra_lsp_server/src/req.rs
@@ -43,27 +43,6 @@ pub struct SyntaxTreeParams {
     pub range: Option<Range>,
 }
 
-pub enum ExtendSelection {}
-
-impl Request for ExtendSelection {
-    type Params = ExtendSelectionParams;
-    type Result = ExtendSelectionResult;
-    const METHOD: &'static str = "rust-analyzer/extendSelection";
-}
-
-#[derive(Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct ExtendSelectionParams {
-    pub text_document: TextDocumentIdentifier,
-    pub selections: Vec<Range>,
-}
-
-#[derive(Serialize, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct ExtendSelectionResult {
-    pub selections: Vec<Range>,
-}
-
 pub enum SelectionRangeRequest {}
 
 impl Request for SelectionRangeRequest {

--- a/editors/emacs/ra-emacs-lsp.el
+++ b/editors/emacs/ra-emacs-lsp.el
@@ -14,7 +14,7 @@
 ;;    - 'hover' type information & documentation (with lsp-ui)
 ;;  - implements source changes (for code actions etc.), except for file system changes
 ;;  - implements joinLines (you need to bind rust-analyzer-join-lines to a key)
-;;  - implements extendSelection (either bind rust-analyzer-extend-selection to a key, or use expand-region)
+;;  - implements selectionRanges (either bind lsp-extend-selection to a key, or use expand-region)
 ;;  - provides rust-analyzer-inlay-hints-mode for inline type hints
 
 ;; What's missing:
@@ -103,39 +103,13 @@
                                        (rust-analyzer--join-lines-params)))
    (rust-analyzer--apply-source-change)))
 
-;; extend selection
-
-(defun rust-analyzer-extend-selection ()
-  (interactive)
-  (-let (((&hash "start" "end") (rust-analyzer--extend-selection)))
-    (rust-analyzer--goto-lsp-loc start)
-    (set-mark (point))
-    (rust-analyzer--goto-lsp-loc end)
-    (exchange-point-and-mark)))
-
-(defun rust-analyzer--extend-selection-params ()
-  "Extend selection params."
-  (list :textDocument (lsp--text-document-identifier)
-        :selections
-        (vector
-         (if (use-region-p)
-             (lsp--region-to-range (region-beginning) (region-end))
-           (lsp--region-to-range (point) (point))))))
-
-(defun rust-analyzer--extend-selection ()
-  (->
-   (lsp-send-request
-    (lsp-make-request
-     "rust-analyzer/extendSelection"
-     (rust-analyzer--extend-selection-params)))
-   (ht-get "selections")
-   (seq-first)))
+;; selection ranges
 
 (defun rust-analyzer--add-er-expansion ()
   (make-variable-buffer-local 'er/try-expand-list)
   (setq er/try-expand-list (append
                             er/try-expand-list
-                            '(rust-analyzer-extend-selection))))
+                            '(lsp-extend-selection))))
 
 (with-eval-after-load 'expand-region
   ;; add the expansion for all existing rust-mode buffers. If expand-region is


### PR DESCRIPTION
Emacs now handles this via native LSP request

https://github.com/emacs-lsp/lsp-mode/commit/dc86bbb227147aa8141e690ad5648fdbd2ebdb9f

r? @flodiebold 

(Have not actually tried elisp code)