### PR TITLE
Make macro scope a real name scope and fix some details

### DIFF
--- a/crates/ra_hir/src/nameres/per_ns.rs
+++ b/crates/ra_hir/src/nameres/per_ns.rs
@@ -4,7 +4,8 @@ use crate::MacroDef;
 pub enum Namespace {
     Types,
     Values,
-    Macro,
+    // Note that only type inference uses this enum, and it doesn't care about macros.
+    // Macro,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -79,14 +80,7 @@ impl<T> PerNs<T> {
         }
     }
 
-    pub fn and_then<U>(self, f: impl Fn(T) -> Option<U>) -> PerNs<U> {
-        PerNs {
-            types: self.types.and_then(&f),
-            values: self.values.and_then(&f),
-            macros: self.macros,
-        }
-    }
-
+    /// Map types and values. Leave macros unchanged.
     pub fn map<U>(self, f: impl Fn(T) -> U) -> PerNs<U> {
         PerNs { types: self.types.map(&f), values: self.values.map(&f), macros: self.macros }
     }

--- a/crates/ra_hir/src/nameres/per_ns.rs
+++ b/crates/ra_hir/src/nameres/per_ns.rs
@@ -1,78 +1,93 @@
+use crate::MacroDef;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Namespace {
     Types,
     Values,
+    Macro,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct PerNs<T> {
     pub types: Option<T>,
     pub values: Option<T>,
+    /// Since macros has different type, many methods simply ignore it.
+    /// We can only use special method like `get_macros` to access it.
+    pub macros: Option<MacroDef>,
 }
 
 impl<T> Default for PerNs<T> {
     fn default() -> Self {
-        PerNs { types: None, values: None }
+        PerNs { types: None, values: None, macros: None }
     }
 }
 
 impl<T> PerNs<T> {
     pub fn none() -> PerNs<T> {
-        PerNs { types: None, values: None }
+        PerNs { types: None, values: None, macros: None }
     }
 
     pub fn values(t: T) -> PerNs<T> {
-        PerNs { types: None, values: Some(t) }
+        PerNs { types: None, values: Some(t), macros: None }
     }
 
     pub fn types(t: T) -> PerNs<T> {
-        PerNs { types: Some(t), values: None }
+        PerNs { types: Some(t), values: None, macros: None }
     }
 
     pub fn both(types: T, values: T) -> PerNs<T> {
-        PerNs { types: Some(types), values: Some(values) }
+        PerNs { types: Some(types), values: Some(values), macros: None }
+    }
+
+    pub fn macros(macro_: MacroDef) -> PerNs<T> {
+        PerNs { types: None, values: None, macros: Some(macro_) }
     }
 
     pub fn is_none(&self) -> bool {
-        self.types.is_none() && self.values.is_none()
+        self.types.is_none() && self.values.is_none() && self.macros.is_none()
     }
 
-    pub fn is_both(&self) -> bool {
-        self.types.is_some() && self.values.is_some()
-    }
-
-    pub fn take(self, namespace: Namespace) -> Option<T> {
-        match namespace {
-            Namespace::Types => self.types,
-            Namespace::Values => self.values,
-        }
+    pub fn is_all(&self) -> bool {
+        self.types.is_some() && self.values.is_some() && self.macros.is_some()
     }
 
     pub fn take_types(self) -> Option<T> {
-        self.take(Namespace::Types)
+        self.types
     }
 
     pub fn take_values(self) -> Option<T> {
-        self.take(Namespace::Values)
+        self.values
     }
 
-    pub fn get(&self, namespace: Namespace) -> Option<&T> {
-        self.as_ref().take(namespace)
+    pub fn get_macros(&self) -> Option<MacroDef> {
+        self.macros
+    }
+
+    pub fn only_macros(&self) -> PerNs<T> {
+        PerNs { types: None, values: None, macros: self.macros }
     }
 
     pub fn as_ref(&self) -> PerNs<&T> {
-        PerNs { types: self.types.as_ref(), values: self.values.as_ref() }
+        PerNs { types: self.types.as_ref(), values: self.values.as_ref(), macros: self.macros }
     }
 
     pub fn or(self, other: PerNs<T>) -> PerNs<T> {
-        PerNs { types: self.types.or(other.types), values: self.values.or(other.values) }
+        PerNs {
+            types: self.types.or(other.types),
+            values: self.values.or(other.values),
+            macros: self.macros.or(other.macros),
+        }
     }
 
     pub fn and_then<U>(self, f: impl Fn(T) -> Option<U>) -> PerNs<U> {
-        PerNs { types: self.types.and_then(&f), values: self.values.and_then(&f) }
+        PerNs {
+            types: self.types.and_then(&f),
+            values: self.values.and_then(&f),
+            macros: self.macros,
+        }
     }
 
     pub fn map<U>(self, f: impl Fn(T) -> U) -> PerNs<U> {
-        PerNs { types: self.types.map(&f), values: self.values.map(&f) }
+        PerNs { types: self.types.map(&f), values: self.values.map(&f), macros: self.macros }
     }
 }

--- a/crates/ra_hir/src/ty/lower.rs
+++ b/crates/ra_hir/src/ty/lower.rs
@@ -429,6 +429,9 @@ pub(crate) fn type_for_def(db: &impl HirDatabase, def: TypableDef, ns: Namespace
         (TypableDef::Const(_), Namespace::Types) => Ty::Unknown,
         (TypableDef::Static(_), Namespace::Types) => Ty::Unknown,
         (TypableDef::BuiltinType(_), Namespace::Values) => Ty::Unknown,
+
+        // Macro is not typeable
+        (_, Namespace::Macro) => Ty::Unknown,
     }
 }
 

--- a/crates/ra_hir/src/ty/lower.rs
+++ b/crates/ra_hir/src/ty/lower.rs
@@ -429,9 +429,6 @@ pub(crate) fn type_for_def(db: &impl HirDatabase, def: TypableDef, ns: Namespace
         (TypableDef::Const(_), Namespace::Types) => Ty::Unknown,
         (TypableDef::Static(_), Namespace::Types) => Ty::Unknown,
         (TypableDef::BuiltinType(_), Namespace::Values) => Ty::Unknown,
-
-        // Macro is not typeable
-        (_, Namespace::Macro) => Ty::Unknown,
     }
 }
 


### PR DESCRIPTION
This PR make macro's module scope a real name scope in `PerNs`, instead of handling `Either<PerNs, MacroDef>` everywhere.

In `rustc`, the macro scope behave exactly the same as type and value scope.
It is valid that macros, types and values having exact the same name, and a `use` statement will import all of them. This happened to module `alloc::vec` and macro `alloc::vec!`.
So `Either` is not suitable here.

There is a trap that not only does `#[macro_use]` import all `#[macro_export] macro_rules`, but also imports all macros `use`d in the crate root.
In other words, it just _imports all macros in the module scope of crate root_. (Visibility of `use` doesn't matter.)

And it also happened to `libstd` which has `use alloc_crate::vec;` in crate root to re-export `alloc::vec`, which it both a module and a macro.
The current implementation of `#[macro_use] extern crate` doesn't work here, so that is why only macros directly from  `libstd` like `dbg!` work, while `vec!` from `liballoc` doesn't.
This PR fixes this.

Another point is that, after some tests, I figure out that _`macro_rules` does NOT define macro in current module scope at all_.
It defines itself in legacy textual scope. And if `#[macro_export]` is given, it also is defined ONLY in module scope of crate root. (Then being `macro_use`d, as mentioned above)
(Well, the nightly [Declarative Macro 2.0](https://github.com/rust-lang/rust/issues/39412) simply always define in current module scope only, just like normal items do. But it is not yet supported by us)

After this PR, in my test, all non-builtin macros are resolved now. (Hover text for documentation is available) So it fixes #1688 . Since compiler builtin macros are marked as `#[rustc_doc_only_macro]` instead of `#[macro_export]`, we can simply tweak the condition to let it resolved, but it may cause expansion error.

Some critical notes are also given in doc-comments.

<img width="447" alt="Screenshot_20190909_223859" src="https://user-images.githubusercontent.com/14816024/64540366-ac1ef600-d352-11e9-804f-566ba7559206.png">
