### PR TITLE
Impl/dyn trait

### DIFF
--- a/crates/ra_hir/src/ty.rs
+++ b/crates/ra_hir/src/ty.rs
@@ -161,13 +161,27 @@ pub enum Ty {
         name: Name,
     },
 
-    /// A bound type variable. Only used during trait resolution to represent
-    /// Chalk variables.
+    /// A bound type variable. Used during trait resolution to represent Chalk
+    /// variables, and in `Dyn` and `Opaque` bounds to represent the `Self` type.
     Bound(u32),
 
     /// A type variable used during type checking. Not to be confused with a
     /// type parameter.
     Infer(InferTy),
+
+    /// A trait object (`dyn Trait` or bare `Trait` in pre-2018 Rust).
+    ///
+    /// The predicates are quantified over the `Self` type, i.e. `Ty::Bound(0)`
+    /// represents the `Self` type inside the bounds. This is currently
+    /// implicit; Chalk has the `Binders` struct to make it explicit, but it
+    /// didn't seem worth the overhead yet.
+    Dyn(Arc<[GenericPredicate]>),
+
+    /// An opaque type (`impl Trait`).
+    ///
+    /// The predicates are quantified over the `Self` type; see `Ty::Dyn` for
+    /// more.
+    Opaque(Arc<[GenericPredicate]>),
 
     /// A placeholder for a type which could not be computed; this is propagated
     /// to avoid useless error messages. Doubles as a placeholder where type
@@ -192,6 +206,12 @@ impl Substs {
 
     pub fn prefix(&self, n: usize) -> Substs {
         Substs(self.0.iter().cloned().take(n).collect::<Vec<_>>().into())
+    }
+
+    pub fn walk(&self, f: &mut impl FnMut(&Ty)) {
+        for t in self.0.iter() {
+            t.walk(f);
+        }
     }
 
     pub fn walk_mut(&mut self, f: &mut impl FnMut(&mut Ty)) {
@@ -270,6 +290,14 @@ impl TraitRef {
         });
         self
     }
+
+    pub fn walk(&self, f: &mut impl FnMut(&Ty)) {
+        self.substs.walk(f);
+    }
+
+    pub fn walk_mut(&mut self, f: &mut impl FnMut(&mut Ty)) {
+        self.substs.walk_mut(f);
+    }
 }
 
 /// Like `generics::WherePredicate`, but with resolved types: A condition on the
@@ -297,6 +325,20 @@ impl GenericPredicate {
                 GenericPredicate::Implemented(trait_ref.subst(substs))
             }
             GenericPredicate::Error => self,
+        }
+    }
+
+    pub fn walk(&self, f: &mut impl FnMut(&Ty)) {
+        match self {
+            GenericPredicate::Implemented(trait_ref) => trait_ref.walk(f),
+            GenericPredicate::Error => {}
+        }
+    }
+
+    pub fn walk_mut(&mut self, f: &mut impl FnMut(&mut Ty)) {
+        match self {
+            GenericPredicate::Implemented(trait_ref) => trait_ref.walk_mut(f),
+            GenericPredicate::Error => {}
         }
     }
 }
@@ -386,6 +428,11 @@ impl Ty {
                     t.walk(f);
                 }
             }
+            Ty::Dyn(predicates) | Ty::Opaque(predicates) => {
+                for p in predicates.iter() {
+                    p.walk(f);
+                }
+            }
             Ty::Param { .. } | Ty::Bound(_) | Ty::Infer(_) | Ty::Unknown => {}
         }
         f(self);
@@ -401,6 +448,13 @@ impl Ty {
             }
             Ty::UnselectedProjection(p_ty) => {
                 p_ty.parameters.walk_mut(f);
+            }
+            Ty::Dyn(predicates) | Ty::Opaque(predicates) => {
+                let mut v: Vec<_> = predicates.iter().cloned().collect();
+                for p in &mut v {
+                    p.walk_mut(f);
+                }
+                *predicates = v.into();
             }
             Ty::Param { .. } | Ty::Bound(_) | Ty::Infer(_) | Ty::Unknown => {}
         }
@@ -669,6 +723,28 @@ impl HirDisplay for Ty {
             Ty::UnselectedProjection(p_ty) => p_ty.hir_fmt(f)?,
             Ty::Param { name, .. } => write!(f, "{}", name)?,
             Ty::Bound(idx) => write!(f, "?{}", idx)?,
+            Ty::Dyn(predicates) | Ty::Opaque(predicates) => {
+                match self {
+                    Ty::Dyn(_) => write!(f, "dyn ")?,
+                    Ty::Opaque(_) => write!(f, "impl ")?,
+                    _ => unreachable!(),
+                };
+                // looping by hand here just to format the bounds in a slightly nicer way
+                let mut first = true;
+                for p in predicates.iter() {
+                    if !first {
+                        write!(f, " + ")?;
+                    }
+                    first = false;
+                    match p {
+                        // don't show the $0 self type
+                        GenericPredicate::Implemented(trait_ref) => {
+                            trait_ref.hir_fmt_ext(f, false)?
+                        }
+                        GenericPredicate::Error => p.hir_fmt(f)?,
+                    }
+                }
+            }
             Ty::Unknown => write!(f, "{{unknown}}")?,
             Ty::Infer(..) => write!(f, "_")?,
         }
@@ -676,18 +752,42 @@ impl HirDisplay for Ty {
     }
 }
 
-impl HirDisplay for TraitRef {
-    fn hir_fmt(&self, f: &mut HirFormatter<impl HirDatabase>) -> fmt::Result {
-        write!(
-            f,
-            "{}: {}",
-            self.substs[0].display(f.db),
-            self.trait_.name(f.db).unwrap_or_else(Name::missing)
-        )?;
+impl TraitRef {
+    fn hir_fmt_ext(
+        &self,
+        f: &mut HirFormatter<impl HirDatabase>,
+        with_self_ty: bool,
+    ) -> fmt::Result {
+        if with_self_ty {
+            write!(f, "{}: ", self.substs[0].display(f.db),)?;
+        }
+        write!(f, "{}", self.trait_.name(f.db).unwrap_or_else(Name::missing))?;
         if self.substs.len() > 1 {
             write!(f, "<")?;
             f.write_joined(&self.substs[1..], ", ")?;
             write!(f, ">")?;
+        }
+        Ok(())
+    }
+}
+
+impl HirDisplay for TraitRef {
+    fn hir_fmt(&self, f: &mut HirFormatter<impl HirDatabase>) -> fmt::Result {
+        self.hir_fmt_ext(f, true)
+    }
+}
+
+impl HirDisplay for &GenericPredicate {
+    fn hir_fmt(&self, f: &mut HirFormatter<impl HirDatabase>) -> fmt::Result {
+        HirDisplay::hir_fmt(*self, f)
+    }
+}
+
+impl HirDisplay for GenericPredicate {
+    fn hir_fmt(&self, f: &mut HirFormatter<impl HirDatabase>) -> fmt::Result {
+        match self {
+            GenericPredicate::Implemented(trait_ref) => trait_ref.hir_fmt(f)?,
+            GenericPredicate::Error => write!(f, "{{error}}")?,
         }
         Ok(())
     }

--- a/crates/ra_hir/src/ty.rs
+++ b/crates/ra_hir/src/ty.rs
@@ -583,6 +583,19 @@ impl Ty {
             ty => ty,
         })
     }
+
+    /// If this is an `impl Trait` or `dyn Trait`, returns that trait.
+    pub fn inherent_trait(&self) -> Option<Trait> {
+        match self {
+            Ty::Dyn(predicates) | Ty::Opaque(predicates) => {
+                predicates.iter().find_map(|pred| match pred {
+                    GenericPredicate::Implemented(tr) => Some(tr.trait_),
+                    _ => None,
+                })
+            }
+            _ => None,
+        }
+    }
 }
 
 impl HirDisplay for &Ty {

--- a/crates/ra_hir/src/ty/tests.rs
+++ b/crates/ra_hir/src/ty/tests.rs
@@ -3279,6 +3279,7 @@ fn impl_trait() {
         infer(r#"
 trait Trait<T> {
     fn foo(&self) -> T;
+    fn foo2(&self) -> i64;
 }
 fn bar() -> impl Trait<u64> {}
 
@@ -3289,26 +3290,36 @@ fn test(x: impl Trait<u64>, y: &impl Trait<u64>) {
     x.foo();
     y.foo();
     z.foo();
+    x.foo2();
+    y.foo2();
+    z.foo2();
 }
 "#),
         @r###"
    ⋮
    ⋮[30; 34) 'self': &Self
-   ⋮[72; 74) '{}': ()
-   ⋮[84; 85) 'x': impl Trait<u64>
-   ⋮[104; 105) 'y': &impl Trait<u64>
-   ⋮[125; 200) '{     ...o(); }': ()
-   ⋮[131; 132) 'x': impl Trait<u64>
-   ⋮[138; 139) 'y': &impl Trait<u64>
-   ⋮[149; 150) 'z': impl Trait<u64>
-   ⋮[153; 156) 'bar': fn bar() -> impl Trait<u64>
-   ⋮[153; 158) 'bar()': impl Trait<u64>
-   ⋮[164; 165) 'x': impl Trait<u64>
-   ⋮[164; 171) 'x.foo()': {unknown}
-   ⋮[177; 178) 'y': &impl Trait<u64>
-   ⋮[177; 184) 'y.foo()': {unknown}
-   ⋮[190; 191) 'z': impl Trait<u64>
-   ⋮[190; 197) 'z.foo()': {unknown}
+   ⋮[55; 59) 'self': &Self
+   ⋮[99; 101) '{}': ()
+   ⋮[111; 112) 'x': impl Trait<u64>
+   ⋮[131; 132) 'y': &impl Trait<u64>
+   ⋮[152; 269) '{     ...2(); }': ()
+   ⋮[158; 159) 'x': impl Trait<u64>
+   ⋮[165; 166) 'y': &impl Trait<u64>
+   ⋮[176; 177) 'z': impl Trait<u64>
+   ⋮[180; 183) 'bar': fn bar() -> impl Trait<u64>
+   ⋮[180; 185) 'bar()': impl Trait<u64>
+   ⋮[191; 192) 'x': impl Trait<u64>
+   ⋮[191; 198) 'x.foo()': {unknown}
+   ⋮[204; 205) 'y': &impl Trait<u64>
+   ⋮[204; 211) 'y.foo()': {unknown}
+   ⋮[217; 218) 'z': impl Trait<u64>
+   ⋮[217; 224) 'z.foo()': {unknown}
+   ⋮[230; 231) 'x': impl Trait<u64>
+   ⋮[230; 238) 'x.foo2()': i64
+   ⋮[244; 245) 'y': &impl Trait<u64>
+   ⋮[244; 252) 'y.foo2()': i64
+   ⋮[258; 259) 'z': impl Trait<u64>
+   ⋮[258; 266) 'z.foo2()': i64
     "###
     );
 }
@@ -3319,6 +3330,7 @@ fn dyn_trait() {
         infer(r#"
 trait Trait<T> {
     fn foo(&self) -> T;
+    fn foo2(&self) -> i64;
 }
 fn bar() -> dyn Trait<u64> {}
 
@@ -3329,26 +3341,36 @@ fn test(x: dyn Trait<u64>, y: &dyn Trait<u64>) {
     x.foo();
     y.foo();
     z.foo();
+    x.foo2();
+    y.foo2();
+    z.foo2();
 }
 "#),
         @r###"
    ⋮
    ⋮[30; 34) 'self': &Self
-   ⋮[71; 73) '{}': ()
-   ⋮[83; 84) 'x': dyn Trait<u64>
-   ⋮[102; 103) 'y': &dyn Trait<u64>
-   ⋮[122; 197) '{     ...o(); }': ()
-   ⋮[128; 129) 'x': dyn Trait<u64>
-   ⋮[135; 136) 'y': &dyn Trait<u64>
-   ⋮[146; 147) 'z': dyn Trait<u64>
-   ⋮[150; 153) 'bar': fn bar() -> dyn Trait<u64>
-   ⋮[150; 155) 'bar()': dyn Trait<u64>
-   ⋮[161; 162) 'x': dyn Trait<u64>
-   ⋮[161; 168) 'x.foo()': {unknown}
-   ⋮[174; 175) 'y': &dyn Trait<u64>
-   ⋮[174; 181) 'y.foo()': {unknown}
-   ⋮[187; 188) 'z': dyn Trait<u64>
-   ⋮[187; 194) 'z.foo()': {unknown}
+   ⋮[55; 59) 'self': &Self
+   ⋮[98; 100) '{}': ()
+   ⋮[110; 111) 'x': dyn Trait<u64>
+   ⋮[129; 130) 'y': &dyn Trait<u64>
+   ⋮[149; 266) '{     ...2(); }': ()
+   ⋮[155; 156) 'x': dyn Trait<u64>
+   ⋮[162; 163) 'y': &dyn Trait<u64>
+   ⋮[173; 174) 'z': dyn Trait<u64>
+   ⋮[177; 180) 'bar': fn bar() -> dyn Trait<u64>
+   ⋮[177; 182) 'bar()': dyn Trait<u64>
+   ⋮[188; 189) 'x': dyn Trait<u64>
+   ⋮[188; 195) 'x.foo()': {unknown}
+   ⋮[201; 202) 'y': &dyn Trait<u64>
+   ⋮[201; 208) 'y.foo()': {unknown}
+   ⋮[214; 215) 'z': dyn Trait<u64>
+   ⋮[214; 221) 'z.foo()': {unknown}
+   ⋮[227; 228) 'x': dyn Trait<u64>
+   ⋮[227; 235) 'x.foo2()': i64
+   ⋮[241; 242) 'y': &dyn Trait<u64>
+   ⋮[241; 249) 'y.foo2()': i64
+   ⋮[255; 256) 'z': dyn Trait<u64>
+   ⋮[255; 263) 'z.foo2()': i64
     "###
     );
 }

--- a/crates/ra_hir/src/ty/traits/chalk.rs
+++ b/crates/ra_hir/src/ty/traits/chalk.rs
@@ -80,7 +80,9 @@ impl ToChalk for Ty {
             // FIXME this is clearly incorrect, but probably not too incorrect
             // and I'm not sure what to actually do with Ty::Unknown
             // maybe an alternative would be `for<T> T`? (meaningless in rust, but expressible in chalk's Ty)
-            Ty::Unknown => {
+            //
+            // FIXME also dyn and impl Trait are currently handled like Unknown because Chalk doesn't have them yet
+            Ty::Unknown | Ty::Dyn(_) | Ty::Opaque(_) => {
                 PlaceholderIndex { ui: UniverseIndex::ROOT, idx: usize::max_value() }.to_ty()
             }
         }

--- a/crates/ra_hir/src/type_ref.rs
+++ b/crates/ra_hir/src/type_ref.rs
@@ -136,7 +136,7 @@ pub(crate) fn type_bounds_from_ast(type_bounds_opt: Option<ast::TypeBoundList>) 
 impl TypeBound {
     pub(crate) fn from_ast(node: ast::TypeBound) -> Self {
         match node.kind() {
-            Some(ast::TypeBoundKind::PathType(path_type)) => {
+            ast::TypeBoundKind::PathType(path_type) => {
                 let path = match path_type.path() {
                     Some(p) => p,
                     None => return TypeBound::Error,
@@ -147,9 +147,7 @@ impl TypeBound {
                 };
                 TypeBound::Path(path)
             }
-            Some(ast::TypeBoundKind::ForType(_)) | Some(ast::TypeBoundKind::Lifetime(_)) | None => {
-                TypeBound::Error
-            }
+            ast::TypeBoundKind::ForType(_) | ast::TypeBoundKind::Lifetime(_) => TypeBound::Error,
         }
     }
 }

--- a/crates/ra_hir/src/type_ref.rs
+++ b/crates/ra_hir/src/type_ref.rs
@@ -1,7 +1,7 @@
 //! HIR for references to types. Paths in these are not yet resolved. They can
 //! be directly created from an ast::TypeRef, without further queries.
 
-use ra_syntax::ast::{self, TypeAscriptionOwner};
+use ra_syntax::ast::{self, TypeAscriptionOwner, TypeBoundsOwner};
 
 use crate::Path;
 
@@ -49,8 +49,16 @@ pub enum TypeRef {
     /// A fn pointer. Last element of the vector is the return type.
     Fn(Vec<TypeRef>),
     // For
-    // ImplTrait,
-    // DynTrait,
+    ImplTrait(Vec<TypeBound>),
+    DynTrait(Vec<TypeBound>),
+    Error,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub enum TypeBound {
+    Path(Path),
+    // also for<> bounds
+    // also Lifetimes
     Error,
 }
 
@@ -95,8 +103,12 @@ impl TypeRef {
             }
             // for types are close enough for our purposes to the inner type for now...
             ast::TypeRef::ForType(inner) => TypeRef::from_ast_opt(inner.type_ref()),
-            ast::TypeRef::ImplTraitType(_inner) => TypeRef::Error,
-            ast::TypeRef::DynTraitType(_inner) => TypeRef::Error,
+            ast::TypeRef::ImplTraitType(inner) => {
+                TypeRef::ImplTrait(type_bounds_from_ast(inner.type_bound_list()))
+            }
+            ast::TypeRef::DynTraitType(inner) => {
+                TypeRef::DynTrait(type_bounds_from_ast(inner.type_bound_list()))
+            }
         }
     }
 
@@ -110,5 +122,34 @@ impl TypeRef {
 
     pub fn unit() -> TypeRef {
         TypeRef::Tuple(Vec::new())
+    }
+}
+
+pub(crate) fn type_bounds_from_ast(type_bounds_opt: Option<ast::TypeBoundList>) -> Vec<TypeBound> {
+    if let Some(type_bounds) = type_bounds_opt {
+        type_bounds.bounds().map(TypeBound::from_ast).collect()
+    } else {
+        vec![]
+    }
+}
+
+impl TypeBound {
+    pub(crate) fn from_ast(node: ast::TypeBound) -> Self {
+        match node.kind() {
+            Some(ast::TypeBoundKind::PathType(path_type)) => {
+                let path = match path_type.path() {
+                    Some(p) => p,
+                    None => return TypeBound::Error,
+                };
+                let path = match Path::from_ast(path) {
+                    Some(p) => p,
+                    None => return TypeBound::Error,
+                };
+                TypeBound::Path(path)
+            }
+            Some(ast::TypeBoundKind::ForType(_)) | Some(ast::TypeBoundKind::Lifetime(_)) | None => {
+                TypeBound::Error
+            }
+        }
     }
 }

--- a/crates/ra_syntax/src/ast.rs
+++ b/crates/ra_syntax/src/ast.rs
@@ -15,7 +15,7 @@ use crate::{
 
 pub use self::{
     expr_extensions::{ArrayExprKind, BinOp, ElseBranch, LiteralKind, PrefixOp},
-    extensions::{FieldKind, PathSegmentKind, SelfParamKind, StructKind},
+    extensions::{FieldKind, PathSegmentKind, SelfParamKind, StructKind, TypeBoundKind},
     generated::*,
     tokens::*,
     traits::*,

--- a/crates/ra_syntax/src/ast/extensions.rs
+++ b/crates/ra_syntax/src/ast/extensions.rs
@@ -399,3 +399,29 @@ impl ast::TraitDef {
         self.syntax().children_with_tokens().any(|t| t.kind() == T![auto])
     }
 }
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum TypeBoundKind {
+    /// Trait
+    PathType(ast::PathType),
+    /// for<'a> ...
+    ForType(ast::ForType),
+    /// 'a
+    Lifetime(ast::SyntaxToken),
+}
+
+impl ast::TypeBound {
+    pub fn kind(&self) -> Option<TypeBoundKind> {
+        let child = self.syntax.first_child_or_token()?;
+        match child.kind() {
+            PATH_TYPE => Some(TypeBoundKind::PathType(
+                ast::PathType::cast(child.into_node().unwrap()).unwrap(),
+            )),
+            FOR_TYPE => Some(TypeBoundKind::ForType(
+                ast::ForType::cast(child.into_node().unwrap()).unwrap(),
+            )),
+            LIFETIME => Some(TypeBoundKind::Lifetime(child.into_token().unwrap())),
+            _ => unreachable!(),
+        }
+    }
+}


### PR DESCRIPTION
This adds support for `impl Trait` and `dyn Trait` types as far as possible without Chalk. So we can represent them in the type system, and handle them in method resolution, but Chalk doesn't know about them yet. There's a small temporary hack here where we bypass Chalk during method resolution, so we can handle simple method calls on them and completion works.

Fixes #1608.