### PR TITLE
Fix outer doc-comments of `macro_rules`

### DIFF
--- a/crates/ra_syntax/src/parsing/text_tree_sink.rs
+++ b/crates/ra_syntax/src/parsing/text_tree_sink.rs
@@ -144,8 +144,8 @@ fn n_attached_trivias<'a>(
     trivias: impl Iterator<Item = (SyntaxKind, &'a str)>,
 ) -> usize {
     match kind {
-        CONST_DEF | TYPE_ALIAS_DEF | STRUCT_DEF | ENUM_DEF | ENUM_VARIANT | FN_DEF | TRAIT_DEF
-        | MODULE | RECORD_FIELD_DEF => {
+        MACRO_CALL | CONST_DEF | TYPE_ALIAS_DEF | STRUCT_DEF | ENUM_DEF | ENUM_VARIANT | FN_DEF
+        | TRAIT_DEF | MODULE | RECORD_FIELD_DEF => {
             let mut res = 0;
             for (i, (kind, text)) in trivias.enumerate() {
                 match kind {

--- a/crates/ra_syntax/test_data/parser/ok/0053_outer_attribute_on_macro_rules.rs
+++ b/crates/ra_syntax/test_data/parser/ok/0053_outer_attribute_on_macro_rules.rs
@@ -1,0 +1,5 @@
+/// Some docs
+#[macro_export]
+macro_rules! foo {
+    () => {};
+}

--- a/crates/ra_syntax/test_data/parser/ok/0053_outer_attribute_on_macro_rules.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0053_outer_attribute_on_macro_rules.txt
@@ -1,0 +1,37 @@
+SOURCE_FILE@[0; 65)
+  MACRO_CALL@[0; 64)
+    COMMENT@[0; 13) "/// Some docs"
+    WHITESPACE@[13; 14) "\n"
+    ATTR@[14; 29)
+      POUND@[14; 15) "#"
+      TOKEN_TREE@[15; 29)
+        L_BRACK@[15; 16) "["
+        IDENT@[16; 28) "macro_export"
+        R_BRACK@[28; 29) "]"
+    WHITESPACE@[29; 30) "\n"
+    PATH@[30; 41)
+      PATH_SEGMENT@[30; 41)
+        NAME_REF@[30; 41)
+          IDENT@[30; 41) "macro_rules"
+    EXCL@[41; 42) "!"
+    WHITESPACE@[42; 43) " "
+    NAME@[43; 46)
+      IDENT@[43; 46) "foo"
+    WHITESPACE@[46; 47) " "
+    TOKEN_TREE@[47; 64)
+      L_CURLY@[47; 48) "{"
+      WHITESPACE@[48; 53) "\n    "
+      TOKEN_TREE@[53; 55)
+        L_PAREN@[53; 54) "("
+        R_PAREN@[54; 55) ")"
+      WHITESPACE@[55; 56) " "
+      EQ@[56; 57) "="
+      R_ANGLE@[57; 58) ">"
+      WHITESPACE@[58; 59) " "
+      TOKEN_TREE@[59; 61)
+        L_CURLY@[59; 60) "{"
+        R_CURLY@[60; 61) "}"
+      SEMI@[61; 62) ";"
+      WHITESPACE@[62; 63) "\n"
+      R_CURLY@[63; 64) "}"
+  WHITESPACE@[64; 65) "\n"


### PR DESCRIPTION
Document comments of `macro_rules!` is currently parsed outside the `MACRO_CALL` node,
which makes `DocCommentsOwner::doc_comments()` always empty.

For the input:
```rust
/// Some docs
macro_rules! foo {
    () => {};
}
```

Current parsing tree is:
```
SOURCE_FILE
  COMMENT    // <- This should be children of MACRO_CALL
  WHITESPACE
  MACRO_CALL
    PATH
<...omitted...>
```

It should be:
```
SOURCE_FILE
  MACRO_CALL
    COMMENT
    WHITESPACE
    PATH
<...omitted...>
```
