### PR TITLE
fix #1424

### DIFF
--- a/editors/code/src/server.ts
+++ b/editors/code/src/server.ts
@@ -1,8 +1,16 @@
+import { homedir } from 'os';
 import * as lc from 'vscode-languageclient';
 
 import { window, workspace } from 'vscode';
 import { Config } from './config';
 import { Highlighter } from './highlighting';
+
+function expandPathResolving(path: string) {
+    if (path.startsWith('~/')) {
+        return path.replace('~', homedir());
+    }
+    return path;
+}
 
 export class Server {
     public static highlighter = new Highlighter();
@@ -20,7 +28,7 @@ export class Server {
         }
 
         const run: lc.Executable = {
-            command: this.config.raLspServerPath,
+            command: expandPathResolving(this.config.raLspServerPath),
             options: { cwd: folder }
         };
         const serverOptions: lc.ServerOptions = {


### PR DESCRIPTION
- resolve "~" in raLspServerPath

I think expanding simply `~/` is quite simple as node provides `homedir`, but expanding `~foo/` is difficult as there is no cross-platform approach of reading home directory of another user. So this pull request only resolves `~/` in `raLspServerPath`.

Besides, the source code is arranged in a way hard to write tests. Would anyone provide me with instructions of writing tests for this feature, or no test is required for this feature?