### PR TITLE
Fix syntax-highlighting for fields (`NAMED_FIELD_DEF`)

### DIFF
--- a/crates/ra_ide_api/src/snapshots/highlighting.html
+++ b/crates/ra_ide_api/src/snapshots/highlighting.html
@@ -21,8 +21,8 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 </style>
 <pre><code><span class="attribute">#</span><span class="attribute">[</span><span class="attribute">derive</span><span class="attribute">(</span><span class="attribute">Clone</span><span class="attribute">,</span><span class="attribute"> </span><span class="attribute">Debug</span><span class="attribute">)</span><span class="attribute">]</span>
 <span class="keyword">struct</span> <span class="type">Foo</span> {
-    <span class="keyword">pub</span> <span class="function">x</span>: <span class="type">i32</span>,
-    <span class="keyword">pub</span> <span class="function">y</span>: <span class="type">i32</span>,
+    <span class="keyword">pub</span> <span class="field">x</span>: <span class="type">i32</span>,
+    <span class="keyword">pub</span> <span class="field">y</span>: <span class="type">i32</span>,
 }
 
 <span class="keyword">fn</span> <span class="function">foo</span>&lt;<span class="type">T</span>&gt;() -&gt; <span class="type">T</span> {

--- a/crates/ra_ide_api/src/syntax_highlighting.rs
+++ b/crates/ra_ide_api/src/syntax_highlighting.rs
@@ -158,21 +158,17 @@ pub(crate) fn highlight(db: &RootDatabase, file_id: FileId) -> Vec<HighlightedRa
                         } else {
                             "variable"
                         }
-                    } else if name
-                        .syntax()
-                        .parent()
-                        .map(|x| {
-                            x.kind() == TYPE_PARAM
-                                || x.kind() == STRUCT_DEF
-                                || x.kind() == ENUM_DEF
-                                || x.kind() == TRAIT_DEF
-                                || x.kind() == TYPE_ALIAS_DEF
-                        })
-                        .unwrap_or(false)
-                    {
-                        "type"
                     } else {
-                        "function"
+                        name.syntax()
+                            .parent()
+                            .map(|x| match x.kind() {
+                                TYPE_PARAM | STRUCT_DEF | ENUM_DEF | TRAIT_DEF | TYPE_ALIAS_DEF => {
+                                    "type"
+                                }
+                                NAMED_FIELD_DEF => "field",
+                                _ => "function",
+                            })
+                            .unwrap_or("function")
                     }
                 } else {
                     "text"


### PR DESCRIPTION
Before:

`ralsp.function: "#ff0000"`

![image](https://user-images.githubusercontent.com/5961244/63473802-13920600-c477-11e9-93df-67c04fc67636.png)

After:

`ralsp.field: "#9cdcfe"`

![image](https://user-images.githubusercontent.com/5961244/63473976-a894ff00-c477-11e9-8731-269a4c942e05.png)

