### PR TITLE
Support completion for macros

### DIFF
--- a/crates/ra_hir/src/nameres.rs
+++ b/crates/ra_hir/src/nameres.rs
@@ -416,7 +416,7 @@ impl CrateDefMap {
                         );
                     }
 
-                    // Since it is a quantified path here, it should not contains legacy macros
+                    // Since it is a qualified path here, it should not contains legacy macros
                     match self[module.module_id].scope.get(&segment.name) {
                         Some(res) => res.def,
                         _ => {

--- a/crates/ra_hir/src/nameres/tests/macros.rs
+++ b/crates/ra_hir/src/nameres/tests/macros.rs
@@ -430,7 +430,7 @@ fn macro_use_can_be_aliased() {
 }
 
 #[test]
-fn path_quantified_macros() {
+fn path_qualified_macros() {
     let map = def_map(
         "
         //- /main.rs

--- a/crates/ra_hir/src/ty/tests.rs
+++ b/crates/ra_hir/src/ty/tests.rs
@@ -2839,7 +2839,7 @@ fn main() {
 }
 
 #[test]
-fn infer_path_quantified_macros_expanded() {
+fn infer_path_qualified_macros_expanded() {
     assert_snapshot!(
         infer(r#"
 #[macro_export]

--- a/crates/ra_ide_api/src/completion.rs
+++ b/crates/ra_ide_api/src/completion.rs
@@ -12,6 +12,7 @@ mod complete_snippet;
 mod complete_path;
 mod complete_scope;
 mod complete_postfix;
+mod complete_macro_in_item_position;
 
 use ra_db::SourceDatabase;
 
@@ -69,5 +70,6 @@ pub(crate) fn completions(db: &db::RootDatabase, position: FilePosition) -> Opti
     complete_record_pattern::complete_record_pattern(&mut acc, &ctx);
     complete_pattern::complete_pattern(&mut acc, &ctx);
     complete_postfix::complete_postfix(&mut acc, &ctx);
+    complete_macro_in_item_position::complete_macro_in_item_position(&mut acc, &ctx);
     Some(acc)
 }

--- a/crates/ra_ide_api/src/completion/complete_macro_in_item_position.rs
+++ b/crates/ra_ide_api/src/completion/complete_macro_in_item_position.rs
@@ -1,0 +1,50 @@
+use crate::completion::{CompletionContext, Completions};
+
+pub(super) fn complete_macro_in_item_position(acc: &mut Completions, ctx: &CompletionContext) {
+    // Show only macros in top level.
+    if ctx.is_new_item {
+        for (name, res) in ctx.analyzer.all_names(ctx.db) {
+            if res.get_macros().is_some() {
+                acc.add_resolution(ctx, name.to_string(), &res.only_macros());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::completion::{do_completion, CompletionItem, CompletionKind};
+    use insta::assert_debug_snapshot;
+
+    fn do_reference_completion(code: &str) -> Vec<CompletionItem> {
+        do_completion(code, CompletionKind::Reference)
+    }
+
+    #[test]
+    fn completes_macros_as_item() {
+        assert_debug_snapshot!(
+            do_reference_completion(
+                "
+                //- /main.rs
+                macro_rules! foo {
+                    () => {}
+                }
+
+                fn foo() {}
+
+                <|>
+                "
+            ),
+            @r##"[
+    CompletionItem {
+        label: "foo",
+        source_range: [46; 46),
+        delete: [46; 46),
+        insert: "foo!",
+        kind: Macro,
+        detail: "macro_rules! foo",
+    },
+]"##
+        );
+    }
+}

--- a/crates/ra_ide_api/src/completion/complete_path.rs
+++ b/crates/ra_ide_api/src/completion/complete_path.rs
@@ -587,4 +587,40 @@ mod tests {
 ]"###
         );
     }
+
+    #[test]
+    fn completes_quantified_macros() {
+        assert_debug_snapshot!(
+            do_reference_completion(
+                "
+                #[macro_export]
+                macro_rules! foo {
+                    () => {}
+                }
+
+                fn main() {
+                    let _ = crate::<|>
+                }
+                "
+            ),
+            @r###"[
+    CompletionItem {
+        label: "foo",
+        source_range: [179; 179),
+        delete: [179; 179),
+        insert: "foo!",
+        kind: Macro,
+        detail: "#[macro_export]\nmacro_rules! foo",
+    },
+    CompletionItem {
+        label: "main",
+        source_range: [179; 179),
+        delete: [179; 179),
+        insert: "main()$0",
+        kind: Function,
+        detail: "fn main()",
+    },
+]"###
+        );
+    }
 }

--- a/crates/ra_ide_api/src/completion/complete_path.rs
+++ b/crates/ra_ide_api/src/completion/complete_path.rs
@@ -589,7 +589,7 @@ mod tests {
     }
 
     #[test]
-    fn completes_quantified_macros() {
+    fn completes_qualified_macros() {
         assert_debug_snapshot!(
             do_reference_completion(
                 "

--- a/crates/ra_ide_api/src/completion/complete_scope.rs
+++ b/crates/ra_ide_api/src/completion/complete_scope.rs
@@ -6,6 +6,15 @@ use rustc_hash::FxHashMap;
 use crate::completion::{CompletionContext, CompletionItem, CompletionKind, Completions};
 
 pub(super) fn complete_scope(acc: &mut Completions, ctx: &CompletionContext) {
+    // Show only macros in top level.
+    if ctx.is_new_item {
+        for (name, res) in ctx.analyzer.all_names(ctx.db) {
+            if res.get_macros().is_some() {
+                acc.add_resolution(ctx, name.to_string(), &res.only_macros());
+            }
+        }
+    }
+
     if !ctx.is_trivial_path {
         return;
     }
@@ -530,6 +539,226 @@ mod tests {
         kind: Module,
     },
 ]"#
+        );
+    }
+
+    #[test]
+    fn completes_macros_as_value() {
+        assert_debug_snapshot!(
+            do_reference_completion(
+                "
+                //- /main.rs
+                macro_rules! foo {
+                    () => {}
+                }
+
+                #[macro_use]
+                mod m1 {
+                    macro_rules! bar {
+                        () => {}
+                    }
+                }
+
+                mod m2 {
+                    macro_rules! nope {
+                        () => {}
+                    }
+
+                    #[macro_export]
+                    macro_rules! baz {
+                        () => {}
+                    }
+                }
+
+                fn main() {
+                    let v = <|>
+                }
+                "
+            ),
+            @r##"[
+    CompletionItem {
+        label: "bar",
+        source_range: [252; 252),
+        delete: [252; 252),
+        insert: "bar!",
+        kind: Macro,
+        detail: "macro_rules! bar",
+    },
+    CompletionItem {
+        label: "baz",
+        source_range: [252; 252),
+        delete: [252; 252),
+        insert: "baz!",
+        kind: Macro,
+        detail: "#[macro_export]\nmacro_rules! baz",
+    },
+    CompletionItem {
+        label: "foo",
+        source_range: [252; 252),
+        delete: [252; 252),
+        insert: "foo!",
+        kind: Macro,
+        detail: "macro_rules! foo",
+    },
+    CompletionItem {
+        label: "m1",
+        source_range: [252; 252),
+        delete: [252; 252),
+        insert: "m1",
+        kind: Module,
+    },
+    CompletionItem {
+        label: "m2",
+        source_range: [252; 252),
+        delete: [252; 252),
+        insert: "m2",
+        kind: Module,
+    },
+    CompletionItem {
+        label: "main",
+        source_range: [252; 252),
+        delete: [252; 252),
+        insert: "main()$0",
+        kind: Function,
+        detail: "fn main()",
+    },
+]"##
+        );
+    }
+
+    #[test]
+    fn completes_both_macro_and_value() {
+        assert_debug_snapshot!(
+            do_reference_completion(
+                "
+                //- /main.rs
+                macro_rules! foo {
+                    () => {}
+                }
+
+                fn foo() {
+                    <|>
+                }
+                "
+            ),
+            @r##"[
+    CompletionItem {
+        label: "foo",
+        source_range: [49; 49),
+        delete: [49; 49),
+        insert: "foo!",
+        kind: Macro,
+        detail: "macro_rules! foo",
+    },
+    CompletionItem {
+        label: "foo",
+        source_range: [49; 49),
+        delete: [49; 49),
+        insert: "foo()$0",
+        kind: Function,
+        detail: "fn foo()",
+    },
+]"##
+        );
+    }
+
+    #[test]
+    fn completes_macros_as_type() {
+        assert_debug_snapshot!(
+            do_reference_completion(
+                "
+                //- /main.rs
+                macro_rules! foo {
+                    () => {}
+                }
+
+                fn main() {
+                    let x: <|>
+                }
+                "
+            ),
+            @r##"[
+    CompletionItem {
+        label: "foo",
+        source_range: [57; 57),
+        delete: [57; 57),
+        insert: "foo!",
+        kind: Macro,
+        detail: "macro_rules! foo",
+    },
+    CompletionItem {
+        label: "main",
+        source_range: [57; 57),
+        delete: [57; 57),
+        insert: "main()$0",
+        kind: Function,
+        detail: "fn main()",
+    },
+]"##
+        );
+    }
+
+    #[test]
+    fn completes_macros_as_stmt() {
+        assert_debug_snapshot!(
+            do_reference_completion(
+                "
+                //- /main.rs
+                macro_rules! foo {
+                    () => {}
+                }
+
+                fn main() {
+                    <|>
+                }
+                "
+            ),
+            @r##"[
+    CompletionItem {
+        label: "foo",
+        source_range: [50; 50),
+        delete: [50; 50),
+        insert: "foo!",
+        kind: Macro,
+        detail: "macro_rules! foo",
+    },
+    CompletionItem {
+        label: "main",
+        source_range: [50; 50),
+        delete: [50; 50),
+        insert: "main()$0",
+        kind: Function,
+        detail: "fn main()",
+    },
+]"##
+        );
+    }
+
+    #[test]
+    fn completes_macros_as_item() {
+        assert_debug_snapshot!(
+            do_reference_completion(
+                "
+                //- /main.rs
+                macro_rules! foo {
+                    () => {}
+                }
+
+                fn foo() {}
+
+                <|>
+                "
+            ),
+            @r##"[
+    CompletionItem {
+        label: "foo",
+        source_range: [46; 46),
+        delete: [46; 46),
+        insert: "foo!",
+        kind: Macro,
+        detail: "macro_rules! foo",
+    },
+]"##
         );
     }
 }

--- a/crates/ra_ide_api/src/completion/complete_scope.rs
+++ b/crates/ra_ide_api/src/completion/complete_scope.rs
@@ -6,15 +6,6 @@ use rustc_hash::FxHashMap;
 use crate::completion::{CompletionContext, CompletionItem, CompletionKind, Completions};
 
 pub(super) fn complete_scope(acc: &mut Completions, ctx: &CompletionContext) {
-    // Show only macros in top level.
-    if ctx.is_new_item {
-        for (name, res) in ctx.analyzer.all_names(ctx.db) {
-            if res.get_macros().is_some() {
-                acc.add_resolution(ctx, name.to_string(), &res.only_macros());
-            }
-        }
-    }
-
     if !ctx.is_trivial_path {
         return;
     }
@@ -729,34 +720,6 @@ mod tests {
         insert: "main()$0",
         kind: Function,
         detail: "fn main()",
-    },
-]"##
-        );
-    }
-
-    #[test]
-    fn completes_macros_as_item() {
-        assert_debug_snapshot!(
-            do_reference_completion(
-                "
-                //- /main.rs
-                macro_rules! foo {
-                    () => {}
-                }
-
-                fn foo() {}
-
-                <|>
-                "
-            ),
-            @r##"[
-    CompletionItem {
-        label: "foo",
-        source_range: [46; 46),
-        delete: [46; 46),
-        insert: "foo!",
-        kind: Macro,
-        detail: "macro_rules! foo",
     },
 ]"##
         );

--- a/crates/ra_ide_api/src/display.rs
+++ b/crates/ra_ide_api/src/display.rs
@@ -7,7 +7,7 @@ mod structure;
 mod short_label;
 
 use ra_syntax::{
-    ast::{self, AstNode, TypeParamsOwner},
+    ast::{self, AstNode, AttrsOwner, NameOwner, TypeParamsOwner},
     SyntaxKind::{ATTR, COMMENT},
 };
 
@@ -59,6 +59,12 @@ pub(crate) fn where_predicates<N: TypeParamsOwner>(node: &N) -> Vec<String> {
         res.extend(clause.predicates().map(|p| p.syntax().text().to_string()));
     }
     res
+}
+
+pub(crate) fn macro_label(node: &ast::MacroCall) -> String {
+    let name = node.name().map(|name| name.syntax().text().to_string()).unwrap_or_default();
+    let vis = if node.has_atom_attr("macro_export") { "#[macro_export]\n" } else { "" };
+    format!("{}macro_rules! {}", vis, name)
 }
 
 pub(crate) fn rust_code_markup<CODE: AsRef<str>>(val: CODE) -> String {


### PR DESCRIPTION
This is based on #1795 , and fixes #1727 

Also prettify hover text of macros.

Some screenshorts below:

Completion in item place.
<img width="416" alt="Screenshot_20190910_134056" src="https://user-images.githubusercontent.com/14816024/64587159-fa72da00-d3d0-11e9-86bb-c98f169ec08d.png">

After pressing `tab`.
<img width="313" alt="Screenshot_20190910_134111" src="https://user-images.githubusercontent.com/14816024/64587160-fa72da00-d3d0-11e9-9464-21e3f6957bd7.png">

Complete macros from `std`.
<img width="588" alt="Screenshot_20190910_134147" src="https://user-images.githubusercontent.com/14816024/64587161-fb0b7080-d3d0-11e9-866e-5161f0d1b546.png">

Hover text.
<img width="521" alt="Screenshot_20190910_134242" src="https://user-images.githubusercontent.com/14816024/64587162-fb0b7080-d3d0-11e9-8f09-ad17e3f6702a.png">

