### PR TITLE
add option to disable notify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,7 +958,7 @@ dependencies = [
  "ra_hir 0.1.0",
  "ra_ide_api 0.1.0",
  "ra_project_model 0.1.0",
- "ra_vfs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ra_vfs 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ra_vfs_glob 0.1.0",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1065,7 +1065,7 @@ dependencies = [
  "ra_project_model 0.1.0",
  "ra_syntax 0.1.0",
  "ra_text_edit 0.1.0",
- "ra_vfs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ra_vfs 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ra_vfs_glob 0.1.0",
  "relative-path 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "ra_vfs"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1183,7 +1183,7 @@ name = "ra_vfs_glob"
 version = "0.1.0"
 dependencies = [
  "globset 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "ra_vfs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ra_vfs 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1945,7 +1945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
-"checksum ra_vfs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ccc8b709e0b7ceec822513451b610df1b9370b01953a8bc545a041a6b3bfef01"
+"checksum ra_vfs 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fdf6a0926414eb0c00866eb9274894182302f879cd06b5459c1d8ee7f1234aed"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d47eab0e83d9693d40f825f86948aa16eff6750ead4bdffc4ab95b8b3a7f052c"
 "checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"

--- a/crates/ra_batch/Cargo.toml
+++ b/crates/ra_batch/Cargo.toml
@@ -9,7 +9,7 @@ log = "0.4.5"
 rustc-hash = "1.0"
 crossbeam-channel = "0.3.5"
 
-ra_vfs = "0.3.0"
+ra_vfs = "0.4.0"
 ra_vfs_glob = { path = "../ra_vfs_glob" }
 ra_db = { path = "../ra_db" }
 ra_ide_api = { path = "../ra_ide_api" }

--- a/crates/ra_batch/src/lib.rs
+++ b/crates/ra_batch/src/lib.rs
@@ -6,7 +6,7 @@ use crossbeam_channel::{unbounded, Receiver};
 use ra_db::{CrateGraph, FileId, SourceRootId};
 use ra_ide_api::{AnalysisChange, AnalysisHost, FeatureFlags};
 use ra_project_model::{PackageRoot, ProjectWorkspace};
-use ra_vfs::{RootEntry, Vfs, VfsChange, VfsTask};
+use ra_vfs::{RootEntry, Vfs, VfsChange, VfsTask, Watch};
 use ra_vfs_glob::RustPackageFilterBuilder;
 
 type Result<T> = std::result::Result<T, Box<dyn Error + Send + Sync>>;
@@ -37,6 +37,7 @@ pub fn load_cargo(root: &Path) -> Result<(AnalysisHost, FxHashMap<SourceRootId, 
             })
             .collect(),
         sender,
+        Watch(false),
     );
     let crate_graph = ws.to_crate_graph(&mut |path: &Path| {
         let vfs_file = vfs.load(path);

--- a/crates/ra_lsp_server/Cargo.toml
+++ b/crates/ra_lsp_server/Cargo.toml
@@ -16,7 +16,7 @@ lsp-types = { version = "0.61.0", features = ["proposed"] }
 rustc-hash = "1.0"
 parking_lot = "0.9.0"
 jod-thread = "0.1.0"
-ra_vfs = "0.3.0"
+ra_vfs = "0.4.0"
 ra_syntax = { path = "../ra_syntax" }
 ra_text_edit = { path = "../ra_text_edit" }
 ra_ide_api = { path = "../ra_ide_api" }

--- a/crates/ra_lsp_server/src/config.rs
+++ b/crates/ra_lsp_server/src/config.rs
@@ -15,6 +15,8 @@ pub struct ServerConfig {
     pub publish_decorations: bool,
 
     pub exclude_globs: Vec<String>,
+    #[serde(deserialize_with = "nullable_bool_false")]
+    pub use_client_watching: bool,
 
     pub lru_capacity: Option<usize>,
 
@@ -31,6 +33,7 @@ impl Default for ServerConfig {
         ServerConfig {
             publish_decorations: false,
             exclude_globs: Vec::new(),
+            use_client_watching: false,
             lru_capacity: None,
             with_sysroot: true,
             feature_flags: FxHashMap::default(),

--- a/crates/ra_lsp_server/src/req.rs
+++ b/crates/ra_lsp_server/src/req.rs
@@ -5,10 +5,11 @@ use serde::{Deserialize, Serialize};
 pub use lsp_types::{
     notification::*, request::*, ApplyWorkspaceEditParams, CodeActionParams, CodeLens,
     CodeLensParams, CompletionParams, CompletionResponse, DidChangeConfigurationParams,
-    DocumentOnTypeFormattingParams, DocumentSymbolParams, DocumentSymbolResponse, Hover,
-    InitializeResult, MessageType, PublishDiagnosticsParams, ReferenceParams, ShowMessageParams,
-    SignatureHelp, TextDocumentEdit, TextDocumentPositionParams, TextEdit, WorkspaceEdit,
-    WorkspaceSymbolParams,
+    DidChangeWatchedFilesParams, DidChangeWatchedFilesRegistrationOptions,
+    DocumentOnTypeFormattingParams, DocumentSymbolParams, DocumentSymbolResponse,
+    FileSystemWatcher, Hover, InitializeResult, MessageType, PublishDiagnosticsParams,
+    ReferenceParams, Registration, RegistrationParams, ShowMessageParams, SignatureHelp,
+    TextDocumentEdit, TextDocumentPositionParams, TextEdit, WorkspaceEdit, WorkspaceSymbolParams,
 };
 
 pub enum AnalyzerStatus {}

--- a/crates/ra_lsp_server/src/world.rs
+++ b/crates/ra_lsp_server/src/world.rs
@@ -12,7 +12,7 @@ use ra_ide_api::{
     SourceRootId,
 };
 use ra_project_model::ProjectWorkspace;
-use ra_vfs::{LineEndings, RootEntry, Vfs, VfsChange, VfsFile, VfsRoot, VfsTask};
+use ra_vfs::{LineEndings, RootEntry, Vfs, VfsChange, VfsFile, VfsRoot, VfsTask, Watch};
 use ra_vfs_glob::{Glob, RustPackageFilterBuilder};
 use relative_path::RelativePathBuf;
 
@@ -60,6 +60,7 @@ impl WorldState {
         workspaces: Vec<ProjectWorkspace>,
         lru_capacity: Option<usize>,
         exclude_globs: &[Glob],
+        watch: Watch,
         options: Options,
         feature_flags: FeatureFlags,
     ) -> WorldState {
@@ -85,7 +86,7 @@ impl WorldState {
         }
         let (task_sender, task_receiver) = unbounded();
         let task_sender = Box::new(move |t| task_sender.send(t).unwrap());
-        let (mut vfs, vfs_roots) = Vfs::new(roots, task_sender);
+        let (mut vfs, vfs_roots) = Vfs::new(roots, task_sender, watch);
         let roots_to_scan = vfs_roots.len();
         for r in vfs_roots {
             let vfs_root_path = vfs.root2path(r);

--- a/crates/ra_vfs_glob/Cargo.toml
+++ b/crates/ra_vfs_glob/Cargo.toml
@@ -5,5 +5,5 @@ version = "0.1.0"
 authors = ["rust-analyzer developers"]
 
 [dependencies]
-ra_vfs = "0.3.0"
+ra_vfs = "0.4.0"
 globset = "0.4.4"

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -74,6 +74,8 @@ See https://github.com/microsoft/vscode/issues/72308[microsoft/vscode#72308] for
 * `rust-analyzer.excludeGlobs`: a list of glob-patterns for exclusion (see globset [docs](https://docs.rs/globset) for syntax).
   Note: glob patterns are applied to all Cargo packages and a rooted at a package root.
   This is not very intuitive and a limitation of a current implementation.
+* `rust-analyzer.useClientWatching`: use client provided file watching instead
+  of notify watching.
 * `rust-analyzer.cargo-watch.check-arguments`: cargo-watch check arguments.
   (e.g: `--features="shumway,pdf"` will run as `cargo watch -x "check --features="shumway,pdf""` )
 * `rust-analyzer.trace.server`: enables internal logging

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -205,6 +205,11 @@
                     "default": [],
                     "description": "Paths to exclude from analysis"
                 },
+                "rust-analyzer.useClientWatching": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "client provided file watching instead of notify watching."
+                },
                 "rust-analyzer.cargo-watch.arguments": {
                     "type": "string",
                     "description": "`cargo-watch` arguments. (e.g: `--features=\"shumway,pdf\"` will run as `cargo watch -x \"check --features=\"shumway,pdf\"\"` )",

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -23,6 +23,7 @@ export class Config {
     public lruCapacity: null | number = null;
     public displayInlayHints = true;
     public excludeGlobs = [];
+    public useClientWatching = false;
     public featureFlags = {};
     public cargoWatchOptions: CargoWatchOptions = {
         enableOnStartup: 'ask',
@@ -132,6 +133,9 @@ export class Config {
         }
         if (config.has('excludeGlobs')) {
             this.excludeGlobs = config.get('excludeGlobs') || [];
+        }
+        if (config.has('useClientWatching')) {
+            this.useClientWatching = config.get('useClientWatching') || false;
         }
         if (config.has('featureFlags')) {
             this.featureFlags = config.get('featureFlags') || {};

--- a/editors/code/src/server.ts
+++ b/editors/code/src/server.ts
@@ -46,6 +46,7 @@ export class Server {
                     Server.config.showWorkspaceLoadedNotification,
                 lruCapacity: Server.config.lruCapacity,
                 excludeGlobs: Server.config.excludeGlobs,
+                useClientWatching: Server.config.useClientWatching,
                 featureFlags: Server.config.featureFlags
             },
             traceOutputChannel


### PR DESCRIPTION
This should help if notify uses 100% of CPU. Put

```
{
    "rust-analyzer.useClientWatching": true,
}
```

into `.vscode/settings.json` (or appropriate config of your editor) to use editor's file watching capabilites instead of notify