### PR TITLE
Use VSCode fs API's in extension

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -13,7 +13,7 @@
         "Other"
     ],
     "engines": {
-        "vscode": "^1.36.0"
+        "vscode": "^1.37.0"
     },
     "scripts": {
         "vscode:prepublish": "npm run compile",

--- a/editors/code/src/commands/cargo_watch.ts
+++ b/editors/code/src/commands/cargo_watch.ts
@@ -1,5 +1,4 @@
 import * as child_process from 'child_process';
-import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
@@ -15,23 +14,23 @@ import {
 import SuggestedFixCollection from '../utils/diagnostics/SuggestedFixCollection';
 import { areDiagnosticsEqual } from '../utils/diagnostics/vscode';
 
-export function registerCargoWatchProvider(
+export async function registerCargoWatchProvider(
     subscriptions: vscode.Disposable[]
-): CargoWatchProvider | undefined {
+): Promise<CargoWatchProvider | undefined> {
     let cargoExists = false;
-    const cargoTomlFile = path.join(vscode.workspace.rootPath!, 'Cargo.toml');
+
     // Check if the working directory is valid cargo root path
-    try {
-        if (fs.existsSync(cargoTomlFile)) {
-            cargoExists = true;
-        }
-    } catch (err) {
-        cargoExists = false;
+    const cargoTomlPath = path.join(vscode.workspace.rootPath!, 'Cargo.toml');
+    const cargoTomlUri = vscode.Uri.file(cargoTomlPath);
+    const cargoTomlFileInfo = await vscode.workspace.fs.stat(cargoTomlUri);
+
+    if (cargoTomlFileInfo) {
+        cargoExists = true;
     }
 
     if (!cargoExists) {
         vscode.window.showErrorMessage(
-            `Couldn\'t find \'Cargo.toml\' in ${cargoTomlFile}`
+            `Couldn\'t find \'Cargo.toml\' at ${cargoTomlPath}`
         );
         return;
     }


### PR DESCRIPTION
This will close #1670.

I've replaced the `CargoWatcher`s `Cargo.toml` check with a version that uses the `fs` API of vscode.

While making this I've identified an issue with the detection of the `cargo.toml`, we can only load projects where the cargo.toml is in the root of the workspace. but that's a separate issue 😄 