### PR TITLE
Support `#[macro_use]` on `extern crate`

### DIFF
--- a/crates/ra_hir/src/marks.rs
+++ b/crates/ra_hir/src/marks.rs
@@ -11,4 +11,5 @@ test_utils::marks!(
     match_ergonomics_ref
     trait_resolution_on_fn_type
     infer_while_let
+    macro_rules_from_other_crates_are_visible_with_macro_use
 );

--- a/crates/ra_hir/src/nameres.rs
+++ b/crates/ra_hir/src/nameres.rs
@@ -101,6 +101,8 @@ pub struct CrateDefMap {
     /// However, do we want to put it as a global variable?
     poison_macros: FxHashSet<MacroDefId>,
 
+    exported_macros: FxHashMap<Name, MacroDefId>,
+
     diagnostics: Vec<DefDiagnostic>,
 }
 
@@ -245,6 +247,7 @@ impl CrateDefMap {
                 root,
                 modules,
                 poison_macros: FxHashSet::default(),
+                exported_macros: FxHashMap::default(),
                 diagnostics: Vec::new(),
             }
         };

--- a/crates/ra_hir/src/nameres/collector.rs
+++ b/crates/ra_hir/src/nameres/collector.rs
@@ -295,6 +295,23 @@ where
                         }
                     }
 
+                    // `#[macro_use] extern crate` glob import macros
+                    if import.is_extern_crate && import.is_macro_use {
+                        if let Some(ModuleDef::Module(m)) =
+                            def.a().and_then(|item| item.take_types())
+                        {
+                            let item_map = self.db.crate_def_map(m.krate);
+                            let scope = &item_map[m.module_id].scope;
+                            let macros = scope
+                                .macros
+                                .iter()
+                                .map(|(name, res)| (name.clone(), Either::B(*res)))
+                                .collect::<Vec<_>>();
+
+                            self.update(module_id, Some(import_id), &macros);
+                        }
+                    }
+
                     let resolution = match def {
                         Either::A(item) => {
                             Either::A(Resolution { def: item, import: Some(import_id) })

--- a/crates/ra_hir/src/nameres/collector.rs
+++ b/crates/ra_hir/src/nameres/collector.rs
@@ -166,6 +166,33 @@ where
         self.global_macro_scope.insert(name, macro_id);
     }
 
+    /// Import macros from `#[macro_use] extern crate`.
+    ///
+    /// They are non-scoped, and will only be inserted into mutable `global_macro_scope`.
+    fn import_macros_from_extern_crate(&mut self, import: &raw::ImportData) {
+        log::debug!(
+            "importing macros from extern crate: {:?} ({:?})",
+            import,
+            self.def_map.edition,
+        );
+
+        let res = self.def_map.resolve_name_in_extern_prelude(
+            &import
+                .path
+                .as_ident()
+                .expect("extern crate should have been desugared to one-element path"),
+        );
+
+        if let Some(ModuleDef::Module(m)) = res.take_types() {
+            tested_by!(macro_rules_from_other_crates_are_visible_with_macro_use);
+
+            let item_map = self.db.crate_def_map(m.krate);
+            for (name, &macro_id) in &item_map.exported_macros {
+                self.global_macro_scope.insert(name.clone(), macro_id);
+            }
+        }
+    }
+
     fn resolve_imports(&mut self) -> ReachedFixedPoint {
         let mut imports = std::mem::replace(&mut self.unresolved_imports, Vec::new());
         let mut resolved = Vec::new();
@@ -296,21 +323,6 @@ where
                     if import.is_extern_crate && module_id == self.def_map.root {
                         if let Some(def) = def.a().and_then(|item| item.take_types()) {
                             self.def_map.extern_prelude.insert(name.clone(), def);
-                        }
-                    }
-
-                    // `#[macro_use] extern crate` glob imports all macros exported,
-                    // ignoring their scopes
-                    if import.is_extern_crate && import.is_macro_use {
-                        if let Some(ModuleDef::Module(m)) =
-                            def.a().and_then(|item| item.take_types())
-                        {
-                            tested_by!(macro_rules_from_other_crates_are_visible_with_macro_use);
-
-                            let item_map = self.db.crate_def_map(m.krate);
-                            for (name, &macro_id) in &item_map.exported_macros {
-                                self.define_macro(module_id, name.clone(), macro_id, false);
-                            }
                         }
                     }
 
@@ -513,11 +525,17 @@ where
         for item in items {
             match *item {
                 raw::RawItem::Module(m) => self.collect_module(&self.raw_items[m]),
-                raw::RawItem::Import(import) => self.def_collector.unresolved_imports.push((
-                    self.module_id,
-                    import,
-                    self.raw_items[import].clone(),
-                )),
+                raw::RawItem::Import(import_id) => {
+                    let import = self.raw_items[import_id].clone();
+                    // This should be processed eagerly instead of deferred to resolving.
+                    // Otherwise, since it will only mutate `global_macro_scope`
+                    // without `update` names in `mod`s, unresolved macros cannot be expanded.
+                    if import.is_extern_crate && import.is_macro_use {
+                        self.def_collector.import_macros_from_extern_crate(&import);
+                    }
+
+                    self.def_collector.unresolved_imports.push((self.module_id, import_id, import));
+                }
                 raw::RawItem::Def(def) => self.define_def(&self.raw_items[def]),
                 raw::RawItem::Macro(mac) => self.collect_macro(&self.raw_items[mac]),
             }

--- a/crates/ra_hir/src/nameres/raw.rs
+++ b/crates/ra_hir/src/nameres/raw.rs
@@ -154,6 +154,7 @@ pub struct ImportData {
     pub(super) is_glob: bool,
     pub(super) is_prelude: bool,
     pub(super) is_extern_crate: bool,
+    pub(super) is_macro_use: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -293,8 +294,14 @@ impl RawItemsCollector {
         let is_prelude = use_item.has_atom_attr("prelude_import");
 
         Path::expand_use_item(&use_item, |path, use_tree, is_glob, alias| {
-            let import_data =
-                ImportData { path, alias, is_glob, is_prelude, is_extern_crate: false };
+            let import_data = ImportData {
+                path,
+                alias,
+                is_glob,
+                is_prelude,
+                is_extern_crate: false,
+                is_macro_use: false,
+            };
             self.push_import(current_module, import_data, Either::A(AstPtr::new(use_tree)));
         })
     }
@@ -307,12 +314,14 @@ impl RawItemsCollector {
         if let Some(name_ref) = extern_crate.name_ref() {
             let path = Path::from_name_ref(&name_ref);
             let alias = extern_crate.alias().and_then(|a| a.name()).map(|it| it.as_name());
+            let is_macro_use = extern_crate.has_atom_attr("macro_use");
             let import_data = ImportData {
                 path,
                 alias,
                 is_glob: false,
                 is_prelude: false,
                 is_extern_crate: true,
+                is_macro_use,
             };
             self.push_import(current_module, import_data, Either::B(AstPtr::new(&extern_crate)));
         }

--- a/crates/ra_hir/src/nameres/tests/macros.rs
+++ b/crates/ra_hir/src/nameres/tests/macros.rs
@@ -150,13 +150,13 @@ fn macro_rules_from_other_crates_are_visible_with_macro_use() {
         structs!(Foo);
         structs_priv!(Bar);
         structs_not_exported!(MacroNotResolved1);
-        crates::structs!(MacroNotResolved2);
+        crate::structs!(MacroNotResolved2);
 
         mod bar;
 
         //- /bar.rs
         structs!(Baz);
-        crates::structs!(MacroNotResolved3);
+        crate::structs!(MacroNotResolved3);
 
         //- /lib.rs
         #[macro_export]

--- a/crates/ra_hir/src/nameres/tests/macros.rs
+++ b/crates/ra_hir/src/nameres/tests/macros.rs
@@ -147,25 +147,31 @@ fn macro_rules_from_other_crates_are_visible_with_macro_use() {
         #[macro_use]
         extern crate foo;
 
-        structs!(Foo, Bar)
+        structs!(Foo);
+        structs_priv!(Bar);
+        structs_not_exported!(MacroNotResolved1);
+        crates::structs!(MacroNotResolved2);
 
         mod bar;
 
         //- /bar.rs
-        use crate::*;
+        structs!(Baz);
+        crates::structs!(MacroNotResolved3);
 
         //- /lib.rs
         #[macro_export]
         macro_rules! structs {
-            ($($i:ident),*) => {
-                $(struct $i { field: u32 } )*
-            }
+            ($i:ident) => { struct $i; }
+        }
+
+        macro_rules! structs_not_exported {
+            ($i:ident) => { struct $i; }
         }
 
         mod priv_mod {
             #[macro_export]
-            macro_rules! baz {
-                () => {};
+            macro_rules! structs_priv {
+                ($i:ident) => { struct $i; }
             }
         }
         ",
@@ -179,16 +185,9 @@ fn macro_rules_from_other_crates_are_visible_with_macro_use() {
    ⋮Bar: t v
    ⋮Foo: t v
    ⋮bar: t
-   ⋮baz: m
    ⋮foo: t
-   ⋮structs: m
    ⋮
    ⋮crate::bar
-   ⋮Bar: t v
-   ⋮Foo: t v
-   ⋮bar: t
-   ⋮baz: m
-   ⋮foo: t
-   ⋮structs: m
+   ⋮Baz: t v
     "###);
 }

--- a/crates/ra_hir/src/nameres/tests/macros.rs
+++ b/crates/ra_hir/src/nameres/tests/macros.rs
@@ -140,6 +140,7 @@ fn unexpanded_macro_should_expand_by_fixedpoint_loop() {
 
 #[test]
 fn macro_rules_from_other_crates_are_visible_with_macro_use() {
+    covers!(macro_rules_from_other_crates_are_visible_with_macro_use);
     let map = def_map_with_crate_graph(
         "
         //- /main.rs
@@ -160,6 +161,13 @@ fn macro_rules_from_other_crates_are_visible_with_macro_use() {
                 $(struct $i { field: u32 } )*
             }
         }
+
+        mod priv_mod {
+            #[macro_export]
+            macro_rules! baz {
+                () => {};
+            }
+        }
         ",
         crate_graph! {
             "main": ("/main.rs", ["foo"]),
@@ -171,6 +179,7 @@ fn macro_rules_from_other_crates_are_visible_with_macro_use() {
    ⋮Bar: t v
    ⋮Foo: t v
    ⋮bar: t
+   ⋮baz: m
    ⋮foo: t
    ⋮structs: m
    ⋮
@@ -178,6 +187,7 @@ fn macro_rules_from_other_crates_are_visible_with_macro_use() {
    ⋮Bar: t v
    ⋮Foo: t v
    ⋮bar: t
+   ⋮baz: m
    ⋮foo: t
    ⋮structs: m
     "###);

--- a/crates/ra_syntax/src/ast/generated.rs
+++ b/crates/ra_syntax/src/ast/generated.rs
@@ -934,6 +934,7 @@ impl AstNode for ExternCrateItem {
         &self.syntax
     }
 }
+impl ast::AttrsOwner for ExternCrateItem {}
 impl ExternCrateItem {
     pub fn name_ref(&self) -> Option<NameRef> {
         AstChildren::new(&self.syntax).next()

--- a/crates/ra_syntax/src/grammar.ron
+++ b/crates/ra_syntax/src/grammar.ron
@@ -669,6 +669,7 @@ Grammar(
             collections: [("use_trees", "UseTree")]
         ),
         "ExternCrateItem": (
+            traits: ["AttrsOwner"],
             options: ["NameRef", "Alias"],
         ),
         "ArgList": (


### PR DESCRIPTION
Unfortunately, #1688 is still an issue. My guess is wrong :(