### PR TITLE
Parse arbitrarily complex `box` patterns.

### DIFF
--- a/crates/ra_hir/src/expr.rs
+++ b/crates/ra_hir/src/expr.rs
@@ -1020,6 +1020,7 @@ where
             }
 
             // FIXME: implement
+            ast::Pat::BoxPat(_) => Pat::Missing,
             ast::Pat::LiteralPat(_) => Pat::Missing,
             ast::Pat::SlicePat(_) | ast::Pat::RangePat(_) => Pat::Missing,
         };

--- a/crates/ra_parser/src/grammar/expressions/atom.rs
+++ b/crates/ra_parser/src/grammar/expressions/atom.rs
@@ -414,8 +414,6 @@ pub(crate) fn match_arm_list(p: &mut Parser) {
 //         X | Y if Z => (),
 //         | X | Y if Z => (),
 //         | X => (),
-//         box X => (),
-//         Some(box X) => (),
 //     };
 // }
 fn match_arm(p: &mut Parser) -> BlockLike {

--- a/crates/ra_parser/src/grammar/patterns.rs
+++ b/crates/ra_parser/src/grammar/patterns.rs
@@ -56,37 +56,33 @@ const PAT_RECOVERY_SET: TokenSet =
     token_set![LET_KW, IF_KW, WHILE_KW, LOOP_KW, MATCH_KW, R_PAREN, COMMA];
 
 fn atom_pat(p: &mut Parser, recovery_set: TokenSet) -> Option<CompletedMarker> {
-    let la0 = p.nth(0);
-    let la1 = p.nth(1);
-    if la0 == T![ref]
-        || la0 == T![mut]
-        || la0 == T![box]
-        || (la0 == IDENT && !(la1 == T![::] || la1 == T!['('] || la1 == T!['{'] || la1 == T![!]))
-    {
-        return Some(bind_pat(p, true));
-    }
-    if paths::is_use_path_start(p) {
-        return Some(path_pat(p));
-    }
+    // Checks the token after an IDENT to see if a pattern is a path (Struct { .. }) or macro
+    // (T![x]).
+    let is_path_or_macro_pat =
+        |la1| la1 == T![::] || la1 == T!['('] || la1 == T!['{'] || la1 == T![!];
 
-    if is_literal_pat_start(p) {
-        return Some(literal_pat(p));
-    }
+    let m = match p.nth(0) {
+        T![box] => box_pat(p),
+        T![ref] | T![mut] | IDENT if !is_path_or_macro_pat(p.nth(1)) => bind_pat(p, true),
 
-    let m = match la0 {
+        _ if paths::is_use_path_start(p) => path_pat(p),
+        _ if is_literal_pat_start(p) => literal_pat(p),
+
         T![_] => placeholder_pat(p),
         T![&] => ref_pat(p),
         T!['('] => tuple_pat(p),
         T!['['] => slice_pat(p),
+
         _ => {
             p.err_recover("expected pattern", recovery_set);
             return None;
         }
     };
+
     Some(m)
 }
 
-fn is_literal_pat_start(p: &mut Parser) -> bool {
+fn is_literal_pat_start(p: &Parser) -> bool {
     p.at(T![-]) && (p.nth(1) == INT_NUMBER || p.nth(1) == FLOAT_NUMBER)
         || p.at_ts(expressions::LITERAL_FIRST)
 }
@@ -261,11 +257,9 @@ fn pat_list(p: &mut Parser, ket: SyntaxKind) {
 //     let ref mut d = ();
 //     let e @ _ = ();
 //     let ref mut f @ g @ _ = ();
-//     let box i = Box::new(1i32);
 // }
 fn bind_pat(p: &mut Parser, with_at: bool) -> CompletedMarker {
     let m = p.start();
-    p.eat(T![box]);
     p.eat(T![ref]);
     p.eat(T![mut]);
     name(p);
@@ -273,4 +267,23 @@ fn bind_pat(p: &mut Parser, with_at: bool) -> CompletedMarker {
         pattern(p);
     }
     m.complete(p, BIND_PAT)
+}
+
+// test_err ref_box_pat
+// fn main() {
+//     let ref box i = ();
+// }
+
+// test box_pat
+// fn main() {
+//     let box i = ();
+//     let box Outer { box i, j: box Inner(box &x) } = ();
+//     let box ref mut i = ();
+// }
+fn box_pat(p: &mut Parser) -> CompletedMarker {
+    assert!(p.at(T![box]));
+    let m = p.start();
+    p.bump();
+    pattern(p);
+    m.complete(p, BOX_PAT)
 }

--- a/crates/ra_parser/src/grammar/patterns.rs
+++ b/crates/ra_parser/src/grammar/patterns.rs
@@ -161,6 +161,9 @@ fn record_field_pat_list(p: &mut Parser) {
             T![..] => p.bump(),
             IDENT if p.nth(1) == T![:] => record_field_pat(p),
             T!['{'] => error_block(p, "expected ident"),
+            T![box] => {
+                box_pat(p);
+            }
             _ => {
                 bind_pat(p, false);
             }

--- a/crates/ra_parser/src/grammar/patterns.rs
+++ b/crates/ra_parser/src/grammar/patterns.rs
@@ -269,11 +269,6 @@ fn bind_pat(p: &mut Parser, with_at: bool) -> CompletedMarker {
     m.complete(p, BIND_PAT)
 }
 
-// test_err ref_box_pat
-// fn main() {
-//     let ref box i = ();
-// }
-
 // test box_pat
 // fn main() {
 //     let box i = ();

--- a/crates/ra_parser/src/syntax_kind/generated.rs
+++ b/crates/ra_parser/src/syntax_kind/generated.rs
@@ -149,6 +149,7 @@ pub enum SyntaxKind {
     IMPL_TRAIT_TYPE,
     DYN_TRAIT_TYPE,
     REF_PAT,
+    BOX_PAT,
     BIND_PAT,
     PLACEHOLDER_PAT,
     PATH_PAT,

--- a/crates/ra_syntax/src/grammar.ron
+++ b/crates/ra_syntax/src/grammar.ron
@@ -158,6 +158,7 @@ Grammar(
         "DYN_TRAIT_TYPE",
 
         "REF_PAT",
+        "BOX_PAT",
         "BIND_PAT",
         "PLACEHOLDER_PAT",
         "PATH_PAT",
@@ -523,6 +524,7 @@ Grammar(
         ),
 
         "RefPat": ( options: [ "Pat" ]),
+        "BoxPat": ( options: [ "Pat" ]),
         "BindPat": (
             options: [ "Pat" ],
             traits: ["NameOwner"]
@@ -552,6 +554,7 @@ Grammar(
         "Pat": (
             enum: [
                 "RefPat",
+                "BoxPat",
                 "BindPat",
                 "PlaceholderPat",
                 "PathPat",

--- a/crates/ra_syntax/test_data/parser/err/0034_bad_box_pattern.rs
+++ b/crates/ra_syntax/test_data/parser/err/0034_bad_box_pattern.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let ref box i = ();
+    let mut box i = ();
+    let ref mut box i = ();
+}
+

--- a/crates/ra_syntax/test_data/parser/err/0034_bad_box_pattern.txt
+++ b/crates/ra_syntax/test_data/parser/err/0034_bad_box_pattern.txt
@@ -1,0 +1,95 @@
+SOURCE_FILE@[0; 91)
+  FN_DEF@[0; 89)
+    FN_KW@[0; 2) "fn"
+    WHITESPACE@[2; 3) " "
+    NAME@[3; 7)
+      IDENT@[3; 7) "main"
+    PARAM_LIST@[7; 9)
+      L_PAREN@[7; 8) "("
+      R_PAREN@[8; 9) ")"
+    WHITESPACE@[9; 10) " "
+    BLOCK@[10; 89)
+      L_CURLY@[10; 11) "{"
+      WHITESPACE@[11; 16) "\n    "
+      LET_STMT@[16; 27)
+        LET_KW@[16; 19) "let"
+        WHITESPACE@[19; 20) " "
+        BIND_PAT@[20; 27)
+          REF_KW@[20; 23) "ref"
+          WHITESPACE@[23; 24) " "
+          ERROR@[24; 27)
+            BOX_KW@[24; 27) "box"
+      WHITESPACE@[27; 28) " "
+      EXPR_STMT@[28; 35)
+        BIN_EXPR@[28; 34)
+          PATH_EXPR@[28; 29)
+            PATH@[28; 29)
+              PATH_SEGMENT@[28; 29)
+                NAME_REF@[28; 29)
+                  IDENT@[28; 29) "i"
+          WHITESPACE@[29; 30) " "
+          EQ@[30; 31) "="
+          WHITESPACE@[31; 32) " "
+          TUPLE_EXPR@[32; 34)
+            L_PAREN@[32; 33) "("
+            R_PAREN@[33; 34) ")"
+        SEMI@[34; 35) ";"
+      WHITESPACE@[35; 40) "\n    "
+      LET_STMT@[40; 51)
+        LET_KW@[40; 43) "let"
+        WHITESPACE@[43; 44) " "
+        BIND_PAT@[44; 51)
+          MUT_KW@[44; 47) "mut"
+          WHITESPACE@[47; 48) " "
+          ERROR@[48; 51)
+            BOX_KW@[48; 51) "box"
+      WHITESPACE@[51; 52) " "
+      EXPR_STMT@[52; 59)
+        BIN_EXPR@[52; 58)
+          PATH_EXPR@[52; 53)
+            PATH@[52; 53)
+              PATH_SEGMENT@[52; 53)
+                NAME_REF@[52; 53)
+                  IDENT@[52; 53) "i"
+          WHITESPACE@[53; 54) " "
+          EQ@[54; 55) "="
+          WHITESPACE@[55; 56) " "
+          TUPLE_EXPR@[56; 58)
+            L_PAREN@[56; 57) "("
+            R_PAREN@[57; 58) ")"
+        SEMI@[58; 59) ";"
+      WHITESPACE@[59; 64) "\n    "
+      LET_STMT@[64; 79)
+        LET_KW@[64; 67) "let"
+        WHITESPACE@[67; 68) " "
+        BIND_PAT@[68; 79)
+          REF_KW@[68; 71) "ref"
+          WHITESPACE@[71; 72) " "
+          MUT_KW@[72; 75) "mut"
+          WHITESPACE@[75; 76) " "
+          ERROR@[76; 79)
+            BOX_KW@[76; 79) "box"
+      WHITESPACE@[79; 80) " "
+      EXPR_STMT@[80; 87)
+        BIN_EXPR@[80; 86)
+          PATH_EXPR@[80; 81)
+            PATH@[80; 81)
+              PATH_SEGMENT@[80; 81)
+                NAME_REF@[80; 81)
+                  IDENT@[80; 81) "i"
+          WHITESPACE@[81; 82) " "
+          EQ@[82; 83) "="
+          WHITESPACE@[83; 84) " "
+          TUPLE_EXPR@[84; 86)
+            L_PAREN@[84; 85) "("
+            R_PAREN@[85; 86) ")"
+        SEMI@[86; 87) ";"
+      WHITESPACE@[87; 88) "\n"
+      R_CURLY@[88; 89) "}"
+  WHITESPACE@[89; 91) "\n\n"
+error 24: expected a name
+error 27: expected SEMI
+error 48: expected a name
+error 51: expected SEMI
+error 76: expected a name
+error 79: expected SEMI

--- a/crates/ra_syntax/test_data/parser/inline/ok/0066_match_arm.rs
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0066_match_arm.rs
@@ -5,7 +5,5 @@ fn foo() {
         X | Y if Z => (),
         | X | Y if Z => (),
         | X => (),
-        box X => (),
-        Some(box X) => (),
     };
 }

--- a/crates/ra_syntax/test_data/parser/inline/ok/0066_match_arm.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0066_match_arm.txt
@@ -1,5 +1,5 @@
-SOURCE_FILE@[0; 215)
-  FN_DEF@[0; 214)
+SOURCE_FILE@[0; 167)
+  FN_DEF@[0; 166)
     FN_KW@[0; 2) "fn"
     WHITESPACE@[2; 3) " "
     NAME@[3; 6)
@@ -8,18 +8,18 @@ SOURCE_FILE@[0; 215)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 214)
+    BLOCK@[9; 166)
       L_CURLY@[9; 10) "{"
       WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 212)
-        MATCH_EXPR@[15; 211)
+      EXPR_STMT@[15; 164)
+        MATCH_EXPR@[15; 163)
           MATCH_KW@[15; 20) "match"
           WHITESPACE@[20; 21) " "
           TUPLE_EXPR@[21; 23)
             L_PAREN@[21; 22) "("
             R_PAREN@[22; 23) ")"
           WHITESPACE@[23; 24) " "
-          MATCH_ARM_LIST@[24; 211)
+          MATCH_ARM_LIST@[24; 163)
             L_CURLY@[24; 25) "{"
             WHITESPACE@[25; 34) "\n        "
             MATCH_ARM@[34; 41)
@@ -141,44 +141,9 @@ SOURCE_FILE@[0; 215)
                 L_PAREN@[154; 155) "("
                 R_PAREN@[155; 156) ")"
             COMMA@[156; 157) ","
-            WHITESPACE@[157; 166) "\n        "
-            MATCH_ARM@[166; 177)
-              BIND_PAT@[166; 171)
-                BOX_KW@[166; 169) "box"
-                WHITESPACE@[169; 170) " "
-                NAME@[170; 171)
-                  IDENT@[170; 171) "X"
-              WHITESPACE@[171; 172) " "
-              FAT_ARROW@[172; 174) "=>"
-              WHITESPACE@[174; 175) " "
-              TUPLE_EXPR@[175; 177)
-                L_PAREN@[175; 176) "("
-                R_PAREN@[176; 177) ")"
-            COMMA@[177; 178) ","
-            WHITESPACE@[178; 187) "\n        "
-            MATCH_ARM@[187; 204)
-              TUPLE_STRUCT_PAT@[187; 198)
-                PATH@[187; 191)
-                  PATH_SEGMENT@[187; 191)
-                    NAME_REF@[187; 191)
-                      IDENT@[187; 191) "Some"
-                L_PAREN@[191; 192) "("
-                BIND_PAT@[192; 197)
-                  BOX_KW@[192; 195) "box"
-                  WHITESPACE@[195; 196) " "
-                  NAME@[196; 197)
-                    IDENT@[196; 197) "X"
-                R_PAREN@[197; 198) ")"
-              WHITESPACE@[198; 199) " "
-              FAT_ARROW@[199; 201) "=>"
-              WHITESPACE@[201; 202) " "
-              TUPLE_EXPR@[202; 204)
-                L_PAREN@[202; 203) "("
-                R_PAREN@[203; 204) ")"
-            COMMA@[204; 205) ","
-            WHITESPACE@[205; 210) "\n    "
-            R_CURLY@[210; 211) "}"
-        SEMI@[211; 212) ";"
-      WHITESPACE@[212; 213) "\n"
-      R_CURLY@[213; 214) "}"
-  WHITESPACE@[214; 215) "\n"
+            WHITESPACE@[157; 162) "\n    "
+            R_CURLY@[162; 163) "}"
+        SEMI@[163; 164) ";"
+      WHITESPACE@[164; 165) "\n"
+      R_CURLY@[165; 166) "}"
+  WHITESPACE@[166; 167) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0112_bind_pat.rs
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0112_bind_pat.rs
@@ -5,5 +5,4 @@ fn main() {
     let ref mut d = ();
     let e @ _ = ();
     let ref mut f @ g @ _ = ();
-    let box i = Box::new(1i32);
 }

--- a/crates/ra_syntax/test_data/parser/inline/ok/0112_bind_pat.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0112_bind_pat.txt
@@ -1,5 +1,5 @@
-SOURCE_FILE@[0; 178)
-  FN_DEF@[0; 177)
+SOURCE_FILE@[0; 146)
+  FN_DEF@[0; 145)
     FN_KW@[0; 2) "fn"
     WHITESPACE@[2; 3) " "
     NAME@[3; 7)
@@ -8,7 +8,7 @@ SOURCE_FILE@[0; 178)
       L_PAREN@[7; 8) "("
       R_PAREN@[8; 9) ")"
     WHITESPACE@[9; 10) " "
-    BLOCK@[10; 177)
+    BLOCK@[10; 145)
       L_CURLY@[10; 11) "{"
       WHITESPACE@[11; 16) "\n    "
       LET_STMT@[16; 27)
@@ -122,35 +122,6 @@ SOURCE_FILE@[0; 178)
           L_PAREN@[140; 141) "("
           R_PAREN@[141; 142) ")"
         SEMI@[142; 143) ";"
-      WHITESPACE@[143; 148) "\n    "
-      LET_STMT@[148; 175)
-        LET_KW@[148; 151) "let"
-        WHITESPACE@[151; 152) " "
-        BIND_PAT@[152; 157)
-          BOX_KW@[152; 155) "box"
-          WHITESPACE@[155; 156) " "
-          NAME@[156; 157)
-            IDENT@[156; 157) "i"
-        WHITESPACE@[157; 158) " "
-        EQ@[158; 159) "="
-        WHITESPACE@[159; 160) " "
-        CALL_EXPR@[160; 174)
-          PATH_EXPR@[160; 168)
-            PATH@[160; 168)
-              PATH@[160; 163)
-                PATH_SEGMENT@[160; 163)
-                  NAME_REF@[160; 163)
-                    IDENT@[160; 163) "Box"
-              COLONCOLON@[163; 165) "::"
-              PATH_SEGMENT@[165; 168)
-                NAME_REF@[165; 168)
-                  IDENT@[165; 168) "new"
-          ARG_LIST@[168; 174)
-            L_PAREN@[168; 169) "("
-            LITERAL@[169; 173)
-              INT_NUMBER@[169; 173) "1i32"
-            R_PAREN@[173; 174) ")"
-        SEMI@[174; 175) ";"
-      WHITESPACE@[175; 176) "\n"
-      R_CURLY@[176; 177) "}"
-  WHITESPACE@[177; 178) "\n"
+      WHITESPACE@[143; 144) "\n"
+      R_CURLY@[144; 145) "}"
+  WHITESPACE@[145; 146) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0143_box_pat.rs
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0143_box_pat.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let box i = ();
+    let box Outer { box i, j: box Inner(box &x) } = ();
+    let box ref mut i = ();
+}

--- a/crates/ra_syntax/test_data/parser/inline/ok/0143_box_pat.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0143_box_pat.txt
@@ -1,0 +1,109 @@
+SOURCE_FILE@[0; 118)
+  FN_DEF@[0; 117)
+    FN_KW@[0; 2) "fn"
+    WHITESPACE@[2; 3) " "
+    NAME@[3; 7)
+      IDENT@[3; 7) "main"
+    PARAM_LIST@[7; 9)
+      L_PAREN@[7; 8) "("
+      R_PAREN@[8; 9) ")"
+    WHITESPACE@[9; 10) " "
+    BLOCK@[10; 117)
+      L_CURLY@[10; 11) "{"
+      WHITESPACE@[11; 16) "\n    "
+      LET_STMT@[16; 31)
+        LET_KW@[16; 19) "let"
+        WHITESPACE@[19; 20) " "
+        BOX_PAT@[20; 25)
+          BOX_KW@[20; 23) "box"
+          WHITESPACE@[23; 24) " "
+          BIND_PAT@[24; 25)
+            NAME@[24; 25)
+              IDENT@[24; 25) "i"
+        WHITESPACE@[25; 26) " "
+        EQ@[26; 27) "="
+        WHITESPACE@[27; 28) " "
+        TUPLE_EXPR@[28; 30)
+          L_PAREN@[28; 29) "("
+          R_PAREN@[29; 30) ")"
+        SEMI@[30; 31) ";"
+      WHITESPACE@[31; 36) "\n    "
+      LET_STMT@[36; 87)
+        LET_KW@[36; 39) "let"
+        WHITESPACE@[39; 40) " "
+        BOX_PAT@[40; 81)
+          BOX_KW@[40; 43) "box"
+          WHITESPACE@[43; 44) " "
+          RECORD_PAT@[44; 81)
+            PATH@[44; 49)
+              PATH_SEGMENT@[44; 49)
+                NAME_REF@[44; 49)
+                  IDENT@[44; 49) "Outer"
+            WHITESPACE@[49; 50) " "
+            RECORD_FIELD_PAT_LIST@[50; 81)
+              L_CURLY@[50; 51) "{"
+              WHITESPACE@[51; 52) " "
+              BOX_PAT@[52; 57)
+                BOX_KW@[52; 55) "box"
+                WHITESPACE@[55; 56) " "
+                BIND_PAT@[56; 57)
+                  NAME@[56; 57)
+                    IDENT@[56; 57) "i"
+              COMMA@[57; 58) ","
+              WHITESPACE@[58; 59) " "
+              RECORD_FIELD_PAT@[59; 79)
+                NAME@[59; 60)
+                  IDENT@[59; 60) "j"
+                COLON@[60; 61) ":"
+                WHITESPACE@[61; 62) " "
+                BOX_PAT@[62; 79)
+                  BOX_KW@[62; 65) "box"
+                  WHITESPACE@[65; 66) " "
+                  TUPLE_STRUCT_PAT@[66; 79)
+                    PATH@[66; 71)
+                      PATH_SEGMENT@[66; 71)
+                        NAME_REF@[66; 71)
+                          IDENT@[66; 71) "Inner"
+                    L_PAREN@[71; 72) "("
+                    BOX_PAT@[72; 78)
+                      BOX_KW@[72; 75) "box"
+                      WHITESPACE@[75; 76) " "
+                      REF_PAT@[76; 78)
+                        AMP@[76; 77) "&"
+                        BIND_PAT@[77; 78)
+                          NAME@[77; 78)
+                            IDENT@[77; 78) "x"
+                    R_PAREN@[78; 79) ")"
+              WHITESPACE@[79; 80) " "
+              R_CURLY@[80; 81) "}"
+        WHITESPACE@[81; 82) " "
+        EQ@[82; 83) "="
+        WHITESPACE@[83; 84) " "
+        TUPLE_EXPR@[84; 86)
+          L_PAREN@[84; 85) "("
+          R_PAREN@[85; 86) ")"
+        SEMI@[86; 87) ";"
+      WHITESPACE@[87; 92) "\n    "
+      LET_STMT@[92; 115)
+        LET_KW@[92; 95) "let"
+        WHITESPACE@[95; 96) " "
+        BOX_PAT@[96; 109)
+          BOX_KW@[96; 99) "box"
+          WHITESPACE@[99; 100) " "
+          BIND_PAT@[100; 109)
+            REF_KW@[100; 103) "ref"
+            WHITESPACE@[103; 104) " "
+            MUT_KW@[104; 107) "mut"
+            WHITESPACE@[107; 108) " "
+            NAME@[108; 109)
+              IDENT@[108; 109) "i"
+        WHITESPACE@[109; 110) " "
+        EQ@[110; 111) "="
+        WHITESPACE@[111; 112) " "
+        TUPLE_EXPR@[112; 114)
+          L_PAREN@[112; 113) "("
+          R_PAREN@[113; 114) ")"
+        SEMI@[114; 115) ";"
+      WHITESPACE@[115; 116) "\n"
+      R_CURLY@[116; 117) "}"
+  WHITESPACE@[117; 118) "\n"


### PR DESCRIPTION
This fully resolves the pattern part of #1412 by enabling the parsing of complex `box` patterns such as:

```rust
let box Struct { box i, j: box Inner(box &x) } = todo!();
```

This introduces a new `ast::BoxPat` (in the mold of `ast::RefPat`) that gets translated to `hir::Pat::Missing`.