### PR TITLE
Always wrap blocks into block expressions

### DIFF
--- a/crates/ra_assists/src/ast_editor.rs
+++ b/crates/ra_assists/src/ast_editor.rs
@@ -274,7 +274,7 @@ impl AstBuilder<ast::Block> {
 
 impl AstBuilder<ast::Expr> {
     fn from_text(text: &str) -> ast::Expr {
-        ast_node_from_file_text(&format!("fn f() {{ {}; }}", text))
+        ast_node_from_file_text(&format!("const C: () = {};", text))
     }
 
     pub fn unit() -> ast::Expr {

--- a/crates/ra_assists/src/move_guard.rs
+++ b/crates/ra_assists/src/move_guard.rs
@@ -65,9 +65,9 @@ pub(crate) fn move_arm_cond_to_match_guard(mut ctx: AssistCtx<impl HirDatabase>)
         "move condition to match guard",
         |edit| {
             edit.target(if_expr.syntax().text_range());
-            let then_only_expr = then_block.statements().next().is_none();
+            let then_only_expr = then_block.block().and_then(|it| it.statements().next()).is_none();
 
-            match &then_block.expr() {
+            match &then_block.block().and_then(|it| it.expr()) {
                 Some(then_expr) if then_only_expr => {
                     edit.replace(if_expr.syntax().text_range(), then_expr.syntax().text())
                 }

--- a/crates/ra_assists/src/replace_if_let_with_match.rs
+++ b/crates/ra_assists/src/replace_if_let_with_match.rs
@@ -1,3 +1,4 @@
+use format_buf::format;
 use hir::db::HirDatabase;
 use ra_fmt::extract_trivial_expression;
 use ra_syntax::{ast, AstNode};
@@ -25,16 +26,21 @@ pub(crate) fn replace_if_let_with_match(mut ctx: AssistCtx<impl HirDatabase>) ->
     ctx.build()
 }
 
-fn build_match_expr(expr: ast::Expr, pat1: ast::Pat, arm1: ast::Block, arm2: ast::Block) -> String {
+fn build_match_expr(
+    expr: ast::Expr,
+    pat1: ast::Pat,
+    arm1: ast::BlockExpr,
+    arm2: ast::BlockExpr,
+) -> String {
     let mut buf = String::new();
-    buf.push_str(&format!("match {} {{\n", expr.syntax().text()));
-    buf.push_str(&format!("    {} => {}\n", pat1.syntax().text(), format_arm(&arm1)));
-    buf.push_str(&format!("    _ => {}\n", format_arm(&arm2)));
+    format!(buf, "match {} {{\n", expr.syntax().text());
+    format!(buf, "    {} => {}\n", pat1.syntax().text(), format_arm(&arm1));
+    format!(buf, "    _ => {}\n", format_arm(&arm2));
     buf.push_str("}");
     buf
 }
 
-fn format_arm(block: &ast::Block) -> String {
+fn format_arm(block: &ast::BlockExpr) -> String {
     match extract_trivial_expression(block) {
         None => block.syntax().text().to_string(),
         Some(e) => format!("{},", e.syntax().text()),

--- a/crates/ra_fmt/src/lib.rs
+++ b/crates/ra_fmt/src/lib.rs
@@ -34,7 +34,8 @@ fn prev_tokens(token: SyntaxToken) -> impl Iterator<Item = SyntaxToken> {
     successors(token.prev_token(), |token| token.prev_token())
 }
 
-pub fn extract_trivial_expression(block: &ast::Block) -> Option<ast::Expr> {
+pub fn extract_trivial_expression(expr: &ast::BlockExpr) -> Option<ast::Expr> {
+    let block = expr.block()?;
     let expr = block.expr()?;
     if expr.syntax().text().contains_char('\n') {
         return None;

--- a/crates/ra_hir/src/code_model/src.rs
+++ b/crates/ra_hir/src/code_model/src.rs
@@ -119,10 +119,10 @@ where
         expr_id: crate::expr::ExprId,
     ) -> Option<Source<ast::Expr>> {
         let source_map = self.body_source_map(db);
-        let expr_syntax = source_map.expr_syntax(expr_id)?;
+        let expr_syntax = source_map.expr_syntax(expr_id)?.a()?;
         let source = self.source(db);
-        let node = expr_syntax.to_node(&source.ast.syntax());
-        ast::Expr::cast(node).map(|ast| Source { file_id: source.file_id, ast })
+        let ast = expr_syntax.to_node(&source.ast.syntax());
+        Some(Source { file_id: source.file_id, ast })
     }
 }
 

--- a/crates/ra_hir/src/expr/scope.rs
+++ b/crates/ra_hir/src/expr/scope.rs
@@ -172,7 +172,7 @@ fn compute_expr_scopes(expr: ExprId, body: &Body, scopes: &mut ExprScopes, scope
 #[cfg(test)]
 mod tests {
     use ra_db::SourceDatabase;
-    use ra_syntax::{algo::find_node_at_offset, ast, AstNode, SyntaxNodePtr};
+    use ra_syntax::{algo::find_node_at_offset, ast, AstNode};
     use test_utils::{assert_eq_text, extract_offset};
 
     use crate::{mock::MockDatabase, source_binder::SourceAnalyzer};
@@ -194,8 +194,7 @@ mod tests {
         let analyzer = SourceAnalyzer::new(&db, file_id, marker.syntax(), None);
 
         let scopes = analyzer.scopes();
-        let expr_id =
-            analyzer.body_source_map().syntax_expr(SyntaxNodePtr::new(marker.syntax())).unwrap();
+        let expr_id = analyzer.body_source_map().node_expr(&marker.into()).unwrap();
         let scope = scopes.scope_for(expr_id);
 
         let actual = scopes

--- a/crates/ra_hir/src/ty/tests.rs
+++ b/crates/ra_hir/src/ty/tests.rs
@@ -3582,7 +3582,7 @@ fn infer(content: &str) -> String {
 
         for (expr, ty) in inference_result.type_of_expr.iter() {
             let syntax_ptr = match body_source_map.expr_syntax(expr) {
-                Some(sp) => sp,
+                Some(sp) => sp.either(|it| it.syntax_node_ptr(), |it| it.syntax_node_ptr()),
                 None => continue,
             };
             types.push((syntax_ptr, ty));

--- a/crates/ra_ide_api/src/join_lines.rs
+++ b/crates/ra_ide_api/src/join_lines.rs
@@ -123,7 +123,7 @@ fn has_comma_after(node: &SyntaxNode) -> bool {
 fn join_single_expr_block(edit: &mut TextEditBuilder, token: &SyntaxToken) -> Option<()> {
     let block = ast::Block::cast(token.parent())?;
     let block_expr = ast::BlockExpr::cast(block.syntax().parent()?)?;
-    let expr = extract_trivial_expression(&block)?;
+    let expr = extract_trivial_expression(&block_expr)?;
 
     let block_range = block_expr.syntax().text_range();
     let mut buf = expr.syntax().text().to_string();

--- a/crates/ra_ide_api/src/syntax_tree.rs
+++ b/crates/ra_ide_api/src/syntax_tree.rs
@@ -116,9 +116,10 @@ SOURCE_FILE@[0; 11)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 11)
-      L_CURLY@[9; 10) "{"
-      R_CURLY@[10; 11) "}"
+    BLOCK_EXPR@[9; 11)
+      BLOCK@[9; 11)
+        L_CURLY@[9; 10) "{"
+        R_CURLY@[10; 11) "}"
 "#
             .trim()
         );
@@ -148,26 +149,27 @@ SOURCE_FILE@[0; 60)
       L_PAREN@[7; 8) "("
       R_PAREN@[8; 9) ")"
     WHITESPACE@[9; 10) " "
-    BLOCK@[10; 60)
-      L_CURLY@[10; 11) "{"
-      WHITESPACE@[11; 16) "\n    "
-      EXPR_STMT@[16; 58)
-        MACRO_CALL@[16; 57)
-          PATH@[16; 22)
-            PATH_SEGMENT@[16; 22)
-              NAME_REF@[16; 22)
-                IDENT@[16; 22) "assert"
-          EXCL@[22; 23) "!"
-          TOKEN_TREE@[23; 57)
-            L_PAREN@[23; 24) "("
-            STRING@[24; 52) "\"\n    fn foo() {\n     ..."
-            COMMA@[52; 53) ","
-            WHITESPACE@[53; 54) " "
-            STRING@[54; 56) "\"\""
-            R_PAREN@[56; 57) ")"
-        SEMI@[57; 58) ";"
-      WHITESPACE@[58; 59) "\n"
-      R_CURLY@[59; 60) "}"
+    BLOCK_EXPR@[10; 60)
+      BLOCK@[10; 60)
+        L_CURLY@[10; 11) "{"
+        WHITESPACE@[11; 16) "\n    "
+        EXPR_STMT@[16; 58)
+          MACRO_CALL@[16; 57)
+            PATH@[16; 22)
+              PATH_SEGMENT@[16; 22)
+                NAME_REF@[16; 22)
+                  IDENT@[16; 22) "assert"
+            EXCL@[22; 23) "!"
+            TOKEN_TREE@[23; 57)
+              L_PAREN@[23; 24) "("
+              STRING@[24; 52) "\"\n    fn foo() {\n     ..."
+              COMMA@[52; 53) ","
+              WHITESPACE@[53; 54) " "
+              STRING@[54; 56) "\"\""
+              R_PAREN@[56; 57) ")"
+          SEMI@[57; 58) ";"
+        WHITESPACE@[58; 59) "\n"
+        R_CURLY@[59; 60) "}"
 "#
             .trim()
         );
@@ -190,9 +192,10 @@ FN_DEF@[0; 11)
     L_PAREN@[6; 7) "("
     R_PAREN@[7; 8) ")"
   WHITESPACE@[8; 9) " "
-  BLOCK@[9; 11)
-    L_CURLY@[9; 10) "{"
-    R_CURLY@[10; 11) "}"
+  BLOCK_EXPR@[9; 11)
+    BLOCK@[9; 11)
+      L_CURLY@[9; 10) "{"
+      R_CURLY@[10; 11) "}"
 "#
             .trim()
         );
@@ -258,10 +261,11 @@ SOURCE_FILE@[0; 12)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 12)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 11) "\n"
-      R_CURLY@[11; 12) "}"
+    BLOCK_EXPR@[9; 12)
+      BLOCK@[9; 12)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 11) "\n"
+        R_CURLY@[11; 12) "}"
 "#
             .trim()
         );
@@ -292,10 +296,11 @@ SOURCE_FILE@[0; 12)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 12)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 11) "\n"
-      R_CURLY@[11; 12) "}"
+    BLOCK_EXPR@[9; 12)
+      BLOCK@[9; 12)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 11) "\n"
+        R_CURLY@[11; 12) "}"
 "#
             .trim()
         );
@@ -325,10 +330,11 @@ SOURCE_FILE@[0; 25)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 12)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 11) "\n"
-      R_CURLY@[11; 12) "}"
+    BLOCK_EXPR@[9; 12)
+      BLOCK@[9; 12)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 11) "\n"
+        R_CURLY@[11; 12) "}"
   WHITESPACE@[12; 13) "\n"
   FN_DEF@[13; 25)
     FN_KW@[13; 15) "fn"
@@ -339,10 +345,11 @@ SOURCE_FILE@[0; 25)
       L_PAREN@[19; 20) "("
       R_PAREN@[20; 21) ")"
     WHITESPACE@[21; 22) " "
-    BLOCK@[22; 25)
-      L_CURLY@[22; 23) "{"
-      WHITESPACE@[23; 24) "\n"
-      R_CURLY@[24; 25) "}"
+    BLOCK_EXPR@[22; 25)
+      BLOCK@[22; 25)
+        L_CURLY@[22; 23) "{"
+        WHITESPACE@[23; 24) "\n"
+        R_CURLY@[24; 25) "}"
 "#
             .trim()
         );

--- a/crates/ra_mbe/src/tests.rs
+++ b/crates/ra_mbe/src/tests.rs
@@ -678,21 +678,22 @@ fn test_expr_order() {
     PARAM_LIST@[5; 7)
       L_PAREN@[5; 6) "("
       R_PAREN@[6; 7) ")"
-    BLOCK@[7; 15)
-      L_CURLY@[7; 8) "{"
-      EXPR_STMT@[8; 14)
-        BIN_EXPR@[8; 13)
-          BIN_EXPR@[8; 11)
-            LITERAL@[8; 9)
-              INT_NUMBER@[8; 9) "1"
-            PLUS@[9; 10) "+"
-            LITERAL@[10; 11)
-              INT_NUMBER@[10; 11) "1"
-          STAR@[11; 12) "*"
-          LITERAL@[12; 13)
-            INT_NUMBER@[12; 13) "2"
-        SEMI@[13; 14) ";"
-      R_CURLY@[14; 15) "}""#,
+    BLOCK_EXPR@[7; 15)
+      BLOCK@[7; 15)
+        L_CURLY@[7; 8) "{"
+        EXPR_STMT@[8; 14)
+          BIN_EXPR@[8; 13)
+            BIN_EXPR@[8; 11)
+              LITERAL@[8; 9)
+                INT_NUMBER@[8; 9) "1"
+              PLUS@[9; 10) "+"
+              LITERAL@[10; 11)
+                INT_NUMBER@[10; 11) "1"
+            STAR@[11; 12) "*"
+            LITERAL@[12; 13)
+              INT_NUMBER@[12; 13) "2"
+          SEMI@[13; 14) ";"
+        R_CURLY@[14; 15) "}""#,
     );
 }
 

--- a/crates/ra_parser/src/grammar.rs
+++ b/crates/ra_parser/src/grammar.rs
@@ -144,7 +144,7 @@ pub(crate) fn reparser(
     parent: Option<SyntaxKind>,
 ) -> Option<fn(&mut Parser)> {
     let res = match node {
-        BLOCK => expressions::block,
+        BLOCK => expressions::naked_block,
         RECORD_FIELD_DEF_LIST => items::record_field_def_list,
         RECORD_FIELD_LIST => items::record_field_list,
         ENUM_VARIANT_LIST => items::enum_variant_list,

--- a/crates/ra_parser/src/grammar/expressions.rs
+++ b/crates/ra_parser/src/grammar/expressions.rs
@@ -40,6 +40,11 @@ pub(crate) fn block(p: &mut Parser) {
         p.error("expected a block");
         return;
     }
+    atom::block_expr(p, None);
+}
+
+pub(crate) fn naked_block(p: &mut Parser) {
+    assert!(p.at(T!['{']));
     let m = p.start();
     p.bump();
     expr_block_contents(p);

--- a/crates/ra_parser/src/grammar/expressions/atom.rs
+++ b/crates/ra_parser/src/grammar/expressions/atom.rs
@@ -463,10 +463,10 @@ fn match_guard(p: &mut Parser) -> CompletedMarker {
 //     unsafe {};
 //     'label: {};
 // }
-fn block_expr(p: &mut Parser, m: Option<Marker>) -> CompletedMarker {
+pub(super) fn block_expr(p: &mut Parser, m: Option<Marker>) -> CompletedMarker {
     assert!(p.at(T!['{']));
     let m = m.unwrap_or_else(|| p.start());
-    block(p);
+    naked_block(p);
     m.complete(p, BLOCK_EXPR)
 }
 

--- a/crates/ra_syntax/src/ast/expr_extensions.rs
+++ b/crates/ra_syntax/src/ast/expr_extensions.rs
@@ -289,6 +289,26 @@ impl ast::Literal {
     }
 }
 
+impl ast::BlockExpr {
+    /// false if the block is an intrinsic part of the syntax and can't be
+    /// replaced with arbitrary expression.
+    ///
+    /// ```not_rust
+    /// fn foo() { not_stand_alone }
+    /// const FOO: () = { stand_alone };
+    /// ```
+    pub fn is_standalone(&self) -> bool {
+        let kind = match self.syntax().parent() {
+            None => return true,
+            Some(it) => it.kind(),
+        };
+        match kind {
+            FN_DEF | MATCH_ARM | IF_EXPR | WHILE_EXPR | LOOP_EXPR | TRY_BLOCK_EXPR => false,
+            _ => true,
+        }
+    }
+}
+
 #[test]
 fn test_literal_with_attr() {
     let parse = ast::SourceFile::parse(r#"const _: &str = { #[attr] "Hello" };"#);

--- a/crates/ra_syntax/src/ast/expr_extensions.rs
+++ b/crates/ra_syntax/src/ast/expr_extensions.rs
@@ -9,12 +9,12 @@ use crate::{
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ElseBranch {
-    Block(ast::Block),
+    Block(ast::BlockExpr),
     IfExpr(ast::IfExpr),
 }
 
 impl ast::IfExpr {
-    pub fn then_branch(&self) -> Option<ast::Block> {
+    pub fn then_branch(&self) -> Option<ast::BlockExpr> {
         self.blocks().nth(0)
     }
     pub fn else_branch(&self) -> Option<ElseBranch> {
@@ -28,7 +28,7 @@ impl ast::IfExpr {
         Some(res)
     }
 
-    fn blocks(&self) -> AstChildren<ast::Block> {
+    fn blocks(&self) -> AstChildren<ast::BlockExpr> {
         children(self)
     }
 }

--- a/crates/ra_syntax/src/ast/generated.rs
+++ b/crates/ra_syntax/src/ast/generated.rs
@@ -3135,7 +3135,7 @@ impl AstNode for TryBlockExpr {
     }
 }
 impl TryBlockExpr {
-    pub fn block(&self) -> Option<Block> {
+    pub fn body(&self) -> Option<BlockExpr> {
         AstChildren::new(&self.syntax).next()
     }
 }

--- a/crates/ra_syntax/src/ast/generated.rs
+++ b/crates/ra_syntax/src/ast/generated.rs
@@ -1003,7 +1003,7 @@ impl FnDef {
     pub fn param_list(&self) -> Option<ParamList> {
         AstChildren::new(&self.syntax).next()
     }
-    pub fn body(&self) -> Option<Block> {
+    pub fn body(&self) -> Option<BlockExpr> {
         AstChildren::new(&self.syntax).next()
     }
     pub fn ret_type(&self) -> Option<RetType> {

--- a/crates/ra_syntax/src/ast/traits.rs
+++ b/crates/ra_syntax/src/ast/traits.rs
@@ -28,7 +28,7 @@ pub trait VisibilityOwner: AstNode {
 }
 
 pub trait LoopBodyOwner: AstNode {
-    fn loop_body(&self) -> Option<ast::Block> {
+    fn loop_body(&self) -> Option<ast::BlockExpr> {
         child_opt(self)
     }
 }

--- a/crates/ra_syntax/src/grammar.ron
+++ b/crates/ra_syntax/src/grammar.ron
@@ -426,7 +426,7 @@ Grammar(
             traits: ["LoopBodyOwner"],
         ),
         "TryBlockExpr": (
-            options: ["Block"],
+            options: [["body", "BlockExpr"]],
         ),
         "ForExpr": (
             traits: ["LoopBodyOwner"],

--- a/crates/ra_syntax/src/grammar.ron
+++ b/crates/ra_syntax/src/grammar.ron
@@ -275,7 +275,7 @@ Grammar(
                 "AttrsOwner",
                 "DocCommentsOwner"
             ],
-            options: [ "ParamList", ["body", "Block"], "RetType" ],
+            options: [ "ParamList", ["body", "BlockExpr"], "RetType" ],
         ),
         "RetType": (options: ["TypeRef"]),
         "StructDef": (

--- a/crates/ra_syntax/src/lib.rs
+++ b/crates/ra_syntax/src/lib.rs
@@ -203,7 +203,8 @@ fn api_walkthrough() {
     assert_eq!(name.text(), "foo");
 
     // Let's get the `1 + 1` expression!
-    let block: ast::Block = func.body().unwrap();
+    let body: ast::BlockExpr = func.body().unwrap();
+    let block = body.block().unwrap();
     let expr: ast::Expr = block.expr().unwrap();
 
     // Enums are used to group related ast nodes together, and can be used for

--- a/crates/ra_syntax/src/validation.rs
+++ b/crates/ra_syntax/src/validation.rs
@@ -97,7 +97,7 @@ pub(crate) fn validate(root: &SyntaxNode) -> Vec<SyntaxError> {
     for node in root.descendants() {
         let _ = visitor_ctx(&mut errors)
             .visit::<ast::Literal, _>(validate_literal)
-            .visit::<ast::Block, _>(block::validate_block_node)
+            .visit::<ast::BlockExpr, _>(block::validate_block_expr)
             .visit::<ast::FieldExpr, _>(|it, errors| validate_numeric_name(it.name_ref(), errors))
             .visit::<ast::RecordField, _>(|it, errors| validate_numeric_name(it.name_ref(), errors))
             .accept(&node);

--- a/crates/ra_syntax/src/validation/block.rs
+++ b/crates/ra_syntax/src/validation/block.rs
@@ -5,18 +5,18 @@ use crate::{
     SyntaxKind::*,
 };
 
-pub(crate) fn validate_block_node(node: ast::Block, errors: &mut Vec<SyntaxError>) {
-    if let Some(parent) = node.syntax().parent() {
+pub(crate) fn validate_block_expr(expr: ast::BlockExpr, errors: &mut Vec<SyntaxError>) {
+    if let Some(parent) = expr.syntax().parent() {
         match parent.kind() {
-            FN_DEF => return,
-            BLOCK_EXPR => match parent.parent().map(|v| v.kind()) {
-                Some(EXPR_STMT) | Some(BLOCK) => return,
-                _ => {}
-            },
+            FN_DEF | EXPR_STMT | BLOCK => return,
             _ => {}
         }
     }
-    errors.extend(
-        node.attrs().map(|attr| SyntaxError::new(InvalidBlockAttr, attr.syntax().text_range())),
-    )
+    if let Some(block) = expr.block() {
+        errors.extend(
+            block
+                .attrs()
+                .map(|attr| SyntaxError::new(InvalidBlockAttr, attr.syntax().text_range())),
+        )
+    }
 }

--- a/crates/ra_syntax/test_data/parser/err/0005_attribute_recover.txt
+++ b/crates/ra_syntax/test_data/parser/err/0005_attribute_recover.txt
@@ -25,10 +25,11 @@ SOURCE_FILE@[0; 54)
       L_PAREN@[25; 26) "("
       R_PAREN@[26; 27) ")"
     WHITESPACE@[27; 28) " "
-    BLOCK@[28; 31)
-      L_CURLY@[28; 29) "{"
-      WHITESPACE@[29; 30) "\n"
-      R_CURLY@[30; 31) "}"
+    BLOCK_EXPR@[28; 31)
+      BLOCK@[28; 31)
+        L_CURLY@[28; 29) "{"
+        WHITESPACE@[29; 30) "\n"
+        R_CURLY@[30; 31) "}"
   WHITESPACE@[31; 34) "\n\n\n"
   ATTR@[34; 53)
     POUND@[34; 35) "#"

--- a/crates/ra_syntax/test_data/parser/err/0007_stray_curly_in_file.txt
+++ b/crates/ra_syntax/test_data/parser/err/0007_stray_curly_in_file.txt
@@ -20,9 +20,10 @@ SOURCE_FILE@[0; 31)
     PARAM_LIST@[23; 25)
       L_PAREN@[23; 24) "("
       R_PAREN@[24; 25) ")"
-    BLOCK@[25; 27)
-      L_CURLY@[25; 26) "{"
-      R_CURLY@[26; 27) "}"
+    BLOCK_EXPR@[25; 27)
+      BLOCK@[25; 27)
+        L_CURLY@[25; 26) "{"
+        R_CURLY@[26; 27) "}"
   WHITESPACE@[27; 29) "\n\n"
   ERROR@[29; 30)
     R_CURLY@[29; 30) "}"

--- a/crates/ra_syntax/test_data/parser/err/0008_item_block_recovery.txt
+++ b/crates/ra_syntax/test_data/parser/err/0008_item_block_recovery.txt
@@ -8,10 +8,11 @@ SOURCE_FILE@[0; 95)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 12)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 11) "\n"
-      R_CURLY@[11; 12) "}"
+    BLOCK_EXPR@[9; 12)
+      BLOCK@[9; 12)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 11) "\n"
+        R_CURLY@[11; 12) "}"
   WHITESPACE@[12; 14) "\n\n"
   MACRO_CALL@[14; 19)
     PATH@[14; 17)
@@ -32,29 +33,31 @@ SOURCE_FILE@[0; 95)
         LITERAL@[29; 33)
           TRUE_KW@[29; 33) "true"
       WHITESPACE@[33; 34) " "
-      BLOCK@[34; 51)
-        L_CURLY@[34; 35) "{"
-        WHITESPACE@[35; 44) "\n        "
-        LITERAL@[44; 45)
-          INT_NUMBER@[44; 45) "1"
-        WHITESPACE@[45; 50) "\n    "
-        R_CURLY@[50; 51) "}"
+      BLOCK_EXPR@[34; 51)
+        BLOCK@[34; 51)
+          L_CURLY@[34; 35) "{"
+          WHITESPACE@[35; 44) "\n        "
+          LITERAL@[44; 45)
+            INT_NUMBER@[44; 45) "1"
+          WHITESPACE@[45; 50) "\n    "
+          R_CURLY@[50; 51) "}"
       WHITESPACE@[51; 52) " "
       ELSE_KW@[52; 56) "else"
       WHITESPACE@[56; 57) " "
-      BLOCK@[57; 78)
-        L_CURLY@[57; 58) "{"
-        WHITESPACE@[58; 67) "\n        "
-        BIN_EXPR@[67; 72)
-          LITERAL@[67; 68)
-            INT_NUMBER@[67; 68) "2"
-          WHITESPACE@[68; 69) " "
-          PLUS@[69; 70) "+"
-          WHITESPACE@[70; 71) " "
-          LITERAL@[71; 72)
-            INT_NUMBER@[71; 72) "3"
-        WHITESPACE@[72; 77) "\n    "
-        R_CURLY@[77; 78) "}"
+      BLOCK_EXPR@[57; 78)
+        BLOCK@[57; 78)
+          L_CURLY@[57; 58) "{"
+          WHITESPACE@[58; 67) "\n        "
+          BIN_EXPR@[67; 72)
+            LITERAL@[67; 68)
+              INT_NUMBER@[67; 68) "2"
+            WHITESPACE@[68; 69) " "
+            PLUS@[69; 70) "+"
+            WHITESPACE@[70; 71) " "
+            LITERAL@[71; 72)
+              INT_NUMBER@[71; 72) "3"
+          WHITESPACE@[72; 77) "\n    "
+          R_CURLY@[77; 78) "}"
     WHITESPACE@[78; 79) "\n"
     R_CURLY@[79; 80) "}"
   WHITESPACE@[80; 82) "\n\n"
@@ -67,10 +70,11 @@ SOURCE_FILE@[0; 95)
       L_PAREN@[88; 89) "("
       R_PAREN@[89; 90) ")"
     WHITESPACE@[90; 91) " "
-    BLOCK@[91; 94)
-      L_CURLY@[91; 92) "{"
-      WHITESPACE@[92; 93) "\n"
-      R_CURLY@[93; 94) "}"
+    BLOCK_EXPR@[91; 94)
+      BLOCK@[91; 94)
+        L_CURLY@[91; 92) "{"
+        WHITESPACE@[92; 93) "\n"
+        R_CURLY@[93; 94) "}"
   WHITESPACE@[94; 95) "\n"
 error 17: expected EXCL
 error 19: expected SEMI

--- a/crates/ra_syntax/test_data/parser/err/0010_unsafe_lambda_block.txt
+++ b/crates/ra_syntax/test_data/parser/err/0010_unsafe_lambda_block.txt
@@ -8,35 +8,36 @@ SOURCE_FILE@[0; 42)
       L_PAREN@[7; 8) "("
       R_PAREN@[8; 9) ")"
     WHITESPACE@[9; 10) " "
-    BLOCK@[10; 41)
-      L_CURLY@[10; 11) "{"
-      WHITESPACE@[11; 16) "\n    "
-      EXPR_STMT@[16; 39)
-        LAMBDA_EXPR@[16; 38)
-          PARAM_LIST@[16; 18)
-            PIPE@[16; 17) "|"
-            PIPE@[17; 18) "|"
-          WHITESPACE@[18; 19) " "
-          RET_TYPE@[19; 24)
-            THIN_ARROW@[19; 21) "->"
-            WHITESPACE@[21; 22) " "
-            TUPLE_TYPE@[22; 24)
-              L_PAREN@[22; 23) "("
-              R_PAREN@[23; 24) ")"
-          WHITESPACE@[24; 25) " "
-          BLOCK_EXPR@[25; 38)
-            UNSAFE_KW@[25; 31) "unsafe"
-            WHITESPACE@[31; 32) " "
-            BLOCK@[32; 38)
-              L_CURLY@[32; 33) "{"
-              WHITESPACE@[33; 34) " "
-              TUPLE_EXPR@[34; 36)
-                L_PAREN@[34; 35) "("
-                R_PAREN@[35; 36) ")"
-              WHITESPACE@[36; 37) " "
-              R_CURLY@[37; 38) "}"
-        SEMI@[38; 39) ";"
-      WHITESPACE@[39; 40) "\n"
-      R_CURLY@[40; 41) "}"
+    BLOCK_EXPR@[10; 41)
+      BLOCK@[10; 41)
+        L_CURLY@[10; 11) "{"
+        WHITESPACE@[11; 16) "\n    "
+        EXPR_STMT@[16; 39)
+          LAMBDA_EXPR@[16; 38)
+            PARAM_LIST@[16; 18)
+              PIPE@[16; 17) "|"
+              PIPE@[17; 18) "|"
+            WHITESPACE@[18; 19) " "
+            RET_TYPE@[19; 24)
+              THIN_ARROW@[19; 21) "->"
+              WHITESPACE@[21; 22) " "
+              TUPLE_TYPE@[22; 24)
+                L_PAREN@[22; 23) "("
+                R_PAREN@[23; 24) ")"
+            WHITESPACE@[24; 25) " "
+            BLOCK_EXPR@[25; 38)
+              UNSAFE_KW@[25; 31) "unsafe"
+              WHITESPACE@[31; 32) " "
+              BLOCK@[32; 38)
+                L_CURLY@[32; 33) "{"
+                WHITESPACE@[33; 34) " "
+                TUPLE_EXPR@[34; 36)
+                  L_PAREN@[34; 35) "("
+                  R_PAREN@[35; 36) ")"
+                WHITESPACE@[36; 37) " "
+                R_CURLY@[37; 38) "}"
+          SEMI@[38; 39) ";"
+        WHITESPACE@[39; 40) "\n"
+        R_CURLY@[40; 41) "}"
   WHITESPACE@[41; 42) "\n"
 error 24: expected `{`

--- a/crates/ra_syntax/test_data/parser/err/0014_where_no_bounds.txt
+++ b/crates/ra_syntax/test_data/parser/err/0014_where_no_bounds.txt
@@ -24,8 +24,9 @@ SOURCE_FILE@[0; 23)
               NAME_REF@[18; 19)
                 IDENT@[18; 19) "T"
     WHITESPACE@[19; 20) " "
-    BLOCK@[20; 22)
-      L_CURLY@[20; 21) "{"
-      R_CURLY@[21; 22) "}"
+    BLOCK_EXPR@[20; 22)
+      BLOCK@[20; 22)
+        L_CURLY@[20; 21) "{"
+        R_CURLY@[21; 22) "}"
   WHITESPACE@[22; 23) "\n"
 error 19: expected colon

--- a/crates/ra_syntax/test_data/parser/err/0016_missing_semi.txt
+++ b/crates/ra_syntax/test_data/parser/err/0016_missing_semi.txt
@@ -8,36 +8,37 @@ SOURCE_FILE@[0; 56)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 55)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 38)
-        CALL_EXPR@[15; 38)
-          PATH_EXPR@[15; 18)
-            PATH@[15; 18)
-              PATH_SEGMENT@[15; 18)
-                NAME_REF@[15; 18)
-                  IDENT@[15; 18) "foo"
-          ARG_LIST@[18; 38)
-            L_PAREN@[18; 19) "("
-            WHITESPACE@[19; 28) "\n        "
-            LITERAL@[28; 29)
-              INT_NUMBER@[28; 29) "1"
-            COMMA@[29; 30) ","
-            WHITESPACE@[30; 31) " "
-            LITERAL@[31; 32)
-              INT_NUMBER@[31; 32) "2"
-            WHITESPACE@[32; 37) "\n    "
-            R_PAREN@[37; 38) ")"
-      WHITESPACE@[38; 43) "\n    "
-      EXPR_STMT@[43; 53)
-        RETURN_EXPR@[43; 52)
-          RETURN_KW@[43; 49) "return"
-          WHITESPACE@[49; 50) " "
-          LITERAL@[50; 52)
-            INT_NUMBER@[50; 52) "92"
-        SEMI@[52; 53) ";"
-      WHITESPACE@[53; 54) "\n"
-      R_CURLY@[54; 55) "}"
+    BLOCK_EXPR@[9; 55)
+      BLOCK@[9; 55)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        EXPR_STMT@[15; 38)
+          CALL_EXPR@[15; 38)
+            PATH_EXPR@[15; 18)
+              PATH@[15; 18)
+                PATH_SEGMENT@[15; 18)
+                  NAME_REF@[15; 18)
+                    IDENT@[15; 18) "foo"
+            ARG_LIST@[18; 38)
+              L_PAREN@[18; 19) "("
+              WHITESPACE@[19; 28) "\n        "
+              LITERAL@[28; 29)
+                INT_NUMBER@[28; 29) "1"
+              COMMA@[29; 30) ","
+              WHITESPACE@[30; 31) " "
+              LITERAL@[31; 32)
+                INT_NUMBER@[31; 32) "2"
+              WHITESPACE@[32; 37) "\n    "
+              R_PAREN@[37; 38) ")"
+        WHITESPACE@[38; 43) "\n    "
+        EXPR_STMT@[43; 53)
+          RETURN_EXPR@[43; 52)
+            RETURN_KW@[43; 49) "return"
+            WHITESPACE@[49; 50) " "
+            LITERAL@[50; 52)
+              INT_NUMBER@[50; 52) "92"
+          SEMI@[52; 53) ";"
+        WHITESPACE@[53; 54) "\n"
+        R_CURLY@[54; 55) "}"
   WHITESPACE@[55; 56) "\n"
 error 38: expected SEMI

--- a/crates/ra_syntax/test_data/parser/err/0017_incomplete_binexpr.txt
+++ b/crates/ra_syntax/test_data/parser/err/0017_incomplete_binexpr.txt
@@ -19,28 +19,29 @@ SOURCE_FILE@[0; 47)
                 IDENT@[12; 15) "i32"
       R_PAREN@[15; 16) ")"
     WHITESPACE@[16; 17) " "
-    BLOCK@[17; 46)
-      L_CURLY@[17; 18) "{"
-      WHITESPACE@[18; 23) "\n    "
-      LET_STMT@[23; 36)
-        LET_KW@[23; 26) "let"
-        WHITESPACE@[26; 27) " "
-        BIND_PAT@[27; 30)
-          NAME@[27; 30)
-            IDENT@[27; 30) "bar"
-        WHITESPACE@[30; 31) " "
-        EQ@[31; 32) "="
-        WHITESPACE@[32; 33) " "
-        LITERAL@[33; 35)
-          INT_NUMBER@[33; 35) "92"
-        SEMI@[35; 36) ";"
-      WHITESPACE@[36; 41) "\n    "
-      BIN_EXPR@[41; 44)
-        LITERAL@[41; 42)
-          INT_NUMBER@[41; 42) "1"
-        WHITESPACE@[42; 43) " "
-        PLUS@[43; 44) "+"
-      WHITESPACE@[44; 45) "\n"
-      R_CURLY@[45; 46) "}"
+    BLOCK_EXPR@[17; 46)
+      BLOCK@[17; 46)
+        L_CURLY@[17; 18) "{"
+        WHITESPACE@[18; 23) "\n    "
+        LET_STMT@[23; 36)
+          LET_KW@[23; 26) "let"
+          WHITESPACE@[26; 27) " "
+          BIND_PAT@[27; 30)
+            NAME@[27; 30)
+              IDENT@[27; 30) "bar"
+          WHITESPACE@[30; 31) " "
+          EQ@[31; 32) "="
+          WHITESPACE@[32; 33) " "
+          LITERAL@[33; 35)
+            INT_NUMBER@[33; 35) "92"
+          SEMI@[35; 36) ";"
+        WHITESPACE@[36; 41) "\n    "
+        BIN_EXPR@[41; 44)
+          LITERAL@[41; 42)
+            INT_NUMBER@[41; 42) "1"
+          WHITESPACE@[42; 43) " "
+          PLUS@[43; 44) "+"
+        WHITESPACE@[44; 45) "\n"
+        R_CURLY@[45; 46) "}"
   WHITESPACE@[46; 47) "\n"
 error 44: expected expression

--- a/crates/ra_syntax/test_data/parser/err/0018_incomplete_fn.txt
+++ b/crates/ra_syntax/test_data/parser/err/0018_incomplete_fn.txt
@@ -32,89 +32,90 @@ SOURCE_FILE@[0; 183)
                 NAME_REF@[39; 46)
                   IDENT@[39; 46) "ScopeId"
         WHITESPACE@[46; 47) " "
-        BLOCK@[47; 161)
-          L_CURLY@[47; 48) "{"
-          WHITESPACE@[48; 57) "\n        "
-          LET_STMT@[57; 85)
-            LET_KW@[57; 60) "let"
-            WHITESPACE@[60; 61) " "
-            BIND_PAT@[61; 64)
-              NAME@[61; 64)
-                IDENT@[61; 64) "res"
-            WHITESPACE@[64; 65) " "
-            EQ@[65; 66) "="
-            WHITESPACE@[66; 67) " "
-            METHOD_CALL_EXPR@[67; 84)
-              FIELD_EXPR@[67; 78)
-                PATH_EXPR@[67; 71)
-                  PATH@[67; 71)
-                    PATH_SEGMENT@[67; 71)
-                      SELF_KW@[67; 71) "self"
-                DOT@[71; 72) "."
-                NAME_REF@[72; 78)
-                  IDENT@[72; 78) "scopes"
-              DOT@[78; 79) "."
-              NAME_REF@[79; 82)
-                IDENT@[79; 82) "len"
-              ARG_LIST@[82; 84)
-                L_PAREN@[82; 83) "("
-                R_PAREN@[83; 84) ")"
-            SEMI@[84; 85) ";"
-          WHITESPACE@[85; 94) "\n        "
-          METHOD_CALL_EXPR@[94; 155)
-            FIELD_EXPR@[94; 105)
-              PATH_EXPR@[94; 98)
-                PATH@[94; 98)
-                  PATH_SEGMENT@[94; 98)
-                    SELF_KW@[94; 98) "self"
-              DOT@[98; 99) "."
-              NAME_REF@[99; 105)
-                IDENT@[99; 105) "scopes"
-            DOT@[105; 106) "."
-            NAME_REF@[106; 110)
-              IDENT@[106; 110) "push"
-            ARG_LIST@[110; 155)
-              L_PAREN@[110; 111) "("
-              RECORD_LIT@[111; 154)
-                PATH@[111; 120)
-                  PATH_SEGMENT@[111; 120)
-                    NAME_REF@[111; 120)
-                      IDENT@[111; 120) "ScopeData"
-                WHITESPACE@[120; 121) " "
-                RECORD_FIELD_LIST@[121; 154)
-                  L_CURLY@[121; 122) "{"
-                  WHITESPACE@[122; 123) " "
-                  RECORD_FIELD@[123; 135)
-                    NAME_REF@[123; 129)
-                      IDENT@[123; 129) "parent"
-                    COLON@[129; 130) ":"
-                    WHITESPACE@[130; 131) " "
-                    PATH_EXPR@[131; 135)
-                      PATH@[131; 135)
-                        PATH_SEGMENT@[131; 135)
-                          NAME_REF@[131; 135)
-                            IDENT@[131; 135) "None"
-                  COMMA@[135; 136) ","
-                  WHITESPACE@[136; 137) " "
-                  RECORD_FIELD@[137; 152)
-                    NAME_REF@[137; 144)
-                      IDENT@[137; 144) "entries"
-                    COLON@[144; 145) ":"
-                    WHITESPACE@[145; 146) " "
-                    MACRO_CALL@[146; 152)
-                      PATH@[146; 149)
-                        PATH_SEGMENT@[146; 149)
-                          NAME_REF@[146; 149)
-                            IDENT@[146; 149) "vec"
-                      EXCL@[149; 150) "!"
-                      TOKEN_TREE@[150; 152)
-                        L_BRACK@[150; 151) "["
-                        R_BRACK@[151; 152) "]"
-                  WHITESPACE@[152; 153) " "
-                  R_CURLY@[153; 154) "}"
-              R_PAREN@[154; 155) ")"
-          WHITESPACE@[155; 160) "\n    "
-          R_CURLY@[160; 161) "}"
+        BLOCK_EXPR@[47; 161)
+          BLOCK@[47; 161)
+            L_CURLY@[47; 48) "{"
+            WHITESPACE@[48; 57) "\n        "
+            LET_STMT@[57; 85)
+              LET_KW@[57; 60) "let"
+              WHITESPACE@[60; 61) " "
+              BIND_PAT@[61; 64)
+                NAME@[61; 64)
+                  IDENT@[61; 64) "res"
+              WHITESPACE@[64; 65) " "
+              EQ@[65; 66) "="
+              WHITESPACE@[66; 67) " "
+              METHOD_CALL_EXPR@[67; 84)
+                FIELD_EXPR@[67; 78)
+                  PATH_EXPR@[67; 71)
+                    PATH@[67; 71)
+                      PATH_SEGMENT@[67; 71)
+                        SELF_KW@[67; 71) "self"
+                  DOT@[71; 72) "."
+                  NAME_REF@[72; 78)
+                    IDENT@[72; 78) "scopes"
+                DOT@[78; 79) "."
+                NAME_REF@[79; 82)
+                  IDENT@[79; 82) "len"
+                ARG_LIST@[82; 84)
+                  L_PAREN@[82; 83) "("
+                  R_PAREN@[83; 84) ")"
+              SEMI@[84; 85) ";"
+            WHITESPACE@[85; 94) "\n        "
+            METHOD_CALL_EXPR@[94; 155)
+              FIELD_EXPR@[94; 105)
+                PATH_EXPR@[94; 98)
+                  PATH@[94; 98)
+                    PATH_SEGMENT@[94; 98)
+                      SELF_KW@[94; 98) "self"
+                DOT@[98; 99) "."
+                NAME_REF@[99; 105)
+                  IDENT@[99; 105) "scopes"
+              DOT@[105; 106) "."
+              NAME_REF@[106; 110)
+                IDENT@[106; 110) "push"
+              ARG_LIST@[110; 155)
+                L_PAREN@[110; 111) "("
+                RECORD_LIT@[111; 154)
+                  PATH@[111; 120)
+                    PATH_SEGMENT@[111; 120)
+                      NAME_REF@[111; 120)
+                        IDENT@[111; 120) "ScopeData"
+                  WHITESPACE@[120; 121) " "
+                  RECORD_FIELD_LIST@[121; 154)
+                    L_CURLY@[121; 122) "{"
+                    WHITESPACE@[122; 123) " "
+                    RECORD_FIELD@[123; 135)
+                      NAME_REF@[123; 129)
+                        IDENT@[123; 129) "parent"
+                      COLON@[129; 130) ":"
+                      WHITESPACE@[130; 131) " "
+                      PATH_EXPR@[131; 135)
+                        PATH@[131; 135)
+                          PATH_SEGMENT@[131; 135)
+                            NAME_REF@[131; 135)
+                              IDENT@[131; 135) "None"
+                    COMMA@[135; 136) ","
+                    WHITESPACE@[136; 137) " "
+                    RECORD_FIELD@[137; 152)
+                      NAME_REF@[137; 144)
+                        IDENT@[137; 144) "entries"
+                      COLON@[144; 145) ":"
+                      WHITESPACE@[145; 146) " "
+                      MACRO_CALL@[146; 152)
+                        PATH@[146; 149)
+                          PATH_SEGMENT@[146; 149)
+                            NAME_REF@[146; 149)
+                              IDENT@[146; 149) "vec"
+                        EXCL@[149; 150) "!"
+                        TOKEN_TREE@[150; 152)
+                          L_BRACK@[150; 151) "["
+                          R_BRACK@[151; 152) "]"
+                    WHITESPACE@[152; 153) " "
+                    R_CURLY@[153; 154) "}"
+                R_PAREN@[154; 155) ")"
+            WHITESPACE@[155; 160) "\n    "
+            R_CURLY@[160; 161) "}"
       WHITESPACE@[161; 167) "\n\n    "
       FN_DEF@[167; 180)
         FN_KW@[167; 169) "fn"

--- a/crates/ra_syntax/test_data/parser/err/0019_let_recover.txt
+++ b/crates/ra_syntax/test_data/parser/err/0019_let_recover.txt
@@ -8,88 +8,92 @@ SOURCE_FILE@[0; 139)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 138)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      LET_STMT@[15; 24)
-        LET_KW@[15; 18) "let"
-        WHITESPACE@[18; 19) " "
-        BIND_PAT@[19; 22)
-          NAME@[19; 22)
-            IDENT@[19; 22) "foo"
-        WHITESPACE@[22; 23) " "
-        EQ@[23; 24) "="
-      WHITESPACE@[24; 29) "\n    "
-      LET_STMT@[29; 41)
-        LET_KW@[29; 32) "let"
-        WHITESPACE@[32; 33) " "
-        BIND_PAT@[33; 36)
-          NAME@[33; 36)
-            IDENT@[33; 36) "bar"
-        WHITESPACE@[36; 37) " "
-        EQ@[37; 38) "="
-        WHITESPACE@[38; 39) " "
-        LITERAL@[39; 40)
-          INT_NUMBER@[39; 40) "1"
-        SEMI@[40; 41) ";"
-      WHITESPACE@[41; 46) "\n    "
-      LET_STMT@[46; 49)
-        LET_KW@[46; 49) "let"
-      WHITESPACE@[49; 54) "\n    "
-      LET_STMT@[54; 67)
-        LET_KW@[54; 57) "let"
-        WHITESPACE@[57; 58) " "
-        BIND_PAT@[58; 61)
-          NAME@[58; 61)
-            IDENT@[58; 61) "baz"
-        WHITESPACE@[61; 62) " "
-        EQ@[62; 63) "="
-        WHITESPACE@[63; 64) " "
-        LITERAL@[64; 66)
-          INT_NUMBER@[64; 66) "92"
-        SEMI@[66; 67) ";"
-      WHITESPACE@[67; 72) "\n    "
-      LET_STMT@[72; 75)
-        LET_KW@[72; 75) "let"
-      WHITESPACE@[75; 80) "\n    "
-      EXPR_STMT@[80; 90)
-        IF_EXPR@[80; 90)
-          IF_KW@[80; 82) "if"
-          WHITESPACE@[82; 83) " "
-          CONDITION@[83; 87)
-            LITERAL@[83; 87)
-              TRUE_KW@[83; 87) "true"
-          WHITESPACE@[87; 88) " "
-          BLOCK@[88; 90)
-            L_CURLY@[88; 89) "{"
-            R_CURLY@[89; 90) "}"
-      WHITESPACE@[90; 95) "\n    "
-      LET_STMT@[95; 98)
-        LET_KW@[95; 98) "let"
-      WHITESPACE@[98; 103) "\n    "
-      EXPR_STMT@[103; 116)
-        WHILE_EXPR@[103; 116)
-          WHILE_KW@[103; 108) "while"
-          WHITESPACE@[108; 109) " "
-          CONDITION@[109; 113)
-            LITERAL@[109; 113)
-              TRUE_KW@[109; 113) "true"
-          WHITESPACE@[113; 114) " "
-          BLOCK@[114; 116)
-            L_CURLY@[114; 115) "{"
-            R_CURLY@[115; 116) "}"
-      WHITESPACE@[116; 121) "\n    "
-      LET_STMT@[121; 124)
-        LET_KW@[121; 124) "let"
-      WHITESPACE@[124; 129) "\n    "
-      LOOP_EXPR@[129; 136)
-        LOOP_KW@[129; 133) "loop"
-        WHITESPACE@[133; 134) " "
-        BLOCK@[134; 136)
-          L_CURLY@[134; 135) "{"
-          R_CURLY@[135; 136) "}"
-      WHITESPACE@[136; 137) "\n"
-      R_CURLY@[137; 138) "}"
+    BLOCK_EXPR@[9; 138)
+      BLOCK@[9; 138)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        LET_STMT@[15; 24)
+          LET_KW@[15; 18) "let"
+          WHITESPACE@[18; 19) " "
+          BIND_PAT@[19; 22)
+            NAME@[19; 22)
+              IDENT@[19; 22) "foo"
+          WHITESPACE@[22; 23) " "
+          EQ@[23; 24) "="
+        WHITESPACE@[24; 29) "\n    "
+        LET_STMT@[29; 41)
+          LET_KW@[29; 32) "let"
+          WHITESPACE@[32; 33) " "
+          BIND_PAT@[33; 36)
+            NAME@[33; 36)
+              IDENT@[33; 36) "bar"
+          WHITESPACE@[36; 37) " "
+          EQ@[37; 38) "="
+          WHITESPACE@[38; 39) " "
+          LITERAL@[39; 40)
+            INT_NUMBER@[39; 40) "1"
+          SEMI@[40; 41) ";"
+        WHITESPACE@[41; 46) "\n    "
+        LET_STMT@[46; 49)
+          LET_KW@[46; 49) "let"
+        WHITESPACE@[49; 54) "\n    "
+        LET_STMT@[54; 67)
+          LET_KW@[54; 57) "let"
+          WHITESPACE@[57; 58) " "
+          BIND_PAT@[58; 61)
+            NAME@[58; 61)
+              IDENT@[58; 61) "baz"
+          WHITESPACE@[61; 62) " "
+          EQ@[62; 63) "="
+          WHITESPACE@[63; 64) " "
+          LITERAL@[64; 66)
+            INT_NUMBER@[64; 66) "92"
+          SEMI@[66; 67) ";"
+        WHITESPACE@[67; 72) "\n    "
+        LET_STMT@[72; 75)
+          LET_KW@[72; 75) "let"
+        WHITESPACE@[75; 80) "\n    "
+        EXPR_STMT@[80; 90)
+          IF_EXPR@[80; 90)
+            IF_KW@[80; 82) "if"
+            WHITESPACE@[82; 83) " "
+            CONDITION@[83; 87)
+              LITERAL@[83; 87)
+                TRUE_KW@[83; 87) "true"
+            WHITESPACE@[87; 88) " "
+            BLOCK_EXPR@[88; 90)
+              BLOCK@[88; 90)
+                L_CURLY@[88; 89) "{"
+                R_CURLY@[89; 90) "}"
+        WHITESPACE@[90; 95) "\n    "
+        LET_STMT@[95; 98)
+          LET_KW@[95; 98) "let"
+        WHITESPACE@[98; 103) "\n    "
+        EXPR_STMT@[103; 116)
+          WHILE_EXPR@[103; 116)
+            WHILE_KW@[103; 108) "while"
+            WHITESPACE@[108; 109) " "
+            CONDITION@[109; 113)
+              LITERAL@[109; 113)
+                TRUE_KW@[109; 113) "true"
+            WHITESPACE@[113; 114) " "
+            BLOCK_EXPR@[114; 116)
+              BLOCK@[114; 116)
+                L_CURLY@[114; 115) "{"
+                R_CURLY@[115; 116) "}"
+        WHITESPACE@[116; 121) "\n    "
+        LET_STMT@[121; 124)
+          LET_KW@[121; 124) "let"
+        WHITESPACE@[124; 129) "\n    "
+        LOOP_EXPR@[129; 136)
+          LOOP_KW@[129; 133) "loop"
+          WHITESPACE@[133; 134) " "
+          BLOCK_EXPR@[134; 136)
+            BLOCK@[134; 136)
+              L_CURLY@[134; 135) "{"
+              R_CURLY@[135; 136) "}"
+        WHITESPACE@[136; 137) "\n"
+        R_CURLY@[137; 138) "}"
   WHITESPACE@[138; 139) "\n"
 error 24: expected expression
 error 24: expected SEMI

--- a/crates/ra_syntax/test_data/parser/err/0020_fn_recover.txt
+++ b/crates/ra_syntax/test_data/parser/err/0020_fn_recover.txt
@@ -11,9 +11,10 @@ SOURCE_FILE@[0; 16)
       L_PAREN@[10; 11) "("
       R_PAREN@[11; 12) ")"
     WHITESPACE@[12; 13) " "
-    BLOCK@[13; 15)
-      L_CURLY@[13; 14) "{"
-      R_CURLY@[14; 15) "}"
+    BLOCK_EXPR@[13; 15)
+      BLOCK@[13; 15)
+        L_CURLY@[13; 14) "{"
+        R_CURLY@[14; 15) "}"
   WHITESPACE@[15; 16) "\n"
 error 2: expected a name
 error 2: expected function arguments

--- a/crates/ra_syntax/test_data/parser/err/0021_incomplete_param.txt
+++ b/crates/ra_syntax/test_data/parser/err/0021_incomplete_param.txt
@@ -25,10 +25,11 @@ SOURCE_FILE@[0; 22)
             IDENT@[15; 16) "y"
       R_PAREN@[16; 17) ")"
     WHITESPACE@[17; 18) " "
-    BLOCK@[18; 21)
-      L_CURLY@[18; 19) "{"
-      WHITESPACE@[19; 20) "\n"
-      R_CURLY@[20; 21) "}"
+    BLOCK_EXPR@[18; 21)
+      BLOCK@[18; 21)
+        L_CURLY@[18; 19) "{"
+        WHITESPACE@[19; 20) "\n"
+        R_CURLY@[20; 21) "}"
   WHITESPACE@[21; 22) "\n"
 error 16: expected COLON
 error 16: expected type

--- a/crates/ra_syntax/test_data/parser/err/0022_bad_exprs.txt
+++ b/crates/ra_syntax/test_data/parser/err/0022_bad_exprs.txt
@@ -8,38 +8,39 @@ SOURCE_FILE@[0; 112)
       L_PAREN@[4; 5) "("
       R_PAREN@[5; 6) ")"
     WHITESPACE@[6; 7) " "
-    BLOCK@[7; 33)
-      L_CURLY@[7; 8) "{"
-      WHITESPACE@[8; 9) " "
-      EXPR_STMT@[9; 15)
-        ARRAY_EXPR@[9; 15)
-          L_BRACK@[9; 10) "["
-          LITERAL@[10; 11)
-            INT_NUMBER@[10; 11) "1"
-          COMMA@[11; 12) ","
-          WHITESPACE@[12; 13) " "
-          LITERAL@[13; 14)
-            INT_NUMBER@[13; 14) "2"
-          COMMA@[14; 15) ","
-      WHITESPACE@[15; 16) " "
-      EXPR_STMT@[16; 17)
-        ERROR@[16; 17)
-          AT@[16; 17) "@"
-      EXPR_STMT@[17; 18)
-        ERROR@[17; 18)
-          COMMA@[17; 18) ","
-      WHITESPACE@[18; 19) " "
-      STRUCT_DEF@[19; 26)
-        STRUCT_KW@[19; 25) "struct"
-        ERROR@[25; 26)
-          COMMA@[25; 26) ","
-      WHITESPACE@[26; 27) " "
-      LET_STMT@[27; 31)
-        LET_KW@[27; 30) "let"
-        ERROR@[30; 31)
-          R_BRACK@[30; 31) "]"
-      WHITESPACE@[31; 32) " "
-      R_CURLY@[32; 33) "}"
+    BLOCK_EXPR@[7; 33)
+      BLOCK@[7; 33)
+        L_CURLY@[7; 8) "{"
+        WHITESPACE@[8; 9) " "
+        EXPR_STMT@[9; 15)
+          ARRAY_EXPR@[9; 15)
+            L_BRACK@[9; 10) "["
+            LITERAL@[10; 11)
+              INT_NUMBER@[10; 11) "1"
+            COMMA@[11; 12) ","
+            WHITESPACE@[12; 13) " "
+            LITERAL@[13; 14)
+              INT_NUMBER@[13; 14) "2"
+            COMMA@[14; 15) ","
+        WHITESPACE@[15; 16) " "
+        EXPR_STMT@[16; 17)
+          ERROR@[16; 17)
+            AT@[16; 17) "@"
+        EXPR_STMT@[17; 18)
+          ERROR@[17; 18)
+            COMMA@[17; 18) ","
+        WHITESPACE@[18; 19) " "
+        STRUCT_DEF@[19; 26)
+          STRUCT_KW@[19; 25) "struct"
+          ERROR@[25; 26)
+            COMMA@[25; 26) ","
+        WHITESPACE@[26; 27) " "
+        LET_STMT@[27; 31)
+          LET_KW@[27; 30) "let"
+          ERROR@[30; 31)
+            R_BRACK@[30; 31) "]"
+        WHITESPACE@[31; 32) " "
+        R_CURLY@[32; 33) "}"
   WHITESPACE@[33; 34) "\n"
   FN_DEF@[34; 68)
     FN_KW@[34; 36) "fn"
@@ -50,45 +51,46 @@ SOURCE_FILE@[0; 112)
       L_PAREN@[38; 39) "("
       R_PAREN@[39; 40) ")"
     WHITESPACE@[40; 41) " "
-    BLOCK@[41; 68)
-      L_CURLY@[41; 42) "{"
-      WHITESPACE@[42; 43) " "
-      EXPR_STMT@[43; 52)
-        CALL_EXPR@[43; 52)
-          PATH_EXPR@[43; 46)
-            PATH@[43; 46)
-              PATH_SEGMENT@[43; 46)
-                NAME_REF@[43; 46)
-                  IDENT@[43; 46) "foo"
-          ARG_LIST@[46; 52)
-            L_PAREN@[46; 47) "("
-            LITERAL@[47; 48)
-              INT_NUMBER@[47; 48) "1"
-            COMMA@[48; 49) ","
-            WHITESPACE@[49; 50) " "
-            LITERAL@[50; 51)
-              INT_NUMBER@[50; 51) "2"
-            COMMA@[51; 52) ","
-      WHITESPACE@[52; 53) " "
-      EXPR_STMT@[53; 54)
-        ERROR@[53; 54)
-          AT@[53; 54) "@"
-      EXPR_STMT@[54; 55)
-        ERROR@[54; 55)
-          COMMA@[54; 55) ","
-      WHITESPACE@[55; 56) " "
-      IMPL_BLOCK@[56; 60)
-        IMPL_KW@[56; 60) "impl"
-      EXPR_STMT@[60; 61)
-        ERROR@[60; 61)
-          COMMA@[60; 61) ","
-      WHITESPACE@[61; 62) " "
-      LET_STMT@[62; 65)
-        LET_KW@[62; 65) "let"
-      ERROR@[65; 66)
-        R_PAREN@[65; 66) ")"
-      WHITESPACE@[66; 67) " "
-      R_CURLY@[67; 68) "}"
+    BLOCK_EXPR@[41; 68)
+      BLOCK@[41; 68)
+        L_CURLY@[41; 42) "{"
+        WHITESPACE@[42; 43) " "
+        EXPR_STMT@[43; 52)
+          CALL_EXPR@[43; 52)
+            PATH_EXPR@[43; 46)
+              PATH@[43; 46)
+                PATH_SEGMENT@[43; 46)
+                  NAME_REF@[43; 46)
+                    IDENT@[43; 46) "foo"
+            ARG_LIST@[46; 52)
+              L_PAREN@[46; 47) "("
+              LITERAL@[47; 48)
+                INT_NUMBER@[47; 48) "1"
+              COMMA@[48; 49) ","
+              WHITESPACE@[49; 50) " "
+              LITERAL@[50; 51)
+                INT_NUMBER@[50; 51) "2"
+              COMMA@[51; 52) ","
+        WHITESPACE@[52; 53) " "
+        EXPR_STMT@[53; 54)
+          ERROR@[53; 54)
+            AT@[53; 54) "@"
+        EXPR_STMT@[54; 55)
+          ERROR@[54; 55)
+            COMMA@[54; 55) ","
+        WHITESPACE@[55; 56) " "
+        IMPL_BLOCK@[56; 60)
+          IMPL_KW@[56; 60) "impl"
+        EXPR_STMT@[60; 61)
+          ERROR@[60; 61)
+            COMMA@[60; 61) ","
+        WHITESPACE@[61; 62) " "
+        LET_STMT@[62; 65)
+          LET_KW@[62; 65) "let"
+        ERROR@[65; 66)
+          R_PAREN@[65; 66) ")"
+        WHITESPACE@[66; 67) " "
+        R_CURLY@[67; 68) "}"
   WHITESPACE@[68; 69) "\n"
   FN_DEF@[69; 111)
     FN_KW@[69; 71) "fn"
@@ -99,54 +101,55 @@ SOURCE_FILE@[0; 112)
       L_PAREN@[73; 74) "("
       R_PAREN@[74; 75) ")"
     WHITESPACE@[75; 76) " "
-    BLOCK@[76; 111)
-      L_CURLY@[76; 77) "{"
-      WHITESPACE@[77; 78) " "
-      EXPR_STMT@[78; 91)
-        METHOD_CALL_EXPR@[78; 91)
-          PATH_EXPR@[78; 81)
-            PATH@[78; 81)
-              PATH_SEGMENT@[78; 81)
-                NAME_REF@[78; 81)
-                  IDENT@[78; 81) "foo"
-          DOT@[81; 82) "."
-          NAME_REF@[82; 85)
-            IDENT@[82; 85) "bar"
-          ARG_LIST@[85; 91)
-            L_PAREN@[85; 86) "("
-            LITERAL@[86; 87)
-              INT_NUMBER@[86; 87) "1"
-            COMMA@[87; 88) ","
-            WHITESPACE@[88; 89) " "
-            LITERAL@[89; 90)
-              INT_NUMBER@[89; 90) "2"
-            COMMA@[90; 91) ","
-      WHITESPACE@[91; 92) " "
-      EXPR_STMT@[92; 93)
-        ERROR@[92; 93)
-          AT@[92; 93) "@"
-      EXPR_STMT@[93; 94)
-        ERROR@[93; 94)
-          COMMA@[93; 94) ","
-      WHITESPACE@[94; 95) " "
-      EXPR_STMT@[95; 96)
-        ERROR@[95; 96)
-          R_BRACK@[95; 96) "]"
-      EXPR_STMT@[96; 97)
-        ERROR@[96; 97)
-          COMMA@[96; 97) ","
-      WHITESPACE@[97; 98) " "
-      TRAIT_DEF@[98; 104)
-        TRAIT_KW@[98; 103) "trait"
-        ERROR@[103; 104)
-          COMMA@[103; 104) ","
-      WHITESPACE@[104; 105) " "
-      LET_STMT@[105; 108)
-        LET_KW@[105; 108) "let"
-      ERROR@[108; 109)
-        R_PAREN@[108; 109) ")"
-      WHITESPACE@[109; 110) " "
-      R_CURLY@[110; 111) "}"
+    BLOCK_EXPR@[76; 111)
+      BLOCK@[76; 111)
+        L_CURLY@[76; 77) "{"
+        WHITESPACE@[77; 78) " "
+        EXPR_STMT@[78; 91)
+          METHOD_CALL_EXPR@[78; 91)
+            PATH_EXPR@[78; 81)
+              PATH@[78; 81)
+                PATH_SEGMENT@[78; 81)
+                  NAME_REF@[78; 81)
+                    IDENT@[78; 81) "foo"
+            DOT@[81; 82) "."
+            NAME_REF@[82; 85)
+              IDENT@[82; 85) "bar"
+            ARG_LIST@[85; 91)
+              L_PAREN@[85; 86) "("
+              LITERAL@[86; 87)
+                INT_NUMBER@[86; 87) "1"
+              COMMA@[87; 88) ","
+              WHITESPACE@[88; 89) " "
+              LITERAL@[89; 90)
+                INT_NUMBER@[89; 90) "2"
+              COMMA@[90; 91) ","
+        WHITESPACE@[91; 92) " "
+        EXPR_STMT@[92; 93)
+          ERROR@[92; 93)
+            AT@[92; 93) "@"
+        EXPR_STMT@[93; 94)
+          ERROR@[93; 94)
+            COMMA@[93; 94) ","
+        WHITESPACE@[94; 95) " "
+        EXPR_STMT@[95; 96)
+          ERROR@[95; 96)
+            R_BRACK@[95; 96) "]"
+        EXPR_STMT@[96; 97)
+          ERROR@[96; 97)
+            COMMA@[96; 97) ","
+        WHITESPACE@[97; 98) " "
+        TRAIT_DEF@[98; 104)
+          TRAIT_KW@[98; 103) "trait"
+          ERROR@[103; 104)
+            COMMA@[103; 104) ","
+        WHITESPACE@[104; 105) " "
+        LET_STMT@[105; 108)
+          LET_KW@[105; 108) "let"
+        ERROR@[108; 109)
+          R_PAREN@[108; 109) ")"
+        WHITESPACE@[109; 110) " "
+        R_CURLY@[110; 111) "}"
   WHITESPACE@[111; 112) "\n"
 error 15: expected expression
 error 15: expected R_BRACK

--- a/crates/ra_syntax/test_data/parser/err/0023_mismatched_paren.txt
+++ b/crates/ra_syntax/test_data/parser/err/0023_mismatched_paren.txt
@@ -8,31 +8,32 @@ SOURCE_FILE@[0; 94)
       L_PAREN@[7; 8) "("
       R_PAREN@[8; 9) ")"
     WHITESPACE@[9; 10) " "
-    BLOCK@[10; 55)
-      L_CURLY@[10; 11) "{"
-      WHITESPACE@[11; 16) "\n    "
-      MACRO_CALL@[16; 49)
-        PATH@[16; 19)
-          PATH_SEGMENT@[16; 19)
-            NAME_REF@[16; 19)
-              IDENT@[16; 19) "foo"
-        EXCL@[19; 20) "!"
-        WHITESPACE@[20; 21) " "
-        TOKEN_TREE@[21; 49)
-          L_PAREN@[21; 22) "("
-          WHITESPACE@[22; 31) "\n        "
-          IDENT@[31; 34) "bar"
-          COMMA@[34; 35) ","
-          WHITESPACE@[35; 36) " "
-          STRING@[36; 41) "\"baz\""
-          COMMA@[41; 42) ","
-          WHITESPACE@[42; 43) " "
-          INT_NUMBER@[43; 44) "1"
-          COMMA@[44; 45) ","
-          WHITESPACE@[45; 46) " "
-          FLOAT_NUMBER@[46; 49) "2.0"
-      WHITESPACE@[49; 54) "\n    "
-      R_CURLY@[54; 55) "}"
+    BLOCK_EXPR@[10; 55)
+      BLOCK@[10; 55)
+        L_CURLY@[10; 11) "{"
+        WHITESPACE@[11; 16) "\n    "
+        MACRO_CALL@[16; 49)
+          PATH@[16; 19)
+            PATH_SEGMENT@[16; 19)
+              NAME_REF@[16; 19)
+                IDENT@[16; 19) "foo"
+          EXCL@[19; 20) "!"
+          WHITESPACE@[20; 21) " "
+          TOKEN_TREE@[21; 49)
+            L_PAREN@[21; 22) "("
+            WHITESPACE@[22; 31) "\n        "
+            IDENT@[31; 34) "bar"
+            COMMA@[34; 35) ","
+            WHITESPACE@[35; 36) " "
+            STRING@[36; 41) "\"baz\""
+            COMMA@[41; 42) ","
+            WHITESPACE@[42; 43) " "
+            INT_NUMBER@[43; 44) "1"
+            COMMA@[44; 45) ","
+            WHITESPACE@[45; 46) " "
+            FLOAT_NUMBER@[46; 49) "2.0"
+        WHITESPACE@[49; 54) "\n    "
+        R_CURLY@[54; 55) "}"
   WHITESPACE@[55; 56) " "
   COMMENT@[56; 91) "//~ ERROR incorrect c ..."
   WHITESPACE@[91; 92) "\n"

--- a/crates/ra_syntax/test_data/parser/err/0024_many_type_parens.txt
+++ b/crates/ra_syntax/test_data/parser/err/0024_many_type_parens.txt
@@ -61,9 +61,10 @@ SOURCE_FILE@[0; 240)
       L_PAREN@[48; 49) "("
       R_PAREN@[49; 50) ")"
     WHITESPACE@[50; 51) " "
-    BLOCK@[51; 53)
-      L_CURLY@[51; 52) "{"
-      R_CURLY@[52; 53) "}"
+    BLOCK_EXPR@[51; 53)
+      BLOCK@[51; 53)
+        L_CURLY@[51; 52) "{"
+        R_CURLY@[52; 53) "}"
   WHITESPACE@[53; 55) "\n\n"
   FN_DEF@[55; 239)
     FN_KW@[55; 57) "fn"
@@ -74,222 +75,223 @@ SOURCE_FILE@[0; 240)
       L_PAREN@[62; 63) "("
       R_PAREN@[63; 64) ")"
     WHITESPACE@[64; 65) " "
-    BLOCK@[65; 239)
-      L_CURLY@[65; 66) "{"
-      WHITESPACE@[66; 71) "\n    "
-      LET_STMT@[71; 121)
-        LET_KW@[71; 74) "let"
-        WHITESPACE@[74; 75) " "
-        PLACEHOLDER_PAT@[75; 76)
-          UNDERSCORE@[75; 76) "_"
-        COLON@[76; 77) ":"
-        WHITESPACE@[77; 78) " "
-        DYN_TRAIT_TYPE@[78; 121)
-          TYPE_BOUND_LIST@[78; 121)
-            TYPE_BOUND@[78; 88)
-              PATH_TYPE@[78; 88)
-                PATH@[78; 88)
-                  PATH_SEGMENT@[78; 88)
-                    NAME_REF@[78; 81)
-                      IDENT@[78; 81) "Box"
-                    TYPE_ARG_LIST@[81; 88)
-                      L_ANGLE@[81; 82) "<"
-                      TYPE_ARG@[82; 88)
-                        PAREN_TYPE@[82; 88)
-                          L_PAREN@[82; 83) "("
-                          PATH_TYPE@[83; 87)
-                            PATH@[83; 87)
-                              PATH_SEGMENT@[83; 87)
-                                NAME_REF@[83; 87)
-                                  IDENT@[83; 87) "Copy"
-                          R_PAREN@[87; 88) ")"
-            WHITESPACE@[88; 89) " "
-            PLUS@[89; 90) "+"
-            WHITESPACE@[90; 91) " "
-            TYPE_BOUND@[91; 99)
-              L_PAREN@[91; 92) "("
-              QUESTION@[92; 93) "?"
-              PATH_TYPE@[93; 98)
-                PATH@[93; 98)
-                  PATH_SEGMENT@[93; 98)
-                    NAME_REF@[93; 98)
-                      IDENT@[93; 98) "Sized"
-              R_PAREN@[98; 99) ")"
-            WHITESPACE@[99; 100) " "
-            PLUS@[100; 101) "+"
-            WHITESPACE@[101; 102) " "
-            TYPE_BOUND@[102; 121)
-              L_PAREN@[102; 103) "("
-              FOR_TYPE@[103; 120)
-                FOR_KW@[103; 106) "for"
-                TYPE_PARAM_LIST@[106; 110)
-                  L_ANGLE@[106; 107) "<"
-                  LIFETIME_PARAM@[107; 109)
-                    LIFETIME@[107; 109) "\'a"
-                  R_ANGLE@[109; 110) ">"
-                WHITESPACE@[110; 111) " "
-                PATH_TYPE@[111; 120)
-                  PATH@[111; 120)
-                    PATH_SEGMENT@[111; 120)
-                      NAME_REF@[111; 116)
-                        IDENT@[111; 116) "Trait"
-                      TYPE_ARG_LIST@[116; 120)
-                        L_ANGLE@[116; 117) "<"
-                        LIFETIME_ARG@[117; 119)
-                          LIFETIME@[117; 119) "\'a"
-                        R_ANGLE@[119; 120) ">"
-              R_PAREN@[120; 121) ")"
-      EXPR_STMT@[121; 123)
-        ERROR@[121; 122)
-          R_ANGLE@[121; 122) ">"
-        SEMI@[122; 123) ";"
-      WHITESPACE@[123; 128) "\n    "
-      LET_STMT@[128; 141)
-        LET_KW@[128; 131) "let"
-        WHITESPACE@[131; 132) " "
-        PLACEHOLDER_PAT@[132; 133)
-          UNDERSCORE@[132; 133) "_"
-        COLON@[133; 134) ":"
-        WHITESPACE@[134; 135) " "
-        PATH_TYPE@[135; 141)
-          PATH@[135; 141)
-            PATH_SEGMENT@[135; 141)
-              NAME_REF@[135; 138)
-                IDENT@[135; 138) "Box"
-              TYPE_ARG_LIST@[138; 141)
-                L_ANGLE@[138; 139) "<"
-                TYPE_ARG@[139; 141)
-                  PAREN_TYPE@[139; 141)
-                    L_PAREN@[139; 140) "("
-                    ERROR@[140; 141)
-                      QUESTION@[140; 141) "?"
-      EXPR_STMT@[141; 146)
-        PATH_EXPR@[141; 146)
-          PATH@[141; 146)
-            PATH_SEGMENT@[141; 146)
-              NAME_REF@[141; 146)
-                IDENT@[141; 146) "Sized"
-      EXPR_STMT@[146; 147)
-        ERROR@[146; 147)
-          R_PAREN@[146; 147) ")"
-      WHITESPACE@[147; 148) " "
-      EXPR_STMT@[148; 149)
-        ERROR@[148; 149)
-          PLUS@[148; 149) "+"
-      WHITESPACE@[149; 150) " "
-      EXPR_STMT@[150; 151)
-        PAREN_EXPR@[150; 151)
-          L_PAREN@[150; 151) "("
-      EXPR_STMT@[151; 157)
-        FOR_EXPR@[151; 157)
-          FOR_KW@[151; 154) "for"
-          ERROR@[154; 155)
-            L_ANGLE@[154; 155) "<"
-          ERROR@[155; 157)
-            LIFETIME@[155; 157) "\'a"
-      EXPR_STMT@[157; 158)
-        ERROR@[157; 158)
-          R_ANGLE@[157; 158) ">"
-      WHITESPACE@[158; 159) " "
-      EXPR_STMT@[159; 180)
-        BIN_EXPR@[159; 180)
-          BIN_EXPR@[159; 178)
-            BIN_EXPR@[159; 169)
-              BIN_EXPR@[159; 167)
-                PATH_EXPR@[159; 164)
-                  PATH@[159; 164)
-                    PATH_SEGMENT@[159; 164)
-                      NAME_REF@[159; 164)
-                        IDENT@[159; 164) "Trait"
-                L_ANGLE@[164; 165) "<"
-                ERROR@[165; 167)
-                  LIFETIME@[165; 167) "\'a"
-              R_ANGLE@[167; 168) ">"
-              ERROR@[168; 169)
-                R_PAREN@[168; 169) ")"
-            WHITESPACE@[169; 170) " "
-            PLUS@[170; 171) "+"
-            WHITESPACE@[171; 172) " "
-            PAREN_EXPR@[172; 178)
-              L_PAREN@[172; 173) "("
-              PATH_EXPR@[173; 177)
-                PATH@[173; 177)
-                  PATH_SEGMENT@[173; 177)
-                    NAME_REF@[173; 177)
-                      IDENT@[173; 177) "Copy"
-              R_PAREN@[177; 178) ")"
-          R_ANGLE@[178; 179) ">"
-          ERROR@[179; 180)
-            SEMI@[179; 180) ";"
-      WHITESPACE@[180; 185) "\n    "
-      LET_STMT@[185; 235)
-        LET_KW@[185; 188) "let"
-        WHITESPACE@[188; 189) " "
-        PLACEHOLDER_PAT@[189; 190)
-          UNDERSCORE@[189; 190) "_"
-        COLON@[190; 191) ":"
-        WHITESPACE@[191; 192) " "
-        DYN_TRAIT_TYPE@[192; 235)
-          TYPE_BOUND_LIST@[192; 235)
-            TYPE_BOUND@[192; 215)
-              PATH_TYPE@[192; 215)
-                PATH@[192; 215)
-                  PATH_SEGMENT@[192; 215)
-                    NAME_REF@[192; 195)
-                      IDENT@[192; 195) "Box"
-                    TYPE_ARG_LIST@[195; 215)
-                      L_ANGLE@[195; 196) "<"
-                      TYPE_ARG@[196; 215)
-                        PAREN_TYPE@[196; 215)
-                          L_PAREN@[196; 197) "("
-                          FOR_TYPE@[197; 214)
-                            FOR_KW@[197; 200) "for"
-                            TYPE_PARAM_LIST@[200; 204)
-                              L_ANGLE@[200; 201) "<"
-                              LIFETIME_PARAM@[201; 203)
-                                LIFETIME@[201; 203) "\'a"
-                              R_ANGLE@[203; 204) ">"
-                            WHITESPACE@[204; 205) " "
-                            PATH_TYPE@[205; 214)
-                              PATH@[205; 214)
-                                PATH_SEGMENT@[205; 214)
-                                  NAME_REF@[205; 210)
-                                    IDENT@[205; 210) "Trait"
-                                  TYPE_ARG_LIST@[210; 214)
-                                    L_ANGLE@[210; 211) "<"
-                                    LIFETIME_ARG@[211; 213)
-                                      LIFETIME@[211; 213) "\'a"
-                                    R_ANGLE@[213; 214) ">"
-                          R_PAREN@[214; 215) ")"
-            WHITESPACE@[215; 216) " "
-            PLUS@[216; 217) "+"
-            WHITESPACE@[217; 218) " "
-            TYPE_BOUND@[218; 224)
-              L_PAREN@[218; 219) "("
-              PATH_TYPE@[219; 223)
-                PATH@[219; 223)
-                  PATH_SEGMENT@[219; 223)
-                    NAME_REF@[219; 223)
-                      IDENT@[219; 223) "Copy"
-              R_PAREN@[223; 224) ")"
-            WHITESPACE@[224; 225) " "
-            PLUS@[225; 226) "+"
-            WHITESPACE@[226; 227) " "
-            TYPE_BOUND@[227; 235)
-              L_PAREN@[227; 228) "("
-              QUESTION@[228; 229) "?"
-              PATH_TYPE@[229; 234)
-                PATH@[229; 234)
-                  PATH_SEGMENT@[229; 234)
-                    NAME_REF@[229; 234)
-                      IDENT@[229; 234) "Sized"
-              R_PAREN@[234; 235) ")"
-      EXPR_STMT@[235; 237)
-        ERROR@[235; 236)
-          R_ANGLE@[235; 236) ">"
-        SEMI@[236; 237) ";"
-      WHITESPACE@[237; 238) "\n"
-      R_CURLY@[238; 239) "}"
+    BLOCK_EXPR@[65; 239)
+      BLOCK@[65; 239)
+        L_CURLY@[65; 66) "{"
+        WHITESPACE@[66; 71) "\n    "
+        LET_STMT@[71; 121)
+          LET_KW@[71; 74) "let"
+          WHITESPACE@[74; 75) " "
+          PLACEHOLDER_PAT@[75; 76)
+            UNDERSCORE@[75; 76) "_"
+          COLON@[76; 77) ":"
+          WHITESPACE@[77; 78) " "
+          DYN_TRAIT_TYPE@[78; 121)
+            TYPE_BOUND_LIST@[78; 121)
+              TYPE_BOUND@[78; 88)
+                PATH_TYPE@[78; 88)
+                  PATH@[78; 88)
+                    PATH_SEGMENT@[78; 88)
+                      NAME_REF@[78; 81)
+                        IDENT@[78; 81) "Box"
+                      TYPE_ARG_LIST@[81; 88)
+                        L_ANGLE@[81; 82) "<"
+                        TYPE_ARG@[82; 88)
+                          PAREN_TYPE@[82; 88)
+                            L_PAREN@[82; 83) "("
+                            PATH_TYPE@[83; 87)
+                              PATH@[83; 87)
+                                PATH_SEGMENT@[83; 87)
+                                  NAME_REF@[83; 87)
+                                    IDENT@[83; 87) "Copy"
+                            R_PAREN@[87; 88) ")"
+              WHITESPACE@[88; 89) " "
+              PLUS@[89; 90) "+"
+              WHITESPACE@[90; 91) " "
+              TYPE_BOUND@[91; 99)
+                L_PAREN@[91; 92) "("
+                QUESTION@[92; 93) "?"
+                PATH_TYPE@[93; 98)
+                  PATH@[93; 98)
+                    PATH_SEGMENT@[93; 98)
+                      NAME_REF@[93; 98)
+                        IDENT@[93; 98) "Sized"
+                R_PAREN@[98; 99) ")"
+              WHITESPACE@[99; 100) " "
+              PLUS@[100; 101) "+"
+              WHITESPACE@[101; 102) " "
+              TYPE_BOUND@[102; 121)
+                L_PAREN@[102; 103) "("
+                FOR_TYPE@[103; 120)
+                  FOR_KW@[103; 106) "for"
+                  TYPE_PARAM_LIST@[106; 110)
+                    L_ANGLE@[106; 107) "<"
+                    LIFETIME_PARAM@[107; 109)
+                      LIFETIME@[107; 109) "\'a"
+                    R_ANGLE@[109; 110) ">"
+                  WHITESPACE@[110; 111) " "
+                  PATH_TYPE@[111; 120)
+                    PATH@[111; 120)
+                      PATH_SEGMENT@[111; 120)
+                        NAME_REF@[111; 116)
+                          IDENT@[111; 116) "Trait"
+                        TYPE_ARG_LIST@[116; 120)
+                          L_ANGLE@[116; 117) "<"
+                          LIFETIME_ARG@[117; 119)
+                            LIFETIME@[117; 119) "\'a"
+                          R_ANGLE@[119; 120) ">"
+                R_PAREN@[120; 121) ")"
+        EXPR_STMT@[121; 123)
+          ERROR@[121; 122)
+            R_ANGLE@[121; 122) ">"
+          SEMI@[122; 123) ";"
+        WHITESPACE@[123; 128) "\n    "
+        LET_STMT@[128; 141)
+          LET_KW@[128; 131) "let"
+          WHITESPACE@[131; 132) " "
+          PLACEHOLDER_PAT@[132; 133)
+            UNDERSCORE@[132; 133) "_"
+          COLON@[133; 134) ":"
+          WHITESPACE@[134; 135) " "
+          PATH_TYPE@[135; 141)
+            PATH@[135; 141)
+              PATH_SEGMENT@[135; 141)
+                NAME_REF@[135; 138)
+                  IDENT@[135; 138) "Box"
+                TYPE_ARG_LIST@[138; 141)
+                  L_ANGLE@[138; 139) "<"
+                  TYPE_ARG@[139; 141)
+                    PAREN_TYPE@[139; 141)
+                      L_PAREN@[139; 140) "("
+                      ERROR@[140; 141)
+                        QUESTION@[140; 141) "?"
+        EXPR_STMT@[141; 146)
+          PATH_EXPR@[141; 146)
+            PATH@[141; 146)
+              PATH_SEGMENT@[141; 146)
+                NAME_REF@[141; 146)
+                  IDENT@[141; 146) "Sized"
+        EXPR_STMT@[146; 147)
+          ERROR@[146; 147)
+            R_PAREN@[146; 147) ")"
+        WHITESPACE@[147; 148) " "
+        EXPR_STMT@[148; 149)
+          ERROR@[148; 149)
+            PLUS@[148; 149) "+"
+        WHITESPACE@[149; 150) " "
+        EXPR_STMT@[150; 151)
+          PAREN_EXPR@[150; 151)
+            L_PAREN@[150; 151) "("
+        EXPR_STMT@[151; 157)
+          FOR_EXPR@[151; 157)
+            FOR_KW@[151; 154) "for"
+            ERROR@[154; 155)
+              L_ANGLE@[154; 155) "<"
+            ERROR@[155; 157)
+              LIFETIME@[155; 157) "\'a"
+        EXPR_STMT@[157; 158)
+          ERROR@[157; 158)
+            R_ANGLE@[157; 158) ">"
+        WHITESPACE@[158; 159) " "
+        EXPR_STMT@[159; 180)
+          BIN_EXPR@[159; 180)
+            BIN_EXPR@[159; 178)
+              BIN_EXPR@[159; 169)
+                BIN_EXPR@[159; 167)
+                  PATH_EXPR@[159; 164)
+                    PATH@[159; 164)
+                      PATH_SEGMENT@[159; 164)
+                        NAME_REF@[159; 164)
+                          IDENT@[159; 164) "Trait"
+                  L_ANGLE@[164; 165) "<"
+                  ERROR@[165; 167)
+                    LIFETIME@[165; 167) "\'a"
+                R_ANGLE@[167; 168) ">"
+                ERROR@[168; 169)
+                  R_PAREN@[168; 169) ")"
+              WHITESPACE@[169; 170) " "
+              PLUS@[170; 171) "+"
+              WHITESPACE@[171; 172) " "
+              PAREN_EXPR@[172; 178)
+                L_PAREN@[172; 173) "("
+                PATH_EXPR@[173; 177)
+                  PATH@[173; 177)
+                    PATH_SEGMENT@[173; 177)
+                      NAME_REF@[173; 177)
+                        IDENT@[173; 177) "Copy"
+                R_PAREN@[177; 178) ")"
+            R_ANGLE@[178; 179) ">"
+            ERROR@[179; 180)
+              SEMI@[179; 180) ";"
+        WHITESPACE@[180; 185) "\n    "
+        LET_STMT@[185; 235)
+          LET_KW@[185; 188) "let"
+          WHITESPACE@[188; 189) " "
+          PLACEHOLDER_PAT@[189; 190)
+            UNDERSCORE@[189; 190) "_"
+          COLON@[190; 191) ":"
+          WHITESPACE@[191; 192) " "
+          DYN_TRAIT_TYPE@[192; 235)
+            TYPE_BOUND_LIST@[192; 235)
+              TYPE_BOUND@[192; 215)
+                PATH_TYPE@[192; 215)
+                  PATH@[192; 215)
+                    PATH_SEGMENT@[192; 215)
+                      NAME_REF@[192; 195)
+                        IDENT@[192; 195) "Box"
+                      TYPE_ARG_LIST@[195; 215)
+                        L_ANGLE@[195; 196) "<"
+                        TYPE_ARG@[196; 215)
+                          PAREN_TYPE@[196; 215)
+                            L_PAREN@[196; 197) "("
+                            FOR_TYPE@[197; 214)
+                              FOR_KW@[197; 200) "for"
+                              TYPE_PARAM_LIST@[200; 204)
+                                L_ANGLE@[200; 201) "<"
+                                LIFETIME_PARAM@[201; 203)
+                                  LIFETIME@[201; 203) "\'a"
+                                R_ANGLE@[203; 204) ">"
+                              WHITESPACE@[204; 205) " "
+                              PATH_TYPE@[205; 214)
+                                PATH@[205; 214)
+                                  PATH_SEGMENT@[205; 214)
+                                    NAME_REF@[205; 210)
+                                      IDENT@[205; 210) "Trait"
+                                    TYPE_ARG_LIST@[210; 214)
+                                      L_ANGLE@[210; 211) "<"
+                                      LIFETIME_ARG@[211; 213)
+                                        LIFETIME@[211; 213) "\'a"
+                                      R_ANGLE@[213; 214) ">"
+                            R_PAREN@[214; 215) ")"
+              WHITESPACE@[215; 216) " "
+              PLUS@[216; 217) "+"
+              WHITESPACE@[217; 218) " "
+              TYPE_BOUND@[218; 224)
+                L_PAREN@[218; 219) "("
+                PATH_TYPE@[219; 223)
+                  PATH@[219; 223)
+                    PATH_SEGMENT@[219; 223)
+                      NAME_REF@[219; 223)
+                        IDENT@[219; 223) "Copy"
+                R_PAREN@[223; 224) ")"
+              WHITESPACE@[224; 225) " "
+              PLUS@[225; 226) "+"
+              WHITESPACE@[226; 227) " "
+              TYPE_BOUND@[227; 235)
+                L_PAREN@[227; 228) "("
+                QUESTION@[228; 229) "?"
+                PATH_TYPE@[229; 234)
+                  PATH@[229; 234)
+                    PATH_SEGMENT@[229; 234)
+                      NAME_REF@[229; 234)
+                        IDENT@[229; 234) "Sized"
+                R_PAREN@[234; 235) ")"
+        EXPR_STMT@[235; 237)
+          ERROR@[235; 236)
+            R_ANGLE@[235; 236) ">"
+          SEMI@[236; 237) ";"
+        WHITESPACE@[237; 238) "\n"
+        R_CURLY@[238; 239) "}"
   WHITESPACE@[239; 240) "\n"
 error 88: expected COMMA
 error 88: expected R_ANGLE

--- a/crates/ra_syntax/test_data/parser/err/0025_nope.txt
+++ b/crates/ra_syntax/test_data/parser/err/0025_nope.txt
@@ -8,187 +8,188 @@ SOURCE_FILE@[0; 575)
       L_PAREN@[7; 8) "("
       R_PAREN@[8; 9) ")"
     WHITESPACE@[9; 10) " "
-    BLOCK@[10; 574)
-      L_CURLY@[10; 11) "{"
-      WHITESPACE@[11; 16) "\n    "
-      ENUM_DEF@[16; 152)
-        ENUM_KW@[16; 20) "enum"
-        WHITESPACE@[20; 21) " "
-        NAME@[21; 25)
-          IDENT@[21; 25) "Test"
-        WHITESPACE@[25; 26) " "
-        ENUM_VARIANT_LIST@[26; 152)
-          L_CURLY@[26; 27) "{"
-          WHITESPACE@[27; 36) "\n        "
-          ENUM_VARIANT@[36; 40)
-            NAME@[36; 40)
-              IDENT@[36; 40) "Var1"
-          COMMA@[40; 41) ","
-          WHITESPACE@[41; 50) "\n        "
-          ENUM_VARIANT@[50; 62)
-            NAME@[50; 54)
-              IDENT@[50; 54) "Var2"
-            TUPLE_FIELD_DEF_LIST@[54; 62)
-              L_PAREN@[54; 55) "("
-              TUPLE_FIELD_DEF@[55; 61)
-                PATH_TYPE@[55; 61)
-                  PATH@[55; 61)
-                    PATH_SEGMENT@[55; 61)
-                      NAME_REF@[55; 61)
-                        IDENT@[55; 61) "String"
-              R_PAREN@[61; 62) ")"
-          COMMA@[62; 63) ","
-          WHITESPACE@[63; 72) "\n        "
-          ENUM_VARIANT@[72; 145)
-            NAME@[72; 76)
-              IDENT@[72; 76) "Var3"
-            WHITESPACE@[76; 77) " "
-            RECORD_FIELD_DEF_LIST@[77; 145)
-              L_CURLY@[77; 78) "{"
-              WHITESPACE@[78; 91) "\n            "
-              RECORD_FIELD_DEF@[91; 95)
-                NAME@[91; 94)
-                  IDENT@[91; 94) "abc"
-                COLON@[94; 95) ":"
-              WHITESPACE@[95; 96) " "
-              ERROR@[96; 98)
-                L_CURLY@[96; 97) "{"
-                R_CURLY@[97; 98) "}"
-              ERROR@[98; 99)
-                COMMA@[98; 99) ","
-              WHITESPACE@[99; 100) " "
-              COMMENT@[100; 135) "//~ ERROR: expected t ..."
-              WHITESPACE@[135; 144) "\n        "
-              R_CURLY@[144; 145) "}"
-          COMMA@[145; 146) ","
-          WHITESPACE@[146; 151) "\n    "
-          R_CURLY@[151; 152) "}"
-      WHITESPACE@[152; 158) "\n\n    "
-      COMMENT@[158; 171) "// recover..."
-      WHITESPACE@[171; 176) "\n    "
-      LET_STMT@[176; 186)
-        LET_KW@[176; 179) "let"
-        WHITESPACE@[179; 180) " "
-        BIND_PAT@[180; 181)
-          NAME@[180; 181)
-            IDENT@[180; 181) "a"
-        WHITESPACE@[181; 182) " "
-        EQ@[182; 183) "="
-        WHITESPACE@[183; 184) " "
-        LITERAL@[184; 185)
-          INT_NUMBER@[184; 185) "1"
-        SEMI@[185; 186) ";"
-      WHITESPACE@[186; 191) "\n    "
-      ENUM_DEF@[191; 223)
-        ENUM_KW@[191; 195) "enum"
-        WHITESPACE@[195; 196) " "
-        NAME@[196; 201)
-          IDENT@[196; 201) "Test2"
-        WHITESPACE@[201; 202) " "
-        ENUM_VARIANT_LIST@[202; 223)
-          L_CURLY@[202; 203) "{"
-          WHITESPACE@[203; 212) "\n        "
-          ENUM_VARIANT@[212; 216)
-            NAME@[212; 216)
-              IDENT@[212; 216) "Fine"
-          COMMA@[216; 217) ","
-          WHITESPACE@[217; 222) "\n    "
-          R_CURLY@[222; 223) "}"
-      WHITESPACE@[223; 229) "\n\n    "
-      ENUM_DEF@[229; 300)
-        ENUM_KW@[229; 233) "enum"
-        WHITESPACE@[233; 234) " "
-        NAME@[234; 239)
-          IDENT@[234; 239) "Test3"
-        WHITESPACE@[239; 240) " "
-        ENUM_VARIANT_LIST@[240; 300)
-          L_CURLY@[240; 241) "{"
-          WHITESPACE@[241; 250) "\n        "
-          ENUM_VARIANT@[250; 293)
-            NAME@[250; 259)
-              IDENT@[250; 259) "StillFine"
-            WHITESPACE@[259; 260) " "
-            RECORD_FIELD_DEF_LIST@[260; 293)
-              L_CURLY@[260; 261) "{"
-              WHITESPACE@[261; 274) "\n            "
-              RECORD_FIELD_DEF@[274; 282)
-                NAME@[274; 277)
-                  IDENT@[274; 277) "def"
-                COLON@[277; 278) ":"
-                WHITESPACE@[278; 279) " "
-                PATH_TYPE@[279; 282)
-                  PATH@[279; 282)
-                    PATH_SEGMENT@[279; 282)
-                      NAME_REF@[279; 282)
-                        IDENT@[279; 282) "i32"
-              COMMA@[282; 283) ","
-              WHITESPACE@[283; 292) "\n        "
-              R_CURLY@[292; 293) "}"
-          COMMA@[293; 294) ","
-          WHITESPACE@[294; 299) "\n    "
-          R_CURLY@[299; 300) "}"
-      WHITESPACE@[300; 306) "\n\n    "
-      EXPR_STMT@[306; 459)
-        BLOCK_EXPR@[306; 459)
-          BLOCK@[306; 459)
-            L_CURLY@[306; 307) "{"
-            WHITESPACE@[307; 316) "\n        "
-            ENUM_DEF@[316; 453)
-              COMMENT@[316; 329) "// fail again"
-              WHITESPACE@[329; 338) "\n        "
-              ENUM_KW@[338; 342) "enum"
-              WHITESPACE@[342; 343) " "
-              NAME@[343; 348)
-                IDENT@[343; 348) "Test4"
-              WHITESPACE@[348; 349) " "
-              ENUM_VARIANT_LIST@[349; 453)
-                L_CURLY@[349; 350) "{"
-                WHITESPACE@[350; 363) "\n            "
-                ENUM_VARIANT@[363; 372)
-                  NAME@[363; 367)
-                    IDENT@[363; 367) "Nope"
-                  TUPLE_FIELD_DEF_LIST@[367; 372)
-                    L_PAREN@[367; 368) "("
-                    TUPLE_FIELD_DEF@[368; 371)
-                      PATH_TYPE@[368; 371)
-                        PATH@[368; 371)
-                          PATH_SEGMENT@[368; 371)
-                            NAME_REF@[368; 371)
-                              IDENT@[368; 371) "i32"
-                    WHITESPACE@[371; 372) " "
-                    ERROR@[372; 372)
-                ERROR@[372; 374)
-                  L_CURLY@[372; 373) "{"
-                  R_CURLY@[373; 374) "}"
-                ERROR@[374; 375)
-                  R_PAREN@[374; 375) ")"
-                WHITESPACE@[375; 376) " "
-                COMMENT@[376; 396) "//~ ERROR: found `{`"
-                WHITESPACE@[396; 422) "\n                     ..."
-                COMMENT@[422; 443) "//~^ ERROR: found `{`"
-                WHITESPACE@[443; 452) "\n        "
-                R_CURLY@[452; 453) "}"
-            WHITESPACE@[453; 458) "\n    "
-            R_CURLY@[458; 459) "}"
-      WHITESPACE@[459; 464) "\n    "
-      COMMENT@[464; 486) "// still recover later"
-      WHITESPACE@[486; 491) "\n    "
-      LET_STMT@[491; 510)
-        LET_KW@[491; 494) "let"
-        WHITESPACE@[494; 495) " "
-        BIND_PAT@[495; 505)
-          NAME@[495; 505)
-            IDENT@[495; 505) "bad_syntax"
-        WHITESPACE@[505; 506) " "
-        EQ@[506; 507) "="
-        WHITESPACE@[507; 508) " "
-        ERROR@[508; 509)
-          UNDERSCORE@[508; 509) "_"
-        SEMI@[509; 510) ";"
-      WHITESPACE@[510; 511) " "
-      COMMENT@[511; 572) "//~ ERROR: expected e ..."
-      WHITESPACE@[572; 573) "\n"
-      R_CURLY@[573; 574) "}"
+    BLOCK_EXPR@[10; 574)
+      BLOCK@[10; 574)
+        L_CURLY@[10; 11) "{"
+        WHITESPACE@[11; 16) "\n    "
+        ENUM_DEF@[16; 152)
+          ENUM_KW@[16; 20) "enum"
+          WHITESPACE@[20; 21) " "
+          NAME@[21; 25)
+            IDENT@[21; 25) "Test"
+          WHITESPACE@[25; 26) " "
+          ENUM_VARIANT_LIST@[26; 152)
+            L_CURLY@[26; 27) "{"
+            WHITESPACE@[27; 36) "\n        "
+            ENUM_VARIANT@[36; 40)
+              NAME@[36; 40)
+                IDENT@[36; 40) "Var1"
+            COMMA@[40; 41) ","
+            WHITESPACE@[41; 50) "\n        "
+            ENUM_VARIANT@[50; 62)
+              NAME@[50; 54)
+                IDENT@[50; 54) "Var2"
+              TUPLE_FIELD_DEF_LIST@[54; 62)
+                L_PAREN@[54; 55) "("
+                TUPLE_FIELD_DEF@[55; 61)
+                  PATH_TYPE@[55; 61)
+                    PATH@[55; 61)
+                      PATH_SEGMENT@[55; 61)
+                        NAME_REF@[55; 61)
+                          IDENT@[55; 61) "String"
+                R_PAREN@[61; 62) ")"
+            COMMA@[62; 63) ","
+            WHITESPACE@[63; 72) "\n        "
+            ENUM_VARIANT@[72; 145)
+              NAME@[72; 76)
+                IDENT@[72; 76) "Var3"
+              WHITESPACE@[76; 77) " "
+              RECORD_FIELD_DEF_LIST@[77; 145)
+                L_CURLY@[77; 78) "{"
+                WHITESPACE@[78; 91) "\n            "
+                RECORD_FIELD_DEF@[91; 95)
+                  NAME@[91; 94)
+                    IDENT@[91; 94) "abc"
+                  COLON@[94; 95) ":"
+                WHITESPACE@[95; 96) " "
+                ERROR@[96; 98)
+                  L_CURLY@[96; 97) "{"
+                  R_CURLY@[97; 98) "}"
+                ERROR@[98; 99)
+                  COMMA@[98; 99) ","
+                WHITESPACE@[99; 100) " "
+                COMMENT@[100; 135) "//~ ERROR: expected t ..."
+                WHITESPACE@[135; 144) "\n        "
+                R_CURLY@[144; 145) "}"
+            COMMA@[145; 146) ","
+            WHITESPACE@[146; 151) "\n    "
+            R_CURLY@[151; 152) "}"
+        WHITESPACE@[152; 158) "\n\n    "
+        COMMENT@[158; 171) "// recover..."
+        WHITESPACE@[171; 176) "\n    "
+        LET_STMT@[176; 186)
+          LET_KW@[176; 179) "let"
+          WHITESPACE@[179; 180) " "
+          BIND_PAT@[180; 181)
+            NAME@[180; 181)
+              IDENT@[180; 181) "a"
+          WHITESPACE@[181; 182) " "
+          EQ@[182; 183) "="
+          WHITESPACE@[183; 184) " "
+          LITERAL@[184; 185)
+            INT_NUMBER@[184; 185) "1"
+          SEMI@[185; 186) ";"
+        WHITESPACE@[186; 191) "\n    "
+        ENUM_DEF@[191; 223)
+          ENUM_KW@[191; 195) "enum"
+          WHITESPACE@[195; 196) " "
+          NAME@[196; 201)
+            IDENT@[196; 201) "Test2"
+          WHITESPACE@[201; 202) " "
+          ENUM_VARIANT_LIST@[202; 223)
+            L_CURLY@[202; 203) "{"
+            WHITESPACE@[203; 212) "\n        "
+            ENUM_VARIANT@[212; 216)
+              NAME@[212; 216)
+                IDENT@[212; 216) "Fine"
+            COMMA@[216; 217) ","
+            WHITESPACE@[217; 222) "\n    "
+            R_CURLY@[222; 223) "}"
+        WHITESPACE@[223; 229) "\n\n    "
+        ENUM_DEF@[229; 300)
+          ENUM_KW@[229; 233) "enum"
+          WHITESPACE@[233; 234) " "
+          NAME@[234; 239)
+            IDENT@[234; 239) "Test3"
+          WHITESPACE@[239; 240) " "
+          ENUM_VARIANT_LIST@[240; 300)
+            L_CURLY@[240; 241) "{"
+            WHITESPACE@[241; 250) "\n        "
+            ENUM_VARIANT@[250; 293)
+              NAME@[250; 259)
+                IDENT@[250; 259) "StillFine"
+              WHITESPACE@[259; 260) " "
+              RECORD_FIELD_DEF_LIST@[260; 293)
+                L_CURLY@[260; 261) "{"
+                WHITESPACE@[261; 274) "\n            "
+                RECORD_FIELD_DEF@[274; 282)
+                  NAME@[274; 277)
+                    IDENT@[274; 277) "def"
+                  COLON@[277; 278) ":"
+                  WHITESPACE@[278; 279) " "
+                  PATH_TYPE@[279; 282)
+                    PATH@[279; 282)
+                      PATH_SEGMENT@[279; 282)
+                        NAME_REF@[279; 282)
+                          IDENT@[279; 282) "i32"
+                COMMA@[282; 283) ","
+                WHITESPACE@[283; 292) "\n        "
+                R_CURLY@[292; 293) "}"
+            COMMA@[293; 294) ","
+            WHITESPACE@[294; 299) "\n    "
+            R_CURLY@[299; 300) "}"
+        WHITESPACE@[300; 306) "\n\n    "
+        EXPR_STMT@[306; 459)
+          BLOCK_EXPR@[306; 459)
+            BLOCK@[306; 459)
+              L_CURLY@[306; 307) "{"
+              WHITESPACE@[307; 316) "\n        "
+              ENUM_DEF@[316; 453)
+                COMMENT@[316; 329) "// fail again"
+                WHITESPACE@[329; 338) "\n        "
+                ENUM_KW@[338; 342) "enum"
+                WHITESPACE@[342; 343) " "
+                NAME@[343; 348)
+                  IDENT@[343; 348) "Test4"
+                WHITESPACE@[348; 349) " "
+                ENUM_VARIANT_LIST@[349; 453)
+                  L_CURLY@[349; 350) "{"
+                  WHITESPACE@[350; 363) "\n            "
+                  ENUM_VARIANT@[363; 372)
+                    NAME@[363; 367)
+                      IDENT@[363; 367) "Nope"
+                    TUPLE_FIELD_DEF_LIST@[367; 372)
+                      L_PAREN@[367; 368) "("
+                      TUPLE_FIELD_DEF@[368; 371)
+                        PATH_TYPE@[368; 371)
+                          PATH@[368; 371)
+                            PATH_SEGMENT@[368; 371)
+                              NAME_REF@[368; 371)
+                                IDENT@[368; 371) "i32"
+                      WHITESPACE@[371; 372) " "
+                      ERROR@[372; 372)
+                  ERROR@[372; 374)
+                    L_CURLY@[372; 373) "{"
+                    R_CURLY@[373; 374) "}"
+                  ERROR@[374; 375)
+                    R_PAREN@[374; 375) ")"
+                  WHITESPACE@[375; 376) " "
+                  COMMENT@[376; 396) "//~ ERROR: found `{`"
+                  WHITESPACE@[396; 422) "\n                     ..."
+                  COMMENT@[422; 443) "//~^ ERROR: found `{`"
+                  WHITESPACE@[443; 452) "\n        "
+                  R_CURLY@[452; 453) "}"
+              WHITESPACE@[453; 458) "\n    "
+              R_CURLY@[458; 459) "}"
+        WHITESPACE@[459; 464) "\n    "
+        COMMENT@[464; 486) "// still recover later"
+        WHITESPACE@[486; 491) "\n    "
+        LET_STMT@[491; 510)
+          LET_KW@[491; 494) "let"
+          WHITESPACE@[494; 495) " "
+          BIND_PAT@[495; 505)
+            NAME@[495; 505)
+              IDENT@[495; 505) "bad_syntax"
+          WHITESPACE@[505; 506) " "
+          EQ@[506; 507) "="
+          WHITESPACE@[507; 508) " "
+          ERROR@[508; 509)
+            UNDERSCORE@[508; 509) "_"
+          SEMI@[509; 510) ";"
+        WHITESPACE@[510; 511) " "
+        COMMENT@[511; 572) "//~ ERROR: expected e ..."
+        WHITESPACE@[572; 573) "\n"
+        R_CURLY@[573; 574) "}"
   WHITESPACE@[574; 575) "\n"
 error 95: expected type
 error 95: expected COMMA

--- a/crates/ra_syntax/test_data/parser/err/0027_incomplere_where_for.txt
+++ b/crates/ra_syntax/test_data/parser/err/0027_incomplere_where_for.txt
@@ -20,9 +20,10 @@ SOURCE_FILE@[0; 30)
               LIFETIME@[23; 25) "\'a"
             R_ANGLE@[25; 26) ">"
     WHITESPACE@[26; 27) "\n"
-    BLOCK@[27; 29)
-      L_CURLY@[27; 28) "{"
-      R_CURLY@[28; 29) "}"
+    BLOCK_EXPR@[27; 29)
+      BLOCK@[27; 29)
+        L_CURLY@[27; 28) "{"
+        R_CURLY@[28; 29) "}"
   WHITESPACE@[29; 30) "\n"
 error 26: expected a path
 error 26: expected colon

--- a/crates/ra_syntax/test_data/parser/err/0028_macro_2.0.txt
+++ b/crates/ra_syntax/test_data/parser/err/0028_macro_2.0.txt
@@ -73,188 +73,189 @@ SOURCE_FILE@[0; 349)
       L_PAREN@[125; 126) "("
       R_PAREN@[126; 127) ")"
     WHITESPACE@[127; 128) " "
-    BLOCK@[128; 348)
-      L_CURLY@[128; 129) "{"
-      WHITESPACE@[129; 134) "\n    "
-      EXPR_STMT@[134; 139)
-        PATH_EXPR@[134; 139)
-          PATH@[134; 139)
-            PATH_SEGMENT@[134; 139)
-              NAME_REF@[134; 139)
-                IDENT@[134; 139) "macro"
-      WHITESPACE@[139; 140) " "
-      EXPR_STMT@[140; 154)
-        CALL_EXPR@[140; 154)
-          PATH_EXPR@[140; 150)
-            PATH@[140; 150)
-              PATH_SEGMENT@[140; 150)
-                NAME_REF@[140; 150)
-                  IDENT@[140; 150) "test_merge"
-          ARG_LIST@[150; 154)
-            L_PAREN@[150; 151) "("
-            ARRAY_EXPR@[151; 154)
-              L_BRACK@[151; 152) "["
-              ERROR@[152; 153)
-                DOLLAR@[152; 153) "$"
-              PAREN_EXPR@[153; 154)
-                L_PAREN@[153; 154) "("
-      EXPR_STMT@[154; 155)
-        ERROR@[154; 155)
-          DOLLAR@[154; 155) "$"
-      EXPR_STMT@[155; 160)
-        PATH_EXPR@[155; 160)
-          PATH@[155; 160)
-            PATH_SEGMENT@[155; 160)
-              NAME_REF@[155; 160)
-                IDENT@[155; 160) "input"
-      EXPR_STMT@[160; 161)
-        ERROR@[160; 161)
-          COLON@[160; 161) ":"
-      EXPR_STMT@[161; 165)
-        PATH_EXPR@[161; 165)
-          PATH@[161; 165)
-            PATH_SEGMENT@[161; 165)
-              NAME_REF@[161; 165)
-                IDENT@[161; 165) "expr"
-      EXPR_STMT@[165; 166)
-        ERROR@[165; 166)
-          R_PAREN@[165; 166) ")"
-      EXPR_STMT@[166; 167)
-        ERROR@[166; 167)
-          COMMA@[166; 167) ","
-      EXPR_STMT@[167; 170)
-        PREFIX_EXPR@[167; 170)
-          STAR@[167; 168) "*"
-          WHITESPACE@[168; 169) " "
-          ERROR@[169; 170)
-            DOLLAR@[169; 170) "$"
-      EXPR_STMT@[170; 171)
-        PAREN_EXPR@[170; 171)
-          L_PAREN@[170; 171) "("
-      EXPR_STMT@[171; 172)
-        ERROR@[171; 172)
-          COMMA@[171; 172) ","
-      EXPR_STMT@[172; 173)
-        ERROR@[172; 173)
-          R_PAREN@[172; 173) ")"
-      EXPR_STMT@[173; 175)
-        PREFIX_EXPR@[173; 175)
-          STAR@[173; 174) "*"
-          ERROR@[174; 175)
-            R_BRACK@[174; 175) "]"
-      EXPR_STMT@[175; 176)
-        ERROR@[175; 176)
-          COMMA@[175; 176) ","
-      WHITESPACE@[176; 177) " "
-      EXPR_STMT@[177; 180)
-        ARRAY_EXPR@[177; 180)
-          L_BRACK@[177; 178) "["
-          ERROR@[178; 179)
-            DOLLAR@[178; 179) "$"
-          PAREN_EXPR@[179; 180)
-            L_PAREN@[179; 180) "("
-      EXPR_STMT@[180; 181)
-        ERROR@[180; 181)
-          DOLLAR@[180; 181) "$"
-      EXPR_STMT@[181; 187)
-        PATH_EXPR@[181; 187)
-          PATH@[181; 187)
-            PATH_SEGMENT@[181; 187)
-              NAME_REF@[181; 187)
-                IDENT@[181; 187) "output"
-      EXPR_STMT@[187; 188)
-        ERROR@[187; 188)
-          COLON@[187; 188) ":"
-      EXPR_STMT@[188; 192)
-        PATH_EXPR@[188; 192)
-          PATH@[188; 192)
-            PATH_SEGMENT@[188; 192)
-              NAME_REF@[188; 192)
-                IDENT@[188; 192) "expr"
-      EXPR_STMT@[192; 193)
-        ERROR@[192; 193)
-          R_PAREN@[192; 193) ")"
-      EXPR_STMT@[193; 194)
-        ERROR@[193; 194)
-          COMMA@[193; 194) ","
-      EXPR_STMT@[194; 197)
-        PREFIX_EXPR@[194; 197)
-          STAR@[194; 195) "*"
-          WHITESPACE@[195; 196) " "
-          ERROR@[196; 197)
-            DOLLAR@[196; 197) "$"
-      EXPR_STMT@[197; 198)
-        PAREN_EXPR@[197; 198)
-          L_PAREN@[197; 198) "("
-      EXPR_STMT@[198; 199)
-        ERROR@[198; 199)
-          COMMA@[198; 199) ","
-      EXPR_STMT@[199; 200)
-        ERROR@[199; 200)
-          R_PAREN@[199; 200) ")"
-      EXPR_STMT@[200; 202)
-        PREFIX_EXPR@[200; 202)
-          STAR@[200; 201) "*"
-          ERROR@[201; 202)
-            R_BRACK@[201; 202) "]"
-      EXPR_STMT@[202; 203)
-        ERROR@[202; 203)
-          R_PAREN@[202; 203) ")"
-      WHITESPACE@[203; 204) " "
-      BLOCK_EXPR@[204; 346)
-        BLOCK@[204; 346)
-          L_CURLY@[204; 205) "{"
-          WHITESPACE@[205; 214) "\n        "
-          EXPR_STMT@[214; 340)
-            MACRO_CALL@[214; 339)
-              PATH@[214; 223)
-                PATH_SEGMENT@[214; 223)
-                  NAME_REF@[214; 223)
-                    IDENT@[214; 223) "assert_eq"
-              EXCL@[223; 224) "!"
-              TOKEN_TREE@[224; 339)
-                L_PAREN@[224; 225) "("
-                WHITESPACE@[225; 238) "\n            "
-                IDENT@[238; 253) "merge_use_trees"
-                TOKEN_TREE@[253; 284)
-                  L_PAREN@[253; 254) "("
-                  IDENT@[254; 269) "parse_use_trees"
-                  EXCL@[269; 270) "!"
-                  TOKEN_TREE@[270; 283)
-                    L_PAREN@[270; 271) "("
-                    DOLLAR@[271; 272) "$"
-                    TOKEN_TREE@[272; 281)
-                      L_PAREN@[272; 273) "("
-                      DOLLAR@[273; 274) "$"
-                      IDENT@[274; 279) "input"
-                      COMMA@[279; 280) ","
-                      R_PAREN@[280; 281) ")"
-                    STAR@[281; 282) "*"
-                    R_PAREN@[282; 283) ")"
-                  R_PAREN@[283; 284) ")"
-                COMMA@[284; 285) ","
-                WHITESPACE@[285; 298) "\n            "
-                IDENT@[298; 313) "parse_use_trees"
-                EXCL@[313; 314) "!"
-                TOKEN_TREE@[314; 328)
-                  L_PAREN@[314; 315) "("
-                  DOLLAR@[315; 316) "$"
-                  TOKEN_TREE@[316; 326)
-                    L_PAREN@[316; 317) "("
-                    DOLLAR@[317; 318) "$"
-                    IDENT@[318; 324) "output"
-                    COMMA@[324; 325) ","
-                    R_PAREN@[325; 326) ")"
-                  STAR@[326; 327) "*"
-                  R_PAREN@[327; 328) ")"
-                COMMA@[328; 329) ","
-                WHITESPACE@[329; 338) "\n        "
-                R_PAREN@[338; 339) ")"
-            SEMI@[339; 340) ";"
-          WHITESPACE@[340; 345) "\n    "
-          R_CURLY@[345; 346) "}"
-      WHITESPACE@[346; 347) "\n"
-      R_CURLY@[347; 348) "}"
+    BLOCK_EXPR@[128; 348)
+      BLOCK@[128; 348)
+        L_CURLY@[128; 129) "{"
+        WHITESPACE@[129; 134) "\n    "
+        EXPR_STMT@[134; 139)
+          PATH_EXPR@[134; 139)
+            PATH@[134; 139)
+              PATH_SEGMENT@[134; 139)
+                NAME_REF@[134; 139)
+                  IDENT@[134; 139) "macro"
+        WHITESPACE@[139; 140) " "
+        EXPR_STMT@[140; 154)
+          CALL_EXPR@[140; 154)
+            PATH_EXPR@[140; 150)
+              PATH@[140; 150)
+                PATH_SEGMENT@[140; 150)
+                  NAME_REF@[140; 150)
+                    IDENT@[140; 150) "test_merge"
+            ARG_LIST@[150; 154)
+              L_PAREN@[150; 151) "("
+              ARRAY_EXPR@[151; 154)
+                L_BRACK@[151; 152) "["
+                ERROR@[152; 153)
+                  DOLLAR@[152; 153) "$"
+                PAREN_EXPR@[153; 154)
+                  L_PAREN@[153; 154) "("
+        EXPR_STMT@[154; 155)
+          ERROR@[154; 155)
+            DOLLAR@[154; 155) "$"
+        EXPR_STMT@[155; 160)
+          PATH_EXPR@[155; 160)
+            PATH@[155; 160)
+              PATH_SEGMENT@[155; 160)
+                NAME_REF@[155; 160)
+                  IDENT@[155; 160) "input"
+        EXPR_STMT@[160; 161)
+          ERROR@[160; 161)
+            COLON@[160; 161) ":"
+        EXPR_STMT@[161; 165)
+          PATH_EXPR@[161; 165)
+            PATH@[161; 165)
+              PATH_SEGMENT@[161; 165)
+                NAME_REF@[161; 165)
+                  IDENT@[161; 165) "expr"
+        EXPR_STMT@[165; 166)
+          ERROR@[165; 166)
+            R_PAREN@[165; 166) ")"
+        EXPR_STMT@[166; 167)
+          ERROR@[166; 167)
+            COMMA@[166; 167) ","
+        EXPR_STMT@[167; 170)
+          PREFIX_EXPR@[167; 170)
+            STAR@[167; 168) "*"
+            WHITESPACE@[168; 169) " "
+            ERROR@[169; 170)
+              DOLLAR@[169; 170) "$"
+        EXPR_STMT@[170; 171)
+          PAREN_EXPR@[170; 171)
+            L_PAREN@[170; 171) "("
+        EXPR_STMT@[171; 172)
+          ERROR@[171; 172)
+            COMMA@[171; 172) ","
+        EXPR_STMT@[172; 173)
+          ERROR@[172; 173)
+            R_PAREN@[172; 173) ")"
+        EXPR_STMT@[173; 175)
+          PREFIX_EXPR@[173; 175)
+            STAR@[173; 174) "*"
+            ERROR@[174; 175)
+              R_BRACK@[174; 175) "]"
+        EXPR_STMT@[175; 176)
+          ERROR@[175; 176)
+            COMMA@[175; 176) ","
+        WHITESPACE@[176; 177) " "
+        EXPR_STMT@[177; 180)
+          ARRAY_EXPR@[177; 180)
+            L_BRACK@[177; 178) "["
+            ERROR@[178; 179)
+              DOLLAR@[178; 179) "$"
+            PAREN_EXPR@[179; 180)
+              L_PAREN@[179; 180) "("
+        EXPR_STMT@[180; 181)
+          ERROR@[180; 181)
+            DOLLAR@[180; 181) "$"
+        EXPR_STMT@[181; 187)
+          PATH_EXPR@[181; 187)
+            PATH@[181; 187)
+              PATH_SEGMENT@[181; 187)
+                NAME_REF@[181; 187)
+                  IDENT@[181; 187) "output"
+        EXPR_STMT@[187; 188)
+          ERROR@[187; 188)
+            COLON@[187; 188) ":"
+        EXPR_STMT@[188; 192)
+          PATH_EXPR@[188; 192)
+            PATH@[188; 192)
+              PATH_SEGMENT@[188; 192)
+                NAME_REF@[188; 192)
+                  IDENT@[188; 192) "expr"
+        EXPR_STMT@[192; 193)
+          ERROR@[192; 193)
+            R_PAREN@[192; 193) ")"
+        EXPR_STMT@[193; 194)
+          ERROR@[193; 194)
+            COMMA@[193; 194) ","
+        EXPR_STMT@[194; 197)
+          PREFIX_EXPR@[194; 197)
+            STAR@[194; 195) "*"
+            WHITESPACE@[195; 196) " "
+            ERROR@[196; 197)
+              DOLLAR@[196; 197) "$"
+        EXPR_STMT@[197; 198)
+          PAREN_EXPR@[197; 198)
+            L_PAREN@[197; 198) "("
+        EXPR_STMT@[198; 199)
+          ERROR@[198; 199)
+            COMMA@[198; 199) ","
+        EXPR_STMT@[199; 200)
+          ERROR@[199; 200)
+            R_PAREN@[199; 200) ")"
+        EXPR_STMT@[200; 202)
+          PREFIX_EXPR@[200; 202)
+            STAR@[200; 201) "*"
+            ERROR@[201; 202)
+              R_BRACK@[201; 202) "]"
+        EXPR_STMT@[202; 203)
+          ERROR@[202; 203)
+            R_PAREN@[202; 203) ")"
+        WHITESPACE@[203; 204) " "
+        BLOCK_EXPR@[204; 346)
+          BLOCK@[204; 346)
+            L_CURLY@[204; 205) "{"
+            WHITESPACE@[205; 214) "\n        "
+            EXPR_STMT@[214; 340)
+              MACRO_CALL@[214; 339)
+                PATH@[214; 223)
+                  PATH_SEGMENT@[214; 223)
+                    NAME_REF@[214; 223)
+                      IDENT@[214; 223) "assert_eq"
+                EXCL@[223; 224) "!"
+                TOKEN_TREE@[224; 339)
+                  L_PAREN@[224; 225) "("
+                  WHITESPACE@[225; 238) "\n            "
+                  IDENT@[238; 253) "merge_use_trees"
+                  TOKEN_TREE@[253; 284)
+                    L_PAREN@[253; 254) "("
+                    IDENT@[254; 269) "parse_use_trees"
+                    EXCL@[269; 270) "!"
+                    TOKEN_TREE@[270; 283)
+                      L_PAREN@[270; 271) "("
+                      DOLLAR@[271; 272) "$"
+                      TOKEN_TREE@[272; 281)
+                        L_PAREN@[272; 273) "("
+                        DOLLAR@[273; 274) "$"
+                        IDENT@[274; 279) "input"
+                        COMMA@[279; 280) ","
+                        R_PAREN@[280; 281) ")"
+                      STAR@[281; 282) "*"
+                      R_PAREN@[282; 283) ")"
+                    R_PAREN@[283; 284) ")"
+                  COMMA@[284; 285) ","
+                  WHITESPACE@[285; 298) "\n            "
+                  IDENT@[298; 313) "parse_use_trees"
+                  EXCL@[313; 314) "!"
+                  TOKEN_TREE@[314; 328)
+                    L_PAREN@[314; 315) "("
+                    DOLLAR@[315; 316) "$"
+                    TOKEN_TREE@[316; 326)
+                      L_PAREN@[316; 317) "("
+                      DOLLAR@[317; 318) "$"
+                      IDENT@[318; 324) "output"
+                      COMMA@[324; 325) ","
+                      R_PAREN@[325; 326) ")"
+                    STAR@[326; 327) "*"
+                    R_PAREN@[327; 328) ")"
+                  COMMA@[328; 329) ","
+                  WHITESPACE@[329; 338) "\n        "
+                  R_PAREN@[338; 339) ")"
+              SEMI@[339; 340) ";"
+            WHITESPACE@[340; 345) "\n    "
+            R_CURLY@[345; 346) "}"
+        WHITESPACE@[346; 347) "\n"
+        R_CURLY@[347; 348) "}"
   WHITESPACE@[348; 349) "\n"
 error 5: expected EXCL
 error 41: expected SEMI

--- a/crates/ra_syntax/test_data/parser/err/0029_field_completion.txt
+++ b/crates/ra_syntax/test_data/parser/err/0029_field_completion.txt
@@ -19,17 +19,18 @@ SOURCE_FILE@[0; 24)
                 IDENT@[10; 11) "A"
       R_PAREN@[11; 12) ")"
     WHITESPACE@[12; 13) " "
-    BLOCK@[13; 23)
-      L_CURLY@[13; 14) "{"
-      WHITESPACE@[14; 19) "\n    "
-      FIELD_EXPR@[19; 21)
-        PATH_EXPR@[19; 20)
-          PATH@[19; 20)
-            PATH_SEGMENT@[19; 20)
-              NAME_REF@[19; 20)
-                IDENT@[19; 20) "a"
-        DOT@[20; 21) "."
-      WHITESPACE@[21; 22) "\n"
-      R_CURLY@[22; 23) "}"
+    BLOCK_EXPR@[13; 23)
+      BLOCK@[13; 23)
+        L_CURLY@[13; 14) "{"
+        WHITESPACE@[14; 19) "\n    "
+        FIELD_EXPR@[19; 21)
+          PATH_EXPR@[19; 20)
+            PATH@[19; 20)
+              PATH_SEGMENT@[19; 20)
+                NAME_REF@[19; 20)
+                  IDENT@[19; 20) "a"
+          DOT@[20; 21) "."
+        WHITESPACE@[21; 22) "\n"
+        R_CURLY@[22; 23) "}"
   WHITESPACE@[23; 24) "\n"
 error 21: expected field name or number

--- a/crates/ra_syntax/test_data/parser/err/0031_block_inner_attrs.txt
+++ b/crates/ra_syntax/test_data/parser/err/0031_block_inner_attrs.txt
@@ -8,105 +8,108 @@ SOURCE_FILE@[0; 350)
       L_PAREN@[8; 9) "("
       R_PAREN@[9; 10) ")"
     WHITESPACE@[10; 11) " "
-    BLOCK@[11; 349)
-      L_CURLY@[11; 12) "{"
-      WHITESPACE@[12; 17) "\n    "
-      LET_STMT@[17; 129)
-        LET_KW@[17; 20) "let"
-        WHITESPACE@[20; 21) " "
-        BIND_PAT@[21; 26)
-          NAME@[21; 26)
-            IDENT@[21; 26) "inner"
-        WHITESPACE@[26; 27) " "
-        EQ@[27; 28) "="
-        WHITESPACE@[28; 29) " "
-        BLOCK_EXPR@[29; 128)
-          BLOCK@[29; 128)
-            L_CURLY@[29; 30) "{"
-            WHITESPACE@[30; 39) "\n        "
-            ATTR@[39; 83)
-              POUND@[39; 40) "#"
-              EXCL@[40; 41) "!"
-              TOKEN_TREE@[41; 83)
-                L_BRACK@[41; 42) "["
-                IDENT@[42; 45) "doc"
-                TOKEN_TREE@[45; 82)
-                  L_PAREN@[45; 46) "("
-                  STRING@[46; 81) "\"Inner attributes not ..."
-                  R_PAREN@[81; 82) ")"
-                R_BRACK@[82; 83) "]"
-            WHITESPACE@[83; 92) "\n        "
-            COMMENT@[92; 122) "//! Nor are ModuleDoc ..."
-            WHITESPACE@[122; 127) "\n    "
-            R_CURLY@[127; 128) "}"
-        SEMI@[128; 129) ";"
-      WHITESPACE@[129; 134) "\n    "
-      EXPR_STMT@[134; 257)
-        IF_EXPR@[134; 257)
-          IF_KW@[134; 136) "if"
-          WHITESPACE@[136; 137) " "
-          CONDITION@[137; 141)
-            LITERAL@[137; 141)
-              TRUE_KW@[137; 141) "true"
-          WHITESPACE@[141; 142) " "
-          BLOCK@[142; 257)
-            L_CURLY@[142; 143) "{"
-            WHITESPACE@[143; 152) "\n        "
-            ATTR@[152; 171)
-              POUND@[152; 153) "#"
-              EXCL@[153; 154) "!"
-              TOKEN_TREE@[154; 171)
-                L_BRACK@[154; 155) "["
-                IDENT@[155; 158) "doc"
-                TOKEN_TREE@[158; 170)
-                  L_PAREN@[158; 159) "("
-                  STRING@[159; 169) "\"Nor here\""
-                  R_PAREN@[169; 170) ")"
-                R_BRACK@[170; 171) "]"
-            WHITESPACE@[171; 180) "\n        "
-            ATTR@[180; 212)
-              POUND@[180; 181) "#"
-              EXCL@[181; 182) "!"
-              TOKEN_TREE@[182; 212)
-                L_BRACK@[182; 183) "["
-                IDENT@[183; 186) "doc"
-                TOKEN_TREE@[186; 211)
-                  L_PAREN@[186; 187) "("
-                  STRING@[187; 210) "\"We error on each attr\""
-                  R_PAREN@[210; 211) ")"
-                R_BRACK@[211; 212) "]"
-            WHITESPACE@[212; 221) "\n        "
-            COMMENT@[221; 251) "//! Nor are ModuleDoc ..."
-            WHITESPACE@[251; 256) "\n    "
-            R_CURLY@[256; 257) "}"
-      WHITESPACE@[257; 262) "\n    "
-      WHILE_EXPR@[262; 347)
-        WHILE_KW@[262; 267) "while"
-        WHITESPACE@[267; 268) " "
-        CONDITION@[268; 272)
-          LITERAL@[268; 272)
-            TRUE_KW@[268; 272) "true"
-        WHITESPACE@[272; 273) " "
-        BLOCK@[273; 347)
-          L_CURLY@[273; 274) "{"
-          WHITESPACE@[274; 283) "\n        "
-          ATTR@[283; 302)
-            POUND@[283; 284) "#"
-            EXCL@[284; 285) "!"
-            TOKEN_TREE@[285; 302)
-              L_BRACK@[285; 286) "["
-              IDENT@[286; 289) "doc"
-              TOKEN_TREE@[289; 301)
-                L_PAREN@[289; 290) "("
-                STRING@[290; 300) "\"Nor here\""
-                R_PAREN@[300; 301) ")"
-              R_BRACK@[301; 302) "]"
-          WHITESPACE@[302; 311) "\n        "
-          COMMENT@[311; 341) "//! Nor are ModuleDoc ..."
-          WHITESPACE@[341; 346) "\n    "
-          R_CURLY@[346; 347) "}"
-      WHITESPACE@[347; 348) "\n"
-      R_CURLY@[348; 349) "}"
+    BLOCK_EXPR@[11; 349)
+      BLOCK@[11; 349)
+        L_CURLY@[11; 12) "{"
+        WHITESPACE@[12; 17) "\n    "
+        LET_STMT@[17; 129)
+          LET_KW@[17; 20) "let"
+          WHITESPACE@[20; 21) " "
+          BIND_PAT@[21; 26)
+            NAME@[21; 26)
+              IDENT@[21; 26) "inner"
+          WHITESPACE@[26; 27) " "
+          EQ@[27; 28) "="
+          WHITESPACE@[28; 29) " "
+          BLOCK_EXPR@[29; 128)
+            BLOCK@[29; 128)
+              L_CURLY@[29; 30) "{"
+              WHITESPACE@[30; 39) "\n        "
+              ATTR@[39; 83)
+                POUND@[39; 40) "#"
+                EXCL@[40; 41) "!"
+                TOKEN_TREE@[41; 83)
+                  L_BRACK@[41; 42) "["
+                  IDENT@[42; 45) "doc"
+                  TOKEN_TREE@[45; 82)
+                    L_PAREN@[45; 46) "("
+                    STRING@[46; 81) "\"Inner attributes not ..."
+                    R_PAREN@[81; 82) ")"
+                  R_BRACK@[82; 83) "]"
+              WHITESPACE@[83; 92) "\n        "
+              COMMENT@[92; 122) "//! Nor are ModuleDoc ..."
+              WHITESPACE@[122; 127) "\n    "
+              R_CURLY@[127; 128) "}"
+          SEMI@[128; 129) ";"
+        WHITESPACE@[129; 134) "\n    "
+        EXPR_STMT@[134; 257)
+          IF_EXPR@[134; 257)
+            IF_KW@[134; 136) "if"
+            WHITESPACE@[136; 137) " "
+            CONDITION@[137; 141)
+              LITERAL@[137; 141)
+                TRUE_KW@[137; 141) "true"
+            WHITESPACE@[141; 142) " "
+            BLOCK_EXPR@[142; 257)
+              BLOCK@[142; 257)
+                L_CURLY@[142; 143) "{"
+                WHITESPACE@[143; 152) "\n        "
+                ATTR@[152; 171)
+                  POUND@[152; 153) "#"
+                  EXCL@[153; 154) "!"
+                  TOKEN_TREE@[154; 171)
+                    L_BRACK@[154; 155) "["
+                    IDENT@[155; 158) "doc"
+                    TOKEN_TREE@[158; 170)
+                      L_PAREN@[158; 159) "("
+                      STRING@[159; 169) "\"Nor here\""
+                      R_PAREN@[169; 170) ")"
+                    R_BRACK@[170; 171) "]"
+                WHITESPACE@[171; 180) "\n        "
+                ATTR@[180; 212)
+                  POUND@[180; 181) "#"
+                  EXCL@[181; 182) "!"
+                  TOKEN_TREE@[182; 212)
+                    L_BRACK@[182; 183) "["
+                    IDENT@[183; 186) "doc"
+                    TOKEN_TREE@[186; 211)
+                      L_PAREN@[186; 187) "("
+                      STRING@[187; 210) "\"We error on each attr\""
+                      R_PAREN@[210; 211) ")"
+                    R_BRACK@[211; 212) "]"
+                WHITESPACE@[212; 221) "\n        "
+                COMMENT@[221; 251) "//! Nor are ModuleDoc ..."
+                WHITESPACE@[251; 256) "\n    "
+                R_CURLY@[256; 257) "}"
+        WHITESPACE@[257; 262) "\n    "
+        WHILE_EXPR@[262; 347)
+          WHILE_KW@[262; 267) "while"
+          WHITESPACE@[267; 268) " "
+          CONDITION@[268; 272)
+            LITERAL@[268; 272)
+              TRUE_KW@[268; 272) "true"
+          WHITESPACE@[272; 273) " "
+          BLOCK_EXPR@[273; 347)
+            BLOCK@[273; 347)
+              L_CURLY@[273; 274) "{"
+              WHITESPACE@[274; 283) "\n        "
+              ATTR@[283; 302)
+                POUND@[283; 284) "#"
+                EXCL@[284; 285) "!"
+                TOKEN_TREE@[285; 302)
+                  L_BRACK@[285; 286) "["
+                  IDENT@[286; 289) "doc"
+                  TOKEN_TREE@[289; 301)
+                    L_PAREN@[289; 290) "("
+                    STRING@[290; 300) "\"Nor here\""
+                    R_PAREN@[300; 301) ")"
+                  R_BRACK@[301; 302) "]"
+              WHITESPACE@[302; 311) "\n        "
+              COMMENT@[311; 341) "//! Nor are ModuleDoc ..."
+              WHITESPACE@[341; 346) "\n    "
+              R_CURLY@[346; 347) "}"
+        WHITESPACE@[347; 348) "\n"
+        R_CURLY@[348; 349) "}"
   WHITESPACE@[349; 350) "\n"
 error [39; 83): A block in this position cannot accept inner attributes
 error [152; 171): A block in this position cannot accept inner attributes

--- a/crates/ra_syntax/test_data/parser/err/0032_match_arms_inner_attrs.txt
+++ b/crates/ra_syntax/test_data/parser/err/0032_match_arms_inner_attrs.txt
@@ -8,185 +8,186 @@ SOURCE_FILE@[0; 293)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 292)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 101)
-        MATCH_EXPR@[15; 101)
-          MATCH_KW@[15; 20) "match"
-          WHITESPACE@[20; 21) " "
-          TUPLE_EXPR@[21; 23)
-            L_PAREN@[21; 22) "("
-            R_PAREN@[22; 23) ")"
-          WHITESPACE@[23; 24) " "
-          MATCH_ARM_LIST@[24; 101)
-            L_CURLY@[24; 25) "{"
-            WHITESPACE@[25; 34) "\n        "
-            MATCH_ARM@[34; 41)
-              PLACEHOLDER_PAT@[34; 35)
-                UNDERSCORE@[34; 35) "_"
-              WHITESPACE@[35; 36) " "
-              FAT_ARROW@[36; 38) "=>"
-              WHITESPACE@[38; 39) " "
-              TUPLE_EXPR@[39; 41)
-                L_PAREN@[39; 40) "("
-                R_PAREN@[40; 41) ")"
-            COMMA@[41; 42) ","
-            WHITESPACE@[42; 51) "\n        "
-            MATCH_ARM@[51; 78)
-              ATTR@[51; 52)
-                POUND@[51; 52) "#"
-              ERROR@[52; 53)
-                EXCL@[52; 53) "!"
-              ARRAY_EXPR@[53; 78)
-                L_BRACK@[53; 54) "["
-                CALL_EXPR@[54; 77)
-                  PATH_EXPR@[54; 57)
-                    PATH@[54; 57)
-                      PATH_SEGMENT@[54; 57)
-                        NAME_REF@[54; 57)
-                          IDENT@[54; 57) "doc"
-                  ARG_LIST@[57; 77)
-                    L_PAREN@[57; 58) "("
-                    LITERAL@[58; 76)
-                      STRING@[58; 76) "\"Not allowed here\""
-                    R_PAREN@[76; 77) ")"
-                R_BRACK@[77; 78) "]"
-            WHITESPACE@[78; 87) "\n        "
-            MATCH_ARM@[87; 94)
-              PLACEHOLDER_PAT@[87; 88)
-                UNDERSCORE@[87; 88) "_"
-              WHITESPACE@[88; 89) " "
-              FAT_ARROW@[89; 91) "=>"
-              WHITESPACE@[91; 92) " "
-              TUPLE_EXPR@[92; 94)
-                L_PAREN@[92; 93) "("
-                R_PAREN@[93; 94) ")"
-            COMMA@[94; 95) ","
-            WHITESPACE@[95; 100) "\n    "
-            R_CURLY@[100; 101) "}"
-      WHITESPACE@[101; 107) "\n\n    "
-      EXPR_STMT@[107; 185)
-        MATCH_EXPR@[107; 185)
-          MATCH_KW@[107; 112) "match"
-          WHITESPACE@[112; 113) " "
-          TUPLE_EXPR@[113; 115)
-            L_PAREN@[113; 114) "("
-            R_PAREN@[114; 115) ")"
-          WHITESPACE@[115; 116) " "
-          MATCH_ARM_LIST@[116; 185)
-            L_CURLY@[116; 117) "{"
-            WHITESPACE@[117; 126) "\n        "
-            MATCH_ARM@[126; 133)
-              PLACEHOLDER_PAT@[126; 127)
-                UNDERSCORE@[126; 127) "_"
-              WHITESPACE@[127; 128) " "
-              FAT_ARROW@[128; 130) "=>"
-              WHITESPACE@[130; 131) " "
-              TUPLE_EXPR@[131; 133)
-                L_PAREN@[131; 132) "("
-                R_PAREN@[132; 133) ")"
-            COMMA@[133; 134) ","
-            WHITESPACE@[134; 143) "\n        "
-            MATCH_ARM@[143; 150)
-              PLACEHOLDER_PAT@[143; 144)
-                UNDERSCORE@[143; 144) "_"
-              WHITESPACE@[144; 145) " "
-              FAT_ARROW@[145; 147) "=>"
-              WHITESPACE@[147; 148) " "
-              TUPLE_EXPR@[148; 150)
-                L_PAREN@[148; 149) "("
-                R_PAREN@[149; 150) ")"
-            COMMA@[150; 151) ","
-            WHITESPACE@[151; 160) "\n        "
-            MATCH_ARM@[160; 179)
-              ATTR@[160; 161)
-                POUND@[160; 161) "#"
-              ERROR@[161; 162)
-                EXCL@[161; 162) "!"
-              ARRAY_EXPR@[162; 179)
-                L_BRACK@[162; 163) "["
-                CALL_EXPR@[163; 178)
-                  PATH_EXPR@[163; 166)
-                    PATH@[163; 166)
-                      PATH_SEGMENT@[163; 166)
-                        NAME_REF@[163; 166)
-                          IDENT@[163; 166) "doc"
-                  ARG_LIST@[166; 178)
-                    L_PAREN@[166; 167) "("
-                    LITERAL@[167; 177)
-                      STRING@[167; 177) "\"Nor here\""
-                    R_PAREN@[177; 178) ")"
-                R_BRACK@[178; 179) "]"
-            WHITESPACE@[179; 184) "\n    "
-            R_CURLY@[184; 185) "}"
-      WHITESPACE@[185; 191) "\n\n    "
-      MATCH_EXPR@[191; 290)
-        MATCH_KW@[191; 196) "match"
-        WHITESPACE@[196; 197) " "
-        TUPLE_EXPR@[197; 199)
-          L_PAREN@[197; 198) "("
-          R_PAREN@[198; 199) ")"
-        WHITESPACE@[199; 200) " "
-        MATCH_ARM_LIST@[200; 290)
-          L_CURLY@[200; 201) "{"
-          WHITESPACE@[201; 210) "\n        "
-          MATCH_ARM@[210; 250)
-            ATTR@[210; 222)
-              POUND@[210; 211) "#"
-              TOKEN_TREE@[211; 222)
-                L_BRACK@[211; 212) "["
-                IDENT@[212; 215) "cfg"
-                TOKEN_TREE@[215; 221)
-                  L_PAREN@[215; 216) "("
-                  IDENT@[216; 220) "test"
-                  R_PAREN@[220; 221) ")"
-                R_BRACK@[221; 222) "]"
-            WHITESPACE@[222; 231) "\n        "
-            ATTR@[231; 232)
-              POUND@[231; 232) "#"
-            ERROR@[232; 233)
-              EXCL@[232; 233) "!"
-            ARRAY_EXPR@[233; 250)
-              L_BRACK@[233; 234) "["
-              CALL_EXPR@[234; 249)
-                PATH_EXPR@[234; 237)
-                  PATH@[234; 237)
-                    PATH_SEGMENT@[234; 237)
-                      NAME_REF@[234; 237)
-                        IDENT@[234; 237) "doc"
-                ARG_LIST@[237; 249)
-                  L_PAREN@[237; 238) "("
-                  LITERAL@[238; 248)
-                    STRING@[238; 248) "\"Nor here\""
-                  R_PAREN@[248; 249) ")"
-              R_BRACK@[249; 250) "]"
-          WHITESPACE@[250; 259) "\n        "
-          MATCH_ARM@[259; 266)
-            PLACEHOLDER_PAT@[259; 260)
-              UNDERSCORE@[259; 260) "_"
-            WHITESPACE@[260; 261) " "
-            FAT_ARROW@[261; 263) "=>"
-            WHITESPACE@[263; 264) " "
-            TUPLE_EXPR@[264; 266)
-              L_PAREN@[264; 265) "("
-              R_PAREN@[265; 266) ")"
-          COMMA@[266; 267) ","
-          WHITESPACE@[267; 276) "\n        "
-          MATCH_ARM@[276; 283)
-            PLACEHOLDER_PAT@[276; 277)
-              UNDERSCORE@[276; 277) "_"
-            WHITESPACE@[277; 278) " "
-            FAT_ARROW@[278; 280) "=>"
-            WHITESPACE@[280; 281) " "
-            TUPLE_EXPR@[281; 283)
-              L_PAREN@[281; 282) "("
-              R_PAREN@[282; 283) ")"
-          COMMA@[283; 284) ","
-          WHITESPACE@[284; 289) "\n    "
-          R_CURLY@[289; 290) "}"
-      WHITESPACE@[290; 291) "\n"
-      R_CURLY@[291; 292) "}"
+    BLOCK_EXPR@[9; 292)
+      BLOCK@[9; 292)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        EXPR_STMT@[15; 101)
+          MATCH_EXPR@[15; 101)
+            MATCH_KW@[15; 20) "match"
+            WHITESPACE@[20; 21) " "
+            TUPLE_EXPR@[21; 23)
+              L_PAREN@[21; 22) "("
+              R_PAREN@[22; 23) ")"
+            WHITESPACE@[23; 24) " "
+            MATCH_ARM_LIST@[24; 101)
+              L_CURLY@[24; 25) "{"
+              WHITESPACE@[25; 34) "\n        "
+              MATCH_ARM@[34; 41)
+                PLACEHOLDER_PAT@[34; 35)
+                  UNDERSCORE@[34; 35) "_"
+                WHITESPACE@[35; 36) " "
+                FAT_ARROW@[36; 38) "=>"
+                WHITESPACE@[38; 39) " "
+                TUPLE_EXPR@[39; 41)
+                  L_PAREN@[39; 40) "("
+                  R_PAREN@[40; 41) ")"
+              COMMA@[41; 42) ","
+              WHITESPACE@[42; 51) "\n        "
+              MATCH_ARM@[51; 78)
+                ATTR@[51; 52)
+                  POUND@[51; 52) "#"
+                ERROR@[52; 53)
+                  EXCL@[52; 53) "!"
+                ARRAY_EXPR@[53; 78)
+                  L_BRACK@[53; 54) "["
+                  CALL_EXPR@[54; 77)
+                    PATH_EXPR@[54; 57)
+                      PATH@[54; 57)
+                        PATH_SEGMENT@[54; 57)
+                          NAME_REF@[54; 57)
+                            IDENT@[54; 57) "doc"
+                    ARG_LIST@[57; 77)
+                      L_PAREN@[57; 58) "("
+                      LITERAL@[58; 76)
+                        STRING@[58; 76) "\"Not allowed here\""
+                      R_PAREN@[76; 77) ")"
+                  R_BRACK@[77; 78) "]"
+              WHITESPACE@[78; 87) "\n        "
+              MATCH_ARM@[87; 94)
+                PLACEHOLDER_PAT@[87; 88)
+                  UNDERSCORE@[87; 88) "_"
+                WHITESPACE@[88; 89) " "
+                FAT_ARROW@[89; 91) "=>"
+                WHITESPACE@[91; 92) " "
+                TUPLE_EXPR@[92; 94)
+                  L_PAREN@[92; 93) "("
+                  R_PAREN@[93; 94) ")"
+              COMMA@[94; 95) ","
+              WHITESPACE@[95; 100) "\n    "
+              R_CURLY@[100; 101) "}"
+        WHITESPACE@[101; 107) "\n\n    "
+        EXPR_STMT@[107; 185)
+          MATCH_EXPR@[107; 185)
+            MATCH_KW@[107; 112) "match"
+            WHITESPACE@[112; 113) " "
+            TUPLE_EXPR@[113; 115)
+              L_PAREN@[113; 114) "("
+              R_PAREN@[114; 115) ")"
+            WHITESPACE@[115; 116) " "
+            MATCH_ARM_LIST@[116; 185)
+              L_CURLY@[116; 117) "{"
+              WHITESPACE@[117; 126) "\n        "
+              MATCH_ARM@[126; 133)
+                PLACEHOLDER_PAT@[126; 127)
+                  UNDERSCORE@[126; 127) "_"
+                WHITESPACE@[127; 128) " "
+                FAT_ARROW@[128; 130) "=>"
+                WHITESPACE@[130; 131) " "
+                TUPLE_EXPR@[131; 133)
+                  L_PAREN@[131; 132) "("
+                  R_PAREN@[132; 133) ")"
+              COMMA@[133; 134) ","
+              WHITESPACE@[134; 143) "\n        "
+              MATCH_ARM@[143; 150)
+                PLACEHOLDER_PAT@[143; 144)
+                  UNDERSCORE@[143; 144) "_"
+                WHITESPACE@[144; 145) " "
+                FAT_ARROW@[145; 147) "=>"
+                WHITESPACE@[147; 148) " "
+                TUPLE_EXPR@[148; 150)
+                  L_PAREN@[148; 149) "("
+                  R_PAREN@[149; 150) ")"
+              COMMA@[150; 151) ","
+              WHITESPACE@[151; 160) "\n        "
+              MATCH_ARM@[160; 179)
+                ATTR@[160; 161)
+                  POUND@[160; 161) "#"
+                ERROR@[161; 162)
+                  EXCL@[161; 162) "!"
+                ARRAY_EXPR@[162; 179)
+                  L_BRACK@[162; 163) "["
+                  CALL_EXPR@[163; 178)
+                    PATH_EXPR@[163; 166)
+                      PATH@[163; 166)
+                        PATH_SEGMENT@[163; 166)
+                          NAME_REF@[163; 166)
+                            IDENT@[163; 166) "doc"
+                    ARG_LIST@[166; 178)
+                      L_PAREN@[166; 167) "("
+                      LITERAL@[167; 177)
+                        STRING@[167; 177) "\"Nor here\""
+                      R_PAREN@[177; 178) ")"
+                  R_BRACK@[178; 179) "]"
+              WHITESPACE@[179; 184) "\n    "
+              R_CURLY@[184; 185) "}"
+        WHITESPACE@[185; 191) "\n\n    "
+        MATCH_EXPR@[191; 290)
+          MATCH_KW@[191; 196) "match"
+          WHITESPACE@[196; 197) " "
+          TUPLE_EXPR@[197; 199)
+            L_PAREN@[197; 198) "("
+            R_PAREN@[198; 199) ")"
+          WHITESPACE@[199; 200) " "
+          MATCH_ARM_LIST@[200; 290)
+            L_CURLY@[200; 201) "{"
+            WHITESPACE@[201; 210) "\n        "
+            MATCH_ARM@[210; 250)
+              ATTR@[210; 222)
+                POUND@[210; 211) "#"
+                TOKEN_TREE@[211; 222)
+                  L_BRACK@[211; 212) "["
+                  IDENT@[212; 215) "cfg"
+                  TOKEN_TREE@[215; 221)
+                    L_PAREN@[215; 216) "("
+                    IDENT@[216; 220) "test"
+                    R_PAREN@[220; 221) ")"
+                  R_BRACK@[221; 222) "]"
+              WHITESPACE@[222; 231) "\n        "
+              ATTR@[231; 232)
+                POUND@[231; 232) "#"
+              ERROR@[232; 233)
+                EXCL@[232; 233) "!"
+              ARRAY_EXPR@[233; 250)
+                L_BRACK@[233; 234) "["
+                CALL_EXPR@[234; 249)
+                  PATH_EXPR@[234; 237)
+                    PATH@[234; 237)
+                      PATH_SEGMENT@[234; 237)
+                        NAME_REF@[234; 237)
+                          IDENT@[234; 237) "doc"
+                  ARG_LIST@[237; 249)
+                    L_PAREN@[237; 238) "("
+                    LITERAL@[238; 248)
+                      STRING@[238; 248) "\"Nor here\""
+                    R_PAREN@[248; 249) ")"
+                R_BRACK@[249; 250) "]"
+            WHITESPACE@[250; 259) "\n        "
+            MATCH_ARM@[259; 266)
+              PLACEHOLDER_PAT@[259; 260)
+                UNDERSCORE@[259; 260) "_"
+              WHITESPACE@[260; 261) " "
+              FAT_ARROW@[261; 263) "=>"
+              WHITESPACE@[263; 264) " "
+              TUPLE_EXPR@[264; 266)
+                L_PAREN@[264; 265) "("
+                R_PAREN@[265; 266) ")"
+            COMMA@[266; 267) ","
+            WHITESPACE@[267; 276) "\n        "
+            MATCH_ARM@[276; 283)
+              PLACEHOLDER_PAT@[276; 277)
+                UNDERSCORE@[276; 277) "_"
+              WHITESPACE@[277; 278) " "
+              FAT_ARROW@[278; 280) "=>"
+              WHITESPACE@[280; 281) " "
+              TUPLE_EXPR@[281; 283)
+                L_PAREN@[281; 282) "("
+                R_PAREN@[282; 283) ")"
+            COMMA@[283; 284) ","
+            WHITESPACE@[284; 289) "\n    "
+            R_CURLY@[289; 290) "}"
+        WHITESPACE@[290; 291) "\n"
+        R_CURLY@[291; 292) "}"
   WHITESPACE@[292; 293) "\n"
 error 52: expected `[`
 error 52: expected pattern

--- a/crates/ra_syntax/test_data/parser/err/0033_match_arms_outer_attrs.txt
+++ b/crates/ra_syntax/test_data/parser/err/0033_match_arms_outer_attrs.txt
@@ -8,56 +8,57 @@ SOURCE_FILE@[0; 89)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 88)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      MATCH_EXPR@[15; 86)
-        MATCH_KW@[15; 20) "match"
-        WHITESPACE@[20; 21) " "
-        TUPLE_EXPR@[21; 23)
-          L_PAREN@[21; 22) "("
-          R_PAREN@[22; 23) ")"
-        WHITESPACE@[23; 24) " "
-        MATCH_ARM_LIST@[24; 86)
-          L_CURLY@[24; 25) "{"
-          WHITESPACE@[25; 34) "\n        "
-          MATCH_ARM@[34; 41)
-            PLACEHOLDER_PAT@[34; 35)
-              UNDERSCORE@[34; 35) "_"
-            WHITESPACE@[35; 36) " "
-            FAT_ARROW@[36; 38) "=>"
-            WHITESPACE@[38; 39) " "
-            TUPLE_EXPR@[39; 41)
-              L_PAREN@[39; 40) "("
-              R_PAREN@[40; 41) ")"
-          COMMA@[41; 42) ","
-          WHITESPACE@[42; 51) "\n        "
-          MATCH_ARM@[51; 58)
-            PLACEHOLDER_PAT@[51; 52)
-              UNDERSCORE@[51; 52) "_"
-            WHITESPACE@[52; 53) " "
-            FAT_ARROW@[53; 55) "=>"
-            WHITESPACE@[55; 56) " "
-            TUPLE_EXPR@[56; 58)
-              L_PAREN@[56; 57) "("
-              R_PAREN@[57; 58) ")"
-          COMMA@[58; 59) ","
-          WHITESPACE@[59; 68) "\n        "
-          MATCH_ARM@[68; 80)
-            ATTR@[68; 80)
-              POUND@[68; 69) "#"
-              TOKEN_TREE@[69; 80)
-                L_BRACK@[69; 70) "["
-                IDENT@[70; 73) "cfg"
-                TOKEN_TREE@[73; 79)
-                  L_PAREN@[73; 74) "("
-                  IDENT@[74; 78) "test"
-                  R_PAREN@[78; 79) ")"
-                R_BRACK@[79; 80) "]"
-          WHITESPACE@[80; 85) "\n    "
-          R_CURLY@[85; 86) "}"
-      WHITESPACE@[86; 87) "\n"
-      R_CURLY@[87; 88) "}"
+    BLOCK_EXPR@[9; 88)
+      BLOCK@[9; 88)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        MATCH_EXPR@[15; 86)
+          MATCH_KW@[15; 20) "match"
+          WHITESPACE@[20; 21) " "
+          TUPLE_EXPR@[21; 23)
+            L_PAREN@[21; 22) "("
+            R_PAREN@[22; 23) ")"
+          WHITESPACE@[23; 24) " "
+          MATCH_ARM_LIST@[24; 86)
+            L_CURLY@[24; 25) "{"
+            WHITESPACE@[25; 34) "\n        "
+            MATCH_ARM@[34; 41)
+              PLACEHOLDER_PAT@[34; 35)
+                UNDERSCORE@[34; 35) "_"
+              WHITESPACE@[35; 36) " "
+              FAT_ARROW@[36; 38) "=>"
+              WHITESPACE@[38; 39) " "
+              TUPLE_EXPR@[39; 41)
+                L_PAREN@[39; 40) "("
+                R_PAREN@[40; 41) ")"
+            COMMA@[41; 42) ","
+            WHITESPACE@[42; 51) "\n        "
+            MATCH_ARM@[51; 58)
+              PLACEHOLDER_PAT@[51; 52)
+                UNDERSCORE@[51; 52) "_"
+              WHITESPACE@[52; 53) " "
+              FAT_ARROW@[53; 55) "=>"
+              WHITESPACE@[55; 56) " "
+              TUPLE_EXPR@[56; 58)
+                L_PAREN@[56; 57) "("
+                R_PAREN@[57; 58) ")"
+            COMMA@[58; 59) ","
+            WHITESPACE@[59; 68) "\n        "
+            MATCH_ARM@[68; 80)
+              ATTR@[68; 80)
+                POUND@[68; 69) "#"
+                TOKEN_TREE@[69; 80)
+                  L_BRACK@[69; 70) "["
+                  IDENT@[70; 73) "cfg"
+                  TOKEN_TREE@[73; 79)
+                    L_PAREN@[73; 74) "("
+                    IDENT@[74; 78) "test"
+                    R_PAREN@[78; 79) ")"
+                  R_BRACK@[79; 80) "]"
+            WHITESPACE@[80; 85) "\n    "
+            R_CURLY@[85; 86) "}"
+        WHITESPACE@[86; 87) "\n"
+        R_CURLY@[87; 88) "}"
   WHITESPACE@[88; 89) "\n"
 error 80: expected pattern
 error 80: expected FAT_ARROW

--- a/crates/ra_syntax/test_data/parser/err/0034_bad_box_pattern.txt
+++ b/crates/ra_syntax/test_data/parser/err/0034_bad_box_pattern.txt
@@ -8,84 +8,85 @@ SOURCE_FILE@[0; 91)
       L_PAREN@[7; 8) "("
       R_PAREN@[8; 9) ")"
     WHITESPACE@[9; 10) " "
-    BLOCK@[10; 89)
-      L_CURLY@[10; 11) "{"
-      WHITESPACE@[11; 16) "\n    "
-      LET_STMT@[16; 27)
-        LET_KW@[16; 19) "let"
-        WHITESPACE@[19; 20) " "
-        BIND_PAT@[20; 27)
-          REF_KW@[20; 23) "ref"
-          WHITESPACE@[23; 24) " "
-          ERROR@[24; 27)
-            BOX_KW@[24; 27) "box"
-      WHITESPACE@[27; 28) " "
-      EXPR_STMT@[28; 35)
-        BIN_EXPR@[28; 34)
-          PATH_EXPR@[28; 29)
-            PATH@[28; 29)
-              PATH_SEGMENT@[28; 29)
-                NAME_REF@[28; 29)
-                  IDENT@[28; 29) "i"
-          WHITESPACE@[29; 30) " "
-          EQ@[30; 31) "="
-          WHITESPACE@[31; 32) " "
-          TUPLE_EXPR@[32; 34)
-            L_PAREN@[32; 33) "("
-            R_PAREN@[33; 34) ")"
-        SEMI@[34; 35) ";"
-      WHITESPACE@[35; 40) "\n    "
-      LET_STMT@[40; 51)
-        LET_KW@[40; 43) "let"
-        WHITESPACE@[43; 44) " "
-        BIND_PAT@[44; 51)
-          MUT_KW@[44; 47) "mut"
-          WHITESPACE@[47; 48) " "
-          ERROR@[48; 51)
-            BOX_KW@[48; 51) "box"
-      WHITESPACE@[51; 52) " "
-      EXPR_STMT@[52; 59)
-        BIN_EXPR@[52; 58)
-          PATH_EXPR@[52; 53)
-            PATH@[52; 53)
-              PATH_SEGMENT@[52; 53)
-                NAME_REF@[52; 53)
-                  IDENT@[52; 53) "i"
-          WHITESPACE@[53; 54) " "
-          EQ@[54; 55) "="
-          WHITESPACE@[55; 56) " "
-          TUPLE_EXPR@[56; 58)
-            L_PAREN@[56; 57) "("
-            R_PAREN@[57; 58) ")"
-        SEMI@[58; 59) ";"
-      WHITESPACE@[59; 64) "\n    "
-      LET_STMT@[64; 79)
-        LET_KW@[64; 67) "let"
-        WHITESPACE@[67; 68) " "
-        BIND_PAT@[68; 79)
-          REF_KW@[68; 71) "ref"
-          WHITESPACE@[71; 72) " "
-          MUT_KW@[72; 75) "mut"
-          WHITESPACE@[75; 76) " "
-          ERROR@[76; 79)
-            BOX_KW@[76; 79) "box"
-      WHITESPACE@[79; 80) " "
-      EXPR_STMT@[80; 87)
-        BIN_EXPR@[80; 86)
-          PATH_EXPR@[80; 81)
-            PATH@[80; 81)
-              PATH_SEGMENT@[80; 81)
-                NAME_REF@[80; 81)
-                  IDENT@[80; 81) "i"
-          WHITESPACE@[81; 82) " "
-          EQ@[82; 83) "="
-          WHITESPACE@[83; 84) " "
-          TUPLE_EXPR@[84; 86)
-            L_PAREN@[84; 85) "("
-            R_PAREN@[85; 86) ")"
-        SEMI@[86; 87) ";"
-      WHITESPACE@[87; 88) "\n"
-      R_CURLY@[88; 89) "}"
+    BLOCK_EXPR@[10; 89)
+      BLOCK@[10; 89)
+        L_CURLY@[10; 11) "{"
+        WHITESPACE@[11; 16) "\n    "
+        LET_STMT@[16; 27)
+          LET_KW@[16; 19) "let"
+          WHITESPACE@[19; 20) " "
+          BIND_PAT@[20; 27)
+            REF_KW@[20; 23) "ref"
+            WHITESPACE@[23; 24) " "
+            ERROR@[24; 27)
+              BOX_KW@[24; 27) "box"
+        WHITESPACE@[27; 28) " "
+        EXPR_STMT@[28; 35)
+          BIN_EXPR@[28; 34)
+            PATH_EXPR@[28; 29)
+              PATH@[28; 29)
+                PATH_SEGMENT@[28; 29)
+                  NAME_REF@[28; 29)
+                    IDENT@[28; 29) "i"
+            WHITESPACE@[29; 30) " "
+            EQ@[30; 31) "="
+            WHITESPACE@[31; 32) " "
+            TUPLE_EXPR@[32; 34)
+              L_PAREN@[32; 33) "("
+              R_PAREN@[33; 34) ")"
+          SEMI@[34; 35) ";"
+        WHITESPACE@[35; 40) "\n    "
+        LET_STMT@[40; 51)
+          LET_KW@[40; 43) "let"
+          WHITESPACE@[43; 44) " "
+          BIND_PAT@[44; 51)
+            MUT_KW@[44; 47) "mut"
+            WHITESPACE@[47; 48) " "
+            ERROR@[48; 51)
+              BOX_KW@[48; 51) "box"
+        WHITESPACE@[51; 52) " "
+        EXPR_STMT@[52; 59)
+          BIN_EXPR@[52; 58)
+            PATH_EXPR@[52; 53)
+              PATH@[52; 53)
+                PATH_SEGMENT@[52; 53)
+                  NAME_REF@[52; 53)
+                    IDENT@[52; 53) "i"
+            WHITESPACE@[53; 54) " "
+            EQ@[54; 55) "="
+            WHITESPACE@[55; 56) " "
+            TUPLE_EXPR@[56; 58)
+              L_PAREN@[56; 57) "("
+              R_PAREN@[57; 58) ")"
+          SEMI@[58; 59) ";"
+        WHITESPACE@[59; 64) "\n    "
+        LET_STMT@[64; 79)
+          LET_KW@[64; 67) "let"
+          WHITESPACE@[67; 68) " "
+          BIND_PAT@[68; 79)
+            REF_KW@[68; 71) "ref"
+            WHITESPACE@[71; 72) " "
+            MUT_KW@[72; 75) "mut"
+            WHITESPACE@[75; 76) " "
+            ERROR@[76; 79)
+              BOX_KW@[76; 79) "box"
+        WHITESPACE@[79; 80) " "
+        EXPR_STMT@[80; 87)
+          BIN_EXPR@[80; 86)
+            PATH_EXPR@[80; 81)
+              PATH@[80; 81)
+                PATH_SEGMENT@[80; 81)
+                  NAME_REF@[80; 81)
+                    IDENT@[80; 81) "i"
+            WHITESPACE@[81; 82) " "
+            EQ@[82; 83) "="
+            WHITESPACE@[83; 84) " "
+            TUPLE_EXPR@[84; 86)
+              L_PAREN@[84; 85) "("
+              R_PAREN@[85; 86) ")"
+          SEMI@[86; 87) ";"
+        WHITESPACE@[87; 88) "\n"
+        R_CURLY@[88; 89) "}"
   WHITESPACE@[89; 91) "\n\n"
 error 24: expected a name
 error 27: expected SEMI

--- a/crates/ra_syntax/test_data/parser/inline/err/0002_misplaced_label_err.txt
+++ b/crates/ra_syntax/test_data/parser/inline/err/0002_misplaced_label_err.txt
@@ -8,19 +8,20 @@ SOURCE_FILE@[0; 30)
       L_PAREN@[7; 8) "("
       R_PAREN@[8; 9) ")"
     WHITESPACE@[9; 10) " "
-    BLOCK@[10; 29)
-      L_CURLY@[10; 11) "{"
-      WHITESPACE@[11; 16) "\n    "
-      EXPR_STMT@[16; 22)
-        ERROR@[16; 22)
-          LABEL@[16; 22)
-            LIFETIME@[16; 21) "\'loop"
-            COLON@[21; 22) ":"
-      WHITESPACE@[22; 23) " "
-      IMPL_BLOCK@[23; 27)
-        IMPL_KW@[23; 27) "impl"
-      WHITESPACE@[27; 28) "\n"
-      R_CURLY@[28; 29) "}"
+    BLOCK_EXPR@[10; 29)
+      BLOCK@[10; 29)
+        L_CURLY@[10; 11) "{"
+        WHITESPACE@[11; 16) "\n    "
+        EXPR_STMT@[16; 22)
+          ERROR@[16; 22)
+            LABEL@[16; 22)
+              LIFETIME@[16; 21) "\'loop"
+              COLON@[21; 22) ":"
+        WHITESPACE@[22; 23) " "
+        IMPL_BLOCK@[23; 27)
+          IMPL_KW@[23; 27) "impl"
+        WHITESPACE@[27; 28) "\n"
+        R_CURLY@[28; 29) "}"
   WHITESPACE@[29; 30) "\n"
 error 22: expected a loop
 error 22: expected SEMI

--- a/crates/ra_syntax/test_data/parser/inline/err/0006_unsafe_block_in_mod.txt
+++ b/crates/ra_syntax/test_data/parser/inline/err/0006_unsafe_block_in_mod.txt
@@ -7,9 +7,10 @@ SOURCE_FILE@[0; 33)
     PARAM_LIST@[6; 8)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
-    BLOCK@[8; 10)
-      L_CURLY@[8; 9) "{"
-      R_CURLY@[9; 10) "}"
+    BLOCK_EXPR@[8; 10)
+      BLOCK@[8; 10)
+        L_CURLY@[8; 9) "{"
+        R_CURLY@[9; 10) "}"
   WHITESPACE@[10; 11) " "
   ERROR@[11; 17)
     UNSAFE_KW@[11; 17) "unsafe"
@@ -27,9 +28,10 @@ SOURCE_FILE@[0; 33)
     PARAM_LIST@[28; 30)
       L_PAREN@[28; 29) "("
       R_PAREN@[29; 30) ")"
-    BLOCK@[30; 32)
-      L_CURLY@[30; 31) "{"
-      R_CURLY@[31; 32) "}"
+    BLOCK_EXPR@[30; 32)
+      BLOCK@[30; 32)
+        L_CURLY@[30; 31) "{"
+        R_CURLY@[31; 32) "}"
   WHITESPACE@[32; 33) "\n"
 error 11: expected an item
 error 18: expected an item

--- a/crates/ra_syntax/test_data/parser/inline/err/0007_async_without_semicolon.txt
+++ b/crates/ra_syntax/test_data/parser/inline/err/0007_async_without_semicolon.txt
@@ -8,24 +8,25 @@ SOURCE_FILE@[0; 30)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 29)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 11) " "
-      LET_STMT@[11; 27)
-        LET_KW@[11; 14) "let"
-        WHITESPACE@[14; 15) " "
-        PLACEHOLDER_PAT@[15; 16)
-          UNDERSCORE@[15; 16) "_"
-        WHITESPACE@[16; 17) " "
-        EQ@[17; 18) "="
-        WHITESPACE@[18; 19) " "
-        BLOCK_EXPR@[19; 27)
-          ASYNC_KW@[19; 24) "async"
-          WHITESPACE@[24; 25) " "
-          BLOCK@[25; 27)
-            L_CURLY@[25; 26) "{"
-            R_CURLY@[26; 27) "}"
-      WHITESPACE@[27; 28) " "
-      R_CURLY@[28; 29) "}"
+    BLOCK_EXPR@[9; 29)
+      BLOCK@[9; 29)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 11) " "
+        LET_STMT@[11; 27)
+          LET_KW@[11; 14) "let"
+          WHITESPACE@[14; 15) " "
+          PLACEHOLDER_PAT@[15; 16)
+            UNDERSCORE@[15; 16) "_"
+          WHITESPACE@[16; 17) " "
+          EQ@[17; 18) "="
+          WHITESPACE@[18; 19) " "
+          BLOCK_EXPR@[19; 27)
+            ASYNC_KW@[19; 24) "async"
+            WHITESPACE@[24; 25) " "
+            BLOCK@[25; 27)
+              L_CURLY@[25; 26) "{"
+              R_CURLY@[26; 27) "}"
+        WHITESPACE@[27; 28) " "
+        R_CURLY@[28; 29) "}"
   WHITESPACE@[29; 30) "\n"
 error 27: expected SEMI

--- a/crates/ra_syntax/test_data/parser/inline/err/0008_pub_expr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/err/0008_pub_expr.txt
@@ -8,18 +8,19 @@ SOURCE_FILE@[0; 21)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 20)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 11) " "
-      ERROR@[11; 14)
-        VISIBILITY@[11; 14)
-          PUB_KW@[11; 14) "pub"
-      WHITESPACE@[14; 15) " "
-      EXPR_STMT@[15; 18)
-        LITERAL@[15; 17)
-          INT_NUMBER@[15; 17) "92"
-        SEMI@[17; 18) ";"
-      WHITESPACE@[18; 19) " "
-      R_CURLY@[19; 20) "}"
+    BLOCK_EXPR@[9; 20)
+      BLOCK@[9; 20)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 11) " "
+        ERROR@[11; 14)
+          VISIBILITY@[11; 14)
+            PUB_KW@[11; 14) "pub"
+        WHITESPACE@[14; 15) " "
+        EXPR_STMT@[15; 18)
+          LITERAL@[15; 17)
+            INT_NUMBER@[15; 17) "92"
+          SEMI@[17; 18) ";"
+        WHITESPACE@[18; 19) " "
+        R_CURLY@[19; 20) "}"
   WHITESPACE@[20; 21) "\n"
 error 14: expected an item

--- a/crates/ra_syntax/test_data/parser/inline/err/0009_attr_on_expr_not_allowed.txt
+++ b/crates/ra_syntax/test_data/parser/inline/err/0009_attr_on_expr_not_allowed.txt
@@ -8,48 +8,50 @@ SOURCE_FILE@[0; 48)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 47)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 14) "\n   "
-      EXPR_STMT@[14; 25)
-        ATTR@[14; 18)
-          POUND@[14; 15) "#"
-          TOKEN_TREE@[15; 18)
-            L_BRACK@[15; 16) "["
-            IDENT@[16; 17) "A"
-            R_BRACK@[17; 18) "]"
-        WHITESPACE@[18; 19) " "
-        BIN_EXPR@[19; 24)
-          LITERAL@[19; 20)
-            INT_NUMBER@[19; 20) "1"
-          WHITESPACE@[20; 21) " "
-          PLUS@[21; 22) "+"
-          WHITESPACE@[22; 23) " "
-          LITERAL@[23; 24)
-            INT_NUMBER@[23; 24) "2"
-        SEMI@[24; 25) ";"
-      WHITESPACE@[25; 29) "\n   "
-      EXPR_STMT@[29; 45)
-        ATTR@[29; 33)
-          POUND@[29; 30) "#"
-          TOKEN_TREE@[30; 33)
-            L_BRACK@[30; 31) "["
-            IDENT@[31; 32) "B"
-            R_BRACK@[32; 33) "]"
-        WHITESPACE@[33; 34) " "
-        IF_EXPR@[34; 44)
-          IF_KW@[34; 36) "if"
-          WHITESPACE@[36; 37) " "
-          CONDITION@[37; 41)
-            LITERAL@[37; 41)
-              TRUE_KW@[37; 41) "true"
-          WHITESPACE@[41; 42) " "
-          BLOCK@[42; 44)
-            L_CURLY@[42; 43) "{"
-            R_CURLY@[43; 44) "}"
-        SEMI@[44; 45) ";"
-      WHITESPACE@[45; 46) "\n"
-      R_CURLY@[46; 47) "}"
+    BLOCK_EXPR@[9; 47)
+      BLOCK@[9; 47)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 14) "\n   "
+        EXPR_STMT@[14; 25)
+          ATTR@[14; 18)
+            POUND@[14; 15) "#"
+            TOKEN_TREE@[15; 18)
+              L_BRACK@[15; 16) "["
+              IDENT@[16; 17) "A"
+              R_BRACK@[17; 18) "]"
+          WHITESPACE@[18; 19) " "
+          BIN_EXPR@[19; 24)
+            LITERAL@[19; 20)
+              INT_NUMBER@[19; 20) "1"
+            WHITESPACE@[20; 21) " "
+            PLUS@[21; 22) "+"
+            WHITESPACE@[22; 23) " "
+            LITERAL@[23; 24)
+              INT_NUMBER@[23; 24) "2"
+          SEMI@[24; 25) ";"
+        WHITESPACE@[25; 29) "\n   "
+        EXPR_STMT@[29; 45)
+          ATTR@[29; 33)
+            POUND@[29; 30) "#"
+            TOKEN_TREE@[30; 33)
+              L_BRACK@[30; 31) "["
+              IDENT@[31; 32) "B"
+              R_BRACK@[32; 33) "]"
+          WHITESPACE@[33; 34) " "
+          IF_EXPR@[34; 44)
+            IF_KW@[34; 36) "if"
+            WHITESPACE@[36; 37) " "
+            CONDITION@[37; 41)
+              LITERAL@[37; 41)
+                TRUE_KW@[37; 41) "true"
+            WHITESPACE@[41; 42) " "
+            BLOCK_EXPR@[42; 44)
+              BLOCK@[42; 44)
+                L_CURLY@[42; 43) "{"
+                R_CURLY@[43; 44) "}"
+          SEMI@[44; 45) ";"
+        WHITESPACE@[45; 46) "\n"
+        R_CURLY@[46; 47) "}"
   WHITESPACE@[47; 48) "\n"
 error 24: attributes are not allowed on BIN_EXPR
 error 44: attributes are not allowed on IF_EXPR

--- a/crates/ra_syntax/test_data/parser/inline/err/0010_bad_tuple_index_expr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/err/0010_bad_tuple_index_expr.txt
@@ -8,45 +8,46 @@ SOURCE_FILE@[0; 47)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 46)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 20)
-        FIELD_EXPR@[15; 19)
-          PATH_EXPR@[15; 16)
-            PATH@[15; 16)
-              PATH_SEGMENT@[15; 16)
-                NAME_REF@[15; 16)
-                  IDENT@[15; 16) "x"
-          DOT@[16; 17) "."
-          FLOAT_NUMBER@[17; 19) "0."
-        SEMI@[19; 20) ";"
-      WHITESPACE@[20; 25) "\n    "
-      EXPR_STMT@[25; 32)
-        FIELD_EXPR@[25; 31)
-          PATH_EXPR@[25; 26)
-            PATH@[25; 26)
-              PATH_SEGMENT@[25; 26)
-                NAME_REF@[25; 26)
-                  IDENT@[25; 26) "x"
-          DOT@[26; 27) "."
-          NAME_REF@[27; 31)
-            INT_NUMBER@[27; 31) "1i32"
-        SEMI@[31; 32) ";"
-      WHITESPACE@[32; 37) "\n    "
-      EXPR_STMT@[37; 44)
-        FIELD_EXPR@[37; 43)
-          PATH_EXPR@[37; 38)
-            PATH@[37; 38)
-              PATH_SEGMENT@[37; 38)
-                NAME_REF@[37; 38)
-                  IDENT@[37; 38) "x"
-          DOT@[38; 39) "."
-          NAME_REF@[39; 43)
-            INT_NUMBER@[39; 43) "0x01"
-        SEMI@[43; 44) ";"
-      WHITESPACE@[44; 45) "\n"
-      R_CURLY@[45; 46) "}"
+    BLOCK_EXPR@[9; 46)
+      BLOCK@[9; 46)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        EXPR_STMT@[15; 20)
+          FIELD_EXPR@[15; 19)
+            PATH_EXPR@[15; 16)
+              PATH@[15; 16)
+                PATH_SEGMENT@[15; 16)
+                  NAME_REF@[15; 16)
+                    IDENT@[15; 16) "x"
+            DOT@[16; 17) "."
+            FLOAT_NUMBER@[17; 19) "0."
+          SEMI@[19; 20) ";"
+        WHITESPACE@[20; 25) "\n    "
+        EXPR_STMT@[25; 32)
+          FIELD_EXPR@[25; 31)
+            PATH_EXPR@[25; 26)
+              PATH@[25; 26)
+                PATH_SEGMENT@[25; 26)
+                  NAME_REF@[25; 26)
+                    IDENT@[25; 26) "x"
+            DOT@[26; 27) "."
+            NAME_REF@[27; 31)
+              INT_NUMBER@[27; 31) "1i32"
+          SEMI@[31; 32) ";"
+        WHITESPACE@[32; 37) "\n    "
+        EXPR_STMT@[37; 44)
+          FIELD_EXPR@[37; 43)
+            PATH_EXPR@[37; 38)
+              PATH@[37; 38)
+                PATH_SEGMENT@[37; 38)
+                  NAME_REF@[37; 38)
+                    IDENT@[37; 38) "x"
+            DOT@[38; 39) "."
+            NAME_REF@[39; 43)
+              INT_NUMBER@[39; 43) "0x01"
+          SEMI@[43; 44) ";"
+        WHITESPACE@[44; 45) "\n"
+        R_CURLY@[45; 46) "}"
   WHITESPACE@[46; 47) "\n"
 error [27; 31): Tuple (struct) field access is only allowed through decimal integers with no underscores or suffix
 error [39; 43): Tuple (struct) field access is only allowed through decimal integers with no underscores or suffix

--- a/crates/ra_syntax/test_data/parser/inline/err/0010_wrong_order_fns.txt
+++ b/crates/ra_syntax/test_data/parser/inline/err/0010_wrong_order_fns.txt
@@ -13,9 +13,10 @@ SOURCE_FILE@[0; 50)
       L_PAREN@[19; 20) "("
       R_PAREN@[20; 21) ")"
     WHITESPACE@[21; 22) " "
-    BLOCK@[22; 24)
-      L_CURLY@[22; 23) "{"
-      R_CURLY@[23; 24) "}"
+    BLOCK_EXPR@[22; 24)
+      BLOCK@[22; 24)
+        L_CURLY@[22; 23) "{"
+        R_CURLY@[23; 24) "}"
   WHITESPACE@[24; 25) "\n"
   ERROR@[25; 31)
     UNSAFE_KW@[25; 31) "unsafe"
@@ -31,9 +32,10 @@ SOURCE_FILE@[0; 50)
       L_PAREN@[44; 45) "("
       R_PAREN@[45; 46) ")"
     WHITESPACE@[46; 47) " "
-    BLOCK@[47; 49)
-      L_CURLY@[47; 48) "{"
-      R_CURLY@[48; 49) "}"
+    BLOCK_EXPR@[47; 49)
+      BLOCK@[47; 49)
+        L_CURLY@[47; 48) "{"
+        R_CURLY@[48; 49) "}"
   WHITESPACE@[49; 50) "\n"
 error 5: expected existential, fn, trait or impl
 error 31: expected existential, fn, trait or impl

--- a/crates/ra_syntax/test_data/parser/inline/err/0014_default_fn_type.txt
+++ b/crates/ra_syntax/test_data/parser/inline/err/0014_default_fn_type.txt
@@ -44,9 +44,10 @@ SOURCE_FILE@[0; 62)
           L_PAREN@[54; 55) "("
           R_PAREN@[55; 56) ")"
         WHITESPACE@[56; 57) " "
-        BLOCK@[57; 59)
-          L_CURLY@[57; 58) "{"
-          R_CURLY@[58; 59) "}"
+        BLOCK_EXPR@[57; 59)
+          BLOCK@[57; 59)
+            L_CURLY@[57; 58) "{"
+            R_CURLY@[58; 59) "}"
       WHITESPACE@[59; 60) "\n"
       R_CURLY@[60; 61) "}"
   WHITESPACE@[61; 62) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0001_trait_item_list.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0001_trait_item_list.txt
@@ -50,9 +50,10 @@ SOURCE_FILE@[0; 83)
           L_PAREN@[56; 57) "("
           R_PAREN@[57; 58) ")"
         WHITESPACE@[58; 59) " "
-        BLOCK@[59; 61)
-          L_CURLY@[59; 60) "{"
-          R_CURLY@[60; 61) "}"
+        BLOCK_EXPR@[59; 61)
+          BLOCK@[59; 61)
+            L_CURLY@[59; 60) "{"
+            R_CURLY@[60; 61) "}"
       WHITESPACE@[61; 66) "\n    "
       FN_DEF@[66; 80)
         FN_KW@[66; 68) "fn"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0003_where_pred_for.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0003_where_pred_for.txt
@@ -54,8 +54,9 @@ SOURCE_FILE@[0; 49)
                                 IDENT@[40; 43) "str"
                     R_PAREN@[43; 44) ")"
     WHITESPACE@[44; 45) "\n"
-    BLOCK@[45; 48)
-      L_CURLY@[45; 46) "{"
-      WHITESPACE@[46; 47) " "
-      R_CURLY@[47; 48) "}"
+    BLOCK_EXPR@[45; 48)
+      BLOCK@[45; 48)
+        L_CURLY@[45; 46) "{"
+        WHITESPACE@[46; 47) " "
+        R_CURLY@[47; 48) "}"
   WHITESPACE@[48; 49) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0005_function_type_params.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0005_function_type_params.txt
@@ -31,7 +31,8 @@ SOURCE_FILE@[0; 28)
     PARAM_LIST@[23; 25)
       L_PAREN@[23; 24) "("
       R_PAREN@[24; 25) ")"
-    BLOCK@[25; 27)
-      L_CURLY@[25; 26) "{"
-      R_CURLY@[26; 27) "}"
+    BLOCK_EXPR@[25; 27)
+      BLOCK@[25; 27)
+        L_CURLY@[25; 26) "{"
+        R_CURLY@[26; 27) "}"
   WHITESPACE@[27; 28) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0006_self_param.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0006_self_param.txt
@@ -22,9 +22,10 @@ SOURCE_FILE@[0; 128)
             SELF_KW@[18; 22) "self"
           R_PAREN@[22; 23) ")"
         WHITESPACE@[23; 24) " "
-        BLOCK@[24; 26)
-          L_CURLY@[24; 25) "{"
-          R_CURLY@[25; 26) "}"
+        BLOCK_EXPR@[24; 26)
+          BLOCK@[24; 26)
+            L_CURLY@[24; 25) "{"
+            R_CURLY@[25; 26) "}"
       WHITESPACE@[26; 31) "\n    "
       FN_DEF@[31; 46)
         FN_KW@[31; 33) "fn"
@@ -39,9 +40,10 @@ SOURCE_FILE@[0; 128)
           COMMA@[41; 42) ","
           R_PAREN@[42; 43) ")"
         WHITESPACE@[43; 44) " "
-        BLOCK@[44; 46)
-          L_CURLY@[44; 45) "{"
-          R_CURLY@[45; 46) "}"
+        BLOCK_EXPR@[44; 46)
+          BLOCK@[44; 46)
+            L_CURLY@[44; 45) "{"
+            R_CURLY@[45; 46) "}"
       WHITESPACE@[46; 51) "\n    "
       FN_DEF@[51; 69)
         FN_KW@[51; 53) "fn"
@@ -58,9 +60,10 @@ SOURCE_FILE@[0; 128)
           COMMA@[64; 65) ","
           R_PAREN@[65; 66) ")"
         WHITESPACE@[66; 67) " "
-        BLOCK@[67; 69)
-          L_CURLY@[67; 68) "{"
-          R_CURLY@[68; 69) "}"
+        BLOCK_EXPR@[67; 69)
+          BLOCK@[67; 69)
+            L_CURLY@[67; 68) "{"
+            R_CURLY@[68; 69) "}"
       WHITESPACE@[69; 74) "\n    "
       FN_DEF@[74; 103)
         FN_KW@[74; 76) "fn"
@@ -91,9 +94,10 @@ SOURCE_FILE@[0; 128)
                     IDENT@[96; 99) "i32"
           R_PAREN@[99; 100) ")"
         WHITESPACE@[100; 101) " "
-        BLOCK@[101; 103)
-          L_CURLY@[101; 102) "{"
-          R_CURLY@[102; 103) "}"
+        BLOCK_EXPR@[101; 103)
+          BLOCK@[101; 103)
+            L_CURLY@[101; 102) "{"
+            R_CURLY@[102; 103) "}"
       WHITESPACE@[103; 108) "\n    "
       FN_DEF@[108; 125)
         FN_KW@[108; 110) "fn"
@@ -108,9 +112,10 @@ SOURCE_FILE@[0; 128)
             SELF_KW@[117; 121) "self"
           R_PAREN@[121; 122) ")"
         WHITESPACE@[122; 123) " "
-        BLOCK@[123; 125)
-          L_CURLY@[123; 124) "{"
-          R_CURLY@[124; 125) "}"
+        BLOCK_EXPR@[123; 125)
+          BLOCK@[123; 125)
+            L_CURLY@[123; 124) "{"
+            R_CURLY@[124; 125) "}"
       WHITESPACE@[125; 126) "\n"
       R_CURLY@[126; 127) "}"
   WHITESPACE@[127; 128) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0008_path_part.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0008_path_part.txt
@@ -8,88 +8,89 @@ SOURCE_FILE@[0; 103)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 102)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      LET_STMT@[15; 33)
-        LET_KW@[15; 18) "let"
-        WHITESPACE@[18; 19) " "
-        PATH_PAT@[19; 27)
-          PATH@[19; 27)
-            PATH@[19; 22)
-              PATH_SEGMENT@[19; 22)
-                NAME_REF@[19; 22)
-                  IDENT@[19; 22) "foo"
-            COLONCOLON@[22; 24) "::"
-            PATH_SEGMENT@[24; 27)
-              NAME_REF@[24; 27)
-                IDENT@[24; 27) "Bar"
-        WHITESPACE@[27; 28) " "
-        EQ@[28; 29) "="
-        WHITESPACE@[29; 30) " "
-        TUPLE_EXPR@[30; 32)
-          L_PAREN@[30; 31) "("
-          R_PAREN@[31; 32) ")"
-        SEMI@[32; 33) ";"
-      WHITESPACE@[33; 38) "\n    "
-      LET_STMT@[38; 53)
-        LET_KW@[38; 41) "let"
-        WHITESPACE@[41; 42) " "
-        PATH_PAT@[42; 47)
-          PATH@[42; 47)
-            PATH_SEGMENT@[42; 47)
-              COLONCOLON@[42; 44) "::"
-              NAME_REF@[44; 47)
-                IDENT@[44; 47) "Bar"
-        WHITESPACE@[47; 48) " "
-        EQ@[48; 49) "="
-        WHITESPACE@[49; 50) " "
-        TUPLE_EXPR@[50; 52)
-          L_PAREN@[50; 51) "("
-          R_PAREN@[51; 52) ")"
-        SEMI@[52; 53) ";"
-      WHITESPACE@[53; 58) "\n    "
-      LET_STMT@[58; 78)
-        LET_KW@[58; 61) "let"
-        WHITESPACE@[61; 62) " "
-        RECORD_PAT@[62; 72)
-          PATH@[62; 65)
-            PATH_SEGMENT@[62; 65)
-              NAME_REF@[62; 65)
-                IDENT@[62; 65) "Bar"
-          WHITESPACE@[65; 66) " "
-          RECORD_FIELD_PAT_LIST@[66; 72)
-            L_CURLY@[66; 67) "{"
-            WHITESPACE@[67; 68) " "
-            DOTDOT@[68; 70) ".."
-            WHITESPACE@[70; 71) " "
-            R_CURLY@[71; 72) "}"
-        WHITESPACE@[72; 73) " "
-        EQ@[73; 74) "="
-        WHITESPACE@[74; 75) " "
-        TUPLE_EXPR@[75; 77)
-          L_PAREN@[75; 76) "("
-          R_PAREN@[76; 77) ")"
-        SEMI@[77; 78) ";"
-      WHITESPACE@[78; 83) "\n    "
-      LET_STMT@[83; 100)
-        LET_KW@[83; 86) "let"
-        WHITESPACE@[86; 87) " "
-        TUPLE_STRUCT_PAT@[87; 94)
-          PATH@[87; 90)
-            PATH_SEGMENT@[87; 90)
-              NAME_REF@[87; 90)
-                IDENT@[87; 90) "Bar"
-          L_PAREN@[90; 91) "("
-          DOTDOT@[91; 93) ".."
-          R_PAREN@[93; 94) ")"
-        WHITESPACE@[94; 95) " "
-        EQ@[95; 96) "="
-        WHITESPACE@[96; 97) " "
-        TUPLE_EXPR@[97; 99)
-          L_PAREN@[97; 98) "("
-          R_PAREN@[98; 99) ")"
-        SEMI@[99; 100) ";"
-      WHITESPACE@[100; 101) "\n"
-      R_CURLY@[101; 102) "}"
+    BLOCK_EXPR@[9; 102)
+      BLOCK@[9; 102)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        LET_STMT@[15; 33)
+          LET_KW@[15; 18) "let"
+          WHITESPACE@[18; 19) " "
+          PATH_PAT@[19; 27)
+            PATH@[19; 27)
+              PATH@[19; 22)
+                PATH_SEGMENT@[19; 22)
+                  NAME_REF@[19; 22)
+                    IDENT@[19; 22) "foo"
+              COLONCOLON@[22; 24) "::"
+              PATH_SEGMENT@[24; 27)
+                NAME_REF@[24; 27)
+                  IDENT@[24; 27) "Bar"
+          WHITESPACE@[27; 28) " "
+          EQ@[28; 29) "="
+          WHITESPACE@[29; 30) " "
+          TUPLE_EXPR@[30; 32)
+            L_PAREN@[30; 31) "("
+            R_PAREN@[31; 32) ")"
+          SEMI@[32; 33) ";"
+        WHITESPACE@[33; 38) "\n    "
+        LET_STMT@[38; 53)
+          LET_KW@[38; 41) "let"
+          WHITESPACE@[41; 42) " "
+          PATH_PAT@[42; 47)
+            PATH@[42; 47)
+              PATH_SEGMENT@[42; 47)
+                COLONCOLON@[42; 44) "::"
+                NAME_REF@[44; 47)
+                  IDENT@[44; 47) "Bar"
+          WHITESPACE@[47; 48) " "
+          EQ@[48; 49) "="
+          WHITESPACE@[49; 50) " "
+          TUPLE_EXPR@[50; 52)
+            L_PAREN@[50; 51) "("
+            R_PAREN@[51; 52) ")"
+          SEMI@[52; 53) ";"
+        WHITESPACE@[53; 58) "\n    "
+        LET_STMT@[58; 78)
+          LET_KW@[58; 61) "let"
+          WHITESPACE@[61; 62) " "
+          RECORD_PAT@[62; 72)
+            PATH@[62; 65)
+              PATH_SEGMENT@[62; 65)
+                NAME_REF@[62; 65)
+                  IDENT@[62; 65) "Bar"
+            WHITESPACE@[65; 66) " "
+            RECORD_FIELD_PAT_LIST@[66; 72)
+              L_CURLY@[66; 67) "{"
+              WHITESPACE@[67; 68) " "
+              DOTDOT@[68; 70) ".."
+              WHITESPACE@[70; 71) " "
+              R_CURLY@[71; 72) "}"
+          WHITESPACE@[72; 73) " "
+          EQ@[73; 74) "="
+          WHITESPACE@[74; 75) " "
+          TUPLE_EXPR@[75; 77)
+            L_PAREN@[75; 76) "("
+            R_PAREN@[76; 77) ")"
+          SEMI@[77; 78) ";"
+        WHITESPACE@[78; 83) "\n    "
+        LET_STMT@[83; 100)
+          LET_KW@[83; 86) "let"
+          WHITESPACE@[86; 87) " "
+          TUPLE_STRUCT_PAT@[87; 94)
+            PATH@[87; 90)
+              PATH_SEGMENT@[87; 90)
+                NAME_REF@[87; 90)
+                  IDENT@[87; 90) "Bar"
+            L_PAREN@[90; 91) "("
+            DOTDOT@[91; 93) ".."
+            R_PAREN@[93; 94) ")"
+          WHITESPACE@[94; 95) " "
+          EQ@[95; 96) "="
+          WHITESPACE@[96; 97) " "
+          TUPLE_EXPR@[97; 99)
+            L_PAREN@[97; 98) "("
+            R_PAREN@[98; 99) ")"
+          SEMI@[99; 100) ";"
+        WHITESPACE@[100; 101) "\n"
+        R_CURLY@[101; 102) "}"
   WHITESPACE@[102; 103) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0009_loop_expr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0009_loop_expr.txt
@@ -8,17 +8,19 @@ SOURCE_FILE@[0; 26)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 25)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 23)
-        LOOP_EXPR@[15; 22)
-          LOOP_KW@[15; 19) "loop"
-          WHITESPACE@[19; 20) " "
-          BLOCK@[20; 22)
-            L_CURLY@[20; 21) "{"
-            R_CURLY@[21; 22) "}"
-        SEMI@[22; 23) ";"
-      WHITESPACE@[23; 24) "\n"
-      R_CURLY@[24; 25) "}"
+    BLOCK_EXPR@[9; 25)
+      BLOCK@[9; 25)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        EXPR_STMT@[15; 23)
+          LOOP_EXPR@[15; 22)
+            LOOP_KW@[15; 19) "loop"
+            WHITESPACE@[19; 20) " "
+            BLOCK_EXPR@[20; 22)
+              BLOCK@[20; 22)
+                L_CURLY@[20; 21) "{"
+                R_CURLY@[21; 22) "}"
+          SEMI@[22; 23) ";"
+        WHITESPACE@[23; 24) "\n"
+        R_CURLY@[24; 25) "}"
   WHITESPACE@[25; 26) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0011_field_expr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0011_field_expr.txt
@@ -8,52 +8,53 @@ SOURCE_FILE@[0; 48)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 47)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 21)
-        FIELD_EXPR@[15; 20)
-          PATH_EXPR@[15; 16)
-            PATH@[15; 16)
-              PATH_SEGMENT@[15; 16)
-                NAME_REF@[15; 16)
-                  IDENT@[15; 16) "x"
-          DOT@[16; 17) "."
-          NAME_REF@[17; 20)
-            IDENT@[17; 20) "foo"
-        SEMI@[20; 21) ";"
-      WHITESPACE@[21; 26) "\n    "
-      EXPR_STMT@[26; 34)
-        FIELD_EXPR@[26; 33)
-          FIELD_EXPR@[26; 29)
-            PATH_EXPR@[26; 27)
-              PATH@[26; 27)
-                PATH_SEGMENT@[26; 27)
-                  NAME_REF@[26; 27)
-                    IDENT@[26; 27) "x"
-            DOT@[27; 28) "."
-            NAME_REF@[28; 29)
-              INT_NUMBER@[28; 29) "0"
-          DOT@[29; 30) "."
-          NAME_REF@[30; 33)
-            IDENT@[30; 33) "bar"
-        SEMI@[33; 34) ";"
-      WHITESPACE@[34; 39) "\n    "
-      EXPR_STMT@[39; 45)
-        CALL_EXPR@[39; 44)
-          FIELD_EXPR@[39; 42)
-            PATH_EXPR@[39; 40)
-              PATH@[39; 40)
-                PATH_SEGMENT@[39; 40)
-                  NAME_REF@[39; 40)
-                    IDENT@[39; 40) "x"
-            DOT@[40; 41) "."
-            NAME_REF@[41; 42)
-              INT_NUMBER@[41; 42) "0"
-          ARG_LIST@[42; 44)
-            L_PAREN@[42; 43) "("
-            R_PAREN@[43; 44) ")"
-        SEMI@[44; 45) ";"
-      WHITESPACE@[45; 46) "\n"
-      R_CURLY@[46; 47) "}"
+    BLOCK_EXPR@[9; 47)
+      BLOCK@[9; 47)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        EXPR_STMT@[15; 21)
+          FIELD_EXPR@[15; 20)
+            PATH_EXPR@[15; 16)
+              PATH@[15; 16)
+                PATH_SEGMENT@[15; 16)
+                  NAME_REF@[15; 16)
+                    IDENT@[15; 16) "x"
+            DOT@[16; 17) "."
+            NAME_REF@[17; 20)
+              IDENT@[17; 20) "foo"
+          SEMI@[20; 21) ";"
+        WHITESPACE@[21; 26) "\n    "
+        EXPR_STMT@[26; 34)
+          FIELD_EXPR@[26; 33)
+            FIELD_EXPR@[26; 29)
+              PATH_EXPR@[26; 27)
+                PATH@[26; 27)
+                  PATH_SEGMENT@[26; 27)
+                    NAME_REF@[26; 27)
+                      IDENT@[26; 27) "x"
+              DOT@[27; 28) "."
+              NAME_REF@[28; 29)
+                INT_NUMBER@[28; 29) "0"
+            DOT@[29; 30) "."
+            NAME_REF@[30; 33)
+              IDENT@[30; 33) "bar"
+          SEMI@[33; 34) ";"
+        WHITESPACE@[34; 39) "\n    "
+        EXPR_STMT@[39; 45)
+          CALL_EXPR@[39; 44)
+            FIELD_EXPR@[39; 42)
+              PATH_EXPR@[39; 40)
+                PATH@[39; 40)
+                  PATH_SEGMENT@[39; 40)
+                    NAME_REF@[39; 40)
+                      IDENT@[39; 40) "x"
+              DOT@[40; 41) "."
+              NAME_REF@[41; 42)
+                INT_NUMBER@[41; 42) "0"
+            ARG_LIST@[42; 44)
+              L_PAREN@[42; 43) "("
+              R_PAREN@[43; 44) ")"
+          SEMI@[44; 45) ";"
+        WHITESPACE@[45; 46) "\n"
+        R_CURLY@[46; 47) "}"
   WHITESPACE@[47; 48) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0015_continue_expr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0015_continue_expr.txt
@@ -8,28 +8,30 @@ SOURCE_FILE@[0; 69)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 68)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      LOOP_EXPR@[15; 66)
-        LOOP_KW@[15; 19) "loop"
-        WHITESPACE@[19; 20) " "
-        BLOCK@[20; 66)
-          L_CURLY@[20; 21) "{"
-          WHITESPACE@[21; 30) "\n        "
-          EXPR_STMT@[30; 39)
-            CONTINUE_EXPR@[30; 38)
-              CONTINUE_KW@[30; 38) "continue"
-            SEMI@[38; 39) ";"
-          WHITESPACE@[39; 48) "\n        "
-          EXPR_STMT@[48; 60)
-            CONTINUE_EXPR@[48; 59)
-              CONTINUE_KW@[48; 56) "continue"
-              WHITESPACE@[56; 57) " "
-              LIFETIME@[57; 59) "\'l"
-            SEMI@[59; 60) ";"
-          WHITESPACE@[60; 65) "\n    "
-          R_CURLY@[65; 66) "}"
-      WHITESPACE@[66; 67) "\n"
-      R_CURLY@[67; 68) "}"
+    BLOCK_EXPR@[9; 68)
+      BLOCK@[9; 68)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        LOOP_EXPR@[15; 66)
+          LOOP_KW@[15; 19) "loop"
+          WHITESPACE@[19; 20) " "
+          BLOCK_EXPR@[20; 66)
+            BLOCK@[20; 66)
+              L_CURLY@[20; 21) "{"
+              WHITESPACE@[21; 30) "\n        "
+              EXPR_STMT@[30; 39)
+                CONTINUE_EXPR@[30; 38)
+                  CONTINUE_KW@[30; 38) "continue"
+                SEMI@[38; 39) ";"
+              WHITESPACE@[39; 48) "\n        "
+              EXPR_STMT@[48; 60)
+                CONTINUE_EXPR@[48; 59)
+                  CONTINUE_KW@[48; 56) "continue"
+                  WHITESPACE@[56; 57) " "
+                  LIFETIME@[57; 59) "\'l"
+                SEMI@[59; 60) ";"
+              WHITESPACE@[60; 65) "\n    "
+              R_CURLY@[65; 66) "}"
+        WHITESPACE@[66; 67) "\n"
+        R_CURLY@[67; 68) "}"
   WHITESPACE@[68; 69) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0018_arb_self_types.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0018_arb_self_types.txt
@@ -31,9 +31,10 @@ SOURCE_FILE@[0; 69)
                       IDENT@[25; 29) "Self"
           R_PAREN@[29; 30) ")"
         WHITESPACE@[30; 31) " "
-        BLOCK@[31; 33)
-          L_CURLY@[31; 32) "{"
-          R_CURLY@[32; 33) "}"
+        BLOCK_EXPR@[31; 33)
+          BLOCK@[31; 33)
+            L_CURLY@[31; 32) "{"
+            R_CURLY@[32; 33) "}"
       WHITESPACE@[33; 38) "\n    "
       FN_DEF@[38; 66)
         FN_KW@[38; 40) "fn"
@@ -64,9 +65,10 @@ SOURCE_FILE@[0; 69)
                     R_ANGLE@[61; 62) ">"
           R_PAREN@[62; 63) ")"
         WHITESPACE@[63; 64) " "
-        BLOCK@[64; 66)
-          L_CURLY@[64; 65) "{"
-          R_CURLY@[65; 66) "}"
+        BLOCK_EXPR@[64; 66)
+          BLOCK@[64; 66)
+            L_CURLY@[64; 65) "{"
+            R_CURLY@[65; 66) "}"
       WHITESPACE@[66; 67) "\n"
       R_CURLY@[67; 68) "}"
   WHITESPACE@[68; 69) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0019_unary_expr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0019_unary_expr.txt
@@ -8,37 +8,38 @@ SOURCE_FILE@[0; 44)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 43)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 20)
-        PREFIX_EXPR@[15; 19)
-          STAR@[15; 16) "*"
-          PREFIX_EXPR@[16; 19)
-            STAR@[16; 17) "*"
-            REF_EXPR@[17; 19)
-              AMP@[17; 18) "&"
-              LITERAL@[18; 19)
-                INT_NUMBER@[18; 19) "1"
-        SEMI@[19; 20) ";"
-      WHITESPACE@[20; 25) "\n    "
-      EXPR_STMT@[25; 32)
-        PREFIX_EXPR@[25; 31)
-          EXCL@[25; 26) "!"
-          PREFIX_EXPR@[26; 31)
-            EXCL@[26; 27) "!"
-            LITERAL@[27; 31)
-              TRUE_KW@[27; 31) "true"
-        SEMI@[31; 32) ";"
-      WHITESPACE@[32; 37) "\n    "
-      EXPR_STMT@[37; 41)
-        PREFIX_EXPR@[37; 40)
-          MINUS@[37; 38) "-"
-          PREFIX_EXPR@[38; 40)
-            MINUS@[38; 39) "-"
-            LITERAL@[39; 40)
-              INT_NUMBER@[39; 40) "1"
-        SEMI@[40; 41) ";"
-      WHITESPACE@[41; 42) "\n"
-      R_CURLY@[42; 43) "}"
+    BLOCK_EXPR@[9; 43)
+      BLOCK@[9; 43)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        EXPR_STMT@[15; 20)
+          PREFIX_EXPR@[15; 19)
+            STAR@[15; 16) "*"
+            PREFIX_EXPR@[16; 19)
+              STAR@[16; 17) "*"
+              REF_EXPR@[17; 19)
+                AMP@[17; 18) "&"
+                LITERAL@[18; 19)
+                  INT_NUMBER@[18; 19) "1"
+          SEMI@[19; 20) ";"
+        WHITESPACE@[20; 25) "\n    "
+        EXPR_STMT@[25; 32)
+          PREFIX_EXPR@[25; 31)
+            EXCL@[25; 26) "!"
+            PREFIX_EXPR@[26; 31)
+              EXCL@[26; 27) "!"
+              LITERAL@[27; 31)
+                TRUE_KW@[27; 31) "true"
+          SEMI@[31; 32) ";"
+        WHITESPACE@[32; 37) "\n    "
+        EXPR_STMT@[37; 41)
+          PREFIX_EXPR@[37; 40)
+            MINUS@[37; 38) "-"
+            PREFIX_EXPR@[38; 40)
+              MINUS@[38; 39) "-"
+              LITERAL@[39; 40)
+                INT_NUMBER@[39; 40) "1"
+          SEMI@[40; 41) ";"
+        WHITESPACE@[41; 42) "\n"
+        R_CURLY@[42; 43) "}"
   WHITESPACE@[43; 44) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0021_impl_item_list.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0021_impl_item_list.txt
@@ -54,9 +54,10 @@ SOURCE_FILE@[0; 89)
           L_PAREN@[60; 61) "("
           R_PAREN@[61; 62) ")"
         WHITESPACE@[62; 63) " "
-        BLOCK@[63; 65)
-          L_CURLY@[63; 64) "{"
-          R_CURLY@[64; 65) "}"
+        BLOCK_EXPR@[63; 65)
+          BLOCK@[63; 65)
+            L_CURLY@[63; 64) "{"
+            R_CURLY@[64; 65) "}"
       WHITESPACE@[65; 70) "\n    "
       FN_DEF@[70; 86)
         FN_KW@[70; 72) "fn"
@@ -70,9 +71,10 @@ SOURCE_FILE@[0; 89)
             SELF_KW@[78; 82) "self"
           R_PAREN@[82; 83) ")"
         WHITESPACE@[83; 84) " "
-        BLOCK@[84; 86)
-          L_CURLY@[84; 85) "{"
-          R_CURLY@[85; 86) "}"
+        BLOCK_EXPR@[84; 86)
+          BLOCK@[84; 86)
+            L_CURLY@[84; 85) "{"
+            R_CURLY@[85; 86) "}"
       WHITESPACE@[86; 87) "\n"
       R_CURLY@[87; 88) "}"
   WHITESPACE@[88; 89) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0024_slice_pat.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0024_slice_pat.txt
@@ -8,33 +8,34 @@ SOURCE_FILE@[0; 39)
       L_PAREN@[7; 8) "("
       R_PAREN@[8; 9) ")"
     WHITESPACE@[9; 10) " "
-    BLOCK@[10; 38)
-      L_CURLY@[10; 11) "{"
-      WHITESPACE@[11; 16) "\n    "
-      LET_STMT@[16; 36)
-        LET_KW@[16; 19) "let"
-        WHITESPACE@[19; 20) " "
-        SLICE_PAT@[20; 30)
-          L_BRACK@[20; 21) "["
-          BIND_PAT@[21; 22)
-            NAME@[21; 22)
-              IDENT@[21; 22) "a"
-          COMMA@[22; 23) ","
-          WHITESPACE@[23; 24) " "
-          BIND_PAT@[24; 25)
-            NAME@[24; 25)
-              IDENT@[24; 25) "b"
-          COMMA@[25; 26) ","
-          WHITESPACE@[26; 27) " "
-          DOTDOT@[27; 29) ".."
-          R_BRACK@[29; 30) "]"
-        WHITESPACE@[30; 31) " "
-        EQ@[31; 32) "="
-        WHITESPACE@[32; 33) " "
-        ARRAY_EXPR@[33; 35)
-          L_BRACK@[33; 34) "["
-          R_BRACK@[34; 35) "]"
-        SEMI@[35; 36) ";"
-      WHITESPACE@[36; 37) "\n"
-      R_CURLY@[37; 38) "}"
+    BLOCK_EXPR@[10; 38)
+      BLOCK@[10; 38)
+        L_CURLY@[10; 11) "{"
+        WHITESPACE@[11; 16) "\n    "
+        LET_STMT@[16; 36)
+          LET_KW@[16; 19) "let"
+          WHITESPACE@[19; 20) " "
+          SLICE_PAT@[20; 30)
+            L_BRACK@[20; 21) "["
+            BIND_PAT@[21; 22)
+              NAME@[21; 22)
+                IDENT@[21; 22) "a"
+            COMMA@[22; 23) ","
+            WHITESPACE@[23; 24) " "
+            BIND_PAT@[24; 25)
+              NAME@[24; 25)
+                IDENT@[24; 25) "b"
+            COMMA@[25; 26) ","
+            WHITESPACE@[26; 27) " "
+            DOTDOT@[27; 29) ".."
+            R_BRACK@[29; 30) "]"
+          WHITESPACE@[30; 31) " "
+          EQ@[31; 32) "="
+          WHITESPACE@[32; 33) " "
+          ARRAY_EXPR@[33; 35)
+            L_BRACK@[33; 34) "["
+            R_BRACK@[34; 35) "]"
+          SEMI@[35; 36) ";"
+        WHITESPACE@[36; 37) "\n"
+        R_CURLY@[37; 38) "}"
   WHITESPACE@[38; 39) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0026_tuple_pat_fields.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0026_tuple_pat_fields.txt
@@ -8,96 +8,97 @@ SOURCE_FILE@[0; 97)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 96)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      LET_STMT@[15; 28)
-        LET_KW@[15; 18) "let"
-        WHITESPACE@[18; 19) " "
-        TUPLE_STRUCT_PAT@[19; 22)
-          PATH@[19; 20)
-            PATH_SEGMENT@[19; 20)
-              NAME_REF@[19; 20)
-                IDENT@[19; 20) "S"
-          L_PAREN@[20; 21) "("
-          R_PAREN@[21; 22) ")"
-        WHITESPACE@[22; 23) " "
-        EQ@[23; 24) "="
-        WHITESPACE@[24; 25) " "
-        TUPLE_EXPR@[25; 27)
-          L_PAREN@[25; 26) "("
-          R_PAREN@[26; 27) ")"
-        SEMI@[27; 28) ";"
-      WHITESPACE@[28; 33) "\n    "
-      LET_STMT@[33; 47)
-        LET_KW@[33; 36) "let"
-        WHITESPACE@[36; 37) " "
-        TUPLE_STRUCT_PAT@[37; 41)
-          PATH@[37; 38)
-            PATH_SEGMENT@[37; 38)
-              NAME_REF@[37; 38)
-                IDENT@[37; 38) "S"
-          L_PAREN@[38; 39) "("
-          PLACEHOLDER_PAT@[39; 40)
-            UNDERSCORE@[39; 40) "_"
-          R_PAREN@[40; 41) ")"
-        WHITESPACE@[41; 42) " "
-        EQ@[42; 43) "="
-        WHITESPACE@[43; 44) " "
-        TUPLE_EXPR@[44; 46)
-          L_PAREN@[44; 45) "("
-          R_PAREN@[45; 46) ")"
-        SEMI@[46; 47) ";"
-      WHITESPACE@[47; 52) "\n    "
-      LET_STMT@[52; 67)
-        LET_KW@[52; 55) "let"
-        WHITESPACE@[55; 56) " "
-        TUPLE_STRUCT_PAT@[56; 61)
-          PATH@[56; 57)
-            PATH_SEGMENT@[56; 57)
-              NAME_REF@[56; 57)
-                IDENT@[56; 57) "S"
-          L_PAREN@[57; 58) "("
-          PLACEHOLDER_PAT@[58; 59)
-            UNDERSCORE@[58; 59) "_"
-          COMMA@[59; 60) ","
-          R_PAREN@[60; 61) ")"
-        WHITESPACE@[61; 62) " "
-        EQ@[62; 63) "="
-        WHITESPACE@[63; 64) " "
-        TUPLE_EXPR@[64; 66)
-          L_PAREN@[64; 65) "("
-          R_PAREN@[65; 66) ")"
-        SEMI@[66; 67) ";"
-      WHITESPACE@[67; 72) "\n    "
-      LET_STMT@[72; 94)
-        LET_KW@[72; 75) "let"
-        WHITESPACE@[75; 76) " "
-        TUPLE_STRUCT_PAT@[76; 88)
-          PATH@[76; 77)
-            PATH_SEGMENT@[76; 77)
-              NAME_REF@[76; 77)
-                IDENT@[76; 77) "S"
-          L_PAREN@[77; 78) "("
-          PLACEHOLDER_PAT@[78; 79)
-            UNDERSCORE@[78; 79) "_"
-          COMMA@[79; 80) ","
-          WHITESPACE@[80; 81) " "
-          DOTDOT@[81; 83) ".."
-          WHITESPACE@[83; 84) " "
-          COMMA@[84; 85) ","
-          WHITESPACE@[85; 86) " "
-          BIND_PAT@[86; 87)
-            NAME@[86; 87)
-              IDENT@[86; 87) "x"
-          R_PAREN@[87; 88) ")"
-        WHITESPACE@[88; 89) " "
-        EQ@[89; 90) "="
-        WHITESPACE@[90; 91) " "
-        TUPLE_EXPR@[91; 93)
-          L_PAREN@[91; 92) "("
-          R_PAREN@[92; 93) ")"
-        SEMI@[93; 94) ";"
-      WHITESPACE@[94; 95) "\n"
-      R_CURLY@[95; 96) "}"
+    BLOCK_EXPR@[9; 96)
+      BLOCK@[9; 96)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        LET_STMT@[15; 28)
+          LET_KW@[15; 18) "let"
+          WHITESPACE@[18; 19) " "
+          TUPLE_STRUCT_PAT@[19; 22)
+            PATH@[19; 20)
+              PATH_SEGMENT@[19; 20)
+                NAME_REF@[19; 20)
+                  IDENT@[19; 20) "S"
+            L_PAREN@[20; 21) "("
+            R_PAREN@[21; 22) ")"
+          WHITESPACE@[22; 23) " "
+          EQ@[23; 24) "="
+          WHITESPACE@[24; 25) " "
+          TUPLE_EXPR@[25; 27)
+            L_PAREN@[25; 26) "("
+            R_PAREN@[26; 27) ")"
+          SEMI@[27; 28) ";"
+        WHITESPACE@[28; 33) "\n    "
+        LET_STMT@[33; 47)
+          LET_KW@[33; 36) "let"
+          WHITESPACE@[36; 37) " "
+          TUPLE_STRUCT_PAT@[37; 41)
+            PATH@[37; 38)
+              PATH_SEGMENT@[37; 38)
+                NAME_REF@[37; 38)
+                  IDENT@[37; 38) "S"
+            L_PAREN@[38; 39) "("
+            PLACEHOLDER_PAT@[39; 40)
+              UNDERSCORE@[39; 40) "_"
+            R_PAREN@[40; 41) ")"
+          WHITESPACE@[41; 42) " "
+          EQ@[42; 43) "="
+          WHITESPACE@[43; 44) " "
+          TUPLE_EXPR@[44; 46)
+            L_PAREN@[44; 45) "("
+            R_PAREN@[45; 46) ")"
+          SEMI@[46; 47) ";"
+        WHITESPACE@[47; 52) "\n    "
+        LET_STMT@[52; 67)
+          LET_KW@[52; 55) "let"
+          WHITESPACE@[55; 56) " "
+          TUPLE_STRUCT_PAT@[56; 61)
+            PATH@[56; 57)
+              PATH_SEGMENT@[56; 57)
+                NAME_REF@[56; 57)
+                  IDENT@[56; 57) "S"
+            L_PAREN@[57; 58) "("
+            PLACEHOLDER_PAT@[58; 59)
+              UNDERSCORE@[58; 59) "_"
+            COMMA@[59; 60) ","
+            R_PAREN@[60; 61) ")"
+          WHITESPACE@[61; 62) " "
+          EQ@[62; 63) "="
+          WHITESPACE@[63; 64) " "
+          TUPLE_EXPR@[64; 66)
+            L_PAREN@[64; 65) "("
+            R_PAREN@[65; 66) ")"
+          SEMI@[66; 67) ";"
+        WHITESPACE@[67; 72) "\n    "
+        LET_STMT@[72; 94)
+          LET_KW@[72; 75) "let"
+          WHITESPACE@[75; 76) " "
+          TUPLE_STRUCT_PAT@[76; 88)
+            PATH@[76; 77)
+              PATH_SEGMENT@[76; 77)
+                NAME_REF@[76; 77)
+                  IDENT@[76; 77) "S"
+            L_PAREN@[77; 78) "("
+            PLACEHOLDER_PAT@[78; 79)
+              UNDERSCORE@[78; 79) "_"
+            COMMA@[79; 80) ","
+            WHITESPACE@[80; 81) " "
+            DOTDOT@[81; 83) ".."
+            WHITESPACE@[83; 84) " "
+            COMMA@[84; 85) ","
+            WHITESPACE@[85; 86) " "
+            BIND_PAT@[86; 87)
+              NAME@[86; 87)
+                IDENT@[86; 87) "x"
+            R_PAREN@[87; 88) ")"
+          WHITESPACE@[88; 89) " "
+          EQ@[89; 90) "="
+          WHITESPACE@[90; 91) " "
+          TUPLE_EXPR@[91; 93)
+            L_PAREN@[91; 92) "("
+            R_PAREN@[92; 93) ")"
+          SEMI@[93; 94) ";"
+        WHITESPACE@[94; 95) "\n"
+        R_CURLY@[95; 96) "}"
   WHITESPACE@[96; 97) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0027_ref_pat.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0027_ref_pat.txt
@@ -8,42 +8,43 @@ SOURCE_FILE@[0; 52)
       L_PAREN@[7; 8) "("
       R_PAREN@[8; 9) ")"
     WHITESPACE@[9; 10) " "
-    BLOCK@[10; 51)
-      L_CURLY@[10; 11) "{"
-      WHITESPACE@[11; 16) "\n    "
-      LET_STMT@[16; 28)
-        LET_KW@[16; 19) "let"
-        WHITESPACE@[19; 20) " "
-        REF_PAT@[20; 22)
-          AMP@[20; 21) "&"
-          BIND_PAT@[21; 22)
-            NAME@[21; 22)
-              IDENT@[21; 22) "a"
-        WHITESPACE@[22; 23) " "
-        EQ@[23; 24) "="
-        WHITESPACE@[24; 25) " "
-        TUPLE_EXPR@[25; 27)
-          L_PAREN@[25; 26) "("
-          R_PAREN@[26; 27) ")"
-        SEMI@[27; 28) ";"
-      WHITESPACE@[28; 33) "\n    "
-      LET_STMT@[33; 49)
-        LET_KW@[33; 36) "let"
-        WHITESPACE@[36; 37) " "
-        REF_PAT@[37; 43)
-          AMP@[37; 38) "&"
-          MUT_KW@[38; 41) "mut"
-          WHITESPACE@[41; 42) " "
-          BIND_PAT@[42; 43)
-            NAME@[42; 43)
-              IDENT@[42; 43) "b"
-        WHITESPACE@[43; 44) " "
-        EQ@[44; 45) "="
-        WHITESPACE@[45; 46) " "
-        TUPLE_EXPR@[46; 48)
-          L_PAREN@[46; 47) "("
-          R_PAREN@[47; 48) ")"
-        SEMI@[48; 49) ";"
-      WHITESPACE@[49; 50) "\n"
-      R_CURLY@[50; 51) "}"
+    BLOCK_EXPR@[10; 51)
+      BLOCK@[10; 51)
+        L_CURLY@[10; 11) "{"
+        WHITESPACE@[11; 16) "\n    "
+        LET_STMT@[16; 28)
+          LET_KW@[16; 19) "let"
+          WHITESPACE@[19; 20) " "
+          REF_PAT@[20; 22)
+            AMP@[20; 21) "&"
+            BIND_PAT@[21; 22)
+              NAME@[21; 22)
+                IDENT@[21; 22) "a"
+          WHITESPACE@[22; 23) " "
+          EQ@[23; 24) "="
+          WHITESPACE@[24; 25) " "
+          TUPLE_EXPR@[25; 27)
+            L_PAREN@[25; 26) "("
+            R_PAREN@[26; 27) ")"
+          SEMI@[27; 28) ";"
+        WHITESPACE@[28; 33) "\n    "
+        LET_STMT@[33; 49)
+          LET_KW@[33; 36) "let"
+          WHITESPACE@[36; 37) " "
+          REF_PAT@[37; 43)
+            AMP@[37; 38) "&"
+            MUT_KW@[38; 41) "mut"
+            WHITESPACE@[41; 42) " "
+            BIND_PAT@[42; 43)
+              NAME@[42; 43)
+                IDENT@[42; 43) "b"
+          WHITESPACE@[43; 44) " "
+          EQ@[44; 45) "="
+          WHITESPACE@[45; 46) " "
+          TUPLE_EXPR@[46; 48)
+            L_PAREN@[46; 47) "("
+            R_PAREN@[47; 48) ")"
+          SEMI@[48; 49) ";"
+        WHITESPACE@[49; 50) "\n"
+        R_CURLY@[50; 51) "}"
   WHITESPACE@[51; 52) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0029_cast_expr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0029_cast_expr.txt
@@ -8,82 +8,83 @@ SOURCE_FILE@[0; 89)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 88)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 25)
-        CAST_EXPR@[15; 24)
-          LITERAL@[15; 17)
-            INT_NUMBER@[15; 17) "82"
-          WHITESPACE@[17; 18) " "
-          AS_KW@[18; 20) "as"
-          WHITESPACE@[20; 21) " "
-          PATH_TYPE@[21; 24)
-            PATH@[21; 24)
-              PATH_SEGMENT@[21; 24)
-                NAME_REF@[21; 24)
-                  IDENT@[21; 24) "i32"
-        SEMI@[24; 25) ";"
-      WHITESPACE@[25; 30) "\n    "
-      EXPR_STMT@[30; 43)
-        BIN_EXPR@[30; 42)
-          CAST_EXPR@[30; 38)
-            LITERAL@[30; 32)
-              INT_NUMBER@[30; 32) "81"
-            WHITESPACE@[32; 33) " "
-            AS_KW@[33; 35) "as"
-            WHITESPACE@[35; 36) " "
-            PATH_TYPE@[36; 38)
-              PATH@[36; 38)
-                PATH_SEGMENT@[36; 38)
-                  NAME_REF@[36; 38)
-                    IDENT@[36; 38) "i8"
-          WHITESPACE@[38; 39) " "
-          PLUS@[39; 40) "+"
-          WHITESPACE@[40; 41) " "
-          LITERAL@[41; 42)
-            INT_NUMBER@[41; 42) "1"
-        SEMI@[42; 43) ";"
-      WHITESPACE@[43; 48) "\n    "
-      EXPR_STMT@[48; 62)
-        BIN_EXPR@[48; 61)
-          CAST_EXPR@[48; 57)
-            LITERAL@[48; 50)
-              INT_NUMBER@[48; 50) "79"
-            WHITESPACE@[50; 51) " "
-            AS_KW@[51; 53) "as"
-            WHITESPACE@[53; 54) " "
-            PATH_TYPE@[54; 57)
-              PATH@[54; 57)
-                PATH_SEGMENT@[54; 57)
-                  NAME_REF@[54; 57)
-                    IDENT@[54; 57) "i16"
-          WHITESPACE@[57; 58) " "
-          MINUS@[58; 59) "-"
-          WHITESPACE@[59; 60) " "
-          LITERAL@[60; 61)
-            INT_NUMBER@[60; 61) "1"
-        SEMI@[61; 62) ";"
-      WHITESPACE@[62; 67) "\n    "
-      EXPR_STMT@[67; 86)
-        BIN_EXPR@[67; 85)
-          CAST_EXPR@[67; 77)
-            LITERAL@[67; 71)
-              INT_NUMBER@[67; 71) "0x36"
-            WHITESPACE@[71; 72) " "
-            AS_KW@[72; 74) "as"
-            WHITESPACE@[74; 75) " "
-            PATH_TYPE@[75; 77)
-              PATH@[75; 77)
-                PATH_SEGMENT@[75; 77)
-                  NAME_REF@[75; 77)
-                    IDENT@[75; 77) "u8"
-          WHITESPACE@[77; 78) " "
-          LTEQ@[78; 80) "<="
-          WHITESPACE@[80; 81) " "
-          LITERAL@[81; 85)
-            INT_NUMBER@[81; 85) "0x37"
-        SEMI@[85; 86) ";"
-      WHITESPACE@[86; 87) "\n"
-      R_CURLY@[87; 88) "}"
+    BLOCK_EXPR@[9; 88)
+      BLOCK@[9; 88)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        EXPR_STMT@[15; 25)
+          CAST_EXPR@[15; 24)
+            LITERAL@[15; 17)
+              INT_NUMBER@[15; 17) "82"
+            WHITESPACE@[17; 18) " "
+            AS_KW@[18; 20) "as"
+            WHITESPACE@[20; 21) " "
+            PATH_TYPE@[21; 24)
+              PATH@[21; 24)
+                PATH_SEGMENT@[21; 24)
+                  NAME_REF@[21; 24)
+                    IDENT@[21; 24) "i32"
+          SEMI@[24; 25) ";"
+        WHITESPACE@[25; 30) "\n    "
+        EXPR_STMT@[30; 43)
+          BIN_EXPR@[30; 42)
+            CAST_EXPR@[30; 38)
+              LITERAL@[30; 32)
+                INT_NUMBER@[30; 32) "81"
+              WHITESPACE@[32; 33) " "
+              AS_KW@[33; 35) "as"
+              WHITESPACE@[35; 36) " "
+              PATH_TYPE@[36; 38)
+                PATH@[36; 38)
+                  PATH_SEGMENT@[36; 38)
+                    NAME_REF@[36; 38)
+                      IDENT@[36; 38) "i8"
+            WHITESPACE@[38; 39) " "
+            PLUS@[39; 40) "+"
+            WHITESPACE@[40; 41) " "
+            LITERAL@[41; 42)
+              INT_NUMBER@[41; 42) "1"
+          SEMI@[42; 43) ";"
+        WHITESPACE@[43; 48) "\n    "
+        EXPR_STMT@[48; 62)
+          BIN_EXPR@[48; 61)
+            CAST_EXPR@[48; 57)
+              LITERAL@[48; 50)
+                INT_NUMBER@[48; 50) "79"
+              WHITESPACE@[50; 51) " "
+              AS_KW@[51; 53) "as"
+              WHITESPACE@[53; 54) " "
+              PATH_TYPE@[54; 57)
+                PATH@[54; 57)
+                  PATH_SEGMENT@[54; 57)
+                    NAME_REF@[54; 57)
+                      IDENT@[54; 57) "i16"
+            WHITESPACE@[57; 58) " "
+            MINUS@[58; 59) "-"
+            WHITESPACE@[59; 60) " "
+            LITERAL@[60; 61)
+              INT_NUMBER@[60; 61) "1"
+          SEMI@[61; 62) ";"
+        WHITESPACE@[62; 67) "\n    "
+        EXPR_STMT@[67; 86)
+          BIN_EXPR@[67; 85)
+            CAST_EXPR@[67; 77)
+              LITERAL@[67; 71)
+                INT_NUMBER@[67; 71) "0x36"
+              WHITESPACE@[71; 72) " "
+              AS_KW@[72; 74) "as"
+              WHITESPACE@[74; 75) " "
+              PATH_TYPE@[75; 77)
+                PATH@[75; 77)
+                  PATH_SEGMENT@[75; 77)
+                    NAME_REF@[75; 77)
+                      IDENT@[75; 77) "u8"
+            WHITESPACE@[77; 78) " "
+            LTEQ@[78; 80) "<="
+            WHITESPACE@[80; 81) " "
+            LITERAL@[81; 85)
+              INT_NUMBER@[81; 85) "0x37"
+          SEMI@[85; 86) ";"
+        WHITESPACE@[86; 87) "\n"
+        R_CURLY@[87; 88) "}"
   WHITESPACE@[88; 89) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0030_cond.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0030_cond.txt
@@ -8,38 +8,40 @@ SOURCE_FILE@[0; 197)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 37)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 11) " "
-      IF_EXPR@[11; 35)
-        IF_KW@[11; 13) "if"
-        WHITESPACE@[13; 14) " "
-        CONDITION@[14; 32)
-          LET_KW@[14; 17) "let"
-          WHITESPACE@[17; 18) " "
-          TUPLE_STRUCT_PAT@[18; 25)
-            PATH@[18; 22)
-              PATH_SEGMENT@[18; 22)
-                NAME_REF@[18; 22)
-                  IDENT@[18; 22) "Some"
-            L_PAREN@[22; 23) "("
-            PLACEHOLDER_PAT@[23; 24)
-              UNDERSCORE@[23; 24) "_"
-            R_PAREN@[24; 25) ")"
-          WHITESPACE@[25; 26) " "
-          EQ@[26; 27) "="
-          WHITESPACE@[27; 28) " "
-          PATH_EXPR@[28; 32)
-            PATH@[28; 32)
-              PATH_SEGMENT@[28; 32)
-                NAME_REF@[28; 32)
-                  IDENT@[28; 32) "None"
-        WHITESPACE@[32; 33) " "
-        BLOCK@[33; 35)
-          L_CURLY@[33; 34) "{"
-          R_CURLY@[34; 35) "}"
-      WHITESPACE@[35; 36) " "
-      R_CURLY@[36; 37) "}"
+    BLOCK_EXPR@[9; 37)
+      BLOCK@[9; 37)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 11) " "
+        IF_EXPR@[11; 35)
+          IF_KW@[11; 13) "if"
+          WHITESPACE@[13; 14) " "
+          CONDITION@[14; 32)
+            LET_KW@[14; 17) "let"
+            WHITESPACE@[17; 18) " "
+            TUPLE_STRUCT_PAT@[18; 25)
+              PATH@[18; 22)
+                PATH_SEGMENT@[18; 22)
+                  NAME_REF@[18; 22)
+                    IDENT@[18; 22) "Some"
+              L_PAREN@[22; 23) "("
+              PLACEHOLDER_PAT@[23; 24)
+                UNDERSCORE@[23; 24) "_"
+              R_PAREN@[24; 25) ")"
+            WHITESPACE@[25; 26) " "
+            EQ@[26; 27) "="
+            WHITESPACE@[27; 28) " "
+            PATH_EXPR@[28; 32)
+              PATH@[28; 32)
+                PATH_SEGMENT@[28; 32)
+                  NAME_REF@[28; 32)
+                    IDENT@[28; 32) "None"
+          WHITESPACE@[32; 33) " "
+          BLOCK_EXPR@[33; 35)
+            BLOCK@[33; 35)
+              L_CURLY@[33; 34) "{"
+              R_CURLY@[34; 35) "}"
+        WHITESPACE@[35; 36) " "
+        R_CURLY@[36; 37) "}"
   WHITESPACE@[37; 38) "\n"
   FN_DEF@[38; 196)
     FN_KW@[38; 40) "fn"
@@ -50,151 +52,156 @@ SOURCE_FILE@[0; 197)
       L_PAREN@[44; 45) "("
       R_PAREN@[45; 46) ")"
     WHITESPACE@[46; 47) " "
-    BLOCK@[47; 196)
-      L_CURLY@[47; 48) "{"
-      WHITESPACE@[48; 53) "\n    "
-      EXPR_STMT@[53; 87)
-        IF_EXPR@[53; 87)
-          IF_KW@[53; 55) "if"
-          WHITESPACE@[55; 56) " "
-          CONDITION@[56; 84)
-            LET_KW@[56; 59) "let"
-            WHITESPACE@[59; 60) " "
-            TUPLE_STRUCT_PAT@[60; 67)
-              PATH@[60; 64)
-                PATH_SEGMENT@[60; 64)
-                  NAME_REF@[60; 64)
-                    IDENT@[60; 64) "Some"
-              L_PAREN@[64; 65) "("
-              PLACEHOLDER_PAT@[65; 66)
-                UNDERSCORE@[65; 66) "_"
-              R_PAREN@[66; 67) ")"
-            WHITESPACE@[67; 68) " "
-            PIPE@[68; 69) "|"
-            WHITESPACE@[69; 70) " "
-            TUPLE_STRUCT_PAT@[70; 77)
-              PATH@[70; 74)
-                PATH_SEGMENT@[70; 74)
-                  NAME_REF@[70; 74)
-                    IDENT@[70; 74) "Some"
-              L_PAREN@[74; 75) "("
-              PLACEHOLDER_PAT@[75; 76)
-                UNDERSCORE@[75; 76) "_"
-              R_PAREN@[76; 77) ")"
-            WHITESPACE@[77; 78) " "
-            EQ@[78; 79) "="
-            WHITESPACE@[79; 80) " "
-            PATH_EXPR@[80; 84)
-              PATH@[80; 84)
-                PATH_SEGMENT@[80; 84)
-                  NAME_REF@[80; 84)
-                    IDENT@[80; 84) "None"
-          WHITESPACE@[84; 85) " "
-          BLOCK@[85; 87)
-            L_CURLY@[85; 86) "{"
-            R_CURLY@[86; 87) "}"
-      WHITESPACE@[87; 92) "\n    "
-      EXPR_STMT@[92; 118)
-        IF_EXPR@[92; 118)
-          IF_KW@[92; 94) "if"
-          WHITESPACE@[94; 95) " "
-          CONDITION@[95; 115)
-            LET_KW@[95; 98) "let"
-            WHITESPACE@[98; 99) " "
-            PIPE@[99; 100) "|"
-            WHITESPACE@[100; 101) " "
-            TUPLE_STRUCT_PAT@[101; 108)
-              PATH@[101; 105)
-                PATH_SEGMENT@[101; 105)
-                  NAME_REF@[101; 105)
-                    IDENT@[101; 105) "Some"
-              L_PAREN@[105; 106) "("
-              PLACEHOLDER_PAT@[106; 107)
-                UNDERSCORE@[106; 107) "_"
-              R_PAREN@[107; 108) ")"
-            WHITESPACE@[108; 109) " "
-            EQ@[109; 110) "="
-            WHITESPACE@[110; 111) " "
-            PATH_EXPR@[111; 115)
-              PATH@[111; 115)
-                PATH_SEGMENT@[111; 115)
-                  NAME_REF@[111; 115)
-                    IDENT@[111; 115) "None"
-          WHITESPACE@[115; 116) " "
-          BLOCK@[116; 118)
-            L_CURLY@[116; 117) "{"
-            R_CURLY@[117; 118) "}"
-      WHITESPACE@[118; 123) "\n    "
-      EXPR_STMT@[123; 160)
-        WHILE_EXPR@[123; 160)
-          WHILE_KW@[123; 128) "while"
-          WHITESPACE@[128; 129) " "
-          CONDITION@[129; 157)
-            LET_KW@[129; 132) "let"
-            WHITESPACE@[132; 133) " "
-            TUPLE_STRUCT_PAT@[133; 140)
-              PATH@[133; 137)
-                PATH_SEGMENT@[133; 137)
-                  NAME_REF@[133; 137)
-                    IDENT@[133; 137) "Some"
-              L_PAREN@[137; 138) "("
-              PLACEHOLDER_PAT@[138; 139)
-                UNDERSCORE@[138; 139) "_"
-              R_PAREN@[139; 140) ")"
-            WHITESPACE@[140; 141) " "
-            PIPE@[141; 142) "|"
-            WHITESPACE@[142; 143) " "
-            TUPLE_STRUCT_PAT@[143; 150)
-              PATH@[143; 147)
-                PATH_SEGMENT@[143; 147)
-                  NAME_REF@[143; 147)
-                    IDENT@[143; 147) "Some"
-              L_PAREN@[147; 148) "("
-              PLACEHOLDER_PAT@[148; 149)
-                UNDERSCORE@[148; 149) "_"
-              R_PAREN@[149; 150) ")"
-            WHITESPACE@[150; 151) " "
-            EQ@[151; 152) "="
-            WHITESPACE@[152; 153) " "
-            PATH_EXPR@[153; 157)
-              PATH@[153; 157)
-                PATH_SEGMENT@[153; 157)
-                  NAME_REF@[153; 157)
-                    IDENT@[153; 157) "None"
-          WHITESPACE@[157; 158) " "
-          BLOCK@[158; 160)
-            L_CURLY@[158; 159) "{"
-            R_CURLY@[159; 160) "}"
-      WHITESPACE@[160; 165) "\n    "
-      WHILE_EXPR@[165; 194)
-        WHILE_KW@[165; 170) "while"
-        WHITESPACE@[170; 171) " "
-        CONDITION@[171; 191)
-          LET_KW@[171; 174) "let"
-          WHITESPACE@[174; 175) " "
-          PIPE@[175; 176) "|"
-          WHITESPACE@[176; 177) " "
-          TUPLE_STRUCT_PAT@[177; 184)
-            PATH@[177; 181)
-              PATH_SEGMENT@[177; 181)
-                NAME_REF@[177; 181)
-                  IDENT@[177; 181) "Some"
-            L_PAREN@[181; 182) "("
-            PLACEHOLDER_PAT@[182; 183)
-              UNDERSCORE@[182; 183) "_"
-            R_PAREN@[183; 184) ")"
-          WHITESPACE@[184; 185) " "
-          EQ@[185; 186) "="
-          WHITESPACE@[186; 187) " "
-          PATH_EXPR@[187; 191)
-            PATH@[187; 191)
-              PATH_SEGMENT@[187; 191)
-                NAME_REF@[187; 191)
-                  IDENT@[187; 191) "None"
-        WHITESPACE@[191; 192) " "
-        BLOCK@[192; 194)
-          L_CURLY@[192; 193) "{"
-          R_CURLY@[193; 194) "}"
-      WHITESPACE@[194; 195) "\n"
-      R_CURLY@[195; 196) "}"
+    BLOCK_EXPR@[47; 196)
+      BLOCK@[47; 196)
+        L_CURLY@[47; 48) "{"
+        WHITESPACE@[48; 53) "\n    "
+        EXPR_STMT@[53; 87)
+          IF_EXPR@[53; 87)
+            IF_KW@[53; 55) "if"
+            WHITESPACE@[55; 56) " "
+            CONDITION@[56; 84)
+              LET_KW@[56; 59) "let"
+              WHITESPACE@[59; 60) " "
+              TUPLE_STRUCT_PAT@[60; 67)
+                PATH@[60; 64)
+                  PATH_SEGMENT@[60; 64)
+                    NAME_REF@[60; 64)
+                      IDENT@[60; 64) "Some"
+                L_PAREN@[64; 65) "("
+                PLACEHOLDER_PAT@[65; 66)
+                  UNDERSCORE@[65; 66) "_"
+                R_PAREN@[66; 67) ")"
+              WHITESPACE@[67; 68) " "
+              PIPE@[68; 69) "|"
+              WHITESPACE@[69; 70) " "
+              TUPLE_STRUCT_PAT@[70; 77)
+                PATH@[70; 74)
+                  PATH_SEGMENT@[70; 74)
+                    NAME_REF@[70; 74)
+                      IDENT@[70; 74) "Some"
+                L_PAREN@[74; 75) "("
+                PLACEHOLDER_PAT@[75; 76)
+                  UNDERSCORE@[75; 76) "_"
+                R_PAREN@[76; 77) ")"
+              WHITESPACE@[77; 78) " "
+              EQ@[78; 79) "="
+              WHITESPACE@[79; 80) " "
+              PATH_EXPR@[80; 84)
+                PATH@[80; 84)
+                  PATH_SEGMENT@[80; 84)
+                    NAME_REF@[80; 84)
+                      IDENT@[80; 84) "None"
+            WHITESPACE@[84; 85) " "
+            BLOCK_EXPR@[85; 87)
+              BLOCK@[85; 87)
+                L_CURLY@[85; 86) "{"
+                R_CURLY@[86; 87) "}"
+        WHITESPACE@[87; 92) "\n    "
+        EXPR_STMT@[92; 118)
+          IF_EXPR@[92; 118)
+            IF_KW@[92; 94) "if"
+            WHITESPACE@[94; 95) " "
+            CONDITION@[95; 115)
+              LET_KW@[95; 98) "let"
+              WHITESPACE@[98; 99) " "
+              PIPE@[99; 100) "|"
+              WHITESPACE@[100; 101) " "
+              TUPLE_STRUCT_PAT@[101; 108)
+                PATH@[101; 105)
+                  PATH_SEGMENT@[101; 105)
+                    NAME_REF@[101; 105)
+                      IDENT@[101; 105) "Some"
+                L_PAREN@[105; 106) "("
+                PLACEHOLDER_PAT@[106; 107)
+                  UNDERSCORE@[106; 107) "_"
+                R_PAREN@[107; 108) ")"
+              WHITESPACE@[108; 109) " "
+              EQ@[109; 110) "="
+              WHITESPACE@[110; 111) " "
+              PATH_EXPR@[111; 115)
+                PATH@[111; 115)
+                  PATH_SEGMENT@[111; 115)
+                    NAME_REF@[111; 115)
+                      IDENT@[111; 115) "None"
+            WHITESPACE@[115; 116) " "
+            BLOCK_EXPR@[116; 118)
+              BLOCK@[116; 118)
+                L_CURLY@[116; 117) "{"
+                R_CURLY@[117; 118) "}"
+        WHITESPACE@[118; 123) "\n    "
+        EXPR_STMT@[123; 160)
+          WHILE_EXPR@[123; 160)
+            WHILE_KW@[123; 128) "while"
+            WHITESPACE@[128; 129) " "
+            CONDITION@[129; 157)
+              LET_KW@[129; 132) "let"
+              WHITESPACE@[132; 133) " "
+              TUPLE_STRUCT_PAT@[133; 140)
+                PATH@[133; 137)
+                  PATH_SEGMENT@[133; 137)
+                    NAME_REF@[133; 137)
+                      IDENT@[133; 137) "Some"
+                L_PAREN@[137; 138) "("
+                PLACEHOLDER_PAT@[138; 139)
+                  UNDERSCORE@[138; 139) "_"
+                R_PAREN@[139; 140) ")"
+              WHITESPACE@[140; 141) " "
+              PIPE@[141; 142) "|"
+              WHITESPACE@[142; 143) " "
+              TUPLE_STRUCT_PAT@[143; 150)
+                PATH@[143; 147)
+                  PATH_SEGMENT@[143; 147)
+                    NAME_REF@[143; 147)
+                      IDENT@[143; 147) "Some"
+                L_PAREN@[147; 148) "("
+                PLACEHOLDER_PAT@[148; 149)
+                  UNDERSCORE@[148; 149) "_"
+                R_PAREN@[149; 150) ")"
+              WHITESPACE@[150; 151) " "
+              EQ@[151; 152) "="
+              WHITESPACE@[152; 153) " "
+              PATH_EXPR@[153; 157)
+                PATH@[153; 157)
+                  PATH_SEGMENT@[153; 157)
+                    NAME_REF@[153; 157)
+                      IDENT@[153; 157) "None"
+            WHITESPACE@[157; 158) " "
+            BLOCK_EXPR@[158; 160)
+              BLOCK@[158; 160)
+                L_CURLY@[158; 159) "{"
+                R_CURLY@[159; 160) "}"
+        WHITESPACE@[160; 165) "\n    "
+        WHILE_EXPR@[165; 194)
+          WHILE_KW@[165; 170) "while"
+          WHITESPACE@[170; 171) " "
+          CONDITION@[171; 191)
+            LET_KW@[171; 174) "let"
+            WHITESPACE@[174; 175) " "
+            PIPE@[175; 176) "|"
+            WHITESPACE@[176; 177) " "
+            TUPLE_STRUCT_PAT@[177; 184)
+              PATH@[177; 181)
+                PATH_SEGMENT@[177; 181)
+                  NAME_REF@[177; 181)
+                    IDENT@[177; 181) "Some"
+              L_PAREN@[181; 182) "("
+              PLACEHOLDER_PAT@[182; 183)
+                UNDERSCORE@[182; 183) "_"
+              R_PAREN@[183; 184) ")"
+            WHITESPACE@[184; 185) " "
+            EQ@[185; 186) "="
+            WHITESPACE@[186; 187) " "
+            PATH_EXPR@[187; 191)
+              PATH@[187; 191)
+                PATH_SEGMENT@[187; 191)
+                  NAME_REF@[187; 191)
+                    IDENT@[187; 191) "None"
+          WHITESPACE@[191; 192) " "
+          BLOCK_EXPR@[192; 194)
+            BLOCK@[192; 194)
+              L_CURLY@[192; 193) "{"
+              R_CURLY@[193; 194) "}"
+        WHITESPACE@[194; 195) "\n"
+        R_CURLY@[195; 196) "}"
   WHITESPACE@[196; 197) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0031_while_expr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0031_while_expr.txt
@@ -8,59 +8,62 @@ SOURCE_FILE@[0; 70)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 69)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 29)
-        WHILE_EXPR@[15; 28)
-          WHILE_KW@[15; 20) "while"
-          WHITESPACE@[20; 21) " "
-          CONDITION@[21; 25)
-            LITERAL@[21; 25)
-              TRUE_KW@[21; 25) "true"
-          WHITESPACE@[25; 26) " "
-          BLOCK@[26; 28)
-            L_CURLY@[26; 27) "{"
-            R_CURLY@[27; 28) "}"
-        SEMI@[28; 29) ";"
-      WHITESPACE@[29; 34) "\n    "
-      EXPR_STMT@[34; 67)
-        WHILE_EXPR@[34; 66)
-          WHILE_KW@[34; 39) "while"
-          WHITESPACE@[39; 40) " "
-          CONDITION@[40; 63)
-            LET_KW@[40; 43) "let"
-            WHITESPACE@[43; 44) " "
-            TUPLE_STRUCT_PAT@[44; 51)
-              PATH@[44; 48)
-                PATH_SEGMENT@[44; 48)
-                  NAME_REF@[44; 48)
-                    IDENT@[44; 48) "Some"
-              L_PAREN@[48; 49) "("
-              BIND_PAT@[49; 50)
-                NAME@[49; 50)
-                  IDENT@[49; 50) "x"
-              R_PAREN@[50; 51) ")"
-            WHITESPACE@[51; 52) " "
-            EQ@[52; 53) "="
-            WHITESPACE@[53; 54) " "
-            METHOD_CALL_EXPR@[54; 63)
-              PATH_EXPR@[54; 56)
-                PATH@[54; 56)
-                  PATH_SEGMENT@[54; 56)
-                    NAME_REF@[54; 56)
-                      IDENT@[54; 56) "it"
-              DOT@[56; 57) "."
-              NAME_REF@[57; 61)
-                IDENT@[57; 61) "next"
-              ARG_LIST@[61; 63)
-                L_PAREN@[61; 62) "("
-                R_PAREN@[62; 63) ")"
-          WHITESPACE@[63; 64) " "
-          BLOCK@[64; 66)
-            L_CURLY@[64; 65) "{"
-            R_CURLY@[65; 66) "}"
-        SEMI@[66; 67) ";"
-      WHITESPACE@[67; 68) "\n"
-      R_CURLY@[68; 69) "}"
+    BLOCK_EXPR@[9; 69)
+      BLOCK@[9; 69)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        EXPR_STMT@[15; 29)
+          WHILE_EXPR@[15; 28)
+            WHILE_KW@[15; 20) "while"
+            WHITESPACE@[20; 21) " "
+            CONDITION@[21; 25)
+              LITERAL@[21; 25)
+                TRUE_KW@[21; 25) "true"
+            WHITESPACE@[25; 26) " "
+            BLOCK_EXPR@[26; 28)
+              BLOCK@[26; 28)
+                L_CURLY@[26; 27) "{"
+                R_CURLY@[27; 28) "}"
+          SEMI@[28; 29) ";"
+        WHITESPACE@[29; 34) "\n    "
+        EXPR_STMT@[34; 67)
+          WHILE_EXPR@[34; 66)
+            WHILE_KW@[34; 39) "while"
+            WHITESPACE@[39; 40) " "
+            CONDITION@[40; 63)
+              LET_KW@[40; 43) "let"
+              WHITESPACE@[43; 44) " "
+              TUPLE_STRUCT_PAT@[44; 51)
+                PATH@[44; 48)
+                  PATH_SEGMENT@[44; 48)
+                    NAME_REF@[44; 48)
+                      IDENT@[44; 48) "Some"
+                L_PAREN@[48; 49) "("
+                BIND_PAT@[49; 50)
+                  NAME@[49; 50)
+                    IDENT@[49; 50) "x"
+                R_PAREN@[50; 51) ")"
+              WHITESPACE@[51; 52) " "
+              EQ@[52; 53) "="
+              WHITESPACE@[53; 54) " "
+              METHOD_CALL_EXPR@[54; 63)
+                PATH_EXPR@[54; 56)
+                  PATH@[54; 56)
+                    PATH_SEGMENT@[54; 56)
+                      NAME_REF@[54; 56)
+                        IDENT@[54; 56) "it"
+                DOT@[56; 57) "."
+                NAME_REF@[57; 61)
+                  IDENT@[57; 61) "next"
+                ARG_LIST@[61; 63)
+                  L_PAREN@[61; 62) "("
+                  R_PAREN@[62; 63) ")"
+            WHITESPACE@[63; 64) " "
+            BLOCK_EXPR@[64; 66)
+              BLOCK@[64; 66)
+                L_CURLY@[64; 65) "{"
+                R_CURLY@[65; 66) "}"
+          SEMI@[66; 67) ";"
+        WHITESPACE@[67; 68) "\n"
+        R_CURLY@[68; 69) "}"
   WHITESPACE@[69; 70) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0034_break_expr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0034_break_expr.txt
@@ -8,46 +8,48 @@ SOURCE_FILE@[0; 102)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 101)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      LOOP_EXPR@[15; 99)
-        LOOP_KW@[15; 19) "loop"
-        WHITESPACE@[19; 20) " "
-        BLOCK@[20; 99)
-          L_CURLY@[20; 21) "{"
-          WHITESPACE@[21; 30) "\n        "
-          EXPR_STMT@[30; 36)
-            BREAK_EXPR@[30; 35)
-              BREAK_KW@[30; 35) "break"
-            SEMI@[35; 36) ";"
-          WHITESPACE@[36; 45) "\n        "
-          EXPR_STMT@[45; 54)
-            BREAK_EXPR@[45; 53)
-              BREAK_KW@[45; 50) "break"
-              WHITESPACE@[50; 51) " "
-              LIFETIME@[51; 53) "\'l"
-            SEMI@[53; 54) ";"
-          WHITESPACE@[54; 63) "\n        "
-          EXPR_STMT@[63; 72)
-            BREAK_EXPR@[63; 71)
-              BREAK_KW@[63; 68) "break"
-              WHITESPACE@[68; 69) " "
-              LITERAL@[69; 71)
-                INT_NUMBER@[69; 71) "92"
-            SEMI@[71; 72) ";"
-          WHITESPACE@[72; 81) "\n        "
-          EXPR_STMT@[81; 93)
-            BREAK_EXPR@[81; 92)
-              BREAK_KW@[81; 86) "break"
-              WHITESPACE@[86; 87) " "
-              LIFETIME@[87; 89) "\'l"
-              WHITESPACE@[89; 90) " "
-              LITERAL@[90; 92)
-                INT_NUMBER@[90; 92) "92"
-            SEMI@[92; 93) ";"
-          WHITESPACE@[93; 98) "\n    "
-          R_CURLY@[98; 99) "}"
-      WHITESPACE@[99; 100) "\n"
-      R_CURLY@[100; 101) "}"
+    BLOCK_EXPR@[9; 101)
+      BLOCK@[9; 101)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        LOOP_EXPR@[15; 99)
+          LOOP_KW@[15; 19) "loop"
+          WHITESPACE@[19; 20) " "
+          BLOCK_EXPR@[20; 99)
+            BLOCK@[20; 99)
+              L_CURLY@[20; 21) "{"
+              WHITESPACE@[21; 30) "\n        "
+              EXPR_STMT@[30; 36)
+                BREAK_EXPR@[30; 35)
+                  BREAK_KW@[30; 35) "break"
+                SEMI@[35; 36) ";"
+              WHITESPACE@[36; 45) "\n        "
+              EXPR_STMT@[45; 54)
+                BREAK_EXPR@[45; 53)
+                  BREAK_KW@[45; 50) "break"
+                  WHITESPACE@[50; 51) " "
+                  LIFETIME@[51; 53) "\'l"
+                SEMI@[53; 54) ";"
+              WHITESPACE@[54; 63) "\n        "
+              EXPR_STMT@[63; 72)
+                BREAK_EXPR@[63; 71)
+                  BREAK_KW@[63; 68) "break"
+                  WHITESPACE@[68; 69) " "
+                  LITERAL@[69; 71)
+                    INT_NUMBER@[69; 71) "92"
+                SEMI@[71; 72) ";"
+              WHITESPACE@[72; 81) "\n        "
+              EXPR_STMT@[81; 93)
+                BREAK_EXPR@[81; 92)
+                  BREAK_KW@[81; 86) "break"
+                  WHITESPACE@[86; 87) " "
+                  LIFETIME@[87; 89) "\'l"
+                  WHITESPACE@[89; 90) " "
+                  LITERAL@[90; 92)
+                    INT_NUMBER@[90; 92) "92"
+                SEMI@[92; 93) ";"
+              WHITESPACE@[93; 98) "\n    "
+              R_CURLY@[98; 99) "}"
+        WHITESPACE@[99; 100) "\n"
+        R_CURLY@[100; 101) "}"
   WHITESPACE@[101; 102) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0036_unsafe_extern_fn.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0036_unsafe_extern_fn.txt
@@ -15,7 +15,8 @@ SOURCE_FILE@[0; 30)
       L_PAREN@[24; 25) "("
       R_PAREN@[25; 26) ")"
     WHITESPACE@[26; 27) " "
-    BLOCK@[27; 29)
-      L_CURLY@[27; 28) "{"
-      R_CURLY@[28; 29) "}"
+    BLOCK_EXPR@[27; 29)
+      BLOCK@[27; 29)
+        L_CURLY@[27; 28) "{"
+        R_CURLY@[28; 29) "}"
   WHITESPACE@[29; 30) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0037_qual_paths.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0037_qual_paths.txt
@@ -41,38 +41,39 @@ SOURCE_FILE@[0; 71)
       L_PAREN@[33; 34) "("
       R_PAREN@[34; 35) ")"
     WHITESPACE@[35; 36) " "
-    BLOCK@[36; 70)
-      L_CURLY@[36; 37) "{"
-      WHITESPACE@[37; 38) " "
-      EXPR_STMT@[38; 68)
-        CALL_EXPR@[38; 67)
-          PATH_EXPR@[38; 65)
-            PATH@[38; 65)
-              PATH@[38; 56)
-                PATH_SEGMENT@[38; 56)
-                  L_ANGLE@[38; 39) "<"
-                  PATH_TYPE@[39; 44)
-                    PATH@[39; 44)
-                      PATH_SEGMENT@[39; 44)
-                        NAME_REF@[39; 44)
-                          IDENT@[39; 44) "usize"
-                  WHITESPACE@[44; 45) " "
-                  AS_KW@[45; 47) "as"
-                  WHITESPACE@[47; 48) " "
-                  PATH_TYPE@[48; 55)
-                    PATH@[48; 55)
-                      PATH_SEGMENT@[48; 55)
-                        NAME_REF@[48; 55)
-                          IDENT@[48; 55) "Default"
-                  R_ANGLE@[55; 56) ">"
-              COLONCOLON@[56; 58) "::"
-              PATH_SEGMENT@[58; 65)
-                NAME_REF@[58; 65)
-                  IDENT@[58; 65) "default"
-          ARG_LIST@[65; 67)
-            L_PAREN@[65; 66) "("
-            R_PAREN@[66; 67) ")"
-        SEMI@[67; 68) ";"
-      WHITESPACE@[68; 69) " "
-      R_CURLY@[69; 70) "}"
+    BLOCK_EXPR@[36; 70)
+      BLOCK@[36; 70)
+        L_CURLY@[36; 37) "{"
+        WHITESPACE@[37; 38) " "
+        EXPR_STMT@[38; 68)
+          CALL_EXPR@[38; 67)
+            PATH_EXPR@[38; 65)
+              PATH@[38; 65)
+                PATH@[38; 56)
+                  PATH_SEGMENT@[38; 56)
+                    L_ANGLE@[38; 39) "<"
+                    PATH_TYPE@[39; 44)
+                      PATH@[39; 44)
+                        PATH_SEGMENT@[39; 44)
+                          NAME_REF@[39; 44)
+                            IDENT@[39; 44) "usize"
+                    WHITESPACE@[44; 45) " "
+                    AS_KW@[45; 47) "as"
+                    WHITESPACE@[47; 48) " "
+                    PATH_TYPE@[48; 55)
+                      PATH@[48; 55)
+                        PATH_SEGMENT@[48; 55)
+                          NAME_REF@[48; 55)
+                            IDENT@[48; 55) "Default"
+                    R_ANGLE@[55; 56) ">"
+                COLONCOLON@[56; 58) "::"
+                PATH_SEGMENT@[58; 65)
+                  NAME_REF@[58; 65)
+                    IDENT@[58; 65) "default"
+            ARG_LIST@[65; 67)
+              L_PAREN@[65; 66) "("
+              R_PAREN@[66; 67) ")"
+          SEMI@[67; 68) ";"
+        WHITESPACE@[68; 69) " "
+        R_CURLY@[69; 70) "}"
   WHITESPACE@[70; 71) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0038_full_range_expr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0038_full_range_expr.txt
@@ -8,21 +8,22 @@ SOURCE_FILE@[0; 21)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 20)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 11) " "
-      EXPR_STMT@[11; 18)
-        INDEX_EXPR@[11; 17)
-          PATH_EXPR@[11; 13)
-            PATH@[11; 13)
-              PATH_SEGMENT@[11; 13)
-                NAME_REF@[11; 13)
-                  IDENT@[11; 13) "xs"
-          L_BRACK@[13; 14) "["
-          RANGE_EXPR@[14; 16)
-            DOTDOT@[14; 16) ".."
-          R_BRACK@[16; 17) "]"
-        SEMI@[17; 18) ";"
-      WHITESPACE@[18; 19) " "
-      R_CURLY@[19; 20) "}"
+    BLOCK_EXPR@[9; 20)
+      BLOCK@[9; 20)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 11) " "
+        EXPR_STMT@[11; 18)
+          INDEX_EXPR@[11; 17)
+            PATH_EXPR@[11; 13)
+              PATH@[11; 13)
+                PATH_SEGMENT@[11; 13)
+                  NAME_REF@[11; 13)
+                    IDENT@[11; 13) "xs"
+            L_BRACK@[13; 14) "["
+            RANGE_EXPR@[14; 16)
+              DOTDOT@[14; 16) ".."
+            R_BRACK@[16; 17) "]"
+          SEMI@[17; 18) ";"
+        WHITESPACE@[18; 19) " "
+        R_CURLY@[19; 20) "}"
   WHITESPACE@[20; 21) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0040_crate_keyword_vis.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0040_crate_keyword_vis.txt
@@ -11,10 +11,11 @@ SOURCE_FILE@[0; 71)
       L_PAREN@[13; 14) "("
       R_PAREN@[14; 15) ")"
     WHITESPACE@[15; 16) " "
-    BLOCK@[16; 19)
-      L_CURLY@[16; 17) "{"
-      WHITESPACE@[17; 18) " "
-      R_CURLY@[18; 19) "}"
+    BLOCK_EXPR@[16; 19)
+      BLOCK@[16; 19)
+        L_CURLY@[16; 17) "{"
+        WHITESPACE@[17; 18) " "
+        R_CURLY@[18; 19) "}"
   WHITESPACE@[19; 20) "\n"
   STRUCT_DEF@[20; 49)
     STRUCT_KW@[20; 26) "struct"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0042_call_expr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0042_call_expr.txt
@@ -8,140 +8,141 @@ SOURCE_FILE@[0; 118)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 117)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      LET_STMT@[15; 27)
-        LET_KW@[15; 18) "let"
-        WHITESPACE@[18; 19) " "
-        PLACEHOLDER_PAT@[19; 20)
-          UNDERSCORE@[19; 20) "_"
-        WHITESPACE@[20; 21) " "
-        EQ@[21; 22) "="
-        WHITESPACE@[22; 23) " "
-        CALL_EXPR@[23; 26)
-          PATH_EXPR@[23; 24)
-            PATH@[23; 24)
-              PATH_SEGMENT@[23; 24)
-                NAME_REF@[23; 24)
-                  IDENT@[23; 24) "f"
-          ARG_LIST@[24; 26)
-            L_PAREN@[24; 25) "("
-            R_PAREN@[25; 26) ")"
-        SEMI@[26; 27) ";"
-      WHITESPACE@[27; 32) "\n    "
-      LET_STMT@[32; 54)
-        LET_KW@[32; 35) "let"
-        WHITESPACE@[35; 36) " "
-        PLACEHOLDER_PAT@[36; 37)
-          UNDERSCORE@[36; 37) "_"
-        WHITESPACE@[37; 38) " "
-        EQ@[38; 39) "="
-        WHITESPACE@[39; 40) " "
-        CALL_EXPR@[40; 53)
-          CALL_EXPR@[40; 46)
-            CALL_EXPR@[40; 43)
-              PATH_EXPR@[40; 41)
-                PATH@[40; 41)
-                  PATH_SEGMENT@[40; 41)
-                    NAME_REF@[40; 41)
-                      IDENT@[40; 41) "f"
-              ARG_LIST@[41; 43)
-                L_PAREN@[41; 42) "("
-                R_PAREN@[42; 43) ")"
-            ARG_LIST@[43; 46)
-              L_PAREN@[43; 44) "("
-              LITERAL@[44; 45)
-                INT_NUMBER@[44; 45) "1"
-              R_PAREN@[45; 46) ")"
-          ARG_LIST@[46; 53)
-            L_PAREN@[46; 47) "("
-            LITERAL@[47; 48)
-              INT_NUMBER@[47; 48) "1"
-            COMMA@[48; 49) ","
-            WHITESPACE@[49; 50) " "
-            LITERAL@[50; 51)
-              INT_NUMBER@[50; 51) "2"
-            COMMA@[51; 52) ","
-            R_PAREN@[52; 53) ")"
-        SEMI@[53; 54) ";"
-      WHITESPACE@[54; 59) "\n    "
-      LET_STMT@[59; 84)
-        LET_KW@[59; 62) "let"
-        WHITESPACE@[62; 63) " "
-        PLACEHOLDER_PAT@[63; 64)
-          UNDERSCORE@[63; 64) "_"
-        WHITESPACE@[64; 65) " "
-        EQ@[65; 66) "="
-        WHITESPACE@[66; 67) " "
-        CALL_EXPR@[67; 83)
-          PATH_EXPR@[67; 68)
-            PATH@[67; 68)
-              PATH_SEGMENT@[67; 68)
-                NAME_REF@[67; 68)
-                  IDENT@[67; 68) "f"
-          ARG_LIST@[68; 83)
-            L_PAREN@[68; 69) "("
-            CALL_EXPR@[69; 82)
-              PATH_EXPR@[69; 80)
-                PATH@[69; 80)
-                  PATH@[69; 74)
-                    PATH_SEGMENT@[69; 74)
-                      L_ANGLE@[69; 70) "<"
-                      PATH_TYPE@[70; 73)
-                        PATH@[70; 73)
-                          PATH_SEGMENT@[70; 73)
-                            NAME_REF@[70; 73)
-                              IDENT@[70; 73) "Foo"
-                      R_ANGLE@[73; 74) ">"
-                  COLONCOLON@[74; 76) "::"
-                  PATH_SEGMENT@[76; 80)
-                    NAME_REF@[76; 80)
-                      IDENT@[76; 80) "func"
-              ARG_LIST@[80; 82)
-                L_PAREN@[80; 81) "("
-                R_PAREN@[81; 82) ")"
-            R_PAREN@[82; 83) ")"
-        SEMI@[83; 84) ";"
-      WHITESPACE@[84; 89) "\n    "
-      EXPR_STMT@[89; 115)
-        CALL_EXPR@[89; 114)
-          PATH_EXPR@[89; 90)
-            PATH@[89; 90)
-              PATH_SEGMENT@[89; 90)
-                NAME_REF@[89; 90)
-                  IDENT@[89; 90) "f"
-          ARG_LIST@[90; 114)
-            L_PAREN@[90; 91) "("
-            CALL_EXPR@[91; 113)
-              PATH_EXPR@[91; 111)
-                PATH@[91; 111)
-                  PATH@[91; 105)
-                    PATH_SEGMENT@[91; 105)
-                      L_ANGLE@[91; 92) "<"
-                      PATH_TYPE@[92; 95)
-                        PATH@[92; 95)
-                          PATH_SEGMENT@[92; 95)
-                            NAME_REF@[92; 95)
-                              IDENT@[92; 95) "Foo"
-                      WHITESPACE@[95; 96) " "
-                      AS_KW@[96; 98) "as"
-                      WHITESPACE@[98; 99) " "
-                      PATH_TYPE@[99; 104)
-                        PATH@[99; 104)
-                          PATH_SEGMENT@[99; 104)
-                            NAME_REF@[99; 104)
-                              IDENT@[99; 104) "Trait"
-                      R_ANGLE@[104; 105) ">"
-                  COLONCOLON@[105; 107) "::"
-                  PATH_SEGMENT@[107; 111)
-                    NAME_REF@[107; 111)
-                      IDENT@[107; 111) "func"
-              ARG_LIST@[111; 113)
-                L_PAREN@[111; 112) "("
-                R_PAREN@[112; 113) ")"
-            R_PAREN@[113; 114) ")"
-        SEMI@[114; 115) ";"
-      WHITESPACE@[115; 116) "\n"
-      R_CURLY@[116; 117) "}"
+    BLOCK_EXPR@[9; 117)
+      BLOCK@[9; 117)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        LET_STMT@[15; 27)
+          LET_KW@[15; 18) "let"
+          WHITESPACE@[18; 19) " "
+          PLACEHOLDER_PAT@[19; 20)
+            UNDERSCORE@[19; 20) "_"
+          WHITESPACE@[20; 21) " "
+          EQ@[21; 22) "="
+          WHITESPACE@[22; 23) " "
+          CALL_EXPR@[23; 26)
+            PATH_EXPR@[23; 24)
+              PATH@[23; 24)
+                PATH_SEGMENT@[23; 24)
+                  NAME_REF@[23; 24)
+                    IDENT@[23; 24) "f"
+            ARG_LIST@[24; 26)
+              L_PAREN@[24; 25) "("
+              R_PAREN@[25; 26) ")"
+          SEMI@[26; 27) ";"
+        WHITESPACE@[27; 32) "\n    "
+        LET_STMT@[32; 54)
+          LET_KW@[32; 35) "let"
+          WHITESPACE@[35; 36) " "
+          PLACEHOLDER_PAT@[36; 37)
+            UNDERSCORE@[36; 37) "_"
+          WHITESPACE@[37; 38) " "
+          EQ@[38; 39) "="
+          WHITESPACE@[39; 40) " "
+          CALL_EXPR@[40; 53)
+            CALL_EXPR@[40; 46)
+              CALL_EXPR@[40; 43)
+                PATH_EXPR@[40; 41)
+                  PATH@[40; 41)
+                    PATH_SEGMENT@[40; 41)
+                      NAME_REF@[40; 41)
+                        IDENT@[40; 41) "f"
+                ARG_LIST@[41; 43)
+                  L_PAREN@[41; 42) "("
+                  R_PAREN@[42; 43) ")"
+              ARG_LIST@[43; 46)
+                L_PAREN@[43; 44) "("
+                LITERAL@[44; 45)
+                  INT_NUMBER@[44; 45) "1"
+                R_PAREN@[45; 46) ")"
+            ARG_LIST@[46; 53)
+              L_PAREN@[46; 47) "("
+              LITERAL@[47; 48)
+                INT_NUMBER@[47; 48) "1"
+              COMMA@[48; 49) ","
+              WHITESPACE@[49; 50) " "
+              LITERAL@[50; 51)
+                INT_NUMBER@[50; 51) "2"
+              COMMA@[51; 52) ","
+              R_PAREN@[52; 53) ")"
+          SEMI@[53; 54) ";"
+        WHITESPACE@[54; 59) "\n    "
+        LET_STMT@[59; 84)
+          LET_KW@[59; 62) "let"
+          WHITESPACE@[62; 63) " "
+          PLACEHOLDER_PAT@[63; 64)
+            UNDERSCORE@[63; 64) "_"
+          WHITESPACE@[64; 65) " "
+          EQ@[65; 66) "="
+          WHITESPACE@[66; 67) " "
+          CALL_EXPR@[67; 83)
+            PATH_EXPR@[67; 68)
+              PATH@[67; 68)
+                PATH_SEGMENT@[67; 68)
+                  NAME_REF@[67; 68)
+                    IDENT@[67; 68) "f"
+            ARG_LIST@[68; 83)
+              L_PAREN@[68; 69) "("
+              CALL_EXPR@[69; 82)
+                PATH_EXPR@[69; 80)
+                  PATH@[69; 80)
+                    PATH@[69; 74)
+                      PATH_SEGMENT@[69; 74)
+                        L_ANGLE@[69; 70) "<"
+                        PATH_TYPE@[70; 73)
+                          PATH@[70; 73)
+                            PATH_SEGMENT@[70; 73)
+                              NAME_REF@[70; 73)
+                                IDENT@[70; 73) "Foo"
+                        R_ANGLE@[73; 74) ">"
+                    COLONCOLON@[74; 76) "::"
+                    PATH_SEGMENT@[76; 80)
+                      NAME_REF@[76; 80)
+                        IDENT@[76; 80) "func"
+                ARG_LIST@[80; 82)
+                  L_PAREN@[80; 81) "("
+                  R_PAREN@[81; 82) ")"
+              R_PAREN@[82; 83) ")"
+          SEMI@[83; 84) ";"
+        WHITESPACE@[84; 89) "\n    "
+        EXPR_STMT@[89; 115)
+          CALL_EXPR@[89; 114)
+            PATH_EXPR@[89; 90)
+              PATH@[89; 90)
+                PATH_SEGMENT@[89; 90)
+                  NAME_REF@[89; 90)
+                    IDENT@[89; 90) "f"
+            ARG_LIST@[90; 114)
+              L_PAREN@[90; 91) "("
+              CALL_EXPR@[91; 113)
+                PATH_EXPR@[91; 111)
+                  PATH@[91; 111)
+                    PATH@[91; 105)
+                      PATH_SEGMENT@[91; 105)
+                        L_ANGLE@[91; 92) "<"
+                        PATH_TYPE@[92; 95)
+                          PATH@[92; 95)
+                            PATH_SEGMENT@[92; 95)
+                              NAME_REF@[92; 95)
+                                IDENT@[92; 95) "Foo"
+                        WHITESPACE@[95; 96) " "
+                        AS_KW@[96; 98) "as"
+                        WHITESPACE@[98; 99) " "
+                        PATH_TYPE@[99; 104)
+                          PATH@[99; 104)
+                            PATH_SEGMENT@[99; 104)
+                              NAME_REF@[99; 104)
+                                IDENT@[99; 104) "Trait"
+                        R_ANGLE@[104; 105) ">"
+                    COLONCOLON@[105; 107) "::"
+                    PATH_SEGMENT@[107; 111)
+                      NAME_REF@[107; 111)
+                        IDENT@[107; 111) "func"
+                ARG_LIST@[111; 113)
+                  L_PAREN@[111; 112) "("
+                  R_PAREN@[112; 113) ")"
+              R_PAREN@[113; 114) ")"
+          SEMI@[114; 115) ";"
+        WHITESPACE@[115; 116) "\n"
+        R_CURLY@[116; 117) "}"
   WHITESPACE@[117; 118) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0044_block_items.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0044_block_items.txt
@@ -8,21 +8,23 @@ SOURCE_FILE@[0; 21)
       L_PAREN@[4; 5) "("
       R_PAREN@[5; 6) ")"
     WHITESPACE@[6; 7) " "
-    BLOCK@[7; 20)
-      L_CURLY@[7; 8) "{"
-      WHITESPACE@[8; 9) " "
-      FN_DEF@[9; 18)
-        FN_KW@[9; 11) "fn"
-        WHITESPACE@[11; 12) " "
-        NAME@[12; 13)
-          IDENT@[12; 13) "b"
-        PARAM_LIST@[13; 15)
-          L_PAREN@[13; 14) "("
-          R_PAREN@[14; 15) ")"
-        WHITESPACE@[15; 16) " "
-        BLOCK@[16; 18)
-          L_CURLY@[16; 17) "{"
-          R_CURLY@[17; 18) "}"
-      WHITESPACE@[18; 19) " "
-      R_CURLY@[19; 20) "}"
+    BLOCK_EXPR@[7; 20)
+      BLOCK@[7; 20)
+        L_CURLY@[7; 8) "{"
+        WHITESPACE@[8; 9) " "
+        FN_DEF@[9; 18)
+          FN_KW@[9; 11) "fn"
+          WHITESPACE@[11; 12) " "
+          NAME@[12; 13)
+            IDENT@[12; 13) "b"
+          PARAM_LIST@[13; 15)
+            L_PAREN@[13; 14) "("
+            R_PAREN@[14; 15) ")"
+          WHITESPACE@[15; 16) " "
+          BLOCK_EXPR@[16; 18)
+            BLOCK@[16; 18)
+              L_CURLY@[16; 17) "{"
+              R_CURLY@[17; 18) "}"
+        WHITESPACE@[18; 19) " "
+        R_CURLY@[19; 20) "}"
   WHITESPACE@[20; 21) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0045_param_list_opt_patterns.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0045_param_list_opt_patterns.txt
@@ -40,7 +40,8 @@ SOURCE_FILE@[0; 35)
     PARAM_LIST@[30; 32)
       L_PAREN@[30; 31) "("
       R_PAREN@[31; 32) ")"
-    BLOCK@[32; 34)
-      L_CURLY@[32; 33) "{"
-      R_CURLY@[33; 34) "}"
+    BLOCK_EXPR@[32; 34)
+      BLOCK@[32; 34)
+        L_CURLY@[32; 33) "{"
+        R_CURLY@[33; 34) "}"
   WHITESPACE@[34; 35) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0048_path_type_with_bounds.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0048_path_type_with_bounds.txt
@@ -34,9 +34,10 @@ SOURCE_FILE@[0; 58)
                       LIFETIME@[20; 22) "\'f"
               R_ANGLE@[22; 23) ">"
     WHITESPACE@[23; 24) " "
-    BLOCK@[24; 26)
-      L_CURLY@[24; 25) "{"
-      R_CURLY@[25; 26) "}"
+    BLOCK_EXPR@[24; 26)
+      BLOCK@[24; 26)
+        L_CURLY@[24; 25) "{"
+        R_CURLY@[25; 26) "}"
   WHITESPACE@[26; 27) "\n"
   FN_DEF@[27; 57)
     FN_KW@[27; 29) "fn"
@@ -75,7 +76,8 @@ SOURCE_FILE@[0; 58)
                       LIFETIME@[51; 53) "\'f"
               R_ANGLE@[53; 54) ">"
     WHITESPACE@[54; 55) " "
-    BLOCK@[55; 57)
-      L_CURLY@[55; 56) "{"
-      R_CURLY@[56; 57) "}"
+    BLOCK_EXPR@[55; 57)
+      BLOCK@[55; 57)
+        L_CURLY@[55; 56) "{"
+        R_CURLY@[56; 57) "}"
   WHITESPACE@[57; 58) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0053_path_expr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0053_path_expr.txt
@@ -8,88 +8,89 @@ SOURCE_FILE@[0; 91)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 90)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      LET_STMT@[15; 25)
-        LET_KW@[15; 18) "let"
-        WHITESPACE@[18; 19) " "
-        PLACEHOLDER_PAT@[19; 20)
-          UNDERSCORE@[19; 20) "_"
-        WHITESPACE@[20; 21) " "
-        EQ@[21; 22) "="
-        WHITESPACE@[22; 23) " "
-        PATH_EXPR@[23; 24)
-          PATH@[23; 24)
-            PATH_SEGMENT@[23; 24)
-              NAME_REF@[23; 24)
-                IDENT@[23; 24) "a"
-        SEMI@[24; 25) ";"
-      WHITESPACE@[25; 30) "\n    "
-      LET_STMT@[30; 43)
-        LET_KW@[30; 33) "let"
-        WHITESPACE@[33; 34) " "
-        PLACEHOLDER_PAT@[34; 35)
-          UNDERSCORE@[34; 35) "_"
-        WHITESPACE@[35; 36) " "
-        EQ@[36; 37) "="
-        WHITESPACE@[37; 38) " "
-        PATH_EXPR@[38; 42)
-          PATH@[38; 42)
-            PATH@[38; 39)
-              PATH_SEGMENT@[38; 39)
-                NAME_REF@[38; 39)
-                  IDENT@[38; 39) "a"
-            COLONCOLON@[39; 41) "::"
-            PATH_SEGMENT@[41; 42)
-              NAME_REF@[41; 42)
-                IDENT@[41; 42) "b"
-        SEMI@[42; 43) ";"
-      WHITESPACE@[43; 48) "\n    "
-      LET_STMT@[48; 65)
-        LET_KW@[48; 51) "let"
-        WHITESPACE@[51; 52) " "
-        PLACEHOLDER_PAT@[52; 53)
-          UNDERSCORE@[52; 53) "_"
-        WHITESPACE@[53; 54) " "
-        EQ@[54; 55) "="
-        WHITESPACE@[55; 56) " "
-        PATH_EXPR@[56; 64)
-          PATH@[56; 64)
-            PATH_SEGMENT@[56; 64)
-              COLONCOLON@[56; 58) "::"
-              NAME_REF@[58; 59)
-                IDENT@[58; 59) "a"
-              TYPE_ARG_LIST@[59; 64)
-                COLONCOLON@[59; 61) "::"
-                L_ANGLE@[61; 62) "<"
-                TYPE_ARG@[62; 63)
-                  PATH_TYPE@[62; 63)
-                    PATH@[62; 63)
-                      PATH_SEGMENT@[62; 63)
-                        NAME_REF@[62; 63)
-                          IDENT@[62; 63) "b"
-                R_ANGLE@[63; 64) ">"
-        SEMI@[64; 65) ";"
-      WHITESPACE@[65; 70) "\n    "
-      LET_STMT@[70; 88)
-        LET_KW@[70; 73) "let"
-        WHITESPACE@[73; 74) " "
-        PLACEHOLDER_PAT@[74; 75)
-          UNDERSCORE@[74; 75) "_"
-        WHITESPACE@[75; 76) " "
-        EQ@[76; 77) "="
-        WHITESPACE@[77; 78) " "
-        MACRO_CALL@[78; 87)
-          PATH@[78; 84)
-            PATH_SEGMENT@[78; 84)
-              NAME_REF@[78; 84)
-                IDENT@[78; 84) "format"
-          EXCL@[84; 85) "!"
-          TOKEN_TREE@[85; 87)
-            L_PAREN@[85; 86) "("
-            R_PAREN@[86; 87) ")"
-        SEMI@[87; 88) ";"
-      WHITESPACE@[88; 89) "\n"
-      R_CURLY@[89; 90) "}"
+    BLOCK_EXPR@[9; 90)
+      BLOCK@[9; 90)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        LET_STMT@[15; 25)
+          LET_KW@[15; 18) "let"
+          WHITESPACE@[18; 19) " "
+          PLACEHOLDER_PAT@[19; 20)
+            UNDERSCORE@[19; 20) "_"
+          WHITESPACE@[20; 21) " "
+          EQ@[21; 22) "="
+          WHITESPACE@[22; 23) " "
+          PATH_EXPR@[23; 24)
+            PATH@[23; 24)
+              PATH_SEGMENT@[23; 24)
+                NAME_REF@[23; 24)
+                  IDENT@[23; 24) "a"
+          SEMI@[24; 25) ";"
+        WHITESPACE@[25; 30) "\n    "
+        LET_STMT@[30; 43)
+          LET_KW@[30; 33) "let"
+          WHITESPACE@[33; 34) " "
+          PLACEHOLDER_PAT@[34; 35)
+            UNDERSCORE@[34; 35) "_"
+          WHITESPACE@[35; 36) " "
+          EQ@[36; 37) "="
+          WHITESPACE@[37; 38) " "
+          PATH_EXPR@[38; 42)
+            PATH@[38; 42)
+              PATH@[38; 39)
+                PATH_SEGMENT@[38; 39)
+                  NAME_REF@[38; 39)
+                    IDENT@[38; 39) "a"
+              COLONCOLON@[39; 41) "::"
+              PATH_SEGMENT@[41; 42)
+                NAME_REF@[41; 42)
+                  IDENT@[41; 42) "b"
+          SEMI@[42; 43) ";"
+        WHITESPACE@[43; 48) "\n    "
+        LET_STMT@[48; 65)
+          LET_KW@[48; 51) "let"
+          WHITESPACE@[51; 52) " "
+          PLACEHOLDER_PAT@[52; 53)
+            UNDERSCORE@[52; 53) "_"
+          WHITESPACE@[53; 54) " "
+          EQ@[54; 55) "="
+          WHITESPACE@[55; 56) " "
+          PATH_EXPR@[56; 64)
+            PATH@[56; 64)
+              PATH_SEGMENT@[56; 64)
+                COLONCOLON@[56; 58) "::"
+                NAME_REF@[58; 59)
+                  IDENT@[58; 59) "a"
+                TYPE_ARG_LIST@[59; 64)
+                  COLONCOLON@[59; 61) "::"
+                  L_ANGLE@[61; 62) "<"
+                  TYPE_ARG@[62; 63)
+                    PATH_TYPE@[62; 63)
+                      PATH@[62; 63)
+                        PATH_SEGMENT@[62; 63)
+                          NAME_REF@[62; 63)
+                            IDENT@[62; 63) "b"
+                  R_ANGLE@[63; 64) ">"
+          SEMI@[64; 65) ";"
+        WHITESPACE@[65; 70) "\n    "
+        LET_STMT@[70; 88)
+          LET_KW@[70; 73) "let"
+          WHITESPACE@[73; 74) " "
+          PLACEHOLDER_PAT@[74; 75)
+            UNDERSCORE@[74; 75) "_"
+          WHITESPACE@[75; 76) " "
+          EQ@[76; 77) "="
+          WHITESPACE@[77; 78) " "
+          MACRO_CALL@[78; 87)
+            PATH@[78; 84)
+              PATH_SEGMENT@[78; 84)
+                NAME_REF@[78; 84)
+                  IDENT@[78; 84) "format"
+            EXCL@[84; 85) "!"
+            TOKEN_TREE@[85; 87)
+              L_PAREN@[85; 86) "("
+              R_PAREN@[86; 87) ")"
+          SEMI@[87; 88) ";"
+        WHITESPACE@[88; 89) "\n"
+        R_CURLY@[89; 90) "}"
   WHITESPACE@[90; 91) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0055_literal_pattern.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0055_literal_pattern.txt
@@ -8,69 +8,70 @@ SOURCE_FILE@[0; 113)
       L_PAREN@[7; 8) "("
       R_PAREN@[8; 9) ")"
     WHITESPACE@[9; 10) " "
-    BLOCK@[10; 112)
-      L_CURLY@[10; 11) "{"
-      WHITESPACE@[11; 16) "\n    "
-      MATCH_EXPR@[16; 110)
-        MATCH_KW@[16; 21) "match"
-        WHITESPACE@[21; 22) " "
-        TUPLE_EXPR@[22; 24)
-          L_PAREN@[22; 23) "("
-          R_PAREN@[23; 24) ")"
-        WHITESPACE@[24; 25) " "
-        MATCH_ARM_LIST@[25; 110)
-          L_CURLY@[25; 26) "{"
-          WHITESPACE@[26; 35) "\n        "
-          MATCH_ARM@[35; 43)
-            LITERAL_PAT@[35; 37)
-              MINUS@[35; 36) "-"
-              LITERAL@[36; 37)
-                INT_NUMBER@[36; 37) "1"
-            WHITESPACE@[37; 38) " "
-            FAT_ARROW@[38; 40) "=>"
-            WHITESPACE@[40; 41) " "
-            TUPLE_EXPR@[41; 43)
-              L_PAREN@[41; 42) "("
-              R_PAREN@[42; 43) ")"
-          COMMA@[43; 44) ","
-          WHITESPACE@[44; 53) "\n        "
-          MATCH_ARM@[53; 61)
-            LITERAL_PAT@[53; 55)
-              LITERAL@[53; 55)
-                INT_NUMBER@[53; 55) "92"
-            WHITESPACE@[55; 56) " "
-            FAT_ARROW@[56; 58) "=>"
-            WHITESPACE@[58; 59) " "
-            TUPLE_EXPR@[59; 61)
-              L_PAREN@[59; 60) "("
-              R_PAREN@[60; 61) ")"
-          COMMA@[61; 62) ","
-          WHITESPACE@[62; 71) "\n        "
-          MATCH_ARM@[71; 80)
-            LITERAL_PAT@[71; 74)
-              LITERAL@[71; 74)
-                CHAR@[71; 74) "\'c\'"
-            WHITESPACE@[74; 75) " "
-            FAT_ARROW@[75; 77) "=>"
-            WHITESPACE@[77; 78) " "
-            TUPLE_EXPR@[78; 80)
-              L_PAREN@[78; 79) "("
-              R_PAREN@[79; 80) ")"
-          COMMA@[80; 81) ","
-          WHITESPACE@[81; 90) "\n        "
-          MATCH_ARM@[90; 103)
-            LITERAL_PAT@[90; 97)
-              LITERAL@[90; 97)
-                STRING@[90; 97) "\"hello\""
-            WHITESPACE@[97; 98) " "
-            FAT_ARROW@[98; 100) "=>"
-            WHITESPACE@[100; 101) " "
-            TUPLE_EXPR@[101; 103)
-              L_PAREN@[101; 102) "("
-              R_PAREN@[102; 103) ")"
-          COMMA@[103; 104) ","
-          WHITESPACE@[104; 109) "\n    "
-          R_CURLY@[109; 110) "}"
-      WHITESPACE@[110; 111) "\n"
-      R_CURLY@[111; 112) "}"
+    BLOCK_EXPR@[10; 112)
+      BLOCK@[10; 112)
+        L_CURLY@[10; 11) "{"
+        WHITESPACE@[11; 16) "\n    "
+        MATCH_EXPR@[16; 110)
+          MATCH_KW@[16; 21) "match"
+          WHITESPACE@[21; 22) " "
+          TUPLE_EXPR@[22; 24)
+            L_PAREN@[22; 23) "("
+            R_PAREN@[23; 24) ")"
+          WHITESPACE@[24; 25) " "
+          MATCH_ARM_LIST@[25; 110)
+            L_CURLY@[25; 26) "{"
+            WHITESPACE@[26; 35) "\n        "
+            MATCH_ARM@[35; 43)
+              LITERAL_PAT@[35; 37)
+                MINUS@[35; 36) "-"
+                LITERAL@[36; 37)
+                  INT_NUMBER@[36; 37) "1"
+              WHITESPACE@[37; 38) " "
+              FAT_ARROW@[38; 40) "=>"
+              WHITESPACE@[40; 41) " "
+              TUPLE_EXPR@[41; 43)
+                L_PAREN@[41; 42) "("
+                R_PAREN@[42; 43) ")"
+            COMMA@[43; 44) ","
+            WHITESPACE@[44; 53) "\n        "
+            MATCH_ARM@[53; 61)
+              LITERAL_PAT@[53; 55)
+                LITERAL@[53; 55)
+                  INT_NUMBER@[53; 55) "92"
+              WHITESPACE@[55; 56) " "
+              FAT_ARROW@[56; 58) "=>"
+              WHITESPACE@[58; 59) " "
+              TUPLE_EXPR@[59; 61)
+                L_PAREN@[59; 60) "("
+                R_PAREN@[60; 61) ")"
+            COMMA@[61; 62) ","
+            WHITESPACE@[62; 71) "\n        "
+            MATCH_ARM@[71; 80)
+              LITERAL_PAT@[71; 74)
+                LITERAL@[71; 74)
+                  CHAR@[71; 74) "\'c\'"
+              WHITESPACE@[74; 75) " "
+              FAT_ARROW@[75; 77) "=>"
+              WHITESPACE@[77; 78) " "
+              TUPLE_EXPR@[78; 80)
+                L_PAREN@[78; 79) "("
+                R_PAREN@[79; 80) ")"
+            COMMA@[80; 81) ","
+            WHITESPACE@[81; 90) "\n        "
+            MATCH_ARM@[90; 103)
+              LITERAL_PAT@[90; 97)
+                LITERAL@[90; 97)
+                  STRING@[90; 97) "\"hello\""
+              WHITESPACE@[97; 98) " "
+              FAT_ARROW@[98; 100) "=>"
+              WHITESPACE@[100; 101) " "
+              TUPLE_EXPR@[101; 103)
+                L_PAREN@[101; 102) "("
+                R_PAREN@[102; 103) ")"
+            COMMA@[103; 104) ","
+            WHITESPACE@[104; 109) "\n    "
+            R_CURLY@[109; 110) "}"
+        WHITESPACE@[110; 111) "\n"
+        R_CURLY@[111; 112) "}"
   WHITESPACE@[112; 113) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0056_where_clause.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0056_where_clause.txt
@@ -104,7 +104,8 @@ SOURCE_FILE@[0; 116)
           TYPE_BOUND@[110; 112)
             LIFETIME@[110; 112) "\'a"
     WHITESPACE@[112; 113) "\n"
-    BLOCK@[113; 115)
-      L_CURLY@[113; 114) "{"
-      R_CURLY@[114; 115) "}"
+    BLOCK_EXPR@[113; 115)
+      BLOCK@[113; 115)
+        L_CURLY@[113; 114) "{"
+        R_CURLY@[114; 115) "}"
   WHITESPACE@[115; 116) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0057_const_fn.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0057_const_fn.txt
@@ -10,7 +10,8 @@ SOURCE_FILE@[0; 18)
       L_PAREN@[12; 13) "("
       R_PAREN@[13; 14) ")"
     WHITESPACE@[14; 15) " "
-    BLOCK@[15; 17)
-      L_CURLY@[15; 16) "{"
-      R_CURLY@[16; 17) "}"
+    BLOCK_EXPR@[15; 17)
+      BLOCK@[15; 17)
+        L_CURLY@[15; 16) "{"
+        R_CURLY@[16; 17) "}"
   WHITESPACE@[17; 18) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0058_range_pat.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0058_range_pat.txt
@@ -8,75 +8,76 @@ SOURCE_FILE@[0; 112)
       L_PAREN@[7; 8) "("
       R_PAREN@[8; 9) ")"
     WHITESPACE@[9; 10) " "
-    BLOCK@[10; 111)
-      L_CURLY@[10; 11) "{"
-      WHITESPACE@[11; 16) "\n    "
-      MATCH_EXPR@[16; 109)
-        MATCH_KW@[16; 21) "match"
-        WHITESPACE@[21; 22) " "
-        LITERAL@[22; 24)
-          INT_NUMBER@[22; 24) "92"
-        WHITESPACE@[24; 25) " "
-        MATCH_ARM_LIST@[25; 109)
-          L_CURLY@[25; 26) "{"
-          WHITESPACE@[26; 35) "\n        "
-          MATCH_ARM@[35; 50)
-            RANGE_PAT@[35; 44)
-              LITERAL_PAT@[35; 36)
-                LITERAL@[35; 36)
-                  INT_NUMBER@[35; 36) "0"
-              WHITESPACE@[36; 37) " "
-              DOTDOTDOT@[37; 40) "..."
-              WHITESPACE@[40; 41) " "
-              LITERAL_PAT@[41; 44)
-                LITERAL@[41; 44)
-                  INT_NUMBER@[41; 44) "100"
-            WHITESPACE@[44; 45) " "
-            FAT_ARROW@[45; 47) "=>"
-            WHITESPACE@[47; 48) " "
-            TUPLE_EXPR@[48; 50)
-              L_PAREN@[48; 49) "("
-              R_PAREN@[49; 50) ")"
-          COMMA@[50; 51) ","
-          WHITESPACE@[51; 60) "\n        "
-          MATCH_ARM@[60; 77)
-            RANGE_PAT@[60; 71)
-              LITERAL_PAT@[60; 63)
-                LITERAL@[60; 63)
-                  INT_NUMBER@[60; 63) "101"
-              WHITESPACE@[63; 64) " "
-              DOTDOTEQ@[64; 67) "..="
-              WHITESPACE@[67; 68) " "
-              LITERAL_PAT@[68; 71)
-                LITERAL@[68; 71)
-                  INT_NUMBER@[68; 71) "200"
-            WHITESPACE@[71; 72) " "
-            FAT_ARROW@[72; 74) "=>"
-            WHITESPACE@[74; 75) " "
-            TUPLE_EXPR@[75; 77)
-              L_PAREN@[75; 76) "("
-              R_PAREN@[76; 77) ")"
-          COMMA@[77; 78) ","
-          WHITESPACE@[78; 87) "\n        "
-          MATCH_ARM@[87; 102)
-            RANGE_PAT@[87; 97)
-              LITERAL_PAT@[87; 90)
-                LITERAL@[87; 90)
-                  INT_NUMBER@[87; 90) "200"
-              WHITESPACE@[90; 91) " "
-              DOTDOT@[91; 93) ".."
-              WHITESPACE@[93; 94) " "
-              LITERAL_PAT@[94; 97)
-                LITERAL@[94; 97)
-                  INT_NUMBER@[94; 97) "301"
-            FAT_ARROW@[97; 99) "=>"
-            WHITESPACE@[99; 100) " "
-            TUPLE_EXPR@[100; 102)
-              L_PAREN@[100; 101) "("
-              R_PAREN@[101; 102) ")"
-          COMMA@[102; 103) ","
-          WHITESPACE@[103; 108) "\n    "
-          R_CURLY@[108; 109) "}"
-      WHITESPACE@[109; 110) "\n"
-      R_CURLY@[110; 111) "}"
+    BLOCK_EXPR@[10; 111)
+      BLOCK@[10; 111)
+        L_CURLY@[10; 11) "{"
+        WHITESPACE@[11; 16) "\n    "
+        MATCH_EXPR@[16; 109)
+          MATCH_KW@[16; 21) "match"
+          WHITESPACE@[21; 22) " "
+          LITERAL@[22; 24)
+            INT_NUMBER@[22; 24) "92"
+          WHITESPACE@[24; 25) " "
+          MATCH_ARM_LIST@[25; 109)
+            L_CURLY@[25; 26) "{"
+            WHITESPACE@[26; 35) "\n        "
+            MATCH_ARM@[35; 50)
+              RANGE_PAT@[35; 44)
+                LITERAL_PAT@[35; 36)
+                  LITERAL@[35; 36)
+                    INT_NUMBER@[35; 36) "0"
+                WHITESPACE@[36; 37) " "
+                DOTDOTDOT@[37; 40) "..."
+                WHITESPACE@[40; 41) " "
+                LITERAL_PAT@[41; 44)
+                  LITERAL@[41; 44)
+                    INT_NUMBER@[41; 44) "100"
+              WHITESPACE@[44; 45) " "
+              FAT_ARROW@[45; 47) "=>"
+              WHITESPACE@[47; 48) " "
+              TUPLE_EXPR@[48; 50)
+                L_PAREN@[48; 49) "("
+                R_PAREN@[49; 50) ")"
+            COMMA@[50; 51) ","
+            WHITESPACE@[51; 60) "\n        "
+            MATCH_ARM@[60; 77)
+              RANGE_PAT@[60; 71)
+                LITERAL_PAT@[60; 63)
+                  LITERAL@[60; 63)
+                    INT_NUMBER@[60; 63) "101"
+                WHITESPACE@[63; 64) " "
+                DOTDOTEQ@[64; 67) "..="
+                WHITESPACE@[67; 68) " "
+                LITERAL_PAT@[68; 71)
+                  LITERAL@[68; 71)
+                    INT_NUMBER@[68; 71) "200"
+              WHITESPACE@[71; 72) " "
+              FAT_ARROW@[72; 74) "=>"
+              WHITESPACE@[74; 75) " "
+              TUPLE_EXPR@[75; 77)
+                L_PAREN@[75; 76) "("
+                R_PAREN@[76; 77) ")"
+            COMMA@[77; 78) ","
+            WHITESPACE@[78; 87) "\n        "
+            MATCH_ARM@[87; 102)
+              RANGE_PAT@[87; 97)
+                LITERAL_PAT@[87; 90)
+                  LITERAL@[87; 90)
+                    INT_NUMBER@[87; 90) "200"
+                WHITESPACE@[90; 91) " "
+                DOTDOT@[91; 93) ".."
+                WHITESPACE@[93; 94) " "
+                LITERAL_PAT@[94; 97)
+                  LITERAL@[94; 97)
+                    INT_NUMBER@[94; 97) "301"
+              FAT_ARROW@[97; 99) "=>"
+              WHITESPACE@[99; 100) " "
+              TUPLE_EXPR@[100; 102)
+                L_PAREN@[100; 101) "("
+                R_PAREN@[101; 102) ")"
+            COMMA@[102; 103) ","
+            WHITESPACE@[103; 108) "\n    "
+            R_CURLY@[108; 109) "}"
+        WHITESPACE@[109; 110) "\n"
+        R_CURLY@[110; 111) "}"
   WHITESPACE@[111; 112) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0059_match_arms_commas.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0059_match_arms_commas.txt
@@ -8,52 +8,53 @@ SOURCE_FILE@[0; 83)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 82)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      MATCH_EXPR@[15; 80)
-        MATCH_KW@[15; 20) "match"
-        WHITESPACE@[20; 21) " "
-        TUPLE_EXPR@[21; 23)
-          L_PAREN@[21; 22) "("
-          R_PAREN@[22; 23) ")"
-        WHITESPACE@[23; 24) " "
-        MATCH_ARM_LIST@[24; 80)
-          L_CURLY@[24; 25) "{"
-          WHITESPACE@[25; 34) "\n        "
-          MATCH_ARM@[34; 41)
-            PLACEHOLDER_PAT@[34; 35)
-              UNDERSCORE@[34; 35) "_"
-            WHITESPACE@[35; 36) " "
-            FAT_ARROW@[36; 38) "=>"
-            WHITESPACE@[38; 39) " "
-            TUPLE_EXPR@[39; 41)
-              L_PAREN@[39; 40) "("
-              R_PAREN@[40; 41) ")"
-          COMMA@[41; 42) ","
-          WHITESPACE@[42; 51) "\n        "
-          MATCH_ARM@[51; 58)
-            PLACEHOLDER_PAT@[51; 52)
-              UNDERSCORE@[51; 52) "_"
-            WHITESPACE@[52; 53) " "
-            FAT_ARROW@[53; 55) "=>"
-            WHITESPACE@[55; 56) " "
-            BLOCK_EXPR@[56; 58)
-              BLOCK@[56; 58)
-                L_CURLY@[56; 57) "{"
-                R_CURLY@[57; 58) "}"
-          WHITESPACE@[58; 67) "\n        "
-          MATCH_ARM@[67; 74)
-            PLACEHOLDER_PAT@[67; 68)
-              UNDERSCORE@[67; 68) "_"
-            WHITESPACE@[68; 69) " "
-            FAT_ARROW@[69; 71) "=>"
-            WHITESPACE@[71; 72) " "
-            TUPLE_EXPR@[72; 74)
-              L_PAREN@[72; 73) "("
-              R_PAREN@[73; 74) ")"
-          WHITESPACE@[74; 79) "\n    "
-          R_CURLY@[79; 80) "}"
-      WHITESPACE@[80; 81) "\n"
-      R_CURLY@[81; 82) "}"
+    BLOCK_EXPR@[9; 82)
+      BLOCK@[9; 82)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        MATCH_EXPR@[15; 80)
+          MATCH_KW@[15; 20) "match"
+          WHITESPACE@[20; 21) " "
+          TUPLE_EXPR@[21; 23)
+            L_PAREN@[21; 22) "("
+            R_PAREN@[22; 23) ")"
+          WHITESPACE@[23; 24) " "
+          MATCH_ARM_LIST@[24; 80)
+            L_CURLY@[24; 25) "{"
+            WHITESPACE@[25; 34) "\n        "
+            MATCH_ARM@[34; 41)
+              PLACEHOLDER_PAT@[34; 35)
+                UNDERSCORE@[34; 35) "_"
+              WHITESPACE@[35; 36) " "
+              FAT_ARROW@[36; 38) "=>"
+              WHITESPACE@[38; 39) " "
+              TUPLE_EXPR@[39; 41)
+                L_PAREN@[39; 40) "("
+                R_PAREN@[40; 41) ")"
+            COMMA@[41; 42) ","
+            WHITESPACE@[42; 51) "\n        "
+            MATCH_ARM@[51; 58)
+              PLACEHOLDER_PAT@[51; 52)
+                UNDERSCORE@[51; 52) "_"
+              WHITESPACE@[52; 53) " "
+              FAT_ARROW@[53; 55) "=>"
+              WHITESPACE@[55; 56) " "
+              BLOCK_EXPR@[56; 58)
+                BLOCK@[56; 58)
+                  L_CURLY@[56; 57) "{"
+                  R_CURLY@[57; 58) "}"
+            WHITESPACE@[58; 67) "\n        "
+            MATCH_ARM@[67; 74)
+              PLACEHOLDER_PAT@[67; 68)
+                UNDERSCORE@[67; 68) "_"
+              WHITESPACE@[68; 69) " "
+              FAT_ARROW@[69; 71) "=>"
+              WHITESPACE@[71; 72) " "
+              TUPLE_EXPR@[72; 74)
+                L_PAREN@[72; 73) "("
+                R_PAREN@[73; 74) ")"
+            WHITESPACE@[74; 79) "\n    "
+            R_CURLY@[79; 80) "}"
+        WHITESPACE@[80; 81) "\n"
+        R_CURLY@[81; 82) "}"
   WHITESPACE@[82; 83) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0061_record_lit.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0061_record_lit.txt
@@ -8,111 +8,112 @@ SOURCE_FILE@[0; 112)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 111)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 20)
-        RECORD_LIT@[15; 19)
-          PATH@[15; 16)
-            PATH_SEGMENT@[15; 16)
-              NAME_REF@[15; 16)
-                IDENT@[15; 16) "S"
-          WHITESPACE@[16; 17) " "
-          RECORD_FIELD_LIST@[17; 19)
-            L_CURLY@[17; 18) "{"
-            R_CURLY@[18; 19) "}"
-        SEMI@[19; 20) ";"
-      WHITESPACE@[20; 25) "\n    "
-      EXPR_STMT@[25; 41)
-        RECORD_LIT@[25; 40)
-          PATH@[25; 26)
-            PATH_SEGMENT@[25; 26)
-              NAME_REF@[25; 26)
-                IDENT@[25; 26) "S"
-          WHITESPACE@[26; 27) " "
-          RECORD_FIELD_LIST@[27; 40)
-            L_CURLY@[27; 28) "{"
-            WHITESPACE@[28; 29) " "
-            RECORD_FIELD@[29; 30)
-              NAME_REF@[29; 30)
-                IDENT@[29; 30) "x"
-            COMMA@[30; 31) ","
-            WHITESPACE@[31; 32) " "
-            RECORD_FIELD@[32; 37)
-              NAME_REF@[32; 33)
-                IDENT@[32; 33) "y"
-              COLON@[33; 34) ":"
-              WHITESPACE@[34; 35) " "
-              LITERAL@[35; 37)
-                INT_NUMBER@[35; 37) "32"
-            COMMA@[37; 38) ","
-            WHITESPACE@[38; 39) " "
-            R_CURLY@[39; 40) "}"
-        SEMI@[40; 41) ";"
-      WHITESPACE@[41; 46) "\n    "
-      EXPR_STMT@[46; 83)
-        RECORD_LIT@[46; 82)
-          PATH@[46; 47)
-            PATH_SEGMENT@[46; 47)
-              NAME_REF@[46; 47)
-                IDENT@[46; 47) "S"
-          WHITESPACE@[47; 48) " "
-          RECORD_FIELD_LIST@[48; 82)
-            L_CURLY@[48; 49) "{"
-            WHITESPACE@[49; 50) " "
-            RECORD_FIELD@[50; 51)
-              NAME_REF@[50; 51)
-                IDENT@[50; 51) "x"
-            COMMA@[51; 52) ","
-            WHITESPACE@[52; 53) " "
-            RECORD_FIELD@[53; 58)
-              NAME_REF@[53; 54)
-                IDENT@[53; 54) "y"
-              COLON@[54; 55) ":"
-              WHITESPACE@[55; 56) " "
-              LITERAL@[56; 58)
-                INT_NUMBER@[56; 58) "32"
-            COMMA@[58; 59) ","
-            WHITESPACE@[59; 60) " "
-            DOTDOT@[60; 62) ".."
-            CALL_EXPR@[62; 80)
-              PATH_EXPR@[62; 78)
-                PATH@[62; 78)
-                  PATH@[62; 69)
-                    PATH_SEGMENT@[62; 69)
-                      NAME_REF@[62; 69)
-                        IDENT@[62; 69) "Default"
-                  COLONCOLON@[69; 71) "::"
-                  PATH_SEGMENT@[71; 78)
-                    NAME_REF@[71; 78)
-                      IDENT@[71; 78) "default"
-              ARG_LIST@[78; 80)
-                L_PAREN@[78; 79) "("
-                R_PAREN@[79; 80) ")"
-            WHITESPACE@[80; 81) " "
-            R_CURLY@[81; 82) "}"
-        SEMI@[82; 83) ";"
-      WHITESPACE@[83; 88) "\n    "
-      EXPR_STMT@[88; 109)
-        RECORD_LIT@[88; 108)
-          PATH@[88; 99)
-            PATH_SEGMENT@[88; 99)
-              NAME_REF@[88; 99)
-                IDENT@[88; 99) "TupleStruct"
-          WHITESPACE@[99; 100) " "
-          RECORD_FIELD_LIST@[100; 108)
-            L_CURLY@[100; 101) "{"
-            WHITESPACE@[101; 102) " "
-            RECORD_FIELD@[102; 106)
-              NAME_REF@[102; 103)
-                INT_NUMBER@[102; 103) "0"
-              COLON@[103; 104) ":"
-              WHITESPACE@[104; 105) " "
-              LITERAL@[105; 106)
-                INT_NUMBER@[105; 106) "1"
-            WHITESPACE@[106; 107) " "
-            R_CURLY@[107; 108) "}"
-        SEMI@[108; 109) ";"
-      WHITESPACE@[109; 110) "\n"
-      R_CURLY@[110; 111) "}"
+    BLOCK_EXPR@[9; 111)
+      BLOCK@[9; 111)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        EXPR_STMT@[15; 20)
+          RECORD_LIT@[15; 19)
+            PATH@[15; 16)
+              PATH_SEGMENT@[15; 16)
+                NAME_REF@[15; 16)
+                  IDENT@[15; 16) "S"
+            WHITESPACE@[16; 17) " "
+            RECORD_FIELD_LIST@[17; 19)
+              L_CURLY@[17; 18) "{"
+              R_CURLY@[18; 19) "}"
+          SEMI@[19; 20) ";"
+        WHITESPACE@[20; 25) "\n    "
+        EXPR_STMT@[25; 41)
+          RECORD_LIT@[25; 40)
+            PATH@[25; 26)
+              PATH_SEGMENT@[25; 26)
+                NAME_REF@[25; 26)
+                  IDENT@[25; 26) "S"
+            WHITESPACE@[26; 27) " "
+            RECORD_FIELD_LIST@[27; 40)
+              L_CURLY@[27; 28) "{"
+              WHITESPACE@[28; 29) " "
+              RECORD_FIELD@[29; 30)
+                NAME_REF@[29; 30)
+                  IDENT@[29; 30) "x"
+              COMMA@[30; 31) ","
+              WHITESPACE@[31; 32) " "
+              RECORD_FIELD@[32; 37)
+                NAME_REF@[32; 33)
+                  IDENT@[32; 33) "y"
+                COLON@[33; 34) ":"
+                WHITESPACE@[34; 35) " "
+                LITERAL@[35; 37)
+                  INT_NUMBER@[35; 37) "32"
+              COMMA@[37; 38) ","
+              WHITESPACE@[38; 39) " "
+              R_CURLY@[39; 40) "}"
+          SEMI@[40; 41) ";"
+        WHITESPACE@[41; 46) "\n    "
+        EXPR_STMT@[46; 83)
+          RECORD_LIT@[46; 82)
+            PATH@[46; 47)
+              PATH_SEGMENT@[46; 47)
+                NAME_REF@[46; 47)
+                  IDENT@[46; 47) "S"
+            WHITESPACE@[47; 48) " "
+            RECORD_FIELD_LIST@[48; 82)
+              L_CURLY@[48; 49) "{"
+              WHITESPACE@[49; 50) " "
+              RECORD_FIELD@[50; 51)
+                NAME_REF@[50; 51)
+                  IDENT@[50; 51) "x"
+              COMMA@[51; 52) ","
+              WHITESPACE@[52; 53) " "
+              RECORD_FIELD@[53; 58)
+                NAME_REF@[53; 54)
+                  IDENT@[53; 54) "y"
+                COLON@[54; 55) ":"
+                WHITESPACE@[55; 56) " "
+                LITERAL@[56; 58)
+                  INT_NUMBER@[56; 58) "32"
+              COMMA@[58; 59) ","
+              WHITESPACE@[59; 60) " "
+              DOTDOT@[60; 62) ".."
+              CALL_EXPR@[62; 80)
+                PATH_EXPR@[62; 78)
+                  PATH@[62; 78)
+                    PATH@[62; 69)
+                      PATH_SEGMENT@[62; 69)
+                        NAME_REF@[62; 69)
+                          IDENT@[62; 69) "Default"
+                    COLONCOLON@[69; 71) "::"
+                    PATH_SEGMENT@[71; 78)
+                      NAME_REF@[71; 78)
+                        IDENT@[71; 78) "default"
+                ARG_LIST@[78; 80)
+                  L_PAREN@[78; 79) "("
+                  R_PAREN@[79; 80) ")"
+              WHITESPACE@[80; 81) " "
+              R_CURLY@[81; 82) "}"
+          SEMI@[82; 83) ";"
+        WHITESPACE@[83; 88) "\n    "
+        EXPR_STMT@[88; 109)
+          RECORD_LIT@[88; 108)
+            PATH@[88; 99)
+              PATH_SEGMENT@[88; 99)
+                NAME_REF@[88; 99)
+                  IDENT@[88; 99) "TupleStruct"
+            WHITESPACE@[99; 100) " "
+            RECORD_FIELD_LIST@[100; 108)
+              L_CURLY@[100; 101) "{"
+              WHITESPACE@[101; 102) " "
+              RECORD_FIELD@[102; 106)
+                NAME_REF@[102; 103)
+                  INT_NUMBER@[102; 103) "0"
+                COLON@[103; 104) ":"
+                WHITESPACE@[104; 105) " "
+                LITERAL@[105; 106)
+                  INT_NUMBER@[105; 106) "1"
+              WHITESPACE@[106; 107) " "
+              R_CURLY@[107; 108) "}"
+          SEMI@[108; 109) ";"
+        WHITESPACE@[109; 110) "\n"
+        R_CURLY@[110; 111) "}"
   WHITESPACE@[111; 112) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0062_mod_contents.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0062_mod_contents.txt
@@ -8,9 +8,10 @@ SOURCE_FILE@[0; 70)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 11)
-      L_CURLY@[9; 10) "{"
-      R_CURLY@[10; 11) "}"
+    BLOCK_EXPR@[9; 11)
+      BLOCK@[9; 11)
+        L_CURLY@[9; 10) "{"
+        R_CURLY@[10; 11) "}"
   WHITESPACE@[11; 12) "\n"
   MACRO_CALL@[12; 31)
     PATH@[12; 23)

--- a/crates/ra_syntax/test_data/parser/inline/ok/0064_if_expr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0064_if_expr.txt
@@ -8,88 +8,96 @@ SOURCE_FILE@[0; 107)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 106)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 26)
-        IF_EXPR@[15; 25)
-          IF_KW@[15; 17) "if"
-          WHITESPACE@[17; 18) " "
-          CONDITION@[18; 22)
-            LITERAL@[18; 22)
-              TRUE_KW@[18; 22) "true"
-          WHITESPACE@[22; 23) " "
-          BLOCK@[23; 25)
-            L_CURLY@[23; 24) "{"
-            R_CURLY@[24; 25) "}"
-        SEMI@[25; 26) ";"
-      WHITESPACE@[26; 31) "\n    "
-      EXPR_STMT@[31; 50)
-        IF_EXPR@[31; 49)
-          IF_KW@[31; 33) "if"
-          WHITESPACE@[33; 34) " "
-          CONDITION@[34; 38)
-            LITERAL@[34; 38)
-              TRUE_KW@[34; 38) "true"
-          WHITESPACE@[38; 39) " "
-          BLOCK@[39; 41)
-            L_CURLY@[39; 40) "{"
-            R_CURLY@[40; 41) "}"
-          WHITESPACE@[41; 42) " "
-          ELSE_KW@[42; 46) "else"
-          WHITESPACE@[46; 47) " "
-          BLOCK@[47; 49)
-            L_CURLY@[47; 48) "{"
-            R_CURLY@[48; 49) "}"
-        SEMI@[49; 50) ";"
-      WHITESPACE@[50; 55) "\n    "
-      EXPR_STMT@[55; 91)
-        IF_EXPR@[55; 90)
-          IF_KW@[55; 57) "if"
-          WHITESPACE@[57; 58) " "
-          CONDITION@[58; 62)
-            LITERAL@[58; 62)
-              TRUE_KW@[58; 62) "true"
-          WHITESPACE@[62; 63) " "
-          BLOCK@[63; 65)
-            L_CURLY@[63; 64) "{"
-            R_CURLY@[64; 65) "}"
-          WHITESPACE@[65; 66) " "
-          ELSE_KW@[66; 70) "else"
-          WHITESPACE@[70; 71) " "
-          IF_EXPR@[71; 90)
-            IF_KW@[71; 73) "if"
-            WHITESPACE@[73; 74) " "
-            CONDITION@[74; 79)
-              LITERAL@[74; 79)
-                FALSE_KW@[74; 79) "false"
-            WHITESPACE@[79; 80) " "
-            BLOCK@[80; 82)
-              L_CURLY@[80; 81) "{"
-              R_CURLY@[81; 82) "}"
-            WHITESPACE@[82; 83) " "
-            ELSE_KW@[83; 87) "else"
-            WHITESPACE@[87; 88) " "
-            BLOCK@[88; 90)
-              L_CURLY@[88; 89) "{"
-              R_CURLY@[89; 90) "}"
-        SEMI@[90; 91) ";"
-      WHITESPACE@[91; 96) "\n    "
-      EXPR_STMT@[96; 104)
-        IF_EXPR@[96; 103)
-          IF_KW@[96; 98) "if"
-          WHITESPACE@[98; 99) " "
-          CONDITION@[99; 100)
-            PATH_EXPR@[99; 100)
-              PATH@[99; 100)
-                PATH_SEGMENT@[99; 100)
-                  NAME_REF@[99; 100)
-                    IDENT@[99; 100) "S"
-          WHITESPACE@[100; 101) " "
-          BLOCK@[101; 103)
-            L_CURLY@[101; 102) "{"
-            R_CURLY@[102; 103) "}"
-        SEMI@[103; 104) ";"
-      WHITESPACE@[104; 105) "\n"
-      R_CURLY@[105; 106) "}"
+    BLOCK_EXPR@[9; 106)
+      BLOCK@[9; 106)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        EXPR_STMT@[15; 26)
+          IF_EXPR@[15; 25)
+            IF_KW@[15; 17) "if"
+            WHITESPACE@[17; 18) " "
+            CONDITION@[18; 22)
+              LITERAL@[18; 22)
+                TRUE_KW@[18; 22) "true"
+            WHITESPACE@[22; 23) " "
+            BLOCK_EXPR@[23; 25)
+              BLOCK@[23; 25)
+                L_CURLY@[23; 24) "{"
+                R_CURLY@[24; 25) "}"
+          SEMI@[25; 26) ";"
+        WHITESPACE@[26; 31) "\n    "
+        EXPR_STMT@[31; 50)
+          IF_EXPR@[31; 49)
+            IF_KW@[31; 33) "if"
+            WHITESPACE@[33; 34) " "
+            CONDITION@[34; 38)
+              LITERAL@[34; 38)
+                TRUE_KW@[34; 38) "true"
+            WHITESPACE@[38; 39) " "
+            BLOCK_EXPR@[39; 41)
+              BLOCK@[39; 41)
+                L_CURLY@[39; 40) "{"
+                R_CURLY@[40; 41) "}"
+            WHITESPACE@[41; 42) " "
+            ELSE_KW@[42; 46) "else"
+            WHITESPACE@[46; 47) " "
+            BLOCK_EXPR@[47; 49)
+              BLOCK@[47; 49)
+                L_CURLY@[47; 48) "{"
+                R_CURLY@[48; 49) "}"
+          SEMI@[49; 50) ";"
+        WHITESPACE@[50; 55) "\n    "
+        EXPR_STMT@[55; 91)
+          IF_EXPR@[55; 90)
+            IF_KW@[55; 57) "if"
+            WHITESPACE@[57; 58) " "
+            CONDITION@[58; 62)
+              LITERAL@[58; 62)
+                TRUE_KW@[58; 62) "true"
+            WHITESPACE@[62; 63) " "
+            BLOCK_EXPR@[63; 65)
+              BLOCK@[63; 65)
+                L_CURLY@[63; 64) "{"
+                R_CURLY@[64; 65) "}"
+            WHITESPACE@[65; 66) " "
+            ELSE_KW@[66; 70) "else"
+            WHITESPACE@[70; 71) " "
+            IF_EXPR@[71; 90)
+              IF_KW@[71; 73) "if"
+              WHITESPACE@[73; 74) " "
+              CONDITION@[74; 79)
+                LITERAL@[74; 79)
+                  FALSE_KW@[74; 79) "false"
+              WHITESPACE@[79; 80) " "
+              BLOCK_EXPR@[80; 82)
+                BLOCK@[80; 82)
+                  L_CURLY@[80; 81) "{"
+                  R_CURLY@[81; 82) "}"
+              WHITESPACE@[82; 83) " "
+              ELSE_KW@[83; 87) "else"
+              WHITESPACE@[87; 88) " "
+              BLOCK_EXPR@[88; 90)
+                BLOCK@[88; 90)
+                  L_CURLY@[88; 89) "{"
+                  R_CURLY@[89; 90) "}"
+          SEMI@[90; 91) ";"
+        WHITESPACE@[91; 96) "\n    "
+        EXPR_STMT@[96; 104)
+          IF_EXPR@[96; 103)
+            IF_KW@[96; 98) "if"
+            WHITESPACE@[98; 99) " "
+            CONDITION@[99; 100)
+              PATH_EXPR@[99; 100)
+                PATH@[99; 100)
+                  PATH_SEGMENT@[99; 100)
+                    NAME_REF@[99; 100)
+                      IDENT@[99; 100) "S"
+            WHITESPACE@[100; 101) " "
+            BLOCK_EXPR@[101; 103)
+              BLOCK@[101; 103)
+                L_CURLY@[101; 102) "{"
+                R_CURLY@[102; 103) "}"
+          SEMI@[103; 104) ";"
+        WHITESPACE@[104; 105) "\n"
+        R_CURLY@[105; 106) "}"
   WHITESPACE@[106; 107) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0066_match_arm.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0066_match_arm.txt
@@ -8,142 +8,143 @@ SOURCE_FILE@[0; 167)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 166)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 164)
-        MATCH_EXPR@[15; 163)
-          MATCH_KW@[15; 20) "match"
-          WHITESPACE@[20; 21) " "
-          TUPLE_EXPR@[21; 23)
-            L_PAREN@[21; 22) "("
-            R_PAREN@[22; 23) ")"
-          WHITESPACE@[23; 24) " "
-          MATCH_ARM_LIST@[24; 163)
-            L_CURLY@[24; 25) "{"
-            WHITESPACE@[25; 34) "\n        "
-            MATCH_ARM@[34; 41)
-              PLACEHOLDER_PAT@[34; 35)
-                UNDERSCORE@[34; 35) "_"
-              WHITESPACE@[35; 36) " "
-              FAT_ARROW@[36; 38) "=>"
-              WHITESPACE@[38; 39) " "
-              TUPLE_EXPR@[39; 41)
-                L_PAREN@[39; 40) "("
-                R_PAREN@[40; 41) ")"
-            COMMA@[41; 42) ","
-            WHITESPACE@[42; 51) "\n        "
-            MATCH_ARM@[51; 83)
-              PLACEHOLDER_PAT@[51; 52)
-                UNDERSCORE@[51; 52) "_"
-              WHITESPACE@[52; 53) " "
-              MATCH_GUARD@[53; 77)
-                IF_KW@[53; 55) "if"
-                WHITESPACE@[55; 56) " "
-                BIN_EXPR@[56; 77)
-                  PATH_EXPR@[56; 60)
-                    PATH@[56; 60)
-                      PATH_SEGMENT@[56; 60)
-                        NAME_REF@[56; 60)
-                          IDENT@[56; 60) "Test"
-                  WHITESPACE@[60; 61) " "
-                  R_ANGLE@[61; 62) ">"
-                  WHITESPACE@[62; 63) " "
-                  RECORD_LIT@[63; 77)
-                    PATH@[63; 67)
-                      PATH_SEGMENT@[63; 67)
-                        NAME_REF@[63; 67)
-                          IDENT@[63; 67) "Test"
-                    RECORD_FIELD_LIST@[67; 77)
-                      L_CURLY@[67; 68) "{"
-                      RECORD_FIELD@[68; 76)
-                        NAME_REF@[68; 73)
-                          IDENT@[68; 73) "field"
-                        COLON@[73; 74) ":"
-                        WHITESPACE@[74; 75) " "
-                        LITERAL@[75; 76)
-                          INT_NUMBER@[75; 76) "0"
-                      R_CURLY@[76; 77) "}"
-              WHITESPACE@[77; 78) " "
-              FAT_ARROW@[78; 80) "=>"
-              WHITESPACE@[80; 81) " "
-              TUPLE_EXPR@[81; 83)
-                L_PAREN@[81; 82) "("
-                R_PAREN@[82; 83) ")"
-            COMMA@[83; 84) ","
-            WHITESPACE@[84; 93) "\n        "
-            MATCH_ARM@[93; 109)
-              BIND_PAT@[93; 94)
-                NAME@[93; 94)
-                  IDENT@[93; 94) "X"
-              WHITESPACE@[94; 95) " "
-              PIPE@[95; 96) "|"
-              WHITESPACE@[96; 97) " "
-              BIND_PAT@[97; 98)
-                NAME@[97; 98)
-                  IDENT@[97; 98) "Y"
-              WHITESPACE@[98; 99) " "
-              MATCH_GUARD@[99; 103)
-                IF_KW@[99; 101) "if"
-                WHITESPACE@[101; 102) " "
-                PATH_EXPR@[102; 103)
-                  PATH@[102; 103)
-                    PATH_SEGMENT@[102; 103)
-                      NAME_REF@[102; 103)
-                        IDENT@[102; 103) "Z"
-              WHITESPACE@[103; 104) " "
-              FAT_ARROW@[104; 106) "=>"
-              WHITESPACE@[106; 107) " "
-              TUPLE_EXPR@[107; 109)
-                L_PAREN@[107; 108) "("
-                R_PAREN@[108; 109) ")"
-            COMMA@[109; 110) ","
-            WHITESPACE@[110; 119) "\n        "
-            MATCH_ARM@[119; 137)
-              PIPE@[119; 120) "|"
-              WHITESPACE@[120; 121) " "
-              BIND_PAT@[121; 122)
-                NAME@[121; 122)
-                  IDENT@[121; 122) "X"
-              WHITESPACE@[122; 123) " "
-              PIPE@[123; 124) "|"
-              WHITESPACE@[124; 125) " "
-              BIND_PAT@[125; 126)
-                NAME@[125; 126)
-                  IDENT@[125; 126) "Y"
-              WHITESPACE@[126; 127) " "
-              MATCH_GUARD@[127; 131)
-                IF_KW@[127; 129) "if"
-                WHITESPACE@[129; 130) " "
-                PATH_EXPR@[130; 131)
-                  PATH@[130; 131)
-                    PATH_SEGMENT@[130; 131)
-                      NAME_REF@[130; 131)
-                        IDENT@[130; 131) "Z"
-              WHITESPACE@[131; 132) " "
-              FAT_ARROW@[132; 134) "=>"
-              WHITESPACE@[134; 135) " "
-              TUPLE_EXPR@[135; 137)
-                L_PAREN@[135; 136) "("
-                R_PAREN@[136; 137) ")"
-            COMMA@[137; 138) ","
-            WHITESPACE@[138; 147) "\n        "
-            MATCH_ARM@[147; 156)
-              PIPE@[147; 148) "|"
-              WHITESPACE@[148; 149) " "
-              BIND_PAT@[149; 150)
-                NAME@[149; 150)
-                  IDENT@[149; 150) "X"
-              WHITESPACE@[150; 151) " "
-              FAT_ARROW@[151; 153) "=>"
-              WHITESPACE@[153; 154) " "
-              TUPLE_EXPR@[154; 156)
-                L_PAREN@[154; 155) "("
-                R_PAREN@[155; 156) ")"
-            COMMA@[156; 157) ","
-            WHITESPACE@[157; 162) "\n    "
-            R_CURLY@[162; 163) "}"
-        SEMI@[163; 164) ";"
-      WHITESPACE@[164; 165) "\n"
-      R_CURLY@[165; 166) "}"
+    BLOCK_EXPR@[9; 166)
+      BLOCK@[9; 166)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        EXPR_STMT@[15; 164)
+          MATCH_EXPR@[15; 163)
+            MATCH_KW@[15; 20) "match"
+            WHITESPACE@[20; 21) " "
+            TUPLE_EXPR@[21; 23)
+              L_PAREN@[21; 22) "("
+              R_PAREN@[22; 23) ")"
+            WHITESPACE@[23; 24) " "
+            MATCH_ARM_LIST@[24; 163)
+              L_CURLY@[24; 25) "{"
+              WHITESPACE@[25; 34) "\n        "
+              MATCH_ARM@[34; 41)
+                PLACEHOLDER_PAT@[34; 35)
+                  UNDERSCORE@[34; 35) "_"
+                WHITESPACE@[35; 36) " "
+                FAT_ARROW@[36; 38) "=>"
+                WHITESPACE@[38; 39) " "
+                TUPLE_EXPR@[39; 41)
+                  L_PAREN@[39; 40) "("
+                  R_PAREN@[40; 41) ")"
+              COMMA@[41; 42) ","
+              WHITESPACE@[42; 51) "\n        "
+              MATCH_ARM@[51; 83)
+                PLACEHOLDER_PAT@[51; 52)
+                  UNDERSCORE@[51; 52) "_"
+                WHITESPACE@[52; 53) " "
+                MATCH_GUARD@[53; 77)
+                  IF_KW@[53; 55) "if"
+                  WHITESPACE@[55; 56) " "
+                  BIN_EXPR@[56; 77)
+                    PATH_EXPR@[56; 60)
+                      PATH@[56; 60)
+                        PATH_SEGMENT@[56; 60)
+                          NAME_REF@[56; 60)
+                            IDENT@[56; 60) "Test"
+                    WHITESPACE@[60; 61) " "
+                    R_ANGLE@[61; 62) ">"
+                    WHITESPACE@[62; 63) " "
+                    RECORD_LIT@[63; 77)
+                      PATH@[63; 67)
+                        PATH_SEGMENT@[63; 67)
+                          NAME_REF@[63; 67)
+                            IDENT@[63; 67) "Test"
+                      RECORD_FIELD_LIST@[67; 77)
+                        L_CURLY@[67; 68) "{"
+                        RECORD_FIELD@[68; 76)
+                          NAME_REF@[68; 73)
+                            IDENT@[68; 73) "field"
+                          COLON@[73; 74) ":"
+                          WHITESPACE@[74; 75) " "
+                          LITERAL@[75; 76)
+                            INT_NUMBER@[75; 76) "0"
+                        R_CURLY@[76; 77) "}"
+                WHITESPACE@[77; 78) " "
+                FAT_ARROW@[78; 80) "=>"
+                WHITESPACE@[80; 81) " "
+                TUPLE_EXPR@[81; 83)
+                  L_PAREN@[81; 82) "("
+                  R_PAREN@[82; 83) ")"
+              COMMA@[83; 84) ","
+              WHITESPACE@[84; 93) "\n        "
+              MATCH_ARM@[93; 109)
+                BIND_PAT@[93; 94)
+                  NAME@[93; 94)
+                    IDENT@[93; 94) "X"
+                WHITESPACE@[94; 95) " "
+                PIPE@[95; 96) "|"
+                WHITESPACE@[96; 97) " "
+                BIND_PAT@[97; 98)
+                  NAME@[97; 98)
+                    IDENT@[97; 98) "Y"
+                WHITESPACE@[98; 99) " "
+                MATCH_GUARD@[99; 103)
+                  IF_KW@[99; 101) "if"
+                  WHITESPACE@[101; 102) " "
+                  PATH_EXPR@[102; 103)
+                    PATH@[102; 103)
+                      PATH_SEGMENT@[102; 103)
+                        NAME_REF@[102; 103)
+                          IDENT@[102; 103) "Z"
+                WHITESPACE@[103; 104) " "
+                FAT_ARROW@[104; 106) "=>"
+                WHITESPACE@[106; 107) " "
+                TUPLE_EXPR@[107; 109)
+                  L_PAREN@[107; 108) "("
+                  R_PAREN@[108; 109) ")"
+              COMMA@[109; 110) ","
+              WHITESPACE@[110; 119) "\n        "
+              MATCH_ARM@[119; 137)
+                PIPE@[119; 120) "|"
+                WHITESPACE@[120; 121) " "
+                BIND_PAT@[121; 122)
+                  NAME@[121; 122)
+                    IDENT@[121; 122) "X"
+                WHITESPACE@[122; 123) " "
+                PIPE@[123; 124) "|"
+                WHITESPACE@[124; 125) " "
+                BIND_PAT@[125; 126)
+                  NAME@[125; 126)
+                    IDENT@[125; 126) "Y"
+                WHITESPACE@[126; 127) " "
+                MATCH_GUARD@[127; 131)
+                  IF_KW@[127; 129) "if"
+                  WHITESPACE@[129; 130) " "
+                  PATH_EXPR@[130; 131)
+                    PATH@[130; 131)
+                      PATH_SEGMENT@[130; 131)
+                        NAME_REF@[130; 131)
+                          IDENT@[130; 131) "Z"
+                WHITESPACE@[131; 132) " "
+                FAT_ARROW@[132; 134) "=>"
+                WHITESPACE@[134; 135) " "
+                TUPLE_EXPR@[135; 137)
+                  L_PAREN@[135; 136) "("
+                  R_PAREN@[136; 137) ")"
+              COMMA@[137; 138) ","
+              WHITESPACE@[138; 147) "\n        "
+              MATCH_ARM@[147; 156)
+                PIPE@[147; 148) "|"
+                WHITESPACE@[148; 149) " "
+                BIND_PAT@[149; 150)
+                  NAME@[149; 150)
+                    IDENT@[149; 150) "X"
+                WHITESPACE@[150; 151) " "
+                FAT_ARROW@[151; 153) "=>"
+                WHITESPACE@[153; 154) " "
+                TUPLE_EXPR@[154; 156)
+                  L_PAREN@[154; 155) "("
+                  R_PAREN@[155; 156) ")"
+              COMMA@[156; 157) ","
+              WHITESPACE@[157; 162) "\n    "
+              R_CURLY@[162; 163) "}"
+          SEMI@[163; 164) ";"
+        WHITESPACE@[164; 165) "\n"
+        R_CURLY@[165; 166) "}"
   WHITESPACE@[166; 167) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0070_stmt_bin_expr_ambiguity.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0070_stmt_bin_expr_ambiguity.txt
@@ -8,45 +8,46 @@ SOURCE_FILE@[0; 46)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 45)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      LET_STMT@[15; 31)
-        LET_KW@[15; 18) "let"
-        WHITESPACE@[18; 19) " "
-        PLACEHOLDER_PAT@[19; 20)
-          UNDERSCORE@[19; 20) "_"
-        WHITESPACE@[20; 21) " "
-        EQ@[21; 22) "="
-        WHITESPACE@[22; 23) " "
-        BIN_EXPR@[23; 30)
-          BLOCK_EXPR@[23; 26)
-            BLOCK@[23; 26)
-              L_CURLY@[23; 24) "{"
-              LITERAL@[24; 25)
-                INT_NUMBER@[24; 25) "1"
-              R_CURLY@[25; 26) "}"
-          WHITESPACE@[26; 27) " "
-          AMP@[27; 28) "&"
-          WHITESPACE@[28; 29) " "
-          LITERAL@[29; 30)
-            INT_NUMBER@[29; 30) "2"
-        SEMI@[30; 31) ";"
-      WHITESPACE@[31; 36) "\n    "
-      EXPR_STMT@[36; 39)
-        BLOCK_EXPR@[36; 39)
-          BLOCK@[36; 39)
-            L_CURLY@[36; 37) "{"
-            LITERAL@[37; 38)
-              INT_NUMBER@[37; 38) "1"
-            R_CURLY@[38; 39) "}"
-      WHITESPACE@[39; 40) " "
-      EXPR_STMT@[40; 43)
-        REF_EXPR@[40; 42)
-          AMP@[40; 41) "&"
-          LITERAL@[41; 42)
-            INT_NUMBER@[41; 42) "2"
-        SEMI@[42; 43) ";"
-      WHITESPACE@[43; 44) "\n"
-      R_CURLY@[44; 45) "}"
+    BLOCK_EXPR@[9; 45)
+      BLOCK@[9; 45)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        LET_STMT@[15; 31)
+          LET_KW@[15; 18) "let"
+          WHITESPACE@[18; 19) " "
+          PLACEHOLDER_PAT@[19; 20)
+            UNDERSCORE@[19; 20) "_"
+          WHITESPACE@[20; 21) " "
+          EQ@[21; 22) "="
+          WHITESPACE@[22; 23) " "
+          BIN_EXPR@[23; 30)
+            BLOCK_EXPR@[23; 26)
+              BLOCK@[23; 26)
+                L_CURLY@[23; 24) "{"
+                LITERAL@[24; 25)
+                  INT_NUMBER@[24; 25) "1"
+                R_CURLY@[25; 26) "}"
+            WHITESPACE@[26; 27) " "
+            AMP@[27; 28) "&"
+            WHITESPACE@[28; 29) " "
+            LITERAL@[29; 30)
+              INT_NUMBER@[29; 30) "2"
+          SEMI@[30; 31) ";"
+        WHITESPACE@[31; 36) "\n    "
+        EXPR_STMT@[36; 39)
+          BLOCK_EXPR@[36; 39)
+            BLOCK@[36; 39)
+              L_CURLY@[36; 37) "{"
+              LITERAL@[37; 38)
+                INT_NUMBER@[37; 38) "1"
+              R_CURLY@[38; 39) "}"
+        WHITESPACE@[39; 40) " "
+        EXPR_STMT@[40; 43)
+          REF_EXPR@[40; 42)
+            AMP@[40; 41) "&"
+            LITERAL@[41; 42)
+              INT_NUMBER@[41; 42) "2"
+          SEMI@[42; 43) ";"
+        WHITESPACE@[43; 44) "\n"
+        R_CURLY@[44; 45) "}"
   WHITESPACE@[45; 46) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0071_match_expr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0071_match_expr.txt
@@ -8,37 +8,38 @@ SOURCE_FILE@[0; 47)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 46)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 28)
-        MATCH_EXPR@[15; 27)
-          MATCH_KW@[15; 20) "match"
-          WHITESPACE@[20; 21) " "
-          TUPLE_EXPR@[21; 23)
-            L_PAREN@[21; 22) "("
-            R_PAREN@[22; 23) ")"
-          WHITESPACE@[23; 24) " "
-          MATCH_ARM_LIST@[24; 27)
-            L_CURLY@[24; 25) "{"
-            WHITESPACE@[25; 26) " "
-            R_CURLY@[26; 27) "}"
-        SEMI@[27; 28) ";"
-      WHITESPACE@[28; 33) "\n    "
-      EXPR_STMT@[33; 44)
-        MATCH_EXPR@[33; 43)
-          MATCH_KW@[33; 38) "match"
-          WHITESPACE@[38; 39) " "
-          PATH_EXPR@[39; 40)
-            PATH@[39; 40)
-              PATH_SEGMENT@[39; 40)
-                NAME_REF@[39; 40)
-                  IDENT@[39; 40) "S"
-          WHITESPACE@[40; 41) " "
-          MATCH_ARM_LIST@[41; 43)
-            L_CURLY@[41; 42) "{"
-            R_CURLY@[42; 43) "}"
-        SEMI@[43; 44) ";"
-      WHITESPACE@[44; 45) "\n"
-      R_CURLY@[45; 46) "}"
+    BLOCK_EXPR@[9; 46)
+      BLOCK@[9; 46)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        EXPR_STMT@[15; 28)
+          MATCH_EXPR@[15; 27)
+            MATCH_KW@[15; 20) "match"
+            WHITESPACE@[20; 21) " "
+            TUPLE_EXPR@[21; 23)
+              L_PAREN@[21; 22) "("
+              R_PAREN@[22; 23) ")"
+            WHITESPACE@[23; 24) " "
+            MATCH_ARM_LIST@[24; 27)
+              L_CURLY@[24; 25) "{"
+              WHITESPACE@[25; 26) " "
+              R_CURLY@[26; 27) "}"
+          SEMI@[27; 28) ";"
+        WHITESPACE@[28; 33) "\n    "
+        EXPR_STMT@[33; 44)
+          MATCH_EXPR@[33; 43)
+            MATCH_KW@[33; 38) "match"
+            WHITESPACE@[38; 39) " "
+            PATH_EXPR@[39; 40)
+              PATH@[39; 40)
+                PATH_SEGMENT@[39; 40)
+                  NAME_REF@[39; 40)
+                    IDENT@[39; 40) "S"
+            WHITESPACE@[40; 41) " "
+            MATCH_ARM_LIST@[41; 43)
+              L_CURLY@[41; 42) "{"
+              R_CURLY@[42; 43) "}"
+          SEMI@[43; 44) ";"
+        WHITESPACE@[44; 45) "\n"
+        R_CURLY@[45; 46) "}"
   WHITESPACE@[46; 47) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0072_return_expr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0072_return_expr.txt
@@ -8,21 +8,22 @@ SOURCE_FILE@[0; 40)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 39)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 22)
-        RETURN_EXPR@[15; 21)
-          RETURN_KW@[15; 21) "return"
-        SEMI@[21; 22) ";"
-      WHITESPACE@[22; 27) "\n    "
-      EXPR_STMT@[27; 37)
-        RETURN_EXPR@[27; 36)
-          RETURN_KW@[27; 33) "return"
-          WHITESPACE@[33; 34) " "
-          LITERAL@[34; 36)
-            INT_NUMBER@[34; 36) "92"
-        SEMI@[36; 37) ";"
-      WHITESPACE@[37; 38) "\n"
-      R_CURLY@[38; 39) "}"
+    BLOCK_EXPR@[9; 39)
+      BLOCK@[9; 39)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        EXPR_STMT@[15; 22)
+          RETURN_EXPR@[15; 21)
+            RETURN_KW@[15; 21) "return"
+          SEMI@[21; 22) ";"
+        WHITESPACE@[22; 27) "\n    "
+        EXPR_STMT@[27; 37)
+          RETURN_EXPR@[27; 36)
+            RETURN_KW@[27; 33) "return"
+            WHITESPACE@[33; 34) " "
+            LITERAL@[34; 36)
+              INT_NUMBER@[34; 36) "92"
+          SEMI@[36; 37) ";"
+        WHITESPACE@[37; 38) "\n"
+        R_CURLY@[38; 39) "}"
   WHITESPACE@[39; 40) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0074_stmt_postfix_expr_ambiguity.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0074_stmt_postfix_expr_ambiguity.txt
@@ -8,55 +8,56 @@ SOURCE_FILE@[0; 84)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 83)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      MATCH_EXPR@[15; 81)
-        MATCH_KW@[15; 20) "match"
-        WHITESPACE@[20; 21) " "
-        TUPLE_EXPR@[21; 23)
-          L_PAREN@[21; 22) "("
-          R_PAREN@[22; 23) ")"
-        WHITESPACE@[23; 24) " "
-        MATCH_ARM_LIST@[24; 81)
-          L_CURLY@[24; 25) "{"
-          WHITESPACE@[25; 34) "\n        "
-          MATCH_ARM@[34; 41)
-            PLACEHOLDER_PAT@[34; 35)
-              UNDERSCORE@[34; 35) "_"
-            WHITESPACE@[35; 36) " "
-            FAT_ARROW@[36; 38) "=>"
-            WHITESPACE@[38; 39) " "
-            BLOCK_EXPR@[39; 41)
-              BLOCK@[39; 41)
-                L_CURLY@[39; 40) "{"
-                R_CURLY@[40; 41) "}"
-          WHITESPACE@[41; 50) "\n        "
-          MATCH_ARM@[50; 58)
-            TUPLE_PAT@[50; 52)
-              L_PAREN@[50; 51) "("
-              R_PAREN@[51; 52) ")"
-            WHITESPACE@[52; 53) " "
-            FAT_ARROW@[53; 55) "=>"
-            WHITESPACE@[55; 56) " "
-            BLOCK_EXPR@[56; 58)
-              BLOCK@[56; 58)
-                L_CURLY@[56; 57) "{"
-                R_CURLY@[57; 58) "}"
-          WHITESPACE@[58; 67) "\n        "
-          MATCH_ARM@[67; 75)
-            SLICE_PAT@[67; 69)
-              L_BRACK@[67; 68) "["
-              R_BRACK@[68; 69) "]"
-            WHITESPACE@[69; 70) " "
-            FAT_ARROW@[70; 72) "=>"
-            WHITESPACE@[72; 73) " "
-            BLOCK_EXPR@[73; 75)
-              BLOCK@[73; 75)
-                L_CURLY@[73; 74) "{"
-                R_CURLY@[74; 75) "}"
-          WHITESPACE@[75; 80) "\n    "
-          R_CURLY@[80; 81) "}"
-      WHITESPACE@[81; 82) "\n"
-      R_CURLY@[82; 83) "}"
+    BLOCK_EXPR@[9; 83)
+      BLOCK@[9; 83)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        MATCH_EXPR@[15; 81)
+          MATCH_KW@[15; 20) "match"
+          WHITESPACE@[20; 21) " "
+          TUPLE_EXPR@[21; 23)
+            L_PAREN@[21; 22) "("
+            R_PAREN@[22; 23) ")"
+          WHITESPACE@[23; 24) " "
+          MATCH_ARM_LIST@[24; 81)
+            L_CURLY@[24; 25) "{"
+            WHITESPACE@[25; 34) "\n        "
+            MATCH_ARM@[34; 41)
+              PLACEHOLDER_PAT@[34; 35)
+                UNDERSCORE@[34; 35) "_"
+              WHITESPACE@[35; 36) " "
+              FAT_ARROW@[36; 38) "=>"
+              WHITESPACE@[38; 39) " "
+              BLOCK_EXPR@[39; 41)
+                BLOCK@[39; 41)
+                  L_CURLY@[39; 40) "{"
+                  R_CURLY@[40; 41) "}"
+            WHITESPACE@[41; 50) "\n        "
+            MATCH_ARM@[50; 58)
+              TUPLE_PAT@[50; 52)
+                L_PAREN@[50; 51) "("
+                R_PAREN@[51; 52) ")"
+              WHITESPACE@[52; 53) " "
+              FAT_ARROW@[53; 55) "=>"
+              WHITESPACE@[55; 56) " "
+              BLOCK_EXPR@[56; 58)
+                BLOCK@[56; 58)
+                  L_CURLY@[56; 57) "{"
+                  R_CURLY@[57; 58) "}"
+            WHITESPACE@[58; 67) "\n        "
+            MATCH_ARM@[67; 75)
+              SLICE_PAT@[67; 69)
+                L_BRACK@[67; 68) "["
+                R_BRACK@[68; 69) "]"
+              WHITESPACE@[69; 70) " "
+              FAT_ARROW@[70; 72) "=>"
+              WHITESPACE@[72; 73) " "
+              BLOCK_EXPR@[73; 75)
+                BLOCK@[73; 75)
+                  L_CURLY@[73; 74) "{"
+                  R_CURLY@[74; 75) "}"
+            WHITESPACE@[75; 80) "\n    "
+            R_CURLY@[80; 81) "}"
+        WHITESPACE@[81; 82) "\n"
+        R_CURLY@[82; 83) "}"
   WHITESPACE@[83; 84) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0075_block.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0075_block.txt
@@ -8,9 +8,10 @@ SOURCE_FILE@[0; 65)
       L_PAREN@[4; 5) "("
       R_PAREN@[5; 6) ")"
     WHITESPACE@[6; 7) " "
-    BLOCK@[7; 9)
-      L_CURLY@[7; 8) "{"
-      R_CURLY@[8; 9) "}"
+    BLOCK_EXPR@[7; 9)
+      BLOCK@[7; 9)
+        L_CURLY@[7; 8) "{"
+        R_CURLY@[8; 9) "}"
   WHITESPACE@[9; 10) "\n"
   FN_DEF@[10; 31)
     FN_KW@[10; 12) "fn"
@@ -21,22 +22,23 @@ SOURCE_FILE@[0; 65)
       L_PAREN@[14; 15) "("
       R_PAREN@[15; 16) ")"
     WHITESPACE@[16; 17) " "
-    BLOCK@[17; 31)
-      L_CURLY@[17; 18) "{"
-      WHITESPACE@[18; 19) " "
-      LET_STMT@[19; 29)
-        LET_KW@[19; 22) "let"
-        WHITESPACE@[22; 23) " "
-        PLACEHOLDER_PAT@[23; 24)
-          UNDERSCORE@[23; 24) "_"
-        WHITESPACE@[24; 25) " "
-        EQ@[25; 26) "="
-        WHITESPACE@[26; 27) " "
-        LITERAL@[27; 28)
-          INT_NUMBER@[27; 28) "1"
-        SEMI@[28; 29) ";"
-      WHITESPACE@[29; 30) " "
-      R_CURLY@[30; 31) "}"
+    BLOCK_EXPR@[17; 31)
+      BLOCK@[17; 31)
+        L_CURLY@[17; 18) "{"
+        WHITESPACE@[18; 19) " "
+        LET_STMT@[19; 29)
+          LET_KW@[19; 22) "let"
+          WHITESPACE@[22; 23) " "
+          PLACEHOLDER_PAT@[23; 24)
+            UNDERSCORE@[23; 24) "_"
+          WHITESPACE@[24; 25) " "
+          EQ@[25; 26) "="
+          WHITESPACE@[26; 27) " "
+          LITERAL@[27; 28)
+            INT_NUMBER@[27; 28) "1"
+          SEMI@[28; 29) ";"
+        WHITESPACE@[29; 30) " "
+        R_CURLY@[30; 31) "}"
   WHITESPACE@[31; 32) "\n"
   FN_DEF@[32; 48)
     FN_KW@[32; 34) "fn"
@@ -47,20 +49,21 @@ SOURCE_FILE@[0; 65)
       L_PAREN@[36; 37) "("
       R_PAREN@[37; 38) ")"
     WHITESPACE@[38; 39) " "
-    BLOCK@[39; 48)
-      L_CURLY@[39; 40) "{"
-      WHITESPACE@[40; 41) " "
-      EXPR_STMT@[41; 43)
-        LITERAL@[41; 42)
-          INT_NUMBER@[41; 42) "1"
-        SEMI@[42; 43) ";"
-      WHITESPACE@[43; 44) " "
-      EXPR_STMT@[44; 46)
-        LITERAL@[44; 45)
-          INT_NUMBER@[44; 45) "2"
-        SEMI@[45; 46) ";"
-      WHITESPACE@[46; 47) " "
-      R_CURLY@[47; 48) "}"
+    BLOCK_EXPR@[39; 48)
+      BLOCK@[39; 48)
+        L_CURLY@[39; 40) "{"
+        WHITESPACE@[40; 41) " "
+        EXPR_STMT@[41; 43)
+          LITERAL@[41; 42)
+            INT_NUMBER@[41; 42) "1"
+          SEMI@[42; 43) ";"
+        WHITESPACE@[43; 44) " "
+        EXPR_STMT@[44; 46)
+          LITERAL@[44; 45)
+            INT_NUMBER@[44; 45) "2"
+          SEMI@[45; 46) ";"
+        WHITESPACE@[46; 47) " "
+        R_CURLY@[47; 48) "}"
   WHITESPACE@[48; 49) "\n"
   FN_DEF@[49; 64)
     FN_KW@[49; 51) "fn"
@@ -71,16 +74,17 @@ SOURCE_FILE@[0; 65)
       L_PAREN@[53; 54) "("
       R_PAREN@[54; 55) ")"
     WHITESPACE@[55; 56) " "
-    BLOCK@[56; 64)
-      L_CURLY@[56; 57) "{"
-      WHITESPACE@[57; 58) " "
-      EXPR_STMT@[58; 60)
-        LITERAL@[58; 59)
-          INT_NUMBER@[58; 59) "1"
-        SEMI@[59; 60) ";"
-      WHITESPACE@[60; 61) " "
-      LITERAL@[61; 62)
-        INT_NUMBER@[61; 62) "2"
-      WHITESPACE@[62; 63) " "
-      R_CURLY@[63; 64) "}"
+    BLOCK_EXPR@[56; 64)
+      BLOCK@[56; 64)
+        L_CURLY@[56; 57) "{"
+        WHITESPACE@[57; 58) " "
+        EXPR_STMT@[58; 60)
+          LITERAL@[58; 59)
+            INT_NUMBER@[58; 59) "1"
+          SEMI@[59; 60) ";"
+        WHITESPACE@[60; 61) " "
+        LITERAL@[61; 62)
+          INT_NUMBER@[61; 62) "2"
+        WHITESPACE@[62; 63) " "
+        R_CURLY@[63; 64) "}"
   WHITESPACE@[64; 65) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0076_function_where_clause.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0076_function_where_clause.txt
@@ -33,7 +33,8 @@ SOURCE_FILE@[0; 29)
                   NAME_REF@[21; 25)
                     IDENT@[21; 25) "Copy"
     WHITESPACE@[25; 26) " "
-    BLOCK@[26; 28)
-      L_CURLY@[26; 27) "{"
-      R_CURLY@[27; 28) "}"
+    BLOCK_EXPR@[26; 28)
+      BLOCK@[26; 28)
+        L_CURLY@[26; 27) "{"
+        R_CURLY@[27; 28) "}"
   WHITESPACE@[28; 29) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0077_try_expr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0077_try_expr.txt
@@ -8,18 +8,19 @@ SOURCE_FILE@[0; 21)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 20)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 18)
-        TRY_EXPR@[15; 17)
-          PATH_EXPR@[15; 16)
-            PATH@[15; 16)
-              PATH_SEGMENT@[15; 16)
-                NAME_REF@[15; 16)
-                  IDENT@[15; 16) "x"
-          QUESTION@[16; 17) "?"
-        SEMI@[17; 18) ";"
-      WHITESPACE@[18; 19) "\n"
-      R_CURLY@[19; 20) "}"
+    BLOCK_EXPR@[9; 20)
+      BLOCK@[9; 20)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        EXPR_STMT@[15; 18)
+          TRY_EXPR@[15; 17)
+            PATH_EXPR@[15; 16)
+              PATH@[15; 16)
+                PATH_SEGMENT@[15; 16)
+                  NAME_REF@[15; 16)
+                    IDENT@[15; 16) "x"
+            QUESTION@[16; 17) "?"
+          SEMI@[17; 18) ";"
+        WHITESPACE@[18; 19) "\n"
+        R_CURLY@[19; 20) "}"
   WHITESPACE@[20; 21) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0080_postfix_range.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0080_postfix_range.txt
@@ -8,23 +8,24 @@ SOURCE_FILE@[0; 26)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 25)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 11) " "
-      LET_STMT@[11; 23)
-        LET_KW@[11; 14) "let"
-        WHITESPACE@[14; 15) " "
-        BIND_PAT@[15; 16)
-          NAME@[15; 16)
-            IDENT@[15; 16) "x"
-        WHITESPACE@[16; 17) " "
-        EQ@[17; 18) "="
-        WHITESPACE@[18; 19) " "
-        RANGE_EXPR@[19; 22)
-          LITERAL@[19; 20)
-            INT_NUMBER@[19; 20) "1"
-          DOTDOT@[20; 22) ".."
-        SEMI@[22; 23) ";"
-      WHITESPACE@[23; 24) " "
-      R_CURLY@[24; 25) "}"
+    BLOCK_EXPR@[9; 25)
+      BLOCK@[9; 25)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 11) " "
+        LET_STMT@[11; 23)
+          LET_KW@[11; 14) "let"
+          WHITESPACE@[14; 15) " "
+          BIND_PAT@[15; 16)
+            NAME@[15; 16)
+              IDENT@[15; 16) "x"
+          WHITESPACE@[16; 17) " "
+          EQ@[17; 18) "="
+          WHITESPACE@[18; 19) " "
+          RANGE_EXPR@[19; 22)
+            LITERAL@[19; 20)
+              INT_NUMBER@[19; 20) "1"
+            DOTDOT@[20; 22) ".."
+          SEMI@[22; 23) ";"
+        WHITESPACE@[23; 24) " "
+        R_CURLY@[24; 25) "}"
   WHITESPACE@[25; 26) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0081_for_type.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0081_for_type.txt
@@ -88,9 +88,10 @@ SOURCE_FILE@[0; 200)
                   NAME_REF@[68; 76)
                     IDENT@[68; 76) "Iterator"
     WHITESPACE@[76; 77) " "
-    BLOCK@[77; 79)
-      L_CURLY@[77; 78) "{"
-      R_CURLY@[78; 79) "}"
+    BLOCK_EXPR@[77; 79)
+      BLOCK@[77; 79)
+        L_CURLY@[77; 78) "{"
+        R_CURLY@[78; 79) "}"
   WHITESPACE@[79; 80) "\n"
   FN_DEF@[80; 134)
     FN_KW@[80; 82) "fn"
@@ -153,9 +154,10 @@ SOURCE_FILE@[0; 200)
                   NAME_REF@[123; 131)
                     IDENT@[123; 131) "Iterator"
     WHITESPACE@[131; 132) " "
-    BLOCK@[132; 134)
-      L_CURLY@[132; 133) "{"
-      R_CURLY@[133; 134) "}"
+    BLOCK_EXPR@[132; 134)
+      BLOCK@[132; 134)
+        L_CURLY@[132; 133) "{"
+        R_CURLY@[133; 134) "}"
   WHITESPACE@[134; 135) "\n"
   FN_DEF@[135; 199)
     FN_KW@[135; 137) "fn"
@@ -234,7 +236,8 @@ SOURCE_FILE@[0; 200)
                   NAME_REF@[188; 196)
                     IDENT@[188; 196) "Iterator"
     WHITESPACE@[196; 197) " "
-    BLOCK@[197; 199)
-      L_CURLY@[197; 198) "{"
-      R_CURLY@[198; 199) "}"
+    BLOCK_EXPR@[197; 199)
+      BLOCK@[197; 199)
+        L_CURLY@[197; 198) "{"
+        R_CURLY@[198; 199) "}"
   WHITESPACE@[199; 200) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0082_ref_expr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0082_ref_expr.txt
@@ -8,47 +8,48 @@ SOURCE_FILE@[0; 52)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 51)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      LET_STMT@[15; 26)
-        LET_KW@[15; 18) "let"
-        WHITESPACE@[18; 19) " "
-        PLACEHOLDER_PAT@[19; 20)
-          UNDERSCORE@[19; 20) "_"
-        WHITESPACE@[20; 21) " "
-        EQ@[21; 22) "="
-        WHITESPACE@[22; 23) " "
-        REF_EXPR@[23; 25)
-          AMP@[23; 24) "&"
-          LITERAL@[24; 25)
-            INT_NUMBER@[24; 25) "1"
-        SEMI@[25; 26) ";"
-      WHITESPACE@[26; 31) "\n    "
-      LET_STMT@[31; 49)
-        LET_KW@[31; 34) "let"
-        WHITESPACE@[34; 35) " "
-        PLACEHOLDER_PAT@[35; 36)
-          UNDERSCORE@[35; 36) "_"
-        WHITESPACE@[36; 37) " "
-        EQ@[37; 38) "="
-        WHITESPACE@[38; 39) " "
-        REF_EXPR@[39; 48)
-          AMP@[39; 40) "&"
-          MUT_KW@[40; 43) "mut"
-          WHITESPACE@[43; 44) " "
-          REF_EXPR@[44; 48)
-            AMP@[44; 45) "&"
-            CALL_EXPR@[45; 48)
-              PATH_EXPR@[45; 46)
-                PATH@[45; 46)
-                  PATH_SEGMENT@[45; 46)
-                    NAME_REF@[45; 46)
-                      IDENT@[45; 46) "f"
-              ARG_LIST@[46; 48)
-                L_PAREN@[46; 47) "("
-                R_PAREN@[47; 48) ")"
-        SEMI@[48; 49) ";"
-      WHITESPACE@[49; 50) "\n"
-      R_CURLY@[50; 51) "}"
+    BLOCK_EXPR@[9; 51)
+      BLOCK@[9; 51)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        LET_STMT@[15; 26)
+          LET_KW@[15; 18) "let"
+          WHITESPACE@[18; 19) " "
+          PLACEHOLDER_PAT@[19; 20)
+            UNDERSCORE@[19; 20) "_"
+          WHITESPACE@[20; 21) " "
+          EQ@[21; 22) "="
+          WHITESPACE@[22; 23) " "
+          REF_EXPR@[23; 25)
+            AMP@[23; 24) "&"
+            LITERAL@[24; 25)
+              INT_NUMBER@[24; 25) "1"
+          SEMI@[25; 26) ";"
+        WHITESPACE@[26; 31) "\n    "
+        LET_STMT@[31; 49)
+          LET_KW@[31; 34) "let"
+          WHITESPACE@[34; 35) " "
+          PLACEHOLDER_PAT@[35; 36)
+            UNDERSCORE@[35; 36) "_"
+          WHITESPACE@[36; 37) " "
+          EQ@[37; 38) "="
+          WHITESPACE@[38; 39) " "
+          REF_EXPR@[39; 48)
+            AMP@[39; 40) "&"
+            MUT_KW@[40; 43) "mut"
+            WHITESPACE@[43; 44) " "
+            REF_EXPR@[44; 48)
+              AMP@[44; 45) "&"
+              CALL_EXPR@[45; 48)
+                PATH_EXPR@[45; 46)
+                  PATH@[45; 46)
+                    PATH_SEGMENT@[45; 46)
+                      NAME_REF@[45; 46)
+                        IDENT@[45; 46) "f"
+                ARG_LIST@[46; 48)
+                  L_PAREN@[46; 47) "("
+                  R_PAREN@[47; 48) ")"
+          SEMI@[48; 49) ";"
+        WHITESPACE@[49; 50) "\n"
+        R_CURLY@[50; 51) "}"
   WHITESPACE@[51; 52) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0085_expr_literals.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0085_expr_literals.txt
@@ -8,128 +8,129 @@ SOURCE_FILE@[0; 189)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 188)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      LET_STMT@[15; 28)
-        LET_KW@[15; 18) "let"
-        WHITESPACE@[18; 19) " "
-        PLACEHOLDER_PAT@[19; 20)
-          UNDERSCORE@[19; 20) "_"
-        WHITESPACE@[20; 21) " "
-        EQ@[21; 22) "="
-        WHITESPACE@[22; 23) " "
-        LITERAL@[23; 27)
-          TRUE_KW@[23; 27) "true"
-        SEMI@[27; 28) ";"
-      WHITESPACE@[28; 33) "\n    "
-      LET_STMT@[33; 47)
-        LET_KW@[33; 36) "let"
-        WHITESPACE@[36; 37) " "
-        PLACEHOLDER_PAT@[37; 38)
-          UNDERSCORE@[37; 38) "_"
-        WHITESPACE@[38; 39) " "
-        EQ@[39; 40) "="
-        WHITESPACE@[40; 41) " "
-        LITERAL@[41; 46)
-          FALSE_KW@[41; 46) "false"
-        SEMI@[46; 47) ";"
-      WHITESPACE@[47; 52) "\n    "
-      LET_STMT@[52; 62)
-        LET_KW@[52; 55) "let"
-        WHITESPACE@[55; 56) " "
-        PLACEHOLDER_PAT@[56; 57)
-          UNDERSCORE@[56; 57) "_"
-        WHITESPACE@[57; 58) " "
-        EQ@[58; 59) "="
-        WHITESPACE@[59; 60) " "
-        LITERAL@[60; 61)
-          INT_NUMBER@[60; 61) "1"
-        SEMI@[61; 62) ";"
-      WHITESPACE@[62; 67) "\n    "
-      LET_STMT@[67; 79)
-        LET_KW@[67; 70) "let"
-        WHITESPACE@[70; 71) " "
-        PLACEHOLDER_PAT@[71; 72)
-          UNDERSCORE@[71; 72) "_"
-        WHITESPACE@[72; 73) " "
-        EQ@[73; 74) "="
-        WHITESPACE@[74; 75) " "
-        LITERAL@[75; 78)
-          FLOAT_NUMBER@[75; 78) "2.0"
-        SEMI@[78; 79) ";"
-      WHITESPACE@[79; 84) "\n    "
-      LET_STMT@[84; 97)
-        LET_KW@[84; 87) "let"
-        WHITESPACE@[87; 88) " "
-        PLACEHOLDER_PAT@[88; 89)
-          UNDERSCORE@[88; 89) "_"
-        WHITESPACE@[89; 90) " "
-        EQ@[90; 91) "="
-        WHITESPACE@[91; 92) " "
-        LITERAL@[92; 96)
-          BYTE@[92; 96) "b\'a\'"
-        SEMI@[96; 97) ";"
-      WHITESPACE@[97; 102) "\n    "
-      LET_STMT@[102; 114)
-        LET_KW@[102; 105) "let"
-        WHITESPACE@[105; 106) " "
-        PLACEHOLDER_PAT@[106; 107)
-          UNDERSCORE@[106; 107) "_"
-        WHITESPACE@[107; 108) " "
-        EQ@[108; 109) "="
-        WHITESPACE@[109; 110) " "
-        LITERAL@[110; 113)
-          CHAR@[110; 113) "\'b\'"
-        SEMI@[113; 114) ";"
-      WHITESPACE@[114; 119) "\n    "
-      LET_STMT@[119; 131)
-        LET_KW@[119; 122) "let"
-        WHITESPACE@[122; 123) " "
-        PLACEHOLDER_PAT@[123; 124)
-          UNDERSCORE@[123; 124) "_"
-        WHITESPACE@[124; 125) " "
-        EQ@[125; 126) "="
-        WHITESPACE@[126; 127) " "
-        LITERAL@[127; 130)
-          STRING@[127; 130) "\"c\""
-        SEMI@[130; 131) ";"
-      WHITESPACE@[131; 136) "\n    "
-      LET_STMT@[136; 149)
-        LET_KW@[136; 139) "let"
-        WHITESPACE@[139; 140) " "
-        PLACEHOLDER_PAT@[140; 141)
-          UNDERSCORE@[140; 141) "_"
-        WHITESPACE@[141; 142) " "
-        EQ@[142; 143) "="
-        WHITESPACE@[143; 144) " "
-        LITERAL@[144; 148)
-          RAW_STRING@[144; 148) "r\"d\""
-        SEMI@[148; 149) ";"
-      WHITESPACE@[149; 154) "\n    "
-      LET_STMT@[154; 167)
-        LET_KW@[154; 157) "let"
-        WHITESPACE@[157; 158) " "
-        PLACEHOLDER_PAT@[158; 159)
-          UNDERSCORE@[158; 159) "_"
-        WHITESPACE@[159; 160) " "
-        EQ@[160; 161) "="
-        WHITESPACE@[161; 162) " "
-        LITERAL@[162; 166)
-          BYTE_STRING@[162; 166) "b\"e\""
-        SEMI@[166; 167) ";"
-      WHITESPACE@[167; 172) "\n    "
-      LET_STMT@[172; 186)
-        LET_KW@[172; 175) "let"
-        WHITESPACE@[175; 176) " "
-        PLACEHOLDER_PAT@[176; 177)
-          UNDERSCORE@[176; 177) "_"
-        WHITESPACE@[177; 178) " "
-        EQ@[178; 179) "="
-        WHITESPACE@[179; 180) " "
-        LITERAL@[180; 185)
-          RAW_BYTE_STRING@[180; 185) "br\"f\""
-        SEMI@[185; 186) ";"
-      WHITESPACE@[186; 187) "\n"
-      R_CURLY@[187; 188) "}"
+    BLOCK_EXPR@[9; 188)
+      BLOCK@[9; 188)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        LET_STMT@[15; 28)
+          LET_KW@[15; 18) "let"
+          WHITESPACE@[18; 19) " "
+          PLACEHOLDER_PAT@[19; 20)
+            UNDERSCORE@[19; 20) "_"
+          WHITESPACE@[20; 21) " "
+          EQ@[21; 22) "="
+          WHITESPACE@[22; 23) " "
+          LITERAL@[23; 27)
+            TRUE_KW@[23; 27) "true"
+          SEMI@[27; 28) ";"
+        WHITESPACE@[28; 33) "\n    "
+        LET_STMT@[33; 47)
+          LET_KW@[33; 36) "let"
+          WHITESPACE@[36; 37) " "
+          PLACEHOLDER_PAT@[37; 38)
+            UNDERSCORE@[37; 38) "_"
+          WHITESPACE@[38; 39) " "
+          EQ@[39; 40) "="
+          WHITESPACE@[40; 41) " "
+          LITERAL@[41; 46)
+            FALSE_KW@[41; 46) "false"
+          SEMI@[46; 47) ";"
+        WHITESPACE@[47; 52) "\n    "
+        LET_STMT@[52; 62)
+          LET_KW@[52; 55) "let"
+          WHITESPACE@[55; 56) " "
+          PLACEHOLDER_PAT@[56; 57)
+            UNDERSCORE@[56; 57) "_"
+          WHITESPACE@[57; 58) " "
+          EQ@[58; 59) "="
+          WHITESPACE@[59; 60) " "
+          LITERAL@[60; 61)
+            INT_NUMBER@[60; 61) "1"
+          SEMI@[61; 62) ";"
+        WHITESPACE@[62; 67) "\n    "
+        LET_STMT@[67; 79)
+          LET_KW@[67; 70) "let"
+          WHITESPACE@[70; 71) " "
+          PLACEHOLDER_PAT@[71; 72)
+            UNDERSCORE@[71; 72) "_"
+          WHITESPACE@[72; 73) " "
+          EQ@[73; 74) "="
+          WHITESPACE@[74; 75) " "
+          LITERAL@[75; 78)
+            FLOAT_NUMBER@[75; 78) "2.0"
+          SEMI@[78; 79) ";"
+        WHITESPACE@[79; 84) "\n    "
+        LET_STMT@[84; 97)
+          LET_KW@[84; 87) "let"
+          WHITESPACE@[87; 88) " "
+          PLACEHOLDER_PAT@[88; 89)
+            UNDERSCORE@[88; 89) "_"
+          WHITESPACE@[89; 90) " "
+          EQ@[90; 91) "="
+          WHITESPACE@[91; 92) " "
+          LITERAL@[92; 96)
+            BYTE@[92; 96) "b\'a\'"
+          SEMI@[96; 97) ";"
+        WHITESPACE@[97; 102) "\n    "
+        LET_STMT@[102; 114)
+          LET_KW@[102; 105) "let"
+          WHITESPACE@[105; 106) " "
+          PLACEHOLDER_PAT@[106; 107)
+            UNDERSCORE@[106; 107) "_"
+          WHITESPACE@[107; 108) " "
+          EQ@[108; 109) "="
+          WHITESPACE@[109; 110) " "
+          LITERAL@[110; 113)
+            CHAR@[110; 113) "\'b\'"
+          SEMI@[113; 114) ";"
+        WHITESPACE@[114; 119) "\n    "
+        LET_STMT@[119; 131)
+          LET_KW@[119; 122) "let"
+          WHITESPACE@[122; 123) " "
+          PLACEHOLDER_PAT@[123; 124)
+            UNDERSCORE@[123; 124) "_"
+          WHITESPACE@[124; 125) " "
+          EQ@[125; 126) "="
+          WHITESPACE@[126; 127) " "
+          LITERAL@[127; 130)
+            STRING@[127; 130) "\"c\""
+          SEMI@[130; 131) ";"
+        WHITESPACE@[131; 136) "\n    "
+        LET_STMT@[136; 149)
+          LET_KW@[136; 139) "let"
+          WHITESPACE@[139; 140) " "
+          PLACEHOLDER_PAT@[140; 141)
+            UNDERSCORE@[140; 141) "_"
+          WHITESPACE@[141; 142) " "
+          EQ@[142; 143) "="
+          WHITESPACE@[143; 144) " "
+          LITERAL@[144; 148)
+            RAW_STRING@[144; 148) "r\"d\""
+          SEMI@[148; 149) ";"
+        WHITESPACE@[149; 154) "\n    "
+        LET_STMT@[154; 167)
+          LET_KW@[154; 157) "let"
+          WHITESPACE@[157; 158) " "
+          PLACEHOLDER_PAT@[158; 159)
+            UNDERSCORE@[158; 159) "_"
+          WHITESPACE@[159; 160) " "
+          EQ@[160; 161) "="
+          WHITESPACE@[161; 162) " "
+          LITERAL@[162; 166)
+            BYTE_STRING@[162; 166) "b\"e\""
+          SEMI@[166; 167) ";"
+        WHITESPACE@[167; 172) "\n    "
+        LET_STMT@[172; 186)
+          LET_KW@[172; 175) "let"
+          WHITESPACE@[175; 176) " "
+          PLACEHOLDER_PAT@[176; 177)
+            UNDERSCORE@[176; 177) "_"
+          WHITESPACE@[177; 178) " "
+          EQ@[178; 179) "="
+          WHITESPACE@[179; 180) " "
+          LITERAL@[180; 185)
+            RAW_BYTE_STRING@[180; 185) "br\"f\""
+          SEMI@[185; 186) ";"
+        WHITESPACE@[186; 187) "\n"
+        R_CURLY@[187; 188) "}"
   WHITESPACE@[188; 189) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0086_function_ret_type.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0086_function_ret_type.txt
@@ -8,9 +8,10 @@ SOURCE_FILE@[0; 30)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 11)
-      L_CURLY@[9; 10) "{"
-      R_CURLY@[10; 11) "}"
+    BLOCK_EXPR@[9; 11)
+      BLOCK@[9; 11)
+        L_CURLY@[9; 10) "{"
+        R_CURLY@[10; 11) "}"
   WHITESPACE@[11; 12) "\n"
   FN_DEF@[12; 29)
     FN_KW@[12; 14) "fn"
@@ -28,7 +29,8 @@ SOURCE_FILE@[0; 30)
         L_PAREN@[24; 25) "("
         R_PAREN@[25; 26) ")"
     WHITESPACE@[26; 27) " "
-    BLOCK@[27; 29)
-      L_CURLY@[27; 28) "{"
-      R_CURLY@[28; 29) "}"
+    BLOCK_EXPR@[27; 29)
+      BLOCK@[27; 29)
+        L_CURLY@[27; 28) "{"
+        R_CURLY@[28; 29) "}"
   WHITESPACE@[29; 30) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0088_break_ambiguity.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0088_break_ambiguity.txt
@@ -7,59 +7,63 @@ SOURCE_FILE@[0; 88)
     PARAM_LIST@[6; 8)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
-    BLOCK@[8; 87)
-      L_CURLY@[8; 9) "{"
-      WHITESPACE@[9; 14) "\n    "
-      EXPR_STMT@[14; 25)
-        IF_EXPR@[14; 25)
-          IF_KW@[14; 16) "if"
-          WHITESPACE@[16; 17) " "
-          CONDITION@[17; 22)
-            BREAK_EXPR@[17; 22)
-              BREAK_KW@[17; 22) "break"
-          WHITESPACE@[22; 23) " "
-          BLOCK@[23; 25)
-            L_CURLY@[23; 24) "{"
-            R_CURLY@[24; 25) "}"
-      WHITESPACE@[25; 30) "\n    "
-      EXPR_STMT@[30; 44)
-        WHILE_EXPR@[30; 44)
-          WHILE_KW@[30; 35) "while"
-          WHITESPACE@[35; 36) " "
-          CONDITION@[36; 41)
-            BREAK_EXPR@[36; 41)
-              BREAK_KW@[36; 41) "break"
-          WHITESPACE@[41; 42) " "
-          BLOCK@[42; 44)
-            L_CURLY@[42; 43) "{"
-            R_CURLY@[43; 44) "}"
-      WHITESPACE@[44; 49) "\n    "
-      EXPR_STMT@[49; 66)
-        FOR_EXPR@[49; 66)
-          FOR_KW@[49; 52) "for"
-          WHITESPACE@[52; 53) " "
-          BIND_PAT@[53; 54)
-            NAME@[53; 54)
-              IDENT@[53; 54) "i"
-          WHITESPACE@[54; 55) " "
-          IN_KW@[55; 57) "in"
-          WHITESPACE@[57; 58) " "
-          BREAK_EXPR@[58; 63)
-            BREAK_KW@[58; 63) "break"
-          WHITESPACE@[63; 64) " "
-          BLOCK@[64; 66)
-            L_CURLY@[64; 65) "{"
-            R_CURLY@[65; 66) "}"
-      WHITESPACE@[66; 71) "\n    "
-      MATCH_EXPR@[71; 85)
-        MATCH_KW@[71; 76) "match"
-        WHITESPACE@[76; 77) " "
-        BREAK_EXPR@[77; 82)
-          BREAK_KW@[77; 82) "break"
-        WHITESPACE@[82; 83) " "
-        MATCH_ARM_LIST@[83; 85)
-          L_CURLY@[83; 84) "{"
-          R_CURLY@[84; 85) "}"
-      WHITESPACE@[85; 86) "\n"
-      R_CURLY@[86; 87) "}"
+    BLOCK_EXPR@[8; 87)
+      BLOCK@[8; 87)
+        L_CURLY@[8; 9) "{"
+        WHITESPACE@[9; 14) "\n    "
+        EXPR_STMT@[14; 25)
+          IF_EXPR@[14; 25)
+            IF_KW@[14; 16) "if"
+            WHITESPACE@[16; 17) " "
+            CONDITION@[17; 22)
+              BREAK_EXPR@[17; 22)
+                BREAK_KW@[17; 22) "break"
+            WHITESPACE@[22; 23) " "
+            BLOCK_EXPR@[23; 25)
+              BLOCK@[23; 25)
+                L_CURLY@[23; 24) "{"
+                R_CURLY@[24; 25) "}"
+        WHITESPACE@[25; 30) "\n    "
+        EXPR_STMT@[30; 44)
+          WHILE_EXPR@[30; 44)
+            WHILE_KW@[30; 35) "while"
+            WHITESPACE@[35; 36) " "
+            CONDITION@[36; 41)
+              BREAK_EXPR@[36; 41)
+                BREAK_KW@[36; 41) "break"
+            WHITESPACE@[41; 42) " "
+            BLOCK_EXPR@[42; 44)
+              BLOCK@[42; 44)
+                L_CURLY@[42; 43) "{"
+                R_CURLY@[43; 44) "}"
+        WHITESPACE@[44; 49) "\n    "
+        EXPR_STMT@[49; 66)
+          FOR_EXPR@[49; 66)
+            FOR_KW@[49; 52) "for"
+            WHITESPACE@[52; 53) " "
+            BIND_PAT@[53; 54)
+              NAME@[53; 54)
+                IDENT@[53; 54) "i"
+            WHITESPACE@[54; 55) " "
+            IN_KW@[55; 57) "in"
+            WHITESPACE@[57; 58) " "
+            BREAK_EXPR@[58; 63)
+              BREAK_KW@[58; 63) "break"
+            WHITESPACE@[63; 64) " "
+            BLOCK_EXPR@[64; 66)
+              BLOCK@[64; 66)
+                L_CURLY@[64; 65) "{"
+                R_CURLY@[65; 66) "}"
+        WHITESPACE@[66; 71) "\n    "
+        MATCH_EXPR@[71; 85)
+          MATCH_KW@[71; 76) "match"
+          WHITESPACE@[76; 77) " "
+          BREAK_EXPR@[77; 82)
+            BREAK_KW@[77; 82) "break"
+          WHITESPACE@[82; 83) " "
+          MATCH_ARM_LIST@[83; 85)
+            L_CURLY@[83; 84) "{"
+            R_CURLY@[84; 85) "}"
+        WHITESPACE@[85; 86) "\n"
+        R_CURLY@[86; 87) "}"
   WHITESPACE@[87; 88) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0089_extern_fn.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0089_extern_fn.txt
@@ -11,7 +11,8 @@ SOURCE_FILE@[0; 19)
       L_PAREN@[13; 14) "("
       R_PAREN@[14; 15) ")"
     WHITESPACE@[15; 16) " "
-    BLOCK@[16; 18)
-      L_CURLY@[16; 17) "{"
-      R_CURLY@[17; 18) "}"
+    BLOCK_EXPR@[16; 18)
+      BLOCK@[16; 18)
+        L_CURLY@[16; 17) "{"
+        R_CURLY@[17; 18) "}"
   WHITESPACE@[18; 19) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0093_index_expr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0093_index_expr.txt
@@ -8,26 +8,27 @@ SOURCE_FILE@[0; 26)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 25)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 23)
-        INDEX_EXPR@[15; 22)
-          INDEX_EXPR@[15; 19)
-            PATH_EXPR@[15; 16)
-              PATH@[15; 16)
-                PATH_SEGMENT@[15; 16)
-                  NAME_REF@[15; 16)
-                    IDENT@[15; 16) "x"
-            L_BRACK@[16; 17) "["
-            LITERAL@[17; 18)
-              INT_NUMBER@[17; 18) "1"
-            R_BRACK@[18; 19) "]"
-          L_BRACK@[19; 20) "["
-          LITERAL@[20; 21)
-            INT_NUMBER@[20; 21) "2"
-          R_BRACK@[21; 22) "]"
-        SEMI@[22; 23) ";"
-      WHITESPACE@[23; 24) "\n"
-      R_CURLY@[24; 25) "}"
+    BLOCK_EXPR@[9; 25)
+      BLOCK@[9; 25)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        EXPR_STMT@[15; 23)
+          INDEX_EXPR@[15; 22)
+            INDEX_EXPR@[15; 19)
+              PATH_EXPR@[15; 16)
+                PATH@[15; 16)
+                  PATH_SEGMENT@[15; 16)
+                    NAME_REF@[15; 16)
+                      IDENT@[15; 16) "x"
+              L_BRACK@[16; 17) "["
+              LITERAL@[17; 18)
+                INT_NUMBER@[17; 18) "1"
+              R_BRACK@[18; 19) "]"
+            L_BRACK@[19; 20) "["
+            LITERAL@[20; 21)
+              INT_NUMBER@[20; 21) "2"
+            R_BRACK@[21; 22) "]"
+          SEMI@[22; 23) ";"
+        WHITESPACE@[23; 24) "\n"
+        R_CURLY@[24; 25) "}"
   WHITESPACE@[25; 26) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0095_placeholder_pat.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0095_placeholder_pat.txt
@@ -8,21 +8,22 @@ SOURCE_FILE@[0; 26)
       L_PAREN@[7; 8) "("
       R_PAREN@[8; 9) ")"
     WHITESPACE@[9; 10) " "
-    BLOCK@[10; 25)
-      L_CURLY@[10; 11) "{"
-      WHITESPACE@[11; 12) " "
-      LET_STMT@[12; 23)
-        LET_KW@[12; 15) "let"
-        WHITESPACE@[15; 16) " "
-        PLACEHOLDER_PAT@[16; 17)
-          UNDERSCORE@[16; 17) "_"
-        WHITESPACE@[17; 18) " "
-        EQ@[18; 19) "="
-        WHITESPACE@[19; 20) " "
-        TUPLE_EXPR@[20; 22)
-          L_PAREN@[20; 21) "("
-          R_PAREN@[21; 22) ")"
-        SEMI@[22; 23) ";"
-      WHITESPACE@[23; 24) " "
-      R_CURLY@[24; 25) "}"
+    BLOCK_EXPR@[10; 25)
+      BLOCK@[10; 25)
+        L_CURLY@[10; 11) "{"
+        WHITESPACE@[11; 12) " "
+        LET_STMT@[12; 23)
+          LET_KW@[12; 15) "let"
+          WHITESPACE@[15; 16) " "
+          PLACEHOLDER_PAT@[16; 17)
+            UNDERSCORE@[16; 17) "_"
+          WHITESPACE@[17; 18) " "
+          EQ@[18; 19) "="
+          WHITESPACE@[19; 20) " "
+          TUPLE_EXPR@[20; 22)
+            L_PAREN@[20; 21) "("
+            R_PAREN@[21; 22) ")"
+          SEMI@[22; 23) ";"
+        WHITESPACE@[23; 24) " "
+        R_CURLY@[24; 25) "}"
   WHITESPACE@[25; 26) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0096_no_semi_after_block.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0096_no_semi_after_block.txt
@@ -8,118 +8,123 @@ SOURCE_FILE@[0; 167)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 166)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 25)
-        IF_EXPR@[15; 25)
-          IF_KW@[15; 17) "if"
-          WHITESPACE@[17; 18) " "
-          CONDITION@[18; 22)
-            LITERAL@[18; 22)
-              TRUE_KW@[18; 22) "true"
-          WHITESPACE@[22; 23) " "
-          BLOCK@[23; 25)
-            L_CURLY@[23; 24) "{"
-            R_CURLY@[24; 25) "}"
-      WHITESPACE@[25; 30) "\n    "
-      EXPR_STMT@[30; 37)
-        LOOP_EXPR@[30; 37)
-          LOOP_KW@[30; 34) "loop"
-          WHITESPACE@[34; 35) " "
-          BLOCK@[35; 37)
-            L_CURLY@[35; 36) "{"
-            R_CURLY@[36; 37) "}"
-      WHITESPACE@[37; 42) "\n    "
-      EXPR_STMT@[42; 53)
-        MATCH_EXPR@[42; 53)
-          MATCH_KW@[42; 47) "match"
-          WHITESPACE@[47; 48) " "
-          TUPLE_EXPR@[48; 50)
-            L_PAREN@[48; 49) "("
-            R_PAREN@[49; 50) ")"
-          WHITESPACE@[50; 51) " "
-          MATCH_ARM_LIST@[51; 53)
-            L_CURLY@[51; 52) "{"
-            R_CURLY@[52; 53) "}"
-      WHITESPACE@[53; 58) "\n    "
-      EXPR_STMT@[58; 71)
-        WHILE_EXPR@[58; 71)
-          WHILE_KW@[58; 63) "while"
-          WHITESPACE@[63; 64) " "
-          CONDITION@[64; 68)
-            LITERAL@[64; 68)
-              TRUE_KW@[64; 68) "true"
-          WHITESPACE@[68; 69) " "
-          BLOCK@[69; 71)
-            L_CURLY@[69; 70) "{"
-            R_CURLY@[70; 71) "}"
-      WHITESPACE@[71; 76) "\n    "
-      EXPR_STMT@[76; 90)
-        FOR_EXPR@[76; 90)
-          FOR_KW@[76; 79) "for"
-          WHITESPACE@[79; 80) " "
-          PLACEHOLDER_PAT@[80; 81)
-            UNDERSCORE@[80; 81) "_"
-          WHITESPACE@[81; 82) " "
-          IN_KW@[82; 84) "in"
-          WHITESPACE@[84; 85) " "
-          TUPLE_EXPR@[85; 87)
-            L_PAREN@[85; 86) "("
-            R_PAREN@[86; 87) ")"
-          WHITESPACE@[87; 88) " "
-          BLOCK@[88; 90)
-            L_CURLY@[88; 89) "{"
-            R_CURLY@[89; 90) "}"
-      WHITESPACE@[90; 95) "\n    "
-      EXPR_STMT@[95; 97)
-        BLOCK_EXPR@[95; 97)
-          BLOCK@[95; 97)
-            L_CURLY@[95; 96) "{"
-            R_CURLY@[96; 97) "}"
-      WHITESPACE@[97; 102) "\n    "
-      EXPR_STMT@[102; 104)
-        BLOCK_EXPR@[102; 104)
-          BLOCK@[102; 104)
-            L_CURLY@[102; 103) "{"
-            R_CURLY@[103; 104) "}"
-      WHITESPACE@[104; 109) "\n    "
-      EXPR_STMT@[109; 152)
-        MACRO_CALL@[109; 152)
-          PATH@[109; 120)
-            PATH_SEGMENT@[109; 120)
-              NAME_REF@[109; 120)
-                IDENT@[109; 120) "macro_rules"
-          EXCL@[120; 121) "!"
-          WHITESPACE@[121; 122) " "
-          NAME@[122; 126)
-            IDENT@[122; 126) "test"
-          WHITESPACE@[126; 127) " "
-          TOKEN_TREE@[127; 152)
-            L_CURLY@[127; 128) "{"
-            WHITESPACE@[128; 138) "\n         "
-            TOKEN_TREE@[138; 140)
-              L_PAREN@[138; 139) "("
-              R_PAREN@[139; 140) ")"
-            WHITESPACE@[140; 141) " "
-            EQ@[141; 142) "="
-            R_ANGLE@[142; 143) ">"
-            WHITESPACE@[143; 144) " "
-            TOKEN_TREE@[144; 146)
-              L_CURLY@[144; 145) "{"
-              R_CURLY@[145; 146) "}"
-            WHITESPACE@[146; 151) "\n    "
-            R_CURLY@[151; 152) "}"
-      WHITESPACE@[152; 157) "\n    "
-      MACRO_CALL@[157; 164)
-        PATH@[157; 161)
-          PATH_SEGMENT@[157; 161)
-            NAME_REF@[157; 161)
-              IDENT@[157; 161) "test"
-        EXCL@[161; 162) "!"
-        TOKEN_TREE@[162; 164)
-          L_CURLY@[162; 163) "{"
-          R_CURLY@[163; 164) "}"
-      WHITESPACE@[164; 165) "\n"
-      R_CURLY@[165; 166) "}"
+    BLOCK_EXPR@[9; 166)
+      BLOCK@[9; 166)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        EXPR_STMT@[15; 25)
+          IF_EXPR@[15; 25)
+            IF_KW@[15; 17) "if"
+            WHITESPACE@[17; 18) " "
+            CONDITION@[18; 22)
+              LITERAL@[18; 22)
+                TRUE_KW@[18; 22) "true"
+            WHITESPACE@[22; 23) " "
+            BLOCK_EXPR@[23; 25)
+              BLOCK@[23; 25)
+                L_CURLY@[23; 24) "{"
+                R_CURLY@[24; 25) "}"
+        WHITESPACE@[25; 30) "\n    "
+        EXPR_STMT@[30; 37)
+          LOOP_EXPR@[30; 37)
+            LOOP_KW@[30; 34) "loop"
+            WHITESPACE@[34; 35) " "
+            BLOCK_EXPR@[35; 37)
+              BLOCK@[35; 37)
+                L_CURLY@[35; 36) "{"
+                R_CURLY@[36; 37) "}"
+        WHITESPACE@[37; 42) "\n    "
+        EXPR_STMT@[42; 53)
+          MATCH_EXPR@[42; 53)
+            MATCH_KW@[42; 47) "match"
+            WHITESPACE@[47; 48) " "
+            TUPLE_EXPR@[48; 50)
+              L_PAREN@[48; 49) "("
+              R_PAREN@[49; 50) ")"
+            WHITESPACE@[50; 51) " "
+            MATCH_ARM_LIST@[51; 53)
+              L_CURLY@[51; 52) "{"
+              R_CURLY@[52; 53) "}"
+        WHITESPACE@[53; 58) "\n    "
+        EXPR_STMT@[58; 71)
+          WHILE_EXPR@[58; 71)
+            WHILE_KW@[58; 63) "while"
+            WHITESPACE@[63; 64) " "
+            CONDITION@[64; 68)
+              LITERAL@[64; 68)
+                TRUE_KW@[64; 68) "true"
+            WHITESPACE@[68; 69) " "
+            BLOCK_EXPR@[69; 71)
+              BLOCK@[69; 71)
+                L_CURLY@[69; 70) "{"
+                R_CURLY@[70; 71) "}"
+        WHITESPACE@[71; 76) "\n    "
+        EXPR_STMT@[76; 90)
+          FOR_EXPR@[76; 90)
+            FOR_KW@[76; 79) "for"
+            WHITESPACE@[79; 80) " "
+            PLACEHOLDER_PAT@[80; 81)
+              UNDERSCORE@[80; 81) "_"
+            WHITESPACE@[81; 82) " "
+            IN_KW@[82; 84) "in"
+            WHITESPACE@[84; 85) " "
+            TUPLE_EXPR@[85; 87)
+              L_PAREN@[85; 86) "("
+              R_PAREN@[86; 87) ")"
+            WHITESPACE@[87; 88) " "
+            BLOCK_EXPR@[88; 90)
+              BLOCK@[88; 90)
+                L_CURLY@[88; 89) "{"
+                R_CURLY@[89; 90) "}"
+        WHITESPACE@[90; 95) "\n    "
+        EXPR_STMT@[95; 97)
+          BLOCK_EXPR@[95; 97)
+            BLOCK@[95; 97)
+              L_CURLY@[95; 96) "{"
+              R_CURLY@[96; 97) "}"
+        WHITESPACE@[97; 102) "\n    "
+        EXPR_STMT@[102; 104)
+          BLOCK_EXPR@[102; 104)
+            BLOCK@[102; 104)
+              L_CURLY@[102; 103) "{"
+              R_CURLY@[103; 104) "}"
+        WHITESPACE@[104; 109) "\n    "
+        EXPR_STMT@[109; 152)
+          MACRO_CALL@[109; 152)
+            PATH@[109; 120)
+              PATH_SEGMENT@[109; 120)
+                NAME_REF@[109; 120)
+                  IDENT@[109; 120) "macro_rules"
+            EXCL@[120; 121) "!"
+            WHITESPACE@[121; 122) " "
+            NAME@[122; 126)
+              IDENT@[122; 126) "test"
+            WHITESPACE@[126; 127) " "
+            TOKEN_TREE@[127; 152)
+              L_CURLY@[127; 128) "{"
+              WHITESPACE@[128; 138) "\n         "
+              TOKEN_TREE@[138; 140)
+                L_PAREN@[138; 139) "("
+                R_PAREN@[139; 140) ")"
+              WHITESPACE@[140; 141) " "
+              EQ@[141; 142) "="
+              R_ANGLE@[142; 143) ">"
+              WHITESPACE@[143; 144) " "
+              TOKEN_TREE@[144; 146)
+                L_CURLY@[144; 145) "{"
+                R_CURLY@[145; 146) "}"
+              WHITESPACE@[146; 151) "\n    "
+              R_CURLY@[151; 152) "}"
+        WHITESPACE@[152; 157) "\n    "
+        MACRO_CALL@[157; 164)
+          PATH@[157; 161)
+            PATH_SEGMENT@[157; 161)
+              NAME_REF@[157; 161)
+                IDENT@[157; 161) "test"
+          EXCL@[161; 162) "!"
+          TOKEN_TREE@[162; 164)
+            L_CURLY@[162; 163) "{"
+            R_CURLY@[163; 164) "}"
+        WHITESPACE@[164; 165) "\n"
+        R_CURLY@[165; 166) "}"
   WHITESPACE@[166; 167) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0098_const_unsafe_fn.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0098_const_unsafe_fn.txt
@@ -12,7 +12,8 @@ SOURCE_FILE@[0; 25)
       L_PAREN@[19; 20) "("
       R_PAREN@[20; 21) ")"
     WHITESPACE@[21; 22) " "
-    BLOCK@[22; 24)
-      L_CURLY@[22; 23) "{"
-      R_CURLY@[23; 24) "}"
+    BLOCK_EXPR@[22; 24)
+      BLOCK@[22; 24)
+        L_CURLY@[22; 23) "{"
+        R_CURLY@[23; 24) "}"
   WHITESPACE@[24; 25) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0099_param_list.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0099_param_list.txt
@@ -8,9 +8,10 @@ SOURCE_FILE@[0; 67)
       L_PAREN@[4; 5) "("
       R_PAREN@[5; 6) ")"
     WHITESPACE@[6; 7) " "
-    BLOCK@[7; 9)
-      L_CURLY@[7; 8) "{"
-      R_CURLY@[8; 9) "}"
+    BLOCK_EXPR@[7; 9)
+      BLOCK@[7; 9)
+        L_CURLY@[7; 8) "{"
+        R_CURLY@[8; 9) "}"
   WHITESPACE@[9; 10) "\n"
   FN_DEF@[10; 25)
     FN_KW@[10; 12) "fn"
@@ -32,9 +33,10 @@ SOURCE_FILE@[0; 67)
                 IDENT@[18; 21) "i32"
       R_PAREN@[21; 22) ")"
     WHITESPACE@[22; 23) " "
-    BLOCK@[23; 25)
-      L_CURLY@[23; 24) "{"
-      R_CURLY@[24; 25) "}"
+    BLOCK_EXPR@[23; 25)
+      BLOCK@[23; 25)
+        L_CURLY@[23; 24) "{"
+        R_CURLY@[24; 25) "}"
   WHITESPACE@[25; 26) "\n"
   FN_DEF@[26; 43)
     FN_KW@[26; 28) "fn"
@@ -58,9 +60,10 @@ SOURCE_FILE@[0; 67)
       WHITESPACE@[38; 39) " "
       R_PAREN@[39; 40) ")"
     WHITESPACE@[40; 41) " "
-    BLOCK@[41; 43)
-      L_CURLY@[41; 42) "{"
-      R_CURLY@[42; 43) "}"
+    BLOCK_EXPR@[41; 43)
+      BLOCK@[41; 43)
+        L_CURLY@[41; 42) "{"
+        R_CURLY@[42; 43) "}"
   WHITESPACE@[43; 44) "\n"
   FN_DEF@[44; 66)
     FN_KW@[44; 46) "fn"
@@ -93,7 +96,8 @@ SOURCE_FILE@[0; 67)
           R_PAREN@[61; 62) ")"
       R_PAREN@[62; 63) ")"
     WHITESPACE@[63; 64) " "
-    BLOCK@[64; 66)
-      L_CURLY@[64; 65) "{"
-      R_CURLY@[65; 66) "}"
+    BLOCK_EXPR@[64; 66)
+      BLOCK@[64; 66)
+        L_CURLY@[64; 65) "{"
+        R_CURLY@[65; 66) "}"
   WHITESPACE@[66; 67) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0100_for_expr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0100_for_expr.txt
@@ -8,27 +8,29 @@ SOURCE_FILE@[0; 33)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 32)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 30)
-        FOR_EXPR@[15; 29)
-          FOR_KW@[15; 18) "for"
-          WHITESPACE@[18; 19) " "
-          BIND_PAT@[19; 20)
-            NAME@[19; 20)
-              IDENT@[19; 20) "x"
-          WHITESPACE@[20; 21) " "
-          IN_KW@[21; 23) "in"
-          WHITESPACE@[23; 24) " "
-          ARRAY_EXPR@[24; 26)
-            L_BRACK@[24; 25) "["
-            R_BRACK@[25; 26) "]"
-          WHITESPACE@[26; 27) " "
-          BLOCK@[27; 29)
-            L_CURLY@[27; 28) "{"
-            R_CURLY@[28; 29) "}"
-        SEMI@[29; 30) ";"
-      WHITESPACE@[30; 31) "\n"
-      R_CURLY@[31; 32) "}"
+    BLOCK_EXPR@[9; 32)
+      BLOCK@[9; 32)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        EXPR_STMT@[15; 30)
+          FOR_EXPR@[15; 29)
+            FOR_KW@[15; 18) "for"
+            WHITESPACE@[18; 19) " "
+            BIND_PAT@[19; 20)
+              NAME@[19; 20)
+                IDENT@[19; 20) "x"
+            WHITESPACE@[20; 21) " "
+            IN_KW@[21; 23) "in"
+            WHITESPACE@[23; 24) " "
+            ARRAY_EXPR@[24; 26)
+              L_BRACK@[24; 25) "["
+              R_BRACK@[25; 26) "]"
+            WHITESPACE@[26; 27) " "
+            BLOCK_EXPR@[27; 29)
+              BLOCK@[27; 29)
+                L_CURLY@[27; 28) "{"
+                R_CURLY@[28; 29) "}"
+          SEMI@[29; 30) ";"
+        WHITESPACE@[30; 31) "\n"
+        R_CURLY@[31; 32) "}"
   WHITESPACE@[32; 33) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0101_unsafe_fn.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0101_unsafe_fn.txt
@@ -10,7 +10,8 @@ SOURCE_FILE@[0; 19)
       L_PAREN@[13; 14) "("
       R_PAREN@[14; 15) ")"
     WHITESPACE@[15; 16) " "
-    BLOCK@[16; 18)
-      L_CURLY@[16; 17) "{"
-      R_CURLY@[17; 18) "}"
+    BLOCK_EXPR@[16; 18)
+      BLOCK@[16; 18)
+        L_CURLY@[16; 17) "{"
+        R_CURLY@[17; 18) "}"
   WHITESPACE@[18; 19) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0102_record_field_pat_list.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0102_record_field_pat_list.txt
@@ -8,123 +8,124 @@ SOURCE_FILE@[0; 119)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 118)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      LET_STMT@[15; 29)
-        LET_KW@[15; 18) "let"
-        WHITESPACE@[18; 19) " "
-        RECORD_PAT@[19; 23)
-          PATH@[19; 20)
-            PATH_SEGMENT@[19; 20)
-              NAME_REF@[19; 20)
-                IDENT@[19; 20) "S"
-          WHITESPACE@[20; 21) " "
-          RECORD_FIELD_PAT_LIST@[21; 23)
-            L_CURLY@[21; 22) "{"
-            R_CURLY@[22; 23) "}"
-        WHITESPACE@[23; 24) " "
-        EQ@[24; 25) "="
-        WHITESPACE@[25; 26) " "
-        TUPLE_EXPR@[26; 28)
-          L_PAREN@[26; 27) "("
-          R_PAREN@[27; 28) ")"
-        SEMI@[28; 29) ";"
-      WHITESPACE@[29; 34) "\n    "
-      LET_STMT@[34; 62)
-        LET_KW@[34; 37) "let"
-        WHITESPACE@[37; 38) " "
-        RECORD_PAT@[38; 56)
-          PATH@[38; 39)
-            PATH_SEGMENT@[38; 39)
-              NAME_REF@[38; 39)
-                IDENT@[38; 39) "S"
-          WHITESPACE@[39; 40) " "
-          RECORD_FIELD_PAT_LIST@[40; 56)
-            L_CURLY@[40; 41) "{"
-            WHITESPACE@[41; 42) " "
-            BIND_PAT@[42; 43)
-              NAME@[42; 43)
-                IDENT@[42; 43) "f"
-            COMMA@[43; 44) ","
-            WHITESPACE@[44; 45) " "
-            BIND_PAT@[45; 54)
-              REF_KW@[45; 48) "ref"
-              WHITESPACE@[48; 49) " "
-              MUT_KW@[49; 52) "mut"
-              WHITESPACE@[52; 53) " "
-              NAME@[53; 54)
-                IDENT@[53; 54) "g"
-            WHITESPACE@[54; 55) " "
-            R_CURLY@[55; 56) "}"
-        WHITESPACE@[56; 57) " "
-        EQ@[57; 58) "="
-        WHITESPACE@[58; 59) " "
-        TUPLE_EXPR@[59; 61)
-          L_PAREN@[59; 60) "("
-          R_PAREN@[60; 61) ")"
-        SEMI@[61; 62) ";"
-      WHITESPACE@[62; 67) "\n    "
-      LET_STMT@[67; 90)
-        LET_KW@[67; 70) "let"
-        WHITESPACE@[70; 71) " "
-        RECORD_PAT@[71; 84)
-          PATH@[71; 72)
-            PATH_SEGMENT@[71; 72)
-              NAME_REF@[71; 72)
-                IDENT@[71; 72) "S"
-          WHITESPACE@[72; 73) " "
-          RECORD_FIELD_PAT_LIST@[73; 84)
-            L_CURLY@[73; 74) "{"
-            WHITESPACE@[74; 75) " "
-            RECORD_FIELD_PAT@[75; 79)
-              NAME@[75; 76)
-                IDENT@[75; 76) "h"
-              COLON@[76; 77) ":"
-              WHITESPACE@[77; 78) " "
-              PLACEHOLDER_PAT@[78; 79)
-                UNDERSCORE@[78; 79) "_"
-            COMMA@[79; 80) ","
-            WHITESPACE@[80; 81) " "
-            DOTDOT@[81; 83) ".."
-            R_CURLY@[83; 84) "}"
-        WHITESPACE@[84; 85) " "
-        EQ@[85; 86) "="
-        WHITESPACE@[86; 87) " "
-        TUPLE_EXPR@[87; 89)
-          L_PAREN@[87; 88) "("
-          R_PAREN@[88; 89) ")"
-        SEMI@[89; 90) ";"
-      WHITESPACE@[90; 95) "\n    "
-      LET_STMT@[95; 116)
-        LET_KW@[95; 98) "let"
-        WHITESPACE@[98; 99) " "
-        RECORD_PAT@[99; 110)
-          PATH@[99; 100)
-            PATH_SEGMENT@[99; 100)
-              NAME_REF@[99; 100)
-                IDENT@[99; 100) "S"
-          WHITESPACE@[100; 101) " "
-          RECORD_FIELD_PAT_LIST@[101; 110)
-            L_CURLY@[101; 102) "{"
-            WHITESPACE@[102; 103) " "
-            RECORD_FIELD_PAT@[103; 107)
-              NAME@[103; 104)
-                IDENT@[103; 104) "h"
-              COLON@[104; 105) ":"
-              WHITESPACE@[105; 106) " "
-              PLACEHOLDER_PAT@[106; 107)
-                UNDERSCORE@[106; 107) "_"
-            COMMA@[107; 108) ","
-            WHITESPACE@[108; 109) " "
-            R_CURLY@[109; 110) "}"
-        WHITESPACE@[110; 111) " "
-        EQ@[111; 112) "="
-        WHITESPACE@[112; 113) " "
-        TUPLE_EXPR@[113; 115)
-          L_PAREN@[113; 114) "("
-          R_PAREN@[114; 115) ")"
-        SEMI@[115; 116) ";"
-      WHITESPACE@[116; 117) "\n"
-      R_CURLY@[117; 118) "}"
+    BLOCK_EXPR@[9; 118)
+      BLOCK@[9; 118)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        LET_STMT@[15; 29)
+          LET_KW@[15; 18) "let"
+          WHITESPACE@[18; 19) " "
+          RECORD_PAT@[19; 23)
+            PATH@[19; 20)
+              PATH_SEGMENT@[19; 20)
+                NAME_REF@[19; 20)
+                  IDENT@[19; 20) "S"
+            WHITESPACE@[20; 21) " "
+            RECORD_FIELD_PAT_LIST@[21; 23)
+              L_CURLY@[21; 22) "{"
+              R_CURLY@[22; 23) "}"
+          WHITESPACE@[23; 24) " "
+          EQ@[24; 25) "="
+          WHITESPACE@[25; 26) " "
+          TUPLE_EXPR@[26; 28)
+            L_PAREN@[26; 27) "("
+            R_PAREN@[27; 28) ")"
+          SEMI@[28; 29) ";"
+        WHITESPACE@[29; 34) "\n    "
+        LET_STMT@[34; 62)
+          LET_KW@[34; 37) "let"
+          WHITESPACE@[37; 38) " "
+          RECORD_PAT@[38; 56)
+            PATH@[38; 39)
+              PATH_SEGMENT@[38; 39)
+                NAME_REF@[38; 39)
+                  IDENT@[38; 39) "S"
+            WHITESPACE@[39; 40) " "
+            RECORD_FIELD_PAT_LIST@[40; 56)
+              L_CURLY@[40; 41) "{"
+              WHITESPACE@[41; 42) " "
+              BIND_PAT@[42; 43)
+                NAME@[42; 43)
+                  IDENT@[42; 43) "f"
+              COMMA@[43; 44) ","
+              WHITESPACE@[44; 45) " "
+              BIND_PAT@[45; 54)
+                REF_KW@[45; 48) "ref"
+                WHITESPACE@[48; 49) " "
+                MUT_KW@[49; 52) "mut"
+                WHITESPACE@[52; 53) " "
+                NAME@[53; 54)
+                  IDENT@[53; 54) "g"
+              WHITESPACE@[54; 55) " "
+              R_CURLY@[55; 56) "}"
+          WHITESPACE@[56; 57) " "
+          EQ@[57; 58) "="
+          WHITESPACE@[58; 59) " "
+          TUPLE_EXPR@[59; 61)
+            L_PAREN@[59; 60) "("
+            R_PAREN@[60; 61) ")"
+          SEMI@[61; 62) ";"
+        WHITESPACE@[62; 67) "\n    "
+        LET_STMT@[67; 90)
+          LET_KW@[67; 70) "let"
+          WHITESPACE@[70; 71) " "
+          RECORD_PAT@[71; 84)
+            PATH@[71; 72)
+              PATH_SEGMENT@[71; 72)
+                NAME_REF@[71; 72)
+                  IDENT@[71; 72) "S"
+            WHITESPACE@[72; 73) " "
+            RECORD_FIELD_PAT_LIST@[73; 84)
+              L_CURLY@[73; 74) "{"
+              WHITESPACE@[74; 75) " "
+              RECORD_FIELD_PAT@[75; 79)
+                NAME@[75; 76)
+                  IDENT@[75; 76) "h"
+                COLON@[76; 77) ":"
+                WHITESPACE@[77; 78) " "
+                PLACEHOLDER_PAT@[78; 79)
+                  UNDERSCORE@[78; 79) "_"
+              COMMA@[79; 80) ","
+              WHITESPACE@[80; 81) " "
+              DOTDOT@[81; 83) ".."
+              R_CURLY@[83; 84) "}"
+          WHITESPACE@[84; 85) " "
+          EQ@[85; 86) "="
+          WHITESPACE@[86; 87) " "
+          TUPLE_EXPR@[87; 89)
+            L_PAREN@[87; 88) "("
+            R_PAREN@[88; 89) ")"
+          SEMI@[89; 90) ";"
+        WHITESPACE@[90; 95) "\n    "
+        LET_STMT@[95; 116)
+          LET_KW@[95; 98) "let"
+          WHITESPACE@[98; 99) " "
+          RECORD_PAT@[99; 110)
+            PATH@[99; 100)
+              PATH_SEGMENT@[99; 100)
+                NAME_REF@[99; 100)
+                  IDENT@[99; 100) "S"
+            WHITESPACE@[100; 101) " "
+            RECORD_FIELD_PAT_LIST@[101; 110)
+              L_CURLY@[101; 102) "{"
+              WHITESPACE@[102; 103) " "
+              RECORD_FIELD_PAT@[103; 107)
+                NAME@[103; 104)
+                  IDENT@[103; 104) "h"
+                COLON@[104; 105) ":"
+                WHITESPACE@[105; 106) " "
+                PLACEHOLDER_PAT@[106; 107)
+                  UNDERSCORE@[106; 107) "_"
+              COMMA@[107; 108) ","
+              WHITESPACE@[108; 109) " "
+              R_CURLY@[109; 110) "}"
+          WHITESPACE@[110; 111) " "
+          EQ@[111; 112) "="
+          WHITESPACE@[112; 113) " "
+          TUPLE_EXPR@[113; 115)
+            L_PAREN@[113; 114) "("
+            R_PAREN@[114; 115) ")"
+          SEMI@[115; 116) ";"
+        WHITESPACE@[116; 117) "\n"
+        R_CURLY@[117; 118) "}"
   WHITESPACE@[118; 119) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0103_array_expr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0103_array_expr.txt
@@ -8,47 +8,48 @@ SOURCE_FILE@[0; 55)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 54)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 18)
-        ARRAY_EXPR@[15; 17)
-          L_BRACK@[15; 16) "["
-          R_BRACK@[16; 17) "]"
-        SEMI@[17; 18) ";"
-      WHITESPACE@[18; 23) "\n    "
-      EXPR_STMT@[23; 27)
-        ARRAY_EXPR@[23; 26)
-          L_BRACK@[23; 24) "["
-          LITERAL@[24; 25)
-            INT_NUMBER@[24; 25) "1"
-          R_BRACK@[25; 26) "]"
-        SEMI@[26; 27) ";"
-      WHITESPACE@[27; 32) "\n    "
-      EXPR_STMT@[32; 40)
-        ARRAY_EXPR@[32; 39)
-          L_BRACK@[32; 33) "["
-          LITERAL@[33; 34)
-            INT_NUMBER@[33; 34) "1"
-          COMMA@[34; 35) ","
-          WHITESPACE@[35; 36) " "
-          LITERAL@[36; 37)
-            INT_NUMBER@[36; 37) "2"
-          COMMA@[37; 38) ","
-          R_BRACK@[38; 39) "]"
-        SEMI@[39; 40) ";"
-      WHITESPACE@[40; 45) "\n    "
-      EXPR_STMT@[45; 52)
-        ARRAY_EXPR@[45; 51)
-          L_BRACK@[45; 46) "["
-          LITERAL@[46; 47)
-            INT_NUMBER@[46; 47) "1"
-          SEMI@[47; 48) ";"
-          WHITESPACE@[48; 49) " "
-          LITERAL@[49; 50)
-            INT_NUMBER@[49; 50) "2"
-          R_BRACK@[50; 51) "]"
-        SEMI@[51; 52) ";"
-      WHITESPACE@[52; 53) "\n"
-      R_CURLY@[53; 54) "}"
+    BLOCK_EXPR@[9; 54)
+      BLOCK@[9; 54)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        EXPR_STMT@[15; 18)
+          ARRAY_EXPR@[15; 17)
+            L_BRACK@[15; 16) "["
+            R_BRACK@[16; 17) "]"
+          SEMI@[17; 18) ";"
+        WHITESPACE@[18; 23) "\n    "
+        EXPR_STMT@[23; 27)
+          ARRAY_EXPR@[23; 26)
+            L_BRACK@[23; 24) "["
+            LITERAL@[24; 25)
+              INT_NUMBER@[24; 25) "1"
+            R_BRACK@[25; 26) "]"
+          SEMI@[26; 27) ";"
+        WHITESPACE@[27; 32) "\n    "
+        EXPR_STMT@[32; 40)
+          ARRAY_EXPR@[32; 39)
+            L_BRACK@[32; 33) "["
+            LITERAL@[33; 34)
+              INT_NUMBER@[33; 34) "1"
+            COMMA@[34; 35) ","
+            WHITESPACE@[35; 36) " "
+            LITERAL@[36; 37)
+              INT_NUMBER@[36; 37) "2"
+            COMMA@[37; 38) ","
+            R_BRACK@[38; 39) "]"
+          SEMI@[39; 40) ";"
+        WHITESPACE@[40; 45) "\n    "
+        EXPR_STMT@[45; 52)
+          ARRAY_EXPR@[45; 51)
+            L_BRACK@[45; 46) "["
+            LITERAL@[46; 47)
+              INT_NUMBER@[46; 47) "1"
+            SEMI@[47; 48) ";"
+            WHITESPACE@[48; 49) " "
+            LITERAL@[49; 50)
+              INT_NUMBER@[49; 50) "2"
+            R_BRACK@[50; 51) "]"
+          SEMI@[51; 52) ";"
+        WHITESPACE@[52; 53) "\n"
+        R_CURLY@[53; 54) "}"
   WHITESPACE@[54; 55) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0105_block_expr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0105_block_expr.txt
@@ -8,35 +8,36 @@ SOURCE_FILE@[0; 52)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 51)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 18)
-        BLOCK_EXPR@[15; 17)
-          BLOCK@[15; 17)
-            L_CURLY@[15; 16) "{"
-            R_CURLY@[16; 17) "}"
-        SEMI@[17; 18) ";"
-      WHITESPACE@[18; 23) "\n    "
-      EXPR_STMT@[23; 33)
-        BLOCK_EXPR@[23; 32)
-          UNSAFE_KW@[23; 29) "unsafe"
-          WHITESPACE@[29; 30) " "
-          BLOCK@[30; 32)
-            L_CURLY@[30; 31) "{"
-            R_CURLY@[31; 32) "}"
-        SEMI@[32; 33) ";"
-      WHITESPACE@[33; 38) "\n    "
-      EXPR_STMT@[38; 49)
-        BLOCK_EXPR@[38; 48)
-          LABEL@[38; 45)
-            LIFETIME@[38; 44) "\'label"
-            COLON@[44; 45) ":"
-          WHITESPACE@[45; 46) " "
-          BLOCK@[46; 48)
-            L_CURLY@[46; 47) "{"
-            R_CURLY@[47; 48) "}"
-        SEMI@[48; 49) ";"
-      WHITESPACE@[49; 50) "\n"
-      R_CURLY@[50; 51) "}"
+    BLOCK_EXPR@[9; 51)
+      BLOCK@[9; 51)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        EXPR_STMT@[15; 18)
+          BLOCK_EXPR@[15; 17)
+            BLOCK@[15; 17)
+              L_CURLY@[15; 16) "{"
+              R_CURLY@[16; 17) "}"
+          SEMI@[17; 18) ";"
+        WHITESPACE@[18; 23) "\n    "
+        EXPR_STMT@[23; 33)
+          BLOCK_EXPR@[23; 32)
+            UNSAFE_KW@[23; 29) "unsafe"
+            WHITESPACE@[29; 30) " "
+            BLOCK@[30; 32)
+              L_CURLY@[30; 31) "{"
+              R_CURLY@[31; 32) "}"
+          SEMI@[32; 33) ";"
+        WHITESPACE@[33; 38) "\n    "
+        EXPR_STMT@[38; 49)
+          BLOCK_EXPR@[38; 48)
+            LABEL@[38; 45)
+              LIFETIME@[38; 44) "\'label"
+              COLON@[44; 45) ":"
+            WHITESPACE@[45; 46) " "
+            BLOCK@[46; 48)
+              L_CURLY@[46; 47) "{"
+              R_CURLY@[47; 48) "}"
+          SEMI@[48; 49) ";"
+        WHITESPACE@[49; 50) "\n"
+        R_CURLY@[50; 51) "}"
   WHITESPACE@[51; 52) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0106_lambda_expr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0106_lambda_expr.txt
@@ -8,132 +8,133 @@ SOURCE_FILE@[0; 134)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 133)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 21)
-        LAMBDA_EXPR@[15; 20)
-          PARAM_LIST@[15; 17)
-            PIPE@[15; 16) "|"
-            PIPE@[16; 17) "|"
-          WHITESPACE@[17; 18) " "
-          TUPLE_EXPR@[18; 20)
-            L_PAREN@[18; 19) "("
-            R_PAREN@[19; 20) ")"
-        SEMI@[20; 21) ";"
-      WHITESPACE@[21; 26) "\n    "
-      EXPR_STMT@[26; 43)
-        LAMBDA_EXPR@[26; 42)
-          PARAM_LIST@[26; 28)
-            PIPE@[26; 27) "|"
-            PIPE@[27; 28) "|"
-          WHITESPACE@[28; 29) " "
-          RET_TYPE@[29; 35)
-            THIN_ARROW@[29; 31) "->"
-            WHITESPACE@[31; 32) " "
-            PATH_TYPE@[32; 35)
-              PATH@[32; 35)
-                PATH_SEGMENT@[32; 35)
-                  NAME_REF@[32; 35)
-                    IDENT@[32; 35) "i32"
-          WHITESPACE@[35; 36) " "
-          BLOCK_EXPR@[36; 42)
-            BLOCK@[36; 42)
-              L_CURLY@[36; 37) "{"
-              WHITESPACE@[37; 38) " "
-              LITERAL@[38; 40)
-                INT_NUMBER@[38; 40) "92"
-              WHITESPACE@[40; 41) " "
-              R_CURLY@[41; 42) "}"
-        SEMI@[42; 43) ";"
-      WHITESPACE@[43; 48) "\n    "
-      EXPR_STMT@[48; 54)
-        LAMBDA_EXPR@[48; 53)
-          PARAM_LIST@[48; 51)
-            PIPE@[48; 49) "|"
-            PARAM@[49; 50)
-              BIND_PAT@[49; 50)
-                NAME@[49; 50)
-                  IDENT@[49; 50) "x"
-            PIPE@[50; 51) "|"
-          WHITESPACE@[51; 52) " "
-          PATH_EXPR@[52; 53)
-            PATH@[52; 53)
-              PATH_SEGMENT@[52; 53)
-                NAME_REF@[52; 53)
-                  IDENT@[52; 53) "x"
-        SEMI@[53; 54) ";"
-      WHITESPACE@[54; 59) "\n    "
-      EXPR_STMT@[59; 76)
-        LAMBDA_EXPR@[59; 75)
-          MOVE_KW@[59; 63) "move"
-          WHITESPACE@[63; 64) " "
-          PARAM_LIST@[64; 73)
-            PIPE@[64; 65) "|"
-            PARAM@[65; 71)
-              BIND_PAT@[65; 66)
-                NAME@[65; 66)
-                  IDENT@[65; 66) "x"
-              COLON@[66; 67) ":"
-              WHITESPACE@[67; 68) " "
-              PATH_TYPE@[68; 71)
-                PATH@[68; 71)
-                  PATH_SEGMENT@[68; 71)
-                    NAME_REF@[68; 71)
-                      IDENT@[68; 71) "i32"
-            COMMA@[71; 72) ","
-            PIPE@[72; 73) "|"
-          WHITESPACE@[73; 74) " "
-          PATH_EXPR@[74; 75)
-            PATH@[74; 75)
-              PATH_SEGMENT@[74; 75)
-                NAME_REF@[74; 75)
-                  IDENT@[74; 75) "x"
-        SEMI@[75; 76) ";"
-      WHITESPACE@[76; 81) "\n    "
-      EXPR_STMT@[81; 93)
-        LAMBDA_EXPR@[81; 92)
-          ASYNC_KW@[81; 86) "async"
-          WHITESPACE@[86; 87) " "
-          PARAM_LIST@[87; 89)
-            PIPE@[87; 88) "|"
-            PIPE@[88; 89) "|"
-          WHITESPACE@[89; 90) " "
-          BLOCK_EXPR@[90; 92)
-            BLOCK@[90; 92)
-              L_CURLY@[90; 91) "{"
-              R_CURLY@[91; 92) "}"
-        SEMI@[92; 93) ";"
-      WHITESPACE@[93; 98) "\n    "
-      EXPR_STMT@[98; 109)
-        LAMBDA_EXPR@[98; 108)
-          MOVE_KW@[98; 102) "move"
-          WHITESPACE@[102; 103) " "
-          PARAM_LIST@[103; 105)
-            PIPE@[103; 104) "|"
-            PIPE@[104; 105) "|"
-          WHITESPACE@[105; 106) " "
-          BLOCK_EXPR@[106; 108)
-            BLOCK@[106; 108)
-              L_CURLY@[106; 107) "{"
-              R_CURLY@[107; 108) "}"
-        SEMI@[108; 109) ";"
-      WHITESPACE@[109; 114) "\n    "
-      EXPR_STMT@[114; 131)
-        LAMBDA_EXPR@[114; 130)
-          ASYNC_KW@[114; 119) "async"
-          WHITESPACE@[119; 120) " "
-          MOVE_KW@[120; 124) "move"
-          WHITESPACE@[124; 125) " "
-          PARAM_LIST@[125; 127)
-            PIPE@[125; 126) "|"
-            PIPE@[126; 127) "|"
-          WHITESPACE@[127; 128) " "
-          BLOCK_EXPR@[128; 130)
-            BLOCK@[128; 130)
-              L_CURLY@[128; 129) "{"
-              R_CURLY@[129; 130) "}"
-        SEMI@[130; 131) ";"
-      WHITESPACE@[131; 132) "\n"
-      R_CURLY@[132; 133) "}"
+    BLOCK_EXPR@[9; 133)
+      BLOCK@[9; 133)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        EXPR_STMT@[15; 21)
+          LAMBDA_EXPR@[15; 20)
+            PARAM_LIST@[15; 17)
+              PIPE@[15; 16) "|"
+              PIPE@[16; 17) "|"
+            WHITESPACE@[17; 18) " "
+            TUPLE_EXPR@[18; 20)
+              L_PAREN@[18; 19) "("
+              R_PAREN@[19; 20) ")"
+          SEMI@[20; 21) ";"
+        WHITESPACE@[21; 26) "\n    "
+        EXPR_STMT@[26; 43)
+          LAMBDA_EXPR@[26; 42)
+            PARAM_LIST@[26; 28)
+              PIPE@[26; 27) "|"
+              PIPE@[27; 28) "|"
+            WHITESPACE@[28; 29) " "
+            RET_TYPE@[29; 35)
+              THIN_ARROW@[29; 31) "->"
+              WHITESPACE@[31; 32) " "
+              PATH_TYPE@[32; 35)
+                PATH@[32; 35)
+                  PATH_SEGMENT@[32; 35)
+                    NAME_REF@[32; 35)
+                      IDENT@[32; 35) "i32"
+            WHITESPACE@[35; 36) " "
+            BLOCK_EXPR@[36; 42)
+              BLOCK@[36; 42)
+                L_CURLY@[36; 37) "{"
+                WHITESPACE@[37; 38) " "
+                LITERAL@[38; 40)
+                  INT_NUMBER@[38; 40) "92"
+                WHITESPACE@[40; 41) " "
+                R_CURLY@[41; 42) "}"
+          SEMI@[42; 43) ";"
+        WHITESPACE@[43; 48) "\n    "
+        EXPR_STMT@[48; 54)
+          LAMBDA_EXPR@[48; 53)
+            PARAM_LIST@[48; 51)
+              PIPE@[48; 49) "|"
+              PARAM@[49; 50)
+                BIND_PAT@[49; 50)
+                  NAME@[49; 50)
+                    IDENT@[49; 50) "x"
+              PIPE@[50; 51) "|"
+            WHITESPACE@[51; 52) " "
+            PATH_EXPR@[52; 53)
+              PATH@[52; 53)
+                PATH_SEGMENT@[52; 53)
+                  NAME_REF@[52; 53)
+                    IDENT@[52; 53) "x"
+          SEMI@[53; 54) ";"
+        WHITESPACE@[54; 59) "\n    "
+        EXPR_STMT@[59; 76)
+          LAMBDA_EXPR@[59; 75)
+            MOVE_KW@[59; 63) "move"
+            WHITESPACE@[63; 64) " "
+            PARAM_LIST@[64; 73)
+              PIPE@[64; 65) "|"
+              PARAM@[65; 71)
+                BIND_PAT@[65; 66)
+                  NAME@[65; 66)
+                    IDENT@[65; 66) "x"
+                COLON@[66; 67) ":"
+                WHITESPACE@[67; 68) " "
+                PATH_TYPE@[68; 71)
+                  PATH@[68; 71)
+                    PATH_SEGMENT@[68; 71)
+                      NAME_REF@[68; 71)
+                        IDENT@[68; 71) "i32"
+              COMMA@[71; 72) ","
+              PIPE@[72; 73) "|"
+            WHITESPACE@[73; 74) " "
+            PATH_EXPR@[74; 75)
+              PATH@[74; 75)
+                PATH_SEGMENT@[74; 75)
+                  NAME_REF@[74; 75)
+                    IDENT@[74; 75) "x"
+          SEMI@[75; 76) ";"
+        WHITESPACE@[76; 81) "\n    "
+        EXPR_STMT@[81; 93)
+          LAMBDA_EXPR@[81; 92)
+            ASYNC_KW@[81; 86) "async"
+            WHITESPACE@[86; 87) " "
+            PARAM_LIST@[87; 89)
+              PIPE@[87; 88) "|"
+              PIPE@[88; 89) "|"
+            WHITESPACE@[89; 90) " "
+            BLOCK_EXPR@[90; 92)
+              BLOCK@[90; 92)
+                L_CURLY@[90; 91) "{"
+                R_CURLY@[91; 92) "}"
+          SEMI@[92; 93) ";"
+        WHITESPACE@[93; 98) "\n    "
+        EXPR_STMT@[98; 109)
+          LAMBDA_EXPR@[98; 108)
+            MOVE_KW@[98; 102) "move"
+            WHITESPACE@[102; 103) " "
+            PARAM_LIST@[103; 105)
+              PIPE@[103; 104) "|"
+              PIPE@[104; 105) "|"
+            WHITESPACE@[105; 106) " "
+            BLOCK_EXPR@[106; 108)
+              BLOCK@[106; 108)
+                L_CURLY@[106; 107) "{"
+                R_CURLY@[107; 108) "}"
+          SEMI@[108; 109) ";"
+        WHITESPACE@[109; 114) "\n    "
+        EXPR_STMT@[114; 131)
+          LAMBDA_EXPR@[114; 130)
+            ASYNC_KW@[114; 119) "async"
+            WHITESPACE@[119; 120) " "
+            MOVE_KW@[120; 124) "move"
+            WHITESPACE@[124; 125) " "
+            PARAM_LIST@[125; 127)
+              PIPE@[125; 126) "|"
+              PIPE@[126; 127) "|"
+            WHITESPACE@[127; 128) " "
+            BLOCK_EXPR@[128; 130)
+              BLOCK@[128; 130)
+                L_CURLY@[128; 129) "{"
+                R_CURLY@[129; 130) "}"
+          SEMI@[130; 131) ";"
+        WHITESPACE@[131; 132) "\n"
+        R_CURLY@[132; 133) "}"
   WHITESPACE@[133; 134) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0107_method_call_expr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0107_method_call_expr.txt
@@ -8,55 +8,56 @@ SOURCE_FILE@[0; 49)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 48)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 23)
-        METHOD_CALL_EXPR@[15; 22)
-          PATH_EXPR@[15; 16)
-            PATH@[15; 16)
-              PATH_SEGMENT@[15; 16)
-                NAME_REF@[15; 16)
-                  IDENT@[15; 16) "x"
-          DOT@[16; 17) "."
-          NAME_REF@[17; 20)
-            IDENT@[17; 20) "foo"
-          ARG_LIST@[20; 22)
-            L_PAREN@[20; 21) "("
-            R_PAREN@[21; 22) ")"
-        SEMI@[22; 23) ";"
-      WHITESPACE@[23; 28) "\n    "
-      EXPR_STMT@[28; 46)
-        METHOD_CALL_EXPR@[28; 45)
-          PATH_EXPR@[28; 29)
-            PATH@[28; 29)
-              PATH_SEGMENT@[28; 29)
-                NAME_REF@[28; 29)
-                  IDENT@[28; 29) "y"
-          DOT@[29; 30) "."
-          NAME_REF@[30; 33)
-            IDENT@[30; 33) "bar"
-          TYPE_ARG_LIST@[33; 38)
-            COLONCOLON@[33; 35) "::"
-            L_ANGLE@[35; 36) "<"
-            TYPE_ARG@[36; 37)
-              PATH_TYPE@[36; 37)
-                PATH@[36; 37)
-                  PATH_SEGMENT@[36; 37)
-                    NAME_REF@[36; 37)
-                      IDENT@[36; 37) "T"
-            R_ANGLE@[37; 38) ">"
-          ARG_LIST@[38; 45)
-            L_PAREN@[38; 39) "("
-            LITERAL@[39; 40)
-              INT_NUMBER@[39; 40) "1"
-            COMMA@[40; 41) ","
-            WHITESPACE@[41; 42) " "
-            LITERAL@[42; 43)
-              INT_NUMBER@[42; 43) "2"
-            COMMA@[43; 44) ","
-            R_PAREN@[44; 45) ")"
-        SEMI@[45; 46) ";"
-      WHITESPACE@[46; 47) "\n"
-      R_CURLY@[47; 48) "}"
+    BLOCK_EXPR@[9; 48)
+      BLOCK@[9; 48)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        EXPR_STMT@[15; 23)
+          METHOD_CALL_EXPR@[15; 22)
+            PATH_EXPR@[15; 16)
+              PATH@[15; 16)
+                PATH_SEGMENT@[15; 16)
+                  NAME_REF@[15; 16)
+                    IDENT@[15; 16) "x"
+            DOT@[16; 17) "."
+            NAME_REF@[17; 20)
+              IDENT@[17; 20) "foo"
+            ARG_LIST@[20; 22)
+              L_PAREN@[20; 21) "("
+              R_PAREN@[21; 22) ")"
+          SEMI@[22; 23) ";"
+        WHITESPACE@[23; 28) "\n    "
+        EXPR_STMT@[28; 46)
+          METHOD_CALL_EXPR@[28; 45)
+            PATH_EXPR@[28; 29)
+              PATH@[28; 29)
+                PATH_SEGMENT@[28; 29)
+                  NAME_REF@[28; 29)
+                    IDENT@[28; 29) "y"
+            DOT@[29; 30) "."
+            NAME_REF@[30; 33)
+              IDENT@[30; 33) "bar"
+            TYPE_ARG_LIST@[33; 38)
+              COLONCOLON@[33; 35) "::"
+              L_ANGLE@[35; 36) "<"
+              TYPE_ARG@[36; 37)
+                PATH_TYPE@[36; 37)
+                  PATH@[36; 37)
+                    PATH_SEGMENT@[36; 37)
+                      NAME_REF@[36; 37)
+                        IDENT@[36; 37) "T"
+              R_ANGLE@[37; 38) ">"
+            ARG_LIST@[38; 45)
+              L_PAREN@[38; 39) "("
+              LITERAL@[39; 40)
+                INT_NUMBER@[39; 40) "1"
+              COMMA@[40; 41) ","
+              WHITESPACE@[41; 42) " "
+              LITERAL@[42; 43)
+                INT_NUMBER@[42; 43) "2"
+              COMMA@[43; 44) ","
+              R_PAREN@[44; 45) ")"
+          SEMI@[45; 46) ";"
+        WHITESPACE@[46; 47) "\n"
+        R_CURLY@[47; 48) "}"
   WHITESPACE@[48; 49) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0108_tuple_expr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0108_tuple_expr.txt
@@ -8,31 +8,32 @@ SOURCE_FILE@[0; 40)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 39)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 18)
-        TUPLE_EXPR@[15; 17)
-          L_PAREN@[15; 16) "("
-          R_PAREN@[16; 17) ")"
-        SEMI@[17; 18) ";"
-      WHITESPACE@[18; 23) "\n    "
-      EXPR_STMT@[23; 27)
-        PAREN_EXPR@[23; 26)
-          L_PAREN@[23; 24) "("
-          LITERAL@[24; 25)
-            INT_NUMBER@[24; 25) "1"
-          R_PAREN@[25; 26) ")"
-        SEMI@[26; 27) ";"
-      WHITESPACE@[27; 32) "\n    "
-      EXPR_STMT@[32; 37)
-        TUPLE_EXPR@[32; 36)
-          L_PAREN@[32; 33) "("
-          LITERAL@[33; 34)
-            INT_NUMBER@[33; 34) "1"
-          COMMA@[34; 35) ","
-          R_PAREN@[35; 36) ")"
-        SEMI@[36; 37) ";"
-      WHITESPACE@[37; 38) "\n"
-      R_CURLY@[38; 39) "}"
+    BLOCK_EXPR@[9; 39)
+      BLOCK@[9; 39)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        EXPR_STMT@[15; 18)
+          TUPLE_EXPR@[15; 17)
+            L_PAREN@[15; 16) "("
+            R_PAREN@[16; 17) ")"
+          SEMI@[17; 18) ";"
+        WHITESPACE@[18; 23) "\n    "
+        EXPR_STMT@[23; 27)
+          PAREN_EXPR@[23; 26)
+            L_PAREN@[23; 24) "("
+            LITERAL@[24; 25)
+              INT_NUMBER@[24; 25) "1"
+            R_PAREN@[25; 26) ")"
+          SEMI@[26; 27) ";"
+        WHITESPACE@[27; 32) "\n    "
+        EXPR_STMT@[32; 37)
+          TUPLE_EXPR@[32; 36)
+            L_PAREN@[32; 33) "("
+            LITERAL@[33; 34)
+              INT_NUMBER@[33; 34) "1"
+            COMMA@[34; 35) ","
+            R_PAREN@[35; 36) ")"
+          SEMI@[36; 37) ";"
+        WHITESPACE@[37; 38) "\n"
+        R_CURLY@[38; 39) "}"
   WHITESPACE@[39; 40) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0109_label.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0109_label.txt
@@ -8,57 +8,61 @@ SOURCE_FILE@[0; 74)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 73)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 26)
-        LOOP_EXPR@[15; 26)
-          LABEL@[15; 18)
-            LIFETIME@[15; 17) "\'a"
-            COLON@[17; 18) ":"
-          WHITESPACE@[18; 19) " "
-          LOOP_KW@[19; 23) "loop"
-          WHITESPACE@[23; 24) " "
-          BLOCK@[24; 26)
-            L_CURLY@[24; 25) "{"
-            R_CURLY@[25; 26) "}"
-      WHITESPACE@[26; 31) "\n    "
-      EXPR_STMT@[31; 48)
-        WHILE_EXPR@[31; 48)
-          LABEL@[31; 34)
-            LIFETIME@[31; 33) "\'b"
-            COLON@[33; 34) ":"
-          WHITESPACE@[34; 35) " "
-          WHILE_KW@[35; 40) "while"
-          WHITESPACE@[40; 41) " "
-          CONDITION@[41; 45)
-            LITERAL@[41; 45)
-              TRUE_KW@[41; 45) "true"
-          WHITESPACE@[45; 46) " "
-          BLOCK@[46; 48)
-            L_CURLY@[46; 47) "{"
-            R_CURLY@[47; 48) "}"
-      WHITESPACE@[48; 53) "\n    "
-      FOR_EXPR@[53; 71)
-        LABEL@[53; 56)
-          LIFETIME@[53; 55) "\'c"
-          COLON@[55; 56) ":"
-        WHITESPACE@[56; 57) " "
-        FOR_KW@[57; 60) "for"
-        WHITESPACE@[60; 61) " "
-        BIND_PAT@[61; 62)
-          NAME@[61; 62)
-            IDENT@[61; 62) "x"
-        WHITESPACE@[62; 63) " "
-        IN_KW@[63; 65) "in"
-        WHITESPACE@[65; 66) " "
-        TUPLE_EXPR@[66; 68)
-          L_PAREN@[66; 67) "("
-          R_PAREN@[67; 68) ")"
-        WHITESPACE@[68; 69) " "
-        BLOCK@[69; 71)
-          L_CURLY@[69; 70) "{"
-          R_CURLY@[70; 71) "}"
-      WHITESPACE@[71; 72) "\n"
-      R_CURLY@[72; 73) "}"
+    BLOCK_EXPR@[9; 73)
+      BLOCK@[9; 73)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        EXPR_STMT@[15; 26)
+          LOOP_EXPR@[15; 26)
+            LABEL@[15; 18)
+              LIFETIME@[15; 17) "\'a"
+              COLON@[17; 18) ":"
+            WHITESPACE@[18; 19) " "
+            LOOP_KW@[19; 23) "loop"
+            WHITESPACE@[23; 24) " "
+            BLOCK_EXPR@[24; 26)
+              BLOCK@[24; 26)
+                L_CURLY@[24; 25) "{"
+                R_CURLY@[25; 26) "}"
+        WHITESPACE@[26; 31) "\n    "
+        EXPR_STMT@[31; 48)
+          WHILE_EXPR@[31; 48)
+            LABEL@[31; 34)
+              LIFETIME@[31; 33) "\'b"
+              COLON@[33; 34) ":"
+            WHITESPACE@[34; 35) " "
+            WHILE_KW@[35; 40) "while"
+            WHITESPACE@[40; 41) " "
+            CONDITION@[41; 45)
+              LITERAL@[41; 45)
+                TRUE_KW@[41; 45) "true"
+            WHITESPACE@[45; 46) " "
+            BLOCK_EXPR@[46; 48)
+              BLOCK@[46; 48)
+                L_CURLY@[46; 47) "{"
+                R_CURLY@[47; 48) "}"
+        WHITESPACE@[48; 53) "\n    "
+        FOR_EXPR@[53; 71)
+          LABEL@[53; 56)
+            LIFETIME@[53; 55) "\'c"
+            COLON@[55; 56) ":"
+          WHITESPACE@[56; 57) " "
+          FOR_KW@[57; 60) "for"
+          WHITESPACE@[60; 61) " "
+          BIND_PAT@[61; 62)
+            NAME@[61; 62)
+              IDENT@[61; 62) "x"
+          WHITESPACE@[62; 63) " "
+          IN_KW@[63; 65) "in"
+          WHITESPACE@[65; 66) " "
+          TUPLE_EXPR@[66; 68)
+            L_PAREN@[66; 67) "("
+            R_PAREN@[67; 68) ")"
+          WHITESPACE@[68; 69) " "
+          BLOCK_EXPR@[69; 71)
+            BLOCK@[69; 71)
+              L_CURLY@[69; 70) "{"
+              R_CURLY@[70; 71) "}"
+        WHITESPACE@[71; 72) "\n"
+        R_CURLY@[72; 73) "}"
   WHITESPACE@[73; 74) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0111_tuple_pat.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0111_tuple_pat.txt
@@ -8,33 +8,34 @@ SOURCE_FILE@[0; 39)
       L_PAREN@[7; 8) "("
       R_PAREN@[8; 9) ")"
     WHITESPACE@[9; 10) " "
-    BLOCK@[10; 38)
-      L_CURLY@[10; 11) "{"
-      WHITESPACE@[11; 16) "\n    "
-      LET_STMT@[16; 36)
-        LET_KW@[16; 19) "let"
-        WHITESPACE@[19; 20) " "
-        TUPLE_PAT@[20; 30)
-          L_PAREN@[20; 21) "("
-          BIND_PAT@[21; 22)
-            NAME@[21; 22)
-              IDENT@[21; 22) "a"
-          COMMA@[22; 23) ","
-          WHITESPACE@[23; 24) " "
-          BIND_PAT@[24; 25)
-            NAME@[24; 25)
-              IDENT@[24; 25) "b"
-          COMMA@[25; 26) ","
-          WHITESPACE@[26; 27) " "
-          DOTDOT@[27; 29) ".."
-          R_PAREN@[29; 30) ")"
-        WHITESPACE@[30; 31) " "
-        EQ@[31; 32) "="
-        WHITESPACE@[32; 33) " "
-        TUPLE_EXPR@[33; 35)
-          L_PAREN@[33; 34) "("
-          R_PAREN@[34; 35) ")"
-        SEMI@[35; 36) ";"
-      WHITESPACE@[36; 37) "\n"
-      R_CURLY@[37; 38) "}"
+    BLOCK_EXPR@[10; 38)
+      BLOCK@[10; 38)
+        L_CURLY@[10; 11) "{"
+        WHITESPACE@[11; 16) "\n    "
+        LET_STMT@[16; 36)
+          LET_KW@[16; 19) "let"
+          WHITESPACE@[19; 20) " "
+          TUPLE_PAT@[20; 30)
+            L_PAREN@[20; 21) "("
+            BIND_PAT@[21; 22)
+              NAME@[21; 22)
+                IDENT@[21; 22) "a"
+            COMMA@[22; 23) ","
+            WHITESPACE@[23; 24) " "
+            BIND_PAT@[24; 25)
+              NAME@[24; 25)
+                IDENT@[24; 25) "b"
+            COMMA@[25; 26) ","
+            WHITESPACE@[26; 27) " "
+            DOTDOT@[27; 29) ".."
+            R_PAREN@[29; 30) ")"
+          WHITESPACE@[30; 31) " "
+          EQ@[31; 32) "="
+          WHITESPACE@[32; 33) " "
+          TUPLE_EXPR@[33; 35)
+            L_PAREN@[33; 34) "("
+            R_PAREN@[34; 35) ")"
+          SEMI@[35; 36) ";"
+        WHITESPACE@[36; 37) "\n"
+        R_CURLY@[37; 38) "}"
   WHITESPACE@[38; 39) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0112_bind_pat.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0112_bind_pat.txt
@@ -8,120 +8,121 @@ SOURCE_FILE@[0; 146)
       L_PAREN@[7; 8) "("
       R_PAREN@[8; 9) ")"
     WHITESPACE@[9; 10) " "
-    BLOCK@[10; 145)
-      L_CURLY@[10; 11) "{"
-      WHITESPACE@[11; 16) "\n    "
-      LET_STMT@[16; 27)
-        LET_KW@[16; 19) "let"
-        WHITESPACE@[19; 20) " "
-        BIND_PAT@[20; 21)
-          NAME@[20; 21)
-            IDENT@[20; 21) "a"
-        WHITESPACE@[21; 22) " "
-        EQ@[22; 23) "="
-        WHITESPACE@[23; 24) " "
-        TUPLE_EXPR@[24; 26)
-          L_PAREN@[24; 25) "("
-          R_PAREN@[25; 26) ")"
-        SEMI@[26; 27) ";"
-      WHITESPACE@[27; 32) "\n    "
-      LET_STMT@[32; 47)
-        LET_KW@[32; 35) "let"
-        WHITESPACE@[35; 36) " "
-        BIND_PAT@[36; 41)
-          MUT_KW@[36; 39) "mut"
-          WHITESPACE@[39; 40) " "
-          NAME@[40; 41)
-            IDENT@[40; 41) "b"
-        WHITESPACE@[41; 42) " "
-        EQ@[42; 43) "="
-        WHITESPACE@[43; 44) " "
-        TUPLE_EXPR@[44; 46)
-          L_PAREN@[44; 45) "("
-          R_PAREN@[45; 46) ")"
-        SEMI@[46; 47) ";"
-      WHITESPACE@[47; 52) "\n    "
-      LET_STMT@[52; 67)
-        LET_KW@[52; 55) "let"
-        WHITESPACE@[55; 56) " "
-        BIND_PAT@[56; 61)
-          REF_KW@[56; 59) "ref"
-          WHITESPACE@[59; 60) " "
-          NAME@[60; 61)
-            IDENT@[60; 61) "c"
-        WHITESPACE@[61; 62) " "
-        EQ@[62; 63) "="
-        WHITESPACE@[63; 64) " "
-        TUPLE_EXPR@[64; 66)
-          L_PAREN@[64; 65) "("
-          R_PAREN@[65; 66) ")"
-        SEMI@[66; 67) ";"
-      WHITESPACE@[67; 72) "\n    "
-      LET_STMT@[72; 91)
-        LET_KW@[72; 75) "let"
-        WHITESPACE@[75; 76) " "
-        BIND_PAT@[76; 85)
-          REF_KW@[76; 79) "ref"
-          WHITESPACE@[79; 80) " "
-          MUT_KW@[80; 83) "mut"
-          WHITESPACE@[83; 84) " "
-          NAME@[84; 85)
-            IDENT@[84; 85) "d"
-        WHITESPACE@[85; 86) " "
-        EQ@[86; 87) "="
-        WHITESPACE@[87; 88) " "
-        TUPLE_EXPR@[88; 90)
-          L_PAREN@[88; 89) "("
-          R_PAREN@[89; 90) ")"
-        SEMI@[90; 91) ";"
-      WHITESPACE@[91; 96) "\n    "
-      LET_STMT@[96; 111)
-        LET_KW@[96; 99) "let"
-        WHITESPACE@[99; 100) " "
-        BIND_PAT@[100; 105)
-          NAME@[100; 101)
-            IDENT@[100; 101) "e"
-          WHITESPACE@[101; 102) " "
-          AT@[102; 103) "@"
-          WHITESPACE@[103; 104) " "
-          PLACEHOLDER_PAT@[104; 105)
-            UNDERSCORE@[104; 105) "_"
-        WHITESPACE@[105; 106) " "
-        EQ@[106; 107) "="
-        WHITESPACE@[107; 108) " "
-        TUPLE_EXPR@[108; 110)
-          L_PAREN@[108; 109) "("
-          R_PAREN@[109; 110) ")"
-        SEMI@[110; 111) ";"
-      WHITESPACE@[111; 116) "\n    "
-      LET_STMT@[116; 143)
-        LET_KW@[116; 119) "let"
-        WHITESPACE@[119; 120) " "
-        BIND_PAT@[120; 137)
-          REF_KW@[120; 123) "ref"
-          WHITESPACE@[123; 124) " "
-          MUT_KW@[124; 127) "mut"
-          WHITESPACE@[127; 128) " "
-          NAME@[128; 129)
-            IDENT@[128; 129) "f"
-          WHITESPACE@[129; 130) " "
-          AT@[130; 131) "@"
-          WHITESPACE@[131; 132) " "
-          BIND_PAT@[132; 137)
-            NAME@[132; 133)
-              IDENT@[132; 133) "g"
-            WHITESPACE@[133; 134) " "
-            AT@[134; 135) "@"
-            WHITESPACE@[135; 136) " "
-            PLACEHOLDER_PAT@[136; 137)
-              UNDERSCORE@[136; 137) "_"
-        WHITESPACE@[137; 138) " "
-        EQ@[138; 139) "="
-        WHITESPACE@[139; 140) " "
-        TUPLE_EXPR@[140; 142)
-          L_PAREN@[140; 141) "("
-          R_PAREN@[141; 142) ")"
-        SEMI@[142; 143) ";"
-      WHITESPACE@[143; 144) "\n"
-      R_CURLY@[144; 145) "}"
+    BLOCK_EXPR@[10; 145)
+      BLOCK@[10; 145)
+        L_CURLY@[10; 11) "{"
+        WHITESPACE@[11; 16) "\n    "
+        LET_STMT@[16; 27)
+          LET_KW@[16; 19) "let"
+          WHITESPACE@[19; 20) " "
+          BIND_PAT@[20; 21)
+            NAME@[20; 21)
+              IDENT@[20; 21) "a"
+          WHITESPACE@[21; 22) " "
+          EQ@[22; 23) "="
+          WHITESPACE@[23; 24) " "
+          TUPLE_EXPR@[24; 26)
+            L_PAREN@[24; 25) "("
+            R_PAREN@[25; 26) ")"
+          SEMI@[26; 27) ";"
+        WHITESPACE@[27; 32) "\n    "
+        LET_STMT@[32; 47)
+          LET_KW@[32; 35) "let"
+          WHITESPACE@[35; 36) " "
+          BIND_PAT@[36; 41)
+            MUT_KW@[36; 39) "mut"
+            WHITESPACE@[39; 40) " "
+            NAME@[40; 41)
+              IDENT@[40; 41) "b"
+          WHITESPACE@[41; 42) " "
+          EQ@[42; 43) "="
+          WHITESPACE@[43; 44) " "
+          TUPLE_EXPR@[44; 46)
+            L_PAREN@[44; 45) "("
+            R_PAREN@[45; 46) ")"
+          SEMI@[46; 47) ";"
+        WHITESPACE@[47; 52) "\n    "
+        LET_STMT@[52; 67)
+          LET_KW@[52; 55) "let"
+          WHITESPACE@[55; 56) " "
+          BIND_PAT@[56; 61)
+            REF_KW@[56; 59) "ref"
+            WHITESPACE@[59; 60) " "
+            NAME@[60; 61)
+              IDENT@[60; 61) "c"
+          WHITESPACE@[61; 62) " "
+          EQ@[62; 63) "="
+          WHITESPACE@[63; 64) " "
+          TUPLE_EXPR@[64; 66)
+            L_PAREN@[64; 65) "("
+            R_PAREN@[65; 66) ")"
+          SEMI@[66; 67) ";"
+        WHITESPACE@[67; 72) "\n    "
+        LET_STMT@[72; 91)
+          LET_KW@[72; 75) "let"
+          WHITESPACE@[75; 76) " "
+          BIND_PAT@[76; 85)
+            REF_KW@[76; 79) "ref"
+            WHITESPACE@[79; 80) " "
+            MUT_KW@[80; 83) "mut"
+            WHITESPACE@[83; 84) " "
+            NAME@[84; 85)
+              IDENT@[84; 85) "d"
+          WHITESPACE@[85; 86) " "
+          EQ@[86; 87) "="
+          WHITESPACE@[87; 88) " "
+          TUPLE_EXPR@[88; 90)
+            L_PAREN@[88; 89) "("
+            R_PAREN@[89; 90) ")"
+          SEMI@[90; 91) ";"
+        WHITESPACE@[91; 96) "\n    "
+        LET_STMT@[96; 111)
+          LET_KW@[96; 99) "let"
+          WHITESPACE@[99; 100) " "
+          BIND_PAT@[100; 105)
+            NAME@[100; 101)
+              IDENT@[100; 101) "e"
+            WHITESPACE@[101; 102) " "
+            AT@[102; 103) "@"
+            WHITESPACE@[103; 104) " "
+            PLACEHOLDER_PAT@[104; 105)
+              UNDERSCORE@[104; 105) "_"
+          WHITESPACE@[105; 106) " "
+          EQ@[106; 107) "="
+          WHITESPACE@[107; 108) " "
+          TUPLE_EXPR@[108; 110)
+            L_PAREN@[108; 109) "("
+            R_PAREN@[109; 110) ")"
+          SEMI@[110; 111) ";"
+        WHITESPACE@[111; 116) "\n    "
+        LET_STMT@[116; 143)
+          LET_KW@[116; 119) "let"
+          WHITESPACE@[119; 120) " "
+          BIND_PAT@[120; 137)
+            REF_KW@[120; 123) "ref"
+            WHITESPACE@[123; 124) " "
+            MUT_KW@[124; 127) "mut"
+            WHITESPACE@[127; 128) " "
+            NAME@[128; 129)
+              IDENT@[128; 129) "f"
+            WHITESPACE@[129; 130) " "
+            AT@[130; 131) "@"
+            WHITESPACE@[131; 132) " "
+            BIND_PAT@[132; 137)
+              NAME@[132; 133)
+                IDENT@[132; 133) "g"
+              WHITESPACE@[133; 134) " "
+              AT@[134; 135) "@"
+              WHITESPACE@[135; 136) " "
+              PLACEHOLDER_PAT@[136; 137)
+                UNDERSCORE@[136; 137) "_"
+          WHITESPACE@[137; 138) " "
+          EQ@[138; 139) "="
+          WHITESPACE@[139; 140) " "
+          TUPLE_EXPR@[140; 142)
+            L_PAREN@[140; 141) "("
+            R_PAREN@[141; 142) ")"
+          SEMI@[142; 143) ";"
+        WHITESPACE@[143; 144) "\n"
+        R_CURLY@[144; 145) "}"
   WHITESPACE@[145; 146) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0113_nocontentexpr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0113_nocontentexpr.txt
@@ -7,50 +7,51 @@ SOURCE_FILE@[0; 50)
     PARAM_LIST@[6; 8)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
-    BLOCK@[8; 49)
-      L_CURLY@[8; 9) "{"
-      WHITESPACE@[9; 14) "\n    "
-      SEMI@[14; 15) ";"
-      SEMI@[15; 16) ";"
-      SEMI@[16; 17) ";"
-      EXPR_STMT@[17; 29)
-        CALL_EXPR@[17; 28)
-          PATH_EXPR@[17; 26)
-            PATH@[17; 26)
-              PATH_SEGMENT@[17; 26)
-                NAME_REF@[17; 26)
-                  IDENT@[17; 26) "some_expr"
-          ARG_LIST@[26; 28)
-            L_PAREN@[26; 27) "("
-            R_PAREN@[27; 28) ")"
-        SEMI@[28; 29) ";"
-      SEMI@[29; 30) ";"
-      SEMI@[30; 31) ";"
-      SEMI@[31; 32) ";"
-      EXPR_STMT@[32; 38)
-        BLOCK_EXPR@[32; 37)
-          BLOCK@[32; 37)
-            L_CURLY@[32; 33) "{"
-            SEMI@[33; 34) ";"
-            SEMI@[34; 35) ";"
-            SEMI@[35; 36) ";"
-            R_CURLY@[36; 37) "}"
-        SEMI@[37; 38) ";"
-      SEMI@[38; 39) ";"
-      SEMI@[39; 40) ";"
-      SEMI@[40; 41) ";"
-      CALL_EXPR@[41; 47)
-        PATH_EXPR@[41; 43)
-          PATH@[41; 43)
-            PATH_SEGMENT@[41; 43)
-              NAME_REF@[41; 43)
-                IDENT@[41; 43) "Ok"
-        ARG_LIST@[43; 47)
-          L_PAREN@[43; 44) "("
-          TUPLE_EXPR@[44; 46)
-            L_PAREN@[44; 45) "("
-            R_PAREN@[45; 46) ")"
-          R_PAREN@[46; 47) ")"
-      WHITESPACE@[47; 48) "\n"
-      R_CURLY@[48; 49) "}"
+    BLOCK_EXPR@[8; 49)
+      BLOCK@[8; 49)
+        L_CURLY@[8; 9) "{"
+        WHITESPACE@[9; 14) "\n    "
+        SEMI@[14; 15) ";"
+        SEMI@[15; 16) ";"
+        SEMI@[16; 17) ";"
+        EXPR_STMT@[17; 29)
+          CALL_EXPR@[17; 28)
+            PATH_EXPR@[17; 26)
+              PATH@[17; 26)
+                PATH_SEGMENT@[17; 26)
+                  NAME_REF@[17; 26)
+                    IDENT@[17; 26) "some_expr"
+            ARG_LIST@[26; 28)
+              L_PAREN@[26; 27) "("
+              R_PAREN@[27; 28) ")"
+          SEMI@[28; 29) ";"
+        SEMI@[29; 30) ";"
+        SEMI@[30; 31) ";"
+        SEMI@[31; 32) ";"
+        EXPR_STMT@[32; 38)
+          BLOCK_EXPR@[32; 37)
+            BLOCK@[32; 37)
+              L_CURLY@[32; 33) "{"
+              SEMI@[33; 34) ";"
+              SEMI@[34; 35) ";"
+              SEMI@[35; 36) ";"
+              R_CURLY@[36; 37) "}"
+          SEMI@[37; 38) ";"
+        SEMI@[38; 39) ";"
+        SEMI@[39; 40) ";"
+        SEMI@[40; 41) ";"
+        CALL_EXPR@[41; 47)
+          PATH_EXPR@[41; 43)
+            PATH@[41; 43)
+              PATH_SEGMENT@[41; 43)
+                NAME_REF@[41; 43)
+                  IDENT@[41; 43) "Ok"
+          ARG_LIST@[43; 47)
+            L_PAREN@[43; 44) "("
+            TUPLE_EXPR@[44; 46)
+              L_PAREN@[44; 45) "("
+              R_PAREN@[45; 46) ")"
+            R_PAREN@[46; 47) ")"
+        WHITESPACE@[47; 48) "\n"
+        R_CURLY@[48; 49) "}"
   WHITESPACE@[49; 50) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0118_match_guard.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0118_match_guard.txt
@@ -8,40 +8,41 @@ SOURCE_FILE@[0; 58)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 57)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      MATCH_EXPR@[15; 55)
-        MATCH_KW@[15; 20) "match"
-        WHITESPACE@[20; 21) " "
-        TUPLE_EXPR@[21; 23)
-          L_PAREN@[21; 22) "("
-          R_PAREN@[22; 23) ")"
-        WHITESPACE@[23; 24) " "
-        MATCH_ARM_LIST@[24; 55)
-          L_CURLY@[24; 25) "{"
-          WHITESPACE@[25; 34) "\n        "
-          MATCH_ARM@[34; 48)
-            PLACEHOLDER_PAT@[34; 35)
-              UNDERSCORE@[34; 35) "_"
-            WHITESPACE@[35; 36) " "
-            MATCH_GUARD@[36; 42)
-              IF_KW@[36; 38) "if"
-              WHITESPACE@[38; 39) " "
-              PATH_EXPR@[39; 42)
-                PATH@[39; 42)
-                  PATH_SEGMENT@[39; 42)
-                    NAME_REF@[39; 42)
-                      IDENT@[39; 42) "foo"
-            WHITESPACE@[42; 43) " "
-            FAT_ARROW@[43; 45) "=>"
-            WHITESPACE@[45; 46) " "
-            TUPLE_EXPR@[46; 48)
-              L_PAREN@[46; 47) "("
-              R_PAREN@[47; 48) ")"
-          COMMA@[48; 49) ","
-          WHITESPACE@[49; 54) "\n    "
-          R_CURLY@[54; 55) "}"
-      WHITESPACE@[55; 56) "\n"
-      R_CURLY@[56; 57) "}"
+    BLOCK_EXPR@[9; 57)
+      BLOCK@[9; 57)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        MATCH_EXPR@[15; 55)
+          MATCH_KW@[15; 20) "match"
+          WHITESPACE@[20; 21) " "
+          TUPLE_EXPR@[21; 23)
+            L_PAREN@[21; 22) "("
+            R_PAREN@[22; 23) ")"
+          WHITESPACE@[23; 24) " "
+          MATCH_ARM_LIST@[24; 55)
+            L_CURLY@[24; 25) "{"
+            WHITESPACE@[25; 34) "\n        "
+            MATCH_ARM@[34; 48)
+              PLACEHOLDER_PAT@[34; 35)
+                UNDERSCORE@[34; 35) "_"
+              WHITESPACE@[35; 36) " "
+              MATCH_GUARD@[36; 42)
+                IF_KW@[36; 38) "if"
+                WHITESPACE@[38; 39) " "
+                PATH_EXPR@[39; 42)
+                  PATH@[39; 42)
+                    PATH_SEGMENT@[39; 42)
+                      NAME_REF@[39; 42)
+                        IDENT@[39; 42) "foo"
+              WHITESPACE@[42; 43) " "
+              FAT_ARROW@[43; 45) "=>"
+              WHITESPACE@[45; 46) " "
+              TUPLE_EXPR@[46; 48)
+                L_PAREN@[46; 47) "("
+                R_PAREN@[47; 48) ")"
+            COMMA@[48; 49) ","
+            WHITESPACE@[49; 54) "\n    "
+            R_CURLY@[54; 55) "}"
+        WHITESPACE@[55; 56) "\n"
+        R_CURLY@[56; 57) "}"
   WHITESPACE@[57; 58) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0120_match_arms_inner_attribute.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0120_match_arms_inner_attribute.txt
@@ -8,67 +8,68 @@ SOURCE_FILE@[0; 139)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 138)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      MATCH_EXPR@[15; 136)
-        MATCH_KW@[15; 20) "match"
-        WHITESPACE@[20; 21) " "
-        TUPLE_EXPR@[21; 23)
-          L_PAREN@[21; 22) "("
-          R_PAREN@[22; 23) ")"
-        WHITESPACE@[23; 24) " "
-        MATCH_ARM_LIST@[24; 136)
-          L_CURLY@[24; 25) "{"
-          WHITESPACE@[25; 34) "\n        "
-          ATTR@[34; 60)
-            POUND@[34; 35) "#"
-            EXCL@[35; 36) "!"
-            TOKEN_TREE@[36; 60)
-              L_BRACK@[36; 37) "["
-              IDENT@[37; 40) "doc"
-              TOKEN_TREE@[40; 59)
-                L_PAREN@[40; 41) "("
-                STRING@[41; 58) "\"Inner attribute\""
-                R_PAREN@[58; 59) ")"
-              R_BRACK@[59; 60) "]"
-          WHITESPACE@[60; 69) "\n        "
-          ATTR@[69; 86)
-            POUND@[69; 70) "#"
-            EXCL@[70; 71) "!"
-            TOKEN_TREE@[71; 86)
-              L_BRACK@[71; 72) "["
-              IDENT@[72; 75) "doc"
-              TOKEN_TREE@[75; 85)
-                L_PAREN@[75; 76) "("
-                STRING@[76; 84) "\"Can be\""
-                R_PAREN@[84; 85) ")"
-              R_BRACK@[85; 86) "]"
-          WHITESPACE@[86; 95) "\n        "
-          ATTR@[95; 113)
-            POUND@[95; 96) "#"
-            EXCL@[96; 97) "!"
-            TOKEN_TREE@[97; 113)
-              L_BRACK@[97; 98) "["
-              IDENT@[98; 101) "doc"
-              TOKEN_TREE@[101; 112)
-                L_PAREN@[101; 102) "("
-                STRING@[102; 111) "\"Stacked\""
-                R_PAREN@[111; 112) ")"
-              R_BRACK@[112; 113) "]"
-          WHITESPACE@[113; 122) "\n        "
-          MATCH_ARM@[122; 129)
-            PLACEHOLDER_PAT@[122; 123)
-              UNDERSCORE@[122; 123) "_"
-            WHITESPACE@[123; 124) " "
-            FAT_ARROW@[124; 126) "=>"
-            WHITESPACE@[126; 127) " "
-            TUPLE_EXPR@[127; 129)
-              L_PAREN@[127; 128) "("
-              R_PAREN@[128; 129) ")"
-          COMMA@[129; 130) ","
-          WHITESPACE@[130; 135) "\n    "
-          R_CURLY@[135; 136) "}"
-      WHITESPACE@[136; 137) "\n"
-      R_CURLY@[137; 138) "}"
+    BLOCK_EXPR@[9; 138)
+      BLOCK@[9; 138)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        MATCH_EXPR@[15; 136)
+          MATCH_KW@[15; 20) "match"
+          WHITESPACE@[20; 21) " "
+          TUPLE_EXPR@[21; 23)
+            L_PAREN@[21; 22) "("
+            R_PAREN@[22; 23) ")"
+          WHITESPACE@[23; 24) " "
+          MATCH_ARM_LIST@[24; 136)
+            L_CURLY@[24; 25) "{"
+            WHITESPACE@[25; 34) "\n        "
+            ATTR@[34; 60)
+              POUND@[34; 35) "#"
+              EXCL@[35; 36) "!"
+              TOKEN_TREE@[36; 60)
+                L_BRACK@[36; 37) "["
+                IDENT@[37; 40) "doc"
+                TOKEN_TREE@[40; 59)
+                  L_PAREN@[40; 41) "("
+                  STRING@[41; 58) "\"Inner attribute\""
+                  R_PAREN@[58; 59) ")"
+                R_BRACK@[59; 60) "]"
+            WHITESPACE@[60; 69) "\n        "
+            ATTR@[69; 86)
+              POUND@[69; 70) "#"
+              EXCL@[70; 71) "!"
+              TOKEN_TREE@[71; 86)
+                L_BRACK@[71; 72) "["
+                IDENT@[72; 75) "doc"
+                TOKEN_TREE@[75; 85)
+                  L_PAREN@[75; 76) "("
+                  STRING@[76; 84) "\"Can be\""
+                  R_PAREN@[84; 85) ")"
+                R_BRACK@[85; 86) "]"
+            WHITESPACE@[86; 95) "\n        "
+            ATTR@[95; 113)
+              POUND@[95; 96) "#"
+              EXCL@[96; 97) "!"
+              TOKEN_TREE@[97; 113)
+                L_BRACK@[97; 98) "["
+                IDENT@[98; 101) "doc"
+                TOKEN_TREE@[101; 112)
+                  L_PAREN@[101; 102) "("
+                  STRING@[102; 111) "\"Stacked\""
+                  R_PAREN@[111; 112) ")"
+                R_BRACK@[112; 113) "]"
+            WHITESPACE@[113; 122) "\n        "
+            MATCH_ARM@[122; 129)
+              PLACEHOLDER_PAT@[122; 123)
+                UNDERSCORE@[122; 123) "_"
+              WHITESPACE@[123; 124) " "
+              FAT_ARROW@[124; 126) "=>"
+              WHITESPACE@[126; 127) " "
+              TUPLE_EXPR@[127; 129)
+                L_PAREN@[127; 128) "("
+                R_PAREN@[128; 129) ")"
+            COMMA@[129; 130) ","
+            WHITESPACE@[130; 135) "\n    "
+            R_CURLY@[135; 136) "}"
+        WHITESPACE@[136; 137) "\n"
+        R_CURLY@[137; 138) "}"
   WHITESPACE@[138; 139) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0121_match_arms_outer_attributes.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0121_match_arms_outer_attributes.txt
@@ -8,128 +8,129 @@ SOURCE_FILE@[0; 259)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 258)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      MATCH_EXPR@[15; 256)
-        MATCH_KW@[15; 20) "match"
-        WHITESPACE@[20; 21) " "
-        TUPLE_EXPR@[21; 23)
-          L_PAREN@[21; 22) "("
-          R_PAREN@[22; 23) ")"
-        WHITESPACE@[23; 24) " "
-        MATCH_ARM_LIST@[24; 256)
-          L_CURLY@[24; 25) "{"
-          WHITESPACE@[25; 34) "\n        "
-          MATCH_ARM@[34; 74)
-            ATTR@[34; 58)
-              POUND@[34; 35) "#"
-              TOKEN_TREE@[35; 58)
-                L_BRACK@[35; 36) "["
-                IDENT@[36; 39) "cfg"
-                TOKEN_TREE@[39; 57)
-                  L_PAREN@[39; 40) "("
-                  IDENT@[40; 47) "feature"
-                  WHITESPACE@[47; 48) " "
-                  EQ@[48; 49) "="
-                  WHITESPACE@[49; 50) " "
-                  STRING@[50; 56) "\"some\""
-                  R_PAREN@[56; 57) ")"
-                R_BRACK@[57; 58) "]"
-            WHITESPACE@[58; 67) "\n        "
-            PLACEHOLDER_PAT@[67; 68)
-              UNDERSCORE@[67; 68) "_"
-            WHITESPACE@[68; 69) " "
-            FAT_ARROW@[69; 71) "=>"
-            WHITESPACE@[71; 72) " "
-            TUPLE_EXPR@[72; 74)
-              L_PAREN@[72; 73) "("
-              R_PAREN@[73; 74) ")"
-          COMMA@[74; 75) ","
-          WHITESPACE@[75; 84) "\n        "
-          MATCH_ARM@[84; 125)
-            ATTR@[84; 109)
-              POUND@[84; 85) "#"
-              TOKEN_TREE@[85; 109)
-                L_BRACK@[85; 86) "["
-                IDENT@[86; 89) "cfg"
-                TOKEN_TREE@[89; 108)
-                  L_PAREN@[89; 90) "("
-                  IDENT@[90; 97) "feature"
-                  WHITESPACE@[97; 98) " "
-                  EQ@[98; 99) "="
-                  WHITESPACE@[99; 100) " "
-                  STRING@[100; 107) "\"other\""
-                  R_PAREN@[107; 108) ")"
-                R_BRACK@[108; 109) "]"
-            WHITESPACE@[109; 118) "\n        "
-            PLACEHOLDER_PAT@[118; 119)
-              UNDERSCORE@[118; 119) "_"
-            WHITESPACE@[119; 120) " "
-            FAT_ARROW@[120; 122) "=>"
-            WHITESPACE@[122; 123) " "
-            TUPLE_EXPR@[123; 125)
-              L_PAREN@[123; 124) "("
-              R_PAREN@[124; 125) ")"
-          COMMA@[125; 126) ","
-          WHITESPACE@[126; 135) "\n        "
-          MATCH_ARM@[135; 249)
-            ATTR@[135; 159)
-              POUND@[135; 136) "#"
-              TOKEN_TREE@[136; 159)
-                L_BRACK@[136; 137) "["
-                IDENT@[137; 140) "cfg"
-                TOKEN_TREE@[140; 158)
-                  L_PAREN@[140; 141) "("
-                  IDENT@[141; 148) "feature"
-                  WHITESPACE@[148; 149) " "
-                  EQ@[149; 150) "="
-                  WHITESPACE@[150; 151) " "
-                  STRING@[151; 157) "\"many\""
-                  R_PAREN@[157; 158) ")"
-                R_BRACK@[158; 159) "]"
-            WHITESPACE@[159; 168) "\n        "
-            ATTR@[168; 198)
-              POUND@[168; 169) "#"
-              TOKEN_TREE@[169; 198)
-                L_BRACK@[169; 170) "["
-                IDENT@[170; 173) "cfg"
-                TOKEN_TREE@[173; 197)
-                  L_PAREN@[173; 174) "("
-                  IDENT@[174; 181) "feature"
-                  WHITESPACE@[181; 182) " "
-                  EQ@[182; 183) "="
-                  WHITESPACE@[183; 184) " "
-                  STRING@[184; 196) "\"attributes\""
-                  R_PAREN@[196; 197) ")"
-                R_BRACK@[197; 198) "]"
-            WHITESPACE@[198; 207) "\n        "
-            ATTR@[207; 233)
-              POUND@[207; 208) "#"
-              TOKEN_TREE@[208; 233)
-                L_BRACK@[208; 209) "["
-                IDENT@[209; 212) "cfg"
-                TOKEN_TREE@[212; 232)
-                  L_PAREN@[212; 213) "("
-                  IDENT@[213; 220) "feature"
-                  WHITESPACE@[220; 221) " "
-                  EQ@[221; 222) "="
-                  WHITESPACE@[222; 223) " "
-                  STRING@[223; 231) "\"before\""
-                  R_PAREN@[231; 232) ")"
-                R_BRACK@[232; 233) "]"
-            WHITESPACE@[233; 242) "\n        "
-            PLACEHOLDER_PAT@[242; 243)
-              UNDERSCORE@[242; 243) "_"
-            WHITESPACE@[243; 244) " "
-            FAT_ARROW@[244; 246) "=>"
-            WHITESPACE@[246; 247) " "
-            TUPLE_EXPR@[247; 249)
-              L_PAREN@[247; 248) "("
-              R_PAREN@[248; 249) ")"
-          COMMA@[249; 250) ","
-          WHITESPACE@[250; 255) "\n    "
-          R_CURLY@[255; 256) "}"
-      WHITESPACE@[256; 257) "\n"
-      R_CURLY@[257; 258) "}"
+    BLOCK_EXPR@[9; 258)
+      BLOCK@[9; 258)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        MATCH_EXPR@[15; 256)
+          MATCH_KW@[15; 20) "match"
+          WHITESPACE@[20; 21) " "
+          TUPLE_EXPR@[21; 23)
+            L_PAREN@[21; 22) "("
+            R_PAREN@[22; 23) ")"
+          WHITESPACE@[23; 24) " "
+          MATCH_ARM_LIST@[24; 256)
+            L_CURLY@[24; 25) "{"
+            WHITESPACE@[25; 34) "\n        "
+            MATCH_ARM@[34; 74)
+              ATTR@[34; 58)
+                POUND@[34; 35) "#"
+                TOKEN_TREE@[35; 58)
+                  L_BRACK@[35; 36) "["
+                  IDENT@[36; 39) "cfg"
+                  TOKEN_TREE@[39; 57)
+                    L_PAREN@[39; 40) "("
+                    IDENT@[40; 47) "feature"
+                    WHITESPACE@[47; 48) " "
+                    EQ@[48; 49) "="
+                    WHITESPACE@[49; 50) " "
+                    STRING@[50; 56) "\"some\""
+                    R_PAREN@[56; 57) ")"
+                  R_BRACK@[57; 58) "]"
+              WHITESPACE@[58; 67) "\n        "
+              PLACEHOLDER_PAT@[67; 68)
+                UNDERSCORE@[67; 68) "_"
+              WHITESPACE@[68; 69) " "
+              FAT_ARROW@[69; 71) "=>"
+              WHITESPACE@[71; 72) " "
+              TUPLE_EXPR@[72; 74)
+                L_PAREN@[72; 73) "("
+                R_PAREN@[73; 74) ")"
+            COMMA@[74; 75) ","
+            WHITESPACE@[75; 84) "\n        "
+            MATCH_ARM@[84; 125)
+              ATTR@[84; 109)
+                POUND@[84; 85) "#"
+                TOKEN_TREE@[85; 109)
+                  L_BRACK@[85; 86) "["
+                  IDENT@[86; 89) "cfg"
+                  TOKEN_TREE@[89; 108)
+                    L_PAREN@[89; 90) "("
+                    IDENT@[90; 97) "feature"
+                    WHITESPACE@[97; 98) " "
+                    EQ@[98; 99) "="
+                    WHITESPACE@[99; 100) " "
+                    STRING@[100; 107) "\"other\""
+                    R_PAREN@[107; 108) ")"
+                  R_BRACK@[108; 109) "]"
+              WHITESPACE@[109; 118) "\n        "
+              PLACEHOLDER_PAT@[118; 119)
+                UNDERSCORE@[118; 119) "_"
+              WHITESPACE@[119; 120) " "
+              FAT_ARROW@[120; 122) "=>"
+              WHITESPACE@[122; 123) " "
+              TUPLE_EXPR@[123; 125)
+                L_PAREN@[123; 124) "("
+                R_PAREN@[124; 125) ")"
+            COMMA@[125; 126) ","
+            WHITESPACE@[126; 135) "\n        "
+            MATCH_ARM@[135; 249)
+              ATTR@[135; 159)
+                POUND@[135; 136) "#"
+                TOKEN_TREE@[136; 159)
+                  L_BRACK@[136; 137) "["
+                  IDENT@[137; 140) "cfg"
+                  TOKEN_TREE@[140; 158)
+                    L_PAREN@[140; 141) "("
+                    IDENT@[141; 148) "feature"
+                    WHITESPACE@[148; 149) " "
+                    EQ@[149; 150) "="
+                    WHITESPACE@[150; 151) " "
+                    STRING@[151; 157) "\"many\""
+                    R_PAREN@[157; 158) ")"
+                  R_BRACK@[158; 159) "]"
+              WHITESPACE@[159; 168) "\n        "
+              ATTR@[168; 198)
+                POUND@[168; 169) "#"
+                TOKEN_TREE@[169; 198)
+                  L_BRACK@[169; 170) "["
+                  IDENT@[170; 173) "cfg"
+                  TOKEN_TREE@[173; 197)
+                    L_PAREN@[173; 174) "("
+                    IDENT@[174; 181) "feature"
+                    WHITESPACE@[181; 182) " "
+                    EQ@[182; 183) "="
+                    WHITESPACE@[183; 184) " "
+                    STRING@[184; 196) "\"attributes\""
+                    R_PAREN@[196; 197) ")"
+                  R_BRACK@[197; 198) "]"
+              WHITESPACE@[198; 207) "\n        "
+              ATTR@[207; 233)
+                POUND@[207; 208) "#"
+                TOKEN_TREE@[208; 233)
+                  L_BRACK@[208; 209) "["
+                  IDENT@[209; 212) "cfg"
+                  TOKEN_TREE@[212; 232)
+                    L_PAREN@[212; 213) "("
+                    IDENT@[213; 220) "feature"
+                    WHITESPACE@[220; 221) " "
+                    EQ@[221; 222) "="
+                    WHITESPACE@[222; 223) " "
+                    STRING@[223; 231) "\"before\""
+                    R_PAREN@[231; 232) ")"
+                  R_BRACK@[232; 233) "]"
+              WHITESPACE@[233; 242) "\n        "
+              PLACEHOLDER_PAT@[242; 243)
+                UNDERSCORE@[242; 243) "_"
+              WHITESPACE@[243; 244) " "
+              FAT_ARROW@[244; 246) "=>"
+              WHITESPACE@[246; 247) " "
+              TUPLE_EXPR@[247; 249)
+                L_PAREN@[247; 248) "("
+                R_PAREN@[248; 249) ")"
+            COMMA@[249; 250) ","
+            WHITESPACE@[250; 255) "\n    "
+            R_CURLY@[255; 256) "}"
+        WHITESPACE@[256; 257) "\n"
+        R_CURLY@[257; 258) "}"
   WHITESPACE@[258; 259) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0122_generic_lifetime_type_attribute.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0122_generic_lifetime_type_attribute.txt
@@ -54,8 +54,9 @@ SOURCE_FILE@[0; 64)
                   IDENT@[57; 58) "T"
       R_PAREN@[58; 59) ")"
     WHITESPACE@[59; 60) " "
-    BLOCK@[60; 63)
-      L_CURLY@[60; 61) "{"
-      WHITESPACE@[61; 62) "\n"
-      R_CURLY@[62; 63) "}"
+    BLOCK_EXPR@[60; 63)
+      BLOCK@[60; 63)
+        L_CURLY@[60; 61) "{"
+        WHITESPACE@[61; 62) "\n"
+        R_CURLY@[62; 63) "}"
   WHITESPACE@[63; 64) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0124_async_fn.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0124_async_fn.txt
@@ -10,7 +10,8 @@ SOURCE_FILE@[0; 18)
       L_PAREN@[12; 13) "("
       R_PAREN@[13; 14) ")"
     WHITESPACE@[14; 15) " "
-    BLOCK@[15; 17)
-      L_CURLY@[15; 16) "{"
-      R_CURLY@[16; 17) "}"
+    BLOCK_EXPR@[15; 17)
+      BLOCK@[15; 17)
+        L_CURLY@[15; 16) "{"
+        R_CURLY@[16; 17) "}"
   WHITESPACE@[17; 18) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0125_crate_keyword_path.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0125_crate_keyword_path.txt
@@ -8,24 +8,25 @@ SOURCE_FILE@[0; 27)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 26)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 11) " "
-      EXPR_STMT@[11; 24)
-        CALL_EXPR@[11; 23)
-          PATH_EXPR@[11; 21)
-            PATH@[11; 21)
-              PATH@[11; 16)
-                PATH_SEGMENT@[11; 16)
-                  CRATE_KW@[11; 16) "crate"
-              COLONCOLON@[16; 18) "::"
-              PATH_SEGMENT@[18; 21)
-                NAME_REF@[18; 21)
-                  IDENT@[18; 21) "foo"
-          ARG_LIST@[21; 23)
-            L_PAREN@[21; 22) "("
-            R_PAREN@[22; 23) ")"
-        SEMI@[23; 24) ";"
-      WHITESPACE@[24; 25) " "
-      R_CURLY@[25; 26) "}"
+    BLOCK_EXPR@[9; 26)
+      BLOCK@[9; 26)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 11) " "
+        EXPR_STMT@[11; 24)
+          CALL_EXPR@[11; 23)
+            PATH_EXPR@[11; 21)
+              PATH@[11; 21)
+                PATH@[11; 16)
+                  PATH_SEGMENT@[11; 16)
+                    CRATE_KW@[11; 16) "crate"
+                COLONCOLON@[16; 18) "::"
+                PATH_SEGMENT@[18; 21)
+                  NAME_REF@[18; 21)
+                    IDENT@[18; 21) "foo"
+            ARG_LIST@[21; 23)
+              L_PAREN@[21; 22) "("
+              R_PAREN@[22; 23) ")"
+          SEMI@[23; 24) ";"
+        WHITESPACE@[24; 25) " "
+        R_CURLY@[25; 26) "}"
   WHITESPACE@[26; 27) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0125_record_literal_field_with_attr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0125_record_literal_field_with_attr.txt
@@ -8,38 +8,39 @@ SOURCE_FILE@[0; 46)
       L_PAREN@[7; 8) "("
       R_PAREN@[8; 9) ")"
     WHITESPACE@[9; 10) " "
-    BLOCK@[10; 45)
-      L_CURLY@[10; 11) "{"
-      WHITESPACE@[11; 16) "\n    "
-      RECORD_LIT@[16; 43)
-        PATH@[16; 17)
-          PATH_SEGMENT@[16; 17)
-            NAME_REF@[16; 17)
-              IDENT@[16; 17) "S"
-        WHITESPACE@[17; 18) " "
-        RECORD_FIELD_LIST@[18; 43)
-          L_CURLY@[18; 19) "{"
-          WHITESPACE@[19; 20) " "
-          RECORD_FIELD@[20; 41)
-            ATTR@[20; 32)
-              POUND@[20; 21) "#"
-              TOKEN_TREE@[21; 32)
-                L_BRACK@[21; 22) "["
-                IDENT@[22; 25) "cfg"
-                TOKEN_TREE@[25; 31)
-                  L_PAREN@[25; 26) "("
-                  IDENT@[26; 30) "test"
-                  R_PAREN@[30; 31) ")"
-                R_BRACK@[31; 32) "]"
-            WHITESPACE@[32; 33) " "
-            NAME_REF@[33; 38)
-              IDENT@[33; 38) "field"
-            COLON@[38; 39) ":"
-            WHITESPACE@[39; 40) " "
-            LITERAL@[40; 41)
-              INT_NUMBER@[40; 41) "1"
-          WHITESPACE@[41; 42) " "
-          R_CURLY@[42; 43) "}"
-      WHITESPACE@[43; 44) "\n"
-      R_CURLY@[44; 45) "}"
+    BLOCK_EXPR@[10; 45)
+      BLOCK@[10; 45)
+        L_CURLY@[10; 11) "{"
+        WHITESPACE@[11; 16) "\n    "
+        RECORD_LIT@[16; 43)
+          PATH@[16; 17)
+            PATH_SEGMENT@[16; 17)
+              NAME_REF@[16; 17)
+                IDENT@[16; 17) "S"
+          WHITESPACE@[17; 18) " "
+          RECORD_FIELD_LIST@[18; 43)
+            L_CURLY@[18; 19) "{"
+            WHITESPACE@[19; 20) " "
+            RECORD_FIELD@[20; 41)
+              ATTR@[20; 32)
+                POUND@[20; 21) "#"
+                TOKEN_TREE@[21; 32)
+                  L_BRACK@[21; 22) "["
+                  IDENT@[22; 25) "cfg"
+                  TOKEN_TREE@[25; 31)
+                    L_PAREN@[25; 26) "("
+                    IDENT@[26; 30) "test"
+                    R_PAREN@[30; 31) ")"
+                  R_BRACK@[31; 32) "]"
+              WHITESPACE@[32; 33) " "
+              NAME_REF@[33; 38)
+                IDENT@[33; 38) "field"
+              COLON@[38; 39) ":"
+              WHITESPACE@[39; 40) " "
+              LITERAL@[40; 41)
+                INT_NUMBER@[40; 41) "1"
+            WHITESPACE@[41; 42) " "
+            R_CURLY@[42; 43) "}"
+        WHITESPACE@[43; 44) "\n"
+        R_CURLY@[44; 45) "}"
   WHITESPACE@[45; 46) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0126_attr_on_expr_stmt.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0126_attr_on_expr_stmt.txt
@@ -8,81 +8,82 @@ SOURCE_FILE@[0; 82)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 81)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 26)
-        ATTR@[15; 19)
-          POUND@[15; 16) "#"
-          TOKEN_TREE@[16; 19)
-            L_BRACK@[16; 17) "["
-            IDENT@[17; 18) "A"
-            R_BRACK@[18; 19) "]"
-        WHITESPACE@[19; 20) " "
-        CALL_EXPR@[20; 25)
-          PATH_EXPR@[20; 23)
-            PATH@[20; 23)
-              PATH_SEGMENT@[20; 23)
-                NAME_REF@[20; 23)
-                  IDENT@[20; 23) "foo"
-          ARG_LIST@[23; 25)
-            L_PAREN@[23; 24) "("
-            R_PAREN@[24; 25) ")"
-        SEMI@[25; 26) ";"
-      WHITESPACE@[26; 31) "\n    "
-      EXPR_STMT@[31; 42)
-        ATTR@[31; 35)
-          POUND@[31; 32) "#"
-          TOKEN_TREE@[32; 35)
-            L_BRACK@[32; 33) "["
-            IDENT@[33; 34) "B"
-            R_BRACK@[34; 35) "]"
-        WHITESPACE@[35; 36) " "
-        MACRO_CALL@[36; 42)
-          PATH@[36; 39)
-            PATH_SEGMENT@[36; 39)
-              NAME_REF@[36; 39)
-                IDENT@[36; 39) "bar"
-          EXCL@[39; 40) "!"
-          TOKEN_TREE@[40; 42)
-            L_CURLY@[40; 41) "{"
-            R_CURLY@[41; 42) "}"
-      WHITESPACE@[42; 47) "\n    "
-      EXPR_STMT@[47; 59)
-        ATTR@[47; 51)
-          POUND@[47; 48) "#"
-          TOKEN_TREE@[48; 51)
-            L_BRACK@[48; 49) "["
-            IDENT@[49; 50) "C"
-            R_BRACK@[50; 51) "]"
-        WHITESPACE@[51; 52) " "
-        ATTR@[52; 56)
-          POUND@[52; 53) "#"
-          TOKEN_TREE@[53; 56)
-            L_BRACK@[53; 54) "["
-            IDENT@[54; 55) "D"
-            R_BRACK@[55; 56) "]"
-        WHITESPACE@[56; 57) " "
-        BLOCK_EXPR@[57; 59)
-          BLOCK@[57; 59)
-            L_CURLY@[57; 58) "{"
-            R_CURLY@[58; 59) "}"
-      WHITESPACE@[59; 64) "\n    "
-      EXPR_STMT@[64; 79)
-        ATTR@[64; 68)
-          POUND@[64; 65) "#"
-          TOKEN_TREE@[65; 68)
-            L_BRACK@[65; 66) "["
-            IDENT@[66; 67) "D"
-            R_BRACK@[67; 68) "]"
-        WHITESPACE@[68; 69) " "
-        RETURN_EXPR@[69; 78)
-          RETURN_KW@[69; 75) "return"
-          WHITESPACE@[75; 76) " "
-          TUPLE_EXPR@[76; 78)
-            L_PAREN@[76; 77) "("
-            R_PAREN@[77; 78) ")"
-        SEMI@[78; 79) ";"
-      WHITESPACE@[79; 80) "\n"
-      R_CURLY@[80; 81) "}"
+    BLOCK_EXPR@[9; 81)
+      BLOCK@[9; 81)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        EXPR_STMT@[15; 26)
+          ATTR@[15; 19)
+            POUND@[15; 16) "#"
+            TOKEN_TREE@[16; 19)
+              L_BRACK@[16; 17) "["
+              IDENT@[17; 18) "A"
+              R_BRACK@[18; 19) "]"
+          WHITESPACE@[19; 20) " "
+          CALL_EXPR@[20; 25)
+            PATH_EXPR@[20; 23)
+              PATH@[20; 23)
+                PATH_SEGMENT@[20; 23)
+                  NAME_REF@[20; 23)
+                    IDENT@[20; 23) "foo"
+            ARG_LIST@[23; 25)
+              L_PAREN@[23; 24) "("
+              R_PAREN@[24; 25) ")"
+          SEMI@[25; 26) ";"
+        WHITESPACE@[26; 31) "\n    "
+        EXPR_STMT@[31; 42)
+          ATTR@[31; 35)
+            POUND@[31; 32) "#"
+            TOKEN_TREE@[32; 35)
+              L_BRACK@[32; 33) "["
+              IDENT@[33; 34) "B"
+              R_BRACK@[34; 35) "]"
+          WHITESPACE@[35; 36) " "
+          MACRO_CALL@[36; 42)
+            PATH@[36; 39)
+              PATH_SEGMENT@[36; 39)
+                NAME_REF@[36; 39)
+                  IDENT@[36; 39) "bar"
+            EXCL@[39; 40) "!"
+            TOKEN_TREE@[40; 42)
+              L_CURLY@[40; 41) "{"
+              R_CURLY@[41; 42) "}"
+        WHITESPACE@[42; 47) "\n    "
+        EXPR_STMT@[47; 59)
+          ATTR@[47; 51)
+            POUND@[47; 48) "#"
+            TOKEN_TREE@[48; 51)
+              L_BRACK@[48; 49) "["
+              IDENT@[49; 50) "C"
+              R_BRACK@[50; 51) "]"
+          WHITESPACE@[51; 52) " "
+          ATTR@[52; 56)
+            POUND@[52; 53) "#"
+            TOKEN_TREE@[53; 56)
+              L_BRACK@[53; 54) "["
+              IDENT@[54; 55) "D"
+              R_BRACK@[55; 56) "]"
+          WHITESPACE@[56; 57) " "
+          BLOCK_EXPR@[57; 59)
+            BLOCK@[57; 59)
+              L_CURLY@[57; 58) "{"
+              R_CURLY@[58; 59) "}"
+        WHITESPACE@[59; 64) "\n    "
+        EXPR_STMT@[64; 79)
+          ATTR@[64; 68)
+            POUND@[64; 65) "#"
+            TOKEN_TREE@[65; 68)
+              L_BRACK@[65; 66) "["
+              IDENT@[66; 67) "D"
+              R_BRACK@[67; 68) "]"
+          WHITESPACE@[68; 69) " "
+          RETURN_EXPR@[69; 78)
+            RETURN_KW@[69; 75) "return"
+            WHITESPACE@[75; 76) " "
+            TUPLE_EXPR@[76; 78)
+              L_PAREN@[76; 77) "("
+              R_PAREN@[77; 78) ")"
+          SEMI@[78; 79) ";"
+        WHITESPACE@[79; 80) "\n"
+        R_CURLY@[80; 81) "}"
   WHITESPACE@[81; 82) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0127_attr_on_last_expr_in_block.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0127_attr_on_last_expr_in_block.txt
@@ -8,47 +8,48 @@ SOURCE_FILE@[0; 47)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 46)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 31)
-        BLOCK_EXPR@[15; 31)
-          BLOCK@[15; 31)
-            L_CURLY@[15; 16) "{"
-            WHITESPACE@[16; 17) " "
-            TRY_EXPR@[17; 29)
-              ATTR@[17; 21)
-                POUND@[17; 18) "#"
-                TOKEN_TREE@[18; 21)
-                  L_BRACK@[18; 19) "["
-                  IDENT@[19; 20) "A"
-                  R_BRACK@[20; 21) "]"
-              WHITESPACE@[21; 22) " "
-              MACRO_CALL@[22; 28)
-                PATH@[22; 25)
-                  PATH_SEGMENT@[22; 25)
-                    NAME_REF@[22; 25)
-                      IDENT@[22; 25) "bar"
-                EXCL@[25; 26) "!"
-                TOKEN_TREE@[26; 28)
-                  L_PAREN@[26; 27) "("
-                  R_PAREN@[27; 28) ")"
-              QUESTION@[28; 29) "?"
-            WHITESPACE@[29; 30) " "
-            R_CURLY@[30; 31) "}"
-      WHITESPACE@[31; 36) "\n    "
-      REF_EXPR@[36; 44)
-        ATTR@[36; 40)
-          POUND@[36; 37) "#"
-          TOKEN_TREE@[37; 40)
-            L_BRACK@[37; 38) "["
-            IDENT@[38; 39) "B"
-            R_BRACK@[39; 40) "]"
-        WHITESPACE@[40; 41) " "
-        AMP@[41; 42) "&"
-        TUPLE_EXPR@[42; 44)
-          L_PAREN@[42; 43) "("
-          R_PAREN@[43; 44) ")"
-      WHITESPACE@[44; 45) "\n"
-      R_CURLY@[45; 46) "}"
+    BLOCK_EXPR@[9; 46)
+      BLOCK@[9; 46)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        EXPR_STMT@[15; 31)
+          BLOCK_EXPR@[15; 31)
+            BLOCK@[15; 31)
+              L_CURLY@[15; 16) "{"
+              WHITESPACE@[16; 17) " "
+              TRY_EXPR@[17; 29)
+                ATTR@[17; 21)
+                  POUND@[17; 18) "#"
+                  TOKEN_TREE@[18; 21)
+                    L_BRACK@[18; 19) "["
+                    IDENT@[19; 20) "A"
+                    R_BRACK@[20; 21) "]"
+                WHITESPACE@[21; 22) " "
+                MACRO_CALL@[22; 28)
+                  PATH@[22; 25)
+                    PATH_SEGMENT@[22; 25)
+                      NAME_REF@[22; 25)
+                        IDENT@[22; 25) "bar"
+                  EXCL@[25; 26) "!"
+                  TOKEN_TREE@[26; 28)
+                    L_PAREN@[26; 27) "("
+                    R_PAREN@[27; 28) ")"
+                QUESTION@[28; 29) "?"
+              WHITESPACE@[29; 30) " "
+              R_CURLY@[30; 31) "}"
+        WHITESPACE@[31; 36) "\n    "
+        REF_EXPR@[36; 44)
+          ATTR@[36; 40)
+            POUND@[36; 37) "#"
+            TOKEN_TREE@[37; 40)
+              L_BRACK@[37; 38) "["
+              IDENT@[38; 39) "B"
+              R_BRACK@[39; 40) "]"
+          WHITESPACE@[40; 41) " "
+          AMP@[41; 42) "&"
+          TUPLE_EXPR@[42; 44)
+            L_PAREN@[42; 43) "("
+            R_PAREN@[43; 44) ")"
+        WHITESPACE@[44; 45) "\n"
+        R_CURLY@[45; 46) "}"
   WHITESPACE@[46; 47) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0128_combined_fns.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0128_combined_fns.txt
@@ -12,9 +12,10 @@ SOURCE_FILE@[0; 50)
       L_PAREN@[19; 20) "("
       R_PAREN@[20; 21) ")"
     WHITESPACE@[21; 22) " "
-    BLOCK@[22; 24)
-      L_CURLY@[22; 23) "{"
-      R_CURLY@[23; 24) "}"
+    BLOCK_EXPR@[22; 24)
+      BLOCK@[22; 24)
+        L_CURLY@[22; 23) "{"
+        R_CURLY@[23; 24) "}"
   WHITESPACE@[24; 25) "\n"
   FN_DEF@[25; 49)
     CONST_KW@[25; 30) "const"
@@ -29,7 +30,8 @@ SOURCE_FILE@[0; 50)
       L_PAREN@[44; 45) "("
       R_PAREN@[45; 46) ")"
     WHITESPACE@[46; 47) " "
-    BLOCK@[47; 49)
-      L_CURLY@[47; 48) "{"
-      R_CURLY@[48; 49) "}"
+    BLOCK_EXPR@[47; 49)
+      BLOCK@[47; 49)
+        L_CURLY@[47; 48) "{"
+        R_CURLY@[48; 49) "}"
   WHITESPACE@[49; 50) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0129_marco_pat.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0129_marco_pat.txt
@@ -8,29 +8,30 @@ SOURCE_FILE@[0; 33)
       L_PAREN@[7; 8) "("
       R_PAREN@[8; 9) ")"
     WHITESPACE@[9; 10) " "
-    BLOCK@[10; 32)
-      L_CURLY@[10; 11) "{"
-      WHITESPACE@[11; 16) "\n    "
-      LET_STMT@[16; 30)
-        LET_KW@[16; 19) "let"
-        WHITESPACE@[19; 20) " "
-        MACRO_CALL@[20; 25)
-          PATH_PAT@[20; 21)
-            PATH@[20; 21)
-              PATH_SEGMENT@[20; 21)
-                NAME_REF@[20; 21)
-                  IDENT@[20; 21) "m"
-          EXCL@[21; 22) "!"
-          TOKEN_TREE@[22; 25)
-            L_PAREN@[22; 23) "("
-            IDENT@[23; 24) "x"
-            R_PAREN@[24; 25) ")"
-        WHITESPACE@[25; 26) " "
-        EQ@[26; 27) "="
-        WHITESPACE@[27; 28) " "
-        LITERAL@[28; 29)
-          INT_NUMBER@[28; 29) "0"
-        SEMI@[29; 30) ";"
-      WHITESPACE@[30; 31) "\n"
-      R_CURLY@[31; 32) "}"
+    BLOCK_EXPR@[10; 32)
+      BLOCK@[10; 32)
+        L_CURLY@[10; 11) "{"
+        WHITESPACE@[11; 16) "\n    "
+        LET_STMT@[16; 30)
+          LET_KW@[16; 19) "let"
+          WHITESPACE@[19; 20) " "
+          MACRO_CALL@[20; 25)
+            PATH_PAT@[20; 21)
+              PATH@[20; 21)
+                PATH_SEGMENT@[20; 21)
+                  NAME_REF@[20; 21)
+                    IDENT@[20; 21) "m"
+            EXCL@[21; 22) "!"
+            TOKEN_TREE@[22; 25)
+              L_PAREN@[22; 23) "("
+              IDENT@[23; 24) "x"
+              R_PAREN@[24; 25) ")"
+          WHITESPACE@[25; 26) " "
+          EQ@[26; 27) "="
+          WHITESPACE@[27; 28) " "
+          LITERAL@[28; 29)
+            INT_NUMBER@[28; 29) "0"
+          SEMI@[29; 30) ";"
+        WHITESPACE@[30; 31) "\n"
+        R_CURLY@[31; 32) "}"
   WHITESPACE@[32; 33) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0130_let_stmt.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0130_let_stmt.txt
@@ -8,94 +8,95 @@ SOURCE_FILE@[0; 110)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 109)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      LET_STMT@[15; 21)
-        LET_KW@[15; 18) "let"
-        WHITESPACE@[18; 19) " "
-        BIND_PAT@[19; 20)
-          NAME@[19; 20)
-            IDENT@[19; 20) "a"
-        SEMI@[20; 21) ";"
-      WHITESPACE@[21; 26) "\n    "
-      LET_STMT@[26; 37)
-        LET_KW@[26; 29) "let"
-        WHITESPACE@[29; 30) " "
-        BIND_PAT@[30; 31)
-          NAME@[30; 31)
-            IDENT@[30; 31) "b"
-        COLON@[31; 32) ":"
-        WHITESPACE@[32; 33) " "
-        PATH_TYPE@[33; 36)
-          PATH@[33; 36)
-            PATH_SEGMENT@[33; 36)
-              NAME_REF@[33; 36)
-                IDENT@[33; 36) "i32"
-        SEMI@[36; 37) ";"
-      WHITESPACE@[37; 42) "\n    "
-      LET_STMT@[42; 53)
-        LET_KW@[42; 45) "let"
-        WHITESPACE@[45; 46) " "
-        BIND_PAT@[46; 47)
-          NAME@[46; 47)
-            IDENT@[46; 47) "c"
-        WHITESPACE@[47; 48) " "
-        EQ@[48; 49) "="
-        WHITESPACE@[49; 50) " "
-        LITERAL@[50; 52)
-          INT_NUMBER@[50; 52) "92"
-        SEMI@[52; 53) ";"
-      WHITESPACE@[53; 58) "\n    "
-      LET_STMT@[58; 74)
-        LET_KW@[58; 61) "let"
-        WHITESPACE@[61; 62) " "
-        BIND_PAT@[62; 63)
-          NAME@[62; 63)
-            IDENT@[62; 63) "d"
-        COLON@[63; 64) ":"
-        WHITESPACE@[64; 65) " "
-        PATH_TYPE@[65; 68)
-          PATH@[65; 68)
-            PATH_SEGMENT@[65; 68)
-              NAME_REF@[65; 68)
-                IDENT@[65; 68) "i32"
-        WHITESPACE@[68; 69) " "
-        EQ@[69; 70) "="
-        WHITESPACE@[70; 71) " "
-        LITERAL@[71; 73)
-          INT_NUMBER@[71; 73) "92"
-        SEMI@[73; 74) ";"
-      WHITESPACE@[74; 79) "\n    "
-      LET_STMT@[79; 88)
-        LET_KW@[79; 82) "let"
-        WHITESPACE@[82; 83) " "
-        BIND_PAT@[83; 84)
-          NAME@[83; 84)
-            IDENT@[83; 84) "e"
-        COLON@[84; 85) ":"
-        WHITESPACE@[85; 86) " "
-        NEVER_TYPE@[86; 87)
-          EXCL@[86; 87) "!"
-        SEMI@[87; 88) ";"
-      WHITESPACE@[88; 93) "\n    "
-      LET_STMT@[93; 107)
-        LET_KW@[93; 96) "let"
-        WHITESPACE@[96; 97) " "
-        PLACEHOLDER_PAT@[97; 98)
-          UNDERSCORE@[97; 98) "_"
-        COLON@[98; 99) ":"
-        WHITESPACE@[99; 100) " "
-        NEVER_TYPE@[100; 101)
-          EXCL@[100; 101) "!"
-        WHITESPACE@[101; 102) " "
-        EQ@[102; 103) "="
-        WHITESPACE@[103; 104) " "
-        BLOCK_EXPR@[104; 106)
-          BLOCK@[104; 106)
-            L_CURLY@[104; 105) "{"
-            R_CURLY@[105; 106) "}"
-        SEMI@[106; 107) ";"
-      WHITESPACE@[107; 108) "\n"
-      R_CURLY@[108; 109) "}"
+    BLOCK_EXPR@[9; 109)
+      BLOCK@[9; 109)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        LET_STMT@[15; 21)
+          LET_KW@[15; 18) "let"
+          WHITESPACE@[18; 19) " "
+          BIND_PAT@[19; 20)
+            NAME@[19; 20)
+              IDENT@[19; 20) "a"
+          SEMI@[20; 21) ";"
+        WHITESPACE@[21; 26) "\n    "
+        LET_STMT@[26; 37)
+          LET_KW@[26; 29) "let"
+          WHITESPACE@[29; 30) " "
+          BIND_PAT@[30; 31)
+            NAME@[30; 31)
+              IDENT@[30; 31) "b"
+          COLON@[31; 32) ":"
+          WHITESPACE@[32; 33) " "
+          PATH_TYPE@[33; 36)
+            PATH@[33; 36)
+              PATH_SEGMENT@[33; 36)
+                NAME_REF@[33; 36)
+                  IDENT@[33; 36) "i32"
+          SEMI@[36; 37) ";"
+        WHITESPACE@[37; 42) "\n    "
+        LET_STMT@[42; 53)
+          LET_KW@[42; 45) "let"
+          WHITESPACE@[45; 46) " "
+          BIND_PAT@[46; 47)
+            NAME@[46; 47)
+              IDENT@[46; 47) "c"
+          WHITESPACE@[47; 48) " "
+          EQ@[48; 49) "="
+          WHITESPACE@[49; 50) " "
+          LITERAL@[50; 52)
+            INT_NUMBER@[50; 52) "92"
+          SEMI@[52; 53) ";"
+        WHITESPACE@[53; 58) "\n    "
+        LET_STMT@[58; 74)
+          LET_KW@[58; 61) "let"
+          WHITESPACE@[61; 62) " "
+          BIND_PAT@[62; 63)
+            NAME@[62; 63)
+              IDENT@[62; 63) "d"
+          COLON@[63; 64) ":"
+          WHITESPACE@[64; 65) " "
+          PATH_TYPE@[65; 68)
+            PATH@[65; 68)
+              PATH_SEGMENT@[65; 68)
+                NAME_REF@[65; 68)
+                  IDENT@[65; 68) "i32"
+          WHITESPACE@[68; 69) " "
+          EQ@[69; 70) "="
+          WHITESPACE@[70; 71) " "
+          LITERAL@[71; 73)
+            INT_NUMBER@[71; 73) "92"
+          SEMI@[73; 74) ";"
+        WHITESPACE@[74; 79) "\n    "
+        LET_STMT@[79; 88)
+          LET_KW@[79; 82) "let"
+          WHITESPACE@[82; 83) " "
+          BIND_PAT@[83; 84)
+            NAME@[83; 84)
+              IDENT@[83; 84) "e"
+          COLON@[84; 85) ":"
+          WHITESPACE@[85; 86) " "
+          NEVER_TYPE@[86; 87)
+            EXCL@[86; 87) "!"
+          SEMI@[87; 88) ";"
+        WHITESPACE@[88; 93) "\n    "
+        LET_STMT@[93; 107)
+          LET_KW@[93; 96) "let"
+          WHITESPACE@[96; 97) " "
+          PLACEHOLDER_PAT@[97; 98)
+            UNDERSCORE@[97; 98) "_"
+          COLON@[98; 99) ":"
+          WHITESPACE@[99; 100) " "
+          NEVER_TYPE@[100; 101)
+            EXCL@[100; 101) "!"
+          WHITESPACE@[101; 102) " "
+          EQ@[102; 103) "="
+          WHITESPACE@[103; 104) " "
+          BLOCK_EXPR@[104; 106)
+            BLOCK@[104; 106)
+              L_CURLY@[104; 105) "{"
+              R_CURLY@[105; 106) "}"
+          SEMI@[106; 107) ";"
+        WHITESPACE@[107; 108) "\n"
+        R_CURLY@[108; 109) "}"
   WHITESPACE@[109; 110) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0130_try_block_expr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0130_try_block_expr.txt
@@ -8,24 +8,26 @@ SOURCE_FILE@[0; 33)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 32)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      LET_STMT@[15; 30)
-        LET_KW@[15; 18) "let"
-        WHITESPACE@[18; 19) " "
-        PLACEHOLDER_PAT@[19; 20)
-          UNDERSCORE@[19; 20) "_"
-        WHITESPACE@[20; 21) " "
-        EQ@[21; 22) "="
-        WHITESPACE@[22; 23) " "
-        TRY_EXPR@[23; 29)
-          TRY_KW@[23; 26) "try"
-          WHITESPACE@[26; 27) " "
-          BLOCK@[27; 29)
-            L_CURLY@[27; 28) "{"
-            R_CURLY@[28; 29) "}"
-        SEMI@[29; 30) ";"
-      WHITESPACE@[30; 31) "\n"
-      R_CURLY@[31; 32) "}"
+    BLOCK_EXPR@[9; 32)
+      BLOCK@[9; 32)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        LET_STMT@[15; 30)
+          LET_KW@[15; 18) "let"
+          WHITESPACE@[18; 19) " "
+          PLACEHOLDER_PAT@[19; 20)
+            UNDERSCORE@[19; 20) "_"
+          WHITESPACE@[20; 21) " "
+          EQ@[21; 22) "="
+          WHITESPACE@[22; 23) " "
+          TRY_EXPR@[23; 29)
+            TRY_KW@[23; 26) "try"
+            WHITESPACE@[26; 27) " "
+            BLOCK_EXPR@[27; 29)
+              BLOCK@[27; 29)
+                L_CURLY@[27; 28) "{"
+                R_CURLY@[28; 29) "}"
+          SEMI@[29; 30) ";"
+        WHITESPACE@[30; 31) "\n"
+        R_CURLY@[31; 32) "}"
   WHITESPACE@[32; 33) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0132_box_expr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0132_box_expr.txt
@@ -8,82 +8,83 @@ SOURCE_FILE@[0; 106)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 105)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      LET_STMT@[15; 32)
-        LET_KW@[15; 18) "let"
-        WHITESPACE@[18; 19) " "
-        BIND_PAT@[19; 20)
-          NAME@[19; 20)
-            IDENT@[19; 20) "x"
-        WHITESPACE@[20; 21) " "
-        EQ@[21; 22) "="
-        WHITESPACE@[22; 23) " "
-        BOX_EXPR@[23; 31)
-          BOX_KW@[23; 26) "box"
-          WHITESPACE@[26; 27) " "
-          LITERAL@[27; 31)
-            INT_NUMBER@[27; 31) "1i32"
-        SEMI@[31; 32) ";"
-      WHITESPACE@[32; 37) "\n    "
-      LET_STMT@[37; 66)
-        LET_KW@[37; 40) "let"
-        WHITESPACE@[40; 41) " "
-        BIND_PAT@[41; 42)
-          NAME@[41; 42)
-            IDENT@[41; 42) "y"
-        WHITESPACE@[42; 43) " "
-        EQ@[43; 44) "="
-        WHITESPACE@[44; 45) " "
-        TUPLE_EXPR@[45; 65)
-          L_PAREN@[45; 46) "("
-          BOX_EXPR@[46; 54)
-            BOX_KW@[46; 49) "box"
-            WHITESPACE@[49; 50) " "
-            LITERAL@[50; 54)
-              INT_NUMBER@[50; 54) "1i32"
-          COMMA@[54; 55) ","
-          WHITESPACE@[55; 56) " "
-          BOX_EXPR@[56; 64)
-            BOX_KW@[56; 59) "box"
-            WHITESPACE@[59; 60) " "
-            LITERAL@[60; 64)
-              INT_NUMBER@[60; 64) "2i32"
-          R_PAREN@[64; 65) ")"
-        SEMI@[65; 66) ";"
-      WHITESPACE@[66; 71) "\n    "
-      LET_STMT@[71; 103)
-        LET_KW@[71; 74) "let"
-        WHITESPACE@[74; 75) " "
-        BIND_PAT@[75; 76)
-          NAME@[75; 76)
-            IDENT@[75; 76) "z"
-        WHITESPACE@[76; 77) " "
-        EQ@[77; 78) "="
-        WHITESPACE@[78; 79) " "
-        CALL_EXPR@[79; 102)
-          PATH_EXPR@[79; 82)
-            PATH@[79; 82)
-              PATH_SEGMENT@[79; 82)
-                NAME_REF@[79; 82)
-                  IDENT@[79; 82) "Foo"
-          ARG_LIST@[82; 102)
-            L_PAREN@[82; 83) "("
-            BOX_EXPR@[83; 91)
-              BOX_KW@[83; 86) "box"
-              WHITESPACE@[86; 87) " "
-              LITERAL@[87; 91)
-                INT_NUMBER@[87; 91) "1i32"
-            COMMA@[91; 92) ","
-            WHITESPACE@[92; 93) " "
-            BOX_EXPR@[93; 101)
-              BOX_KW@[93; 96) "box"
-              WHITESPACE@[96; 97) " "
-              LITERAL@[97; 101)
-                INT_NUMBER@[97; 101) "2i32"
-            R_PAREN@[101; 102) ")"
-        SEMI@[102; 103) ";"
-      WHITESPACE@[103; 104) "\n"
-      R_CURLY@[104; 105) "}"
+    BLOCK_EXPR@[9; 105)
+      BLOCK@[9; 105)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        LET_STMT@[15; 32)
+          LET_KW@[15; 18) "let"
+          WHITESPACE@[18; 19) " "
+          BIND_PAT@[19; 20)
+            NAME@[19; 20)
+              IDENT@[19; 20) "x"
+          WHITESPACE@[20; 21) " "
+          EQ@[21; 22) "="
+          WHITESPACE@[22; 23) " "
+          BOX_EXPR@[23; 31)
+            BOX_KW@[23; 26) "box"
+            WHITESPACE@[26; 27) " "
+            LITERAL@[27; 31)
+              INT_NUMBER@[27; 31) "1i32"
+          SEMI@[31; 32) ";"
+        WHITESPACE@[32; 37) "\n    "
+        LET_STMT@[37; 66)
+          LET_KW@[37; 40) "let"
+          WHITESPACE@[40; 41) " "
+          BIND_PAT@[41; 42)
+            NAME@[41; 42)
+              IDENT@[41; 42) "y"
+          WHITESPACE@[42; 43) " "
+          EQ@[43; 44) "="
+          WHITESPACE@[44; 45) " "
+          TUPLE_EXPR@[45; 65)
+            L_PAREN@[45; 46) "("
+            BOX_EXPR@[46; 54)
+              BOX_KW@[46; 49) "box"
+              WHITESPACE@[49; 50) " "
+              LITERAL@[50; 54)
+                INT_NUMBER@[50; 54) "1i32"
+            COMMA@[54; 55) ","
+            WHITESPACE@[55; 56) " "
+            BOX_EXPR@[56; 64)
+              BOX_KW@[56; 59) "box"
+              WHITESPACE@[59; 60) " "
+              LITERAL@[60; 64)
+                INT_NUMBER@[60; 64) "2i32"
+            R_PAREN@[64; 65) ")"
+          SEMI@[65; 66) ";"
+        WHITESPACE@[66; 71) "\n    "
+        LET_STMT@[71; 103)
+          LET_KW@[71; 74) "let"
+          WHITESPACE@[74; 75) " "
+          BIND_PAT@[75; 76)
+            NAME@[75; 76)
+              IDENT@[75; 76) "z"
+          WHITESPACE@[76; 77) " "
+          EQ@[77; 78) "="
+          WHITESPACE@[78; 79) " "
+          CALL_EXPR@[79; 102)
+            PATH_EXPR@[79; 82)
+              PATH@[79; 82)
+                PATH_SEGMENT@[79; 82)
+                  NAME_REF@[79; 82)
+                    IDENT@[79; 82) "Foo"
+            ARG_LIST@[82; 102)
+              L_PAREN@[82; 83) "("
+              BOX_EXPR@[83; 91)
+                BOX_KW@[83; 86) "box"
+                WHITESPACE@[86; 87) " "
+                LITERAL@[87; 91)
+                  INT_NUMBER@[87; 91) "1i32"
+              COMMA@[91; 92) ","
+              WHITESPACE@[92; 93) " "
+              BOX_EXPR@[93; 101)
+                BOX_KW@[93; 96) "box"
+                WHITESPACE@[96; 97) " "
+                LITERAL@[97; 101)
+                  INT_NUMBER@[97; 101) "2i32"
+              R_PAREN@[101; 102) ")"
+          SEMI@[102; 103) ";"
+        WHITESPACE@[103; 104) "\n"
+        R_CURLY@[104; 105) "}"
   WHITESPACE@[105; 106) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0132_default_fn_type.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0132_default_fn_type.txt
@@ -47,9 +47,10 @@ SOURCE_FILE@[0; 69)
           L_PAREN@[61; 62) "("
           R_PAREN@[62; 63) ")"
         WHITESPACE@[63; 64) " "
-        BLOCK@[64; 66)
-          L_CURLY@[64; 65) "{"
-          R_CURLY@[65; 66) "}"
+        BLOCK_EXPR@[64; 66)
+          BLOCK@[64; 66)
+            L_CURLY@[64; 65) "{"
+            R_CURLY@[65; 66) "}"
       WHITESPACE@[66; 67) "\n"
       R_CURLY@[67; 68) "}"
   WHITESPACE@[68; 69) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0134_nocontentexpr_after_item.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0134_nocontentexpr_after_item.txt
@@ -8,55 +8,57 @@ SOURCE_FILE@[0; 111)
       L_PAREN@[18; 19) "("
       R_PAREN@[19; 20) ")"
     WHITESPACE@[20; 21) " "
-    BLOCK@[21; 110)
-      L_CURLY@[21; 22) "{"
-      WHITESPACE@[22; 27) "\n    "
-      ENUM_DEF@[27; 75)
-        ENUM_KW@[27; 31) "enum"
-        WHITESPACE@[31; 32) " "
-        NAME@[32; 41)
-          IDENT@[32; 41) "LocalEnum"
-        WHITESPACE@[41; 42) " "
-        ENUM_VARIANT_LIST@[42; 75)
-          L_CURLY@[42; 43) "{"
-          WHITESPACE@[43; 52) "\n        "
-          ENUM_VARIANT@[52; 55)
-            NAME@[52; 55)
-              IDENT@[52; 55) "One"
-          COMMA@[55; 56) ","
-          WHITESPACE@[56; 65) "\n        "
-          ENUM_VARIANT@[65; 68)
-            NAME@[65; 68)
-              IDENT@[65; 68) "Two"
-          COMMA@[68; 69) ","
-          WHITESPACE@[69; 74) "\n    "
-          R_CURLY@[74; 75) "}"
-      SEMI@[75; 76) ";"
-      WHITESPACE@[76; 81) "\n    "
-      FN_DEF@[81; 90)
-        FN_KW@[81; 83) "fn"
-        WHITESPACE@[83; 84) " "
-        NAME@[84; 85)
-          IDENT@[84; 85) "f"
-        PARAM_LIST@[85; 87)
-          L_PAREN@[85; 86) "("
-          R_PAREN@[86; 87) ")"
-        WHITESPACE@[87; 88) " "
-        BLOCK@[88; 90)
-          L_CURLY@[88; 89) "{"
-          R_CURLY@[89; 90) "}"
-      SEMI@[90; 91) ";"
-      WHITESPACE@[91; 96) "\n    "
-      STRUCT_DEF@[96; 107)
-        STRUCT_KW@[96; 102) "struct"
-        WHITESPACE@[102; 103) " "
-        NAME@[103; 104)
-          IDENT@[103; 104) "S"
-        WHITESPACE@[104; 105) " "
-        RECORD_FIELD_DEF_LIST@[105; 107)
-          L_CURLY@[105; 106) "{"
-          R_CURLY@[106; 107) "}"
-      SEMI@[107; 108) ";"
-      WHITESPACE@[108; 109) "\n"
-      R_CURLY@[109; 110) "}"
+    BLOCK_EXPR@[21; 110)
+      BLOCK@[21; 110)
+        L_CURLY@[21; 22) "{"
+        WHITESPACE@[22; 27) "\n    "
+        ENUM_DEF@[27; 75)
+          ENUM_KW@[27; 31) "enum"
+          WHITESPACE@[31; 32) " "
+          NAME@[32; 41)
+            IDENT@[32; 41) "LocalEnum"
+          WHITESPACE@[41; 42) " "
+          ENUM_VARIANT_LIST@[42; 75)
+            L_CURLY@[42; 43) "{"
+            WHITESPACE@[43; 52) "\n        "
+            ENUM_VARIANT@[52; 55)
+              NAME@[52; 55)
+                IDENT@[52; 55) "One"
+            COMMA@[55; 56) ","
+            WHITESPACE@[56; 65) "\n        "
+            ENUM_VARIANT@[65; 68)
+              NAME@[65; 68)
+                IDENT@[65; 68) "Two"
+            COMMA@[68; 69) ","
+            WHITESPACE@[69; 74) "\n    "
+            R_CURLY@[74; 75) "}"
+        SEMI@[75; 76) ";"
+        WHITESPACE@[76; 81) "\n    "
+        FN_DEF@[81; 90)
+          FN_KW@[81; 83) "fn"
+          WHITESPACE@[83; 84) " "
+          NAME@[84; 85)
+            IDENT@[84; 85) "f"
+          PARAM_LIST@[85; 87)
+            L_PAREN@[85; 86) "("
+            R_PAREN@[86; 87) ")"
+          WHITESPACE@[87; 88) " "
+          BLOCK_EXPR@[88; 90)
+            BLOCK@[88; 90)
+              L_CURLY@[88; 89) "{"
+              R_CURLY@[89; 90) "}"
+        SEMI@[90; 91) ";"
+        WHITESPACE@[91; 96) "\n    "
+        STRUCT_DEF@[96; 107)
+          STRUCT_KW@[96; 102) "struct"
+          WHITESPACE@[102; 103) " "
+          NAME@[103; 104)
+            IDENT@[103; 104) "S"
+          WHITESPACE@[104; 105) " "
+          RECORD_FIELD_DEF_LIST@[105; 107)
+            L_CURLY@[105; 106) "{"
+            R_CURLY@[106; 107) "}"
+        SEMI@[107; 108) ";"
+        WHITESPACE@[108; 109) "\n"
+        R_CURLY@[109; 110) "}"
   WHITESPACE@[110; 111) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0137_await_expr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0137_await_expr.txt
@@ -8,62 +8,63 @@ SOURCE_FILE@[0; 67)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 66)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 23)
-        AWAIT_EXPR@[15; 22)
-          PATH_EXPR@[15; 16)
-            PATH@[15; 16)
-              PATH_SEGMENT@[15; 16)
-                NAME_REF@[15; 16)
-                  IDENT@[15; 16) "x"
-          DOT@[16; 17) "."
-          AWAIT_KW@[17; 22) "await"
-        SEMI@[22; 23) ";"
-      WHITESPACE@[23; 28) "\n    "
-      EXPR_STMT@[28; 38)
-        AWAIT_EXPR@[28; 37)
-          FIELD_EXPR@[28; 31)
-            PATH_EXPR@[28; 29)
-              PATH@[28; 29)
-                PATH_SEGMENT@[28; 29)
-                  NAME_REF@[28; 29)
-                    IDENT@[28; 29) "x"
-            DOT@[29; 30) "."
-            NAME_REF@[30; 31)
-              INT_NUMBER@[30; 31) "0"
-          DOT@[31; 32) "."
-          AWAIT_KW@[32; 37) "await"
-        SEMI@[37; 38) ";"
-      WHITESPACE@[38; 43) "\n    "
-      EXPR_STMT@[43; 64)
-        METHOD_CALL_EXPR@[43; 63)
-          TRY_EXPR@[43; 55)
-            AWAIT_EXPR@[43; 54)
-              CALL_EXPR@[43; 48)
-                FIELD_EXPR@[43; 46)
-                  PATH_EXPR@[43; 44)
-                    PATH@[43; 44)
-                      PATH_SEGMENT@[43; 44)
-                        NAME_REF@[43; 44)
-                          IDENT@[43; 44) "x"
-                  DOT@[44; 45) "."
-                  NAME_REF@[45; 46)
-                    INT_NUMBER@[45; 46) "0"
-                ARG_LIST@[46; 48)
-                  L_PAREN@[46; 47) "("
-                  R_PAREN@[47; 48) ")"
-              DOT@[48; 49) "."
-              AWAIT_KW@[49; 54) "await"
-            QUESTION@[54; 55) "?"
-          DOT@[55; 56) "."
-          NAME_REF@[56; 61)
-            IDENT@[56; 61) "hello"
-          ARG_LIST@[61; 63)
-            L_PAREN@[61; 62) "("
-            R_PAREN@[62; 63) ")"
-        SEMI@[63; 64) ";"
-      WHITESPACE@[64; 65) "\n"
-      R_CURLY@[65; 66) "}"
+    BLOCK_EXPR@[9; 66)
+      BLOCK@[9; 66)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        EXPR_STMT@[15; 23)
+          AWAIT_EXPR@[15; 22)
+            PATH_EXPR@[15; 16)
+              PATH@[15; 16)
+                PATH_SEGMENT@[15; 16)
+                  NAME_REF@[15; 16)
+                    IDENT@[15; 16) "x"
+            DOT@[16; 17) "."
+            AWAIT_KW@[17; 22) "await"
+          SEMI@[22; 23) ";"
+        WHITESPACE@[23; 28) "\n    "
+        EXPR_STMT@[28; 38)
+          AWAIT_EXPR@[28; 37)
+            FIELD_EXPR@[28; 31)
+              PATH_EXPR@[28; 29)
+                PATH@[28; 29)
+                  PATH_SEGMENT@[28; 29)
+                    NAME_REF@[28; 29)
+                      IDENT@[28; 29) "x"
+              DOT@[29; 30) "."
+              NAME_REF@[30; 31)
+                INT_NUMBER@[30; 31) "0"
+            DOT@[31; 32) "."
+            AWAIT_KW@[32; 37) "await"
+          SEMI@[37; 38) ";"
+        WHITESPACE@[38; 43) "\n    "
+        EXPR_STMT@[43; 64)
+          METHOD_CALL_EXPR@[43; 63)
+            TRY_EXPR@[43; 55)
+              AWAIT_EXPR@[43; 54)
+                CALL_EXPR@[43; 48)
+                  FIELD_EXPR@[43; 46)
+                    PATH_EXPR@[43; 44)
+                      PATH@[43; 44)
+                        PATH_SEGMENT@[43; 44)
+                          NAME_REF@[43; 44)
+                            IDENT@[43; 44) "x"
+                    DOT@[44; 45) "."
+                    NAME_REF@[45; 46)
+                      INT_NUMBER@[45; 46) "0"
+                  ARG_LIST@[46; 48)
+                    L_PAREN@[46; 47) "("
+                    R_PAREN@[47; 48) ")"
+                DOT@[48; 49) "."
+                AWAIT_KW@[49; 54) "await"
+              QUESTION@[54; 55) "?"
+            DOT@[55; 56) "."
+            NAME_REF@[56; 61)
+              IDENT@[56; 61) "hello"
+            ARG_LIST@[61; 63)
+              L_PAREN@[61; 62) "("
+              R_PAREN@[62; 63) ")"
+          SEMI@[63; 64) ";"
+        WHITESPACE@[64; 65) "\n"
+        R_CURLY@[65; 66) "}"
   WHITESPACE@[66; 67) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0138_associated_type_bounds.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0138_associated_type_bounds.txt
@@ -49,7 +49,8 @@ SOURCE_FILE@[0; 59)
                 IDENT@[53; 54) "T"
       R_PAREN@[54; 55) ")"
     WHITESPACE@[55; 56) " "
-    BLOCK@[56; 58)
-      L_CURLY@[56; 57) "{"
-      R_CURLY@[57; 58) "}"
+    BLOCK_EXPR@[56; 58)
+      BLOCK@[56; 58)
+        L_CURLY@[56; 57) "{"
+        R_CURLY@[57; 58) "}"
   WHITESPACE@[58; 59) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0138_expression_after_block.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0138_expression_after_block.txt
@@ -8,58 +8,59 @@ SOURCE_FILE@[0; 52)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 51)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 14) "\n   "
-      LET_STMT@[14; 34)
-        LET_KW@[14; 17) "let"
-        WHITESPACE@[17; 18) " "
-        BIND_PAT@[18; 23)
-          MUT_KW@[18; 21) "mut"
-          WHITESPACE@[21; 22) " "
-          NAME@[22; 23)
-            IDENT@[22; 23) "p"
-        WHITESPACE@[23; 24) " "
-        EQ@[24; 25) "="
-        WHITESPACE@[25; 26) " "
-        RECORD_LIT@[26; 33)
-          PATH@[26; 27)
-            PATH_SEGMENT@[26; 27)
-              NAME_REF@[26; 27)
-                IDENT@[26; 27) "F"
-          RECORD_FIELD_LIST@[27; 33)
-            L_CURLY@[27; 28) "{"
-            RECORD_FIELD@[28; 32)
-              NAME_REF@[28; 29)
-                IDENT@[28; 29) "x"
-              COLON@[29; 30) ":"
-              WHITESPACE@[30; 31) " "
-              LITERAL@[31; 32)
-                INT_NUMBER@[31; 32) "5"
-            R_CURLY@[32; 33) "}"
-        SEMI@[33; 34) ";"
-      WHITESPACE@[34; 38) "\n   "
-      EXPR_STMT@[38; 49)
-        BIN_EXPR@[38; 48)
-          FIELD_EXPR@[38; 43)
-            BLOCK_EXPR@[38; 41)
-              BLOCK@[38; 41)
-                L_CURLY@[38; 39) "{"
-                PATH_EXPR@[39; 40)
-                  PATH@[39; 40)
-                    PATH_SEGMENT@[39; 40)
-                      NAME_REF@[39; 40)
-                        IDENT@[39; 40) "p"
-                R_CURLY@[40; 41) "}"
-            DOT@[41; 42) "."
-            NAME_REF@[42; 43)
-              IDENT@[42; 43) "x"
-          WHITESPACE@[43; 44) " "
-          EQ@[44; 45) "="
-          WHITESPACE@[45; 46) " "
-          LITERAL@[46; 48)
-            INT_NUMBER@[46; 48) "10"
-        SEMI@[48; 49) ";"
-      WHITESPACE@[49; 50) "\n"
-      R_CURLY@[50; 51) "}"
+    BLOCK_EXPR@[9; 51)
+      BLOCK@[9; 51)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 14) "\n   "
+        LET_STMT@[14; 34)
+          LET_KW@[14; 17) "let"
+          WHITESPACE@[17; 18) " "
+          BIND_PAT@[18; 23)
+            MUT_KW@[18; 21) "mut"
+            WHITESPACE@[21; 22) " "
+            NAME@[22; 23)
+              IDENT@[22; 23) "p"
+          WHITESPACE@[23; 24) " "
+          EQ@[24; 25) "="
+          WHITESPACE@[25; 26) " "
+          RECORD_LIT@[26; 33)
+            PATH@[26; 27)
+              PATH_SEGMENT@[26; 27)
+                NAME_REF@[26; 27)
+                  IDENT@[26; 27) "F"
+            RECORD_FIELD_LIST@[27; 33)
+              L_CURLY@[27; 28) "{"
+              RECORD_FIELD@[28; 32)
+                NAME_REF@[28; 29)
+                  IDENT@[28; 29) "x"
+                COLON@[29; 30) ":"
+                WHITESPACE@[30; 31) " "
+                LITERAL@[31; 32)
+                  INT_NUMBER@[31; 32) "5"
+              R_CURLY@[32; 33) "}"
+          SEMI@[33; 34) ";"
+        WHITESPACE@[34; 38) "\n   "
+        EXPR_STMT@[38; 49)
+          BIN_EXPR@[38; 48)
+            FIELD_EXPR@[38; 43)
+              BLOCK_EXPR@[38; 41)
+                BLOCK@[38; 41)
+                  L_CURLY@[38; 39) "{"
+                  PATH_EXPR@[39; 40)
+                    PATH@[39; 40)
+                      PATH_SEGMENT@[39; 40)
+                        NAME_REF@[39; 40)
+                          IDENT@[39; 40) "p"
+                  R_CURLY@[40; 41) "}"
+              DOT@[41; 42) "."
+              NAME_REF@[42; 43)
+                IDENT@[42; 43) "x"
+            WHITESPACE@[43; 44) " "
+            EQ@[44; 45) "="
+            WHITESPACE@[45; 46) " "
+            LITERAL@[46; 48)
+              INT_NUMBER@[46; 48) "10"
+          SEMI@[48; 49) ";"
+        WHITESPACE@[49; 50) "\n"
+        R_CURLY@[50; 51) "}"
   WHITESPACE@[51; 52) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0138_self_param_outer_attr.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0138_self_param_outer_attr.txt
@@ -17,7 +17,8 @@ SOURCE_FILE@[0; 26)
         SELF_KW@[17; 21) "self"
       R_PAREN@[21; 22) ")"
     WHITESPACE@[22; 23) " "
-    BLOCK@[23; 25)
-      L_CURLY@[23; 24) "{"
-      R_CURLY@[24; 25) "}"
+    BLOCK_EXPR@[23; 25)
+      BLOCK@[23; 25)
+        L_CURLY@[23; 24) "{"
+        R_CURLY@[24; 25) "}"
   WHITESPACE@[25; 26) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0139_param_outer_arg.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0139_param_outer_arg.txt
@@ -26,7 +26,8 @@ SOURCE_FILE@[0; 28)
                 IDENT@[19; 23) "Type"
       R_PAREN@[23; 24) ")"
     WHITESPACE@[24; 25) " "
-    BLOCK@[25; 27)
-      L_CURLY@[25; 26) "{"
-      R_CURLY@[26; 27) "}"
+    BLOCK_EXPR@[25; 27)
+      BLOCK@[25; 27)
+        L_CURLY@[25; 26) "{"
+        R_CURLY@[26; 27) "}"
   WHITESPACE@[27; 28) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0142_for_range_from.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0142_for_range_from.txt
@@ -8,33 +8,35 @@ SOURCE_FILE@[0; 51)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 50)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 14) "\n   "
-      FOR_EXPR@[14; 48)
-        FOR_KW@[14; 17) "for"
-        WHITESPACE@[17; 18) " "
-        BIND_PAT@[18; 19)
-          NAME@[18; 19)
-            IDENT@[18; 19) "x"
-        WHITESPACE@[19; 20) " "
-        IN_KW@[20; 22) "in"
-        WHITESPACE@[22; 23) " "
-        RANGE_EXPR@[23; 27)
-          LITERAL@[23; 24)
-            INT_NUMBER@[23; 24) "0"
-          WHITESPACE@[24; 25) " "
-          DOTDOT@[25; 27) ".."
-        WHITESPACE@[27; 28) " "
-        BLOCK@[28; 48)
-          L_CURLY@[28; 29) "{"
-          WHITESPACE@[29; 37) "\n       "
-          EXPR_STMT@[37; 43)
-            BREAK_EXPR@[37; 42)
-              BREAK_KW@[37; 42) "break"
-            SEMI@[42; 43) ";"
-          WHITESPACE@[43; 47) "\n   "
-          R_CURLY@[47; 48) "}"
-      WHITESPACE@[48; 49) "\n"
-      R_CURLY@[49; 50) "}"
+    BLOCK_EXPR@[9; 50)
+      BLOCK@[9; 50)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 14) "\n   "
+        FOR_EXPR@[14; 48)
+          FOR_KW@[14; 17) "for"
+          WHITESPACE@[17; 18) " "
+          BIND_PAT@[18; 19)
+            NAME@[18; 19)
+              IDENT@[18; 19) "x"
+          WHITESPACE@[19; 20) " "
+          IN_KW@[20; 22) "in"
+          WHITESPACE@[22; 23) " "
+          RANGE_EXPR@[23; 27)
+            LITERAL@[23; 24)
+              INT_NUMBER@[23; 24) "0"
+            WHITESPACE@[24; 25) " "
+            DOTDOT@[25; 27) ".."
+          WHITESPACE@[27; 28) " "
+          BLOCK_EXPR@[28; 48)
+            BLOCK@[28; 48)
+              L_CURLY@[28; 29) "{"
+              WHITESPACE@[29; 37) "\n       "
+              EXPR_STMT@[37; 43)
+                BREAK_EXPR@[37; 42)
+                  BREAK_KW@[37; 42) "break"
+                SEMI@[42; 43) ";"
+              WHITESPACE@[43; 47) "\n   "
+              R_CURLY@[47; 48) "}"
+        WHITESPACE@[48; 49) "\n"
+        R_CURLY@[49; 50) "}"
   WHITESPACE@[50; 51) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0143_box_pat.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0143_box_pat.txt
@@ -8,102 +8,103 @@ SOURCE_FILE@[0; 118)
       L_PAREN@[7; 8) "("
       R_PAREN@[8; 9) ")"
     WHITESPACE@[9; 10) " "
-    BLOCK@[10; 117)
-      L_CURLY@[10; 11) "{"
-      WHITESPACE@[11; 16) "\n    "
-      LET_STMT@[16; 31)
-        LET_KW@[16; 19) "let"
-        WHITESPACE@[19; 20) " "
-        BOX_PAT@[20; 25)
-          BOX_KW@[20; 23) "box"
-          WHITESPACE@[23; 24) " "
-          BIND_PAT@[24; 25)
-            NAME@[24; 25)
-              IDENT@[24; 25) "i"
-        WHITESPACE@[25; 26) " "
-        EQ@[26; 27) "="
-        WHITESPACE@[27; 28) " "
-        TUPLE_EXPR@[28; 30)
-          L_PAREN@[28; 29) "("
-          R_PAREN@[29; 30) ")"
-        SEMI@[30; 31) ";"
-      WHITESPACE@[31; 36) "\n    "
-      LET_STMT@[36; 87)
-        LET_KW@[36; 39) "let"
-        WHITESPACE@[39; 40) " "
-        BOX_PAT@[40; 81)
-          BOX_KW@[40; 43) "box"
-          WHITESPACE@[43; 44) " "
-          RECORD_PAT@[44; 81)
-            PATH@[44; 49)
-              PATH_SEGMENT@[44; 49)
-                NAME_REF@[44; 49)
-                  IDENT@[44; 49) "Outer"
-            WHITESPACE@[49; 50) " "
-            RECORD_FIELD_PAT_LIST@[50; 81)
-              L_CURLY@[50; 51) "{"
-              WHITESPACE@[51; 52) " "
-              BOX_PAT@[52; 57)
-                BOX_KW@[52; 55) "box"
-                WHITESPACE@[55; 56) " "
-                BIND_PAT@[56; 57)
-                  NAME@[56; 57)
-                    IDENT@[56; 57) "i"
-              COMMA@[57; 58) ","
-              WHITESPACE@[58; 59) " "
-              RECORD_FIELD_PAT@[59; 79)
-                NAME@[59; 60)
-                  IDENT@[59; 60) "j"
-                COLON@[60; 61) ":"
-                WHITESPACE@[61; 62) " "
-                BOX_PAT@[62; 79)
-                  BOX_KW@[62; 65) "box"
-                  WHITESPACE@[65; 66) " "
-                  TUPLE_STRUCT_PAT@[66; 79)
-                    PATH@[66; 71)
-                      PATH_SEGMENT@[66; 71)
-                        NAME_REF@[66; 71)
-                          IDENT@[66; 71) "Inner"
-                    L_PAREN@[71; 72) "("
-                    BOX_PAT@[72; 78)
-                      BOX_KW@[72; 75) "box"
-                      WHITESPACE@[75; 76) " "
-                      REF_PAT@[76; 78)
-                        AMP@[76; 77) "&"
-                        BIND_PAT@[77; 78)
-                          NAME@[77; 78)
-                            IDENT@[77; 78) "x"
-                    R_PAREN@[78; 79) ")"
-              WHITESPACE@[79; 80) " "
-              R_CURLY@[80; 81) "}"
-        WHITESPACE@[81; 82) " "
-        EQ@[82; 83) "="
-        WHITESPACE@[83; 84) " "
-        TUPLE_EXPR@[84; 86)
-          L_PAREN@[84; 85) "("
-          R_PAREN@[85; 86) ")"
-        SEMI@[86; 87) ";"
-      WHITESPACE@[87; 92) "\n    "
-      LET_STMT@[92; 115)
-        LET_KW@[92; 95) "let"
-        WHITESPACE@[95; 96) " "
-        BOX_PAT@[96; 109)
-          BOX_KW@[96; 99) "box"
-          WHITESPACE@[99; 100) " "
-          BIND_PAT@[100; 109)
-            REF_KW@[100; 103) "ref"
-            WHITESPACE@[103; 104) " "
-            MUT_KW@[104; 107) "mut"
-            WHITESPACE@[107; 108) " "
-            NAME@[108; 109)
-              IDENT@[108; 109) "i"
-        WHITESPACE@[109; 110) " "
-        EQ@[110; 111) "="
-        WHITESPACE@[111; 112) " "
-        TUPLE_EXPR@[112; 114)
-          L_PAREN@[112; 113) "("
-          R_PAREN@[113; 114) ")"
-        SEMI@[114; 115) ";"
-      WHITESPACE@[115; 116) "\n"
-      R_CURLY@[116; 117) "}"
+    BLOCK_EXPR@[10; 117)
+      BLOCK@[10; 117)
+        L_CURLY@[10; 11) "{"
+        WHITESPACE@[11; 16) "\n    "
+        LET_STMT@[16; 31)
+          LET_KW@[16; 19) "let"
+          WHITESPACE@[19; 20) " "
+          BOX_PAT@[20; 25)
+            BOX_KW@[20; 23) "box"
+            WHITESPACE@[23; 24) " "
+            BIND_PAT@[24; 25)
+              NAME@[24; 25)
+                IDENT@[24; 25) "i"
+          WHITESPACE@[25; 26) " "
+          EQ@[26; 27) "="
+          WHITESPACE@[27; 28) " "
+          TUPLE_EXPR@[28; 30)
+            L_PAREN@[28; 29) "("
+            R_PAREN@[29; 30) ")"
+          SEMI@[30; 31) ";"
+        WHITESPACE@[31; 36) "\n    "
+        LET_STMT@[36; 87)
+          LET_KW@[36; 39) "let"
+          WHITESPACE@[39; 40) " "
+          BOX_PAT@[40; 81)
+            BOX_KW@[40; 43) "box"
+            WHITESPACE@[43; 44) " "
+            RECORD_PAT@[44; 81)
+              PATH@[44; 49)
+                PATH_SEGMENT@[44; 49)
+                  NAME_REF@[44; 49)
+                    IDENT@[44; 49) "Outer"
+              WHITESPACE@[49; 50) " "
+              RECORD_FIELD_PAT_LIST@[50; 81)
+                L_CURLY@[50; 51) "{"
+                WHITESPACE@[51; 52) " "
+                BOX_PAT@[52; 57)
+                  BOX_KW@[52; 55) "box"
+                  WHITESPACE@[55; 56) " "
+                  BIND_PAT@[56; 57)
+                    NAME@[56; 57)
+                      IDENT@[56; 57) "i"
+                COMMA@[57; 58) ","
+                WHITESPACE@[58; 59) " "
+                RECORD_FIELD_PAT@[59; 79)
+                  NAME@[59; 60)
+                    IDENT@[59; 60) "j"
+                  COLON@[60; 61) ":"
+                  WHITESPACE@[61; 62) " "
+                  BOX_PAT@[62; 79)
+                    BOX_KW@[62; 65) "box"
+                    WHITESPACE@[65; 66) " "
+                    TUPLE_STRUCT_PAT@[66; 79)
+                      PATH@[66; 71)
+                        PATH_SEGMENT@[66; 71)
+                          NAME_REF@[66; 71)
+                            IDENT@[66; 71) "Inner"
+                      L_PAREN@[71; 72) "("
+                      BOX_PAT@[72; 78)
+                        BOX_KW@[72; 75) "box"
+                        WHITESPACE@[75; 76) " "
+                        REF_PAT@[76; 78)
+                          AMP@[76; 77) "&"
+                          BIND_PAT@[77; 78)
+                            NAME@[77; 78)
+                              IDENT@[77; 78) "x"
+                      R_PAREN@[78; 79) ")"
+                WHITESPACE@[79; 80) " "
+                R_CURLY@[80; 81) "}"
+          WHITESPACE@[81; 82) " "
+          EQ@[82; 83) "="
+          WHITESPACE@[83; 84) " "
+          TUPLE_EXPR@[84; 86)
+            L_PAREN@[84; 85) "("
+            R_PAREN@[85; 86) ")"
+          SEMI@[86; 87) ";"
+        WHITESPACE@[87; 92) "\n    "
+        LET_STMT@[92; 115)
+          LET_KW@[92; 95) "let"
+          WHITESPACE@[95; 96) " "
+          BOX_PAT@[96; 109)
+            BOX_KW@[96; 99) "box"
+            WHITESPACE@[99; 100) " "
+            BIND_PAT@[100; 109)
+              REF_KW@[100; 103) "ref"
+              WHITESPACE@[103; 104) " "
+              MUT_KW@[104; 107) "mut"
+              WHITESPACE@[107; 108) " "
+              NAME@[108; 109)
+                IDENT@[108; 109) "i"
+          WHITESPACE@[109; 110) " "
+          EQ@[110; 111) "="
+          WHITESPACE@[111; 112) " "
+          TUPLE_EXPR@[112; 114)
+            L_PAREN@[112; 113) "("
+            R_PAREN@[113; 114) ")"
+          SEMI@[114; 115) ";"
+        WHITESPACE@[115; 116) "\n"
+        R_CURLY@[116; 117) "}"
   WHITESPACE@[117; 118) "\n"

--- a/crates/ra_syntax/test_data/parser/ok/0005_fn_item.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0005_fn_item.txt
@@ -8,8 +8,9 @@ SOURCE_FILE@[0; 13)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 12)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 11) "\n"
-      R_CURLY@[11; 12) "}"
+    BLOCK_EXPR@[9; 12)
+      BLOCK@[9; 12)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 11) "\n"
+        R_CURLY@[11; 12) "}"
   WHITESPACE@[12; 13) "\n"

--- a/crates/ra_syntax/test_data/parser/ok/0008_mod_item.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0008_mod_item.txt
@@ -35,10 +35,11 @@ SOURCE_FILE@[0; 118)
           L_PAREN@[37; 38) "("
           R_PAREN@[38; 39) ")"
         WHITESPACE@[39; 40) " "
-        BLOCK@[40; 47)
-          L_CURLY@[40; 41) "{"
-          WHITESPACE@[41; 46) "\n    "
-          R_CURLY@[46; 47) "}"
+        BLOCK_EXPR@[40; 47)
+          BLOCK@[40; 47)
+            L_CURLY@[40; 41) "{"
+            WHITESPACE@[41; 46) "\n    "
+            R_CURLY@[46; 47) "}"
       WHITESPACE@[47; 52) "\n    "
       STRUCT_DEF@[52; 63)
         STRUCT_KW@[52; 58) "struct"

--- a/crates/ra_syntax/test_data/parser/ok/0011_outer_attribute.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0011_outer_attribute.txt
@@ -26,7 +26,8 @@ SOURCE_FILE@[0; 35)
       L_PAREN@[29; 30) "("
       R_PAREN@[30; 31) ")"
     WHITESPACE@[31; 32) " "
-    BLOCK@[32; 34)
-      L_CURLY@[32; 33) "{"
-      R_CURLY@[33; 34) "}"
+    BLOCK_EXPR@[32; 34)
+      BLOCK@[32; 34)
+        L_CURLY@[32; 33) "{"
+        R_CURLY@[33; 34) "}"
   WHITESPACE@[34; 35) "\n"

--- a/crates/ra_syntax/test_data/parser/ok/0012_visibility.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0012_visibility.txt
@@ -8,9 +8,10 @@ SOURCE_FILE@[0; 98)
       L_PAREN@[4; 5) "("
       R_PAREN@[5; 6) ")"
     WHITESPACE@[6; 7) " "
-    BLOCK@[7; 9)
-      L_CURLY@[7; 8) "{"
-      R_CURLY@[8; 9) "}"
+    BLOCK_EXPR@[7; 9)
+      BLOCK@[7; 9)
+        L_CURLY@[7; 8) "{"
+        R_CURLY@[8; 9) "}"
   WHITESPACE@[9; 10) "\n"
   FN_DEF@[10; 23)
     VISIBILITY@[10; 13)
@@ -24,9 +25,10 @@ SOURCE_FILE@[0; 98)
       L_PAREN@[18; 19) "("
       R_PAREN@[19; 20) ")"
     WHITESPACE@[20; 21) " "
-    BLOCK@[21; 23)
-      L_CURLY@[21; 22) "{"
-      R_CURLY@[22; 23) "}"
+    BLOCK_EXPR@[21; 23)
+      BLOCK@[21; 23)
+        L_CURLY@[21; 22) "{"
+        R_CURLY@[22; 23) "}"
   WHITESPACE@[23; 24) "\n"
   FN_DEF@[24; 44)
     VISIBILITY@[24; 34)
@@ -43,9 +45,10 @@ SOURCE_FILE@[0; 98)
       L_PAREN@[39; 40) "("
       R_PAREN@[40; 41) ")"
     WHITESPACE@[41; 42) " "
-    BLOCK@[42; 44)
-      L_CURLY@[42; 43) "{"
-      R_CURLY@[43; 44) "}"
+    BLOCK_EXPR@[42; 44)
+      BLOCK@[42; 44)
+        L_CURLY@[42; 43) "{"
+        R_CURLY@[43; 44) "}"
   WHITESPACE@[44; 45) "\n"
   FN_DEF@[45; 65)
     VISIBILITY@[45; 55)
@@ -62,9 +65,10 @@ SOURCE_FILE@[0; 98)
       L_PAREN@[60; 61) "("
       R_PAREN@[61; 62) ")"
     WHITESPACE@[62; 63) " "
-    BLOCK@[63; 65)
-      L_CURLY@[63; 64) "{"
-      R_CURLY@[64; 65) "}"
+    BLOCK_EXPR@[63; 65)
+      BLOCK@[63; 65)
+        L_CURLY@[63; 64) "{"
+        R_CURLY@[64; 65) "}"
   WHITESPACE@[65; 66) "\n"
   FN_DEF@[66; 97)
     VISIBILITY@[66; 87)
@@ -96,7 +100,8 @@ SOURCE_FILE@[0; 98)
       L_PAREN@[92; 93) "("
       R_PAREN@[93; 94) ")"
     WHITESPACE@[94; 95) " "
-    BLOCK@[95; 97)
-      L_CURLY@[95; 96) "{"
-      R_CURLY@[96; 97) "}"
+    BLOCK_EXPR@[95; 97)
+      BLOCK@[95; 97)
+        L_CURLY@[95; 96) "{"
+        R_CURLY@[96; 97) "}"
   WHITESPACE@[97; 98) "\n"

--- a/crates/ra_syntax/test_data/parser/ok/0017_attr_trailing_comma.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0017_attr_trailing_comma.txt
@@ -20,7 +20,8 @@ SOURCE_FILE@[0; 23)
       L_PAREN@[17; 18) "("
       R_PAREN@[18; 19) ")"
     WHITESPACE@[19; 20) " "
-    BLOCK@[20; 22)
-      L_CURLY@[20; 21) "{"
-      R_CURLY@[21; 22) "}"
+    BLOCK_EXPR@[20; 22)
+      BLOCK@[20; 22)
+        L_CURLY@[20; 21) "{"
+        R_CURLY@[21; 22) "}"
   WHITESPACE@[22; 23) "\n"

--- a/crates/ra_syntax/test_data/parser/ok/0021_extern_fn.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0021_extern_fn.txt
@@ -11,10 +11,11 @@ SOURCE_FILE@[0; 71)
       L_PAREN@[13; 14) "("
       R_PAREN@[14; 15) ")"
     WHITESPACE@[15; 16) " "
-    BLOCK@[16; 19)
-      L_CURLY@[16; 17) "{"
-      WHITESPACE@[17; 18) "\n"
-      R_CURLY@[18; 19) "}"
+    BLOCK_EXPR@[16; 19)
+      BLOCK@[16; 19)
+        L_CURLY@[16; 17) "{"
+        WHITESPACE@[17; 18) "\n"
+        R_CURLY@[18; 19) "}"
   WHITESPACE@[19; 21) "\n\n"
   FN_DEF@[21; 44)
     ABI@[21; 31)
@@ -30,10 +31,11 @@ SOURCE_FILE@[0; 71)
       L_PAREN@[38; 39) "("
       R_PAREN@[39; 40) ")"
     WHITESPACE@[40; 41) " "
-    BLOCK@[41; 44)
-      L_CURLY@[41; 42) "{"
-      WHITESPACE@[42; 43) "\n"
-      R_CURLY@[43; 44) "}"
+    BLOCK_EXPR@[41; 44)
+      BLOCK@[41; 44)
+        L_CURLY@[41; 42) "{"
+        WHITESPACE@[42; 43) "\n"
+        R_CURLY@[43; 44) "}"
   WHITESPACE@[44; 46) "\n\n"
   FN_DEF@[46; 70)
     ABI@[46; 57)
@@ -49,8 +51,9 @@ SOURCE_FILE@[0; 71)
       L_PAREN@[64; 65) "("
       R_PAREN@[65; 66) ")"
     WHITESPACE@[66; 67) " "
-    BLOCK@[67; 70)
-      L_CURLY@[67; 68) "{"
-      WHITESPACE@[68; 69) "\n"
-      R_CURLY@[69; 70) "}"
+    BLOCK_EXPR@[67; 70)
+      BLOCK@[67; 70)
+        L_CURLY@[67; 68) "{"
+        WHITESPACE@[68; 69) "\n"
+        R_CURLY@[69; 70) "}"
   WHITESPACE@[70; 71) "\n"

--- a/crates/ra_syntax/test_data/parser/ok/0025_extern_fn_in_block.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0025_extern_fn_in_block.txt
@@ -8,24 +8,26 @@ SOURCE_FILE@[0; 35)
       L_PAREN@[7; 8) "("
       R_PAREN@[8; 9) ")"
     WHITESPACE@[9; 10) " "
-    BLOCK@[10; 34)
-      L_CURLY@[10; 11) "{"
-      WHITESPACE@[11; 16) "\n    "
-      FN_DEF@[16; 32)
-        ABI@[16; 22)
-          EXTERN_KW@[16; 22) "extern"
-        WHITESPACE@[22; 23) " "
-        FN_KW@[23; 25) "fn"
-        WHITESPACE@[25; 26) " "
-        NAME@[26; 27)
-          IDENT@[26; 27) "f"
-        PARAM_LIST@[27; 29)
-          L_PAREN@[27; 28) "("
-          R_PAREN@[28; 29) ")"
-        WHITESPACE@[29; 30) " "
-        BLOCK@[30; 32)
-          L_CURLY@[30; 31) "{"
-          R_CURLY@[31; 32) "}"
-      WHITESPACE@[32; 33) "\n"
-      R_CURLY@[33; 34) "}"
+    BLOCK_EXPR@[10; 34)
+      BLOCK@[10; 34)
+        L_CURLY@[10; 11) "{"
+        WHITESPACE@[11; 16) "\n    "
+        FN_DEF@[16; 32)
+          ABI@[16; 22)
+            EXTERN_KW@[16; 22) "extern"
+          WHITESPACE@[22; 23) " "
+          FN_KW@[23; 25) "fn"
+          WHITESPACE@[25; 26) " "
+          NAME@[26; 27)
+            IDENT@[26; 27) "f"
+          PARAM_LIST@[27; 29)
+            L_PAREN@[27; 28) "("
+            R_PAREN@[28; 29) ")"
+          WHITESPACE@[29; 30) " "
+          BLOCK_EXPR@[30; 32)
+            BLOCK@[30; 32)
+              L_CURLY@[30; 31) "{"
+              R_CURLY@[31; 32) "}"
+        WHITESPACE@[32; 33) "\n"
+        R_CURLY@[33; 34) "}"
   WHITESPACE@[34; 35) "\n"

--- a/crates/ra_syntax/test_data/parser/ok/0026_const_fn_in_block.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0026_const_fn_in_block.txt
@@ -8,23 +8,25 @@ SOURCE_FILE@[0; 34)
       L_PAREN@[7; 8) "("
       R_PAREN@[8; 9) ")"
     WHITESPACE@[9; 10) " "
-    BLOCK@[10; 33)
-      L_CURLY@[10; 11) "{"
-      WHITESPACE@[11; 16) "\n    "
-      FN_DEF@[16; 31)
-        CONST_KW@[16; 21) "const"
-        WHITESPACE@[21; 22) " "
-        FN_KW@[22; 24) "fn"
-        WHITESPACE@[24; 25) " "
-        NAME@[25; 26)
-          IDENT@[25; 26) "f"
-        PARAM_LIST@[26; 28)
-          L_PAREN@[26; 27) "("
-          R_PAREN@[27; 28) ")"
-        WHITESPACE@[28; 29) " "
-        BLOCK@[29; 31)
-          L_CURLY@[29; 30) "{"
-          R_CURLY@[30; 31) "}"
-      WHITESPACE@[31; 32) "\n"
-      R_CURLY@[32; 33) "}"
+    BLOCK_EXPR@[10; 33)
+      BLOCK@[10; 33)
+        L_CURLY@[10; 11) "{"
+        WHITESPACE@[11; 16) "\n    "
+        FN_DEF@[16; 31)
+          CONST_KW@[16; 21) "const"
+          WHITESPACE@[21; 22) " "
+          FN_KW@[22; 24) "fn"
+          WHITESPACE@[24; 25) " "
+          NAME@[25; 26)
+            IDENT@[25; 26) "f"
+          PARAM_LIST@[26; 28)
+            L_PAREN@[26; 27) "("
+            R_PAREN@[27; 28) ")"
+          WHITESPACE@[28; 29) " "
+          BLOCK_EXPR@[29; 31)
+            BLOCK@[29; 31)
+              L_CURLY@[29; 30) "{"
+              R_CURLY@[30; 31) "}"
+        WHITESPACE@[31; 32) "\n"
+        R_CURLY@[32; 33) "}"
   WHITESPACE@[33; 34) "\n"

--- a/crates/ra_syntax/test_data/parser/ok/0027_unsafe_fn_in_block.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0027_unsafe_fn_in_block.txt
@@ -8,34 +8,36 @@ SOURCE_FILE@[0; 53)
       L_PAREN@[7; 8) "("
       R_PAREN@[8; 9) ")"
     WHITESPACE@[9; 10) " "
-    BLOCK@[10; 52)
-      L_CURLY@[10; 11) "{"
-      WHITESPACE@[11; 16) "\n    "
-      FN_DEF@[16; 32)
-        UNSAFE_KW@[16; 22) "unsafe"
-        WHITESPACE@[22; 23) " "
-        FN_KW@[23; 25) "fn"
-        WHITESPACE@[25; 26) " "
-        NAME@[26; 27)
-          IDENT@[26; 27) "f"
-        PARAM_LIST@[27; 29)
-          L_PAREN@[27; 28) "("
-          R_PAREN@[28; 29) ")"
-        WHITESPACE@[29; 30) " "
-        BLOCK@[30; 32)
-          L_CURLY@[30; 31) "{"
-          R_CURLY@[31; 32) "}"
-      WHITESPACE@[32; 37) "\n    "
-      BLOCK_EXPR@[37; 50)
-        UNSAFE_KW@[37; 43) "unsafe"
-        WHITESPACE@[43; 44) " "
-        BLOCK@[44; 50)
-          L_CURLY@[44; 45) "{"
-          WHITESPACE@[45; 46) " "
-          LITERAL@[46; 48)
-            INT_NUMBER@[46; 48) "92"
-          WHITESPACE@[48; 49) " "
-          R_CURLY@[49; 50) "}"
-      WHITESPACE@[50; 51) "\n"
-      R_CURLY@[51; 52) "}"
+    BLOCK_EXPR@[10; 52)
+      BLOCK@[10; 52)
+        L_CURLY@[10; 11) "{"
+        WHITESPACE@[11; 16) "\n    "
+        FN_DEF@[16; 32)
+          UNSAFE_KW@[16; 22) "unsafe"
+          WHITESPACE@[22; 23) " "
+          FN_KW@[23; 25) "fn"
+          WHITESPACE@[25; 26) " "
+          NAME@[26; 27)
+            IDENT@[26; 27) "f"
+          PARAM_LIST@[27; 29)
+            L_PAREN@[27; 28) "("
+            R_PAREN@[28; 29) ")"
+          WHITESPACE@[29; 30) " "
+          BLOCK_EXPR@[30; 32)
+            BLOCK@[30; 32)
+              L_CURLY@[30; 31) "{"
+              R_CURLY@[31; 32) "}"
+        WHITESPACE@[32; 37) "\n    "
+        BLOCK_EXPR@[37; 50)
+          UNSAFE_KW@[37; 43) "unsafe"
+          WHITESPACE@[43; 44) " "
+          BLOCK@[44; 50)
+            L_CURLY@[44; 45) "{"
+            WHITESPACE@[45; 46) " "
+            LITERAL@[46; 48)
+              INT_NUMBER@[46; 48) "92"
+            WHITESPACE@[48; 49) " "
+            R_CURLY@[49; 50) "}"
+        WHITESPACE@[50; 51) "\n"
+        R_CURLY@[51; 52) "}"
   WHITESPACE@[52; 53) "\n"

--- a/crates/ra_syntax/test_data/parser/ok/0028_operator_binding_power.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0028_operator_binding_power.txt
@@ -8,178 +8,179 @@ SOURCE_FILE@[0; 248)
       L_PAREN@[16; 17) "("
       R_PAREN@[17; 18) ")"
     WHITESPACE@[18; 19) " "
-    BLOCK@[19; 247)
-      L_CURLY@[19; 20) "{"
-      WHITESPACE@[20; 25) "\n    "
-      LET_STMT@[25; 55)
-        LET_KW@[25; 28) "let"
-        WHITESPACE@[28; 29) " "
-        BIND_PAT@[29; 30)
-          NAME@[29; 30)
-            IDENT@[29; 30) "x"
-        WHITESPACE@[30; 31) " "
-        EQ@[31; 32) "="
-        WHITESPACE@[32; 33) " "
-        BIN_EXPR@[33; 54)
-          BIN_EXPR@[33; 46)
-            LITERAL@[33; 34)
-              INT_NUMBER@[33; 34) "1"
-            WHITESPACE@[34; 35) " "
-            PLUS@[35; 36) "+"
-            WHITESPACE@[36; 37) " "
-            BIN_EXPR@[37; 46)
-              BIN_EXPR@[37; 42)
-                LITERAL@[37; 38)
-                  INT_NUMBER@[37; 38) "2"
-                WHITESPACE@[38; 39) " "
-                STAR@[39; 40) "*"
-                WHITESPACE@[40; 41) " "
-                LITERAL@[41; 42)
-                  INT_NUMBER@[41; 42) "3"
-              WHITESPACE@[42; 43) " "
-              PERCENT@[43; 44) "%"
-              WHITESPACE@[44; 45) " "
-              LITERAL@[45; 46)
-                INT_NUMBER@[45; 46) "4"
-          WHITESPACE@[46; 47) " "
-          MINUS@[47; 48) "-"
-          WHITESPACE@[48; 49) " "
-          BIN_EXPR@[49; 54)
-            LITERAL@[49; 50)
-              INT_NUMBER@[49; 50) "5"
-            WHITESPACE@[50; 51) " "
-            SLASH@[51; 52) "/"
-            WHITESPACE@[52; 53) " "
-            LITERAL@[53; 54)
-              INT_NUMBER@[53; 54) "6"
-        SEMI@[54; 55) ";"
-      WHITESPACE@[55; 60) "\n    "
-      EXPR_STMT@[60; 70)
-        BIN_EXPR@[60; 69)
-          LITERAL@[60; 61)
-            INT_NUMBER@[60; 61) "1"
-          WHITESPACE@[61; 62) " "
-          PLUS@[62; 63) "+"
-          WHITESPACE@[63; 64) " "
-          BIN_EXPR@[64; 69)
-            LITERAL@[64; 65)
-              INT_NUMBER@[64; 65) "2"
-            WHITESPACE@[65; 66) " "
-            STAR@[66; 67) "*"
-            WHITESPACE@[67; 68) " "
-            LITERAL@[68; 69)
-              INT_NUMBER@[68; 69) "3"
-        SEMI@[69; 70) ";"
-      WHITESPACE@[70; 75) "\n    "
-      EXPR_STMT@[75; 86)
-        BIN_EXPR@[75; 85)
-          LITERAL@[75; 76)
-            INT_NUMBER@[75; 76) "1"
-          WHITESPACE@[76; 77) " "
-          SHL@[77; 79) "<<"
-          WHITESPACE@[79; 80) " "
-          BIN_EXPR@[80; 85)
-            LITERAL@[80; 81)
-              INT_NUMBER@[80; 81) "2"
-            WHITESPACE@[81; 82) " "
-            PLUS@[82; 83) "+"
-            WHITESPACE@[83; 84) " "
-            LITERAL@[84; 85)
-              INT_NUMBER@[84; 85) "3"
-        SEMI@[85; 86) ";"
-      WHITESPACE@[86; 91) "\n    "
-      EXPR_STMT@[91; 102)
-        BIN_EXPR@[91; 101)
-          LITERAL@[91; 92)
-            INT_NUMBER@[91; 92) "1"
-          WHITESPACE@[92; 93) " "
-          AMP@[93; 94) "&"
-          WHITESPACE@[94; 95) " "
-          BIN_EXPR@[95; 101)
-            LITERAL@[95; 96)
-              INT_NUMBER@[95; 96) "2"
-            WHITESPACE@[96; 97) " "
-            SHR@[97; 99) ">>"
-            WHITESPACE@[99; 100) " "
-            LITERAL@[100; 101)
-              INT_NUMBER@[100; 101) "3"
-        SEMI@[101; 102) ";"
-      WHITESPACE@[102; 107) "\n    "
-      EXPR_STMT@[107; 117)
-        BIN_EXPR@[107; 116)
-          LITERAL@[107; 108)
-            INT_NUMBER@[107; 108) "1"
-          WHITESPACE@[108; 109) " "
-          CARET@[109; 110) "^"
-          WHITESPACE@[110; 111) " "
-          BIN_EXPR@[111; 116)
-            LITERAL@[111; 112)
-              INT_NUMBER@[111; 112) "2"
-            WHITESPACE@[112; 113) " "
-            AMP@[113; 114) "&"
-            WHITESPACE@[114; 115) " "
-            LITERAL@[115; 116)
-              INT_NUMBER@[115; 116) "3"
-        SEMI@[116; 117) ";"
-      WHITESPACE@[117; 122) "\n    "
-      EXPR_STMT@[122; 132)
-        BIN_EXPR@[122; 131)
-          LITERAL@[122; 123)
-            INT_NUMBER@[122; 123) "1"
-          WHITESPACE@[123; 124) " "
-          PIPE@[124; 125) "|"
-          WHITESPACE@[125; 126) " "
-          BIN_EXPR@[126; 131)
-            LITERAL@[126; 127)
-              INT_NUMBER@[126; 127) "2"
-            WHITESPACE@[127; 128) " "
-            CARET@[128; 129) "^"
-            WHITESPACE@[129; 130) " "
-            LITERAL@[130; 131)
-              INT_NUMBER@[130; 131) "3"
-        SEMI@[131; 132) ";"
-      WHITESPACE@[132; 137) "\n    "
-      EXPR_STMT@[137; 148)
-        BIN_EXPR@[137; 147)
-          LITERAL@[137; 138)
-            INT_NUMBER@[137; 138) "1"
-          WHITESPACE@[138; 139) " "
-          EQEQ@[139; 141) "=="
-          WHITESPACE@[141; 142) " "
-          BIN_EXPR@[142; 147)
-            LITERAL@[142; 143)
-              INT_NUMBER@[142; 143) "2"
-            WHITESPACE@[143; 144) " "
-            PIPE@[144; 145) "|"
-            WHITESPACE@[145; 146) " "
-            LITERAL@[146; 147)
-              INT_NUMBER@[146; 147) "3"
-        SEMI@[147; 148) ";"
-      WHITESPACE@[148; 153) "\n    "
-      EXPR_STMT@[153; 165)
-        BIN_EXPR@[153; 164)
-          LITERAL@[153; 154)
-            INT_NUMBER@[153; 154) "1"
-          WHITESPACE@[154; 155) " "
-          AMPAMP@[155; 157) "&&"
-          WHITESPACE@[157; 158) " "
-          BIN_EXPR@[158; 164)
-            LITERAL@[158; 159)
-              INT_NUMBER@[158; 159) "2"
-            WHITESPACE@[159; 160) " "
-            EQEQ@[160; 162) "=="
-            WHITESPACE@[162; 163) " "
-            LITERAL@[163; 164)
-              INT_NUMBER@[163; 164) "3"
-        SEMI@[164; 165) ";"
-      WHITESPACE@[165; 170) "\n    "
-      COMMENT@[170; 184) "//1 || 2 && 2;"
-      WHITESPACE@[184; 189) "\n    "
-      COMMENT@[189; 203) "//1 .. 2 || 3;"
-      WHITESPACE@[203; 208) "\n    "
-      COMMENT@[208; 221) "//1 = 2 .. 3;"
-      WHITESPACE@[221; 226) "\n    "
-      COMMENT@[226; 245) "//---&*1 - --2 * 9;"
-      WHITESPACE@[245; 246) "\n"
-      R_CURLY@[246; 247) "}"
+    BLOCK_EXPR@[19; 247)
+      BLOCK@[19; 247)
+        L_CURLY@[19; 20) "{"
+        WHITESPACE@[20; 25) "\n    "
+        LET_STMT@[25; 55)
+          LET_KW@[25; 28) "let"
+          WHITESPACE@[28; 29) " "
+          BIND_PAT@[29; 30)
+            NAME@[29; 30)
+              IDENT@[29; 30) "x"
+          WHITESPACE@[30; 31) " "
+          EQ@[31; 32) "="
+          WHITESPACE@[32; 33) " "
+          BIN_EXPR@[33; 54)
+            BIN_EXPR@[33; 46)
+              LITERAL@[33; 34)
+                INT_NUMBER@[33; 34) "1"
+              WHITESPACE@[34; 35) " "
+              PLUS@[35; 36) "+"
+              WHITESPACE@[36; 37) " "
+              BIN_EXPR@[37; 46)
+                BIN_EXPR@[37; 42)
+                  LITERAL@[37; 38)
+                    INT_NUMBER@[37; 38) "2"
+                  WHITESPACE@[38; 39) " "
+                  STAR@[39; 40) "*"
+                  WHITESPACE@[40; 41) " "
+                  LITERAL@[41; 42)
+                    INT_NUMBER@[41; 42) "3"
+                WHITESPACE@[42; 43) " "
+                PERCENT@[43; 44) "%"
+                WHITESPACE@[44; 45) " "
+                LITERAL@[45; 46)
+                  INT_NUMBER@[45; 46) "4"
+            WHITESPACE@[46; 47) " "
+            MINUS@[47; 48) "-"
+            WHITESPACE@[48; 49) " "
+            BIN_EXPR@[49; 54)
+              LITERAL@[49; 50)
+                INT_NUMBER@[49; 50) "5"
+              WHITESPACE@[50; 51) " "
+              SLASH@[51; 52) "/"
+              WHITESPACE@[52; 53) " "
+              LITERAL@[53; 54)
+                INT_NUMBER@[53; 54) "6"
+          SEMI@[54; 55) ";"
+        WHITESPACE@[55; 60) "\n    "
+        EXPR_STMT@[60; 70)
+          BIN_EXPR@[60; 69)
+            LITERAL@[60; 61)
+              INT_NUMBER@[60; 61) "1"
+            WHITESPACE@[61; 62) " "
+            PLUS@[62; 63) "+"
+            WHITESPACE@[63; 64) " "
+            BIN_EXPR@[64; 69)
+              LITERAL@[64; 65)
+                INT_NUMBER@[64; 65) "2"
+              WHITESPACE@[65; 66) " "
+              STAR@[66; 67) "*"
+              WHITESPACE@[67; 68) " "
+              LITERAL@[68; 69)
+                INT_NUMBER@[68; 69) "3"
+          SEMI@[69; 70) ";"
+        WHITESPACE@[70; 75) "\n    "
+        EXPR_STMT@[75; 86)
+          BIN_EXPR@[75; 85)
+            LITERAL@[75; 76)
+              INT_NUMBER@[75; 76) "1"
+            WHITESPACE@[76; 77) " "
+            SHL@[77; 79) "<<"
+            WHITESPACE@[79; 80) " "
+            BIN_EXPR@[80; 85)
+              LITERAL@[80; 81)
+                INT_NUMBER@[80; 81) "2"
+              WHITESPACE@[81; 82) " "
+              PLUS@[82; 83) "+"
+              WHITESPACE@[83; 84) " "
+              LITERAL@[84; 85)
+                INT_NUMBER@[84; 85) "3"
+          SEMI@[85; 86) ";"
+        WHITESPACE@[86; 91) "\n    "
+        EXPR_STMT@[91; 102)
+          BIN_EXPR@[91; 101)
+            LITERAL@[91; 92)
+              INT_NUMBER@[91; 92) "1"
+            WHITESPACE@[92; 93) " "
+            AMP@[93; 94) "&"
+            WHITESPACE@[94; 95) " "
+            BIN_EXPR@[95; 101)
+              LITERAL@[95; 96)
+                INT_NUMBER@[95; 96) "2"
+              WHITESPACE@[96; 97) " "
+              SHR@[97; 99) ">>"
+              WHITESPACE@[99; 100) " "
+              LITERAL@[100; 101)
+                INT_NUMBER@[100; 101) "3"
+          SEMI@[101; 102) ";"
+        WHITESPACE@[102; 107) "\n    "
+        EXPR_STMT@[107; 117)
+          BIN_EXPR@[107; 116)
+            LITERAL@[107; 108)
+              INT_NUMBER@[107; 108) "1"
+            WHITESPACE@[108; 109) " "
+            CARET@[109; 110) "^"
+            WHITESPACE@[110; 111) " "
+            BIN_EXPR@[111; 116)
+              LITERAL@[111; 112)
+                INT_NUMBER@[111; 112) "2"
+              WHITESPACE@[112; 113) " "
+              AMP@[113; 114) "&"
+              WHITESPACE@[114; 115) " "
+              LITERAL@[115; 116)
+                INT_NUMBER@[115; 116) "3"
+          SEMI@[116; 117) ";"
+        WHITESPACE@[117; 122) "\n    "
+        EXPR_STMT@[122; 132)
+          BIN_EXPR@[122; 131)
+            LITERAL@[122; 123)
+              INT_NUMBER@[122; 123) "1"
+            WHITESPACE@[123; 124) " "
+            PIPE@[124; 125) "|"
+            WHITESPACE@[125; 126) " "
+            BIN_EXPR@[126; 131)
+              LITERAL@[126; 127)
+                INT_NUMBER@[126; 127) "2"
+              WHITESPACE@[127; 128) " "
+              CARET@[128; 129) "^"
+              WHITESPACE@[129; 130) " "
+              LITERAL@[130; 131)
+                INT_NUMBER@[130; 131) "3"
+          SEMI@[131; 132) ";"
+        WHITESPACE@[132; 137) "\n    "
+        EXPR_STMT@[137; 148)
+          BIN_EXPR@[137; 147)
+            LITERAL@[137; 138)
+              INT_NUMBER@[137; 138) "1"
+            WHITESPACE@[138; 139) " "
+            EQEQ@[139; 141) "=="
+            WHITESPACE@[141; 142) " "
+            BIN_EXPR@[142; 147)
+              LITERAL@[142; 143)
+                INT_NUMBER@[142; 143) "2"
+              WHITESPACE@[143; 144) " "
+              PIPE@[144; 145) "|"
+              WHITESPACE@[145; 146) " "
+              LITERAL@[146; 147)
+                INT_NUMBER@[146; 147) "3"
+          SEMI@[147; 148) ";"
+        WHITESPACE@[148; 153) "\n    "
+        EXPR_STMT@[153; 165)
+          BIN_EXPR@[153; 164)
+            LITERAL@[153; 154)
+              INT_NUMBER@[153; 154) "1"
+            WHITESPACE@[154; 155) " "
+            AMPAMP@[155; 157) "&&"
+            WHITESPACE@[157; 158) " "
+            BIN_EXPR@[158; 164)
+              LITERAL@[158; 159)
+                INT_NUMBER@[158; 159) "2"
+              WHITESPACE@[159; 160) " "
+              EQEQ@[160; 162) "=="
+              WHITESPACE@[162; 163) " "
+              LITERAL@[163; 164)
+                INT_NUMBER@[163; 164) "3"
+          SEMI@[164; 165) ";"
+        WHITESPACE@[165; 170) "\n    "
+        COMMENT@[170; 184) "//1 || 2 && 2;"
+        WHITESPACE@[184; 189) "\n    "
+        COMMENT@[189; 203) "//1 .. 2 || 3;"
+        WHITESPACE@[203; 208) "\n    "
+        COMMENT@[208; 221) "//1 = 2 .. 3;"
+        WHITESPACE@[221; 226) "\n    "
+        COMMENT@[226; 245) "//---&*1 - --2 * 9;"
+        WHITESPACE@[245; 246) "\n"
+        R_CURLY@[246; 247) "}"
   WHITESPACE@[247; 248) "\n"

--- a/crates/ra_syntax/test_data/parser/ok/0029_range_forms.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0029_range_forms.txt
@@ -8,144 +8,145 @@ SOURCE_FILE@[0; 153)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 152)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 23)
-        RANGE_EXPR@[15; 22)
-          DOTDOT@[15; 17) ".."
-          BIN_EXPR@[17; 22)
-            LITERAL@[17; 18)
-              INT_NUMBER@[17; 18) "1"
-            WHITESPACE@[18; 19) " "
-            PLUS@[19; 20) "+"
-            WHITESPACE@[20; 21) " "
-            LITERAL@[21; 22)
-              INT_NUMBER@[21; 22) "1"
-        SEMI@[22; 23) ";"
-      WHITESPACE@[23; 28) "\n    "
-      EXPR_STMT@[28; 36)
-        BIN_EXPR@[28; 35)
-          RANGE_EXPR@[28; 31)
-            DOTDOT@[28; 30) ".."
-            PATH_EXPR@[30; 31)
-              PATH@[30; 31)
-                PATH_SEGMENT@[30; 31)
-                  NAME_REF@[30; 31)
-                    IDENT@[30; 31) "z"
-          WHITESPACE@[31; 32) " "
-          EQ@[32; 33) "="
-          WHITESPACE@[33; 34) " "
-          LITERAL@[34; 35)
-            INT_NUMBER@[34; 35) "2"
-        SEMI@[35; 36) ";"
-      WHITESPACE@[36; 41) "\n    "
-      EXPR_STMT@[41; 59)
-        BIN_EXPR@[41; 58)
-          PATH_EXPR@[41; 42)
-            PATH@[41; 42)
-              PATH_SEGMENT@[41; 42)
-                NAME_REF@[41; 42)
-                  IDENT@[41; 42) "x"
-          WHITESPACE@[42; 43) " "
-          EQ@[43; 44) "="
-          WHITESPACE@[44; 45) " "
-          RANGE_EXPR@[45; 58)
-            LITERAL@[45; 50)
-              FALSE_KW@[45; 50) "false"
-            DOTDOT@[50; 52) ".."
-            BIN_EXPR@[52; 58)
-              LITERAL@[52; 53)
-                INT_NUMBER@[52; 53) "1"
-              WHITESPACE@[53; 54) " "
-              EQEQ@[54; 56) "=="
-              WHITESPACE@[56; 57) " "
-              LITERAL@[57; 58)
-                INT_NUMBER@[57; 58) "1"
-        SEMI@[58; 59) ";"
-      WHITESPACE@[59; 64) "\n    "
-      LET_STMT@[64; 76)
-        LET_KW@[64; 67) "let"
-        WHITESPACE@[67; 68) " "
-        BIND_PAT@[68; 69)
-          NAME@[68; 69)
-            IDENT@[68; 69) "x"
-        WHITESPACE@[69; 70) " "
-        EQ@[70; 71) "="
-        WHITESPACE@[71; 72) " "
-        RANGE_EXPR@[72; 75)
-          LITERAL@[72; 73)
-            INT_NUMBER@[72; 73) "1"
-          DOTDOT@[73; 75) ".."
-        SEMI@[75; 76) ";"
-      WHITESPACE@[76; 86) "\n    \n    "
-      EXPR_STMT@[86; 95)
-        RANGE_EXPR@[86; 94)
-          DOTDOTEQ@[86; 89) "..="
-          BIN_EXPR@[89; 94)
-            LITERAL@[89; 90)
-              INT_NUMBER@[89; 90) "1"
-            WHITESPACE@[90; 91) " "
-            PLUS@[91; 92) "+"
-            WHITESPACE@[92; 93) " "
-            LITERAL@[93; 94)
-              INT_NUMBER@[93; 94) "1"
-        SEMI@[94; 95) ";"
-      WHITESPACE@[95; 100) "\n    "
-      EXPR_STMT@[100; 109)
-        BIN_EXPR@[100; 108)
-          RANGE_EXPR@[100; 104)
-            DOTDOTEQ@[100; 103) "..="
-            PATH_EXPR@[103; 104)
-              PATH@[103; 104)
-                PATH_SEGMENT@[103; 104)
-                  NAME_REF@[103; 104)
-                    IDENT@[103; 104) "z"
-          WHITESPACE@[104; 105) " "
-          EQ@[105; 106) "="
-          WHITESPACE@[106; 107) " "
-          LITERAL@[107; 108)
-            INT_NUMBER@[107; 108) "2"
-        SEMI@[108; 109) ";"
-      WHITESPACE@[109; 114) "\n    "
-      EXPR_STMT@[114; 133)
-        BIN_EXPR@[114; 132)
-          PATH_EXPR@[114; 115)
-            PATH@[114; 115)
-              PATH_SEGMENT@[114; 115)
-                NAME_REF@[114; 115)
-                  IDENT@[114; 115) "x"
-          WHITESPACE@[115; 116) " "
-          EQ@[116; 117) "="
-          WHITESPACE@[117; 118) " "
-          RANGE_EXPR@[118; 132)
-            LITERAL@[118; 123)
-              FALSE_KW@[118; 123) "false"
-            DOTDOTEQ@[123; 126) "..="
-            BIN_EXPR@[126; 132)
-              LITERAL@[126; 127)
-                INT_NUMBER@[126; 127) "1"
-              WHITESPACE@[127; 128) " "
-              EQEQ@[128; 130) "=="
-              WHITESPACE@[130; 131) " "
-              LITERAL@[131; 132)
-                INT_NUMBER@[131; 132) "1"
-        SEMI@[132; 133) ";"
-      WHITESPACE@[133; 138) "\n    "
-      LET_STMT@[138; 150)
-        LET_KW@[138; 141) "let"
-        WHITESPACE@[141; 142) " "
-        BIND_PAT@[142; 143)
-          NAME@[142; 143)
-            IDENT@[142; 143) "x"
-        WHITESPACE@[143; 144) " "
-        EQ@[144; 145) "="
-        WHITESPACE@[145; 146) " "
-        RANGE_EXPR@[146; 149)
-          LITERAL@[146; 147)
-            INT_NUMBER@[146; 147) "1"
-          DOTDOT@[147; 149) ".."
-        SEMI@[149; 150) ";"
-      WHITESPACE@[150; 151) "\n"
-      R_CURLY@[151; 152) "}"
+    BLOCK_EXPR@[9; 152)
+      BLOCK@[9; 152)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        EXPR_STMT@[15; 23)
+          RANGE_EXPR@[15; 22)
+            DOTDOT@[15; 17) ".."
+            BIN_EXPR@[17; 22)
+              LITERAL@[17; 18)
+                INT_NUMBER@[17; 18) "1"
+              WHITESPACE@[18; 19) " "
+              PLUS@[19; 20) "+"
+              WHITESPACE@[20; 21) " "
+              LITERAL@[21; 22)
+                INT_NUMBER@[21; 22) "1"
+          SEMI@[22; 23) ";"
+        WHITESPACE@[23; 28) "\n    "
+        EXPR_STMT@[28; 36)
+          BIN_EXPR@[28; 35)
+            RANGE_EXPR@[28; 31)
+              DOTDOT@[28; 30) ".."
+              PATH_EXPR@[30; 31)
+                PATH@[30; 31)
+                  PATH_SEGMENT@[30; 31)
+                    NAME_REF@[30; 31)
+                      IDENT@[30; 31) "z"
+            WHITESPACE@[31; 32) " "
+            EQ@[32; 33) "="
+            WHITESPACE@[33; 34) " "
+            LITERAL@[34; 35)
+              INT_NUMBER@[34; 35) "2"
+          SEMI@[35; 36) ";"
+        WHITESPACE@[36; 41) "\n    "
+        EXPR_STMT@[41; 59)
+          BIN_EXPR@[41; 58)
+            PATH_EXPR@[41; 42)
+              PATH@[41; 42)
+                PATH_SEGMENT@[41; 42)
+                  NAME_REF@[41; 42)
+                    IDENT@[41; 42) "x"
+            WHITESPACE@[42; 43) " "
+            EQ@[43; 44) "="
+            WHITESPACE@[44; 45) " "
+            RANGE_EXPR@[45; 58)
+              LITERAL@[45; 50)
+                FALSE_KW@[45; 50) "false"
+              DOTDOT@[50; 52) ".."
+              BIN_EXPR@[52; 58)
+                LITERAL@[52; 53)
+                  INT_NUMBER@[52; 53) "1"
+                WHITESPACE@[53; 54) " "
+                EQEQ@[54; 56) "=="
+                WHITESPACE@[56; 57) " "
+                LITERAL@[57; 58)
+                  INT_NUMBER@[57; 58) "1"
+          SEMI@[58; 59) ";"
+        WHITESPACE@[59; 64) "\n    "
+        LET_STMT@[64; 76)
+          LET_KW@[64; 67) "let"
+          WHITESPACE@[67; 68) " "
+          BIND_PAT@[68; 69)
+            NAME@[68; 69)
+              IDENT@[68; 69) "x"
+          WHITESPACE@[69; 70) " "
+          EQ@[70; 71) "="
+          WHITESPACE@[71; 72) " "
+          RANGE_EXPR@[72; 75)
+            LITERAL@[72; 73)
+              INT_NUMBER@[72; 73) "1"
+            DOTDOT@[73; 75) ".."
+          SEMI@[75; 76) ";"
+        WHITESPACE@[76; 86) "\n    \n    "
+        EXPR_STMT@[86; 95)
+          RANGE_EXPR@[86; 94)
+            DOTDOTEQ@[86; 89) "..="
+            BIN_EXPR@[89; 94)
+              LITERAL@[89; 90)
+                INT_NUMBER@[89; 90) "1"
+              WHITESPACE@[90; 91) " "
+              PLUS@[91; 92) "+"
+              WHITESPACE@[92; 93) " "
+              LITERAL@[93; 94)
+                INT_NUMBER@[93; 94) "1"
+          SEMI@[94; 95) ";"
+        WHITESPACE@[95; 100) "\n    "
+        EXPR_STMT@[100; 109)
+          BIN_EXPR@[100; 108)
+            RANGE_EXPR@[100; 104)
+              DOTDOTEQ@[100; 103) "..="
+              PATH_EXPR@[103; 104)
+                PATH@[103; 104)
+                  PATH_SEGMENT@[103; 104)
+                    NAME_REF@[103; 104)
+                      IDENT@[103; 104) "z"
+            WHITESPACE@[104; 105) " "
+            EQ@[105; 106) "="
+            WHITESPACE@[106; 107) " "
+            LITERAL@[107; 108)
+              INT_NUMBER@[107; 108) "2"
+          SEMI@[108; 109) ";"
+        WHITESPACE@[109; 114) "\n    "
+        EXPR_STMT@[114; 133)
+          BIN_EXPR@[114; 132)
+            PATH_EXPR@[114; 115)
+              PATH@[114; 115)
+                PATH_SEGMENT@[114; 115)
+                  NAME_REF@[114; 115)
+                    IDENT@[114; 115) "x"
+            WHITESPACE@[115; 116) " "
+            EQ@[116; 117) "="
+            WHITESPACE@[117; 118) " "
+            RANGE_EXPR@[118; 132)
+              LITERAL@[118; 123)
+                FALSE_KW@[118; 123) "false"
+              DOTDOTEQ@[123; 126) "..="
+              BIN_EXPR@[126; 132)
+                LITERAL@[126; 127)
+                  INT_NUMBER@[126; 127) "1"
+                WHITESPACE@[127; 128) " "
+                EQEQ@[128; 130) "=="
+                WHITESPACE@[130; 131) " "
+                LITERAL@[131; 132)
+                  INT_NUMBER@[131; 132) "1"
+          SEMI@[132; 133) ";"
+        WHITESPACE@[133; 138) "\n    "
+        LET_STMT@[138; 150)
+          LET_KW@[138; 141) "let"
+          WHITESPACE@[141; 142) " "
+          BIND_PAT@[142; 143)
+            NAME@[142; 143)
+              IDENT@[142; 143) "x"
+          WHITESPACE@[143; 144) " "
+          EQ@[144; 145) "="
+          WHITESPACE@[145; 146) " "
+          RANGE_EXPR@[146; 149)
+            LITERAL@[146; 147)
+              INT_NUMBER@[146; 147) "1"
+            DOTDOT@[147; 149) ".."
+          SEMI@[149; 150) ";"
+        WHITESPACE@[150; 151) "\n"
+        R_CURLY@[151; 152) "}"
   WHITESPACE@[152; 153) "\n"

--- a/crates/ra_syntax/test_data/parser/ok/0030_string_suffixes.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0030_string_suffixes.txt
@@ -8,56 +8,57 @@ SOURCE_FILE@[0; 112)
       L_PAREN@[7; 8) "("
       R_PAREN@[8; 9) ")"
     WHITESPACE@[9; 10) " "
-    BLOCK@[10; 111)
-      L_CURLY@[10; 11) "{"
-      WHITESPACE@[11; 16) "\n    "
-      LET_STMT@[16; 31)
-        LET_KW@[16; 19) "let"
-        WHITESPACE@[19; 20) " "
-        PLACEHOLDER_PAT@[20; 21)
-          UNDERSCORE@[20; 21) "_"
-        WHITESPACE@[21; 22) " "
-        EQ@[22; 23) "="
-        WHITESPACE@[23; 24) " "
-        LITERAL@[24; 30)
-          CHAR@[24; 30) "\'c\'u32"
-        SEMI@[30; 31) ";"
-      WHITESPACE@[31; 36) "\n    "
-      LET_STMT@[36; 60)
-        LET_KW@[36; 39) "let"
-        WHITESPACE@[39; 40) " "
-        PLACEHOLDER_PAT@[40; 41)
-          UNDERSCORE@[40; 41) "_"
-        WHITESPACE@[41; 42) " "
-        EQ@[42; 43) "="
-        WHITESPACE@[43; 44) " "
-        LITERAL@[44; 59)
-          STRING@[44; 59) "\"string\"invalid"
-        SEMI@[59; 60) ";"
-      WHITESPACE@[60; 65) "\n    "
-      LET_STMT@[65; 83)
-        LET_KW@[65; 68) "let"
-        WHITESPACE@[68; 69) " "
-        PLACEHOLDER_PAT@[69; 70)
-          UNDERSCORE@[69; 70) "_"
-        WHITESPACE@[70; 71) " "
-        EQ@[71; 72) "="
-        WHITESPACE@[72; 73) " "
-        LITERAL@[73; 82)
-          BYTE@[73; 82) "b\'b\'_suff"
-        SEMI@[82; 83) ";"
-      WHITESPACE@[83; 88) "\n    "
-      LET_STMT@[88; 109)
-        LET_KW@[88; 91) "let"
-        WHITESPACE@[91; 92) " "
-        PLACEHOLDER_PAT@[92; 93)
-          UNDERSCORE@[92; 93) "_"
-        WHITESPACE@[93; 94) " "
-        EQ@[94; 95) "="
-        WHITESPACE@[95; 96) " "
-        LITERAL@[96; 108)
-          BYTE_STRING@[96; 108) "b\"bs\"invalid"
-        SEMI@[108; 109) ";"
-      WHITESPACE@[109; 110) "\n"
-      R_CURLY@[110; 111) "}"
+    BLOCK_EXPR@[10; 111)
+      BLOCK@[10; 111)
+        L_CURLY@[10; 11) "{"
+        WHITESPACE@[11; 16) "\n    "
+        LET_STMT@[16; 31)
+          LET_KW@[16; 19) "let"
+          WHITESPACE@[19; 20) " "
+          PLACEHOLDER_PAT@[20; 21)
+            UNDERSCORE@[20; 21) "_"
+          WHITESPACE@[21; 22) " "
+          EQ@[22; 23) "="
+          WHITESPACE@[23; 24) " "
+          LITERAL@[24; 30)
+            CHAR@[24; 30) "\'c\'u32"
+          SEMI@[30; 31) ";"
+        WHITESPACE@[31; 36) "\n    "
+        LET_STMT@[36; 60)
+          LET_KW@[36; 39) "let"
+          WHITESPACE@[39; 40) " "
+          PLACEHOLDER_PAT@[40; 41)
+            UNDERSCORE@[40; 41) "_"
+          WHITESPACE@[41; 42) " "
+          EQ@[42; 43) "="
+          WHITESPACE@[43; 44) " "
+          LITERAL@[44; 59)
+            STRING@[44; 59) "\"string\"invalid"
+          SEMI@[59; 60) ";"
+        WHITESPACE@[60; 65) "\n    "
+        LET_STMT@[65; 83)
+          LET_KW@[65; 68) "let"
+          WHITESPACE@[68; 69) " "
+          PLACEHOLDER_PAT@[69; 70)
+            UNDERSCORE@[69; 70) "_"
+          WHITESPACE@[70; 71) " "
+          EQ@[71; 72) "="
+          WHITESPACE@[72; 73) " "
+          LITERAL@[73; 82)
+            BYTE@[73; 82) "b\'b\'_suff"
+          SEMI@[82; 83) ";"
+        WHITESPACE@[83; 88) "\n    "
+        LET_STMT@[88; 109)
+          LET_KW@[88; 91) "let"
+          WHITESPACE@[91; 92) " "
+          PLACEHOLDER_PAT@[92; 93)
+            UNDERSCORE@[92; 93) "_"
+          WHITESPACE@[93; 94) " "
+          EQ@[94; 95) "="
+          WHITESPACE@[95; 96) " "
+          LITERAL@[96; 108)
+            BYTE_STRING@[96; 108) "b\"bs\"invalid"
+          SEMI@[108; 109) ";"
+        WHITESPACE@[109; 110) "\n"
+        R_CURLY@[110; 111) "}"
   WHITESPACE@[111; 112) "\n"

--- a/crates/ra_syntax/test_data/parser/ok/0032_where_for.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0032_where_for.txt
@@ -84,7 +84,8 @@ SOURCE_FILE@[0; 116)
                     IDENT@[106; 111) "Debug"
       COMMA@[111; 112) ","
     WHITESPACE@[112; 113) "\n"
-    BLOCK@[113; 115)
-      L_CURLY@[113; 114) "{"
-      R_CURLY@[114; 115) "}"
+    BLOCK_EXPR@[113; 115)
+      BLOCK@[113; 115)
+        L_CURLY@[113; 114) "{"
+        R_CURLY@[114; 115) "}"
   WHITESPACE@[115; 116) "\n"

--- a/crates/ra_syntax/test_data/parser/ok/0033_label_break.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0033_label_break.txt
@@ -10,206 +10,211 @@ SOURCE_FILE@[0; 506)
       L_PAREN@[41; 42) "("
       R_PAREN@[42; 43) ")"
     WHITESPACE@[43; 44) " "
-    BLOCK@[44; 505)
-      L_CURLY@[44; 45) "{"
-      WHITESPACE@[45; 50) "\n    "
-      EXPR_STMT@[50; 66)
-        BLOCK_EXPR@[50; 66)
-          LABEL@[50; 63)
-            LIFETIME@[50; 62) "\'empty_block"
-            COLON@[62; 63) ":"
-          WHITESPACE@[63; 64) " "
-          BLOCK@[64; 66)
-            L_CURLY@[64; 65) "{"
-            R_CURLY@[65; 66) "}"
-      WHITESPACE@[66; 72) "\n\n    "
-      EXPR_STMT@[72; 295)
-        BLOCK_EXPR@[72; 295)
-          LABEL@[72; 79)
-            LIFETIME@[72; 78) "\'block"
-            COLON@[78; 79) ":"
-          WHITESPACE@[79; 80) " "
-          BLOCK@[80; 295)
-            L_CURLY@[80; 81) "{"
-            WHITESPACE@[81; 90) "\n        "
-            EXPR_STMT@[90; 101)
-              CALL_EXPR@[90; 100)
-                PATH_EXPR@[90; 98)
-                  PATH@[90; 98)
-                    PATH_SEGMENT@[90; 98)
-                      NAME_REF@[90; 98)
-                        IDENT@[90; 98) "do_thing"
-                ARG_LIST@[98; 100)
-                  L_PAREN@[98; 99) "("
-                  R_PAREN@[99; 100) ")"
-              SEMI@[100; 101) ";"
-            WHITESPACE@[101; 110) "\n        "
-            EXPR_STMT@[110; 170)
-              IF_EXPR@[110; 170)
-                IF_KW@[110; 112) "if"
-                WHITESPACE@[112; 113) " "
-                CONDITION@[113; 132)
-                  CALL_EXPR@[113; 132)
-                    PATH_EXPR@[113; 130)
-                      PATH@[113; 130)
-                        PATH_SEGMENT@[113; 130)
-                          NAME_REF@[113; 130)
-                            IDENT@[113; 130) "condition_not_met"
-                    ARG_LIST@[130; 132)
-                      L_PAREN@[130; 131) "("
-                      R_PAREN@[131; 132) ")"
-                WHITESPACE@[132; 133) " "
-                BLOCK@[133; 170)
-                  L_CURLY@[133; 134) "{"
-                  WHITESPACE@[134; 147) "\n            "
-                  EXPR_STMT@[147; 160)
-                    BREAK_EXPR@[147; 159)
-                      BREAK_KW@[147; 152) "break"
-                      WHITESPACE@[152; 153) " "
-                      LIFETIME@[153; 159) "\'block"
-                    SEMI@[159; 160) ";"
-                  WHITESPACE@[160; 169) "\n        "
-                  R_CURLY@[169; 170) "}"
-            WHITESPACE@[170; 179) "\n        "
-            EXPR_STMT@[179; 195)
-              CALL_EXPR@[179; 194)
-                PATH_EXPR@[179; 192)
-                  PATH@[179; 192)
-                    PATH_SEGMENT@[179; 192)
-                      NAME_REF@[179; 192)
-                        IDENT@[179; 192) "do_next_thing"
-                ARG_LIST@[192; 194)
-                  L_PAREN@[192; 193) "("
-                  R_PAREN@[193; 194) ")"
-              SEMI@[194; 195) ";"
-            WHITESPACE@[195; 204) "\n        "
-            EXPR_STMT@[204; 264)
-              IF_EXPR@[204; 264)
-                IF_KW@[204; 206) "if"
-                WHITESPACE@[206; 207) " "
-                CONDITION@[207; 226)
-                  CALL_EXPR@[207; 226)
-                    PATH_EXPR@[207; 224)
-                      PATH@[207; 224)
-                        PATH_SEGMENT@[207; 224)
-                          NAME_REF@[207; 224)
-                            IDENT@[207; 224) "condition_not_met"
-                    ARG_LIST@[224; 226)
-                      L_PAREN@[224; 225) "("
-                      R_PAREN@[225; 226) ")"
-                WHITESPACE@[226; 227) " "
-                BLOCK@[227; 264)
-                  L_CURLY@[227; 228) "{"
-                  WHITESPACE@[228; 241) "\n            "
-                  EXPR_STMT@[241; 254)
-                    BREAK_EXPR@[241; 253)
-                      BREAK_KW@[241; 246) "break"
-                      WHITESPACE@[246; 247) " "
-                      LIFETIME@[247; 253) "\'block"
-                    SEMI@[253; 254) ";"
-                  WHITESPACE@[254; 263) "\n        "
-                  R_CURLY@[263; 264) "}"
-            WHITESPACE@[264; 273) "\n        "
-            EXPR_STMT@[273; 289)
-              CALL_EXPR@[273; 288)
-                PATH_EXPR@[273; 286)
-                  PATH@[273; 286)
-                    PATH_SEGMENT@[273; 286)
-                      NAME_REF@[273; 286)
-                        IDENT@[273; 286) "do_last_thing"
-                ARG_LIST@[286; 288)
-                  L_PAREN@[286; 287) "("
-                  R_PAREN@[287; 288) ")"
-              SEMI@[288; 289) ";"
-            WHITESPACE@[289; 294) "\n    "
-            R_CURLY@[294; 295) "}"
-      WHITESPACE@[295; 301) "\n\n    "
-      LET_STMT@[301; 503)
-        LET_KW@[301; 304) "let"
-        WHITESPACE@[304; 305) " "
-        BIND_PAT@[305; 311)
-          NAME@[305; 311)
-            IDENT@[305; 311) "result"
-        WHITESPACE@[311; 312) " "
-        EQ@[312; 313) "="
-        WHITESPACE@[313; 314) " "
-        BLOCK_EXPR@[314; 502)
-          LABEL@[314; 321)
-            LIFETIME@[314; 320) "\'block"
-            COLON@[320; 321) ":"
-          WHITESPACE@[321; 322) " "
-          BLOCK@[322; 502)
-            L_CURLY@[322; 323) "{"
-            WHITESPACE@[323; 332) "\n        "
-            EXPR_STMT@[332; 403)
-              IF_EXPR@[332; 403)
-                IF_KW@[332; 334) "if"
-                WHITESPACE@[334; 335) " "
-                CONDITION@[335; 340)
-                  CALL_EXPR@[335; 340)
-                    PATH_EXPR@[335; 338)
-                      PATH@[335; 338)
-                        PATH_SEGMENT@[335; 338)
-                          NAME_REF@[335; 338)
-                            IDENT@[335; 338) "foo"
-                    ARG_LIST@[338; 340)
-                      L_PAREN@[338; 339) "("
-                      R_PAREN@[339; 340) ")"
-                WHITESPACE@[340; 341) " "
-                BLOCK@[341; 403)
-                  L_CURLY@[341; 342) "{"
-                  WHITESPACE@[342; 355) "\n            "
-                  COMMENT@[355; 365) "// comment"
-                  WHITESPACE@[365; 378) "\n            "
-                  EXPR_STMT@[378; 393)
-                    BREAK_EXPR@[378; 392)
-                      BREAK_KW@[378; 383) "break"
-                      WHITESPACE@[383; 384) " "
-                      LIFETIME@[384; 390) "\'block"
-                      WHITESPACE@[390; 391) " "
-                      LITERAL@[391; 392)
-                        INT_NUMBER@[391; 392) "1"
-                    SEMI@[392; 393) ";"
-                  WHITESPACE@[393; 402) "\n        "
-                  R_CURLY@[402; 403) "}"
-            WHITESPACE@[403; 412) "\n        "
-            EXPR_STMT@[412; 486)
-              IF_EXPR@[412; 486)
-                IF_KW@[412; 414) "if"
-                WHITESPACE@[414; 415) " "
-                CONDITION@[415; 420)
-                  CALL_EXPR@[415; 420)
-                    PATH_EXPR@[415; 418)
-                      PATH@[415; 418)
-                        PATH_SEGMENT@[415; 418)
-                          NAME_REF@[415; 418)
-                            IDENT@[415; 418) "bar"
-                    ARG_LIST@[418; 420)
-                      L_PAREN@[418; 419) "("
-                      R_PAREN@[419; 420) ")"
-                WHITESPACE@[420; 421) " "
-                BLOCK@[421; 486)
-                  L_CURLY@[421; 422) "{"
-                  WHITESPACE@[422; 435) "\n            "
-                  COMMENT@[435; 448) "/* comment */"
-                  WHITESPACE@[448; 461) "\n            "
-                  EXPR_STMT@[461; 476)
-                    BREAK_EXPR@[461; 475)
-                      BREAK_KW@[461; 466) "break"
-                      WHITESPACE@[466; 467) " "
-                      LIFETIME@[467; 473) "\'block"
-                      WHITESPACE@[473; 474) " "
-                      LITERAL@[474; 475)
-                        INT_NUMBER@[474; 475) "2"
-                    SEMI@[475; 476) ";"
-                  WHITESPACE@[476; 485) "\n        "
-                  R_CURLY@[485; 486) "}"
-            WHITESPACE@[486; 495) "\n        "
-            LITERAL@[495; 496)
-              INT_NUMBER@[495; 496) "3"
-            WHITESPACE@[496; 501) "\n    "
-            R_CURLY@[501; 502) "}"
-        SEMI@[502; 503) ";"
-      WHITESPACE@[503; 504) "\n"
-      R_CURLY@[504; 505) "}"
+    BLOCK_EXPR@[44; 505)
+      BLOCK@[44; 505)
+        L_CURLY@[44; 45) "{"
+        WHITESPACE@[45; 50) "\n    "
+        EXPR_STMT@[50; 66)
+          BLOCK_EXPR@[50; 66)
+            LABEL@[50; 63)
+              LIFETIME@[50; 62) "\'empty_block"
+              COLON@[62; 63) ":"
+            WHITESPACE@[63; 64) " "
+            BLOCK@[64; 66)
+              L_CURLY@[64; 65) "{"
+              R_CURLY@[65; 66) "}"
+        WHITESPACE@[66; 72) "\n\n    "
+        EXPR_STMT@[72; 295)
+          BLOCK_EXPR@[72; 295)
+            LABEL@[72; 79)
+              LIFETIME@[72; 78) "\'block"
+              COLON@[78; 79) ":"
+            WHITESPACE@[79; 80) " "
+            BLOCK@[80; 295)
+              L_CURLY@[80; 81) "{"
+              WHITESPACE@[81; 90) "\n        "
+              EXPR_STMT@[90; 101)
+                CALL_EXPR@[90; 100)
+                  PATH_EXPR@[90; 98)
+                    PATH@[90; 98)
+                      PATH_SEGMENT@[90; 98)
+                        NAME_REF@[90; 98)
+                          IDENT@[90; 98) "do_thing"
+                  ARG_LIST@[98; 100)
+                    L_PAREN@[98; 99) "("
+                    R_PAREN@[99; 100) ")"
+                SEMI@[100; 101) ";"
+              WHITESPACE@[101; 110) "\n        "
+              EXPR_STMT@[110; 170)
+                IF_EXPR@[110; 170)
+                  IF_KW@[110; 112) "if"
+                  WHITESPACE@[112; 113) " "
+                  CONDITION@[113; 132)
+                    CALL_EXPR@[113; 132)
+                      PATH_EXPR@[113; 130)
+                        PATH@[113; 130)
+                          PATH_SEGMENT@[113; 130)
+                            NAME_REF@[113; 130)
+                              IDENT@[113; 130) "condition_not_met"
+                      ARG_LIST@[130; 132)
+                        L_PAREN@[130; 131) "("
+                        R_PAREN@[131; 132) ")"
+                  WHITESPACE@[132; 133) " "
+                  BLOCK_EXPR@[133; 170)
+                    BLOCK@[133; 170)
+                      L_CURLY@[133; 134) "{"
+                      WHITESPACE@[134; 147) "\n            "
+                      EXPR_STMT@[147; 160)
+                        BREAK_EXPR@[147; 159)
+                          BREAK_KW@[147; 152) "break"
+                          WHITESPACE@[152; 153) " "
+                          LIFETIME@[153; 159) "\'block"
+                        SEMI@[159; 160) ";"
+                      WHITESPACE@[160; 169) "\n        "
+                      R_CURLY@[169; 170) "}"
+              WHITESPACE@[170; 179) "\n        "
+              EXPR_STMT@[179; 195)
+                CALL_EXPR@[179; 194)
+                  PATH_EXPR@[179; 192)
+                    PATH@[179; 192)
+                      PATH_SEGMENT@[179; 192)
+                        NAME_REF@[179; 192)
+                          IDENT@[179; 192) "do_next_thing"
+                  ARG_LIST@[192; 194)
+                    L_PAREN@[192; 193) "("
+                    R_PAREN@[193; 194) ")"
+                SEMI@[194; 195) ";"
+              WHITESPACE@[195; 204) "\n        "
+              EXPR_STMT@[204; 264)
+                IF_EXPR@[204; 264)
+                  IF_KW@[204; 206) "if"
+                  WHITESPACE@[206; 207) " "
+                  CONDITION@[207; 226)
+                    CALL_EXPR@[207; 226)
+                      PATH_EXPR@[207; 224)
+                        PATH@[207; 224)
+                          PATH_SEGMENT@[207; 224)
+                            NAME_REF@[207; 224)
+                              IDENT@[207; 224) "condition_not_met"
+                      ARG_LIST@[224; 226)
+                        L_PAREN@[224; 225) "("
+                        R_PAREN@[225; 226) ")"
+                  WHITESPACE@[226; 227) " "
+                  BLOCK_EXPR@[227; 264)
+                    BLOCK@[227; 264)
+                      L_CURLY@[227; 228) "{"
+                      WHITESPACE@[228; 241) "\n            "
+                      EXPR_STMT@[241; 254)
+                        BREAK_EXPR@[241; 253)
+                          BREAK_KW@[241; 246) "break"
+                          WHITESPACE@[246; 247) " "
+                          LIFETIME@[247; 253) "\'block"
+                        SEMI@[253; 254) ";"
+                      WHITESPACE@[254; 263) "\n        "
+                      R_CURLY@[263; 264) "}"
+              WHITESPACE@[264; 273) "\n        "
+              EXPR_STMT@[273; 289)
+                CALL_EXPR@[273; 288)
+                  PATH_EXPR@[273; 286)
+                    PATH@[273; 286)
+                      PATH_SEGMENT@[273; 286)
+                        NAME_REF@[273; 286)
+                          IDENT@[273; 286) "do_last_thing"
+                  ARG_LIST@[286; 288)
+                    L_PAREN@[286; 287) "("
+                    R_PAREN@[287; 288) ")"
+                SEMI@[288; 289) ";"
+              WHITESPACE@[289; 294) "\n    "
+              R_CURLY@[294; 295) "}"
+        WHITESPACE@[295; 301) "\n\n    "
+        LET_STMT@[301; 503)
+          LET_KW@[301; 304) "let"
+          WHITESPACE@[304; 305) " "
+          BIND_PAT@[305; 311)
+            NAME@[305; 311)
+              IDENT@[305; 311) "result"
+          WHITESPACE@[311; 312) " "
+          EQ@[312; 313) "="
+          WHITESPACE@[313; 314) " "
+          BLOCK_EXPR@[314; 502)
+            LABEL@[314; 321)
+              LIFETIME@[314; 320) "\'block"
+              COLON@[320; 321) ":"
+            WHITESPACE@[321; 322) " "
+            BLOCK@[322; 502)
+              L_CURLY@[322; 323) "{"
+              WHITESPACE@[323; 332) "\n        "
+              EXPR_STMT@[332; 403)
+                IF_EXPR@[332; 403)
+                  IF_KW@[332; 334) "if"
+                  WHITESPACE@[334; 335) " "
+                  CONDITION@[335; 340)
+                    CALL_EXPR@[335; 340)
+                      PATH_EXPR@[335; 338)
+                        PATH@[335; 338)
+                          PATH_SEGMENT@[335; 338)
+                            NAME_REF@[335; 338)
+                              IDENT@[335; 338) "foo"
+                      ARG_LIST@[338; 340)
+                        L_PAREN@[338; 339) "("
+                        R_PAREN@[339; 340) ")"
+                  WHITESPACE@[340; 341) " "
+                  BLOCK_EXPR@[341; 403)
+                    BLOCK@[341; 403)
+                      L_CURLY@[341; 342) "{"
+                      WHITESPACE@[342; 355) "\n            "
+                      COMMENT@[355; 365) "// comment"
+                      WHITESPACE@[365; 378) "\n            "
+                      EXPR_STMT@[378; 393)
+                        BREAK_EXPR@[378; 392)
+                          BREAK_KW@[378; 383) "break"
+                          WHITESPACE@[383; 384) " "
+                          LIFETIME@[384; 390) "\'block"
+                          WHITESPACE@[390; 391) " "
+                          LITERAL@[391; 392)
+                            INT_NUMBER@[391; 392) "1"
+                        SEMI@[392; 393) ";"
+                      WHITESPACE@[393; 402) "\n        "
+                      R_CURLY@[402; 403) "}"
+              WHITESPACE@[403; 412) "\n        "
+              EXPR_STMT@[412; 486)
+                IF_EXPR@[412; 486)
+                  IF_KW@[412; 414) "if"
+                  WHITESPACE@[414; 415) " "
+                  CONDITION@[415; 420)
+                    CALL_EXPR@[415; 420)
+                      PATH_EXPR@[415; 418)
+                        PATH@[415; 418)
+                          PATH_SEGMENT@[415; 418)
+                            NAME_REF@[415; 418)
+                              IDENT@[415; 418) "bar"
+                      ARG_LIST@[418; 420)
+                        L_PAREN@[418; 419) "("
+                        R_PAREN@[419; 420) ")"
+                  WHITESPACE@[420; 421) " "
+                  BLOCK_EXPR@[421; 486)
+                    BLOCK@[421; 486)
+                      L_CURLY@[421; 422) "{"
+                      WHITESPACE@[422; 435) "\n            "
+                      COMMENT@[435; 448) "/* comment */"
+                      WHITESPACE@[448; 461) "\n            "
+                      EXPR_STMT@[461; 476)
+                        BREAK_EXPR@[461; 475)
+                          BREAK_KW@[461; 466) "break"
+                          WHITESPACE@[466; 467) " "
+                          LIFETIME@[467; 473) "\'block"
+                          WHITESPACE@[473; 474) " "
+                          LITERAL@[474; 475)
+                            INT_NUMBER@[474; 475) "2"
+                        SEMI@[475; 476) ";"
+                      WHITESPACE@[476; 485) "\n        "
+                      R_CURLY@[485; 486) "}"
+              WHITESPACE@[486; 495) "\n        "
+              LITERAL@[495; 496)
+                INT_NUMBER@[495; 496) "3"
+              WHITESPACE@[496; 501) "\n    "
+              R_CURLY@[501; 502) "}"
+          SEMI@[502; 503) ";"
+        WHITESPACE@[503; 504) "\n"
+        R_CURLY@[504; 505) "}"
   WHITESPACE@[505; 506) "\n"

--- a/crates/ra_syntax/test_data/parser/ok/0034_crate_path_in_call.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0034_crate_path_in_call.txt
@@ -8,34 +8,35 @@ SOURCE_FILE@[0; 62)
       L_PAREN@[7; 8) "("
       R_PAREN@[8; 9) ")"
     WHITESPACE@[9; 10) " "
-    BLOCK@[10; 61)
-      L_CURLY@[10; 11) "{"
-      WHITESPACE@[11; 16) "\n    "
-      EXPR_STMT@[16; 59)
-        CALL_EXPR@[16; 58)
-          PATH_EXPR@[16; 26)
-            PATH@[16; 26)
-              PATH_SEGMENT@[16; 26)
-                NAME_REF@[16; 26)
-                  IDENT@[16; 26) "make_query"
-          ARG_LIST@[26; 58)
-            L_PAREN@[26; 27) "("
-            PATH_EXPR@[27; 57)
-              PATH@[27; 57)
-                PATH@[27; 44)
-                  PATH@[27; 32)
-                    PATH_SEGMENT@[27; 32)
-                      CRATE_KW@[27; 32) "crate"
-                  COLONCOLON@[32; 34) "::"
-                  PATH_SEGMENT@[34; 44)
-                    NAME_REF@[34; 44)
-                      IDENT@[34; 44) "module_map"
-                COLONCOLON@[44; 46) "::"
-                PATH_SEGMENT@[46; 57)
-                  NAME_REF@[46; 57)
-                    IDENT@[46; 57) "module_tree"
-            R_PAREN@[57; 58) ")"
-        SEMI@[58; 59) ";"
-      WHITESPACE@[59; 60) "\n"
-      R_CURLY@[60; 61) "}"
+    BLOCK_EXPR@[10; 61)
+      BLOCK@[10; 61)
+        L_CURLY@[10; 11) "{"
+        WHITESPACE@[11; 16) "\n    "
+        EXPR_STMT@[16; 59)
+          CALL_EXPR@[16; 58)
+            PATH_EXPR@[16; 26)
+              PATH@[16; 26)
+                PATH_SEGMENT@[16; 26)
+                  NAME_REF@[16; 26)
+                    IDENT@[16; 26) "make_query"
+            ARG_LIST@[26; 58)
+              L_PAREN@[26; 27) "("
+              PATH_EXPR@[27; 57)
+                PATH@[27; 57)
+                  PATH@[27; 44)
+                    PATH@[27; 32)
+                      PATH_SEGMENT@[27; 32)
+                        CRATE_KW@[27; 32) "crate"
+                    COLONCOLON@[32; 34) "::"
+                    PATH_SEGMENT@[34; 44)
+                      NAME_REF@[34; 44)
+                        IDENT@[34; 44) "module_map"
+                  COLONCOLON@[44; 46) "::"
+                  PATH_SEGMENT@[46; 57)
+                    NAME_REF@[46; 57)
+                      IDENT@[46; 57) "module_tree"
+              R_PAREN@[57; 58) ")"
+          SEMI@[58; 59) ";"
+        WHITESPACE@[59; 60) "\n"
+        R_CURLY@[60; 61) "}"
   WHITESPACE@[61; 62) "\n"

--- a/crates/ra_syntax/test_data/parser/ok/0035_weird_exprs.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0035_weird_exprs.txt
@@ -127,33 +127,34 @@ SOURCE_FILE@[0; 3813)
             NAME_REF@[536; 540)
               IDENT@[536; 540) "bool"
     WHITESPACE@[540; 541) " "
-    BLOCK@[541; 572)
-      L_CURLY@[541; 542) "{"
-      WHITESPACE@[542; 543) " "
-      LET_STMT@[543; 570)
-        LET_KW@[543; 546) "let"
-        WHITESPACE@[546; 547) " "
-        BIND_PAT@[547; 549)
-          NAME@[547; 549)
-            IDENT@[547; 549) "_x"
-        COLON@[549; 550) ":"
-        WHITESPACE@[550; 551) " "
-        PATH_TYPE@[551; 555)
-          PATH@[551; 555)
-            PATH_SEGMENT@[551; 555)
-              NAME_REF@[551; 555)
-                IDENT@[551; 555) "bool"
-        WHITESPACE@[555; 556) " "
-        EQ@[556; 557) "="
-        WHITESPACE@[557; 558) " "
-        RETURN_EXPR@[558; 569)
-          RETURN_KW@[558; 564) "return"
-          WHITESPACE@[564; 565) " "
-          LITERAL@[565; 569)
-            TRUE_KW@[565; 569) "true"
-        SEMI@[569; 570) ";"
-      WHITESPACE@[570; 571) " "
-      R_CURLY@[571; 572) "}"
+    BLOCK_EXPR@[541; 572)
+      BLOCK@[541; 572)
+        L_CURLY@[541; 542) "{"
+        WHITESPACE@[542; 543) " "
+        LET_STMT@[543; 570)
+          LET_KW@[543; 546) "let"
+          WHITESPACE@[546; 547) " "
+          BIND_PAT@[547; 549)
+            NAME@[547; 549)
+              IDENT@[547; 549) "_x"
+          COLON@[549; 550) ":"
+          WHITESPACE@[550; 551) " "
+          PATH_TYPE@[551; 555)
+            PATH@[551; 555)
+              PATH_SEGMENT@[551; 555)
+                NAME_REF@[551; 555)
+                  IDENT@[551; 555) "bool"
+          WHITESPACE@[555; 556) " "
+          EQ@[556; 557) "="
+          WHITESPACE@[557; 558) " "
+          RETURN_EXPR@[558; 569)
+            RETURN_KW@[558; 564) "return"
+            WHITESPACE@[564; 565) " "
+            LITERAL@[565; 569)
+              TRUE_KW@[565; 569) "true"
+          SEMI@[569; 570) ";"
+        WHITESPACE@[570; 571) " "
+        R_CURLY@[571; 572) "}"
   WHITESPACE@[572; 574) "\n\n"
   FN_DEF@[574; 624)
     FN_KW@[574; 576) "fn"
@@ -164,47 +165,49 @@ SOURCE_FILE@[0; 3813)
       L_PAREN@[582; 583) "("
       R_PAREN@[583; 584) ")"
     WHITESPACE@[584; 585) " "
-    BLOCK@[585; 624)
-      L_CURLY@[585; 586) "{"
-      WHITESPACE@[586; 591) "\n    "
-      FN_DEF@[591; 607)
-        FN_KW@[591; 593) "fn"
-        WHITESPACE@[593; 594) " "
-        NAME@[594; 595)
-          IDENT@[594; 595) "f"
-        PARAM_LIST@[595; 603)
-          L_PAREN@[595; 596) "("
-          PARAM@[596; 602)
-            BIND_PAT@[596; 598)
-              NAME@[596; 598)
-                IDENT@[596; 598) "_x"
-            COLON@[598; 599) ":"
-            WHITESPACE@[599; 600) " "
-            TUPLE_TYPE@[600; 602)
-              L_PAREN@[600; 601) "("
-              R_PAREN@[601; 602) ")"
-          R_PAREN@[602; 603) ")"
-        WHITESPACE@[603; 604) " "
-        BLOCK@[604; 607)
-          L_CURLY@[604; 605) "{"
-          WHITESPACE@[605; 606) " "
-          R_CURLY@[606; 607) "}"
-      WHITESPACE@[607; 612) "\n    "
-      EXPR_STMT@[612; 622)
-        CALL_EXPR@[612; 621)
-          PATH_EXPR@[612; 613)
-            PATH@[612; 613)
-              PATH_SEGMENT@[612; 613)
-                NAME_REF@[612; 613)
-                  IDENT@[612; 613) "f"
-          ARG_LIST@[613; 621)
-            L_PAREN@[613; 614) "("
-            RETURN_EXPR@[614; 620)
-              RETURN_KW@[614; 620) "return"
-            R_PAREN@[620; 621) ")"
-        SEMI@[621; 622) ";"
-      WHITESPACE@[622; 623) "\n"
-      R_CURLY@[623; 624) "}"
+    BLOCK_EXPR@[585; 624)
+      BLOCK@[585; 624)
+        L_CURLY@[585; 586) "{"
+        WHITESPACE@[586; 591) "\n    "
+        FN_DEF@[591; 607)
+          FN_KW@[591; 593) "fn"
+          WHITESPACE@[593; 594) " "
+          NAME@[594; 595)
+            IDENT@[594; 595) "f"
+          PARAM_LIST@[595; 603)
+            L_PAREN@[595; 596) "("
+            PARAM@[596; 602)
+              BIND_PAT@[596; 598)
+                NAME@[596; 598)
+                  IDENT@[596; 598) "_x"
+              COLON@[598; 599) ":"
+              WHITESPACE@[599; 600) " "
+              TUPLE_TYPE@[600; 602)
+                L_PAREN@[600; 601) "("
+                R_PAREN@[601; 602) ")"
+            R_PAREN@[602; 603) ")"
+          WHITESPACE@[603; 604) " "
+          BLOCK_EXPR@[604; 607)
+            BLOCK@[604; 607)
+              L_CURLY@[604; 605) "{"
+              WHITESPACE@[605; 606) " "
+              R_CURLY@[606; 607) "}"
+        WHITESPACE@[607; 612) "\n    "
+        EXPR_STMT@[612; 622)
+          CALL_EXPR@[612; 621)
+            PATH_EXPR@[612; 613)
+              PATH@[612; 613)
+                PATH_SEGMENT@[612; 613)
+                  NAME_REF@[612; 613)
+                    IDENT@[612; 613) "f"
+            ARG_LIST@[613; 621)
+              L_PAREN@[613; 614) "("
+              RETURN_EXPR@[614; 620)
+                RETURN_KW@[614; 620) "return"
+              R_PAREN@[620; 621) ")"
+          SEMI@[621; 622) ";"
+        WHITESPACE@[622; 623) "\n"
+        R_CURLY@[623; 624) "}"
   WHITESPACE@[624; 626) "\n\n"
   FN_DEF@[626; 816)
     FN_KW@[626; 628) "fn"
@@ -215,187 +218,190 @@ SOURCE_FILE@[0; 3813)
       L_PAREN@[633; 634) "("
       R_PAREN@[634; 635) ")"
     WHITESPACE@[635; 636) " "
-    BLOCK@[636; 816)
-      L_CURLY@[636; 637) "{"
-      WHITESPACE@[637; 642) "\n    "
-      FN_DEF@[642; 720)
-        FN_KW@[642; 644) "fn"
-        WHITESPACE@[644; 645) " "
-        NAME@[645; 648)
-          IDENT@[645; 648) "the"
-        PARAM_LIST@[648; 664)
-          L_PAREN@[648; 649) "("
-          PARAM@[649; 663)
-            BIND_PAT@[649; 650)
-              NAME@[649; 650)
-                IDENT@[649; 650) "x"
-            COLON@[650; 651) ":"
-            WHITESPACE@[651; 652) " "
-            REFERENCE_TYPE@[652; 663)
-              AMP@[652; 653) "&"
-              PATH_TYPE@[653; 663)
-                PATH@[653; 663)
-                  PATH_SEGMENT@[653; 663)
-                    NAME_REF@[653; 657)
-                      IDENT@[653; 657) "Cell"
-                    TYPE_ARG_LIST@[657; 663)
-                      L_ANGLE@[657; 658) "<"
-                      TYPE_ARG@[658; 662)
-                        PATH_TYPE@[658; 662)
-                          PATH@[658; 662)
-                            PATH_SEGMENT@[658; 662)
-                              NAME_REF@[658; 662)
-                                IDENT@[658; 662) "bool"
-                      R_ANGLE@[662; 663) ">"
-          R_PAREN@[663; 664) ")"
-        WHITESPACE@[664; 665) " "
-        BLOCK@[665; 720)
-          L_CURLY@[665; 666) "{"
-          WHITESPACE@[666; 675) "\n        "
-          EXPR_STMT@[675; 714)
-            RETURN_EXPR@[675; 713)
-              RETURN_KW@[675; 681) "return"
-              WHITESPACE@[681; 682) " "
-              WHILE_EXPR@[682; 713)
-                WHILE_KW@[682; 687) "while"
-                WHITESPACE@[687; 688) " "
-                CONDITION@[688; 696)
-                  PREFIX_EXPR@[688; 696)
-                    EXCL@[688; 689) "!"
-                    METHOD_CALL_EXPR@[689; 696)
-                      PATH_EXPR@[689; 690)
-                        PATH@[689; 690)
-                          PATH_SEGMENT@[689; 690)
-                            NAME_REF@[689; 690)
-                              IDENT@[689; 690) "x"
-                      DOT@[690; 691) "."
-                      NAME_REF@[691; 694)
-                        IDENT@[691; 694) "get"
-                      ARG_LIST@[694; 696)
-                        L_PAREN@[694; 695) "("
-                        R_PAREN@[695; 696) ")"
-                WHITESPACE@[696; 697) " "
-                BLOCK@[697; 713)
-                  L_CURLY@[697; 698) "{"
-                  WHITESPACE@[698; 699) " "
-                  EXPR_STMT@[699; 711)
-                    METHOD_CALL_EXPR@[699; 710)
-                      PATH_EXPR@[699; 700)
-                        PATH@[699; 700)
-                          PATH_SEGMENT@[699; 700)
-                            NAME_REF@[699; 700)
-                              IDENT@[699; 700) "x"
-                      DOT@[700; 701) "."
-                      NAME_REF@[701; 704)
-                        IDENT@[701; 704) "set"
-                      ARG_LIST@[704; 710)
-                        L_PAREN@[704; 705) "("
-                        LITERAL@[705; 709)
-                          TRUE_KW@[705; 709) "true"
-                        R_PAREN@[709; 710) ")"
-                    SEMI@[710; 711) ";"
-                  WHITESPACE@[711; 712) " "
-                  R_CURLY@[712; 713) "}"
-            SEMI@[713; 714) ";"
-          WHITESPACE@[714; 719) "\n    "
-          R_CURLY@[719; 720) "}"
-      WHITESPACE@[720; 725) "\n    "
-      LET_STMT@[725; 751)
-        LET_KW@[725; 728) "let"
-        WHITESPACE@[728; 729) " "
-        BIND_PAT@[729; 730)
-          NAME@[729; 730)
-            IDENT@[729; 730) "i"
-        WHITESPACE@[730; 731) " "
-        EQ@[731; 732) "="
-        WHITESPACE@[732; 733) " "
-        REF_EXPR@[733; 750)
-          AMP@[733; 734) "&"
-          CALL_EXPR@[734; 750)
-            PATH_EXPR@[734; 743)
-              PATH@[734; 743)
-                PATH@[734; 738)
-                  PATH_SEGMENT@[734; 738)
-                    NAME_REF@[734; 738)
-                      IDENT@[734; 738) "Cell"
-                COLONCOLON@[738; 740) "::"
-                PATH_SEGMENT@[740; 743)
-                  NAME_REF@[740; 743)
-                    IDENT@[740; 743) "new"
-            ARG_LIST@[743; 750)
-              L_PAREN@[743; 744) "("
-              LITERAL@[744; 749)
-                FALSE_KW@[744; 749) "false"
-              R_PAREN@[749; 750) ")"
-        SEMI@[750; 751) ";"
-      WHITESPACE@[751; 756) "\n    "
-      LET_STMT@[756; 778)
-        LET_KW@[756; 759) "let"
-        WHITESPACE@[759; 760) " "
-        BIND_PAT@[760; 764)
-          NAME@[760; 764)
-            IDENT@[760; 764) "dont"
-        WHITESPACE@[764; 765) " "
-        EQ@[765; 766) "="
-        WHITESPACE@[766; 767) " "
-        BLOCK_EXPR@[767; 777)
-          BLOCK@[767; 777)
-            L_CURLY@[767; 768) "{"
-            LAMBDA_EXPR@[768; 776)
-              PARAM_LIST@[768; 770)
-                PIPE@[768; 769) "|"
-                PIPE@[769; 770) "|"
-              CALL_EXPR@[770; 776)
-                PATH_EXPR@[770; 773)
-                  PATH@[770; 773)
-                    PATH_SEGMENT@[770; 773)
-                      NAME_REF@[770; 773)
-                        IDENT@[770; 773) "the"
-                ARG_LIST@[773; 776)
-                  L_PAREN@[773; 774) "("
-                  PATH_EXPR@[774; 775)
-                    PATH@[774; 775)
-                      PATH_SEGMENT@[774; 775)
-                        NAME_REF@[774; 775)
-                          IDENT@[774; 775) "i"
-                  R_PAREN@[775; 776) ")"
-            R_CURLY@[776; 777) "}"
-        SEMI@[777; 778) ";"
-      WHITESPACE@[778; 783) "\n    "
-      EXPR_STMT@[783; 790)
-        CALL_EXPR@[783; 789)
-          PATH_EXPR@[783; 787)
-            PATH@[783; 787)
-              PATH_SEGMENT@[783; 787)
-                NAME_REF@[783; 787)
-                  IDENT@[783; 787) "dont"
-          ARG_LIST@[787; 789)
-            L_PAREN@[787; 788) "("
-            R_PAREN@[788; 789) ")"
-        SEMI@[789; 790) ";"
-      WHITESPACE@[790; 795) "\n    "
-      EXPR_STMT@[795; 814)
-        MACRO_CALL@[795; 813)
-          PATH@[795; 801)
-            PATH_SEGMENT@[795; 801)
-              NAME_REF@[795; 801)
-                IDENT@[795; 801) "assert"
-          EXCL@[801; 802) "!"
-          TOKEN_TREE@[802; 813)
-            L_PAREN@[802; 803) "("
-            TOKEN_TREE@[803; 812)
-              L_PAREN@[803; 804) "("
-              IDENT@[804; 805) "i"
-              DOT@[805; 806) "."
-              IDENT@[806; 809) "get"
-              TOKEN_TREE@[809; 811)
-                L_PAREN@[809; 810) "("
-                R_PAREN@[810; 811) ")"
-              R_PAREN@[811; 812) ")"
-            R_PAREN@[812; 813) ")"
-        SEMI@[813; 814) ";"
-      WHITESPACE@[814; 815) "\n"
-      R_CURLY@[815; 816) "}"
+    BLOCK_EXPR@[636; 816)
+      BLOCK@[636; 816)
+        L_CURLY@[636; 637) "{"
+        WHITESPACE@[637; 642) "\n    "
+        FN_DEF@[642; 720)
+          FN_KW@[642; 644) "fn"
+          WHITESPACE@[644; 645) " "
+          NAME@[645; 648)
+            IDENT@[645; 648) "the"
+          PARAM_LIST@[648; 664)
+            L_PAREN@[648; 649) "("
+            PARAM@[649; 663)
+              BIND_PAT@[649; 650)
+                NAME@[649; 650)
+                  IDENT@[649; 650) "x"
+              COLON@[650; 651) ":"
+              WHITESPACE@[651; 652) " "
+              REFERENCE_TYPE@[652; 663)
+                AMP@[652; 653) "&"
+                PATH_TYPE@[653; 663)
+                  PATH@[653; 663)
+                    PATH_SEGMENT@[653; 663)
+                      NAME_REF@[653; 657)
+                        IDENT@[653; 657) "Cell"
+                      TYPE_ARG_LIST@[657; 663)
+                        L_ANGLE@[657; 658) "<"
+                        TYPE_ARG@[658; 662)
+                          PATH_TYPE@[658; 662)
+                            PATH@[658; 662)
+                              PATH_SEGMENT@[658; 662)
+                                NAME_REF@[658; 662)
+                                  IDENT@[658; 662) "bool"
+                        R_ANGLE@[662; 663) ">"
+            R_PAREN@[663; 664) ")"
+          WHITESPACE@[664; 665) " "
+          BLOCK_EXPR@[665; 720)
+            BLOCK@[665; 720)
+              L_CURLY@[665; 666) "{"
+              WHITESPACE@[666; 675) "\n        "
+              EXPR_STMT@[675; 714)
+                RETURN_EXPR@[675; 713)
+                  RETURN_KW@[675; 681) "return"
+                  WHITESPACE@[681; 682) " "
+                  WHILE_EXPR@[682; 713)
+                    WHILE_KW@[682; 687) "while"
+                    WHITESPACE@[687; 688) " "
+                    CONDITION@[688; 696)
+                      PREFIX_EXPR@[688; 696)
+                        EXCL@[688; 689) "!"
+                        METHOD_CALL_EXPR@[689; 696)
+                          PATH_EXPR@[689; 690)
+                            PATH@[689; 690)
+                              PATH_SEGMENT@[689; 690)
+                                NAME_REF@[689; 690)
+                                  IDENT@[689; 690) "x"
+                          DOT@[690; 691) "."
+                          NAME_REF@[691; 694)
+                            IDENT@[691; 694) "get"
+                          ARG_LIST@[694; 696)
+                            L_PAREN@[694; 695) "("
+                            R_PAREN@[695; 696) ")"
+                    WHITESPACE@[696; 697) " "
+                    BLOCK_EXPR@[697; 713)
+                      BLOCK@[697; 713)
+                        L_CURLY@[697; 698) "{"
+                        WHITESPACE@[698; 699) " "
+                        EXPR_STMT@[699; 711)
+                          METHOD_CALL_EXPR@[699; 710)
+                            PATH_EXPR@[699; 700)
+                              PATH@[699; 700)
+                                PATH_SEGMENT@[699; 700)
+                                  NAME_REF@[699; 700)
+                                    IDENT@[699; 700) "x"
+                            DOT@[700; 701) "."
+                            NAME_REF@[701; 704)
+                              IDENT@[701; 704) "set"
+                            ARG_LIST@[704; 710)
+                              L_PAREN@[704; 705) "("
+                              LITERAL@[705; 709)
+                                TRUE_KW@[705; 709) "true"
+                              R_PAREN@[709; 710) ")"
+                          SEMI@[710; 711) ";"
+                        WHITESPACE@[711; 712) " "
+                        R_CURLY@[712; 713) "}"
+                SEMI@[713; 714) ";"
+              WHITESPACE@[714; 719) "\n    "
+              R_CURLY@[719; 720) "}"
+        WHITESPACE@[720; 725) "\n    "
+        LET_STMT@[725; 751)
+          LET_KW@[725; 728) "let"
+          WHITESPACE@[728; 729) " "
+          BIND_PAT@[729; 730)
+            NAME@[729; 730)
+              IDENT@[729; 730) "i"
+          WHITESPACE@[730; 731) " "
+          EQ@[731; 732) "="
+          WHITESPACE@[732; 733) " "
+          REF_EXPR@[733; 750)
+            AMP@[733; 734) "&"
+            CALL_EXPR@[734; 750)
+              PATH_EXPR@[734; 743)
+                PATH@[734; 743)
+                  PATH@[734; 738)
+                    PATH_SEGMENT@[734; 738)
+                      NAME_REF@[734; 738)
+                        IDENT@[734; 738) "Cell"
+                  COLONCOLON@[738; 740) "::"
+                  PATH_SEGMENT@[740; 743)
+                    NAME_REF@[740; 743)
+                      IDENT@[740; 743) "new"
+              ARG_LIST@[743; 750)
+                L_PAREN@[743; 744) "("
+                LITERAL@[744; 749)
+                  FALSE_KW@[744; 749) "false"
+                R_PAREN@[749; 750) ")"
+          SEMI@[750; 751) ";"
+        WHITESPACE@[751; 756) "\n    "
+        LET_STMT@[756; 778)
+          LET_KW@[756; 759) "let"
+          WHITESPACE@[759; 760) " "
+          BIND_PAT@[760; 764)
+            NAME@[760; 764)
+              IDENT@[760; 764) "dont"
+          WHITESPACE@[764; 765) " "
+          EQ@[765; 766) "="
+          WHITESPACE@[766; 767) " "
+          BLOCK_EXPR@[767; 777)
+            BLOCK@[767; 777)
+              L_CURLY@[767; 768) "{"
+              LAMBDA_EXPR@[768; 776)
+                PARAM_LIST@[768; 770)
+                  PIPE@[768; 769) "|"
+                  PIPE@[769; 770) "|"
+                CALL_EXPR@[770; 776)
+                  PATH_EXPR@[770; 773)
+                    PATH@[770; 773)
+                      PATH_SEGMENT@[770; 773)
+                        NAME_REF@[770; 773)
+                          IDENT@[770; 773) "the"
+                  ARG_LIST@[773; 776)
+                    L_PAREN@[773; 774) "("
+                    PATH_EXPR@[774; 775)
+                      PATH@[774; 775)
+                        PATH_SEGMENT@[774; 775)
+                          NAME_REF@[774; 775)
+                            IDENT@[774; 775) "i"
+                    R_PAREN@[775; 776) ")"
+              R_CURLY@[776; 777) "}"
+          SEMI@[777; 778) ";"
+        WHITESPACE@[778; 783) "\n    "
+        EXPR_STMT@[783; 790)
+          CALL_EXPR@[783; 789)
+            PATH_EXPR@[783; 787)
+              PATH@[783; 787)
+                PATH_SEGMENT@[783; 787)
+                  NAME_REF@[783; 787)
+                    IDENT@[783; 787) "dont"
+            ARG_LIST@[787; 789)
+              L_PAREN@[787; 788) "("
+              R_PAREN@[788; 789) ")"
+          SEMI@[789; 790) ";"
+        WHITESPACE@[790; 795) "\n    "
+        EXPR_STMT@[795; 814)
+          MACRO_CALL@[795; 813)
+            PATH@[795; 801)
+              PATH_SEGMENT@[795; 801)
+                NAME_REF@[795; 801)
+                  IDENT@[795; 801) "assert"
+            EXCL@[801; 802) "!"
+            TOKEN_TREE@[802; 813)
+              L_PAREN@[802; 803) "("
+              TOKEN_TREE@[803; 812)
+                L_PAREN@[803; 804) "("
+                IDENT@[804; 805) "i"
+                DOT@[805; 806) "."
+                IDENT@[806; 809) "get"
+                TOKEN_TREE@[809; 811)
+                  L_PAREN@[809; 810) "("
+                  R_PAREN@[810; 811) ")"
+                R_PAREN@[811; 812) ")"
+              R_PAREN@[812; 813) ")"
+          SEMI@[813; 814) ";"
+        WHITESPACE@[814; 815) "\n"
+        R_CURLY@[815; 816) "}"
   WHITESPACE@[816; 818) "\n\n"
   FN_DEF@[818; 1322)
     FN_KW@[818; 820) "fn"
@@ -406,163 +412,171 @@ SOURCE_FILE@[0; 3813)
       L_PAREN@[832; 833) "("
       R_PAREN@[833; 834) ")"
     WHITESPACE@[834; 835) " "
-    BLOCK@[835; 1322)
-      L_CURLY@[835; 836) "{"
-      WHITESPACE@[836; 841) "\n    "
-      LOOP_EXPR@[841; 1320)
-        LOOP_KW@[841; 845) "loop"
-        WHITESPACE@[845; 846) " "
-        BLOCK@[846; 1320)
-          L_CURLY@[846; 847) "{"
-          WHITESPACE@[847; 856) "\n        "
-          EXPR_STMT@[856; 1283)
-            WHILE_EXPR@[856; 1283)
-              WHILE_KW@[856; 861) "while"
-              WHITESPACE@[861; 862) " "
-              CONDITION@[862; 870)
-                PAREN_EXPR@[862; 870)
-                  L_PAREN@[862; 863) "("
-                  RETURN_EXPR@[863; 869)
-                    RETURN_KW@[863; 869) "return"
-                  R_PAREN@[869; 870) ")"
-              WHITESPACE@[870; 871) " "
-              BLOCK@[871; 1283)
-                L_CURLY@[871; 872) "{"
-                WHITESPACE@[872; 885) "\n            "
-                IF_EXPR@[885; 1273)
-                  IF_KW@[885; 887) "if"
-                  WHITESPACE@[887; 888) " "
-                  CONDITION@[888; 896)
-                    PAREN_EXPR@[888; 896)
-                      L_PAREN@[888; 889) "("
-                      RETURN_EXPR@[889; 895)
-                        RETURN_KW@[889; 895) "return"
-                      R_PAREN@[895; 896) ")"
-                  WHITESPACE@[896; 897) " "
-                  BLOCK@[897; 1216)
-                    L_CURLY@[897; 898) "{"
-                    WHITESPACE@[898; 915) "\n                "
-                    EXPR_STMT@[915; 1202)
-                      MATCH_EXPR@[915; 1201)
-                        MATCH_KW@[915; 920) "match"
-                        WHITESPACE@[920; 921) " "
-                        PAREN_EXPR@[921; 929)
-                          L_PAREN@[921; 922) "("
-                          RETURN_EXPR@[922; 928)
-                            RETURN_KW@[922; 928) "return"
-                          R_PAREN@[928; 929) ")"
-                        WHITESPACE@[929; 930) " "
-                        MATCH_ARM_LIST@[930; 1201)
-                          L_CURLY@[930; 931) "{"
-                          WHITESPACE@[931; 952) "\n                    "
-                          MATCH_ARM@[952; 1147)
-                            LITERAL_PAT@[952; 953)
-                              LITERAL@[952; 953)
-                                INT_NUMBER@[952; 953) "1"
-                            WHITESPACE@[953; 954) " "
-                            FAT_ARROW@[954; 956) "=>"
-                            WHITESPACE@[956; 957) " "
-                            BLOCK_EXPR@[957; 1147)
-                              BLOCK@[957; 1147)
-                                L_CURLY@[957; 958) "{"
-                                WHITESPACE@[958; 983) "\n                     ..."
-                                IF_EXPR@[983; 1125)
-                                  IF_KW@[983; 985) "if"
-                                  WHITESPACE@[985; 986) " "
-                                  CONDITION@[986; 994)
-                                    PAREN_EXPR@[986; 994)
-                                      L_PAREN@[986; 987) "("
-                                      RETURN_EXPR@[987; 993)
-                                        RETURN_KW@[987; 993) "return"
-                                      R_PAREN@[993; 994) ")"
-                                  WHITESPACE@[994; 995) " "
-                                  BLOCK@[995; 1057)
-                                    L_CURLY@[995; 996) "{"
-                                    WHITESPACE@[996; 1025) "\n                     ..."
-                                    RETURN_EXPR@[1025; 1031)
-                                      RETURN_KW@[1025; 1031) "return"
-                                    WHITESPACE@[1031; 1056) "\n                     ..."
-                                    R_CURLY@[1056; 1057) "}"
-                                  WHITESPACE@[1057; 1058) " "
-                                  ELSE_KW@[1058; 1062) "else"
-                                  WHITESPACE@[1062; 1063) " "
-                                  BLOCK@[1063; 1125)
-                                    L_CURLY@[1063; 1064) "{"
-                                    WHITESPACE@[1064; 1093) "\n                     ..."
-                                    RETURN_EXPR@[1093; 1099)
-                                      RETURN_KW@[1093; 1099) "return"
-                                    WHITESPACE@[1099; 1124) "\n                     ..."
-                                    R_CURLY@[1124; 1125) "}"
-                                WHITESPACE@[1125; 1146) "\n                    "
-                                R_CURLY@[1146; 1147) "}"
-                          WHITESPACE@[1147; 1168) "\n                    "
-                          MATCH_ARM@[1168; 1183)
-                            PLACEHOLDER_PAT@[1168; 1169)
-                              UNDERSCORE@[1168; 1169) "_"
-                            WHITESPACE@[1169; 1170) " "
-                            FAT_ARROW@[1170; 1172) "=>"
-                            WHITESPACE@[1172; 1173) " "
-                            BLOCK_EXPR@[1173; 1183)
-                              BLOCK@[1173; 1183)
-                                L_CURLY@[1173; 1174) "{"
-                                WHITESPACE@[1174; 1175) " "
-                                RETURN_EXPR@[1175; 1181)
-                                  RETURN_KW@[1175; 1181) "return"
-                                WHITESPACE@[1181; 1182) " "
-                                R_CURLY@[1182; 1183) "}"
-                          WHITESPACE@[1183; 1200) "\n                "
-                          R_CURLY@[1200; 1201) "}"
-                      SEMI@[1201; 1202) ";"
-                    WHITESPACE@[1202; 1215) "\n            "
-                    R_CURLY@[1215; 1216) "}"
-                  WHITESPACE@[1216; 1217) " "
-                  ELSE_KW@[1217; 1221) "else"
-                  WHITESPACE@[1221; 1222) " "
-                  IF_EXPR@[1222; 1273)
-                    IF_KW@[1222; 1224) "if"
-                    WHITESPACE@[1224; 1225) " "
-                    CONDITION@[1225; 1233)
-                      PAREN_EXPR@[1225; 1233)
-                        L_PAREN@[1225; 1226) "("
-                        RETURN_EXPR@[1226; 1232)
-                          RETURN_KW@[1226; 1232) "return"
-                        R_PAREN@[1232; 1233) ")"
-                    WHITESPACE@[1233; 1234) " "
-                    BLOCK@[1234; 1273)
-                      L_CURLY@[1234; 1235) "{"
-                      WHITESPACE@[1235; 1252) "\n                "
-                      EXPR_STMT@[1252; 1259)
-                        RETURN_EXPR@[1252; 1258)
-                          RETURN_KW@[1252; 1258) "return"
-                        SEMI@[1258; 1259) ";"
-                      WHITESPACE@[1259; 1272) "\n            "
-                      R_CURLY@[1272; 1273) "}"
-                WHITESPACE@[1273; 1282) "\n        "
-                R_CURLY@[1282; 1283) "}"
-          WHITESPACE@[1283; 1292) "\n        "
-          IF_EXPR@[1292; 1314)
-            IF_KW@[1292; 1294) "if"
-            WHITESPACE@[1294; 1295) " "
-            CONDITION@[1295; 1303)
-              PAREN_EXPR@[1295; 1303)
-                L_PAREN@[1295; 1296) "("
-                RETURN_EXPR@[1296; 1302)
-                  RETURN_KW@[1296; 1302) "return"
-                R_PAREN@[1302; 1303) ")"
-            WHITESPACE@[1303; 1304) " "
-            BLOCK@[1304; 1314)
-              L_CURLY@[1304; 1305) "{"
-              WHITESPACE@[1305; 1306) " "
-              EXPR_STMT@[1306; 1312)
-                BREAK_EXPR@[1306; 1311)
-                  BREAK_KW@[1306; 1311) "break"
-                SEMI@[1311; 1312) ";"
-              WHITESPACE@[1312; 1313) " "
-              R_CURLY@[1313; 1314) "}"
-          WHITESPACE@[1314; 1319) "\n    "
-          R_CURLY@[1319; 1320) "}"
-      WHITESPACE@[1320; 1321) "\n"
-      R_CURLY@[1321; 1322) "}"
+    BLOCK_EXPR@[835; 1322)
+      BLOCK@[835; 1322)
+        L_CURLY@[835; 836) "{"
+        WHITESPACE@[836; 841) "\n    "
+        LOOP_EXPR@[841; 1320)
+          LOOP_KW@[841; 845) "loop"
+          WHITESPACE@[845; 846) " "
+          BLOCK_EXPR@[846; 1320)
+            BLOCK@[846; 1320)
+              L_CURLY@[846; 847) "{"
+              WHITESPACE@[847; 856) "\n        "
+              EXPR_STMT@[856; 1283)
+                WHILE_EXPR@[856; 1283)
+                  WHILE_KW@[856; 861) "while"
+                  WHITESPACE@[861; 862) " "
+                  CONDITION@[862; 870)
+                    PAREN_EXPR@[862; 870)
+                      L_PAREN@[862; 863) "("
+                      RETURN_EXPR@[863; 869)
+                        RETURN_KW@[863; 869) "return"
+                      R_PAREN@[869; 870) ")"
+                  WHITESPACE@[870; 871) " "
+                  BLOCK_EXPR@[871; 1283)
+                    BLOCK@[871; 1283)
+                      L_CURLY@[871; 872) "{"
+                      WHITESPACE@[872; 885) "\n            "
+                      IF_EXPR@[885; 1273)
+                        IF_KW@[885; 887) "if"
+                        WHITESPACE@[887; 888) " "
+                        CONDITION@[888; 896)
+                          PAREN_EXPR@[888; 896)
+                            L_PAREN@[888; 889) "("
+                            RETURN_EXPR@[889; 895)
+                              RETURN_KW@[889; 895) "return"
+                            R_PAREN@[895; 896) ")"
+                        WHITESPACE@[896; 897) " "
+                        BLOCK_EXPR@[897; 1216)
+                          BLOCK@[897; 1216)
+                            L_CURLY@[897; 898) "{"
+                            WHITESPACE@[898; 915) "\n                "
+                            EXPR_STMT@[915; 1202)
+                              MATCH_EXPR@[915; 1201)
+                                MATCH_KW@[915; 920) "match"
+                                WHITESPACE@[920; 921) " "
+                                PAREN_EXPR@[921; 929)
+                                  L_PAREN@[921; 922) "("
+                                  RETURN_EXPR@[922; 928)
+                                    RETURN_KW@[922; 928) "return"
+                                  R_PAREN@[928; 929) ")"
+                                WHITESPACE@[929; 930) " "
+                                MATCH_ARM_LIST@[930; 1201)
+                                  L_CURLY@[930; 931) "{"
+                                  WHITESPACE@[931; 952) "\n                    "
+                                  MATCH_ARM@[952; 1147)
+                                    LITERAL_PAT@[952; 953)
+                                      LITERAL@[952; 953)
+                                        INT_NUMBER@[952; 953) "1"
+                                    WHITESPACE@[953; 954) " "
+                                    FAT_ARROW@[954; 956) "=>"
+                                    WHITESPACE@[956; 957) " "
+                                    BLOCK_EXPR@[957; 1147)
+                                      BLOCK@[957; 1147)
+                                        L_CURLY@[957; 958) "{"
+                                        WHITESPACE@[958; 983) "\n                     ..."
+                                        IF_EXPR@[983; 1125)
+                                          IF_KW@[983; 985) "if"
+                                          WHITESPACE@[985; 986) " "
+                                          CONDITION@[986; 994)
+                                            PAREN_EXPR@[986; 994)
+                                              L_PAREN@[986; 987) "("
+                                              RETURN_EXPR@[987; 993)
+                                                RETURN_KW@[987; 993) "return"
+                                              R_PAREN@[993; 994) ")"
+                                          WHITESPACE@[994; 995) " "
+                                          BLOCK_EXPR@[995; 1057)
+                                            BLOCK@[995; 1057)
+                                              L_CURLY@[995; 996) "{"
+                                              WHITESPACE@[996; 1025) "\n                     ..."
+                                              RETURN_EXPR@[1025; 1031)
+                                                RETURN_KW@[1025; 1031) "return"
+                                              WHITESPACE@[1031; 1056) "\n                     ..."
+                                              R_CURLY@[1056; 1057) "}"
+                                          WHITESPACE@[1057; 1058) " "
+                                          ELSE_KW@[1058; 1062) "else"
+                                          WHITESPACE@[1062; 1063) " "
+                                          BLOCK_EXPR@[1063; 1125)
+                                            BLOCK@[1063; 1125)
+                                              L_CURLY@[1063; 1064) "{"
+                                              WHITESPACE@[1064; 1093) "\n                     ..."
+                                              RETURN_EXPR@[1093; 1099)
+                                                RETURN_KW@[1093; 1099) "return"
+                                              WHITESPACE@[1099; 1124) "\n                     ..."
+                                              R_CURLY@[1124; 1125) "}"
+                                        WHITESPACE@[1125; 1146) "\n                    "
+                                        R_CURLY@[1146; 1147) "}"
+                                  WHITESPACE@[1147; 1168) "\n                    "
+                                  MATCH_ARM@[1168; 1183)
+                                    PLACEHOLDER_PAT@[1168; 1169)
+                                      UNDERSCORE@[1168; 1169) "_"
+                                    WHITESPACE@[1169; 1170) " "
+                                    FAT_ARROW@[1170; 1172) "=>"
+                                    WHITESPACE@[1172; 1173) " "
+                                    BLOCK_EXPR@[1173; 1183)
+                                      BLOCK@[1173; 1183)
+                                        L_CURLY@[1173; 1174) "{"
+                                        WHITESPACE@[1174; 1175) " "
+                                        RETURN_EXPR@[1175; 1181)
+                                          RETURN_KW@[1175; 1181) "return"
+                                        WHITESPACE@[1181; 1182) " "
+                                        R_CURLY@[1182; 1183) "}"
+                                  WHITESPACE@[1183; 1200) "\n                "
+                                  R_CURLY@[1200; 1201) "}"
+                              SEMI@[1201; 1202) ";"
+                            WHITESPACE@[1202; 1215) "\n            "
+                            R_CURLY@[1215; 1216) "}"
+                        WHITESPACE@[1216; 1217) " "
+                        ELSE_KW@[1217; 1221) "else"
+                        WHITESPACE@[1221; 1222) " "
+                        IF_EXPR@[1222; 1273)
+                          IF_KW@[1222; 1224) "if"
+                          WHITESPACE@[1224; 1225) " "
+                          CONDITION@[1225; 1233)
+                            PAREN_EXPR@[1225; 1233)
+                              L_PAREN@[1225; 1226) "("
+                              RETURN_EXPR@[1226; 1232)
+                                RETURN_KW@[1226; 1232) "return"
+                              R_PAREN@[1232; 1233) ")"
+                          WHITESPACE@[1233; 1234) " "
+                          BLOCK_EXPR@[1234; 1273)
+                            BLOCK@[1234; 1273)
+                              L_CURLY@[1234; 1235) "{"
+                              WHITESPACE@[1235; 1252) "\n                "
+                              EXPR_STMT@[1252; 1259)
+                                RETURN_EXPR@[1252; 1258)
+                                  RETURN_KW@[1252; 1258) "return"
+                                SEMI@[1258; 1259) ";"
+                              WHITESPACE@[1259; 1272) "\n            "
+                              R_CURLY@[1272; 1273) "}"
+                      WHITESPACE@[1273; 1282) "\n        "
+                      R_CURLY@[1282; 1283) "}"
+              WHITESPACE@[1283; 1292) "\n        "
+              IF_EXPR@[1292; 1314)
+                IF_KW@[1292; 1294) "if"
+                WHITESPACE@[1294; 1295) " "
+                CONDITION@[1295; 1303)
+                  PAREN_EXPR@[1295; 1303)
+                    L_PAREN@[1295; 1296) "("
+                    RETURN_EXPR@[1296; 1302)
+                      RETURN_KW@[1296; 1302) "return"
+                    R_PAREN@[1302; 1303) ")"
+                WHITESPACE@[1303; 1304) " "
+                BLOCK_EXPR@[1304; 1314)
+                  BLOCK@[1304; 1314)
+                    L_CURLY@[1304; 1305) "{"
+                    WHITESPACE@[1305; 1306) " "
+                    EXPR_STMT@[1306; 1312)
+                      BREAK_EXPR@[1306; 1311)
+                        BREAK_KW@[1306; 1311) "break"
+                      SEMI@[1311; 1312) ";"
+                    WHITESPACE@[1312; 1313) " "
+                    R_CURLY@[1313; 1314) "}"
+              WHITESPACE@[1314; 1319) "\n    "
+              R_CURLY@[1319; 1320) "}"
+        WHITESPACE@[1320; 1321) "\n"
+        R_CURLY@[1321; 1322) "}"
   WHITESPACE@[1322; 1324) "\n\n"
   FN_DEF@[1324; 1539)
     FN_KW@[1324; 1326) "fn"
@@ -573,233 +587,234 @@ SOURCE_FILE@[0; 3813)
       L_PAREN@[1334; 1335) "("
       R_PAREN@[1335; 1336) ")"
     WHITESPACE@[1336; 1337) " "
-    BLOCK@[1337; 1539)
-      L_CURLY@[1337; 1338) "{"
-      WHITESPACE@[1338; 1343) "\n    "
-      LET_STMT@[1343; 1361)
-        LET_KW@[1343; 1346) "let"
-        WHITESPACE@[1346; 1347) " "
-        BIND_PAT@[1347; 1353)
-          MUT_KW@[1347; 1350) "mut"
-          WHITESPACE@[1350; 1351) " "
-          NAME@[1351; 1353)
-            IDENT@[1351; 1353) "_x"
-        COLON@[1353; 1354) ":"
-        WHITESPACE@[1354; 1355) " "
-        PATH_TYPE@[1355; 1360)
-          PATH@[1355; 1360)
-            PATH_SEGMENT@[1355; 1360)
-              NAME_REF@[1355; 1360)
-                IDENT@[1355; 1360) "isize"
-        SEMI@[1360; 1361) ";"
-      WHITESPACE@[1361; 1366) "\n    "
-      LET_STMT@[1366; 1400)
-        LET_KW@[1366; 1369) "let"
-        WHITESPACE@[1369; 1370) " "
-        BIND_PAT@[1370; 1376)
-          MUT_KW@[1370; 1373) "mut"
-          WHITESPACE@[1373; 1374) " "
-          NAME@[1374; 1376)
-            IDENT@[1374; 1376) "_y"
-        WHITESPACE@[1376; 1377) " "
-        EQ@[1377; 1378) "="
-        WHITESPACE@[1378; 1379) " "
-        BIN_EXPR@[1379; 1399)
-          PAREN_EXPR@[1379; 1387)
-            L_PAREN@[1379; 1380) "("
-            BIN_EXPR@[1380; 1386)
-              PATH_EXPR@[1380; 1382)
-                PATH@[1380; 1382)
-                  PATH_SEGMENT@[1380; 1382)
-                    NAME_REF@[1380; 1382)
-                      IDENT@[1380; 1382) "_x"
-              WHITESPACE@[1382; 1383) " "
-              EQ@[1383; 1384) "="
-              WHITESPACE@[1384; 1385) " "
-              LITERAL@[1385; 1386)
-                INT_NUMBER@[1385; 1386) "0"
-            R_PAREN@[1386; 1387) ")"
-          WHITESPACE@[1387; 1388) " "
-          EQEQ@[1388; 1390) "=="
-          WHITESPACE@[1390; 1391) " "
-          PAREN_EXPR@[1391; 1399)
-            L_PAREN@[1391; 1392) "("
-            BIN_EXPR@[1392; 1398)
-              PATH_EXPR@[1392; 1394)
-                PATH@[1392; 1394)
-                  PATH_SEGMENT@[1392; 1394)
-                    NAME_REF@[1392; 1394)
-                      IDENT@[1392; 1394) "_x"
-              WHITESPACE@[1394; 1395) " "
-              EQ@[1395; 1396) "="
-              WHITESPACE@[1396; 1397) " "
-              LITERAL@[1397; 1398)
-                INT_NUMBER@[1397; 1398) "0"
-            R_PAREN@[1398; 1399) ")"
-        SEMI@[1399; 1400) ";"
-      WHITESPACE@[1400; 1405) "\n    "
-      LET_STMT@[1405; 1438)
-        LET_KW@[1405; 1408) "let"
-        WHITESPACE@[1408; 1409) " "
-        BIND_PAT@[1409; 1415)
-          MUT_KW@[1409; 1412) "mut"
-          WHITESPACE@[1412; 1413) " "
-          NAME@[1413; 1415)
-            IDENT@[1413; 1415) "_z"
-        WHITESPACE@[1415; 1416) " "
-        EQ@[1416; 1417) "="
-        WHITESPACE@[1417; 1418) " "
-        BIN_EXPR@[1418; 1437)
-          PAREN_EXPR@[1418; 1426)
-            L_PAREN@[1418; 1419) "("
-            BIN_EXPR@[1419; 1425)
-              PATH_EXPR@[1419; 1421)
-                PATH@[1419; 1421)
-                  PATH_SEGMENT@[1419; 1421)
-                    NAME_REF@[1419; 1421)
-                      IDENT@[1419; 1421) "_x"
-              WHITESPACE@[1421; 1422) " "
-              EQ@[1422; 1423) "="
-              WHITESPACE@[1423; 1424) " "
-              LITERAL@[1424; 1425)
-                INT_NUMBER@[1424; 1425) "0"
-            R_PAREN@[1425; 1426) ")"
-          WHITESPACE@[1426; 1427) " "
-          L_ANGLE@[1427; 1428) "<"
-          WHITESPACE@[1428; 1429) " "
-          PAREN_EXPR@[1429; 1437)
-            L_PAREN@[1429; 1430) "("
-            BIN_EXPR@[1430; 1436)
-              PATH_EXPR@[1430; 1432)
-                PATH@[1430; 1432)
-                  PATH_SEGMENT@[1430; 1432)
-                    NAME_REF@[1430; 1432)
-                      IDENT@[1430; 1432) "_x"
-              WHITESPACE@[1432; 1433) " "
-              EQ@[1433; 1434) "="
-              WHITESPACE@[1434; 1435) " "
-              LITERAL@[1435; 1436)
-                INT_NUMBER@[1435; 1436) "0"
-            R_PAREN@[1436; 1437) ")"
-        SEMI@[1437; 1438) ";"
-      WHITESPACE@[1438; 1443) "\n    "
-      LET_STMT@[1443; 1474)
-        LET_KW@[1443; 1446) "let"
-        WHITESPACE@[1446; 1447) " "
-        BIND_PAT@[1447; 1449)
-          NAME@[1447; 1449)
-            IDENT@[1447; 1449) "_a"
-        WHITESPACE@[1449; 1450) " "
-        EQ@[1450; 1451) "="
-        WHITESPACE@[1451; 1452) " "
-        BIN_EXPR@[1452; 1473)
-          PAREN_EXPR@[1452; 1461)
-            L_PAREN@[1452; 1453) "("
-            BIN_EXPR@[1453; 1460)
-              PATH_EXPR@[1453; 1455)
-                PATH@[1453; 1455)
-                  PATH_SEGMENT@[1453; 1455)
-                    NAME_REF@[1453; 1455)
-                      IDENT@[1453; 1455) "_x"
-              WHITESPACE@[1455; 1456) " "
-              PLUSEQ@[1456; 1458) "+="
-              WHITESPACE@[1458; 1459) " "
-              LITERAL@[1459; 1460)
-                INT_NUMBER@[1459; 1460) "0"
-            R_PAREN@[1460; 1461) ")"
-          WHITESPACE@[1461; 1462) " "
-          EQEQ@[1462; 1464) "=="
-          WHITESPACE@[1464; 1465) " "
-          PAREN_EXPR@[1465; 1473)
-            L_PAREN@[1465; 1466) "("
-            BIN_EXPR@[1466; 1472)
-              PATH_EXPR@[1466; 1468)
-                PATH@[1466; 1468)
-                  PATH_SEGMENT@[1466; 1468)
-                    NAME_REF@[1466; 1468)
-                      IDENT@[1466; 1468) "_x"
-              WHITESPACE@[1468; 1469) " "
-              EQ@[1469; 1470) "="
-              WHITESPACE@[1470; 1471) " "
-              LITERAL@[1471; 1472)
-                INT_NUMBER@[1471; 1472) "0"
-            R_PAREN@[1472; 1473) ")"
-        SEMI@[1473; 1474) ";"
-      WHITESPACE@[1474; 1479) "\n    "
-      LET_STMT@[1479; 1537)
-        LET_KW@[1479; 1482) "let"
-        WHITESPACE@[1482; 1483) " "
-        BIND_PAT@[1483; 1485)
-          NAME@[1483; 1485)
-            IDENT@[1483; 1485) "_b"
-        WHITESPACE@[1485; 1486) " "
-        EQ@[1486; 1487) "="
-        WHITESPACE@[1487; 1488) " "
-        BIN_EXPR@[1488; 1536)
-          CALL_EXPR@[1488; 1510)
-            PATH_EXPR@[1488; 1492)
-              PATH@[1488; 1492)
-                PATH_SEGMENT@[1488; 1492)
-                  NAME_REF@[1488; 1492)
-                    IDENT@[1488; 1492) "swap"
-            ARG_LIST@[1492; 1510)
-              L_PAREN@[1492; 1493) "("
-              REF_EXPR@[1493; 1500)
-                AMP@[1493; 1494) "&"
-                MUT_KW@[1494; 1497) "mut"
-                WHITESPACE@[1497; 1498) " "
-                PATH_EXPR@[1498; 1500)
-                  PATH@[1498; 1500)
-                    PATH_SEGMENT@[1498; 1500)
-                      NAME_REF@[1498; 1500)
-                        IDENT@[1498; 1500) "_y"
-              COMMA@[1500; 1501) ","
-              WHITESPACE@[1501; 1502) " "
-              REF_EXPR@[1502; 1509)
-                AMP@[1502; 1503) "&"
-                MUT_KW@[1503; 1506) "mut"
-                WHITESPACE@[1506; 1507) " "
-                PATH_EXPR@[1507; 1509)
-                  PATH@[1507; 1509)
-                    PATH_SEGMENT@[1507; 1509)
-                      NAME_REF@[1507; 1509)
-                        IDENT@[1507; 1509) "_z"
-              R_PAREN@[1509; 1510) ")"
-          WHITESPACE@[1510; 1511) " "
-          EQEQ@[1511; 1513) "=="
-          WHITESPACE@[1513; 1514) " "
-          CALL_EXPR@[1514; 1536)
-            PATH_EXPR@[1514; 1518)
-              PATH@[1514; 1518)
-                PATH_SEGMENT@[1514; 1518)
-                  NAME_REF@[1514; 1518)
-                    IDENT@[1514; 1518) "swap"
-            ARG_LIST@[1518; 1536)
-              L_PAREN@[1518; 1519) "("
-              REF_EXPR@[1519; 1526)
-                AMP@[1519; 1520) "&"
-                MUT_KW@[1520; 1523) "mut"
-                WHITESPACE@[1523; 1524) " "
-                PATH_EXPR@[1524; 1526)
-                  PATH@[1524; 1526)
-                    PATH_SEGMENT@[1524; 1526)
-                      NAME_REF@[1524; 1526)
-                        IDENT@[1524; 1526) "_y"
-              COMMA@[1526; 1527) ","
-              WHITESPACE@[1527; 1528) " "
-              REF_EXPR@[1528; 1535)
-                AMP@[1528; 1529) "&"
-                MUT_KW@[1529; 1532) "mut"
-                WHITESPACE@[1532; 1533) " "
-                PATH_EXPR@[1533; 1535)
-                  PATH@[1533; 1535)
-                    PATH_SEGMENT@[1533; 1535)
-                      NAME_REF@[1533; 1535)
-                        IDENT@[1533; 1535) "_z"
-              R_PAREN@[1535; 1536) ")"
-        SEMI@[1536; 1537) ";"
-      WHITESPACE@[1537; 1538) "\n"
-      R_CURLY@[1538; 1539) "}"
+    BLOCK_EXPR@[1337; 1539)
+      BLOCK@[1337; 1539)
+        L_CURLY@[1337; 1338) "{"
+        WHITESPACE@[1338; 1343) "\n    "
+        LET_STMT@[1343; 1361)
+          LET_KW@[1343; 1346) "let"
+          WHITESPACE@[1346; 1347) " "
+          BIND_PAT@[1347; 1353)
+            MUT_KW@[1347; 1350) "mut"
+            WHITESPACE@[1350; 1351) " "
+            NAME@[1351; 1353)
+              IDENT@[1351; 1353) "_x"
+          COLON@[1353; 1354) ":"
+          WHITESPACE@[1354; 1355) " "
+          PATH_TYPE@[1355; 1360)
+            PATH@[1355; 1360)
+              PATH_SEGMENT@[1355; 1360)
+                NAME_REF@[1355; 1360)
+                  IDENT@[1355; 1360) "isize"
+          SEMI@[1360; 1361) ";"
+        WHITESPACE@[1361; 1366) "\n    "
+        LET_STMT@[1366; 1400)
+          LET_KW@[1366; 1369) "let"
+          WHITESPACE@[1369; 1370) " "
+          BIND_PAT@[1370; 1376)
+            MUT_KW@[1370; 1373) "mut"
+            WHITESPACE@[1373; 1374) " "
+            NAME@[1374; 1376)
+              IDENT@[1374; 1376) "_y"
+          WHITESPACE@[1376; 1377) " "
+          EQ@[1377; 1378) "="
+          WHITESPACE@[1378; 1379) " "
+          BIN_EXPR@[1379; 1399)
+            PAREN_EXPR@[1379; 1387)
+              L_PAREN@[1379; 1380) "("
+              BIN_EXPR@[1380; 1386)
+                PATH_EXPR@[1380; 1382)
+                  PATH@[1380; 1382)
+                    PATH_SEGMENT@[1380; 1382)
+                      NAME_REF@[1380; 1382)
+                        IDENT@[1380; 1382) "_x"
+                WHITESPACE@[1382; 1383) " "
+                EQ@[1383; 1384) "="
+                WHITESPACE@[1384; 1385) " "
+                LITERAL@[1385; 1386)
+                  INT_NUMBER@[1385; 1386) "0"
+              R_PAREN@[1386; 1387) ")"
+            WHITESPACE@[1387; 1388) " "
+            EQEQ@[1388; 1390) "=="
+            WHITESPACE@[1390; 1391) " "
+            PAREN_EXPR@[1391; 1399)
+              L_PAREN@[1391; 1392) "("
+              BIN_EXPR@[1392; 1398)
+                PATH_EXPR@[1392; 1394)
+                  PATH@[1392; 1394)
+                    PATH_SEGMENT@[1392; 1394)
+                      NAME_REF@[1392; 1394)
+                        IDENT@[1392; 1394) "_x"
+                WHITESPACE@[1394; 1395) " "
+                EQ@[1395; 1396) "="
+                WHITESPACE@[1396; 1397) " "
+                LITERAL@[1397; 1398)
+                  INT_NUMBER@[1397; 1398) "0"
+              R_PAREN@[1398; 1399) ")"
+          SEMI@[1399; 1400) ";"
+        WHITESPACE@[1400; 1405) "\n    "
+        LET_STMT@[1405; 1438)
+          LET_KW@[1405; 1408) "let"
+          WHITESPACE@[1408; 1409) " "
+          BIND_PAT@[1409; 1415)
+            MUT_KW@[1409; 1412) "mut"
+            WHITESPACE@[1412; 1413) " "
+            NAME@[1413; 1415)
+              IDENT@[1413; 1415) "_z"
+          WHITESPACE@[1415; 1416) " "
+          EQ@[1416; 1417) "="
+          WHITESPACE@[1417; 1418) " "
+          BIN_EXPR@[1418; 1437)
+            PAREN_EXPR@[1418; 1426)
+              L_PAREN@[1418; 1419) "("
+              BIN_EXPR@[1419; 1425)
+                PATH_EXPR@[1419; 1421)
+                  PATH@[1419; 1421)
+                    PATH_SEGMENT@[1419; 1421)
+                      NAME_REF@[1419; 1421)
+                        IDENT@[1419; 1421) "_x"
+                WHITESPACE@[1421; 1422) " "
+                EQ@[1422; 1423) "="
+                WHITESPACE@[1423; 1424) " "
+                LITERAL@[1424; 1425)
+                  INT_NUMBER@[1424; 1425) "0"
+              R_PAREN@[1425; 1426) ")"
+            WHITESPACE@[1426; 1427) " "
+            L_ANGLE@[1427; 1428) "<"
+            WHITESPACE@[1428; 1429) " "
+            PAREN_EXPR@[1429; 1437)
+              L_PAREN@[1429; 1430) "("
+              BIN_EXPR@[1430; 1436)
+                PATH_EXPR@[1430; 1432)
+                  PATH@[1430; 1432)
+                    PATH_SEGMENT@[1430; 1432)
+                      NAME_REF@[1430; 1432)
+                        IDENT@[1430; 1432) "_x"
+                WHITESPACE@[1432; 1433) " "
+                EQ@[1433; 1434) "="
+                WHITESPACE@[1434; 1435) " "
+                LITERAL@[1435; 1436)
+                  INT_NUMBER@[1435; 1436) "0"
+              R_PAREN@[1436; 1437) ")"
+          SEMI@[1437; 1438) ";"
+        WHITESPACE@[1438; 1443) "\n    "
+        LET_STMT@[1443; 1474)
+          LET_KW@[1443; 1446) "let"
+          WHITESPACE@[1446; 1447) " "
+          BIND_PAT@[1447; 1449)
+            NAME@[1447; 1449)
+              IDENT@[1447; 1449) "_a"
+          WHITESPACE@[1449; 1450) " "
+          EQ@[1450; 1451) "="
+          WHITESPACE@[1451; 1452) " "
+          BIN_EXPR@[1452; 1473)
+            PAREN_EXPR@[1452; 1461)
+              L_PAREN@[1452; 1453) "("
+              BIN_EXPR@[1453; 1460)
+                PATH_EXPR@[1453; 1455)
+                  PATH@[1453; 1455)
+                    PATH_SEGMENT@[1453; 1455)
+                      NAME_REF@[1453; 1455)
+                        IDENT@[1453; 1455) "_x"
+                WHITESPACE@[1455; 1456) " "
+                PLUSEQ@[1456; 1458) "+="
+                WHITESPACE@[1458; 1459) " "
+                LITERAL@[1459; 1460)
+                  INT_NUMBER@[1459; 1460) "0"
+              R_PAREN@[1460; 1461) ")"
+            WHITESPACE@[1461; 1462) " "
+            EQEQ@[1462; 1464) "=="
+            WHITESPACE@[1464; 1465) " "
+            PAREN_EXPR@[1465; 1473)
+              L_PAREN@[1465; 1466) "("
+              BIN_EXPR@[1466; 1472)
+                PATH_EXPR@[1466; 1468)
+                  PATH@[1466; 1468)
+                    PATH_SEGMENT@[1466; 1468)
+                      NAME_REF@[1466; 1468)
+                        IDENT@[1466; 1468) "_x"
+                WHITESPACE@[1468; 1469) " "
+                EQ@[1469; 1470) "="
+                WHITESPACE@[1470; 1471) " "
+                LITERAL@[1471; 1472)
+                  INT_NUMBER@[1471; 1472) "0"
+              R_PAREN@[1472; 1473) ")"
+          SEMI@[1473; 1474) ";"
+        WHITESPACE@[1474; 1479) "\n    "
+        LET_STMT@[1479; 1537)
+          LET_KW@[1479; 1482) "let"
+          WHITESPACE@[1482; 1483) " "
+          BIND_PAT@[1483; 1485)
+            NAME@[1483; 1485)
+              IDENT@[1483; 1485) "_b"
+          WHITESPACE@[1485; 1486) " "
+          EQ@[1486; 1487) "="
+          WHITESPACE@[1487; 1488) " "
+          BIN_EXPR@[1488; 1536)
+            CALL_EXPR@[1488; 1510)
+              PATH_EXPR@[1488; 1492)
+                PATH@[1488; 1492)
+                  PATH_SEGMENT@[1488; 1492)
+                    NAME_REF@[1488; 1492)
+                      IDENT@[1488; 1492) "swap"
+              ARG_LIST@[1492; 1510)
+                L_PAREN@[1492; 1493) "("
+                REF_EXPR@[1493; 1500)
+                  AMP@[1493; 1494) "&"
+                  MUT_KW@[1494; 1497) "mut"
+                  WHITESPACE@[1497; 1498) " "
+                  PATH_EXPR@[1498; 1500)
+                    PATH@[1498; 1500)
+                      PATH_SEGMENT@[1498; 1500)
+                        NAME_REF@[1498; 1500)
+                          IDENT@[1498; 1500) "_y"
+                COMMA@[1500; 1501) ","
+                WHITESPACE@[1501; 1502) " "
+                REF_EXPR@[1502; 1509)
+                  AMP@[1502; 1503) "&"
+                  MUT_KW@[1503; 1506) "mut"
+                  WHITESPACE@[1506; 1507) " "
+                  PATH_EXPR@[1507; 1509)
+                    PATH@[1507; 1509)
+                      PATH_SEGMENT@[1507; 1509)
+                        NAME_REF@[1507; 1509)
+                          IDENT@[1507; 1509) "_z"
+                R_PAREN@[1509; 1510) ")"
+            WHITESPACE@[1510; 1511) " "
+            EQEQ@[1511; 1513) "=="
+            WHITESPACE@[1513; 1514) " "
+            CALL_EXPR@[1514; 1536)
+              PATH_EXPR@[1514; 1518)
+                PATH@[1514; 1518)
+                  PATH_SEGMENT@[1514; 1518)
+                    NAME_REF@[1514; 1518)
+                      IDENT@[1514; 1518) "swap"
+              ARG_LIST@[1518; 1536)
+                L_PAREN@[1518; 1519) "("
+                REF_EXPR@[1519; 1526)
+                  AMP@[1519; 1520) "&"
+                  MUT_KW@[1520; 1523) "mut"
+                  WHITESPACE@[1523; 1524) " "
+                  PATH_EXPR@[1524; 1526)
+                    PATH@[1524; 1526)
+                      PATH_SEGMENT@[1524; 1526)
+                        NAME_REF@[1524; 1526)
+                          IDENT@[1524; 1526) "_y"
+                COMMA@[1526; 1527) ","
+                WHITESPACE@[1527; 1528) " "
+                REF_EXPR@[1528; 1535)
+                  AMP@[1528; 1529) "&"
+                  MUT_KW@[1529; 1532) "mut"
+                  WHITESPACE@[1532; 1533) " "
+                  PATH_EXPR@[1533; 1535)
+                    PATH@[1533; 1535)
+                      PATH_SEGMENT@[1533; 1535)
+                        NAME_REF@[1533; 1535)
+                          IDENT@[1533; 1535) "_z"
+                R_PAREN@[1535; 1536) ")"
+          SEMI@[1536; 1537) ";"
+        WHITESPACE@[1537; 1538) "\n"
+        R_CURLY@[1538; 1539) "}"
   WHITESPACE@[1539; 1541) "\n\n"
   FN_DEF@[1541; 1741)
     FN_KW@[1541; 1543) "fn"
@@ -819,166 +834,168 @@ SOURCE_FILE@[0; 3813)
             NAME_REF@[1563; 1568)
               IDENT@[1563; 1568) "usize"
     WHITESPACE@[1568; 1569) " "
-    BLOCK@[1569; 1741)
-      L_CURLY@[1569; 1570) "{"
-      WHITESPACE@[1570; 1575) "\n    "
-      FN_DEF@[1575; 1598)
-        FN_KW@[1575; 1577) "fn"
-        WHITESPACE@[1577; 1578) " "
-        NAME@[1578; 1579)
-          IDENT@[1578; 1579) "p"
-        PARAM_LIST@[1579; 1581)
-          L_PAREN@[1579; 1580) "("
-          R_PAREN@[1580; 1581) ")"
-        WHITESPACE@[1581; 1582) " "
-        RET_TYPE@[1582; 1589)
-          THIN_ARROW@[1582; 1584) "->"
-          WHITESPACE@[1584; 1585) " "
-          PATH_TYPE@[1585; 1589)
-            PATH@[1585; 1589)
-              PATH_SEGMENT@[1585; 1589)
-                NAME_REF@[1585; 1589)
-                  IDENT@[1585; 1589) "bool"
-        WHITESPACE@[1589; 1590) " "
-        BLOCK@[1590; 1598)
-          L_CURLY@[1590; 1591) "{"
-          WHITESPACE@[1591; 1592) " "
-          LITERAL@[1592; 1596)
-            TRUE_KW@[1592; 1596) "true"
-          WHITESPACE@[1596; 1597) " "
-          R_CURLY@[1597; 1598) "}"
-      WHITESPACE@[1598; 1603) "\n    "
-      LET_STMT@[1603; 1648)
-        LET_KW@[1603; 1606) "let"
-        WHITESPACE@[1606; 1607) " "
-        BIND_PAT@[1607; 1609)
-          NAME@[1607; 1609)
-            IDENT@[1607; 1609) "_a"
-        WHITESPACE@[1609; 1610) " "
-        EQ@[1610; 1611) "="
-        WHITESPACE@[1611; 1612) " "
-        PAREN_EXPR@[1612; 1647)
-          L_PAREN@[1612; 1613) "("
-          BIN_EXPR@[1613; 1646)
-            MACRO_CALL@[1613; 1628)
-              PATH@[1613; 1619)
-                PATH_SEGMENT@[1613; 1619)
-                  NAME_REF@[1613; 1619)
-                    IDENT@[1613; 1619) "assert"
-              EXCL@[1619; 1620) "!"
-              TOKEN_TREE@[1620; 1628)
-                L_PAREN@[1620; 1621) "("
-                TOKEN_TREE@[1621; 1627)
-                  L_PAREN@[1621; 1622) "("
-                  TRUE_KW@[1622; 1626) "true"
-                  R_PAREN@[1626; 1627) ")"
-                R_PAREN@[1627; 1628) ")"
-            WHITESPACE@[1628; 1629) " "
-            EQEQ@[1629; 1631) "=="
-            WHITESPACE@[1631; 1632) " "
-            PAREN_EXPR@[1632; 1646)
-              L_PAREN@[1632; 1633) "("
-              MACRO_CALL@[1633; 1645)
-                PATH@[1633; 1639)
-                  PATH_SEGMENT@[1633; 1639)
-                    NAME_REF@[1633; 1639)
-                      IDENT@[1633; 1639) "assert"
-                EXCL@[1639; 1640) "!"
-                TOKEN_TREE@[1640; 1645)
-                  L_PAREN@[1640; 1641) "("
-                  IDENT@[1641; 1642) "p"
-                  TOKEN_TREE@[1642; 1644)
-                    L_PAREN@[1642; 1643) "("
-                    R_PAREN@[1643; 1644) ")"
-                  R_PAREN@[1644; 1645) ")"
-              R_PAREN@[1645; 1646) ")"
-          R_PAREN@[1646; 1647) ")"
-        SEMI@[1647; 1648) ";"
-      WHITESPACE@[1648; 1653) "\n    "
-      LET_STMT@[1653; 1685)
-        LET_KW@[1653; 1656) "let"
-        WHITESPACE@[1656; 1657) " "
-        BIND_PAT@[1657; 1659)
-          NAME@[1657; 1659)
-            IDENT@[1657; 1659) "_c"
-        WHITESPACE@[1659; 1660) " "
-        EQ@[1660; 1661) "="
-        WHITESPACE@[1661; 1662) " "
-        PAREN_EXPR@[1662; 1684)
-          L_PAREN@[1662; 1663) "("
-          BIN_EXPR@[1663; 1683)
-            MACRO_CALL@[1663; 1677)
-              PATH@[1663; 1669)
-                PATH_SEGMENT@[1663; 1669)
-                  NAME_REF@[1663; 1669)
-                    IDENT@[1663; 1669) "assert"
-              EXCL@[1669; 1670) "!"
-              TOKEN_TREE@[1670; 1677)
-                L_PAREN@[1670; 1671) "("
-                TOKEN_TREE@[1671; 1676)
-                  L_PAREN@[1671; 1672) "("
-                  IDENT@[1672; 1673) "p"
-                  TOKEN_TREE@[1673; 1675)
-                    L_PAREN@[1673; 1674) "("
-                    R_PAREN@[1674; 1675) ")"
-                  R_PAREN@[1675; 1676) ")"
-                R_PAREN@[1676; 1677) ")"
-            WHITESPACE@[1677; 1678) " "
-            EQEQ@[1678; 1680) "=="
-            WHITESPACE@[1680; 1681) " "
-            TUPLE_EXPR@[1681; 1683)
-              L_PAREN@[1681; 1682) "("
-              R_PAREN@[1682; 1683) ")"
-          R_PAREN@[1683; 1684) ")"
-        SEMI@[1684; 1685) ";"
-      WHITESPACE@[1685; 1690) "\n    "
-      LET_STMT@[1690; 1739)
-        LET_KW@[1690; 1693) "let"
-        WHITESPACE@[1693; 1694) " "
-        BIND_PAT@[1694; 1696)
-          NAME@[1694; 1696)
-            IDENT@[1694; 1696) "_b"
-        COLON@[1696; 1697) ":"
-        WHITESPACE@[1697; 1698) " "
-        PATH_TYPE@[1698; 1702)
-          PATH@[1698; 1702)
-            PATH_SEGMENT@[1698; 1702)
-              NAME_REF@[1698; 1702)
-                IDENT@[1698; 1702) "bool"
-        WHITESPACE@[1702; 1703) " "
-        EQ@[1703; 1704) "="
-        WHITESPACE@[1704; 1705) " "
-        PAREN_EXPR@[1705; 1738)
-          L_PAREN@[1705; 1706) "("
-          BIN_EXPR@[1706; 1737)
-            MACRO_CALL@[1706; 1723)
-              PATH@[1706; 1713)
-                PATH_SEGMENT@[1706; 1713)
-                  NAME_REF@[1706; 1713)
-                    IDENT@[1706; 1713) "println"
-              EXCL@[1713; 1714) "!"
-              TOKEN_TREE@[1714; 1723)
-                L_PAREN@[1714; 1715) "("
-                STRING@[1715; 1719) "\"{}\""
-                COMMA@[1719; 1720) ","
-                WHITESPACE@[1720; 1721) " "
-                INT_NUMBER@[1721; 1722) "0"
-                R_PAREN@[1722; 1723) ")"
-            WHITESPACE@[1723; 1724) " "
-            EQEQ@[1724; 1726) "=="
-            WHITESPACE@[1726; 1727) " "
-            PAREN_EXPR@[1727; 1737)
-              L_PAREN@[1727; 1728) "("
-              RETURN_EXPR@[1728; 1736)
-                RETURN_KW@[1728; 1734) "return"
-                WHITESPACE@[1734; 1735) " "
-                LITERAL@[1735; 1736)
-                  INT_NUMBER@[1735; 1736) "0"
-              R_PAREN@[1736; 1737) ")"
-          R_PAREN@[1737; 1738) ")"
-        SEMI@[1738; 1739) ";"
-      WHITESPACE@[1739; 1740) "\n"
-      R_CURLY@[1740; 1741) "}"
+    BLOCK_EXPR@[1569; 1741)
+      BLOCK@[1569; 1741)
+        L_CURLY@[1569; 1570) "{"
+        WHITESPACE@[1570; 1575) "\n    "
+        FN_DEF@[1575; 1598)
+          FN_KW@[1575; 1577) "fn"
+          WHITESPACE@[1577; 1578) " "
+          NAME@[1578; 1579)
+            IDENT@[1578; 1579) "p"
+          PARAM_LIST@[1579; 1581)
+            L_PAREN@[1579; 1580) "("
+            R_PAREN@[1580; 1581) ")"
+          WHITESPACE@[1581; 1582) " "
+          RET_TYPE@[1582; 1589)
+            THIN_ARROW@[1582; 1584) "->"
+            WHITESPACE@[1584; 1585) " "
+            PATH_TYPE@[1585; 1589)
+              PATH@[1585; 1589)
+                PATH_SEGMENT@[1585; 1589)
+                  NAME_REF@[1585; 1589)
+                    IDENT@[1585; 1589) "bool"
+          WHITESPACE@[1589; 1590) " "
+          BLOCK_EXPR@[1590; 1598)
+            BLOCK@[1590; 1598)
+              L_CURLY@[1590; 1591) "{"
+              WHITESPACE@[1591; 1592) " "
+              LITERAL@[1592; 1596)
+                TRUE_KW@[1592; 1596) "true"
+              WHITESPACE@[1596; 1597) " "
+              R_CURLY@[1597; 1598) "}"
+        WHITESPACE@[1598; 1603) "\n    "
+        LET_STMT@[1603; 1648)
+          LET_KW@[1603; 1606) "let"
+          WHITESPACE@[1606; 1607) " "
+          BIND_PAT@[1607; 1609)
+            NAME@[1607; 1609)
+              IDENT@[1607; 1609) "_a"
+          WHITESPACE@[1609; 1610) " "
+          EQ@[1610; 1611) "="
+          WHITESPACE@[1611; 1612) " "
+          PAREN_EXPR@[1612; 1647)
+            L_PAREN@[1612; 1613) "("
+            BIN_EXPR@[1613; 1646)
+              MACRO_CALL@[1613; 1628)
+                PATH@[1613; 1619)
+                  PATH_SEGMENT@[1613; 1619)
+                    NAME_REF@[1613; 1619)
+                      IDENT@[1613; 1619) "assert"
+                EXCL@[1619; 1620) "!"
+                TOKEN_TREE@[1620; 1628)
+                  L_PAREN@[1620; 1621) "("
+                  TOKEN_TREE@[1621; 1627)
+                    L_PAREN@[1621; 1622) "("
+                    TRUE_KW@[1622; 1626) "true"
+                    R_PAREN@[1626; 1627) ")"
+                  R_PAREN@[1627; 1628) ")"
+              WHITESPACE@[1628; 1629) " "
+              EQEQ@[1629; 1631) "=="
+              WHITESPACE@[1631; 1632) " "
+              PAREN_EXPR@[1632; 1646)
+                L_PAREN@[1632; 1633) "("
+                MACRO_CALL@[1633; 1645)
+                  PATH@[1633; 1639)
+                    PATH_SEGMENT@[1633; 1639)
+                      NAME_REF@[1633; 1639)
+                        IDENT@[1633; 1639) "assert"
+                  EXCL@[1639; 1640) "!"
+                  TOKEN_TREE@[1640; 1645)
+                    L_PAREN@[1640; 1641) "("
+                    IDENT@[1641; 1642) "p"
+                    TOKEN_TREE@[1642; 1644)
+                      L_PAREN@[1642; 1643) "("
+                      R_PAREN@[1643; 1644) ")"
+                    R_PAREN@[1644; 1645) ")"
+                R_PAREN@[1645; 1646) ")"
+            R_PAREN@[1646; 1647) ")"
+          SEMI@[1647; 1648) ";"
+        WHITESPACE@[1648; 1653) "\n    "
+        LET_STMT@[1653; 1685)
+          LET_KW@[1653; 1656) "let"
+          WHITESPACE@[1656; 1657) " "
+          BIND_PAT@[1657; 1659)
+            NAME@[1657; 1659)
+              IDENT@[1657; 1659) "_c"
+          WHITESPACE@[1659; 1660) " "
+          EQ@[1660; 1661) "="
+          WHITESPACE@[1661; 1662) " "
+          PAREN_EXPR@[1662; 1684)
+            L_PAREN@[1662; 1663) "("
+            BIN_EXPR@[1663; 1683)
+              MACRO_CALL@[1663; 1677)
+                PATH@[1663; 1669)
+                  PATH_SEGMENT@[1663; 1669)
+                    NAME_REF@[1663; 1669)
+                      IDENT@[1663; 1669) "assert"
+                EXCL@[1669; 1670) "!"
+                TOKEN_TREE@[1670; 1677)
+                  L_PAREN@[1670; 1671) "("
+                  TOKEN_TREE@[1671; 1676)
+                    L_PAREN@[1671; 1672) "("
+                    IDENT@[1672; 1673) "p"
+                    TOKEN_TREE@[1673; 1675)
+                      L_PAREN@[1673; 1674) "("
+                      R_PAREN@[1674; 1675) ")"
+                    R_PAREN@[1675; 1676) ")"
+                  R_PAREN@[1676; 1677) ")"
+              WHITESPACE@[1677; 1678) " "
+              EQEQ@[1678; 1680) "=="
+              WHITESPACE@[1680; 1681) " "
+              TUPLE_EXPR@[1681; 1683)
+                L_PAREN@[1681; 1682) "("
+                R_PAREN@[1682; 1683) ")"
+            R_PAREN@[1683; 1684) ")"
+          SEMI@[1684; 1685) ";"
+        WHITESPACE@[1685; 1690) "\n    "
+        LET_STMT@[1690; 1739)
+          LET_KW@[1690; 1693) "let"
+          WHITESPACE@[1693; 1694) " "
+          BIND_PAT@[1694; 1696)
+            NAME@[1694; 1696)
+              IDENT@[1694; 1696) "_b"
+          COLON@[1696; 1697) ":"
+          WHITESPACE@[1697; 1698) " "
+          PATH_TYPE@[1698; 1702)
+            PATH@[1698; 1702)
+              PATH_SEGMENT@[1698; 1702)
+                NAME_REF@[1698; 1702)
+                  IDENT@[1698; 1702) "bool"
+          WHITESPACE@[1702; 1703) " "
+          EQ@[1703; 1704) "="
+          WHITESPACE@[1704; 1705) " "
+          PAREN_EXPR@[1705; 1738)
+            L_PAREN@[1705; 1706) "("
+            BIN_EXPR@[1706; 1737)
+              MACRO_CALL@[1706; 1723)
+                PATH@[1706; 1713)
+                  PATH_SEGMENT@[1706; 1713)
+                    NAME_REF@[1706; 1713)
+                      IDENT@[1706; 1713) "println"
+                EXCL@[1713; 1714) "!"
+                TOKEN_TREE@[1714; 1723)
+                  L_PAREN@[1714; 1715) "("
+                  STRING@[1715; 1719) "\"{}\""
+                  COMMA@[1719; 1720) ","
+                  WHITESPACE@[1720; 1721) " "
+                  INT_NUMBER@[1721; 1722) "0"
+                  R_PAREN@[1722; 1723) ")"
+              WHITESPACE@[1723; 1724) " "
+              EQEQ@[1724; 1726) "=="
+              WHITESPACE@[1726; 1727) " "
+              PAREN_EXPR@[1727; 1737)
+                L_PAREN@[1727; 1728) "("
+                RETURN_EXPR@[1728; 1736)
+                  RETURN_KW@[1728; 1734) "return"
+                  WHITESPACE@[1734; 1735) " "
+                  LITERAL@[1735; 1736)
+                    INT_NUMBER@[1735; 1736) "0"
+                R_PAREN@[1736; 1737) ")"
+            R_PAREN@[1737; 1738) ")"
+          SEMI@[1738; 1739) ";"
+        WHITESPACE@[1739; 1740) "\n"
+        R_CURLY@[1740; 1741) "}"
   WHITESPACE@[1741; 1743) "\n\n"
   FN_DEF@[1743; 1904)
     FN_KW@[1743; 1745) "fn"
@@ -989,140 +1006,145 @@ SOURCE_FILE@[0; 3813)
       L_PAREN@[1755; 1756) "("
       R_PAREN@[1756; 1757) ")"
     WHITESPACE@[1757; 1758) " "
-    BLOCK@[1758; 1904)
-      L_CURLY@[1758; 1759) "{"
-      WHITESPACE@[1759; 1764) "\n    "
-      EXPR_STMT@[1764; 1785)
-        LOOP_EXPR@[1764; 1785)
-          LOOP_KW@[1764; 1768) "loop"
-          WHITESPACE@[1768; 1769) " "
-          BLOCK@[1769; 1785)
-            L_CURLY@[1769; 1770) "{"
-            WHITESPACE@[1770; 1771) " "
-            IF_EXPR@[1771; 1783)
-              IF_KW@[1771; 1773) "if"
-              WHITESPACE@[1773; 1774) " "
-              CONDITION@[1774; 1779)
-                BREAK_EXPR@[1774; 1779)
-                  BREAK_KW@[1774; 1779) "break"
-              WHITESPACE@[1779; 1780) " "
-              BLOCK@[1780; 1783)
-                L_CURLY@[1780; 1781) "{"
-                WHITESPACE@[1781; 1782) " "
-                R_CURLY@[1782; 1783) "}"
-            WHITESPACE@[1783; 1784) " "
-            R_CURLY@[1784; 1785) "}"
-      WHITESPACE@[1785; 1790) "\n    "
-      LET_STMT@[1790; 1804)
-        LET_KW@[1790; 1793) "let"
-        WHITESPACE@[1793; 1794) " "
-        BIND_PAT@[1794; 1799)
-          MUT_KW@[1794; 1797) "mut"
-          WHITESPACE@[1797; 1798) " "
-          NAME@[1798; 1799)
-            IDENT@[1798; 1799) "i"
-        WHITESPACE@[1799; 1800) " "
-        EQ@[1800; 1801) "="
-        WHITESPACE@[1801; 1802) " "
-        LITERAL@[1802; 1803)
-          INT_NUMBER@[1802; 1803) "0"
-        SEMI@[1803; 1804) ";"
-      WHITESPACE@[1804; 1809) "\n    "
-      LOOP_EXPR@[1809; 1902)
-        LOOP_KW@[1809; 1813) "loop"
-        WHITESPACE@[1813; 1814) " "
-        BLOCK@[1814; 1902)
-          L_CURLY@[1814; 1815) "{"
-          WHITESPACE@[1815; 1816) " "
-          EXPR_STMT@[1816; 1823)
-            BIN_EXPR@[1816; 1822)
-              PATH_EXPR@[1816; 1817)
-                PATH@[1816; 1817)
-                  PATH_SEGMENT@[1816; 1817)
-                    NAME_REF@[1816; 1817)
-                      IDENT@[1816; 1817) "i"
-              WHITESPACE@[1817; 1818) " "
-              PLUSEQ@[1818; 1820) "+="
-              WHITESPACE@[1820; 1821) " "
-              LITERAL@[1821; 1822)
-                INT_NUMBER@[1821; 1822) "1"
-            SEMI@[1822; 1823) ";"
-          WHITESPACE@[1823; 1824) " "
-          EXPR_STMT@[1824; 1887)
-            IF_EXPR@[1824; 1887)
-              IF_KW@[1824; 1826) "if"
-              WHITESPACE@[1826; 1827) " "
-              CONDITION@[1827; 1833)
-                BIN_EXPR@[1827; 1833)
-                  PATH_EXPR@[1827; 1828)
-                    PATH@[1827; 1828)
-                      PATH_SEGMENT@[1827; 1828)
-                        NAME_REF@[1827; 1828)
-                          IDENT@[1827; 1828) "i"
-                  WHITESPACE@[1828; 1829) " "
-                  EQEQ@[1829; 1831) "=="
-                  WHITESPACE@[1831; 1832) " "
-                  LITERAL@[1832; 1833)
-                    INT_NUMBER@[1832; 1833) "1"
-              WHITESPACE@[1833; 1834) " "
-              BLOCK@[1834; 1887)
-                L_CURLY@[1834; 1835) "{"
-                WHITESPACE@[1835; 1836) " "
-                MATCH_EXPR@[1836; 1885)
-                  MATCH_KW@[1836; 1841) "match"
-                  WHITESPACE@[1841; 1842) " "
-                  PAREN_EXPR@[1842; 1852)
-                    L_PAREN@[1842; 1843) "("
-                    CONTINUE_EXPR@[1843; 1851)
-                      CONTINUE_KW@[1843; 1851) "continue"
-                    R_PAREN@[1851; 1852) ")"
-                  WHITESPACE@[1852; 1853) " "
-                  MATCH_ARM_LIST@[1853; 1885)
-                    L_CURLY@[1853; 1854) "{"
-                    WHITESPACE@[1854; 1855) " "
-                    MATCH_ARM@[1855; 1863)
-                      LITERAL_PAT@[1855; 1856)
-                        LITERAL@[1855; 1856)
-                          INT_NUMBER@[1855; 1856) "1"
-                      WHITESPACE@[1856; 1857) " "
-                      FAT_ARROW@[1857; 1859) "=>"
-                      WHITESPACE@[1859; 1860) " "
-                      BLOCK_EXPR@[1860; 1863)
-                        BLOCK@[1860; 1863)
-                          L_CURLY@[1860; 1861) "{"
-                          WHITESPACE@[1861; 1862) " "
-                          R_CURLY@[1862; 1863) "}"
-                    COMMA@[1863; 1864) ","
-                    WHITESPACE@[1864; 1865) " "
-                    MATCH_ARM@[1865; 1883)
-                      PLACEHOLDER_PAT@[1865; 1866)
-                        UNDERSCORE@[1865; 1866) "_"
-                      WHITESPACE@[1866; 1867) " "
-                      FAT_ARROW@[1867; 1869) "=>"
-                      WHITESPACE@[1869; 1870) " "
-                      MACRO_CALL@[1870; 1883)
-                        PATH@[1870; 1875)
-                          PATH_SEGMENT@[1870; 1875)
-                            NAME_REF@[1870; 1875)
-                              IDENT@[1870; 1875) "panic"
-                        EXCL@[1875; 1876) "!"
-                        TOKEN_TREE@[1876; 1883)
-                          L_PAREN@[1876; 1877) "("
-                          STRING@[1877; 1882) "\"wat\""
-                          R_PAREN@[1882; 1883) ")"
-                    WHITESPACE@[1883; 1884) " "
-                    R_CURLY@[1884; 1885) "}"
-                WHITESPACE@[1885; 1886) " "
-                R_CURLY@[1886; 1887) "}"
-          WHITESPACE@[1887; 1894) "\n      "
-          EXPR_STMT@[1894; 1900)
-            BREAK_EXPR@[1894; 1899)
-              BREAK_KW@[1894; 1899) "break"
-            SEMI@[1899; 1900) ";"
-          WHITESPACE@[1900; 1901) " "
-          R_CURLY@[1901; 1902) "}"
-      WHITESPACE@[1902; 1903) "\n"
-      R_CURLY@[1903; 1904) "}"
+    BLOCK_EXPR@[1758; 1904)
+      BLOCK@[1758; 1904)
+        L_CURLY@[1758; 1759) "{"
+        WHITESPACE@[1759; 1764) "\n    "
+        EXPR_STMT@[1764; 1785)
+          LOOP_EXPR@[1764; 1785)
+            LOOP_KW@[1764; 1768) "loop"
+            WHITESPACE@[1768; 1769) " "
+            BLOCK_EXPR@[1769; 1785)
+              BLOCK@[1769; 1785)
+                L_CURLY@[1769; 1770) "{"
+                WHITESPACE@[1770; 1771) " "
+                IF_EXPR@[1771; 1783)
+                  IF_KW@[1771; 1773) "if"
+                  WHITESPACE@[1773; 1774) " "
+                  CONDITION@[1774; 1779)
+                    BREAK_EXPR@[1774; 1779)
+                      BREAK_KW@[1774; 1779) "break"
+                  WHITESPACE@[1779; 1780) " "
+                  BLOCK_EXPR@[1780; 1783)
+                    BLOCK@[1780; 1783)
+                      L_CURLY@[1780; 1781) "{"
+                      WHITESPACE@[1781; 1782) " "
+                      R_CURLY@[1782; 1783) "}"
+                WHITESPACE@[1783; 1784) " "
+                R_CURLY@[1784; 1785) "}"
+        WHITESPACE@[1785; 1790) "\n    "
+        LET_STMT@[1790; 1804)
+          LET_KW@[1790; 1793) "let"
+          WHITESPACE@[1793; 1794) " "
+          BIND_PAT@[1794; 1799)
+            MUT_KW@[1794; 1797) "mut"
+            WHITESPACE@[1797; 1798) " "
+            NAME@[1798; 1799)
+              IDENT@[1798; 1799) "i"
+          WHITESPACE@[1799; 1800) " "
+          EQ@[1800; 1801) "="
+          WHITESPACE@[1801; 1802) " "
+          LITERAL@[1802; 1803)
+            INT_NUMBER@[1802; 1803) "0"
+          SEMI@[1803; 1804) ";"
+        WHITESPACE@[1804; 1809) "\n    "
+        LOOP_EXPR@[1809; 1902)
+          LOOP_KW@[1809; 1813) "loop"
+          WHITESPACE@[1813; 1814) " "
+          BLOCK_EXPR@[1814; 1902)
+            BLOCK@[1814; 1902)
+              L_CURLY@[1814; 1815) "{"
+              WHITESPACE@[1815; 1816) " "
+              EXPR_STMT@[1816; 1823)
+                BIN_EXPR@[1816; 1822)
+                  PATH_EXPR@[1816; 1817)
+                    PATH@[1816; 1817)
+                      PATH_SEGMENT@[1816; 1817)
+                        NAME_REF@[1816; 1817)
+                          IDENT@[1816; 1817) "i"
+                  WHITESPACE@[1817; 1818) " "
+                  PLUSEQ@[1818; 1820) "+="
+                  WHITESPACE@[1820; 1821) " "
+                  LITERAL@[1821; 1822)
+                    INT_NUMBER@[1821; 1822) "1"
+                SEMI@[1822; 1823) ";"
+              WHITESPACE@[1823; 1824) " "
+              EXPR_STMT@[1824; 1887)
+                IF_EXPR@[1824; 1887)
+                  IF_KW@[1824; 1826) "if"
+                  WHITESPACE@[1826; 1827) " "
+                  CONDITION@[1827; 1833)
+                    BIN_EXPR@[1827; 1833)
+                      PATH_EXPR@[1827; 1828)
+                        PATH@[1827; 1828)
+                          PATH_SEGMENT@[1827; 1828)
+                            NAME_REF@[1827; 1828)
+                              IDENT@[1827; 1828) "i"
+                      WHITESPACE@[1828; 1829) " "
+                      EQEQ@[1829; 1831) "=="
+                      WHITESPACE@[1831; 1832) " "
+                      LITERAL@[1832; 1833)
+                        INT_NUMBER@[1832; 1833) "1"
+                  WHITESPACE@[1833; 1834) " "
+                  BLOCK_EXPR@[1834; 1887)
+                    BLOCK@[1834; 1887)
+                      L_CURLY@[1834; 1835) "{"
+                      WHITESPACE@[1835; 1836) " "
+                      MATCH_EXPR@[1836; 1885)
+                        MATCH_KW@[1836; 1841) "match"
+                        WHITESPACE@[1841; 1842) " "
+                        PAREN_EXPR@[1842; 1852)
+                          L_PAREN@[1842; 1843) "("
+                          CONTINUE_EXPR@[1843; 1851)
+                            CONTINUE_KW@[1843; 1851) "continue"
+                          R_PAREN@[1851; 1852) ")"
+                        WHITESPACE@[1852; 1853) " "
+                        MATCH_ARM_LIST@[1853; 1885)
+                          L_CURLY@[1853; 1854) "{"
+                          WHITESPACE@[1854; 1855) " "
+                          MATCH_ARM@[1855; 1863)
+                            LITERAL_PAT@[1855; 1856)
+                              LITERAL@[1855; 1856)
+                                INT_NUMBER@[1855; 1856) "1"
+                            WHITESPACE@[1856; 1857) " "
+                            FAT_ARROW@[1857; 1859) "=>"
+                            WHITESPACE@[1859; 1860) " "
+                            BLOCK_EXPR@[1860; 1863)
+                              BLOCK@[1860; 1863)
+                                L_CURLY@[1860; 1861) "{"
+                                WHITESPACE@[1861; 1862) " "
+                                R_CURLY@[1862; 1863) "}"
+                          COMMA@[1863; 1864) ","
+                          WHITESPACE@[1864; 1865) " "
+                          MATCH_ARM@[1865; 1883)
+                            PLACEHOLDER_PAT@[1865; 1866)
+                              UNDERSCORE@[1865; 1866) "_"
+                            WHITESPACE@[1866; 1867) " "
+                            FAT_ARROW@[1867; 1869) "=>"
+                            WHITESPACE@[1869; 1870) " "
+                            MACRO_CALL@[1870; 1883)
+                              PATH@[1870; 1875)
+                                PATH_SEGMENT@[1870; 1875)
+                                  NAME_REF@[1870; 1875)
+                                    IDENT@[1870; 1875) "panic"
+                              EXCL@[1875; 1876) "!"
+                              TOKEN_TREE@[1876; 1883)
+                                L_PAREN@[1876; 1877) "("
+                                STRING@[1877; 1882) "\"wat\""
+                                R_PAREN@[1882; 1883) ")"
+                          WHITESPACE@[1883; 1884) " "
+                          R_CURLY@[1884; 1885) "}"
+                      WHITESPACE@[1885; 1886) " "
+                      R_CURLY@[1886; 1887) "}"
+              WHITESPACE@[1887; 1894) "\n      "
+              EXPR_STMT@[1894; 1900)
+                BREAK_EXPR@[1894; 1899)
+                  BREAK_KW@[1894; 1899) "break"
+                SEMI@[1899; 1900) ";"
+              WHITESPACE@[1900; 1901) " "
+              R_CURLY@[1901; 1902) "}"
+        WHITESPACE@[1902; 1903) "\n"
+        R_CURLY@[1903; 1904) "}"
   WHITESPACE@[1904; 1906) "\n\n"
   FN_DEF@[1906; 1960)
     FN_KW@[1906; 1908) "fn"
@@ -1133,31 +1155,32 @@ SOURCE_FILE@[0; 3813)
       L_PAREN@[1921; 1922) "("
       R_PAREN@[1922; 1923) ")"
     WHITESPACE@[1923; 1924) " "
-    BLOCK@[1924; 1960)
-      L_CURLY@[1924; 1925) "{"
-      WHITESPACE@[1925; 1926) " "
-      LET_STMT@[1926; 1958)
-        LET_KW@[1926; 1929) "let"
-        WHITESPACE@[1929; 1930) " "
-        BIND_PAT@[1930; 1935)
-          NAME@[1930; 1935)
-            IDENT@[1930; 1935) "_evil"
-        WHITESPACE@[1935; 1936) " "
-        EQ@[1936; 1937) "="
-        WHITESPACE@[1937; 1938) " "
-        MACRO_CALL@[1938; 1957)
-          PATH@[1938; 1945)
-            PATH_SEGMENT@[1938; 1945)
-              NAME_REF@[1938; 1945)
-                IDENT@[1938; 1945) "println"
-          EXCL@[1945; 1946) "!"
-          TOKEN_TREE@[1946; 1957)
-            L_PAREN@[1946; 1947) "("
-            STRING@[1947; 1956) "\"lincoln\""
-            R_PAREN@[1956; 1957) ")"
-        SEMI@[1957; 1958) ";"
-      WHITESPACE@[1958; 1959) " "
-      R_CURLY@[1959; 1960) "}"
+    BLOCK_EXPR@[1924; 1960)
+      BLOCK@[1924; 1960)
+        L_CURLY@[1924; 1925) "{"
+        WHITESPACE@[1925; 1926) " "
+        LET_STMT@[1926; 1958)
+          LET_KW@[1926; 1929) "let"
+          WHITESPACE@[1929; 1930) " "
+          BIND_PAT@[1930; 1935)
+            NAME@[1930; 1935)
+              IDENT@[1930; 1935) "_evil"
+          WHITESPACE@[1935; 1936) " "
+          EQ@[1936; 1937) "="
+          WHITESPACE@[1937; 1938) " "
+          MACRO_CALL@[1938; 1957)
+            PATH@[1938; 1945)
+              PATH_SEGMENT@[1938; 1945)
+                NAME_REF@[1938; 1945)
+                  IDENT@[1938; 1945) "println"
+            EXCL@[1945; 1946) "!"
+            TOKEN_TREE@[1946; 1957)
+              L_PAREN@[1946; 1947) "("
+              STRING@[1947; 1956) "\"lincoln\""
+              R_PAREN@[1956; 1957) ")"
+          SEMI@[1957; 1958) ";"
+        WHITESPACE@[1958; 1959) " "
+        R_CURLY@[1959; 1960) "}"
   WHITESPACE@[1960; 1962) "\n\n"
   FN_DEF@[1962; 2198)
     FN_KW@[1962; 1964) "fn"
@@ -1168,114 +1191,115 @@ SOURCE_FILE@[0; 3813)
       L_PAREN@[1969; 1970) "("
       R_PAREN@[1970; 1971) ")"
     WHITESPACE@[1971; 1972) " "
-    BLOCK@[1972; 2198)
-      L_CURLY@[1972; 1973) "{"
-      WHITESPACE@[1973; 1978) "\n    "
-      EXPR_STMT@[1978; 2196)
-        MACRO_CALL@[1978; 2195)
-          PATH@[1978; 1987)
-            PATH_SEGMENT@[1978; 1987)
-              NAME_REF@[1978; 1987)
-                IDENT@[1978; 1987) "assert_eq"
-          EXCL@[1987; 1988) "!"
-          TOKEN_TREE@[1988; 2195)
-            L_PAREN@[1988; 1989) "("
-            IDENT@[1989; 1995) "String"
-            COLON@[1995; 1996) ":"
-            COLON@[1996; 1997) ":"
-            IDENT@[1997; 2001) "from"
-            TOKEN_TREE@[2001; 2055)
-              L_PAREN@[2001; 2002) "("
-              STRING@[2002; 2054) "\".................... ..."
-              R_PAREN@[2054; 2055) ")"
-            COMMA@[2055; 2056) ","
-            WHITESPACE@[2056; 2072) "\n               "
-            IDENT@[2072; 2078) "format"
-            EXCL@[2078; 2079) "!"
-            TOKEN_TREE@[2079; 2194)
-              L_PAREN@[2079; 2080) "("
-              STRING@[2080; 2086) "\"{:?}\""
-              COMMA@[2086; 2087) ","
-              WHITESPACE@[2087; 2088) " "
-              DOT@[2088; 2089) "."
-              DOT@[2089; 2090) "."
-              WHITESPACE@[2090; 2091) " "
-              DOT@[2091; 2092) "."
-              DOT@[2092; 2093) "."
-              WHITESPACE@[2093; 2094) " "
-              DOT@[2094; 2095) "."
-              DOT@[2095; 2096) "."
-              WHITESPACE@[2096; 2097) " "
-              DOT@[2097; 2098) "."
-              DOT@[2098; 2099) "."
-              WHITESPACE@[2099; 2100) " "
-              DOT@[2100; 2101) "."
-              DOT@[2101; 2102) "."
-              WHITESPACE@[2102; 2103) " "
-              DOT@[2103; 2104) "."
-              DOT@[2104; 2105) "."
-              WHITESPACE@[2105; 2106) " "
-              DOT@[2106; 2107) "."
-              DOT@[2107; 2108) "."
-              WHITESPACE@[2108; 2109) " "
-              DOT@[2109; 2110) "."
-              DOT@[2110; 2111) "."
-              WHITESPACE@[2111; 2112) " "
-              DOT@[2112; 2113) "."
-              DOT@[2113; 2114) "."
-              WHITESPACE@[2114; 2115) " "
-              DOT@[2115; 2116) "."
-              DOT@[2116; 2117) "."
-              WHITESPACE@[2117; 2118) " "
-              DOT@[2118; 2119) "."
-              DOT@[2119; 2120) "."
-              WHITESPACE@[2120; 2121) " "
-              DOT@[2121; 2122) "."
-              DOT@[2122; 2123) "."
-              WHITESPACE@[2123; 2124) " "
-              DOT@[2124; 2125) "."
-              DOT@[2125; 2126) "."
-              WHITESPACE@[2126; 2158) "\n                     ..."
-              DOT@[2158; 2159) "."
-              DOT@[2159; 2160) "."
-              WHITESPACE@[2160; 2161) " "
-              DOT@[2161; 2162) "."
-              DOT@[2162; 2163) "."
-              WHITESPACE@[2163; 2164) " "
-              DOT@[2164; 2165) "."
-              DOT@[2165; 2166) "."
-              WHITESPACE@[2166; 2167) " "
-              DOT@[2167; 2168) "."
-              DOT@[2168; 2169) "."
-              WHITESPACE@[2169; 2170) " "
-              DOT@[2170; 2171) "."
-              DOT@[2171; 2172) "."
-              WHITESPACE@[2172; 2173) " "
-              DOT@[2173; 2174) "."
-              DOT@[2174; 2175) "."
-              WHITESPACE@[2175; 2176) " "
-              DOT@[2176; 2177) "."
-              DOT@[2177; 2178) "."
-              WHITESPACE@[2178; 2179) " "
-              DOT@[2179; 2180) "."
-              DOT@[2180; 2181) "."
-              WHITESPACE@[2181; 2182) " "
-              DOT@[2182; 2183) "."
-              DOT@[2183; 2184) "."
-              WHITESPACE@[2184; 2185) " "
-              DOT@[2185; 2186) "."
-              DOT@[2186; 2187) "."
-              WHITESPACE@[2187; 2188) " "
-              DOT@[2188; 2189) "."
-              DOT@[2189; 2190) "."
-              WHITESPACE@[2190; 2191) " "
-              DOT@[2191; 2192) "."
-              DOT@[2192; 2193) "."
-              R_PAREN@[2193; 2194) ")"
-            R_PAREN@[2194; 2195) ")"
-        SEMI@[2195; 2196) ";"
-      WHITESPACE@[2196; 2197) "\n"
-      R_CURLY@[2197; 2198) "}"
+    BLOCK_EXPR@[1972; 2198)
+      BLOCK@[1972; 2198)
+        L_CURLY@[1972; 1973) "{"
+        WHITESPACE@[1973; 1978) "\n    "
+        EXPR_STMT@[1978; 2196)
+          MACRO_CALL@[1978; 2195)
+            PATH@[1978; 1987)
+              PATH_SEGMENT@[1978; 1987)
+                NAME_REF@[1978; 1987)
+                  IDENT@[1978; 1987) "assert_eq"
+            EXCL@[1987; 1988) "!"
+            TOKEN_TREE@[1988; 2195)
+              L_PAREN@[1988; 1989) "("
+              IDENT@[1989; 1995) "String"
+              COLON@[1995; 1996) ":"
+              COLON@[1996; 1997) ":"
+              IDENT@[1997; 2001) "from"
+              TOKEN_TREE@[2001; 2055)
+                L_PAREN@[2001; 2002) "("
+                STRING@[2002; 2054) "\".................... ..."
+                R_PAREN@[2054; 2055) ")"
+              COMMA@[2055; 2056) ","
+              WHITESPACE@[2056; 2072) "\n               "
+              IDENT@[2072; 2078) "format"
+              EXCL@[2078; 2079) "!"
+              TOKEN_TREE@[2079; 2194)
+                L_PAREN@[2079; 2080) "("
+                STRING@[2080; 2086) "\"{:?}\""
+                COMMA@[2086; 2087) ","
+                WHITESPACE@[2087; 2088) " "
+                DOT@[2088; 2089) "."
+                DOT@[2089; 2090) "."
+                WHITESPACE@[2090; 2091) " "
+                DOT@[2091; 2092) "."
+                DOT@[2092; 2093) "."
+                WHITESPACE@[2093; 2094) " "
+                DOT@[2094; 2095) "."
+                DOT@[2095; 2096) "."
+                WHITESPACE@[2096; 2097) " "
+                DOT@[2097; 2098) "."
+                DOT@[2098; 2099) "."
+                WHITESPACE@[2099; 2100) " "
+                DOT@[2100; 2101) "."
+                DOT@[2101; 2102) "."
+                WHITESPACE@[2102; 2103) " "
+                DOT@[2103; 2104) "."
+                DOT@[2104; 2105) "."
+                WHITESPACE@[2105; 2106) " "
+                DOT@[2106; 2107) "."
+                DOT@[2107; 2108) "."
+                WHITESPACE@[2108; 2109) " "
+                DOT@[2109; 2110) "."
+                DOT@[2110; 2111) "."
+                WHITESPACE@[2111; 2112) " "
+                DOT@[2112; 2113) "."
+                DOT@[2113; 2114) "."
+                WHITESPACE@[2114; 2115) " "
+                DOT@[2115; 2116) "."
+                DOT@[2116; 2117) "."
+                WHITESPACE@[2117; 2118) " "
+                DOT@[2118; 2119) "."
+                DOT@[2119; 2120) "."
+                WHITESPACE@[2120; 2121) " "
+                DOT@[2121; 2122) "."
+                DOT@[2122; 2123) "."
+                WHITESPACE@[2123; 2124) " "
+                DOT@[2124; 2125) "."
+                DOT@[2125; 2126) "."
+                WHITESPACE@[2126; 2158) "\n                     ..."
+                DOT@[2158; 2159) "."
+                DOT@[2159; 2160) "."
+                WHITESPACE@[2160; 2161) " "
+                DOT@[2161; 2162) "."
+                DOT@[2162; 2163) "."
+                WHITESPACE@[2163; 2164) " "
+                DOT@[2164; 2165) "."
+                DOT@[2165; 2166) "."
+                WHITESPACE@[2166; 2167) " "
+                DOT@[2167; 2168) "."
+                DOT@[2168; 2169) "."
+                WHITESPACE@[2169; 2170) " "
+                DOT@[2170; 2171) "."
+                DOT@[2171; 2172) "."
+                WHITESPACE@[2172; 2173) " "
+                DOT@[2173; 2174) "."
+                DOT@[2174; 2175) "."
+                WHITESPACE@[2175; 2176) " "
+                DOT@[2176; 2177) "."
+                DOT@[2177; 2178) "."
+                WHITESPACE@[2178; 2179) " "
+                DOT@[2179; 2180) "."
+                DOT@[2180; 2181) "."
+                WHITESPACE@[2181; 2182) " "
+                DOT@[2182; 2183) "."
+                DOT@[2183; 2184) "."
+                WHITESPACE@[2184; 2185) " "
+                DOT@[2185; 2186) "."
+                DOT@[2186; 2187) "."
+                WHITESPACE@[2187; 2188) " "
+                DOT@[2188; 2189) "."
+                DOT@[2189; 2190) "."
+                WHITESPACE@[2190; 2191) " "
+                DOT@[2191; 2192) "."
+                DOT@[2192; 2193) "."
+                R_PAREN@[2193; 2194) ")"
+              R_PAREN@[2194; 2195) ")"
+          SEMI@[2195; 2196) ";"
+        WHITESPACE@[2196; 2197) "\n"
+        R_CURLY@[2197; 2198) "}"
   WHITESPACE@[2198; 2200) "\n\n"
   FN_DEF@[2200; 2693)
     FN_KW@[2200; 2202) "fn"
@@ -1297,169 +1321,171 @@ SOURCE_FILE@[0; 3813)
                 IDENT@[2210; 2212) "u8"
       R_PAREN@[2212; 2213) ")"
     WHITESPACE@[2213; 2214) " "
-    BLOCK@[2214; 2693)
-      L_CURLY@[2214; 2215) "{"
-      WHITESPACE@[2215; 2220) "\n    "
-      IF_EXPR@[2220; 2691)
-        IF_KW@[2220; 2222) "if"
-        WHITESPACE@[2222; 2223) " "
-        CONDITION@[2223; 2232)
-          BIN_EXPR@[2223; 2232)
-            PATH_EXPR@[2223; 2225)
-              PATH@[2223; 2225)
-                PATH_SEGMENT@[2223; 2225)
-                  NAME_REF@[2223; 2225)
-                    IDENT@[2223; 2225) "u8"
-            WHITESPACE@[2225; 2226) " "
-            NEQ@[2226; 2228) "!="
-            WHITESPACE@[2228; 2229) " "
-            LITERAL@[2229; 2232)
-              INT_NUMBER@[2229; 2232) "0u8"
-        WHITESPACE@[2232; 2233) " "
-        BLOCK@[2233; 2691)
-          L_CURLY@[2233; 2234) "{"
-          WHITESPACE@[2234; 2243) "\n        "
-          EXPR_STMT@[2243; 2685)
-            MACRO_CALL@[2243; 2684)
-              PATH@[2243; 2252)
-                PATH_SEGMENT@[2243; 2252)
-                  NAME_REF@[2243; 2252)
-                    IDENT@[2243; 2252) "assert_eq"
-              EXCL@[2252; 2253) "!"
-              TOKEN_TREE@[2253; 2684)
-                L_PAREN@[2253; 2254) "("
-                INT_NUMBER@[2254; 2257) "8u8"
-                COMMA@[2257; 2258) ","
-                WHITESPACE@[2258; 2259) " "
-                TOKEN_TREE@[2259; 2683)
-                  L_CURLY@[2259; 2260) "{"
-                  WHITESPACE@[2260; 2273) "\n            "
-                  IDENT@[2273; 2284) "macro_rules"
-                  EXCL@[2284; 2285) "!"
-                  WHITESPACE@[2285; 2286) " "
-                  IDENT@[2286; 2288) "u8"
-                  WHITESPACE@[2288; 2289) " "
-                  TOKEN_TREE@[2289; 2567)
-                    L_CURLY@[2289; 2290) "{"
-                    WHITESPACE@[2290; 2307) "\n                "
-                    TOKEN_TREE@[2307; 2311)
-                      L_PAREN@[2307; 2308) "("
-                      IDENT@[2308; 2310) "u8"
-                      R_PAREN@[2310; 2311) ")"
-                    WHITESPACE@[2311; 2312) " "
-                    EQ@[2312; 2313) "="
-                    R_ANGLE@[2313; 2314) ">"
-                    WHITESPACE@[2314; 2315) " "
-                    TOKEN_TREE@[2315; 2552)
-                      L_CURLY@[2315; 2316) "{"
-                      WHITESPACE@[2316; 2337) "\n                    "
-                      MOD_KW@[2337; 2340) "mod"
-                      WHITESPACE@[2340; 2341) " "
-                      IDENT@[2341; 2343) "u8"
-                      WHITESPACE@[2343; 2344) " "
-                      TOKEN_TREE@[2344; 2534)
-                        L_CURLY@[2344; 2345) "{"
-                        WHITESPACE@[2345; 2370) "\n                     ..."
-                        PUB_KW@[2370; 2373) "pub"
-                        WHITESPACE@[2373; 2374) " "
-                        FN_KW@[2374; 2376) "fn"
-                        WHITESPACE@[2376; 2377) " "
-                        IDENT@[2377; 2379) "u8"
-                        L_ANGLE@[2379; 2380) "<"
-                        LIFETIME@[2380; 2383) "\'u8"
-                        COLON@[2383; 2384) ":"
-                        WHITESPACE@[2384; 2385) " "
-                        LIFETIME@[2385; 2388) "\'u8"
-                        WHITESPACE@[2388; 2389) " "
-                        PLUS@[2389; 2390) "+"
-                        WHITESPACE@[2390; 2391) " "
-                        LIFETIME@[2391; 2394) "\'u8"
-                        R_ANGLE@[2394; 2395) ">"
-                        TOKEN_TREE@[2395; 2408)
-                          L_PAREN@[2395; 2396) "("
-                          IDENT@[2396; 2398) "u8"
-                          COLON@[2398; 2399) ":"
-                          WHITESPACE@[2399; 2400) " "
-                          AMP@[2400; 2401) "&"
-                          LIFETIME@[2401; 2404) "\'u8"
-                          WHITESPACE@[2404; 2405) " "
-                          IDENT@[2405; 2407) "u8"
-                          R_PAREN@[2407; 2408) ")"
-                        WHITESPACE@[2408; 2409) " "
-                        MINUS@[2409; 2410) "-"
-                        R_ANGLE@[2410; 2411) ">"
-                        WHITESPACE@[2411; 2412) " "
-                        AMP@[2412; 2413) "&"
-                        LIFETIME@[2413; 2416) "\'u8"
-                        WHITESPACE@[2416; 2417) " "
-                        IDENT@[2417; 2419) "u8"
-                        WHITESPACE@[2419; 2420) " "
-                        TOKEN_TREE@[2420; 2512)
-                          L_CURLY@[2420; 2421) "{"
-                          WHITESPACE@[2421; 2450) "\n                     ..."
-                          STRING@[2450; 2454) "\"u8\""
-                          SEMI@[2454; 2455) ";"
-                          WHITESPACE@[2455; 2484) "\n                     ..."
-                          IDENT@[2484; 2486) "u8"
-                          WHITESPACE@[2486; 2511) "\n                     ..."
-                          R_CURLY@[2511; 2512) "}"
-                        WHITESPACE@[2512; 2533) "\n                    "
-                        R_CURLY@[2533; 2534) "}"
-                      WHITESPACE@[2534; 2551) "\n                "
-                      R_CURLY@[2551; 2552) "}"
-                    SEMI@[2552; 2553) ";"
-                    WHITESPACE@[2553; 2566) "\n            "
-                    R_CURLY@[2566; 2567) "}"
-                  WHITESPACE@[2567; 2581) "\n\n            "
-                  IDENT@[2581; 2583) "u8"
-                  EXCL@[2583; 2584) "!"
-                  TOKEN_TREE@[2584; 2588)
-                    L_PAREN@[2584; 2585) "("
-                    IDENT@[2585; 2587) "u8"
-                    R_PAREN@[2587; 2588) ")"
-                  SEMI@[2588; 2589) ";"
-                  WHITESPACE@[2589; 2602) "\n            "
-                  LET_KW@[2602; 2605) "let"
-                  WHITESPACE@[2605; 2606) " "
-                  AMP@[2606; 2607) "&"
-                  IDENT@[2607; 2609) "u8"
-                  COLON@[2609; 2610) ":"
-                  WHITESPACE@[2610; 2611) " "
-                  AMP@[2611; 2612) "&"
-                  IDENT@[2612; 2614) "u8"
-                  WHITESPACE@[2614; 2615) " "
-                  EQ@[2615; 2616) "="
-                  WHITESPACE@[2616; 2617) " "
-                  IDENT@[2617; 2619) "u8"
-                  COLON@[2619; 2620) ":"
-                  COLON@[2620; 2621) ":"
-                  IDENT@[2621; 2623) "u8"
-                  TOKEN_TREE@[2623; 2629)
-                    L_PAREN@[2623; 2624) "("
-                    AMP@[2624; 2625) "&"
-                    INT_NUMBER@[2625; 2628) "8u8"
-                    R_PAREN@[2628; 2629) ")"
-                  SEMI@[2629; 2630) ";"
-                  WHITESPACE@[2630; 2643) "\n            "
-                  CRATE_KW@[2643; 2648) "crate"
-                  COLON@[2648; 2649) ":"
-                  COLON@[2649; 2650) ":"
-                  IDENT@[2650; 2652) "u8"
-                  TOKEN_TREE@[2652; 2657)
-                    L_PAREN@[2652; 2653) "("
-                    INT_NUMBER@[2653; 2656) "0u8"
-                    R_PAREN@[2656; 2657) ")"
-                  SEMI@[2657; 2658) ";"
-                  WHITESPACE@[2658; 2671) "\n            "
-                  IDENT@[2671; 2673) "u8"
-                  WHITESPACE@[2673; 2682) "\n        "
-                  R_CURLY@[2682; 2683) "}"
-                R_PAREN@[2683; 2684) ")"
-            SEMI@[2684; 2685) ";"
-          WHITESPACE@[2685; 2690) "\n    "
-          R_CURLY@[2690; 2691) "}"
-      WHITESPACE@[2691; 2692) "\n"
-      R_CURLY@[2692; 2693) "}"
+    BLOCK_EXPR@[2214; 2693)
+      BLOCK@[2214; 2693)
+        L_CURLY@[2214; 2215) "{"
+        WHITESPACE@[2215; 2220) "\n    "
+        IF_EXPR@[2220; 2691)
+          IF_KW@[2220; 2222) "if"
+          WHITESPACE@[2222; 2223) " "
+          CONDITION@[2223; 2232)
+            BIN_EXPR@[2223; 2232)
+              PATH_EXPR@[2223; 2225)
+                PATH@[2223; 2225)
+                  PATH_SEGMENT@[2223; 2225)
+                    NAME_REF@[2223; 2225)
+                      IDENT@[2223; 2225) "u8"
+              WHITESPACE@[2225; 2226) " "
+              NEQ@[2226; 2228) "!="
+              WHITESPACE@[2228; 2229) " "
+              LITERAL@[2229; 2232)
+                INT_NUMBER@[2229; 2232) "0u8"
+          WHITESPACE@[2232; 2233) " "
+          BLOCK_EXPR@[2233; 2691)
+            BLOCK@[2233; 2691)
+              L_CURLY@[2233; 2234) "{"
+              WHITESPACE@[2234; 2243) "\n        "
+              EXPR_STMT@[2243; 2685)
+                MACRO_CALL@[2243; 2684)
+                  PATH@[2243; 2252)
+                    PATH_SEGMENT@[2243; 2252)
+                      NAME_REF@[2243; 2252)
+                        IDENT@[2243; 2252) "assert_eq"
+                  EXCL@[2252; 2253) "!"
+                  TOKEN_TREE@[2253; 2684)
+                    L_PAREN@[2253; 2254) "("
+                    INT_NUMBER@[2254; 2257) "8u8"
+                    COMMA@[2257; 2258) ","
+                    WHITESPACE@[2258; 2259) " "
+                    TOKEN_TREE@[2259; 2683)
+                      L_CURLY@[2259; 2260) "{"
+                      WHITESPACE@[2260; 2273) "\n            "
+                      IDENT@[2273; 2284) "macro_rules"
+                      EXCL@[2284; 2285) "!"
+                      WHITESPACE@[2285; 2286) " "
+                      IDENT@[2286; 2288) "u8"
+                      WHITESPACE@[2288; 2289) " "
+                      TOKEN_TREE@[2289; 2567)
+                        L_CURLY@[2289; 2290) "{"
+                        WHITESPACE@[2290; 2307) "\n                "
+                        TOKEN_TREE@[2307; 2311)
+                          L_PAREN@[2307; 2308) "("
+                          IDENT@[2308; 2310) "u8"
+                          R_PAREN@[2310; 2311) ")"
+                        WHITESPACE@[2311; 2312) " "
+                        EQ@[2312; 2313) "="
+                        R_ANGLE@[2313; 2314) ">"
+                        WHITESPACE@[2314; 2315) " "
+                        TOKEN_TREE@[2315; 2552)
+                          L_CURLY@[2315; 2316) "{"
+                          WHITESPACE@[2316; 2337) "\n                    "
+                          MOD_KW@[2337; 2340) "mod"
+                          WHITESPACE@[2340; 2341) " "
+                          IDENT@[2341; 2343) "u8"
+                          WHITESPACE@[2343; 2344) " "
+                          TOKEN_TREE@[2344; 2534)
+                            L_CURLY@[2344; 2345) "{"
+                            WHITESPACE@[2345; 2370) "\n                     ..."
+                            PUB_KW@[2370; 2373) "pub"
+                            WHITESPACE@[2373; 2374) " "
+                            FN_KW@[2374; 2376) "fn"
+                            WHITESPACE@[2376; 2377) " "
+                            IDENT@[2377; 2379) "u8"
+                            L_ANGLE@[2379; 2380) "<"
+                            LIFETIME@[2380; 2383) "\'u8"
+                            COLON@[2383; 2384) ":"
+                            WHITESPACE@[2384; 2385) " "
+                            LIFETIME@[2385; 2388) "\'u8"
+                            WHITESPACE@[2388; 2389) " "
+                            PLUS@[2389; 2390) "+"
+                            WHITESPACE@[2390; 2391) " "
+                            LIFETIME@[2391; 2394) "\'u8"
+                            R_ANGLE@[2394; 2395) ">"
+                            TOKEN_TREE@[2395; 2408)
+                              L_PAREN@[2395; 2396) "("
+                              IDENT@[2396; 2398) "u8"
+                              COLON@[2398; 2399) ":"
+                              WHITESPACE@[2399; 2400) " "
+                              AMP@[2400; 2401) "&"
+                              LIFETIME@[2401; 2404) "\'u8"
+                              WHITESPACE@[2404; 2405) " "
+                              IDENT@[2405; 2407) "u8"
+                              R_PAREN@[2407; 2408) ")"
+                            WHITESPACE@[2408; 2409) " "
+                            MINUS@[2409; 2410) "-"
+                            R_ANGLE@[2410; 2411) ">"
+                            WHITESPACE@[2411; 2412) " "
+                            AMP@[2412; 2413) "&"
+                            LIFETIME@[2413; 2416) "\'u8"
+                            WHITESPACE@[2416; 2417) " "
+                            IDENT@[2417; 2419) "u8"
+                            WHITESPACE@[2419; 2420) " "
+                            TOKEN_TREE@[2420; 2512)
+                              L_CURLY@[2420; 2421) "{"
+                              WHITESPACE@[2421; 2450) "\n                     ..."
+                              STRING@[2450; 2454) "\"u8\""
+                              SEMI@[2454; 2455) ";"
+                              WHITESPACE@[2455; 2484) "\n                     ..."
+                              IDENT@[2484; 2486) "u8"
+                              WHITESPACE@[2486; 2511) "\n                     ..."
+                              R_CURLY@[2511; 2512) "}"
+                            WHITESPACE@[2512; 2533) "\n                    "
+                            R_CURLY@[2533; 2534) "}"
+                          WHITESPACE@[2534; 2551) "\n                "
+                          R_CURLY@[2551; 2552) "}"
+                        SEMI@[2552; 2553) ";"
+                        WHITESPACE@[2553; 2566) "\n            "
+                        R_CURLY@[2566; 2567) "}"
+                      WHITESPACE@[2567; 2581) "\n\n            "
+                      IDENT@[2581; 2583) "u8"
+                      EXCL@[2583; 2584) "!"
+                      TOKEN_TREE@[2584; 2588)
+                        L_PAREN@[2584; 2585) "("
+                        IDENT@[2585; 2587) "u8"
+                        R_PAREN@[2587; 2588) ")"
+                      SEMI@[2588; 2589) ";"
+                      WHITESPACE@[2589; 2602) "\n            "
+                      LET_KW@[2602; 2605) "let"
+                      WHITESPACE@[2605; 2606) " "
+                      AMP@[2606; 2607) "&"
+                      IDENT@[2607; 2609) "u8"
+                      COLON@[2609; 2610) ":"
+                      WHITESPACE@[2610; 2611) " "
+                      AMP@[2611; 2612) "&"
+                      IDENT@[2612; 2614) "u8"
+                      WHITESPACE@[2614; 2615) " "
+                      EQ@[2615; 2616) "="
+                      WHITESPACE@[2616; 2617) " "
+                      IDENT@[2617; 2619) "u8"
+                      COLON@[2619; 2620) ":"
+                      COLON@[2620; 2621) ":"
+                      IDENT@[2621; 2623) "u8"
+                      TOKEN_TREE@[2623; 2629)
+                        L_PAREN@[2623; 2624) "("
+                        AMP@[2624; 2625) "&"
+                        INT_NUMBER@[2625; 2628) "8u8"
+                        R_PAREN@[2628; 2629) ")"
+                      SEMI@[2629; 2630) ";"
+                      WHITESPACE@[2630; 2643) "\n            "
+                      CRATE_KW@[2643; 2648) "crate"
+                      COLON@[2648; 2649) ":"
+                      COLON@[2649; 2650) ":"
+                      IDENT@[2650; 2652) "u8"
+                      TOKEN_TREE@[2652; 2657)
+                        L_PAREN@[2652; 2653) "("
+                        INT_NUMBER@[2653; 2656) "0u8"
+                        R_PAREN@[2656; 2657) ")"
+                      SEMI@[2657; 2658) ";"
+                      WHITESPACE@[2658; 2671) "\n            "
+                      IDENT@[2671; 2673) "u8"
+                      WHITESPACE@[2673; 2682) "\n        "
+                      R_CURLY@[2682; 2683) "}"
+                    R_PAREN@[2683; 2684) ")"
+                SEMI@[2684; 2685) ";"
+              WHITESPACE@[2685; 2690) "\n    "
+              R_CURLY@[2690; 2691) "}"
+        WHITESPACE@[2691; 2692) "\n"
+        R_CURLY@[2692; 2693) "}"
   WHITESPACE@[2693; 2695) "\n\n"
   FN_DEF@[2695; 2832)
     FN_KW@[2695; 2697) "fn"
@@ -1470,76 +1496,77 @@ SOURCE_FILE@[0; 3813)
       L_PAREN@[2703; 2704) "("
       R_PAREN@[2704; 2705) ")"
     WHITESPACE@[2705; 2706) " "
-    BLOCK@[2706; 2832)
-      L_CURLY@[2706; 2707) "{"
-      WHITESPACE@[2707; 2712) "\n    "
-      EXPR_STMT@[2712; 2830)
-        MACRO_CALL@[2712; 2829)
-          PATH@[2712; 2721)
-            PATH_SEGMENT@[2712; 2721)
-              NAME_REF@[2712; 2721)
-                IDENT@[2712; 2721) "assert_eq"
-          EXCL@[2721; 2722) "!"
-          TOKEN_TREE@[2722; 2829)
-            L_PAREN@[2722; 2723) "("
-            IDENT@[2723; 2729) "String"
-            COLON@[2729; 2730) ":"
-            COLON@[2730; 2731) ":"
-            IDENT@[2731; 2735) "from"
-            TOKEN_TREE@[2735; 2742)
-              L_PAREN@[2735; 2736) "("
-              STRING@[2736; 2741) "\"><>\""
-              R_PAREN@[2741; 2742) ")"
-            COMMA@[2742; 2743) ","
-            WHITESPACE@[2743; 2759) "\n               "
-            IDENT@[2759; 2765) "String"
-            COLON@[2765; 2766) ":"
-            COLON@[2766; 2767) ":"
-            L_ANGLE@[2767; 2768) "<"
-            R_ANGLE@[2768; 2769) ">"
-            COLON@[2769; 2770) ":"
-            COLON@[2770; 2771) ":"
-            IDENT@[2771; 2775) "from"
-            COLON@[2775; 2776) ":"
-            COLON@[2776; 2777) ":"
-            L_ANGLE@[2777; 2778) "<"
-            R_ANGLE@[2778; 2779) ">"
-            TOKEN_TREE@[2779; 2786)
-              L_PAREN@[2779; 2780) "("
-              STRING@[2780; 2785) "\"><>\""
-              R_PAREN@[2785; 2786) ")"
-            DOT@[2786; 2787) "."
-            IDENT@[2787; 2792) "chars"
-            COLON@[2792; 2793) ":"
-            COLON@[2793; 2794) ":"
-            L_ANGLE@[2794; 2795) "<"
-            R_ANGLE@[2795; 2796) ">"
-            TOKEN_TREE@[2796; 2798)
-              L_PAREN@[2796; 2797) "("
-              R_PAREN@[2797; 2798) ")"
-            DOT@[2798; 2799) "."
-            IDENT@[2799; 2802) "rev"
-            COLON@[2802; 2803) ":"
-            COLON@[2803; 2804) ":"
-            L_ANGLE@[2804; 2805) "<"
-            R_ANGLE@[2805; 2806) ">"
-            TOKEN_TREE@[2806; 2808)
-              L_PAREN@[2806; 2807) "("
-              R_PAREN@[2807; 2808) ")"
-            DOT@[2808; 2809) "."
-            IDENT@[2809; 2816) "collect"
-            COLON@[2816; 2817) ":"
-            COLON@[2817; 2818) ":"
-            L_ANGLE@[2818; 2819) "<"
-            IDENT@[2819; 2825) "String"
-            R_ANGLE@[2825; 2826) ">"
-            TOKEN_TREE@[2826; 2828)
-              L_PAREN@[2826; 2827) "("
-              R_PAREN@[2827; 2828) ")"
-            R_PAREN@[2828; 2829) ")"
-        SEMI@[2829; 2830) ";"
-      WHITESPACE@[2830; 2831) "\n"
-      R_CURLY@[2831; 2832) "}"
+    BLOCK_EXPR@[2706; 2832)
+      BLOCK@[2706; 2832)
+        L_CURLY@[2706; 2707) "{"
+        WHITESPACE@[2707; 2712) "\n    "
+        EXPR_STMT@[2712; 2830)
+          MACRO_CALL@[2712; 2829)
+            PATH@[2712; 2721)
+              PATH_SEGMENT@[2712; 2721)
+                NAME_REF@[2712; 2721)
+                  IDENT@[2712; 2721) "assert_eq"
+            EXCL@[2721; 2722) "!"
+            TOKEN_TREE@[2722; 2829)
+              L_PAREN@[2722; 2723) "("
+              IDENT@[2723; 2729) "String"
+              COLON@[2729; 2730) ":"
+              COLON@[2730; 2731) ":"
+              IDENT@[2731; 2735) "from"
+              TOKEN_TREE@[2735; 2742)
+                L_PAREN@[2735; 2736) "("
+                STRING@[2736; 2741) "\"><>\""
+                R_PAREN@[2741; 2742) ")"
+              COMMA@[2742; 2743) ","
+              WHITESPACE@[2743; 2759) "\n               "
+              IDENT@[2759; 2765) "String"
+              COLON@[2765; 2766) ":"
+              COLON@[2766; 2767) ":"
+              L_ANGLE@[2767; 2768) "<"
+              R_ANGLE@[2768; 2769) ">"
+              COLON@[2769; 2770) ":"
+              COLON@[2770; 2771) ":"
+              IDENT@[2771; 2775) "from"
+              COLON@[2775; 2776) ":"
+              COLON@[2776; 2777) ":"
+              L_ANGLE@[2777; 2778) "<"
+              R_ANGLE@[2778; 2779) ">"
+              TOKEN_TREE@[2779; 2786)
+                L_PAREN@[2779; 2780) "("
+                STRING@[2780; 2785) "\"><>\""
+                R_PAREN@[2785; 2786) ")"
+              DOT@[2786; 2787) "."
+              IDENT@[2787; 2792) "chars"
+              COLON@[2792; 2793) ":"
+              COLON@[2793; 2794) ":"
+              L_ANGLE@[2794; 2795) "<"
+              R_ANGLE@[2795; 2796) ">"
+              TOKEN_TREE@[2796; 2798)
+                L_PAREN@[2796; 2797) "("
+                R_PAREN@[2797; 2798) ")"
+              DOT@[2798; 2799) "."
+              IDENT@[2799; 2802) "rev"
+              COLON@[2802; 2803) ":"
+              COLON@[2803; 2804) ":"
+              L_ANGLE@[2804; 2805) "<"
+              R_ANGLE@[2805; 2806) ">"
+              TOKEN_TREE@[2806; 2808)
+                L_PAREN@[2806; 2807) "("
+                R_PAREN@[2807; 2808) ")"
+              DOT@[2808; 2809) "."
+              IDENT@[2809; 2816) "collect"
+              COLON@[2816; 2817) ":"
+              COLON@[2817; 2818) ":"
+              L_ANGLE@[2818; 2819) "<"
+              IDENT@[2819; 2825) "String"
+              R_ANGLE@[2825; 2826) ">"
+              TOKEN_TREE@[2826; 2828)
+                L_PAREN@[2826; 2827) "("
+                R_PAREN@[2827; 2828) ")"
+              R_PAREN@[2828; 2829) ")"
+          SEMI@[2829; 2830) ";"
+        WHITESPACE@[2830; 2831) "\n"
+        R_CURLY@[2831; 2832) "}"
   WHITESPACE@[2832; 2834) "\n\n"
   FN_DEF@[2834; 2906)
     FN_KW@[2834; 2836) "fn"
@@ -1550,47 +1577,48 @@ SOURCE_FILE@[0; 3813)
       L_PAREN@[2842; 2843) "("
       R_PAREN@[2843; 2844) ")"
     WHITESPACE@[2844; 2845) " "
-    BLOCK@[2845; 2906)
-      L_CURLY@[2845; 2846) "{"
-      WHITESPACE@[2846; 2851) "\n    "
-      STRUCT_DEF@[2851; 2904)
-        UNION_KW@[2851; 2856) "union"
-        WHITESPACE@[2856; 2857) " "
-        NAME@[2857; 2862)
-          IDENT@[2857; 2862) "union"
-        TYPE_PARAM_LIST@[2862; 2870)
-          L_ANGLE@[2862; 2863) "<"
-          LIFETIME_PARAM@[2863; 2869)
-            LIFETIME@[2863; 2869) "\'union"
-          R_ANGLE@[2869; 2870) ">"
-        WHITESPACE@[2870; 2871) " "
-        RECORD_FIELD_DEF_LIST@[2871; 2904)
-          L_CURLY@[2871; 2872) "{"
-          WHITESPACE@[2872; 2873) " "
-          RECORD_FIELD_DEF@[2873; 2901)
-            NAME@[2873; 2878)
-              IDENT@[2873; 2878) "union"
-            COLON@[2878; 2879) ":"
-            WHITESPACE@[2879; 2880) " "
-            REFERENCE_TYPE@[2880; 2901)
-              AMP@[2880; 2881) "&"
-              LIFETIME@[2881; 2887) "\'union"
-              WHITESPACE@[2887; 2888) " "
-              PATH_TYPE@[2888; 2901)
-                PATH@[2888; 2901)
-                  PATH_SEGMENT@[2888; 2901)
-                    NAME_REF@[2888; 2893)
-                      IDENT@[2888; 2893) "union"
-                    TYPE_ARG_LIST@[2893; 2901)
-                      L_ANGLE@[2893; 2894) "<"
-                      LIFETIME_ARG@[2894; 2900)
-                        LIFETIME@[2894; 2900) "\'union"
-                      R_ANGLE@[2900; 2901) ">"
-          COMMA@[2901; 2902) ","
-          WHITESPACE@[2902; 2903) " "
-          R_CURLY@[2903; 2904) "}"
-      WHITESPACE@[2904; 2905) "\n"
-      R_CURLY@[2905; 2906) "}"
+    BLOCK_EXPR@[2845; 2906)
+      BLOCK@[2845; 2906)
+        L_CURLY@[2845; 2846) "{"
+        WHITESPACE@[2846; 2851) "\n    "
+        STRUCT_DEF@[2851; 2904)
+          UNION_KW@[2851; 2856) "union"
+          WHITESPACE@[2856; 2857) " "
+          NAME@[2857; 2862)
+            IDENT@[2857; 2862) "union"
+          TYPE_PARAM_LIST@[2862; 2870)
+            L_ANGLE@[2862; 2863) "<"
+            LIFETIME_PARAM@[2863; 2869)
+              LIFETIME@[2863; 2869) "\'union"
+            R_ANGLE@[2869; 2870) ">"
+          WHITESPACE@[2870; 2871) " "
+          RECORD_FIELD_DEF_LIST@[2871; 2904)
+            L_CURLY@[2871; 2872) "{"
+            WHITESPACE@[2872; 2873) " "
+            RECORD_FIELD_DEF@[2873; 2901)
+              NAME@[2873; 2878)
+                IDENT@[2873; 2878) "union"
+              COLON@[2878; 2879) ":"
+              WHITESPACE@[2879; 2880) " "
+              REFERENCE_TYPE@[2880; 2901)
+                AMP@[2880; 2881) "&"
+                LIFETIME@[2881; 2887) "\'union"
+                WHITESPACE@[2887; 2888) " "
+                PATH_TYPE@[2888; 2901)
+                  PATH@[2888; 2901)
+                    PATH_SEGMENT@[2888; 2901)
+                      NAME_REF@[2888; 2893)
+                        IDENT@[2888; 2893) "union"
+                      TYPE_ARG_LIST@[2893; 2901)
+                        L_ANGLE@[2893; 2894) "<"
+                        LIFETIME_ARG@[2894; 2900)
+                          LIFETIME@[2894; 2900) "\'union"
+                        R_ANGLE@[2900; 2901) ">"
+            COMMA@[2901; 2902) ","
+            WHITESPACE@[2902; 2903) " "
+            R_CURLY@[2903; 2904) "}"
+        WHITESPACE@[2904; 2905) "\n"
+        R_CURLY@[2905; 2906) "}"
   WHITESPACE@[2906; 2908) "\n\n"
   FN_DEF@[2908; 3042)
     FN_KW@[2908; 2910) "fn"
@@ -1601,120 +1629,121 @@ SOURCE_FILE@[0; 3813)
       L_PAREN@[2929; 2930) "("
       R_PAREN@[2930; 2931) ")"
     WHITESPACE@[2931; 2932) " "
-    BLOCK@[2932; 3042)
-      L_CURLY@[2932; 2933) "{"
-      WHITESPACE@[2933; 2938) "\n    "
-      LET_STMT@[2938; 3021)
-        LET_KW@[2938; 2941) "let"
-        WHITESPACE@[2941; 2942) " "
-        BIND_PAT@[2942; 2945)
-          NAME@[2942; 2945)
-            IDENT@[2942; 2945) "val"
-        WHITESPACE@[2945; 2946) " "
-        EQ@[2946; 2947) "="
-        WHITESPACE@[2947; 2948) " "
-        PREFIX_EXPR@[2948; 3013)
-          EXCL@[2948; 2949) "!"
-          PAREN_EXPR@[2949; 3013)
-            L_PAREN@[2949; 2950) "("
-            BIN_EXPR@[2950; 3012)
-              CALL_EXPR@[2950; 2995)
-                PAREN_EXPR@[2950; 2971)
-                  L_PAREN@[2950; 2951) "("
-                  LAMBDA_EXPR@[2951; 2970)
-                    PARAM_LIST@[2951; 2968)
-                      PIPE@[2951; 2952) "|"
-                      PARAM@[2952; 2962)
-                        TUPLE_PAT@[2952; 2956)
-                          L_PAREN@[2952; 2953) "("
-                          DOTDOT@[2953; 2955) ".."
-                          R_PAREN@[2955; 2956) ")"
-                        COLON@[2956; 2957) ":"
-                        TUPLE_TYPE@[2957; 2962)
-                          L_PAREN@[2957; 2958) "("
-                          PLACEHOLDER_TYPE@[2958; 2959)
-                            UNDERSCORE@[2958; 2959) "_"
-                          COMMA@[2959; 2960) ","
-                          PLACEHOLDER_TYPE@[2960; 2961)
-                            UNDERSCORE@[2960; 2961) "_"
-                          R_PAREN@[2961; 2962) ")"
-                      COMMA@[2962; 2963) ","
-                      PARAM@[2963; 2967)
-                        BIND_PAT@[2963; 2967)
-                          NAME@[2963; 2965)
-                            IDENT@[2963; 2965) "__"
-                          AT@[2965; 2966) "@"
-                          PLACEHOLDER_PAT@[2966; 2967)
-                            UNDERSCORE@[2966; 2967) "_"
-                      PIPE@[2967; 2968) "|"
-                    PATH_EXPR@[2968; 2970)
-                      PATH@[2968; 2970)
-                        PATH_SEGMENT@[2968; 2970)
-                          NAME_REF@[2968; 2970)
-                            IDENT@[2968; 2970) "__"
-                  R_PAREN@[2970; 2971) ")"
-                ARG_LIST@[2971; 2995)
-                  L_PAREN@[2971; 2972) "("
-                  TUPLE_EXPR@[2972; 2987)
-                    L_PAREN@[2972; 2973) "("
-                    REF_EXPR@[2973; 2979)
-                      AMP@[2973; 2974) "&"
-                      PREFIX_EXPR@[2974; 2979)
-                        STAR@[2974; 2975) "*"
-                        LITERAL@[2975; 2979)
-                          STRING@[2975; 2979) "\"\\\\\""
-                    COMMA@[2979; 2980) ","
-                    LITERAL@[2980; 2986)
-                      CHAR@[2980; 2986) "\'🤔\'"
-                    R_PAREN@[2986; 2987) ")"
-                  COMMENT@[2987; 2991) "/**/"
-                  COMMA@[2991; 2992) ","
-                  BLOCK_EXPR@[2992; 2994)
-                    BLOCK@[2992; 2994)
-                      L_CURLY@[2992; 2993) "{"
-                      R_CURLY@[2993; 2994) "}"
-                  R_PAREN@[2994; 2995) ")"
-              EQEQ@[2995; 2997) "=="
-              BLOCK_EXPR@[2997; 3012)
-                BLOCK@[2997; 3012)
-                  L_CURLY@[2997; 2998) "{"
-                  EXPR_STMT@[2998; 3011)
-                    REF_EXPR@[2998; 3010)
-                      AMP@[2998; 2999) "&"
-                      INDEX_EXPR@[2999; 3010)
-                        ARRAY_EXPR@[2999; 3006)
-                          L_BRACK@[2999; 3000) "["
-                          RANGE_EXPR@[3000; 3005)
-                            DOTDOTEQ@[3000; 3003) "..="
-                            RANGE_EXPR@[3003; 3005)
-                              DOTDOT@[3003; 3005) ".."
-                          R_BRACK@[3005; 3006) "]"
-                        L_BRACK@[3006; 3007) "["
-                        RANGE_EXPR@[3007; 3009)
-                          DOTDOT@[3007; 3009) ".."
-                        R_BRACK@[3009; 3010) "]"
-                    SEMI@[3010; 3011) ";"
-                  R_CURLY@[3011; 3012) "}"
-            R_PAREN@[3012; 3013) ")"
-        COMMENT@[3013; 3015) "//"
-        WHITESPACE@[3015; 3020) "\n    "
-        SEMI@[3020; 3021) ";"
-      WHITESPACE@[3021; 3026) "\n    "
-      EXPR_STMT@[3026; 3040)
-        MACRO_CALL@[3026; 3039)
-          PATH@[3026; 3032)
-            PATH_SEGMENT@[3026; 3032)
-              NAME_REF@[3026; 3032)
-                IDENT@[3026; 3032) "assert"
-          EXCL@[3032; 3033) "!"
-          TOKEN_TREE@[3033; 3039)
-            L_PAREN@[3033; 3034) "("
-            EXCL@[3034; 3035) "!"
-            IDENT@[3035; 3038) "val"
-            R_PAREN@[3038; 3039) ")"
-        SEMI@[3039; 3040) ";"
-      WHITESPACE@[3040; 3041) "\n"
-      R_CURLY@[3041; 3042) "}"
+    BLOCK_EXPR@[2932; 3042)
+      BLOCK@[2932; 3042)
+        L_CURLY@[2932; 2933) "{"
+        WHITESPACE@[2933; 2938) "\n    "
+        LET_STMT@[2938; 3021)
+          LET_KW@[2938; 2941) "let"
+          WHITESPACE@[2941; 2942) " "
+          BIND_PAT@[2942; 2945)
+            NAME@[2942; 2945)
+              IDENT@[2942; 2945) "val"
+          WHITESPACE@[2945; 2946) " "
+          EQ@[2946; 2947) "="
+          WHITESPACE@[2947; 2948) " "
+          PREFIX_EXPR@[2948; 3013)
+            EXCL@[2948; 2949) "!"
+            PAREN_EXPR@[2949; 3013)
+              L_PAREN@[2949; 2950) "("
+              BIN_EXPR@[2950; 3012)
+                CALL_EXPR@[2950; 2995)
+                  PAREN_EXPR@[2950; 2971)
+                    L_PAREN@[2950; 2951) "("
+                    LAMBDA_EXPR@[2951; 2970)
+                      PARAM_LIST@[2951; 2968)
+                        PIPE@[2951; 2952) "|"
+                        PARAM@[2952; 2962)
+                          TUPLE_PAT@[2952; 2956)
+                            L_PAREN@[2952; 2953) "("
+                            DOTDOT@[2953; 2955) ".."
+                            R_PAREN@[2955; 2956) ")"
+                          COLON@[2956; 2957) ":"
+                          TUPLE_TYPE@[2957; 2962)
+                            L_PAREN@[2957; 2958) "("
+                            PLACEHOLDER_TYPE@[2958; 2959)
+                              UNDERSCORE@[2958; 2959) "_"
+                            COMMA@[2959; 2960) ","
+                            PLACEHOLDER_TYPE@[2960; 2961)
+                              UNDERSCORE@[2960; 2961) "_"
+                            R_PAREN@[2961; 2962) ")"
+                        COMMA@[2962; 2963) ","
+                        PARAM@[2963; 2967)
+                          BIND_PAT@[2963; 2967)
+                            NAME@[2963; 2965)
+                              IDENT@[2963; 2965) "__"
+                            AT@[2965; 2966) "@"
+                            PLACEHOLDER_PAT@[2966; 2967)
+                              UNDERSCORE@[2966; 2967) "_"
+                        PIPE@[2967; 2968) "|"
+                      PATH_EXPR@[2968; 2970)
+                        PATH@[2968; 2970)
+                          PATH_SEGMENT@[2968; 2970)
+                            NAME_REF@[2968; 2970)
+                              IDENT@[2968; 2970) "__"
+                    R_PAREN@[2970; 2971) ")"
+                  ARG_LIST@[2971; 2995)
+                    L_PAREN@[2971; 2972) "("
+                    TUPLE_EXPR@[2972; 2987)
+                      L_PAREN@[2972; 2973) "("
+                      REF_EXPR@[2973; 2979)
+                        AMP@[2973; 2974) "&"
+                        PREFIX_EXPR@[2974; 2979)
+                          STAR@[2974; 2975) "*"
+                          LITERAL@[2975; 2979)
+                            STRING@[2975; 2979) "\"\\\\\""
+                      COMMA@[2979; 2980) ","
+                      LITERAL@[2980; 2986)
+                        CHAR@[2980; 2986) "\'🤔\'"
+                      R_PAREN@[2986; 2987) ")"
+                    COMMENT@[2987; 2991) "/**/"
+                    COMMA@[2991; 2992) ","
+                    BLOCK_EXPR@[2992; 2994)
+                      BLOCK@[2992; 2994)
+                        L_CURLY@[2992; 2993) "{"
+                        R_CURLY@[2993; 2994) "}"
+                    R_PAREN@[2994; 2995) ")"
+                EQEQ@[2995; 2997) "=="
+                BLOCK_EXPR@[2997; 3012)
+                  BLOCK@[2997; 3012)
+                    L_CURLY@[2997; 2998) "{"
+                    EXPR_STMT@[2998; 3011)
+                      REF_EXPR@[2998; 3010)
+                        AMP@[2998; 2999) "&"
+                        INDEX_EXPR@[2999; 3010)
+                          ARRAY_EXPR@[2999; 3006)
+                            L_BRACK@[2999; 3000) "["
+                            RANGE_EXPR@[3000; 3005)
+                              DOTDOTEQ@[3000; 3003) "..="
+                              RANGE_EXPR@[3003; 3005)
+                                DOTDOT@[3003; 3005) ".."
+                            R_BRACK@[3005; 3006) "]"
+                          L_BRACK@[3006; 3007) "["
+                          RANGE_EXPR@[3007; 3009)
+                            DOTDOT@[3007; 3009) ".."
+                          R_BRACK@[3009; 3010) "]"
+                      SEMI@[3010; 3011) ";"
+                    R_CURLY@[3011; 3012) "}"
+              R_PAREN@[3012; 3013) ")"
+          COMMENT@[3013; 3015) "//"
+          WHITESPACE@[3015; 3020) "\n    "
+          SEMI@[3020; 3021) ";"
+        WHITESPACE@[3021; 3026) "\n    "
+        EXPR_STMT@[3026; 3040)
+          MACRO_CALL@[3026; 3039)
+            PATH@[3026; 3032)
+              PATH_SEGMENT@[3026; 3032)
+                NAME_REF@[3026; 3032)
+                  IDENT@[3026; 3032) "assert"
+            EXCL@[3032; 3033) "!"
+            TOKEN_TREE@[3033; 3039)
+              L_PAREN@[3033; 3034) "("
+              EXCL@[3034; 3035) "!"
+              IDENT@[3035; 3038) "val"
+              R_PAREN@[3038; 3039) ")"
+          SEMI@[3039; 3040) ";"
+        WHITESPACE@[3040; 3041) "\n"
+        R_CURLY@[3041; 3042) "}"
   WHITESPACE@[3042; 3044) "\n\n"
   FN_DEF@[3044; 3514)
     FN_KW@[3044; 3046) "fn"
@@ -1749,306 +1778,307 @@ SOURCE_FILE@[0; 3813)
                   NAME_REF@[3078; 3083)
                     IDENT@[3078; 3083) "Debug"
     WHITESPACE@[3083; 3084) " "
-    BLOCK@[3084; 3514)
-      L_CURLY@[3084; 3085) "{"
-      WHITESPACE@[3085; 3090) "\n    "
-      RANGE_EXPR@[3090; 3512)
-        DOTDOTEQ@[3090; 3093) "..="
-        RANGE_EXPR@[3093; 3512)
-          DOTDOTEQ@[3093; 3096) "..="
-          RANGE_EXPR@[3096; 3512)
-            DOTDOT@[3096; 3098) ".."
-            WHITESPACE@[3098; 3099) " "
-            RANGE_EXPR@[3099; 3512)
-              DOTDOT@[3099; 3101) ".."
-              WHITESPACE@[3101; 3105) "    "
-              RANGE_EXPR@[3105; 3512)
-                DOTDOT@[3105; 3107) ".."
-                WHITESPACE@[3107; 3108) " "
-                RANGE_EXPR@[3108; 3512)
-                  DOTDOT@[3108; 3110) ".."
-                  WHITESPACE@[3110; 3111) " "
-                  RANGE_EXPR@[3111; 3512)
-                    DOTDOT@[3111; 3113) ".."
-                    WHITESPACE@[3113; 3114) " "
-                    RANGE_EXPR@[3114; 3512)
-                      DOTDOT@[3114; 3116) ".."
-                      WHITESPACE@[3116; 3120) "    "
-                      RANGE_EXPR@[3120; 3512)
-                        DOTDOT@[3120; 3122) ".."
-                        WHITESPACE@[3122; 3123) " "
-                        RANGE_EXPR@[3123; 3512)
-                          DOTDOT@[3123; 3125) ".."
-                          WHITESPACE@[3125; 3126) " "
-                          RANGE_EXPR@[3126; 3512)
-                            DOTDOT@[3126; 3128) ".."
-                            WHITESPACE@[3128; 3129) " "
-                            RANGE_EXPR@[3129; 3512)
-                              DOTDOT@[3129; 3131) ".."
-                              WHITESPACE@[3131; 3135) "    "
-                              RANGE_EXPR@[3135; 3512)
-                                DOTDOT@[3135; 3137) ".."
-                                WHITESPACE@[3137; 3138) " "
-                                RANGE_EXPR@[3138; 3512)
-                                  DOTDOTEQ@[3138; 3141) "..="
-                                  RANGE_EXPR@[3141; 3512)
-                                    DOTDOT@[3141; 3143) ".."
-                                    WHITESPACE@[3143; 3144) " "
-                                    RANGE_EXPR@[3144; 3512)
-                                      DOTDOT@[3144; 3146) ".."
-                                      WHITESPACE@[3146; 3151) "\n    "
-                                      RANGE_EXPR@[3151; 3512)
-                                        DOTDOTEQ@[3151; 3154) "..="
-                                        RANGE_EXPR@[3154; 3512)
-                                          DOTDOT@[3154; 3156) ".."
-                                          WHITESPACE@[3156; 3157) " "
-                                          RANGE_EXPR@[3157; 3512)
-                                            DOTDOTEQ@[3157; 3160) "..="
-                                            RANGE_EXPR@[3160; 3512)
-                                              DOTDOT@[3160; 3162) ".."
-                                              WHITESPACE@[3162; 3166) "    "
-                                              RANGE_EXPR@[3166; 3512)
-                                                DOTDOT@[3166; 3168) ".."
-                                                WHITESPACE@[3168; 3169) " "
-                                                RANGE_EXPR@[3169; 3512)
-                                                  DOTDOT@[3169; 3171) ".."
-                                                  WHITESPACE@[3171; 3172) " "
-                                                  RANGE_EXPR@[3172; 3512)
-                                                    DOTDOT@[3172; 3174) ".."
-                                                    WHITESPACE@[3174; 3175) " "
-                                                    RANGE_EXPR@[3175; 3512)
-                                                      DOTDOT@[3175; 3177) ".."
-                                                      WHITESPACE@[3177; 3181) "    "
-                                                      RANGE_EXPR@[3181; 3512)
-                                                        DOTDOT@[3181; 3183) ".."
-                                                        WHITESPACE@[3183; 3184) " "
-                                                        RANGE_EXPR@[3184; 3512)
-                                                          DOTDOT@[3184; 3186) ".."
-                                                          WHITESPACE@[3186; 3187) " "
-                                                          RANGE_EXPR@[3187; 3512)
-                                                            DOTDOT@[3187; 3189) ".."
-                                                            WHITESPACE@[3189; 3190) " "
-                                                            RANGE_EXPR@[3190; 3512)
-                                                              DOTDOT@[3190; 3192) ".."
-                                                              WHITESPACE@[3192; 3196) "    "
-                                                              RANGE_EXPR@[3196; 3512)
-                                                                DOTDOTEQ@[3196; 3199) "..="
-                                                                RANGE_EXPR@[3199; 3512)
-                                                                  DOTDOTEQ@[3199; 3202) "..="
-                                                                  RANGE_EXPR@[3202; 3512)
-                                                                    DOTDOTEQ@[3202; 3205) "..="
-                                                                    RANGE_EXPR@[3205; 3512)
-                                                                      DOTDOT@[3205; 3207) ".."
-                                                                      WHITESPACE@[3207; 3212) "\n    "
-                                                                      RANGE_EXPR@[3212; 3512)
-                                                                        DOTDOTEQ@[3212; 3215) "..="
-                                                                        RANGE_EXPR@[3215; 3512)
-                                                                          DOTDOT@[3215; 3217) ".."
-                                                                          WHITESPACE@[3217; 3218) " "
-                                                                          RANGE_EXPR@[3218; 3512)
-                                                                            DOTDOTEQ@[3218; 3221) "..="
-                                                                            RANGE_EXPR@[3221; 3512)
-                                                                              DOTDOT@[3221; 3223) ".."
-                                                                              WHITESPACE@[3223; 3227) "    "
-                                                                              RANGE_EXPR@[3227; 3512)
-                                                                                DOTDOTEQ@[3227; 3230) "..="
-                                                                                RANGE_EXPR@[3230; 3512)
-                                                                                  DOTDOT@[3230; 3232) ".."
-                                                                                  WHITESPACE@[3232; 3233) " "
-                                                                                  RANGE_EXPR@[3233; 3512)
-                                                                                    DOTDOTEQ@[3233; 3236) "..="
-                                                                                    RANGE_EXPR@[3236; 3512)
-                                                                                      DOTDOT@[3236; 3238) ".."
-                                                                                      WHITESPACE@[3238; 3242) "    "
-                                                                                      RANGE_EXPR@[3242; 3512)
-                                                                                        DOTDOT@[3242; 3244) ".."
-                                                                                        WHITESPACE@[3244; 3245) " "
-                                                                                        RANGE_EXPR@[3245; 3512)
-                                                                                          DOTDOTEQ@[3245; 3248) "..="
-                                                                                          RANGE_EXPR@[3248; 3512)
-                                                                                            DOTDOTEQ@[3248; 3251) "..="
-                                                                                            RANGE_EXPR@[3251; 3512)
-                                                                                              DOTDOT@[3251; 3253) ".."
-                                                                                              WHITESPACE@[3253; 3257) "    "
-                                                                                              RANGE_EXPR@[3257; 3512)
-                                                                                                DOTDOT@[3257; 3259) ".."
-                                                                                                WHITESPACE@[3259; 3260) " "
-                                                                                                RANGE_EXPR@[3260; 3512)
-                                                                                                  DOTDOTEQ@[3260; 3263) "..="
-                                                                                                  RANGE_EXPR@[3263; 3512)
-                                                                                                    DOTDOT@[3263; 3265) ".."
-                                                                                                    WHITESPACE@[3265; 3266) " "
-                                                                                                    RANGE_EXPR@[3266; 3512)
-                                                                                                      DOTDOT@[3266; 3268) ".."
-                                                                                                      WHITESPACE@[3268; 3273) "\n    "
-                                                                                                      RANGE_EXPR@[3273; 3512)
-                                                                                                        DOTDOTEQ@[3273; 3276) "..="
-                                                                                                        RANGE_EXPR@[3276; 3512)
-                                                                                                          DOTDOTEQ@[3276; 3279) "..="
-                                                                                                          RANGE_EXPR@[3279; 3512)
-                                                                                                            DOTDOT@[3279; 3281) ".."
-                                                                                                            WHITESPACE@[3281; 3282) " "
-                                                                                                            RANGE_EXPR@[3282; 3512)
-                                                                                                              DOTDOT@[3282; 3284) ".."
-                                                                                                              WHITESPACE@[3284; 3288) "    "
-                                                                                                              RANGE_EXPR@[3288; 3512)
-                                                                                                                DOTDOTEQ@[3288; 3291) "..="
-                                                                                                                RANGE_EXPR@[3291; 3512)
-                                                                                                                  DOTDOT@[3291; 3293) ".."
-                                                                                                                  WHITESPACE@[3293; 3294) " "
-                                                                                                                  RANGE_EXPR@[3294; 3512)
-                                                                                                                    DOTDOTEQ@[3294; 3297) "..="
-                                                                                                                    RANGE_EXPR@[3297; 3512)
-                                                                                                                      DOTDOT@[3297; 3299) ".."
-                                                                                                                      WHITESPACE@[3299; 3303) "    "
-                                                                                                                      RANGE_EXPR@[3303; 3512)
-                                                                                                                        DOTDOTEQ@[3303; 3306) "..="
-                                                                                                                        RANGE_EXPR@[3306; 3512)
-                                                                                                                          DOTDOT@[3306; 3308) ".."
-                                                                                                                          WHITESPACE@[3308; 3309) " "
-                                                                                                                          RANGE_EXPR@[3309; 3512)
-                                                                                                                            DOTDOT@[3309; 3311) ".."
-                                                                                                                            WHITESPACE@[3311; 3312) " "
-                                                                                                                            RANGE_EXPR@[3312; 3512)
-                                                                                                                              DOTDOT@[3312; 3314) ".."
-                                                                                                                              WHITESPACE@[3314; 3318) "    "
-                                                                                                                              RANGE_EXPR@[3318; 3512)
-                                                                                                                                DOTDOT@[3318; 3320) ".."
-                                                                                                                                WHITESPACE@[3320; 3321) " "
-                                                                                                                                RANGE_EXPR@[3321; 3512)
-                                                                                                                                  DOTDOTEQ@[3321; 3324) "..="
-                                                                                                                                  RANGE_EXPR@[3324; 3512)
-                                                                                                                                    DOTDOT@[3324; 3326) ".."
-                                                                                                                                    WHITESPACE@[3326; 3327) " "
-                                                                                                                                    RANGE_EXPR@[3327; 3512)
-                                                                                                                                      DOTDOT@[3327; 3329) ".."
-                                                                                                                                      WHITESPACE@[3329; 3334) "\n    "
-                                                                                                                                      RANGE_EXPR@[3334; 3512)
-                                                                                                                                        DOTDOTEQ@[3334; 3337) "..="
-                                                                                                                                        RANGE_EXPR@[3337; 3512)
-                                                                                                                                          DOTDOT@[3337; 3339) ".."
-                                                                                                                                          WHITESPACE@[3339; 3340) " "
-                                                                                                                                          RANGE_EXPR@[3340; 3512)
-                                                                                                                                            DOTDOTEQ@[3340; 3343) "..="
-                                                                                                                                            RANGE_EXPR@[3343; 3512)
-                                                                                                                                              DOTDOT@[3343; 3345) ".."
-                                                                                                                                              WHITESPACE@[3345; 3349) "    "
-                                                                                                                                              RANGE_EXPR@[3349; 3512)
-                                                                                                                                                DOTDOTEQ@[3349; 3352) "..="
-                                                                                                                                                RANGE_EXPR@[3352; 3512)
-                                                                                                                                                  DOTDOT@[3352; 3354) ".."
-                                                                                                                                                  WHITESPACE@[3354; 3355) " "
-                                                                                                                                                  RANGE_EXPR@[3355; 3512)
-                                                                                                                                                    DOTDOTEQ@[3355; 3358) "..="
-                                                                                                                                                    RANGE_EXPR@[3358; 3512)
-                                                                                                                                                      DOTDOT@[3358; 3360) ".."
-                                                                                                                                                      WHITESPACE@[3360; 3364) "    "
-                                                                                                                                                      RANGE_EXPR@[3364; 3512)
-                                                                                                                                                        DOTDOT@[3364; 3366) ".."
-                                                                                                                                                        WHITESPACE@[3366; 3367) " "
-                                                                                                                                                        RANGE_EXPR@[3367; 3512)
-                                                                                                                                                          DOTDOTEQ@[3367; 3370) "..="
-                                                                                                                                                          RANGE_EXPR@[3370; 3512)
-                                                                                                                                                            DOTDOT@[3370; 3372) ".."
-                                                                                                                                                            WHITESPACE@[3372; 3373) " "
-                                                                                                                                                            RANGE_EXPR@[3373; 3512)
-                                                                                                                                                              DOTDOT@[3373; 3375) ".."
-                                                                                                                                                              WHITESPACE@[3375; 3379) "    "
-                                                                                                                                                              RANGE_EXPR@[3379; 3512)
-                                                                                                                                                                DOTDOT@[3379; 3381) ".."
-                                                                                                                                                                WHITESPACE@[3381; 3382) " "
-                                                                                                                                                                RANGE_EXPR@[3382; 3512)
-                                                                                                                                                                  DOTDOTEQ@[3382; 3385) "..="
-                                                                                                                                                                  RANGE_EXPR@[3385; 3512)
-                                                                                                                                                                    DOTDOT@[3385; 3387) ".."
-                                                                                                                                                                    WHITESPACE@[3387; 3388) " "
-                                                                                                                                                                    RANGE_EXPR@[3388; 3512)
-                                                                                                                                                                      DOTDOT@[3388; 3390) ".."
-                                                                                                                                                                      WHITESPACE@[3390; 3395) "\n    "
-                                                                                                                                                                      RANGE_EXPR@[3395; 3512)
-                                                                                                                                                                        DOTDOTEQ@[3395; 3398) "..="
-                                                                                                                                                                        RANGE_EXPR@[3398; 3512)
-                                                                                                                                                                          DOTDOT@[3398; 3400) ".."
-                                                                                                                                                                          WHITESPACE@[3400; 3401) " "
-                                                                                                                                                                          RANGE_EXPR@[3401; 3512)
-                                                                                                                                                                            DOTDOTEQ@[3401; 3404) "..="
-                                                                                                                                                                            RANGE_EXPR@[3404; 3512)
-                                                                                                                                                                              DOTDOT@[3404; 3406) ".."
-                                                                                                                                                                              WHITESPACE@[3406; 3410) "    "
-                                                                                                                                                                              RANGE_EXPR@[3410; 3512)
-                                                                                                                                                                                DOTDOTEQ@[3410; 3413) "..="
-                                                                                                                                                                                RANGE_EXPR@[3413; 3512)
-                                                                                                                                                                                  DOTDOT@[3413; 3415) ".."
-                                                                                                                                                                                  WHITESPACE@[3415; 3416) " "
-                                                                                                                                                                                  RANGE_EXPR@[3416; 3512)
-                                                                                                                                                                                    DOTDOTEQ@[3416; 3419) "..="
-                                                                                                                                                                                    RANGE_EXPR@[3419; 3512)
-                                                                                                                                                                                      DOTDOT@[3419; 3421) ".."
-                                                                                                                                                                                      WHITESPACE@[3421; 3425) "    "
-                                                                                                                                                                                      RANGE_EXPR@[3425; 3512)
-                                                                                                                                                                                        DOTDOT@[3425; 3427) ".."
-                                                                                                                                                                                        WHITESPACE@[3427; 3428) " "
-                                                                                                                                                                                        RANGE_EXPR@[3428; 3512)
-                                                                                                                                                                                          DOTDOT@[3428; 3430) ".."
-                                                                                                                                                                                          WHITESPACE@[3430; 3431) " "
-                                                                                                                                                                                          RANGE_EXPR@[3431; 3512)
-                                                                                                                                                                                            DOTDOTEQ@[3431; 3434) "..="
-                                                                                                                                                                                            RANGE_EXPR@[3434; 3512)
-                                                                                                                                                                                              DOTDOT@[3434; 3436) ".."
-                                                                                                                                                                                              WHITESPACE@[3436; 3440) "    "
-                                                                                                                                                                                              RANGE_EXPR@[3440; 3512)
-                                                                                                                                                                                                DOTDOT@[3440; 3442) ".."
-                                                                                                                                                                                                WHITESPACE@[3442; 3443) " "
-                                                                                                                                                                                                RANGE_EXPR@[3443; 3512)
-                                                                                                                                                                                                  DOTDOTEQ@[3443; 3446) "..="
-                                                                                                                                                                                                  RANGE_EXPR@[3446; 3512)
-                                                                                                                                                                                                    DOTDOT@[3446; 3448) ".."
-                                                                                                                                                                                                    WHITESPACE@[3448; 3449) " "
-                                                                                                                                                                                                    RANGE_EXPR@[3449; 3512)
-                                                                                                                                                                                                      DOTDOT@[3449; 3451) ".."
-                                                                                                                                                                                                      WHITESPACE@[3451; 3456) "\n    "
-                                                                                                                                                                                                      RANGE_EXPR@[3456; 3512)
-                                                                                                                                                                                                        DOTDOTEQ@[3456; 3459) "..="
-                                                                                                                                                                                                        RANGE_EXPR@[3459; 3512)
-                                                                                                                                                                                                          DOTDOT@[3459; 3461) ".."
-                                                                                                                                                                                                          WHITESPACE@[3461; 3462) " "
-                                                                                                                                                                                                          RANGE_EXPR@[3462; 3512)
-                                                                                                                                                                                                            DOTDOTEQ@[3462; 3465) "..="
-                                                                                                                                                                                                            RANGE_EXPR@[3465; 3512)
-                                                                                                                                                                                                              DOTDOT@[3465; 3467) ".."
-                                                                                                                                                                                                              WHITESPACE@[3467; 3471) "    "
-                                                                                                                                                                                                              RANGE_EXPR@[3471; 3512)
-                                                                                                                                                                                                                DOTDOT@[3471; 3473) ".."
-                                                                                                                                                                                                                WHITESPACE@[3473; 3474) " "
-                                                                                                                                                                                                                RANGE_EXPR@[3474; 3512)
-                                                                                                                                                                                                                  DOTDOTEQ@[3474; 3477) "..="
-                                                                                                                                                                                                                  RANGE_EXPR@[3477; 3512)
-                                                                                                                                                                                                                    DOTDOTEQ@[3477; 3480) "..="
-                                                                                                                                                                                                                    RANGE_EXPR@[3480; 3512)
-                                                                                                                                                                                                                      DOTDOT@[3480; 3482) ".."
-                                                                                                                                                                                                                      WHITESPACE@[3482; 3486) "    "
-                                                                                                                                                                                                                      RANGE_EXPR@[3486; 3512)
-                                                                                                                                                                                                                        DOTDOTEQ@[3486; 3489) "..="
-                                                                                                                                                                                                                        RANGE_EXPR@[3489; 3512)
-                                                                                                                                                                                                                          DOTDOTEQ@[3489; 3492) "..="
-                                                                                                                                                                                                                          RANGE_EXPR@[3492; 3512)
-                                                                                                                                                                                                                            DOTDOT@[3492; 3494) ".."
-                                                                                                                                                                                                                            WHITESPACE@[3494; 3495) " "
-                                                                                                                                                                                                                            RANGE_EXPR@[3495; 3512)
-                                                                                                                                                                                                                              DOTDOT@[3495; 3497) ".."
-                                                                                                                                                                                                                              WHITESPACE@[3497; 3501) "    "
-                                                                                                                                                                                                                              RANGE_EXPR@[3501; 3512)
-                                                                                                                                                                                                                                DOTDOT@[3501; 3503) ".."
-                                                                                                                                                                                                                                WHITESPACE@[3503; 3504) " "
-                                                                                                                                                                                                                                RANGE_EXPR@[3504; 3512)
-                                                                                                                                                                                                                                  DOTDOTEQ@[3504; 3507) "..="
-                                                                                                                                                                                                                                  RANGE_EXPR@[3507; 3512)
-                                                                                                                                                                                                                                    DOTDOT@[3507; 3509) ".."
-                                                                                                                                                                                                                                    WHITESPACE@[3509; 3510) " "
-                                                                                                                                                                                                                                    RANGE_EXPR@[3510; 3512)
-                                                                                                                                                                                                                                      DOTDOT@[3510; 3512) ".."
-      WHITESPACE@[3512; 3513) "\n"
-      R_CURLY@[3513; 3514) "}"
+    BLOCK_EXPR@[3084; 3514)
+      BLOCK@[3084; 3514)
+        L_CURLY@[3084; 3085) "{"
+        WHITESPACE@[3085; 3090) "\n    "
+        RANGE_EXPR@[3090; 3512)
+          DOTDOTEQ@[3090; 3093) "..="
+          RANGE_EXPR@[3093; 3512)
+            DOTDOTEQ@[3093; 3096) "..="
+            RANGE_EXPR@[3096; 3512)
+              DOTDOT@[3096; 3098) ".."
+              WHITESPACE@[3098; 3099) " "
+              RANGE_EXPR@[3099; 3512)
+                DOTDOT@[3099; 3101) ".."
+                WHITESPACE@[3101; 3105) "    "
+                RANGE_EXPR@[3105; 3512)
+                  DOTDOT@[3105; 3107) ".."
+                  WHITESPACE@[3107; 3108) " "
+                  RANGE_EXPR@[3108; 3512)
+                    DOTDOT@[3108; 3110) ".."
+                    WHITESPACE@[3110; 3111) " "
+                    RANGE_EXPR@[3111; 3512)
+                      DOTDOT@[3111; 3113) ".."
+                      WHITESPACE@[3113; 3114) " "
+                      RANGE_EXPR@[3114; 3512)
+                        DOTDOT@[3114; 3116) ".."
+                        WHITESPACE@[3116; 3120) "    "
+                        RANGE_EXPR@[3120; 3512)
+                          DOTDOT@[3120; 3122) ".."
+                          WHITESPACE@[3122; 3123) " "
+                          RANGE_EXPR@[3123; 3512)
+                            DOTDOT@[3123; 3125) ".."
+                            WHITESPACE@[3125; 3126) " "
+                            RANGE_EXPR@[3126; 3512)
+                              DOTDOT@[3126; 3128) ".."
+                              WHITESPACE@[3128; 3129) " "
+                              RANGE_EXPR@[3129; 3512)
+                                DOTDOT@[3129; 3131) ".."
+                                WHITESPACE@[3131; 3135) "    "
+                                RANGE_EXPR@[3135; 3512)
+                                  DOTDOT@[3135; 3137) ".."
+                                  WHITESPACE@[3137; 3138) " "
+                                  RANGE_EXPR@[3138; 3512)
+                                    DOTDOTEQ@[3138; 3141) "..="
+                                    RANGE_EXPR@[3141; 3512)
+                                      DOTDOT@[3141; 3143) ".."
+                                      WHITESPACE@[3143; 3144) " "
+                                      RANGE_EXPR@[3144; 3512)
+                                        DOTDOT@[3144; 3146) ".."
+                                        WHITESPACE@[3146; 3151) "\n    "
+                                        RANGE_EXPR@[3151; 3512)
+                                          DOTDOTEQ@[3151; 3154) "..="
+                                          RANGE_EXPR@[3154; 3512)
+                                            DOTDOT@[3154; 3156) ".."
+                                            WHITESPACE@[3156; 3157) " "
+                                            RANGE_EXPR@[3157; 3512)
+                                              DOTDOTEQ@[3157; 3160) "..="
+                                              RANGE_EXPR@[3160; 3512)
+                                                DOTDOT@[3160; 3162) ".."
+                                                WHITESPACE@[3162; 3166) "    "
+                                                RANGE_EXPR@[3166; 3512)
+                                                  DOTDOT@[3166; 3168) ".."
+                                                  WHITESPACE@[3168; 3169) " "
+                                                  RANGE_EXPR@[3169; 3512)
+                                                    DOTDOT@[3169; 3171) ".."
+                                                    WHITESPACE@[3171; 3172) " "
+                                                    RANGE_EXPR@[3172; 3512)
+                                                      DOTDOT@[3172; 3174) ".."
+                                                      WHITESPACE@[3174; 3175) " "
+                                                      RANGE_EXPR@[3175; 3512)
+                                                        DOTDOT@[3175; 3177) ".."
+                                                        WHITESPACE@[3177; 3181) "    "
+                                                        RANGE_EXPR@[3181; 3512)
+                                                          DOTDOT@[3181; 3183) ".."
+                                                          WHITESPACE@[3183; 3184) " "
+                                                          RANGE_EXPR@[3184; 3512)
+                                                            DOTDOT@[3184; 3186) ".."
+                                                            WHITESPACE@[3186; 3187) " "
+                                                            RANGE_EXPR@[3187; 3512)
+                                                              DOTDOT@[3187; 3189) ".."
+                                                              WHITESPACE@[3189; 3190) " "
+                                                              RANGE_EXPR@[3190; 3512)
+                                                                DOTDOT@[3190; 3192) ".."
+                                                                WHITESPACE@[3192; 3196) "    "
+                                                                RANGE_EXPR@[3196; 3512)
+                                                                  DOTDOTEQ@[3196; 3199) "..="
+                                                                  RANGE_EXPR@[3199; 3512)
+                                                                    DOTDOTEQ@[3199; 3202) "..="
+                                                                    RANGE_EXPR@[3202; 3512)
+                                                                      DOTDOTEQ@[3202; 3205) "..="
+                                                                      RANGE_EXPR@[3205; 3512)
+                                                                        DOTDOT@[3205; 3207) ".."
+                                                                        WHITESPACE@[3207; 3212) "\n    "
+                                                                        RANGE_EXPR@[3212; 3512)
+                                                                          DOTDOTEQ@[3212; 3215) "..="
+                                                                          RANGE_EXPR@[3215; 3512)
+                                                                            DOTDOT@[3215; 3217) ".."
+                                                                            WHITESPACE@[3217; 3218) " "
+                                                                            RANGE_EXPR@[3218; 3512)
+                                                                              DOTDOTEQ@[3218; 3221) "..="
+                                                                              RANGE_EXPR@[3221; 3512)
+                                                                                DOTDOT@[3221; 3223) ".."
+                                                                                WHITESPACE@[3223; 3227) "    "
+                                                                                RANGE_EXPR@[3227; 3512)
+                                                                                  DOTDOTEQ@[3227; 3230) "..="
+                                                                                  RANGE_EXPR@[3230; 3512)
+                                                                                    DOTDOT@[3230; 3232) ".."
+                                                                                    WHITESPACE@[3232; 3233) " "
+                                                                                    RANGE_EXPR@[3233; 3512)
+                                                                                      DOTDOTEQ@[3233; 3236) "..="
+                                                                                      RANGE_EXPR@[3236; 3512)
+                                                                                        DOTDOT@[3236; 3238) ".."
+                                                                                        WHITESPACE@[3238; 3242) "    "
+                                                                                        RANGE_EXPR@[3242; 3512)
+                                                                                          DOTDOT@[3242; 3244) ".."
+                                                                                          WHITESPACE@[3244; 3245) " "
+                                                                                          RANGE_EXPR@[3245; 3512)
+                                                                                            DOTDOTEQ@[3245; 3248) "..="
+                                                                                            RANGE_EXPR@[3248; 3512)
+                                                                                              DOTDOTEQ@[3248; 3251) "..="
+                                                                                              RANGE_EXPR@[3251; 3512)
+                                                                                                DOTDOT@[3251; 3253) ".."
+                                                                                                WHITESPACE@[3253; 3257) "    "
+                                                                                                RANGE_EXPR@[3257; 3512)
+                                                                                                  DOTDOT@[3257; 3259) ".."
+                                                                                                  WHITESPACE@[3259; 3260) " "
+                                                                                                  RANGE_EXPR@[3260; 3512)
+                                                                                                    DOTDOTEQ@[3260; 3263) "..="
+                                                                                                    RANGE_EXPR@[3263; 3512)
+                                                                                                      DOTDOT@[3263; 3265) ".."
+                                                                                                      WHITESPACE@[3265; 3266) " "
+                                                                                                      RANGE_EXPR@[3266; 3512)
+                                                                                                        DOTDOT@[3266; 3268) ".."
+                                                                                                        WHITESPACE@[3268; 3273) "\n    "
+                                                                                                        RANGE_EXPR@[3273; 3512)
+                                                                                                          DOTDOTEQ@[3273; 3276) "..="
+                                                                                                          RANGE_EXPR@[3276; 3512)
+                                                                                                            DOTDOTEQ@[3276; 3279) "..="
+                                                                                                            RANGE_EXPR@[3279; 3512)
+                                                                                                              DOTDOT@[3279; 3281) ".."
+                                                                                                              WHITESPACE@[3281; 3282) " "
+                                                                                                              RANGE_EXPR@[3282; 3512)
+                                                                                                                DOTDOT@[3282; 3284) ".."
+                                                                                                                WHITESPACE@[3284; 3288) "    "
+                                                                                                                RANGE_EXPR@[3288; 3512)
+                                                                                                                  DOTDOTEQ@[3288; 3291) "..="
+                                                                                                                  RANGE_EXPR@[3291; 3512)
+                                                                                                                    DOTDOT@[3291; 3293) ".."
+                                                                                                                    WHITESPACE@[3293; 3294) " "
+                                                                                                                    RANGE_EXPR@[3294; 3512)
+                                                                                                                      DOTDOTEQ@[3294; 3297) "..="
+                                                                                                                      RANGE_EXPR@[3297; 3512)
+                                                                                                                        DOTDOT@[3297; 3299) ".."
+                                                                                                                        WHITESPACE@[3299; 3303) "    "
+                                                                                                                        RANGE_EXPR@[3303; 3512)
+                                                                                                                          DOTDOTEQ@[3303; 3306) "..="
+                                                                                                                          RANGE_EXPR@[3306; 3512)
+                                                                                                                            DOTDOT@[3306; 3308) ".."
+                                                                                                                            WHITESPACE@[3308; 3309) " "
+                                                                                                                            RANGE_EXPR@[3309; 3512)
+                                                                                                                              DOTDOT@[3309; 3311) ".."
+                                                                                                                              WHITESPACE@[3311; 3312) " "
+                                                                                                                              RANGE_EXPR@[3312; 3512)
+                                                                                                                                DOTDOT@[3312; 3314) ".."
+                                                                                                                                WHITESPACE@[3314; 3318) "    "
+                                                                                                                                RANGE_EXPR@[3318; 3512)
+                                                                                                                                  DOTDOT@[3318; 3320) ".."
+                                                                                                                                  WHITESPACE@[3320; 3321) " "
+                                                                                                                                  RANGE_EXPR@[3321; 3512)
+                                                                                                                                    DOTDOTEQ@[3321; 3324) "..="
+                                                                                                                                    RANGE_EXPR@[3324; 3512)
+                                                                                                                                      DOTDOT@[3324; 3326) ".."
+                                                                                                                                      WHITESPACE@[3326; 3327) " "
+                                                                                                                                      RANGE_EXPR@[3327; 3512)
+                                                                                                                                        DOTDOT@[3327; 3329) ".."
+                                                                                                                                        WHITESPACE@[3329; 3334) "\n    "
+                                                                                                                                        RANGE_EXPR@[3334; 3512)
+                                                                                                                                          DOTDOTEQ@[3334; 3337) "..="
+                                                                                                                                          RANGE_EXPR@[3337; 3512)
+                                                                                                                                            DOTDOT@[3337; 3339) ".."
+                                                                                                                                            WHITESPACE@[3339; 3340) " "
+                                                                                                                                            RANGE_EXPR@[3340; 3512)
+                                                                                                                                              DOTDOTEQ@[3340; 3343) "..="
+                                                                                                                                              RANGE_EXPR@[3343; 3512)
+                                                                                                                                                DOTDOT@[3343; 3345) ".."
+                                                                                                                                                WHITESPACE@[3345; 3349) "    "
+                                                                                                                                                RANGE_EXPR@[3349; 3512)
+                                                                                                                                                  DOTDOTEQ@[3349; 3352) "..="
+                                                                                                                                                  RANGE_EXPR@[3352; 3512)
+                                                                                                                                                    DOTDOT@[3352; 3354) ".."
+                                                                                                                                                    WHITESPACE@[3354; 3355) " "
+                                                                                                                                                    RANGE_EXPR@[3355; 3512)
+                                                                                                                                                      DOTDOTEQ@[3355; 3358) "..="
+                                                                                                                                                      RANGE_EXPR@[3358; 3512)
+                                                                                                                                                        DOTDOT@[3358; 3360) ".."
+                                                                                                                                                        WHITESPACE@[3360; 3364) "    "
+                                                                                                                                                        RANGE_EXPR@[3364; 3512)
+                                                                                                                                                          DOTDOT@[3364; 3366) ".."
+                                                                                                                                                          WHITESPACE@[3366; 3367) " "
+                                                                                                                                                          RANGE_EXPR@[3367; 3512)
+                                                                                                                                                            DOTDOTEQ@[3367; 3370) "..="
+                                                                                                                                                            RANGE_EXPR@[3370; 3512)
+                                                                                                                                                              DOTDOT@[3370; 3372) ".."
+                                                                                                                                                              WHITESPACE@[3372; 3373) " "
+                                                                                                                                                              RANGE_EXPR@[3373; 3512)
+                                                                                                                                                                DOTDOT@[3373; 3375) ".."
+                                                                                                                                                                WHITESPACE@[3375; 3379) "    "
+                                                                                                                                                                RANGE_EXPR@[3379; 3512)
+                                                                                                                                                                  DOTDOT@[3379; 3381) ".."
+                                                                                                                                                                  WHITESPACE@[3381; 3382) " "
+                                                                                                                                                                  RANGE_EXPR@[3382; 3512)
+                                                                                                                                                                    DOTDOTEQ@[3382; 3385) "..="
+                                                                                                                                                                    RANGE_EXPR@[3385; 3512)
+                                                                                                                                                                      DOTDOT@[3385; 3387) ".."
+                                                                                                                                                                      WHITESPACE@[3387; 3388) " "
+                                                                                                                                                                      RANGE_EXPR@[3388; 3512)
+                                                                                                                                                                        DOTDOT@[3388; 3390) ".."
+                                                                                                                                                                        WHITESPACE@[3390; 3395) "\n    "
+                                                                                                                                                                        RANGE_EXPR@[3395; 3512)
+                                                                                                                                                                          DOTDOTEQ@[3395; 3398) "..="
+                                                                                                                                                                          RANGE_EXPR@[3398; 3512)
+                                                                                                                                                                            DOTDOT@[3398; 3400) ".."
+                                                                                                                                                                            WHITESPACE@[3400; 3401) " "
+                                                                                                                                                                            RANGE_EXPR@[3401; 3512)
+                                                                                                                                                                              DOTDOTEQ@[3401; 3404) "..="
+                                                                                                                                                                              RANGE_EXPR@[3404; 3512)
+                                                                                                                                                                                DOTDOT@[3404; 3406) ".."
+                                                                                                                                                                                WHITESPACE@[3406; 3410) "    "
+                                                                                                                                                                                RANGE_EXPR@[3410; 3512)
+                                                                                                                                                                                  DOTDOTEQ@[3410; 3413) "..="
+                                                                                                                                                                                  RANGE_EXPR@[3413; 3512)
+                                                                                                                                                                                    DOTDOT@[3413; 3415) ".."
+                                                                                                                                                                                    WHITESPACE@[3415; 3416) " "
+                                                                                                                                                                                    RANGE_EXPR@[3416; 3512)
+                                                                                                                                                                                      DOTDOTEQ@[3416; 3419) "..="
+                                                                                                                                                                                      RANGE_EXPR@[3419; 3512)
+                                                                                                                                                                                        DOTDOT@[3419; 3421) ".."
+                                                                                                                                                                                        WHITESPACE@[3421; 3425) "    "
+                                                                                                                                                                                        RANGE_EXPR@[3425; 3512)
+                                                                                                                                                                                          DOTDOT@[3425; 3427) ".."
+                                                                                                                                                                                          WHITESPACE@[3427; 3428) " "
+                                                                                                                                                                                          RANGE_EXPR@[3428; 3512)
+                                                                                                                                                                                            DOTDOT@[3428; 3430) ".."
+                                                                                                                                                                                            WHITESPACE@[3430; 3431) " "
+                                                                                                                                                                                            RANGE_EXPR@[3431; 3512)
+                                                                                                                                                                                              DOTDOTEQ@[3431; 3434) "..="
+                                                                                                                                                                                              RANGE_EXPR@[3434; 3512)
+                                                                                                                                                                                                DOTDOT@[3434; 3436) ".."
+                                                                                                                                                                                                WHITESPACE@[3436; 3440) "    "
+                                                                                                                                                                                                RANGE_EXPR@[3440; 3512)
+                                                                                                                                                                                                  DOTDOT@[3440; 3442) ".."
+                                                                                                                                                                                                  WHITESPACE@[3442; 3443) " "
+                                                                                                                                                                                                  RANGE_EXPR@[3443; 3512)
+                                                                                                                                                                                                    DOTDOTEQ@[3443; 3446) "..="
+                                                                                                                                                                                                    RANGE_EXPR@[3446; 3512)
+                                                                                                                                                                                                      DOTDOT@[3446; 3448) ".."
+                                                                                                                                                                                                      WHITESPACE@[3448; 3449) " "
+                                                                                                                                                                                                      RANGE_EXPR@[3449; 3512)
+                                                                                                                                                                                                        DOTDOT@[3449; 3451) ".."
+                                                                                                                                                                                                        WHITESPACE@[3451; 3456) "\n    "
+                                                                                                                                                                                                        RANGE_EXPR@[3456; 3512)
+                                                                                                                                                                                                          DOTDOTEQ@[3456; 3459) "..="
+                                                                                                                                                                                                          RANGE_EXPR@[3459; 3512)
+                                                                                                                                                                                                            DOTDOT@[3459; 3461) ".."
+                                                                                                                                                                                                            WHITESPACE@[3461; 3462) " "
+                                                                                                                                                                                                            RANGE_EXPR@[3462; 3512)
+                                                                                                                                                                                                              DOTDOTEQ@[3462; 3465) "..="
+                                                                                                                                                                                                              RANGE_EXPR@[3465; 3512)
+                                                                                                                                                                                                                DOTDOT@[3465; 3467) ".."
+                                                                                                                                                                                                                WHITESPACE@[3467; 3471) "    "
+                                                                                                                                                                                                                RANGE_EXPR@[3471; 3512)
+                                                                                                                                                                                                                  DOTDOT@[3471; 3473) ".."
+                                                                                                                                                                                                                  WHITESPACE@[3473; 3474) " "
+                                                                                                                                                                                                                  RANGE_EXPR@[3474; 3512)
+                                                                                                                                                                                                                    DOTDOTEQ@[3474; 3477) "..="
+                                                                                                                                                                                                                    RANGE_EXPR@[3477; 3512)
+                                                                                                                                                                                                                      DOTDOTEQ@[3477; 3480) "..="
+                                                                                                                                                                                                                      RANGE_EXPR@[3480; 3512)
+                                                                                                                                                                                                                        DOTDOT@[3480; 3482) ".."
+                                                                                                                                                                                                                        WHITESPACE@[3482; 3486) "    "
+                                                                                                                                                                                                                        RANGE_EXPR@[3486; 3512)
+                                                                                                                                                                                                                          DOTDOTEQ@[3486; 3489) "..="
+                                                                                                                                                                                                                          RANGE_EXPR@[3489; 3512)
+                                                                                                                                                                                                                            DOTDOTEQ@[3489; 3492) "..="
+                                                                                                                                                                                                                            RANGE_EXPR@[3492; 3512)
+                                                                                                                                                                                                                              DOTDOT@[3492; 3494) ".."
+                                                                                                                                                                                                                              WHITESPACE@[3494; 3495) " "
+                                                                                                                                                                                                                              RANGE_EXPR@[3495; 3512)
+                                                                                                                                                                                                                                DOTDOT@[3495; 3497) ".."
+                                                                                                                                                                                                                                WHITESPACE@[3497; 3501) "    "
+                                                                                                                                                                                                                                RANGE_EXPR@[3501; 3512)
+                                                                                                                                                                                                                                  DOTDOT@[3501; 3503) ".."
+                                                                                                                                                                                                                                  WHITESPACE@[3503; 3504) " "
+                                                                                                                                                                                                                                  RANGE_EXPR@[3504; 3512)
+                                                                                                                                                                                                                                    DOTDOTEQ@[3504; 3507) "..="
+                                                                                                                                                                                                                                    RANGE_EXPR@[3507; 3512)
+                                                                                                                                                                                                                                      DOTDOT@[3507; 3509) ".."
+                                                                                                                                                                                                                                      WHITESPACE@[3509; 3510) " "
+                                                                                                                                                                                                                                      RANGE_EXPR@[3510; 3512)
+                                                                                                                                                                                                                                        DOTDOT@[3510; 3512) ".."
+        WHITESPACE@[3512; 3513) "\n"
+        R_CURLY@[3513; 3514) "}"
   WHITESPACE@[3514; 3516) "\n\n"
   FN_DEF@[3516; 3552)
     FN_KW@[3516; 3518) "fn"
@@ -2059,30 +2089,31 @@ SOURCE_FILE@[0; 3813)
       L_PAREN@[3525; 3526) "("
       R_PAREN@[3526; 3527) ")"
     WHITESPACE@[3527; 3528) " "
-    BLOCK@[3528; 3552)
-      L_CURLY@[3528; 3529) "{"
-      WHITESPACE@[3529; 3534) "\n    "
-      SEMI@[3534; 3535) ";"
-      SEMI@[3535; 3536) ";"
-      SEMI@[3536; 3537) ";"
-      EXPR_STMT@[3537; 3540)
-        TUPLE_EXPR@[3537; 3539)
-          L_PAREN@[3537; 3538) "("
-          R_PAREN@[3538; 3539) ")"
-        SEMI@[3539; 3540) ";"
-      SEMI@[3540; 3541) ";"
-      SEMI@[3541; 3542) ";"
-      SEMI@[3542; 3543) ";"
-      SEMI@[3543; 3544) ";"
-      SEMI@[3544; 3545) ";"
-      SEMI@[3545; 3546) ";"
-      SEMI@[3546; 3547) ";"
-      SEMI@[3547; 3548) ";"
-      TUPLE_EXPR@[3548; 3550)
-        L_PAREN@[3548; 3549) "("
-        R_PAREN@[3549; 3550) ")"
-      WHITESPACE@[3550; 3551) "\n"
-      R_CURLY@[3551; 3552) "}"
+    BLOCK_EXPR@[3528; 3552)
+      BLOCK@[3528; 3552)
+        L_CURLY@[3528; 3529) "{"
+        WHITESPACE@[3529; 3534) "\n    "
+        SEMI@[3534; 3535) ";"
+        SEMI@[3535; 3536) ";"
+        SEMI@[3536; 3537) ";"
+        EXPR_STMT@[3537; 3540)
+          TUPLE_EXPR@[3537; 3539)
+            L_PAREN@[3537; 3538) "("
+            R_PAREN@[3538; 3539) ")"
+          SEMI@[3539; 3540) ";"
+        SEMI@[3540; 3541) ";"
+        SEMI@[3541; 3542) ";"
+        SEMI@[3542; 3543) ";"
+        SEMI@[3543; 3544) ";"
+        SEMI@[3544; 3545) ";"
+        SEMI@[3545; 3546) ";"
+        SEMI@[3546; 3547) ";"
+        SEMI@[3547; 3548) ";"
+        TUPLE_EXPR@[3548; 3550)
+          L_PAREN@[3548; 3549) "("
+          R_PAREN@[3549; 3550) ")"
+        WHITESPACE@[3550; 3551) "\n"
+        R_CURLY@[3551; 3552) "}"
   WHITESPACE@[3552; 3554) "\n\n"
   FN_DEF@[3554; 3812)
     VISIBILITY@[3554; 3557)
@@ -2096,190 +2127,191 @@ SOURCE_FILE@[0; 3813)
       L_PAREN@[3565; 3566) "("
       R_PAREN@[3566; 3567) ")"
     WHITESPACE@[3567; 3568) " "
-    BLOCK@[3568; 3812)
-      L_CURLY@[3568; 3569) "{"
-      WHITESPACE@[3569; 3574) "\n    "
-      EXPR_STMT@[3574; 3584)
-        CALL_EXPR@[3574; 3583)
-          PATH_EXPR@[3574; 3581)
-            PATH@[3574; 3581)
-              PATH_SEGMENT@[3574; 3581)
-                NAME_REF@[3574; 3581)
-                  IDENT@[3574; 3581) "strange"
-          ARG_LIST@[3581; 3583)
-            L_PAREN@[3581; 3582) "("
-            R_PAREN@[3582; 3583) ")"
-        SEMI@[3583; 3584) ";"
-      WHITESPACE@[3584; 3589) "\n    "
-      EXPR_STMT@[3589; 3597)
-        CALL_EXPR@[3589; 3596)
-          PATH_EXPR@[3589; 3594)
-            PATH@[3589; 3594)
-              PATH_SEGMENT@[3589; 3594)
-                NAME_REF@[3589; 3594)
-                  IDENT@[3589; 3594) "funny"
-          ARG_LIST@[3594; 3596)
-            L_PAREN@[3594; 3595) "("
-            R_PAREN@[3595; 3596) ")"
-        SEMI@[3596; 3597) ";"
-      WHITESPACE@[3597; 3602) "\n    "
-      EXPR_STMT@[3602; 3609)
-        CALL_EXPR@[3602; 3608)
-          PATH_EXPR@[3602; 3606)
-            PATH@[3602; 3606)
-              PATH_SEGMENT@[3602; 3606)
-                NAME_REF@[3602; 3606)
-                  IDENT@[3602; 3606) "what"
-          ARG_LIST@[3606; 3608)
-            L_PAREN@[3606; 3607) "("
-            R_PAREN@[3607; 3608) ")"
-        SEMI@[3608; 3609) ";"
-      WHITESPACE@[3609; 3614) "\n    "
-      EXPR_STMT@[3614; 3628)
-        CALL_EXPR@[3614; 3627)
-          PATH_EXPR@[3614; 3625)
-            PATH@[3614; 3625)
-              PATH_SEGMENT@[3614; 3625)
-                NAME_REF@[3614; 3625)
-                  IDENT@[3614; 3625) "zombiejesus"
-          ARG_LIST@[3625; 3627)
-            L_PAREN@[3625; 3626) "("
-            R_PAREN@[3626; 3627) ")"
-        SEMI@[3627; 3628) ";"
-      WHITESPACE@[3628; 3633) "\n    "
-      EXPR_STMT@[3633; 3643)
-        CALL_EXPR@[3633; 3642)
-          PATH_EXPR@[3633; 3640)
-            PATH@[3633; 3640)
-              PATH_SEGMENT@[3633; 3640)
-                NAME_REF@[3633; 3640)
-                  IDENT@[3633; 3640) "notsure"
-          ARG_LIST@[3640; 3642)
-            L_PAREN@[3640; 3641) "("
-            R_PAREN@[3641; 3642) ")"
-        SEMI@[3642; 3643) ";"
-      WHITESPACE@[3643; 3648) "\n    "
-      EXPR_STMT@[3648; 3664)
-        CALL_EXPR@[3648; 3663)
-          PATH_EXPR@[3648; 3661)
-            PATH@[3648; 3661)
-              PATH_SEGMENT@[3648; 3661)
-                NAME_REF@[3648; 3661)
-                  IDENT@[3648; 3661) "canttouchthis"
-          ARG_LIST@[3661; 3663)
-            L_PAREN@[3661; 3662) "("
-            R_PAREN@[3662; 3663) ")"
-        SEMI@[3663; 3664) ";"
-      WHITESPACE@[3664; 3669) "\n    "
-      EXPR_STMT@[3669; 3681)
-        CALL_EXPR@[3669; 3680)
-          PATH_EXPR@[3669; 3678)
-            PATH@[3669; 3678)
-              PATH_SEGMENT@[3669; 3678)
-                NAME_REF@[3669; 3678)
-                  IDENT@[3669; 3678) "angrydome"
-          ARG_LIST@[3678; 3680)
-            L_PAREN@[3678; 3679) "("
-            R_PAREN@[3679; 3680) ")"
-        SEMI@[3680; 3681) ";"
-      WHITESPACE@[3681; 3686) "\n    "
-      EXPR_STMT@[3686; 3701)
-        CALL_EXPR@[3686; 3700)
-          PATH_EXPR@[3686; 3698)
-            PATH@[3686; 3698)
-              PATH_SEGMENT@[3686; 3698)
-                NAME_REF@[3686; 3698)
-                  IDENT@[3686; 3698) "evil_lincoln"
-          ARG_LIST@[3698; 3700)
-            L_PAREN@[3698; 3699) "("
-            R_PAREN@[3699; 3700) ")"
-        SEMI@[3700; 3701) ";"
-      WHITESPACE@[3701; 3706) "\n    "
-      EXPR_STMT@[3706; 3713)
-        CALL_EXPR@[3706; 3712)
-          PATH_EXPR@[3706; 3710)
-            PATH@[3706; 3710)
-              PATH_SEGMENT@[3706; 3710)
-                NAME_REF@[3706; 3710)
-                  IDENT@[3706; 3710) "dots"
-          ARG_LIST@[3710; 3712)
-            L_PAREN@[3710; 3711) "("
-            R_PAREN@[3711; 3712) ")"
-        SEMI@[3712; 3713) ";"
-      WHITESPACE@[3713; 3718) "\n    "
-      EXPR_STMT@[3718; 3726)
-        CALL_EXPR@[3718; 3725)
-          PATH_EXPR@[3718; 3720)
-            PATH@[3718; 3720)
-              PATH_SEGMENT@[3718; 3720)
-                NAME_REF@[3718; 3720)
-                  IDENT@[3718; 3720) "u8"
-          ARG_LIST@[3720; 3725)
-            L_PAREN@[3720; 3721) "("
-            LITERAL@[3721; 3724)
-              INT_NUMBER@[3721; 3724) "8u8"
-            R_PAREN@[3724; 3725) ")"
-        SEMI@[3725; 3726) ";"
-      WHITESPACE@[3726; 3731) "\n    "
-      EXPR_STMT@[3731; 3739)
-        CALL_EXPR@[3731; 3738)
-          PATH_EXPR@[3731; 3736)
-            PATH@[3731; 3736)
-              PATH_SEGMENT@[3731; 3736)
-                NAME_REF@[3731; 3736)
-                  IDENT@[3731; 3736) "fishy"
-          ARG_LIST@[3736; 3738)
-            L_PAREN@[3736; 3737) "("
-            R_PAREN@[3737; 3738) ")"
-        SEMI@[3738; 3739) ";"
-      WHITESPACE@[3739; 3744) "\n    "
-      EXPR_STMT@[3744; 3752)
-        CALL_EXPR@[3744; 3751)
-          PATH_EXPR@[3744; 3749)
-            PATH@[3744; 3749)
-              PATH_SEGMENT@[3744; 3749)
-                NAME_REF@[3744; 3749)
-                  IDENT@[3744; 3749) "union"
-          ARG_LIST@[3749; 3751)
-            L_PAREN@[3749; 3750) "("
-            R_PAREN@[3750; 3751) ")"
-        SEMI@[3751; 3752) ";"
-      WHITESPACE@[3752; 3757) "\n    "
-      EXPR_STMT@[3757; 3778)
-        CALL_EXPR@[3757; 3777)
-          PATH_EXPR@[3757; 3775)
-            PATH@[3757; 3775)
-              PATH_SEGMENT@[3757; 3775)
-                NAME_REF@[3757; 3775)
-                  IDENT@[3757; 3775) "special_characters"
-          ARG_LIST@[3775; 3777)
-            L_PAREN@[3775; 3776) "("
-            R_PAREN@[3776; 3777) ")"
-        SEMI@[3777; 3778) ";"
-      WHITESPACE@[3778; 3783) "\n    "
-      EXPR_STMT@[3783; 3796)
-        CALL_EXPR@[3783; 3795)
-          PATH_EXPR@[3783; 3793)
-            PATH@[3783; 3793)
-              PATH_SEGMENT@[3783; 3793)
-                NAME_REF@[3783; 3793)
-                  IDENT@[3783; 3793) "punch_card"
-          ARG_LIST@[3793; 3795)
-            L_PAREN@[3793; 3794) "("
-            R_PAREN@[3794; 3795) ")"
-        SEMI@[3795; 3796) ";"
-      WHITESPACE@[3796; 3801) "\n    "
-      EXPR_STMT@[3801; 3810)
-        CALL_EXPR@[3801; 3809)
-          PATH_EXPR@[3801; 3807)
-            PATH@[3801; 3807)
-              PATH_SEGMENT@[3801; 3807)
-                NAME_REF@[3801; 3807)
-                  IDENT@[3801; 3807) "ktulhu"
-          ARG_LIST@[3807; 3809)
-            L_PAREN@[3807; 3808) "("
-            R_PAREN@[3808; 3809) ")"
-        SEMI@[3809; 3810) ";"
-      WHITESPACE@[3810; 3811) "\n"
-      R_CURLY@[3811; 3812) "}"
+    BLOCK_EXPR@[3568; 3812)
+      BLOCK@[3568; 3812)
+        L_CURLY@[3568; 3569) "{"
+        WHITESPACE@[3569; 3574) "\n    "
+        EXPR_STMT@[3574; 3584)
+          CALL_EXPR@[3574; 3583)
+            PATH_EXPR@[3574; 3581)
+              PATH@[3574; 3581)
+                PATH_SEGMENT@[3574; 3581)
+                  NAME_REF@[3574; 3581)
+                    IDENT@[3574; 3581) "strange"
+            ARG_LIST@[3581; 3583)
+              L_PAREN@[3581; 3582) "("
+              R_PAREN@[3582; 3583) ")"
+          SEMI@[3583; 3584) ";"
+        WHITESPACE@[3584; 3589) "\n    "
+        EXPR_STMT@[3589; 3597)
+          CALL_EXPR@[3589; 3596)
+            PATH_EXPR@[3589; 3594)
+              PATH@[3589; 3594)
+                PATH_SEGMENT@[3589; 3594)
+                  NAME_REF@[3589; 3594)
+                    IDENT@[3589; 3594) "funny"
+            ARG_LIST@[3594; 3596)
+              L_PAREN@[3594; 3595) "("
+              R_PAREN@[3595; 3596) ")"
+          SEMI@[3596; 3597) ";"
+        WHITESPACE@[3597; 3602) "\n    "
+        EXPR_STMT@[3602; 3609)
+          CALL_EXPR@[3602; 3608)
+            PATH_EXPR@[3602; 3606)
+              PATH@[3602; 3606)
+                PATH_SEGMENT@[3602; 3606)
+                  NAME_REF@[3602; 3606)
+                    IDENT@[3602; 3606) "what"
+            ARG_LIST@[3606; 3608)
+              L_PAREN@[3606; 3607) "("
+              R_PAREN@[3607; 3608) ")"
+          SEMI@[3608; 3609) ";"
+        WHITESPACE@[3609; 3614) "\n    "
+        EXPR_STMT@[3614; 3628)
+          CALL_EXPR@[3614; 3627)
+            PATH_EXPR@[3614; 3625)
+              PATH@[3614; 3625)
+                PATH_SEGMENT@[3614; 3625)
+                  NAME_REF@[3614; 3625)
+                    IDENT@[3614; 3625) "zombiejesus"
+            ARG_LIST@[3625; 3627)
+              L_PAREN@[3625; 3626) "("
+              R_PAREN@[3626; 3627) ")"
+          SEMI@[3627; 3628) ";"
+        WHITESPACE@[3628; 3633) "\n    "
+        EXPR_STMT@[3633; 3643)
+          CALL_EXPR@[3633; 3642)
+            PATH_EXPR@[3633; 3640)
+              PATH@[3633; 3640)
+                PATH_SEGMENT@[3633; 3640)
+                  NAME_REF@[3633; 3640)
+                    IDENT@[3633; 3640) "notsure"
+            ARG_LIST@[3640; 3642)
+              L_PAREN@[3640; 3641) "("
+              R_PAREN@[3641; 3642) ")"
+          SEMI@[3642; 3643) ";"
+        WHITESPACE@[3643; 3648) "\n    "
+        EXPR_STMT@[3648; 3664)
+          CALL_EXPR@[3648; 3663)
+            PATH_EXPR@[3648; 3661)
+              PATH@[3648; 3661)
+                PATH_SEGMENT@[3648; 3661)
+                  NAME_REF@[3648; 3661)
+                    IDENT@[3648; 3661) "canttouchthis"
+            ARG_LIST@[3661; 3663)
+              L_PAREN@[3661; 3662) "("
+              R_PAREN@[3662; 3663) ")"
+          SEMI@[3663; 3664) ";"
+        WHITESPACE@[3664; 3669) "\n    "
+        EXPR_STMT@[3669; 3681)
+          CALL_EXPR@[3669; 3680)
+            PATH_EXPR@[3669; 3678)
+              PATH@[3669; 3678)
+                PATH_SEGMENT@[3669; 3678)
+                  NAME_REF@[3669; 3678)
+                    IDENT@[3669; 3678) "angrydome"
+            ARG_LIST@[3678; 3680)
+              L_PAREN@[3678; 3679) "("
+              R_PAREN@[3679; 3680) ")"
+          SEMI@[3680; 3681) ";"
+        WHITESPACE@[3681; 3686) "\n    "
+        EXPR_STMT@[3686; 3701)
+          CALL_EXPR@[3686; 3700)
+            PATH_EXPR@[3686; 3698)
+              PATH@[3686; 3698)
+                PATH_SEGMENT@[3686; 3698)
+                  NAME_REF@[3686; 3698)
+                    IDENT@[3686; 3698) "evil_lincoln"
+            ARG_LIST@[3698; 3700)
+              L_PAREN@[3698; 3699) "("
+              R_PAREN@[3699; 3700) ")"
+          SEMI@[3700; 3701) ";"
+        WHITESPACE@[3701; 3706) "\n    "
+        EXPR_STMT@[3706; 3713)
+          CALL_EXPR@[3706; 3712)
+            PATH_EXPR@[3706; 3710)
+              PATH@[3706; 3710)
+                PATH_SEGMENT@[3706; 3710)
+                  NAME_REF@[3706; 3710)
+                    IDENT@[3706; 3710) "dots"
+            ARG_LIST@[3710; 3712)
+              L_PAREN@[3710; 3711) "("
+              R_PAREN@[3711; 3712) ")"
+          SEMI@[3712; 3713) ";"
+        WHITESPACE@[3713; 3718) "\n    "
+        EXPR_STMT@[3718; 3726)
+          CALL_EXPR@[3718; 3725)
+            PATH_EXPR@[3718; 3720)
+              PATH@[3718; 3720)
+                PATH_SEGMENT@[3718; 3720)
+                  NAME_REF@[3718; 3720)
+                    IDENT@[3718; 3720) "u8"
+            ARG_LIST@[3720; 3725)
+              L_PAREN@[3720; 3721) "("
+              LITERAL@[3721; 3724)
+                INT_NUMBER@[3721; 3724) "8u8"
+              R_PAREN@[3724; 3725) ")"
+          SEMI@[3725; 3726) ";"
+        WHITESPACE@[3726; 3731) "\n    "
+        EXPR_STMT@[3731; 3739)
+          CALL_EXPR@[3731; 3738)
+            PATH_EXPR@[3731; 3736)
+              PATH@[3731; 3736)
+                PATH_SEGMENT@[3731; 3736)
+                  NAME_REF@[3731; 3736)
+                    IDENT@[3731; 3736) "fishy"
+            ARG_LIST@[3736; 3738)
+              L_PAREN@[3736; 3737) "("
+              R_PAREN@[3737; 3738) ")"
+          SEMI@[3738; 3739) ";"
+        WHITESPACE@[3739; 3744) "\n    "
+        EXPR_STMT@[3744; 3752)
+          CALL_EXPR@[3744; 3751)
+            PATH_EXPR@[3744; 3749)
+              PATH@[3744; 3749)
+                PATH_SEGMENT@[3744; 3749)
+                  NAME_REF@[3744; 3749)
+                    IDENT@[3744; 3749) "union"
+            ARG_LIST@[3749; 3751)
+              L_PAREN@[3749; 3750) "("
+              R_PAREN@[3750; 3751) ")"
+          SEMI@[3751; 3752) ";"
+        WHITESPACE@[3752; 3757) "\n    "
+        EXPR_STMT@[3757; 3778)
+          CALL_EXPR@[3757; 3777)
+            PATH_EXPR@[3757; 3775)
+              PATH@[3757; 3775)
+                PATH_SEGMENT@[3757; 3775)
+                  NAME_REF@[3757; 3775)
+                    IDENT@[3757; 3775) "special_characters"
+            ARG_LIST@[3775; 3777)
+              L_PAREN@[3775; 3776) "("
+              R_PAREN@[3776; 3777) ")"
+          SEMI@[3777; 3778) ";"
+        WHITESPACE@[3778; 3783) "\n    "
+        EXPR_STMT@[3783; 3796)
+          CALL_EXPR@[3783; 3795)
+            PATH_EXPR@[3783; 3793)
+              PATH@[3783; 3793)
+                PATH_SEGMENT@[3783; 3793)
+                  NAME_REF@[3783; 3793)
+                    IDENT@[3783; 3793) "punch_card"
+            ARG_LIST@[3793; 3795)
+              L_PAREN@[3793; 3794) "("
+              R_PAREN@[3794; 3795) ")"
+          SEMI@[3795; 3796) ";"
+        WHITESPACE@[3796; 3801) "\n    "
+        EXPR_STMT@[3801; 3810)
+          CALL_EXPR@[3801; 3809)
+            PATH_EXPR@[3801; 3807)
+              PATH@[3801; 3807)
+                PATH_SEGMENT@[3801; 3807)
+                  NAME_REF@[3801; 3807)
+                    IDENT@[3801; 3807) "ktulhu"
+            ARG_LIST@[3807; 3809)
+              L_PAREN@[3807; 3808) "("
+              R_PAREN@[3808; 3809) ")"
+          SEMI@[3809; 3810) ";"
+        WHITESPACE@[3810; 3811) "\n"
+        R_CURLY@[3811; 3812) "}"
   WHITESPACE@[3812; 3813) "\n"

--- a/crates/ra_syntax/test_data/parser/ok/0036_fully_qualified.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0036_fully_qualified.txt
@@ -75,18 +75,19 @@ SOURCE_FILE@[0; 157)
                     IDENT@[131; 133) "Eq"
       COMMA@[133; 134) ","
     WHITESPACE@[134; 135) "\n"
-    BLOCK@[135; 156)
-      L_CURLY@[135; 136) "{"
-      WHITESPACE@[136; 141) "\n    "
-      METHOD_CALL_EXPR@[141; 154)
-        LITERAL@[141; 143)
-          STRING@[141; 143) "\"\""
-        DOT@[143; 144) "."
-        NAME_REF@[144; 152)
-          IDENT@[144; 152) "to_owned"
-        ARG_LIST@[152; 154)
-          L_PAREN@[152; 153) "("
-          R_PAREN@[153; 154) ")"
-      WHITESPACE@[154; 155) "\n"
-      R_CURLY@[155; 156) "}"
+    BLOCK_EXPR@[135; 156)
+      BLOCK@[135; 156)
+        L_CURLY@[135; 136) "{"
+        WHITESPACE@[136; 141) "\n    "
+        METHOD_CALL_EXPR@[141; 154)
+          LITERAL@[141; 143)
+            STRING@[141; 143) "\"\""
+          DOT@[143; 144) "."
+          NAME_REF@[144; 152)
+            IDENT@[144; 152) "to_owned"
+          ARG_LIST@[152; 154)
+            L_PAREN@[152; 153) "("
+            R_PAREN@[153; 154) ")"
+        WHITESPACE@[154; 155) "\n"
+        R_CURLY@[155; 156) "}"
   WHITESPACE@[156; 157) "\n"

--- a/crates/ra_syntax/test_data/parser/ok/0038_where_pred_type.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0038_where_pred_type.txt
@@ -37,6 +37,7 @@ SOURCE_FILE@[0; 34)
                   NAME_REF@[28; 31)
                     IDENT@[28; 31) "Foo"
     WHITESPACE@[31; 32) " "
-    BLOCK@[32; 34)
-      L_CURLY@[32; 33) "{"
-      R_CURLY@[33; 34) "}"
+    BLOCK_EXPR@[32; 34)
+      BLOCK@[32; 34)
+        L_CURLY@[32; 33) "{"
+        R_CURLY@[33; 34) "}"

--- a/crates/ra_syntax/test_data/parser/ok/0039_raw_fn_item.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0039_raw_fn_item.txt
@@ -8,8 +8,9 @@ SOURCE_FILE@[0; 15)
       L_PAREN@[8; 9) "("
       R_PAREN@[9; 10) ")"
     WHITESPACE@[10; 11) " "
-    BLOCK@[11; 14)
-      L_CURLY@[11; 12) "{"
-      WHITESPACE@[12; 13) "\n"
-      R_CURLY@[13; 14) "}"
+    BLOCK_EXPR@[11; 14)
+      BLOCK@[11; 14)
+        L_CURLY@[11; 12) "{"
+        WHITESPACE@[12; 13) "\n"
+        R_CURLY@[13; 14) "}"
   WHITESPACE@[14; 15) "\n"

--- a/crates/ra_syntax/test_data/parser/ok/0041_raw_keywords.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0041_raw_keywords.txt
@@ -8,42 +8,43 @@ SOURCE_FILE@[0; 59)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 59)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 11) " "
-      LET_STMT@[11; 29)
-        LET_KW@[11; 14) "let"
-        WHITESPACE@[14; 15) " "
-        BIND_PAT@[15; 23)
-          NAME@[15; 23)
-            IDENT@[15; 23) "r#struct"
-        WHITESPACE@[23; 24) " "
-        EQ@[24; 25) "="
-        WHITESPACE@[25; 26) " "
-        LITERAL@[26; 28)
-          INT_NUMBER@[26; 28) "92"
-        SEMI@[28; 29) ";"
-      WHITESPACE@[29; 30) " "
-      LET_STMT@[30; 57)
-        LET_KW@[30; 33) "let"
-        WHITESPACE@[33; 34) " "
-        BIND_PAT@[34; 41)
-          NAME@[34; 41)
-            IDENT@[34; 41) "r#trait"
-        WHITESPACE@[41; 42) " "
-        EQ@[42; 43) "="
-        WHITESPACE@[43; 44) " "
-        BIN_EXPR@[44; 56)
-          PATH_EXPR@[44; 52)
-            PATH@[44; 52)
-              PATH_SEGMENT@[44; 52)
-                NAME_REF@[44; 52)
-                  IDENT@[44; 52) "r#struct"
-          WHITESPACE@[52; 53) " "
-          STAR@[53; 54) "*"
-          WHITESPACE@[54; 55) " "
-          LITERAL@[55; 56)
-            INT_NUMBER@[55; 56) "2"
-        SEMI@[56; 57) ";"
-      WHITESPACE@[57; 58) " "
-      R_CURLY@[58; 59) "}"
+    BLOCK_EXPR@[9; 59)
+      BLOCK@[9; 59)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 11) " "
+        LET_STMT@[11; 29)
+          LET_KW@[11; 14) "let"
+          WHITESPACE@[14; 15) " "
+          BIND_PAT@[15; 23)
+            NAME@[15; 23)
+              IDENT@[15; 23) "r#struct"
+          WHITESPACE@[23; 24) " "
+          EQ@[24; 25) "="
+          WHITESPACE@[25; 26) " "
+          LITERAL@[26; 28)
+            INT_NUMBER@[26; 28) "92"
+          SEMI@[28; 29) ";"
+        WHITESPACE@[29; 30) " "
+        LET_STMT@[30; 57)
+          LET_KW@[30; 33) "let"
+          WHITESPACE@[33; 34) " "
+          BIND_PAT@[34; 41)
+            NAME@[34; 41)
+              IDENT@[34; 41) "r#trait"
+          WHITESPACE@[41; 42) " "
+          EQ@[42; 43) "="
+          WHITESPACE@[43; 44) " "
+          BIN_EXPR@[44; 56)
+            PATH_EXPR@[44; 52)
+              PATH@[44; 52)
+                PATH_SEGMENT@[44; 52)
+                  NAME_REF@[44; 52)
+                    IDENT@[44; 52) "r#struct"
+            WHITESPACE@[52; 53) " "
+            STAR@[53; 54) "*"
+            WHITESPACE@[54; 55) " "
+            LITERAL@[55; 56)
+              INT_NUMBER@[55; 56) "2"
+          SEMI@[56; 57) ";"
+        WHITESPACE@[57; 58) " "
+        R_CURLY@[58; 59) "}"

--- a/crates/ra_syntax/test_data/parser/ok/0042_ufcs_call_list.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0042_ufcs_call_list.txt
@@ -38,20 +38,21 @@ SOURCE_FILE@[0; 199)
                 NAME_REF@[102; 106)
                   IDENT@[102; 106) "bool"
         WHITESPACE@[106; 107) " "
-        BLOCK@[107; 139)
-          L_CURLY@[107; 108) "{"
-          WHITESPACE@[108; 117) "\n        "
-          MACRO_CALL@[117; 133)
-            PATH@[117; 130)
-              PATH_SEGMENT@[117; 130)
-                NAME_REF@[117; 130)
-                  IDENT@[117; 130) "unimplemented"
-            EXCL@[130; 131) "!"
-            TOKEN_TREE@[131; 133)
-              L_PAREN@[131; 132) "("
-              R_PAREN@[132; 133) ")"
-          WHITESPACE@[133; 138) "\n    "
-          R_CURLY@[138; 139) "}"
+        BLOCK_EXPR@[107; 139)
+          BLOCK@[107; 139)
+            L_CURLY@[107; 108) "{"
+            WHITESPACE@[108; 117) "\n        "
+            MACRO_CALL@[117; 133)
+              PATH@[117; 130)
+                PATH_SEGMENT@[117; 130)
+                  NAME_REF@[117; 130)
+                    IDENT@[117; 130) "unimplemented"
+              EXCL@[130; 131) "!"
+              TOKEN_TREE@[131; 133)
+                L_PAREN@[131; 132) "("
+                R_PAREN@[132; 133) ")"
+            WHITESPACE@[133; 138) "\n    "
+            R_CURLY@[138; 139) "}"
       WHITESPACE@[139; 140) "\n"
       R_CURLY@[140; 141) "}"
   WHITESPACE@[141; 143) "\n\n"
@@ -74,9 +75,10 @@ SOURCE_FILE@[0; 199)
                 IDENT@[153; 157) "bool"
       R_PAREN@[157; 158) ")"
     WHITESPACE@[158; 159) " "
-    BLOCK@[159; 161)
-      L_CURLY@[159; 160) "{"
-      R_CURLY@[160; 161) "}"
+    BLOCK_EXPR@[159; 161)
+      BLOCK@[159; 161)
+        L_CURLY@[159; 160) "{"
+        R_CURLY@[160; 161) "}"
   WHITESPACE@[161; 163) "\n\n"
   FN_DEF@[163; 198)
     FN_KW@[163; 165) "fn"
@@ -87,37 +89,38 @@ SOURCE_FILE@[0; 199)
       L_PAREN@[170; 171) "("
       R_PAREN@[171; 172) ")"
     WHITESPACE@[172; 173) " "
-    BLOCK@[173; 198)
-      L_CURLY@[173; 174) "{"
-      WHITESPACE@[174; 179) "\n    "
-      CALL_EXPR@[179; 196)
-        PATH_EXPR@[179; 182)
-          PATH@[179; 182)
-            PATH_SEGMENT@[179; 182)
-              NAME_REF@[179; 182)
-                IDENT@[179; 182) "baz"
-        ARG_LIST@[182; 196)
-          L_PAREN@[182; 183) "("
-          CALL_EXPR@[183; 195)
-            PATH_EXPR@[183; 193)
-              PATH@[183; 193)
-                PATH@[183; 188)
-                  PATH_SEGMENT@[183; 188)
-                    L_ANGLE@[183; 184) "<"
-                    PATH_TYPE@[184; 187)
-                      PATH@[184; 187)
-                        PATH_SEGMENT@[184; 187)
-                          NAME_REF@[184; 187)
-                            IDENT@[184; 187) "Foo"
-                    R_ANGLE@[187; 188) ">"
-                COLONCOLON@[188; 190) "::"
-                PATH_SEGMENT@[190; 193)
-                  NAME_REF@[190; 193)
-                    IDENT@[190; 193) "bar"
-            ARG_LIST@[193; 195)
-              L_PAREN@[193; 194) "("
-              R_PAREN@[194; 195) ")"
-          R_PAREN@[195; 196) ")"
-      WHITESPACE@[196; 197) "\n"
-      R_CURLY@[197; 198) "}"
+    BLOCK_EXPR@[173; 198)
+      BLOCK@[173; 198)
+        L_CURLY@[173; 174) "{"
+        WHITESPACE@[174; 179) "\n    "
+        CALL_EXPR@[179; 196)
+          PATH_EXPR@[179; 182)
+            PATH@[179; 182)
+              PATH_SEGMENT@[179; 182)
+                NAME_REF@[179; 182)
+                  IDENT@[179; 182) "baz"
+          ARG_LIST@[182; 196)
+            L_PAREN@[182; 183) "("
+            CALL_EXPR@[183; 195)
+              PATH_EXPR@[183; 193)
+                PATH@[183; 193)
+                  PATH@[183; 188)
+                    PATH_SEGMENT@[183; 188)
+                      L_ANGLE@[183; 184) "<"
+                      PATH_TYPE@[184; 187)
+                        PATH@[184; 187)
+                          PATH_SEGMENT@[184; 187)
+                            NAME_REF@[184; 187)
+                              IDENT@[184; 187) "Foo"
+                      R_ANGLE@[187; 188) ">"
+                  COLONCOLON@[188; 190) "::"
+                  PATH_SEGMENT@[190; 193)
+                    NAME_REF@[190; 193)
+                      IDENT@[190; 193) "bar"
+              ARG_LIST@[193; 195)
+                L_PAREN@[193; 194) "("
+                R_PAREN@[194; 195) ")"
+            R_PAREN@[195; 196) ")"
+        WHITESPACE@[196; 197) "\n"
+        R_CURLY@[197; 198) "}"
   WHITESPACE@[198; 199) "\n"

--- a/crates/ra_syntax/test_data/parser/ok/0043_complex_assignment.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0043_complex_assignment.txt
@@ -39,71 +39,72 @@ SOURCE_FILE@[0; 160)
       L_PAREN@[98; 99) "("
       R_PAREN@[99; 100) ")"
     WHITESPACE@[100; 101) " "
-    BLOCK@[101; 159)
-      L_CURLY@[101; 102) "{"
-      WHITESPACE@[102; 107) "\n    "
-      EXPR_STMT@[107; 136)
-        BIN_EXPR@[107; 135)
-          INDEX_EXPR@[107; 131)
-            FIELD_EXPR@[107; 128)
-              RECORD_LIT@[107; 124)
-                PATH@[107; 111)
-                  PATH_SEGMENT@[107; 111)
-                    NAME_REF@[107; 111)
-                      IDENT@[107; 111) "Repr"
-                WHITESPACE@[111; 112) " "
-                RECORD_FIELD_LIST@[112; 124)
-                  L_CURLY@[112; 113) "{"
-                  WHITESPACE@[113; 114) " "
-                  RECORD_FIELD@[114; 122)
-                    NAME_REF@[114; 117)
-                      IDENT@[114; 117) "raw"
-                    COLON@[117; 118) ":"
-                    WHITESPACE@[118; 119) " "
-                    ARRAY_EXPR@[119; 122)
-                      L_BRACK@[119; 120) "["
-                      LITERAL@[120; 121)
-                        INT_NUMBER@[120; 121) "0"
-                      R_BRACK@[121; 122) "]"
-                  WHITESPACE@[122; 123) " "
-                  R_CURLY@[123; 124) "}"
-              DOT@[124; 125) "."
-              NAME_REF@[125; 128)
-                IDENT@[125; 128) "raw"
-            L_BRACK@[128; 129) "["
-            LITERAL@[129; 130)
-              INT_NUMBER@[129; 130) "0"
-            R_BRACK@[130; 131) "]"
-          WHITESPACE@[131; 132) " "
-          EQ@[132; 133) "="
-          WHITESPACE@[133; 134) " "
-          LITERAL@[134; 135)
-            INT_NUMBER@[134; 135) "0"
-        SEMI@[135; 136) ";"
-      WHITESPACE@[136; 141) "\n    "
-      EXPR_STMT@[141; 157)
-        CALL_EXPR@[141; 156)
-          RECORD_LIT@[141; 154)
-            PATH@[141; 145)
-              PATH_SEGMENT@[141; 145)
-                NAME_REF@[141; 145)
-                  IDENT@[141; 145) "Repr"
-            RECORD_FIELD_LIST@[145; 154)
-              L_CURLY@[145; 146) "{"
-              RECORD_FIELD@[146; 153)
-                NAME_REF@[146; 149)
-                  IDENT@[146; 149) "raw"
-                COLON@[149; 150) ":"
-                ARRAY_EXPR@[150; 153)
-                  L_BRACK@[150; 151) "["
-                  LITERAL@[151; 152)
-                    INT_NUMBER@[151; 152) "0"
-                  R_BRACK@[152; 153) "]"
-              R_CURLY@[153; 154) "}"
-          ARG_LIST@[154; 156)
-            L_PAREN@[154; 155) "("
-            R_PAREN@[155; 156) ")"
-        SEMI@[156; 157) ";"
-      WHITESPACE@[157; 158) "\n"
-      R_CURLY@[158; 159) "}"
+    BLOCK_EXPR@[101; 159)
+      BLOCK@[101; 159)
+        L_CURLY@[101; 102) "{"
+        WHITESPACE@[102; 107) "\n    "
+        EXPR_STMT@[107; 136)
+          BIN_EXPR@[107; 135)
+            INDEX_EXPR@[107; 131)
+              FIELD_EXPR@[107; 128)
+                RECORD_LIT@[107; 124)
+                  PATH@[107; 111)
+                    PATH_SEGMENT@[107; 111)
+                      NAME_REF@[107; 111)
+                        IDENT@[107; 111) "Repr"
+                  WHITESPACE@[111; 112) " "
+                  RECORD_FIELD_LIST@[112; 124)
+                    L_CURLY@[112; 113) "{"
+                    WHITESPACE@[113; 114) " "
+                    RECORD_FIELD@[114; 122)
+                      NAME_REF@[114; 117)
+                        IDENT@[114; 117) "raw"
+                      COLON@[117; 118) ":"
+                      WHITESPACE@[118; 119) " "
+                      ARRAY_EXPR@[119; 122)
+                        L_BRACK@[119; 120) "["
+                        LITERAL@[120; 121)
+                          INT_NUMBER@[120; 121) "0"
+                        R_BRACK@[121; 122) "]"
+                    WHITESPACE@[122; 123) " "
+                    R_CURLY@[123; 124) "}"
+                DOT@[124; 125) "."
+                NAME_REF@[125; 128)
+                  IDENT@[125; 128) "raw"
+              L_BRACK@[128; 129) "["
+              LITERAL@[129; 130)
+                INT_NUMBER@[129; 130) "0"
+              R_BRACK@[130; 131) "]"
+            WHITESPACE@[131; 132) " "
+            EQ@[132; 133) "="
+            WHITESPACE@[133; 134) " "
+            LITERAL@[134; 135)
+              INT_NUMBER@[134; 135) "0"
+          SEMI@[135; 136) ";"
+        WHITESPACE@[136; 141) "\n    "
+        EXPR_STMT@[141; 157)
+          CALL_EXPR@[141; 156)
+            RECORD_LIT@[141; 154)
+              PATH@[141; 145)
+                PATH_SEGMENT@[141; 145)
+                  NAME_REF@[141; 145)
+                    IDENT@[141; 145) "Repr"
+              RECORD_FIELD_LIST@[145; 154)
+                L_CURLY@[145; 146) "{"
+                RECORD_FIELD@[146; 153)
+                  NAME_REF@[146; 149)
+                    IDENT@[146; 149) "raw"
+                  COLON@[149; 150) ":"
+                  ARRAY_EXPR@[150; 153)
+                    L_BRACK@[150; 151) "["
+                    LITERAL@[151; 152)
+                      INT_NUMBER@[151; 152) "0"
+                    R_BRACK@[152; 153) "]"
+                R_CURLY@[153; 154) "}"
+            ARG_LIST@[154; 156)
+              L_PAREN@[154; 155) "("
+              R_PAREN@[155; 156) ")"
+          SEMI@[156; 157) ";"
+        WHITESPACE@[157; 158) "\n"
+        R_CURLY@[158; 159) "}"
   WHITESPACE@[159; 160) "\n"

--- a/crates/ra_syntax/test_data/parser/ok/0044_let_attrs.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0044_let_attrs.txt
@@ -10,64 +10,65 @@ SOURCE_FILE@[0; 166)
       L_PAREN@[68; 69) "("
       R_PAREN@[69; 70) ")"
     WHITESPACE@[70; 71) " "
-    BLOCK@[71; 165)
-      L_CURLY@[71; 72) "{"
-      WHITESPACE@[72; 77) "\n    "
-      LET_STMT@[77; 163)
-        ATTR@[77; 106)
-          POUND@[77; 78) "#"
-          TOKEN_TREE@[78; 106)
-            L_BRACK@[78; 79) "["
-            IDENT@[79; 82) "cfg"
-            TOKEN_TREE@[82; 105)
-              L_PAREN@[82; 83) "("
-              IDENT@[83; 90) "feature"
-              WHITESPACE@[90; 91) " "
-              EQ@[91; 92) "="
-              WHITESPACE@[92; 93) " "
-              STRING@[93; 104) "\"backtrace\""
-              R_PAREN@[104; 105) ")"
-            R_BRACK@[105; 106) "]"
-        WHITESPACE@[106; 111) "\n    "
-        LET_KW@[111; 114) "let"
-        WHITESPACE@[114; 115) " "
-        BIND_PAT@[115; 124)
-          NAME@[115; 124)
-            IDENT@[115; 124) "exit_code"
-        WHITESPACE@[124; 125) " "
-        EQ@[125; 126) "="
-        WHITESPACE@[126; 127) " "
-        CALL_EXPR@[127; 162)
-          PATH_EXPR@[127; 146)
-            PATH@[127; 146)
-              PATH@[127; 132)
-                PATH_SEGMENT@[127; 132)
-                  NAME_REF@[127; 132)
-                    IDENT@[127; 132) "panic"
-              COLONCOLON@[132; 134) "::"
-              PATH_SEGMENT@[134; 146)
-                NAME_REF@[134; 146)
-                  IDENT@[134; 146) "catch_unwind"
-          ARG_LIST@[146; 162)
-            L_PAREN@[146; 147) "("
-            LAMBDA_EXPR@[147; 161)
-              MOVE_KW@[147; 151) "move"
-              WHITESPACE@[151; 152) " "
-              PARAM_LIST@[152; 154)
-                PIPE@[152; 153) "|"
-                PIPE@[153; 154) "|"
-              WHITESPACE@[154; 155) " "
-              CALL_EXPR@[155; 161)
-                PATH_EXPR@[155; 159)
-                  PATH@[155; 159)
-                    PATH_SEGMENT@[155; 159)
-                      NAME_REF@[155; 159)
-                        IDENT@[155; 159) "main"
-                ARG_LIST@[159; 161)
-                  L_PAREN@[159; 160) "("
-                  R_PAREN@[160; 161) ")"
-            R_PAREN@[161; 162) ")"
-        SEMI@[162; 163) ";"
-      WHITESPACE@[163; 164) "\n"
-      R_CURLY@[164; 165) "}"
+    BLOCK_EXPR@[71; 165)
+      BLOCK@[71; 165)
+        L_CURLY@[71; 72) "{"
+        WHITESPACE@[72; 77) "\n    "
+        LET_STMT@[77; 163)
+          ATTR@[77; 106)
+            POUND@[77; 78) "#"
+            TOKEN_TREE@[78; 106)
+              L_BRACK@[78; 79) "["
+              IDENT@[79; 82) "cfg"
+              TOKEN_TREE@[82; 105)
+                L_PAREN@[82; 83) "("
+                IDENT@[83; 90) "feature"
+                WHITESPACE@[90; 91) " "
+                EQ@[91; 92) "="
+                WHITESPACE@[92; 93) " "
+                STRING@[93; 104) "\"backtrace\""
+                R_PAREN@[104; 105) ")"
+              R_BRACK@[105; 106) "]"
+          WHITESPACE@[106; 111) "\n    "
+          LET_KW@[111; 114) "let"
+          WHITESPACE@[114; 115) " "
+          BIND_PAT@[115; 124)
+            NAME@[115; 124)
+              IDENT@[115; 124) "exit_code"
+          WHITESPACE@[124; 125) " "
+          EQ@[125; 126) "="
+          WHITESPACE@[126; 127) " "
+          CALL_EXPR@[127; 162)
+            PATH_EXPR@[127; 146)
+              PATH@[127; 146)
+                PATH@[127; 132)
+                  PATH_SEGMENT@[127; 132)
+                    NAME_REF@[127; 132)
+                      IDENT@[127; 132) "panic"
+                COLONCOLON@[132; 134) "::"
+                PATH_SEGMENT@[134; 146)
+                  NAME_REF@[134; 146)
+                    IDENT@[134; 146) "catch_unwind"
+            ARG_LIST@[146; 162)
+              L_PAREN@[146; 147) "("
+              LAMBDA_EXPR@[147; 161)
+                MOVE_KW@[147; 151) "move"
+                WHITESPACE@[151; 152) " "
+                PARAM_LIST@[152; 154)
+                  PIPE@[152; 153) "|"
+                  PIPE@[153; 154) "|"
+                WHITESPACE@[154; 155) " "
+                CALL_EXPR@[155; 161)
+                  PATH_EXPR@[155; 159)
+                    PATH@[155; 159)
+                      PATH_SEGMENT@[155; 159)
+                        NAME_REF@[155; 159)
+                          IDENT@[155; 159) "main"
+                  ARG_LIST@[159; 161)
+                    L_PAREN@[159; 160) "("
+                    R_PAREN@[160; 161) ")"
+              R_PAREN@[161; 162) ")"
+          SEMI@[162; 163) ";"
+        WHITESPACE@[163; 164) "\n"
+        R_CURLY@[164; 165) "}"
   WHITESPACE@[165; 166) "\n"

--- a/crates/ra_syntax/test_data/parser/ok/0045_block_inner_attrs.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0045_block_inner_attrs.txt
@@ -8,78 +8,79 @@ SOURCE_FILE@[0; 686)
       L_PAREN@[8; 9) "("
       R_PAREN@[9; 10) ")"
     WHITESPACE@[10; 11) " "
-    BLOCK@[11; 461)
-      L_CURLY@[11; 12) "{"
-      WHITESPACE@[12; 17) "\n    "
-      ATTR@[17; 57)
-        POUND@[17; 18) "#"
-        EXCL@[18; 19) "!"
-        TOKEN_TREE@[19; 57)
-          L_BRACK@[19; 20) "["
-          IDENT@[20; 23) "doc"
-          TOKEN_TREE@[23; 56)
-            L_PAREN@[23; 24) "("
-            STRING@[24; 55) "\"Inner attributes all ..."
-            R_PAREN@[55; 56) ")"
-          R_BRACK@[56; 57) "]"
-      WHITESPACE@[57; 62) "\n    "
-      COMMENT@[62; 97) "//! As are ModuleDoc  ..."
-      WHITESPACE@[97; 102) "\n    "
-      EXPR_STMT@[102; 295)
-        BLOCK_EXPR@[102; 294)
-          BLOCK@[102; 294)
-            L_CURLY@[102; 103) "{"
-            WHITESPACE@[103; 112) "\n        "
-            ATTR@[112; 180)
-              POUND@[112; 113) "#"
-              EXCL@[113; 114) "!"
-              TOKEN_TREE@[114; 180)
-                L_BRACK@[114; 115) "["
-                IDENT@[115; 118) "doc"
-                TOKEN_TREE@[118; 179)
-                  L_PAREN@[118; 119) "("
-                  STRING@[119; 178) "\"Inner attributes are ..."
-                  R_PAREN@[178; 179) ")"
-                R_BRACK@[179; 180) "]"
-            WHITESPACE@[180; 189) "\n        "
-            ATTR@[189; 244)
-              POUND@[189; 190) "#"
-              EXCL@[190; 191) "!"
-              TOKEN_TREE@[191; 244)
-                L_BRACK@[191; 192) "["
-                IDENT@[192; 195) "doc"
-                TOKEN_TREE@[195; 243)
-                  L_PAREN@[195; 196) "("
-                  STRING@[196; 242) "\"Being validated is n ..."
-                  R_PAREN@[242; 243) ")"
-                R_BRACK@[243; 244) "]"
-            WHITESPACE@[244; 253) "\n        "
-            COMMENT@[253; 288) "//! As are ModuleDoc  ..."
-            WHITESPACE@[288; 293) "\n    "
-            R_CURLY@[293; 294) "}"
-        SEMI@[294; 295) ";"
-      WHITESPACE@[295; 300) "\n    "
-      BLOCK_EXPR@[300; 459)
-        BLOCK@[300; 459)
-          L_CURLY@[300; 301) "{"
-          WHITESPACE@[301; 310) "\n        "
-          ATTR@[310; 409)
-            POUND@[310; 311) "#"
-            EXCL@[311; 312) "!"
-            TOKEN_TREE@[312; 409)
-              L_BRACK@[312; 313) "["
-              IDENT@[313; 316) "doc"
-              TOKEN_TREE@[316; 408)
-                L_PAREN@[316; 317) "("
-                STRING@[317; 407) "\"Inner attributes are ..."
-                R_PAREN@[407; 408) ")"
-              R_BRACK@[408; 409) "]"
-          WHITESPACE@[409; 418) "\n        "
-          COMMENT@[418; 453) "//! As are ModuleDoc  ..."
-          WHITESPACE@[453; 458) "\n    "
-          R_CURLY@[458; 459) "}"
-      WHITESPACE@[459; 460) "\n"
-      R_CURLY@[460; 461) "}"
+    BLOCK_EXPR@[11; 461)
+      BLOCK@[11; 461)
+        L_CURLY@[11; 12) "{"
+        WHITESPACE@[12; 17) "\n    "
+        ATTR@[17; 57)
+          POUND@[17; 18) "#"
+          EXCL@[18; 19) "!"
+          TOKEN_TREE@[19; 57)
+            L_BRACK@[19; 20) "["
+            IDENT@[20; 23) "doc"
+            TOKEN_TREE@[23; 56)
+              L_PAREN@[23; 24) "("
+              STRING@[24; 55) "\"Inner attributes all ..."
+              R_PAREN@[55; 56) ")"
+            R_BRACK@[56; 57) "]"
+        WHITESPACE@[57; 62) "\n    "
+        COMMENT@[62; 97) "//! As are ModuleDoc  ..."
+        WHITESPACE@[97; 102) "\n    "
+        EXPR_STMT@[102; 295)
+          BLOCK_EXPR@[102; 294)
+            BLOCK@[102; 294)
+              L_CURLY@[102; 103) "{"
+              WHITESPACE@[103; 112) "\n        "
+              ATTR@[112; 180)
+                POUND@[112; 113) "#"
+                EXCL@[113; 114) "!"
+                TOKEN_TREE@[114; 180)
+                  L_BRACK@[114; 115) "["
+                  IDENT@[115; 118) "doc"
+                  TOKEN_TREE@[118; 179)
+                    L_PAREN@[118; 119) "("
+                    STRING@[119; 178) "\"Inner attributes are ..."
+                    R_PAREN@[178; 179) ")"
+                  R_BRACK@[179; 180) "]"
+              WHITESPACE@[180; 189) "\n        "
+              ATTR@[189; 244)
+                POUND@[189; 190) "#"
+                EXCL@[190; 191) "!"
+                TOKEN_TREE@[191; 244)
+                  L_BRACK@[191; 192) "["
+                  IDENT@[192; 195) "doc"
+                  TOKEN_TREE@[195; 243)
+                    L_PAREN@[195; 196) "("
+                    STRING@[196; 242) "\"Being validated is n ..."
+                    R_PAREN@[242; 243) ")"
+                  R_BRACK@[243; 244) "]"
+              WHITESPACE@[244; 253) "\n        "
+              COMMENT@[253; 288) "//! As are ModuleDoc  ..."
+              WHITESPACE@[288; 293) "\n    "
+              R_CURLY@[293; 294) "}"
+          SEMI@[294; 295) ";"
+        WHITESPACE@[295; 300) "\n    "
+        BLOCK_EXPR@[300; 459)
+          BLOCK@[300; 459)
+            L_CURLY@[300; 301) "{"
+            WHITESPACE@[301; 310) "\n        "
+            ATTR@[310; 409)
+              POUND@[310; 311) "#"
+              EXCL@[311; 312) "!"
+              TOKEN_TREE@[312; 409)
+                L_BRACK@[312; 313) "["
+                IDENT@[313; 316) "doc"
+                TOKEN_TREE@[316; 408)
+                  L_PAREN@[316; 317) "("
+                  STRING@[317; 407) "\"Inner attributes are ..."
+                  R_PAREN@[407; 408) ")"
+                R_BRACK@[408; 409) "]"
+            WHITESPACE@[409; 418) "\n        "
+            COMMENT@[418; 453) "//! As are ModuleDoc  ..."
+            WHITESPACE@[453; 458) "\n    "
+            R_CURLY@[458; 459) "}"
+        WHITESPACE@[459; 460) "\n"
+        R_CURLY@[460; 461) "}"
   WHITESPACE@[461; 463) "\n\n"
   COMMENT@[463; 523) "// https://github.com ..."
   WHITESPACE@[523; 524) "\n"
@@ -146,24 +147,25 @@ SOURCE_FILE@[0; 686)
                                   R_ANGLE@[599; 600) ">"
           R_PAREN@[600; 601) ")"
         WHITESPACE@[601; 602) " "
-        BLOCK@[602; 683)
-          L_CURLY@[602; 603) "{"
-          WHITESPACE@[603; 612) "\n        "
-          ATTR@[612; 639)
-            POUND@[612; 613) "#"
-            EXCL@[613; 614) "!"
-            TOKEN_TREE@[614; 639)
-              L_BRACK@[614; 615) "["
-              IDENT@[615; 620) "allow"
-              TOKEN_TREE@[620; 638)
-                L_PAREN@[620; 621) "("
-                IDENT@[621; 637) "unused_variables"
-                R_PAREN@[637; 638) ")"
-              R_BRACK@[638; 639) "]"
-          WHITESPACE@[639; 640) " "
-          COMMENT@[640; 677) "// this is  `inner_at ..."
-          WHITESPACE@[677; 682) "\n    "
-          R_CURLY@[682; 683) "}"
+        BLOCK_EXPR@[602; 683)
+          BLOCK@[602; 683)
+            L_CURLY@[602; 603) "{"
+            WHITESPACE@[603; 612) "\n        "
+            ATTR@[612; 639)
+              POUND@[612; 613) "#"
+              EXCL@[613; 614) "!"
+              TOKEN_TREE@[614; 639)
+                L_BRACK@[614; 615) "["
+                IDENT@[615; 620) "allow"
+                TOKEN_TREE@[620; 638)
+                  L_PAREN@[620; 621) "("
+                  IDENT@[621; 637) "unused_variables"
+                  R_PAREN@[637; 638) ")"
+                R_BRACK@[638; 639) "]"
+            WHITESPACE@[639; 640) " "
+            COMMENT@[640; 677) "// this is  `inner_at ..."
+            WHITESPACE@[677; 682) "\n    "
+            R_CURLY@[682; 683) "}"
       WHITESPACE@[683; 684) "\n"
       R_CURLY@[684; 685) "}"
   WHITESPACE@[685; 686) "\n"

--- a/crates/ra_syntax/test_data/parser/ok/0047_minus_in_inner_pattern.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0047_minus_in_inner_pattern.txt
@@ -10,251 +10,253 @@ SOURCE_FILE@[0; 395)
       L_PAREN@[69; 70) "("
       R_PAREN@[70; 71) ")"
     WHITESPACE@[71; 72) " "
-    BLOCK@[72; 341)
-      L_CURLY@[72; 73) "{"
-      WHITESPACE@[73; 78) "\n    "
-      EXPR_STMT@[78; 141)
-        MATCH_EXPR@[78; 141)
-          MATCH_KW@[78; 83) "match"
-          WHITESPACE@[83; 84) " "
-          CALL_EXPR@[84; 92)
-            PATH_EXPR@[84; 88)
-              PATH@[84; 88)
-                PATH_SEGMENT@[84; 88)
-                  NAME_REF@[84; 88)
-                    IDENT@[84; 88) "Some"
-            ARG_LIST@[88; 92)
-              L_PAREN@[88; 89) "("
-              PREFIX_EXPR@[89; 91)
-                MINUS@[89; 90) "-"
-                LITERAL@[90; 91)
-                  INT_NUMBER@[90; 91) "1"
-              R_PAREN@[91; 92) ")"
-          WHITESPACE@[92; 93) " "
-          MATCH_ARM_LIST@[93; 141)
-            L_CURLY@[93; 94) "{"
-            WHITESPACE@[94; 103) "\n        "
-            MATCH_ARM@[103; 117)
-              TUPLE_STRUCT_PAT@[103; 111)
-                PATH@[103; 107)
-                  PATH_SEGMENT@[103; 107)
-                    NAME_REF@[103; 107)
-                      IDENT@[103; 107) "Some"
-                L_PAREN@[107; 108) "("
-                LITERAL_PAT@[108; 110)
-                  MINUS@[108; 109) "-"
-                  LITERAL@[109; 110)
-                    INT_NUMBER@[109; 110) "1"
-                R_PAREN@[110; 111) ")"
-              WHITESPACE@[111; 112) " "
-              FAT_ARROW@[112; 114) "=>"
-              WHITESPACE@[114; 115) " "
-              TUPLE_EXPR@[115; 117)
-                L_PAREN@[115; 116) "("
-                R_PAREN@[116; 117) ")"
-            COMMA@[117; 118) ","
-            WHITESPACE@[118; 127) "\n        "
-            MATCH_ARM@[127; 134)
-              PLACEHOLDER_PAT@[127; 128)
-                UNDERSCORE@[127; 128) "_"
-              WHITESPACE@[128; 129) " "
-              FAT_ARROW@[129; 131) "=>"
-              WHITESPACE@[131; 132) " "
-              TUPLE_EXPR@[132; 134)
-                L_PAREN@[132; 133) "("
-                R_PAREN@[133; 134) ")"
-            COMMA@[134; 135) ","
-            WHITESPACE@[135; 140) "\n    "
-            R_CURLY@[140; 141) "}"
-      WHITESPACE@[141; 147) "\n\n    "
-      EXPR_STMT@[147; 222)
-        MATCH_EXPR@[147; 222)
-          MATCH_KW@[147; 152) "match"
-          WHITESPACE@[152; 153) " "
-          CALL_EXPR@[153; 167)
-            PATH_EXPR@[153; 157)
-              PATH@[153; 157)
-                PATH_SEGMENT@[153; 157)
-                  NAME_REF@[153; 157)
-                    IDENT@[153; 157) "Some"
-            ARG_LIST@[157; 167)
-              L_PAREN@[157; 158) "("
-              TUPLE_EXPR@[158; 166)
-                L_PAREN@[158; 159) "("
-                PREFIX_EXPR@[159; 161)
-                  MINUS@[159; 160) "-"
-                  LITERAL@[160; 161)
-                    INT_NUMBER@[160; 161) "1"
-                COMMA@[161; 162) ","
-                WHITESPACE@[162; 163) " "
-                PREFIX_EXPR@[163; 165)
-                  MINUS@[163; 164) "-"
-                  LITERAL@[164; 165)
-                    INT_NUMBER@[164; 165) "1"
-                R_PAREN@[165; 166) ")"
-              R_PAREN@[166; 167) ")"
-          WHITESPACE@[167; 168) " "
-          MATCH_ARM_LIST@[168; 222)
-            L_CURLY@[168; 169) "{"
-            WHITESPACE@[169; 178) "\n        "
-            MATCH_ARM@[178; 198)
-              TUPLE_STRUCT_PAT@[178; 192)
-                PATH@[178; 182)
-                  PATH_SEGMENT@[178; 182)
-                    NAME_REF@[178; 182)
-                      IDENT@[178; 182) "Some"
-                L_PAREN@[182; 183) "("
-                TUPLE_PAT@[183; 191)
-                  L_PAREN@[183; 184) "("
-                  LITERAL_PAT@[184; 186)
-                    MINUS@[184; 185) "-"
-                    LITERAL@[185; 186)
-                      INT_NUMBER@[185; 186) "1"
-                  COMMA@[186; 187) ","
-                  WHITESPACE@[187; 188) " "
-                  LITERAL_PAT@[188; 190)
-                    MINUS@[188; 189) "-"
-                    LITERAL@[189; 190)
-                      INT_NUMBER@[189; 190) "1"
-                  R_PAREN@[190; 191) ")"
-                R_PAREN@[191; 192) ")"
-              WHITESPACE@[192; 193) " "
-              FAT_ARROW@[193; 195) "=>"
-              WHITESPACE@[195; 196) " "
-              TUPLE_EXPR@[196; 198)
-                L_PAREN@[196; 197) "("
-                R_PAREN@[197; 198) ")"
-            COMMA@[198; 199) ","
-            WHITESPACE@[199; 208) "\n        "
-            MATCH_ARM@[208; 215)
-              PLACEHOLDER_PAT@[208; 209)
-                UNDERSCORE@[208; 209) "_"
-              WHITESPACE@[209; 210) " "
-              FAT_ARROW@[210; 212) "=>"
-              WHITESPACE@[212; 213) " "
-              TUPLE_EXPR@[213; 215)
-                L_PAREN@[213; 214) "("
-                R_PAREN@[214; 215) ")"
-            COMMA@[215; 216) ","
-            WHITESPACE@[216; 221) "\n    "
-            R_CURLY@[221; 222) "}"
-      WHITESPACE@[222; 228) "\n\n    "
-      EXPR_STMT@[228; 299)
-        MATCH_EXPR@[228; 299)
-          MATCH_KW@[228; 233) "match"
-          WHITESPACE@[233; 234) " "
-          CALL_EXPR@[234; 246)
-            PATH_EXPR@[234; 238)
-              PATH@[234; 238)
-                PATH@[234; 235)
-                  PATH_SEGMENT@[234; 235)
-                    NAME_REF@[234; 235)
-                      IDENT@[234; 235) "A"
-                COLONCOLON@[235; 237) "::"
-                PATH_SEGMENT@[237; 238)
-                  NAME_REF@[237; 238)
-                    IDENT@[237; 238) "B"
-            ARG_LIST@[238; 246)
-              L_PAREN@[238; 239) "("
-              PREFIX_EXPR@[239; 241)
-                MINUS@[239; 240) "-"
-                LITERAL@[240; 241)
-                  INT_NUMBER@[240; 241) "1"
-              COMMA@[241; 242) ","
-              WHITESPACE@[242; 243) " "
-              PREFIX_EXPR@[243; 245)
-                MINUS@[243; 244) "-"
-                LITERAL@[244; 245)
-                  INT_NUMBER@[244; 245) "1"
-              R_PAREN@[245; 246) ")"
-          WHITESPACE@[246; 247) " "
-          MATCH_ARM_LIST@[247; 299)
-            L_CURLY@[247; 248) "{"
-            WHITESPACE@[248; 257) "\n        "
-            MATCH_ARM@[257; 275)
-              TUPLE_STRUCT_PAT@[257; 269)
-                PATH@[257; 261)
-                  PATH@[257; 258)
-                    PATH_SEGMENT@[257; 258)
-                      NAME_REF@[257; 258)
-                        IDENT@[257; 258) "A"
-                  COLONCOLON@[258; 260) "::"
-                  PATH_SEGMENT@[260; 261)
-                    NAME_REF@[260; 261)
-                      IDENT@[260; 261) "B"
-                L_PAREN@[261; 262) "("
-                LITERAL_PAT@[262; 264)
-                  MINUS@[262; 263) "-"
-                  LITERAL@[263; 264)
-                    INT_NUMBER@[263; 264) "1"
-                COMMA@[264; 265) ","
-                WHITESPACE@[265; 266) " "
-                LITERAL_PAT@[266; 268)
-                  MINUS@[266; 267) "-"
-                  LITERAL@[267; 268)
-                    INT_NUMBER@[267; 268) "1"
-                R_PAREN@[268; 269) ")"
-              WHITESPACE@[269; 270) " "
-              FAT_ARROW@[270; 272) "=>"
-              WHITESPACE@[272; 273) " "
-              TUPLE_EXPR@[273; 275)
-                L_PAREN@[273; 274) "("
-                R_PAREN@[274; 275) ")"
-            COMMA@[275; 276) ","
-            WHITESPACE@[276; 285) "\n        "
-            MATCH_ARM@[285; 292)
-              PLACEHOLDER_PAT@[285; 286)
-                UNDERSCORE@[285; 286) "_"
-              WHITESPACE@[286; 287) " "
-              FAT_ARROW@[287; 289) "=>"
-              WHITESPACE@[289; 290) " "
-              TUPLE_EXPR@[290; 292)
-                L_PAREN@[290; 291) "("
-                R_PAREN@[291; 292) ")"
-            COMMA@[292; 293) ","
-            WHITESPACE@[293; 298) "\n    "
-            R_CURLY@[298; 299) "}"
-      WHITESPACE@[299; 305) "\n\n    "
-      IF_EXPR@[305; 339)
-        IF_KW@[305; 307) "if"
-        WHITESPACE@[307; 308) " "
-        CONDITION@[308; 331)
-          LET_KW@[308; 311) "let"
-          WHITESPACE@[311; 312) " "
-          TUPLE_STRUCT_PAT@[312; 320)
-            PATH@[312; 316)
-              PATH_SEGMENT@[312; 316)
-                NAME_REF@[312; 316)
-                  IDENT@[312; 316) "Some"
-            L_PAREN@[316; 317) "("
-            LITERAL_PAT@[317; 319)
-              MINUS@[317; 318) "-"
-              LITERAL@[318; 319)
-                INT_NUMBER@[318; 319) "1"
-            R_PAREN@[319; 320) ")"
-          WHITESPACE@[320; 321) " "
-          EQ@[321; 322) "="
-          WHITESPACE@[322; 323) " "
-          CALL_EXPR@[323; 331)
-            PATH_EXPR@[323; 327)
-              PATH@[323; 327)
-                PATH_SEGMENT@[323; 327)
-                  NAME_REF@[323; 327)
-                    IDENT@[323; 327) "Some"
-            ARG_LIST@[327; 331)
-              L_PAREN@[327; 328) "("
-              PREFIX_EXPR@[328; 330)
-                MINUS@[328; 329) "-"
-                LITERAL@[329; 330)
-                  INT_NUMBER@[329; 330) "1"
-              R_PAREN@[330; 331) ")"
-        WHITESPACE@[331; 332) " "
-        BLOCK@[332; 339)
-          L_CURLY@[332; 333) "{"
-          WHITESPACE@[333; 338) "\n    "
-          R_CURLY@[338; 339) "}"
-      WHITESPACE@[339; 340) "\n"
-      R_CURLY@[340; 341) "}"
+    BLOCK_EXPR@[72; 341)
+      BLOCK@[72; 341)
+        L_CURLY@[72; 73) "{"
+        WHITESPACE@[73; 78) "\n    "
+        EXPR_STMT@[78; 141)
+          MATCH_EXPR@[78; 141)
+            MATCH_KW@[78; 83) "match"
+            WHITESPACE@[83; 84) " "
+            CALL_EXPR@[84; 92)
+              PATH_EXPR@[84; 88)
+                PATH@[84; 88)
+                  PATH_SEGMENT@[84; 88)
+                    NAME_REF@[84; 88)
+                      IDENT@[84; 88) "Some"
+              ARG_LIST@[88; 92)
+                L_PAREN@[88; 89) "("
+                PREFIX_EXPR@[89; 91)
+                  MINUS@[89; 90) "-"
+                  LITERAL@[90; 91)
+                    INT_NUMBER@[90; 91) "1"
+                R_PAREN@[91; 92) ")"
+            WHITESPACE@[92; 93) " "
+            MATCH_ARM_LIST@[93; 141)
+              L_CURLY@[93; 94) "{"
+              WHITESPACE@[94; 103) "\n        "
+              MATCH_ARM@[103; 117)
+                TUPLE_STRUCT_PAT@[103; 111)
+                  PATH@[103; 107)
+                    PATH_SEGMENT@[103; 107)
+                      NAME_REF@[103; 107)
+                        IDENT@[103; 107) "Some"
+                  L_PAREN@[107; 108) "("
+                  LITERAL_PAT@[108; 110)
+                    MINUS@[108; 109) "-"
+                    LITERAL@[109; 110)
+                      INT_NUMBER@[109; 110) "1"
+                  R_PAREN@[110; 111) ")"
+                WHITESPACE@[111; 112) " "
+                FAT_ARROW@[112; 114) "=>"
+                WHITESPACE@[114; 115) " "
+                TUPLE_EXPR@[115; 117)
+                  L_PAREN@[115; 116) "("
+                  R_PAREN@[116; 117) ")"
+              COMMA@[117; 118) ","
+              WHITESPACE@[118; 127) "\n        "
+              MATCH_ARM@[127; 134)
+                PLACEHOLDER_PAT@[127; 128)
+                  UNDERSCORE@[127; 128) "_"
+                WHITESPACE@[128; 129) " "
+                FAT_ARROW@[129; 131) "=>"
+                WHITESPACE@[131; 132) " "
+                TUPLE_EXPR@[132; 134)
+                  L_PAREN@[132; 133) "("
+                  R_PAREN@[133; 134) ")"
+              COMMA@[134; 135) ","
+              WHITESPACE@[135; 140) "\n    "
+              R_CURLY@[140; 141) "}"
+        WHITESPACE@[141; 147) "\n\n    "
+        EXPR_STMT@[147; 222)
+          MATCH_EXPR@[147; 222)
+            MATCH_KW@[147; 152) "match"
+            WHITESPACE@[152; 153) " "
+            CALL_EXPR@[153; 167)
+              PATH_EXPR@[153; 157)
+                PATH@[153; 157)
+                  PATH_SEGMENT@[153; 157)
+                    NAME_REF@[153; 157)
+                      IDENT@[153; 157) "Some"
+              ARG_LIST@[157; 167)
+                L_PAREN@[157; 158) "("
+                TUPLE_EXPR@[158; 166)
+                  L_PAREN@[158; 159) "("
+                  PREFIX_EXPR@[159; 161)
+                    MINUS@[159; 160) "-"
+                    LITERAL@[160; 161)
+                      INT_NUMBER@[160; 161) "1"
+                  COMMA@[161; 162) ","
+                  WHITESPACE@[162; 163) " "
+                  PREFIX_EXPR@[163; 165)
+                    MINUS@[163; 164) "-"
+                    LITERAL@[164; 165)
+                      INT_NUMBER@[164; 165) "1"
+                  R_PAREN@[165; 166) ")"
+                R_PAREN@[166; 167) ")"
+            WHITESPACE@[167; 168) " "
+            MATCH_ARM_LIST@[168; 222)
+              L_CURLY@[168; 169) "{"
+              WHITESPACE@[169; 178) "\n        "
+              MATCH_ARM@[178; 198)
+                TUPLE_STRUCT_PAT@[178; 192)
+                  PATH@[178; 182)
+                    PATH_SEGMENT@[178; 182)
+                      NAME_REF@[178; 182)
+                        IDENT@[178; 182) "Some"
+                  L_PAREN@[182; 183) "("
+                  TUPLE_PAT@[183; 191)
+                    L_PAREN@[183; 184) "("
+                    LITERAL_PAT@[184; 186)
+                      MINUS@[184; 185) "-"
+                      LITERAL@[185; 186)
+                        INT_NUMBER@[185; 186) "1"
+                    COMMA@[186; 187) ","
+                    WHITESPACE@[187; 188) " "
+                    LITERAL_PAT@[188; 190)
+                      MINUS@[188; 189) "-"
+                      LITERAL@[189; 190)
+                        INT_NUMBER@[189; 190) "1"
+                    R_PAREN@[190; 191) ")"
+                  R_PAREN@[191; 192) ")"
+                WHITESPACE@[192; 193) " "
+                FAT_ARROW@[193; 195) "=>"
+                WHITESPACE@[195; 196) " "
+                TUPLE_EXPR@[196; 198)
+                  L_PAREN@[196; 197) "("
+                  R_PAREN@[197; 198) ")"
+              COMMA@[198; 199) ","
+              WHITESPACE@[199; 208) "\n        "
+              MATCH_ARM@[208; 215)
+                PLACEHOLDER_PAT@[208; 209)
+                  UNDERSCORE@[208; 209) "_"
+                WHITESPACE@[209; 210) " "
+                FAT_ARROW@[210; 212) "=>"
+                WHITESPACE@[212; 213) " "
+                TUPLE_EXPR@[213; 215)
+                  L_PAREN@[213; 214) "("
+                  R_PAREN@[214; 215) ")"
+              COMMA@[215; 216) ","
+              WHITESPACE@[216; 221) "\n    "
+              R_CURLY@[221; 222) "}"
+        WHITESPACE@[222; 228) "\n\n    "
+        EXPR_STMT@[228; 299)
+          MATCH_EXPR@[228; 299)
+            MATCH_KW@[228; 233) "match"
+            WHITESPACE@[233; 234) " "
+            CALL_EXPR@[234; 246)
+              PATH_EXPR@[234; 238)
+                PATH@[234; 238)
+                  PATH@[234; 235)
+                    PATH_SEGMENT@[234; 235)
+                      NAME_REF@[234; 235)
+                        IDENT@[234; 235) "A"
+                  COLONCOLON@[235; 237) "::"
+                  PATH_SEGMENT@[237; 238)
+                    NAME_REF@[237; 238)
+                      IDENT@[237; 238) "B"
+              ARG_LIST@[238; 246)
+                L_PAREN@[238; 239) "("
+                PREFIX_EXPR@[239; 241)
+                  MINUS@[239; 240) "-"
+                  LITERAL@[240; 241)
+                    INT_NUMBER@[240; 241) "1"
+                COMMA@[241; 242) ","
+                WHITESPACE@[242; 243) " "
+                PREFIX_EXPR@[243; 245)
+                  MINUS@[243; 244) "-"
+                  LITERAL@[244; 245)
+                    INT_NUMBER@[244; 245) "1"
+                R_PAREN@[245; 246) ")"
+            WHITESPACE@[246; 247) " "
+            MATCH_ARM_LIST@[247; 299)
+              L_CURLY@[247; 248) "{"
+              WHITESPACE@[248; 257) "\n        "
+              MATCH_ARM@[257; 275)
+                TUPLE_STRUCT_PAT@[257; 269)
+                  PATH@[257; 261)
+                    PATH@[257; 258)
+                      PATH_SEGMENT@[257; 258)
+                        NAME_REF@[257; 258)
+                          IDENT@[257; 258) "A"
+                    COLONCOLON@[258; 260) "::"
+                    PATH_SEGMENT@[260; 261)
+                      NAME_REF@[260; 261)
+                        IDENT@[260; 261) "B"
+                  L_PAREN@[261; 262) "("
+                  LITERAL_PAT@[262; 264)
+                    MINUS@[262; 263) "-"
+                    LITERAL@[263; 264)
+                      INT_NUMBER@[263; 264) "1"
+                  COMMA@[264; 265) ","
+                  WHITESPACE@[265; 266) " "
+                  LITERAL_PAT@[266; 268)
+                    MINUS@[266; 267) "-"
+                    LITERAL@[267; 268)
+                      INT_NUMBER@[267; 268) "1"
+                  R_PAREN@[268; 269) ")"
+                WHITESPACE@[269; 270) " "
+                FAT_ARROW@[270; 272) "=>"
+                WHITESPACE@[272; 273) " "
+                TUPLE_EXPR@[273; 275)
+                  L_PAREN@[273; 274) "("
+                  R_PAREN@[274; 275) ")"
+              COMMA@[275; 276) ","
+              WHITESPACE@[276; 285) "\n        "
+              MATCH_ARM@[285; 292)
+                PLACEHOLDER_PAT@[285; 286)
+                  UNDERSCORE@[285; 286) "_"
+                WHITESPACE@[286; 287) " "
+                FAT_ARROW@[287; 289) "=>"
+                WHITESPACE@[289; 290) " "
+                TUPLE_EXPR@[290; 292)
+                  L_PAREN@[290; 291) "("
+                  R_PAREN@[291; 292) ")"
+              COMMA@[292; 293) ","
+              WHITESPACE@[293; 298) "\n    "
+              R_CURLY@[298; 299) "}"
+        WHITESPACE@[299; 305) "\n\n    "
+        IF_EXPR@[305; 339)
+          IF_KW@[305; 307) "if"
+          WHITESPACE@[307; 308) " "
+          CONDITION@[308; 331)
+            LET_KW@[308; 311) "let"
+            WHITESPACE@[311; 312) " "
+            TUPLE_STRUCT_PAT@[312; 320)
+              PATH@[312; 316)
+                PATH_SEGMENT@[312; 316)
+                  NAME_REF@[312; 316)
+                    IDENT@[312; 316) "Some"
+              L_PAREN@[316; 317) "("
+              LITERAL_PAT@[317; 319)
+                MINUS@[317; 318) "-"
+                LITERAL@[318; 319)
+                  INT_NUMBER@[318; 319) "1"
+              R_PAREN@[319; 320) ")"
+            WHITESPACE@[320; 321) " "
+            EQ@[321; 322) "="
+            WHITESPACE@[322; 323) " "
+            CALL_EXPR@[323; 331)
+              PATH_EXPR@[323; 327)
+                PATH@[323; 327)
+                  PATH_SEGMENT@[323; 327)
+                    NAME_REF@[323; 327)
+                      IDENT@[323; 327) "Some"
+              ARG_LIST@[327; 331)
+                L_PAREN@[327; 328) "("
+                PREFIX_EXPR@[328; 330)
+                  MINUS@[328; 329) "-"
+                  LITERAL@[329; 330)
+                    INT_NUMBER@[329; 330) "1"
+                R_PAREN@[330; 331) ")"
+          WHITESPACE@[331; 332) " "
+          BLOCK_EXPR@[332; 339)
+            BLOCK@[332; 339)
+              L_CURLY@[332; 333) "{"
+              WHITESPACE@[333; 338) "\n    "
+              R_CURLY@[338; 339) "}"
+        WHITESPACE@[339; 340) "\n"
+        R_CURLY@[340; 341) "}"
   WHITESPACE@[341; 343) "\n\n"
   ENUM_DEF@[343; 367)
     ENUM_KW@[343; 347) "enum"
@@ -314,7 +316,8 @@ SOURCE_FILE@[0; 395)
                 IDENT@[388; 390) "i8"
       R_PAREN@[390; 391) ")"
     WHITESPACE@[391; 392) " "
-    BLOCK@[392; 394)
-      L_CURLY@[392; 393) "{"
-      R_CURLY@[393; 394) "}"
+    BLOCK_EXPR@[392; 394)
+      BLOCK@[392; 394)
+        L_CURLY@[392; 393) "{"
+        R_CURLY@[393; 394) "}"
   WHITESPACE@[394; 395) "\n"

--- a/crates/ra_syntax/test_data/parser/ok/0048_compound_assignment.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0048_compound_assignment.txt
@@ -10,191 +10,192 @@ SOURCE_FILE@[0; 257)
       L_PAREN@[82; 83) "("
       R_PAREN@[83; 84) ")"
     WHITESPACE@[84; 85) " "
-    BLOCK@[85; 256)
-      L_CURLY@[85; 86) "{"
-      WHITESPACE@[86; 91) "\n    "
-      LET_STMT@[91; 105)
-        LET_KW@[91; 94) "let"
-        WHITESPACE@[94; 95) " "
-        BIND_PAT@[95; 100)
-          MUT_KW@[95; 98) "mut"
-          WHITESPACE@[98; 99) " "
-          NAME@[99; 100)
-            IDENT@[99; 100) "a"
-        WHITESPACE@[100; 101) " "
-        EQ@[101; 102) "="
-        WHITESPACE@[102; 103) " "
-        LITERAL@[103; 104)
-          INT_NUMBER@[103; 104) "0"
-        SEMI@[104; 105) ";"
-      WHITESPACE@[105; 110) "\n    "
-      EXPR_STMT@[110; 117)
-        BIN_EXPR@[110; 116)
-          PATH_EXPR@[110; 111)
-            PATH@[110; 111)
-              PATH_SEGMENT@[110; 111)
-                NAME_REF@[110; 111)
-                  IDENT@[110; 111) "a"
-          WHITESPACE@[111; 112) " "
-          PLUSEQ@[112; 114) "+="
-          WHITESPACE@[114; 115) " "
-          LITERAL@[115; 116)
-            INT_NUMBER@[115; 116) "1"
-        SEMI@[116; 117) ";"
-      WHITESPACE@[117; 122) "\n    "
-      EXPR_STMT@[122; 129)
-        BIN_EXPR@[122; 128)
-          PATH_EXPR@[122; 123)
-            PATH@[122; 123)
-              PATH_SEGMENT@[122; 123)
-                NAME_REF@[122; 123)
-                  IDENT@[122; 123) "a"
-          WHITESPACE@[123; 124) " "
-          MINUSEQ@[124; 126) "-="
-          WHITESPACE@[126; 127) " "
-          LITERAL@[127; 128)
-            INT_NUMBER@[127; 128) "2"
-        SEMI@[128; 129) ";"
-      WHITESPACE@[129; 134) "\n    "
-      EXPR_STMT@[134; 141)
-        BIN_EXPR@[134; 140)
-          PATH_EXPR@[134; 135)
-            PATH@[134; 135)
-              PATH_SEGMENT@[134; 135)
-                NAME_REF@[134; 135)
-                  IDENT@[134; 135) "a"
-          WHITESPACE@[135; 136) " "
-          STAREQ@[136; 138) "*="
-          WHITESPACE@[138; 139) " "
-          LITERAL@[139; 140)
-            INT_NUMBER@[139; 140) "3"
-        SEMI@[140; 141) ";"
-      WHITESPACE@[141; 146) "\n    "
-      EXPR_STMT@[146; 153)
-        BIN_EXPR@[146; 152)
-          PATH_EXPR@[146; 147)
-            PATH@[146; 147)
-              PATH_SEGMENT@[146; 147)
-                NAME_REF@[146; 147)
-                  IDENT@[146; 147) "a"
-          WHITESPACE@[147; 148) " "
-          PERCENTEQ@[148; 150) "%="
-          WHITESPACE@[150; 151) " "
-          LITERAL@[151; 152)
-            INT_NUMBER@[151; 152) "4"
-        SEMI@[152; 153) ";"
-      WHITESPACE@[153; 158) "\n    "
-      EXPR_STMT@[158; 165)
-        BIN_EXPR@[158; 164)
-          PATH_EXPR@[158; 159)
-            PATH@[158; 159)
-              PATH_SEGMENT@[158; 159)
-                NAME_REF@[158; 159)
-                  IDENT@[158; 159) "a"
-          WHITESPACE@[159; 160) " "
-          SLASHEQ@[160; 162) "/="
-          WHITESPACE@[162; 163) " "
-          LITERAL@[163; 164)
-            INT_NUMBER@[163; 164) "5"
-        SEMI@[164; 165) ";"
-      WHITESPACE@[165; 170) "\n    "
-      EXPR_STMT@[170; 177)
-        BIN_EXPR@[170; 176)
-          PATH_EXPR@[170; 171)
-            PATH@[170; 171)
-              PATH_SEGMENT@[170; 171)
-                NAME_REF@[170; 171)
-                  IDENT@[170; 171) "a"
-          WHITESPACE@[171; 172) " "
-          PIPEEQ@[172; 174) "|="
-          WHITESPACE@[174; 175) " "
-          LITERAL@[175; 176)
-            INT_NUMBER@[175; 176) "6"
-        SEMI@[176; 177) ";"
-      WHITESPACE@[177; 182) "\n    "
-      EXPR_STMT@[182; 189)
-        BIN_EXPR@[182; 188)
-          PATH_EXPR@[182; 183)
-            PATH@[182; 183)
-              PATH_SEGMENT@[182; 183)
-                NAME_REF@[182; 183)
-                  IDENT@[182; 183) "a"
-          WHITESPACE@[183; 184) " "
-          AMPEQ@[184; 186) "&="
-          WHITESPACE@[186; 187) " "
-          LITERAL@[187; 188)
-            INT_NUMBER@[187; 188) "7"
-        SEMI@[188; 189) ";"
-      WHITESPACE@[189; 194) "\n    "
-      EXPR_STMT@[194; 201)
-        BIN_EXPR@[194; 200)
-          PATH_EXPR@[194; 195)
-            PATH@[194; 195)
-              PATH_SEGMENT@[194; 195)
-                NAME_REF@[194; 195)
-                  IDENT@[194; 195) "a"
-          WHITESPACE@[195; 196) " "
-          CARETEQ@[196; 198) "^="
-          WHITESPACE@[198; 199) " "
-          LITERAL@[199; 200)
-            INT_NUMBER@[199; 200) "8"
-        SEMI@[200; 201) ";"
-      WHITESPACE@[201; 206) "\n    "
-      EXPR_STMT@[206; 213)
-        BIN_EXPR@[206; 212)
-          PATH_EXPR@[206; 207)
-            PATH@[206; 207)
-              PATH_SEGMENT@[206; 207)
-                NAME_REF@[206; 207)
-                  IDENT@[206; 207) "a"
-          WHITESPACE@[207; 208) " "
-          LTEQ@[208; 210) "<="
-          WHITESPACE@[210; 211) " "
-          LITERAL@[211; 212)
-            INT_NUMBER@[211; 212) "9"
-        SEMI@[212; 213) ";"
-      WHITESPACE@[213; 218) "\n    "
-      EXPR_STMT@[218; 226)
-        BIN_EXPR@[218; 225)
-          PATH_EXPR@[218; 219)
-            PATH@[218; 219)
-              PATH_SEGMENT@[218; 219)
-                NAME_REF@[218; 219)
-                  IDENT@[218; 219) "a"
-          WHITESPACE@[219; 220) " "
-          GTEQ@[220; 222) ">="
-          WHITESPACE@[222; 223) " "
-          LITERAL@[223; 225)
-            INT_NUMBER@[223; 225) "10"
-        SEMI@[225; 226) ";"
-      WHITESPACE@[226; 231) "\n    "
-      EXPR_STMT@[231; 240)
-        BIN_EXPR@[231; 239)
-          PATH_EXPR@[231; 232)
-            PATH@[231; 232)
-              PATH_SEGMENT@[231; 232)
-                NAME_REF@[231; 232)
-                  IDENT@[231; 232) "a"
-          WHITESPACE@[232; 233) " "
-          SHREQ@[233; 236) ">>="
-          WHITESPACE@[236; 237) " "
-          LITERAL@[237; 239)
-            INT_NUMBER@[237; 239) "11"
-        SEMI@[239; 240) ";"
-      WHITESPACE@[240; 245) "\n    "
-      EXPR_STMT@[245; 254)
-        BIN_EXPR@[245; 253)
-          PATH_EXPR@[245; 246)
-            PATH@[245; 246)
-              PATH_SEGMENT@[245; 246)
-                NAME_REF@[245; 246)
-                  IDENT@[245; 246) "a"
-          WHITESPACE@[246; 247) " "
-          SHLEQ@[247; 250) "<<="
-          WHITESPACE@[250; 251) " "
-          LITERAL@[251; 253)
-            INT_NUMBER@[251; 253) "12"
-        SEMI@[253; 254) ";"
-      WHITESPACE@[254; 255) "\n"
-      R_CURLY@[255; 256) "}"
+    BLOCK_EXPR@[85; 256)
+      BLOCK@[85; 256)
+        L_CURLY@[85; 86) "{"
+        WHITESPACE@[86; 91) "\n    "
+        LET_STMT@[91; 105)
+          LET_KW@[91; 94) "let"
+          WHITESPACE@[94; 95) " "
+          BIND_PAT@[95; 100)
+            MUT_KW@[95; 98) "mut"
+            WHITESPACE@[98; 99) " "
+            NAME@[99; 100)
+              IDENT@[99; 100) "a"
+          WHITESPACE@[100; 101) " "
+          EQ@[101; 102) "="
+          WHITESPACE@[102; 103) " "
+          LITERAL@[103; 104)
+            INT_NUMBER@[103; 104) "0"
+          SEMI@[104; 105) ";"
+        WHITESPACE@[105; 110) "\n    "
+        EXPR_STMT@[110; 117)
+          BIN_EXPR@[110; 116)
+            PATH_EXPR@[110; 111)
+              PATH@[110; 111)
+                PATH_SEGMENT@[110; 111)
+                  NAME_REF@[110; 111)
+                    IDENT@[110; 111) "a"
+            WHITESPACE@[111; 112) " "
+            PLUSEQ@[112; 114) "+="
+            WHITESPACE@[114; 115) " "
+            LITERAL@[115; 116)
+              INT_NUMBER@[115; 116) "1"
+          SEMI@[116; 117) ";"
+        WHITESPACE@[117; 122) "\n    "
+        EXPR_STMT@[122; 129)
+          BIN_EXPR@[122; 128)
+            PATH_EXPR@[122; 123)
+              PATH@[122; 123)
+                PATH_SEGMENT@[122; 123)
+                  NAME_REF@[122; 123)
+                    IDENT@[122; 123) "a"
+            WHITESPACE@[123; 124) " "
+            MINUSEQ@[124; 126) "-="
+            WHITESPACE@[126; 127) " "
+            LITERAL@[127; 128)
+              INT_NUMBER@[127; 128) "2"
+          SEMI@[128; 129) ";"
+        WHITESPACE@[129; 134) "\n    "
+        EXPR_STMT@[134; 141)
+          BIN_EXPR@[134; 140)
+            PATH_EXPR@[134; 135)
+              PATH@[134; 135)
+                PATH_SEGMENT@[134; 135)
+                  NAME_REF@[134; 135)
+                    IDENT@[134; 135) "a"
+            WHITESPACE@[135; 136) " "
+            STAREQ@[136; 138) "*="
+            WHITESPACE@[138; 139) " "
+            LITERAL@[139; 140)
+              INT_NUMBER@[139; 140) "3"
+          SEMI@[140; 141) ";"
+        WHITESPACE@[141; 146) "\n    "
+        EXPR_STMT@[146; 153)
+          BIN_EXPR@[146; 152)
+            PATH_EXPR@[146; 147)
+              PATH@[146; 147)
+                PATH_SEGMENT@[146; 147)
+                  NAME_REF@[146; 147)
+                    IDENT@[146; 147) "a"
+            WHITESPACE@[147; 148) " "
+            PERCENTEQ@[148; 150) "%="
+            WHITESPACE@[150; 151) " "
+            LITERAL@[151; 152)
+              INT_NUMBER@[151; 152) "4"
+          SEMI@[152; 153) ";"
+        WHITESPACE@[153; 158) "\n    "
+        EXPR_STMT@[158; 165)
+          BIN_EXPR@[158; 164)
+            PATH_EXPR@[158; 159)
+              PATH@[158; 159)
+                PATH_SEGMENT@[158; 159)
+                  NAME_REF@[158; 159)
+                    IDENT@[158; 159) "a"
+            WHITESPACE@[159; 160) " "
+            SLASHEQ@[160; 162) "/="
+            WHITESPACE@[162; 163) " "
+            LITERAL@[163; 164)
+              INT_NUMBER@[163; 164) "5"
+          SEMI@[164; 165) ";"
+        WHITESPACE@[165; 170) "\n    "
+        EXPR_STMT@[170; 177)
+          BIN_EXPR@[170; 176)
+            PATH_EXPR@[170; 171)
+              PATH@[170; 171)
+                PATH_SEGMENT@[170; 171)
+                  NAME_REF@[170; 171)
+                    IDENT@[170; 171) "a"
+            WHITESPACE@[171; 172) " "
+            PIPEEQ@[172; 174) "|="
+            WHITESPACE@[174; 175) " "
+            LITERAL@[175; 176)
+              INT_NUMBER@[175; 176) "6"
+          SEMI@[176; 177) ";"
+        WHITESPACE@[177; 182) "\n    "
+        EXPR_STMT@[182; 189)
+          BIN_EXPR@[182; 188)
+            PATH_EXPR@[182; 183)
+              PATH@[182; 183)
+                PATH_SEGMENT@[182; 183)
+                  NAME_REF@[182; 183)
+                    IDENT@[182; 183) "a"
+            WHITESPACE@[183; 184) " "
+            AMPEQ@[184; 186) "&="
+            WHITESPACE@[186; 187) " "
+            LITERAL@[187; 188)
+              INT_NUMBER@[187; 188) "7"
+          SEMI@[188; 189) ";"
+        WHITESPACE@[189; 194) "\n    "
+        EXPR_STMT@[194; 201)
+          BIN_EXPR@[194; 200)
+            PATH_EXPR@[194; 195)
+              PATH@[194; 195)
+                PATH_SEGMENT@[194; 195)
+                  NAME_REF@[194; 195)
+                    IDENT@[194; 195) "a"
+            WHITESPACE@[195; 196) " "
+            CARETEQ@[196; 198) "^="
+            WHITESPACE@[198; 199) " "
+            LITERAL@[199; 200)
+              INT_NUMBER@[199; 200) "8"
+          SEMI@[200; 201) ";"
+        WHITESPACE@[201; 206) "\n    "
+        EXPR_STMT@[206; 213)
+          BIN_EXPR@[206; 212)
+            PATH_EXPR@[206; 207)
+              PATH@[206; 207)
+                PATH_SEGMENT@[206; 207)
+                  NAME_REF@[206; 207)
+                    IDENT@[206; 207) "a"
+            WHITESPACE@[207; 208) " "
+            LTEQ@[208; 210) "<="
+            WHITESPACE@[210; 211) " "
+            LITERAL@[211; 212)
+              INT_NUMBER@[211; 212) "9"
+          SEMI@[212; 213) ";"
+        WHITESPACE@[213; 218) "\n    "
+        EXPR_STMT@[218; 226)
+          BIN_EXPR@[218; 225)
+            PATH_EXPR@[218; 219)
+              PATH@[218; 219)
+                PATH_SEGMENT@[218; 219)
+                  NAME_REF@[218; 219)
+                    IDENT@[218; 219) "a"
+            WHITESPACE@[219; 220) " "
+            GTEQ@[220; 222) ">="
+            WHITESPACE@[222; 223) " "
+            LITERAL@[223; 225)
+              INT_NUMBER@[223; 225) "10"
+          SEMI@[225; 226) ";"
+        WHITESPACE@[226; 231) "\n    "
+        EXPR_STMT@[231; 240)
+          BIN_EXPR@[231; 239)
+            PATH_EXPR@[231; 232)
+              PATH@[231; 232)
+                PATH_SEGMENT@[231; 232)
+                  NAME_REF@[231; 232)
+                    IDENT@[231; 232) "a"
+            WHITESPACE@[232; 233) " "
+            SHREQ@[233; 236) ">>="
+            WHITESPACE@[236; 237) " "
+            LITERAL@[237; 239)
+              INT_NUMBER@[237; 239) "11"
+          SEMI@[239; 240) ";"
+        WHITESPACE@[240; 245) "\n    "
+        EXPR_STMT@[245; 254)
+          BIN_EXPR@[245; 253)
+            PATH_EXPR@[245; 246)
+              PATH@[245; 246)
+                PATH_SEGMENT@[245; 246)
+                  NAME_REF@[245; 246)
+                    IDENT@[245; 246) "a"
+            WHITESPACE@[246; 247) " "
+            SHLEQ@[247; 250) "<<="
+            WHITESPACE@[250; 251) " "
+            LITERAL@[251; 253)
+              INT_NUMBER@[251; 253) "12"
+          SEMI@[253; 254) ";"
+        WHITESPACE@[254; 255) "\n"
+        R_CURLY@[255; 256) "}"
   WHITESPACE@[256; 257) "\n"

--- a/crates/ra_syntax/test_data/parser/ok/0049_async_block.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0049_async_block.txt
@@ -8,28 +8,29 @@ SOURCE_FILE@[0; 47)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 45)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 15) "\n    "
-      EXPR_STMT@[15; 24)
-        BLOCK_EXPR@[15; 23)
-          ASYNC_KW@[15; 20) "async"
-          WHITESPACE@[20; 21) " "
-          BLOCK@[21; 23)
-            L_CURLY@[21; 22) "{"
-            R_CURLY@[22; 23) "}"
-        SEMI@[23; 24) ";"
-      WHITESPACE@[24; 29) "\n    "
-      EXPR_STMT@[29; 43)
-        BLOCK_EXPR@[29; 42)
-          ASYNC_KW@[29; 34) "async"
-          WHITESPACE@[34; 35) " "
-          MOVE_KW@[35; 39) "move"
-          WHITESPACE@[39; 40) " "
-          BLOCK@[40; 42)
-            L_CURLY@[40; 41) "{"
-            R_CURLY@[41; 42) "}"
-        SEMI@[42; 43) ";"
-      WHITESPACE@[43; 44) "\n"
-      R_CURLY@[44; 45) "}"
+    BLOCK_EXPR@[9; 45)
+      BLOCK@[9; 45)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 15) "\n    "
+        EXPR_STMT@[15; 24)
+          BLOCK_EXPR@[15; 23)
+            ASYNC_KW@[15; 20) "async"
+            WHITESPACE@[20; 21) " "
+            BLOCK@[21; 23)
+              L_CURLY@[21; 22) "{"
+              R_CURLY@[22; 23) "}"
+          SEMI@[23; 24) ";"
+        WHITESPACE@[24; 29) "\n    "
+        EXPR_STMT@[29; 43)
+          BLOCK_EXPR@[29; 42)
+            ASYNC_KW@[29; 34) "async"
+            WHITESPACE@[34; 35) " "
+            MOVE_KW@[35; 39) "move"
+            WHITESPACE@[39; 40) " "
+            BLOCK@[40; 42)
+              L_CURLY@[40; 41) "{"
+              R_CURLY@[41; 42) "}"
+          SEMI@[42; 43) ";"
+        WHITESPACE@[43; 44) "\n"
+        R_CURLY@[44; 45) "}"
   WHITESPACE@[45; 47) "\n\n"

--- a/crates/ra_syntax/test_data/parser/ok/0050_async_block_as_argument.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0050_async_block_as_argument.txt
@@ -48,9 +48,10 @@ SOURCE_FILE@[0; 95)
                       R_ANGLE@[47; 48) ">"
       R_PAREN@[48; 49) ")"
     WHITESPACE@[49; 50) " "
-    BLOCK@[50; 52)
-      L_CURLY@[50; 51) "{"
-      R_CURLY@[51; 52) "}"
+    BLOCK_EXPR@[50; 52)
+      BLOCK@[50; 52)
+        L_CURLY@[50; 51) "{"
+        R_CURLY@[51; 52) "}"
   WHITESPACE@[52; 54) "\n\n"
   FN_DEF@[54; 94)
     FN_KW@[54; 56) "fn"
@@ -61,30 +62,31 @@ SOURCE_FILE@[0; 95)
       L_PAREN@[61; 62) "("
       R_PAREN@[62; 63) ")"
     WHITESPACE@[63; 64) " "
-    BLOCK@[64; 94)
-      L_CURLY@[64; 65) "{"
-      WHITESPACE@[65; 70) "\n    "
-      CALL_EXPR@[70; 92)
-        PATH_EXPR@[70; 73)
-          PATH@[70; 73)
-            PATH_SEGMENT@[70; 73)
-              NAME_REF@[70; 73)
-                IDENT@[70; 73) "foo"
-        ARG_LIST@[73; 92)
-          L_PAREN@[73; 74) "("
-          BLOCK_EXPR@[74; 91)
-            ASYNC_KW@[74; 79) "async"
-            WHITESPACE@[79; 80) " "
-            MOVE_KW@[80; 84) "move"
-            WHITESPACE@[84; 85) " "
-            BLOCK@[85; 91)
-              L_CURLY@[85; 86) "{"
-              WHITESPACE@[86; 87) " "
-              LITERAL@[87; 89)
-                INT_NUMBER@[87; 89) "12"
-              WHITESPACE@[89; 90) " "
-              R_CURLY@[90; 91) "}"
-          R_PAREN@[91; 92) ")"
-      WHITESPACE@[92; 93) "\n"
-      R_CURLY@[93; 94) "}"
+    BLOCK_EXPR@[64; 94)
+      BLOCK@[64; 94)
+        L_CURLY@[64; 65) "{"
+        WHITESPACE@[65; 70) "\n    "
+        CALL_EXPR@[70; 92)
+          PATH_EXPR@[70; 73)
+            PATH@[70; 73)
+              PATH_SEGMENT@[70; 73)
+                NAME_REF@[70; 73)
+                  IDENT@[70; 73) "foo"
+          ARG_LIST@[73; 92)
+            L_PAREN@[73; 74) "("
+            BLOCK_EXPR@[74; 91)
+              ASYNC_KW@[74; 79) "async"
+              WHITESPACE@[79; 80) " "
+              MOVE_KW@[80; 84) "move"
+              WHITESPACE@[84; 85) " "
+              BLOCK@[85; 91)
+                L_CURLY@[85; 86) "{"
+                WHITESPACE@[86; 87) " "
+                LITERAL@[87; 89)
+                  INT_NUMBER@[87; 89) "12"
+                WHITESPACE@[89; 90) " "
+                R_CURLY@[90; 91) "}"
+            R_PAREN@[91; 92) ")"
+        WHITESPACE@[92; 93) "\n"
+        R_CURLY@[93; 94) "}"
   WHITESPACE@[94; 95) "\n"

--- a/crates/ra_syntax/test_data/parser/ok/0051_parameter_attrs.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0051_parameter_attrs.txt
@@ -33,9 +33,10 @@ SOURCE_FILE@[0; 519)
                 IDENT@[29; 33) "Type"
       R_PAREN@[33; 34) ")"
     WHITESPACE@[34; 35) " "
-    BLOCK@[35; 37)
-      L_CURLY@[35; 36) "{"
-      R_CURLY@[36; 37) "}"
+    BLOCK_EXPR@[35; 37)
+      BLOCK@[35; 37)
+        L_CURLY@[35; 36) "{"
+        R_CURLY@[36; 37) "}"
   WHITESPACE@[37; 38) "\n"
   FN_DEF@[38; 62)
     FN_KW@[38; 40) "fn"
@@ -64,9 +65,10 @@ SOURCE_FILE@[0; 519)
                 IDENT@[56; 58) "u8"
       R_PAREN@[58; 59) ")"
     WHITESPACE@[59; 60) " "
-    BLOCK@[60; 62)
-      L_CURLY@[60; 61) "{"
-      R_CURLY@[61; 62) "}"
+    BLOCK_EXPR@[60; 62)
+      BLOCK@[60; 62)
+        L_CURLY@[60; 61) "{"
+        R_CURLY@[61; 62) "}"
   WHITESPACE@[62; 64) "\n\n"
   EXTERN_BLOCK@[64; 128)
     ABI@[64; 74)
@@ -171,9 +173,10 @@ SOURCE_FILE@[0; 519)
     PARAM_LIST@[168; 170)
       L_PAREN@[168; 169) "("
       R_PAREN@[169; 170) ")"
-    BLOCK@[170; 172)
-      L_CURLY@[170; 171) "{"
-      R_CURLY@[171; 172) "}"
+    BLOCK_EXPR@[170; 172)
+      BLOCK@[170; 172)
+        L_CURLY@[170; 171) "{"
+        R_CURLY@[171; 172) "}"
   WHITESPACE@[172; 174) "\n\n"
   TRAIT_DEF@[174; 236)
     TRAIT_KW@[174; 179) "trait"
@@ -266,9 +269,10 @@ SOURCE_FILE@[0; 519)
             SELF_KW@[269; 273) "self"
           R_PAREN@[273; 274) ")"
         WHITESPACE@[274; 275) " "
-        BLOCK@[275; 277)
-          L_CURLY@[275; 276) "{"
-          R_CURLY@[276; 277) "}"
+        BLOCK_EXPR@[275; 277)
+          BLOCK@[275; 277)
+            L_CURLY@[275; 276) "{"
+            R_CURLY@[276; 277) "}"
       WHITESPACE@[277; 283) "\n     "
       FN_DEF@[283; 305)
         FN_KW@[283; 285) "fn"
@@ -288,9 +292,10 @@ SOURCE_FILE@[0; 519)
             SELF_KW@[297; 301) "self"
           R_PAREN@[301; 302) ")"
         WHITESPACE@[302; 303) " "
-        BLOCK@[303; 305)
-          L_CURLY@[303; 304) "{"
-          R_CURLY@[304; 305) "}"
+        BLOCK_EXPR@[303; 305)
+          BLOCK@[303; 305)
+            L_CURLY@[303; 304) "{"
+            R_CURLY@[304; 305) "}"
       WHITESPACE@[305; 311) "\n     "
       FN_DEF@[311; 334)
         FN_KW@[311; 313) "fn"
@@ -311,9 +316,10 @@ SOURCE_FILE@[0; 519)
             SELF_KW@[326; 330) "self"
           R_PAREN@[330; 331) ")"
         WHITESPACE@[331; 332) " "
-        BLOCK@[332; 334)
-          L_CURLY@[332; 333) "{"
-          R_CURLY@[333; 334) "}"
+        BLOCK_EXPR@[332; 334)
+          BLOCK@[332; 334)
+            L_CURLY@[332; 333) "{"
+            R_CURLY@[333; 334) "}"
       WHITESPACE@[334; 340) "\n     "
       FN_DEF@[340; 371)
         FN_KW@[340; 342) "fn"
@@ -341,9 +347,10 @@ SOURCE_FILE@[0; 519)
             SELF_KW@[363; 367) "self"
           R_PAREN@[367; 368) ")"
         WHITESPACE@[368; 369) " "
-        BLOCK@[369; 371)
-          L_CURLY@[369; 370) "{"
-          R_CURLY@[370; 371) "}"
+        BLOCK_EXPR@[369; 371)
+          BLOCK@[369; 371)
+            L_CURLY@[369; 370) "{"
+            R_CURLY@[370; 371) "}"
       WHITESPACE@[371; 377) "\n     "
       FN_DEF@[377; 407)
         FN_KW@[377; 379) "fn"
@@ -371,9 +378,10 @@ SOURCE_FILE@[0; 519)
             SELF_KW@[399; 403) "self"
           R_PAREN@[403; 404) ")"
         WHITESPACE@[404; 405) " "
-        BLOCK@[405; 407)
-          L_CURLY@[405; 406) "{"
-          R_CURLY@[406; 407) "}"
+        BLOCK_EXPR@[405; 407)
+          BLOCK@[405; 407)
+            L_CURLY@[405; 406) "{"
+            R_CURLY@[406; 407) "}"
       WHITESPACE@[407; 413) "\n     "
       FN_DEF@[413; 447)
         FN_KW@[413; 415) "fn"
@@ -403,9 +411,10 @@ SOURCE_FILE@[0; 519)
             SELF_KW@[439; 443) "self"
           R_PAREN@[443; 444) ")"
         WHITESPACE@[444; 445) " "
-        BLOCK@[445; 447)
-          L_CURLY@[445; 446) "{"
-          R_CURLY@[446; 447) "}"
+        BLOCK_EXPR@[445; 447)
+          BLOCK@[445; 447)
+            L_CURLY@[445; 446) "{"
+            R_CURLY@[446; 447) "}"
       WHITESPACE@[447; 453) "\n     "
       FN_DEF@[453; 480)
         FN_KW@[453; 455) "fn"
@@ -432,9 +441,10 @@ SOURCE_FILE@[0; 519)
                     IDENT@[472; 476) "Self"
           R_PAREN@[476; 477) ")"
         WHITESPACE@[477; 478) " "
-        BLOCK@[478; 480)
-          L_CURLY@[478; 479) "{"
-          R_CURLY@[479; 480) "}"
+        BLOCK_EXPR@[478; 480)
+          BLOCK@[478; 480)
+            L_CURLY@[478; 479) "{"
+            R_CURLY@[479; 480) "}"
       WHITESPACE@[480; 486) "\n     "
       FN_DEF@[486; 517)
         FN_KW@[486; 488) "fn"
@@ -470,8 +480,9 @@ SOURCE_FILE@[0; 519)
                     R_ANGLE@[512; 513) ">"
           R_PAREN@[513; 514) ")"
         WHITESPACE@[514; 515) " "
-        BLOCK@[515; 517)
-          L_CURLY@[515; 516) "{"
-          R_CURLY@[516; 517) "}"
+        BLOCK_EXPR@[515; 517)
+          BLOCK@[515; 517)
+            L_CURLY@[515; 516) "{"
+            R_CURLY@[516; 517) "}"
       WHITESPACE@[517; 518) "\n"
       R_CURLY@[518; 519) "}"

--- a/crates/ra_syntax/test_data/parser/ok/0052_for_range_block.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0052_for_range_block.txt
@@ -8,72 +8,74 @@ SOURCE_FILE@[0; 80)
       L_PAREN@[6; 7) "("
       R_PAREN@[7; 8) ")"
     WHITESPACE@[8; 9) " "
-    BLOCK@[9; 79)
-      L_CURLY@[9; 10) "{"
-      WHITESPACE@[10; 14) "\n   "
-      FOR_EXPR@[14; 77)
-        FOR_KW@[14; 17) "for"
-        WHITESPACE@[17; 18) " "
-        BIND_PAT@[18; 20)
-          NAME@[18; 20)
-            IDENT@[18; 20) "_x"
-        WHITESPACE@[20; 21) " "
-        IN_KW@[21; 23) "in"
-        WHITESPACE@[23; 24) " "
-        RANGE_EXPR@[24; 56)
-          LITERAL@[24; 25)
-            INT_NUMBER@[24; 25) "0"
-          WHITESPACE@[25; 26) " "
-          DOTDOT@[26; 28) ".."
-          WHITESPACE@[28; 29) " "
-          METHOD_CALL_EXPR@[29; 56)
-            PAREN_EXPR@[29; 43)
-              L_PAREN@[29; 30) "("
-              RANGE_EXPR@[30; 42)
-                LITERAL@[30; 31)
-                  INT_NUMBER@[30; 31) "0"
-                WHITESPACE@[31; 32) " "
-                DOTDOT@[32; 34) ".."
-                WHITESPACE@[34; 35) " "
-                BLOCK_EXPR@[35; 42)
-                  BLOCK@[35; 42)
-                    L_CURLY@[35; 36) "{"
-                    BIN_EXPR@[36; 41)
-                      LITERAL@[36; 37)
-                        INT_NUMBER@[36; 37) "1"
-                      WHITESPACE@[37; 38) " "
-                      PLUS@[38; 39) "+"
-                      WHITESPACE@[39; 40) " "
-                      LITERAL@[40; 41)
-                        INT_NUMBER@[40; 41) "2"
-                    R_CURLY@[41; 42) "}"
-              R_PAREN@[42; 43) ")"
-            DOT@[43; 44) "."
-            NAME_REF@[44; 47)
-              IDENT@[44; 47) "sum"
-            TYPE_ARG_LIST@[47; 54)
-              COLONCOLON@[47; 49) "::"
-              L_ANGLE@[49; 50) "<"
-              TYPE_ARG@[50; 53)
-                PATH_TYPE@[50; 53)
-                  PATH@[50; 53)
-                    PATH_SEGMENT@[50; 53)
-                      NAME_REF@[50; 53)
-                        IDENT@[50; 53) "u32"
-              R_ANGLE@[53; 54) ">"
-            ARG_LIST@[54; 56)
-              L_PAREN@[54; 55) "("
-              R_PAREN@[55; 56) ")"
-        WHITESPACE@[56; 57) " "
-        BLOCK@[57; 77)
-          L_CURLY@[57; 58) "{"
-          WHITESPACE@[58; 66) "\n       "
-          EXPR_STMT@[66; 72)
-            BREAK_EXPR@[66; 71)
-              BREAK_KW@[66; 71) "break"
-            SEMI@[71; 72) ";"
-          WHITESPACE@[72; 76) "\n   "
-          R_CURLY@[76; 77) "}"
-      WHITESPACE@[77; 78) "\n"
-      R_CURLY@[78; 79) "}"
+    BLOCK_EXPR@[9; 79)
+      BLOCK@[9; 79)
+        L_CURLY@[9; 10) "{"
+        WHITESPACE@[10; 14) "\n   "
+        FOR_EXPR@[14; 77)
+          FOR_KW@[14; 17) "for"
+          WHITESPACE@[17; 18) " "
+          BIND_PAT@[18; 20)
+            NAME@[18; 20)
+              IDENT@[18; 20) "_x"
+          WHITESPACE@[20; 21) " "
+          IN_KW@[21; 23) "in"
+          WHITESPACE@[23; 24) " "
+          RANGE_EXPR@[24; 56)
+            LITERAL@[24; 25)
+              INT_NUMBER@[24; 25) "0"
+            WHITESPACE@[25; 26) " "
+            DOTDOT@[26; 28) ".."
+            WHITESPACE@[28; 29) " "
+            METHOD_CALL_EXPR@[29; 56)
+              PAREN_EXPR@[29; 43)
+                L_PAREN@[29; 30) "("
+                RANGE_EXPR@[30; 42)
+                  LITERAL@[30; 31)
+                    INT_NUMBER@[30; 31) "0"
+                  WHITESPACE@[31; 32) " "
+                  DOTDOT@[32; 34) ".."
+                  WHITESPACE@[34; 35) " "
+                  BLOCK_EXPR@[35; 42)
+                    BLOCK@[35; 42)
+                      L_CURLY@[35; 36) "{"
+                      BIN_EXPR@[36; 41)
+                        LITERAL@[36; 37)
+                          INT_NUMBER@[36; 37) "1"
+                        WHITESPACE@[37; 38) " "
+                        PLUS@[38; 39) "+"
+                        WHITESPACE@[39; 40) " "
+                        LITERAL@[40; 41)
+                          INT_NUMBER@[40; 41) "2"
+                      R_CURLY@[41; 42) "}"
+                R_PAREN@[42; 43) ")"
+              DOT@[43; 44) "."
+              NAME_REF@[44; 47)
+                IDENT@[44; 47) "sum"
+              TYPE_ARG_LIST@[47; 54)
+                COLONCOLON@[47; 49) "::"
+                L_ANGLE@[49; 50) "<"
+                TYPE_ARG@[50; 53)
+                  PATH_TYPE@[50; 53)
+                    PATH@[50; 53)
+                      PATH_SEGMENT@[50; 53)
+                        NAME_REF@[50; 53)
+                          IDENT@[50; 53) "u32"
+                R_ANGLE@[53; 54) ">"
+              ARG_LIST@[54; 56)
+                L_PAREN@[54; 55) "("
+                R_PAREN@[55; 56) ")"
+          WHITESPACE@[56; 57) " "
+          BLOCK_EXPR@[57; 77)
+            BLOCK@[57; 77)
+              L_CURLY@[57; 58) "{"
+              WHITESPACE@[58; 66) "\n       "
+              EXPR_STMT@[66; 72)
+                BREAK_EXPR@[66; 71)
+                  BREAK_KW@[66; 71) "break"
+                SEMI@[71; 72) ";"
+              WHITESPACE@[72; 76) "\n   "
+              R_CURLY@[76; 77) "}"
+        WHITESPACE@[77; 78) "\n"
+        R_CURLY@[78; 79) "}"
   WHITESPACE@[79; 80) "\n"


### PR DESCRIPTION
This way, things like function bodies are expressions, and we don't have to single them out