### PR TITLE
Report type mismatches in analysis-stats

### DIFF
--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -510,18 +510,6 @@ pub enum DefWithBody {
 impl_froms!(DefWithBody: Function, Const, Static);
 
 impl DefWithBody {
-    pub fn infer(self, db: &impl HirDatabase) -> Arc<InferenceResult> {
-        db.infer(self)
-    }
-
-    pub fn body(self, db: &impl HirDatabase) -> Arc<Body> {
-        db.body_hir(self)
-    }
-
-    pub fn body_source_map(self, db: &impl HirDatabase) -> Arc<BodySourceMap> {
-        db.body_with_source_map(self).1
-    }
-
     /// Builds a resolver for code inside this item.
     pub(crate) fn resolver(self, db: &impl HirDatabase) -> Resolver {
         match self {
@@ -529,6 +517,43 @@ impl DefWithBody {
             DefWithBody::Function(f) => f.resolver(db),
             DefWithBody::Static(s) => s.resolver(db),
         }
+    }
+}
+
+pub trait HasBody: Copy {
+    fn infer(self, db: &impl HirDatabase) -> Arc<InferenceResult>;
+    fn body(self, db: &impl HirDatabase) -> Arc<Body>;
+    fn body_source_map(self, db: &impl HirDatabase) -> Arc<BodySourceMap>;
+}
+
+impl<T> HasBody for T
+where
+    T: Into<DefWithBody> + Copy + HasSource,
+{
+    fn infer(self, db: &impl HirDatabase) -> Arc<InferenceResult> {
+        db.infer(self.into())
+    }
+
+    fn body(self, db: &impl HirDatabase) -> Arc<Body> {
+        db.body_hir(self.into())
+    }
+
+    fn body_source_map(self, db: &impl HirDatabase) -> Arc<BodySourceMap> {
+        db.body_with_source_map(self.into()).1
+    }
+}
+
+impl HasBody for DefWithBody {
+    fn infer(self, db: &impl HirDatabase) -> Arc<InferenceResult> {
+        db.infer(self)
+    }
+
+    fn body(self, db: &impl HirDatabase) -> Arc<Body> {
+        db.body_hir(self)
+    }
+
+    fn body_source_map(self, db: &impl HirDatabase) -> Arc<BodySourceMap> {
+        db.body_with_source_map(self).1
     }
 }
 
@@ -617,7 +642,7 @@ impl Function {
         self.data(db).name.clone()
     }
 
-    pub fn body_source_map(self, db: &impl HirDatabase) -> Arc<BodySourceMap> {
+    pub(crate) fn body_source_map(self, db: &impl HirDatabase) -> Arc<BodySourceMap> {
         db.body_with_source_map(self.into()).1
     }
 

--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -617,7 +617,7 @@ impl Function {
         self.data(db).name.clone()
     }
 
-    pub(crate) fn body_source_map(self, db: &impl HirDatabase) -> Arc<BodySourceMap> {
+    pub fn body_source_map(self, db: &impl HirDatabase) -> Arc<BodySourceMap> {
         db.body_with_source_map(self.into()).1
     }
 

--- a/crates/ra_hir/src/expr.rs
+++ b/crates/ra_hir/src/expr.rs
@@ -128,27 +128,27 @@ impl Index<PatId> for Body {
 }
 
 impl BodySourceMap {
-    pub(crate) fn expr_syntax(&self, expr: ExprId) -> Option<SyntaxNodePtr> {
+    pub fn expr_syntax(&self, expr: ExprId) -> Option<SyntaxNodePtr> {
         self.expr_map_back.get(expr).cloned()
     }
 
-    pub(crate) fn syntax_expr(&self, ptr: SyntaxNodePtr) -> Option<ExprId> {
+    pub fn syntax_expr(&self, ptr: SyntaxNodePtr) -> Option<ExprId> {
         self.expr_map.get(&ptr).cloned()
     }
 
-    pub(crate) fn node_expr(&self, node: &ast::Expr) -> Option<ExprId> {
+    pub fn node_expr(&self, node: &ast::Expr) -> Option<ExprId> {
         self.expr_map.get(&SyntaxNodePtr::new(node.syntax())).cloned()
     }
 
-    pub(crate) fn pat_syntax(&self, pat: PatId) -> Option<PatPtr> {
+    pub fn pat_syntax(&self, pat: PatId) -> Option<PatPtr> {
         self.pat_map_back.get(pat).cloned()
     }
 
-    pub(crate) fn node_pat(&self, node: &ast::Pat) -> Option<PatId> {
+    pub fn node_pat(&self, node: &ast::Pat) -> Option<PatId> {
         self.pat_map.get(&Either::A(AstPtr::new(node))).cloned()
     }
 
-    pub(crate) fn field_syntax(&self, expr: ExprId, field: usize) -> AstPtr<ast::RecordField> {
+    pub fn field_syntax(&self, expr: ExprId, field: usize) -> AstPtr<ast::RecordField> {
         self.field_map[&(expr, field)]
     }
 }

--- a/crates/ra_hir/src/expr.rs
+++ b/crates/ra_hir/src/expr.rs
@@ -128,27 +128,27 @@ impl Index<PatId> for Body {
 }
 
 impl BodySourceMap {
-    pub fn expr_syntax(&self, expr: ExprId) -> Option<SyntaxNodePtr> {
+    pub(crate) fn expr_syntax(&self, expr: ExprId) -> Option<SyntaxNodePtr> {
         self.expr_map_back.get(expr).cloned()
     }
 
-    pub fn syntax_expr(&self, ptr: SyntaxNodePtr) -> Option<ExprId> {
+    pub(crate) fn syntax_expr(&self, ptr: SyntaxNodePtr) -> Option<ExprId> {
         self.expr_map.get(&ptr).cloned()
     }
 
-    pub fn node_expr(&self, node: &ast::Expr) -> Option<ExprId> {
+    pub(crate) fn node_expr(&self, node: &ast::Expr) -> Option<ExprId> {
         self.expr_map.get(&SyntaxNodePtr::new(node.syntax())).cloned()
     }
 
-    pub fn pat_syntax(&self, pat: PatId) -> Option<PatPtr> {
+    pub(crate) fn pat_syntax(&self, pat: PatId) -> Option<PatPtr> {
         self.pat_map_back.get(pat).cloned()
     }
 
-    pub fn node_pat(&self, node: &ast::Pat) -> Option<PatId> {
+    pub(crate) fn node_pat(&self, node: &ast::Pat) -> Option<PatId> {
         self.pat_map.get(&Either::A(AstPtr::new(node))).cloned()
     }
 
-    pub fn field_syntax(&self, expr: ExprId, field: usize) -> AstPtr<ast::RecordField> {
+    pub(crate) fn field_syntax(&self, expr: ExprId, field: usize) -> AstPtr<ast::RecordField> {
         self.field_map[&(expr, field)]
     }
 }

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -75,8 +75,8 @@ pub use self::{
 
 pub use self::code_model::{
     docs::{DocDef, Docs, Documentation},
-    src::{HasSource, Source},
+    src::{HasBodySource, HasSource, Source},
     BuiltinType, Const, ConstData, Container, Crate, CrateDependency, DefWithBody, Enum,
-    EnumVariant, FieldSource, FnData, Function, MacroDef, Module, ModuleDef, ModuleSource, Static,
-    Struct, StructField, Trait, TypeAlias, Union,
+    EnumVariant, FieldSource, FnData, Function, HasBody, MacroDef, Module, ModuleDef, ModuleSource,
+    Static, Struct, StructField, Trait, TypeAlias, Union,
 };

--- a/crates/ra_hir/src/source_binder.rs
+++ b/crates/ra_hir/src/source_binder.rs
@@ -27,9 +27,9 @@ use crate::{
     name,
     path::{PathKind, PathSegment},
     ty::method_resolution::implements_trait,
-    AsName, AstId, Const, Crate, DefWithBody, Either, Enum, Function, HirDatabase, HirFileId,
-    MacroDef, Module, ModuleDef, Name, Path, PerNs, Resolution, Resolver, Static, Struct, Trait,
-    Ty,
+    AsName, AstId, Const, Crate, DefWithBody, Either, Enum, Function, HasBody, HirDatabase,
+    HirFileId, MacroDef, Module, ModuleDef, Name, Path, PerNs, Resolution, Resolver, Static,
+    Struct, Trait, Ty,
 };
 
 /// Locates the module by `FileId`. Picks topmost module in the file.

--- a/crates/ra_hir/src/ty/infer.rs
+++ b/crates/ra_hir/src/ty/infer.rs
@@ -50,8 +50,8 @@ use crate::{
     },
     ty::infer::diagnostics::InferenceDiagnostic,
     type_ref::{Mutability, TypeRef},
-    AdtDef, ConstData, DefWithBody, FnData, Function, HirDatabase, ImplItem, ModuleDef, Name, Path,
-    StructField,
+    AdtDef, ConstData, DefWithBody, FnData, Function, HasBody, HirDatabase, ImplItem, ModuleDef,
+    Name, Path, StructField,
 };
 
 mod unify;

--- a/crates/ra_syntax/src/ptr.rs
+++ b/crates/ra_syntax/src/ptr.rs
@@ -15,9 +15,8 @@ impl SyntaxNodePtr {
         SyntaxNodePtr { range: node.text_range(), kind: node.kind() }
     }
 
-    pub fn to_node(self, root: &SyntaxNode) -> SyntaxNode {
-        assert!(root.parent().is_none());
-        successors(Some(root.clone()), |node| {
+    pub fn to_node(self, parent: &SyntaxNode) -> SyntaxNode {
+        successors(Some(parent.clone()), |node| {
             node.children().find(|it| self.range.is_subrange(&it.text_range()))
         })
         .find(|it| it.text_range() == self.range && it.kind() == self.kind)


### PR DESCRIPTION
Only the number usually; each one individually when running with `-v`.

Getting the file/line locations for the exprs was really annoying and I had to make some stuff public (that I didn't remember why it would be `pub(crate)`); maybe I missed some easier way? It would be nice to have some general way for mapping locations :thinking: 

This reports 1768 mismatches on RA currently; from skimming, this seems to be mostly various kinds of coercions, though there were also some other things.