### PR TITLE
make all traits non-enumerable

### DIFF
--- a/crates/ra_hir/src/ty/tests.rs
+++ b/crates/ra_hir/src/ty/tests.rs
@@ -3007,7 +3007,7 @@ impl<T, U> Into<U> for T where U: From<T> {}
 fn test() { S2.into()<|>; }
 "#,
     );
-    assert_eq!(t, "S1");
+    assert_eq!(t, "{unknown}");
 }
 
 #[test]
@@ -3024,7 +3024,7 @@ impl<T, U: From<T>> Into<U> for T {}
 fn test() { S2.into()<|>; }
 "#,
     );
-    assert_eq!(t, "S1");
+    assert_eq!(t, "{unknown}");
 }
 
 #[test]
@@ -3066,7 +3066,7 @@ impl<B, C> Trait for S<B, C> where C: FnX, B: SendX {}
 fn test() { (S {}).method()<|>; }
 "#,
     );
-    assert_eq!(t, "{unknown}");
+    assert_eq!(t, "()");
 }
 
 #[test]
@@ -3546,11 +3546,11 @@ fn test(x: Trait, y: &Trait) -> u64 {
     [129; 132) 'bar': fn bar() -> {unknown}
     [129; 134) 'bar()': {unknown}
     [140; 141) 'x': {unknown}
-    [140; 147) 'x.foo()': {unknown}
+    [140; 147) 'x.foo()': u64
     [153; 154) 'y': &{unknown}
-    [153; 160) 'y.foo()': {unknown}
+    [153; 160) 'y.foo()': u64
     [166; 167) 'z': {unknown}
-    [166; 173) 'z.foo()': {unknown}
+    [166; 173) 'z.foo()': u64
     "###
     );
 }

--- a/crates/ra_hir/src/ty/traits/chalk.rs
+++ b/crates/ra_hir/src/ty/traits/chalk.rs
@@ -478,7 +478,7 @@ pub(crate) fn trait_datum_query(
             associated_ty_ids: Vec::new(),
             where_clauses: Vec::new(),
             flags: chalk_rust_ir::TraitFlags {
-                non_enumerable: false,
+                non_enumerable: true,
                 auto: false,
                 marker: false,
                 upstream: true,

--- a/crates/ra_hir/src/ty/traits/chalk.rs
+++ b/crates/ra_hir/src/ty/traits/chalk.rs
@@ -356,14 +356,6 @@ fn make_binders<T>(value: T, num_vars: usize) -> chalk_ir::Binders<T> {
     }
 }
 
-fn is_non_enumerable_trait(db: &impl HirDatabase, trait_: Trait) -> bool {
-    let name = trait_.name(db).unwrap_or_else(crate::Name::missing).to_string();
-    match &*name {
-        "Sized" => true,
-        _ => false,
-    }
-}
-
 fn convert_where_clauses(
     db: &impl HirDatabase,
     def: GenericDef,
@@ -503,7 +495,7 @@ pub(crate) fn trait_datum_query(
     let flags = chalk_rust_ir::TraitFlags {
         auto: trait_.is_auto(db),
         upstream: trait_.module(db).krate(db) != Some(krate),
-        non_enumerable: is_non_enumerable_trait(db, trait_),
+        non_enumerable: true,
         // FIXME set these flags correctly
         marker: false,
         fundamental: false,


### PR DESCRIPTION
As discussed on Zulip, this actually matches the present behavior of rustc.

r? @flodiebold 