### PR TITLE
Support correct `$crate` expansion in macros

### DIFF
--- a/crates/ra_assists/src/assists/auto_import.rs
+++ b/crates/ra_assists/src/assists/auto_import.rs
@@ -512,7 +512,7 @@ pub fn collect_hir_path_segments(path: &hir::Path) -> Option<Vec<SmolStr>> {
         hir::PathKind::Plain => {}
         hir::PathKind::Self_ => ps.push("self".into()),
         hir::PathKind::Super => ps.push("super".into()),
-        hir::PathKind::Type(_) => return None,
+        hir::PathKind::Type(_) | hir::PathKind::DollarCrate(_) => return None,
     }
     for s in path.segments.iter() {
         ps.push(s.name.to_string().into());

--- a/crates/ra_hir/src/adt.rs
+++ b/crates/ra_hir/src/adt.rs
@@ -133,7 +133,7 @@ impl VariantData {
                     .fields()
                     .enumerate()
                     .map(|(i, fd)| StructFieldData {
-                        name: Name::tuple_field_name(i),
+                        name: Name::new_tuple_field(i),
                         type_ref: TypeRef::from_ast_opt(fd.type_ref()),
                     })
                     .collect();

--- a/crates/ra_hir/src/code_model/src.rs
+++ b/crates/ra_hir/src/code_model/src.rs
@@ -119,7 +119,7 @@ impl HasSource for TypeAlias {
 impl HasSource for MacroDef {
     type Ast = ast::MacroCall;
     fn source(self, db: &(impl DefDatabase + AstDatabase)) -> Source<ast::MacroCall> {
-        Source { file_id: self.id.0.file_id(), ast: self.id.0.to_node(db) }
+        Source { file_id: self.id.ast_id.file_id(), ast: self.id.ast_id.to_node(db) }
     }
 }
 

--- a/crates/ra_hir/src/generics.rs
+++ b/crates/ra_hir/src/generics.rs
@@ -132,6 +132,7 @@ impl GenericParams {
     fn fill_params(&mut self, params: ast::TypeParamList, start: u32) {
         for (idx, type_param) in params.type_params().enumerate() {
             let name = type_param.name().map_or_else(Name::missing, |it| it.as_name());
+            // FIXME: Use `Path::from_src`
             let default = type_param.default_type().and_then(|t| t.path()).and_then(Path::from_ast);
 
             let param = GenericParam { idx: idx as u32 + start, name: name.clone(), default };

--- a/crates/ra_hir/src/ids.rs
+++ b/crates/ra_hir/src/ids.rs
@@ -10,7 +10,7 @@ use ra_syntax::{ast, AstNode, Parse, SyntaxNode};
 
 use crate::{
     db::{AstDatabase, DefDatabase, InternDatabase},
-    AstId, FileAstId, Module, Source,
+    AstId, Crate, FileAstId, Module, Source,
 };
 
 /// hir makes heavy use of ids: integer (u32) handlers to various things. You
@@ -121,10 +121,13 @@ impl From<FileId> for HirFileId {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct MacroDefId(pub(crate) AstId<ast::MacroCall>);
+pub struct MacroDefId {
+    pub(crate) ast_id: AstId<ast::MacroCall>,
+    pub(crate) krate: Crate,
+}
 
 pub(crate) fn macro_def_query(db: &impl AstDatabase, id: MacroDefId) -> Option<Arc<MacroRules>> {
-    let macro_call = id.0.to_node(db);
+    let macro_call = id.ast_id.to_node(db);
     let arg = macro_call.token_tree()?;
     let (tt, _) = mbe::ast_to_token_tree(&arg).or_else(|| {
         log::warn!("fail on macro_def to token tree: {:#?}", arg);

--- a/crates/ra_hir/src/ids.rs
+++ b/crates/ra_hir/src/ids.rs
@@ -58,6 +58,17 @@ impl HirFileId {
         }
     }
 
+    /// Get the crate which the macro lives in, if it is a macro file.
+    pub(crate) fn macro_crate(self, db: &impl AstDatabase) -> Option<Crate> {
+        match self.0 {
+            HirFileIdRepr::File(_) => None,
+            HirFileIdRepr::Macro(macro_file) => {
+                let loc = macro_file.macro_call_id.loc(db);
+                Some(loc.def.krate)
+            }
+        }
+    }
+
     pub(crate) fn parse_or_expand_query(
         db: &impl AstDatabase,
         file_id: HirFileId,

--- a/crates/ra_hir/src/impl_block.rs
+++ b/crates/ra_hir/src/impl_block.rs
@@ -218,7 +218,10 @@ impl ModuleImplBlocks {
                 ast::ItemOrMacro::Macro(macro_call) => {
                     //FIXME: we should really cut down on the boilerplate required to process a macro
                     let ast_id = db.ast_id_map(file_id).ast_id(&macro_call).with_file_id(file_id);
-                    if let Some(path) = macro_call.path().and_then(Path::from_ast) {
+                    if let Some(path) = macro_call
+                        .path()
+                        .and_then(|path| Path::from_src(Source { ast: path, file_id }, db))
+                    {
                         if let Some(def) = self.module.resolver(db).resolve_path_as_macro(db, &path)
                         {
                             let call_id = MacroCallLoc { def: def.id, ast_id }.id(db);

--- a/crates/ra_hir/src/marks.rs
+++ b/crates/ra_hir/src/marks.rs
@@ -14,4 +14,6 @@ test_utils::marks!(
     macro_rules_from_other_crates_are_visible_with_macro_use
     prelude_is_macro_use
     coerce_merge_fail_fallback
+    macro_dollar_crate_self
+    macro_dollar_crate_other
 );

--- a/crates/ra_hir/src/name.rs
+++ b/crates/ra_hir/src/name.rs
@@ -5,20 +5,21 @@ use ra_syntax::{ast, SmolStr};
 /// `Name` is a wrapper around string, which is used in hir for both references
 /// and declarations. In theory, names should also carry hygiene info, but we are
 /// not there yet!
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct Name {
-    text: SmolStr,
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Name(Repr);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+enum Repr {
+    Text(SmolStr),
+    TupleField(usize),
 }
 
 impl fmt::Display for Name {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(&self.text, f)
-    }
-}
-
-impl fmt::Debug for Name {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(&self.text, f)
+        match &self.0 {
+            Repr::Text(text) => fmt::Display::fmt(&text, f),
+            Repr::TupleField(idx) => fmt::Display::fmt(&idx, f),
+        }
     }
 }
 
@@ -26,29 +27,38 @@ impl Name {
     /// Note: this is private to make creating name from random string hard.
     /// Hopefully, this should allow us to integrate hygiene cleaner in the
     /// future, and to switch to interned representation of names.
-    const fn new(text: SmolStr) -> Name {
-        Name { text }
+    const fn new_text(text: SmolStr) -> Name {
+        Name(Repr::Text(text))
+    }
+
+    pub(crate) fn new_tuple_field(idx: usize) -> Name {
+        Name(Repr::TupleField(idx))
+    }
+
+    /// Shortcut to create inline plain text name
+    const fn new_inline_ascii(len: usize, text: &[u8]) -> Name {
+        Name::new_text(SmolStr::new_inline_from_ascii(len, text))
+    }
+
+    /// Resolve a name from the text of token.
+    fn resolve(raw_text: &SmolStr) -> Name {
+        let raw_start = "r#";
+        if raw_text.as_str().starts_with(raw_start) {
+            Name::new_text(SmolStr::new(&raw_text[raw_start.len()..]))
+        } else {
+            Name::new_text(raw_text.clone())
+        }
     }
 
     pub(crate) fn missing() -> Name {
-        Name::new("[missing name]".into())
+        Name::new_text("[missing name]".into())
     }
 
-    pub(crate) fn tuple_field_name(idx: usize) -> Name {
-        Name::new(idx.to_string().into())
-    }
-
-    // There's should be no way to extract a string out of `Name`: `Name` in the
-    // future, `Name` will include hygiene information, and you can't encode
-    // hygiene into a String.
-    //
-    // If you need to compare something with `Name`, compare `Name`s directly.
-    //
-    // If you need to render `Name` for the user, use the `Display` impl, but be
-    // aware that it strips hygiene info.
-    #[deprecated(note = "use to_string instead")]
-    pub fn as_smolstr(&self) -> &SmolStr {
-        &self.text
+    pub(crate) fn as_tuple_index(&self) -> Option<usize> {
+        match self.0 {
+            Repr::TupleField(idx) => Some(idx),
+            _ => None,
+        }
     }
 }
 
@@ -58,15 +68,16 @@ pub(crate) trait AsName {
 
 impl AsName for ast::NameRef {
     fn as_name(&self) -> Name {
-        let name = resolve_name(self.text());
-        Name::new(name)
+        match self.as_tuple_field() {
+            Some(idx) => Name::new_tuple_field(idx),
+            None => Name::resolve(self.text()),
+        }
     }
 }
 
 impl AsName for ast::Name {
     fn as_name(&self) -> Name {
-        let name = resolve_name(self.text());
-        Name::new(name)
+        Name::resolve(self.text())
     }
 }
 
@@ -74,66 +85,56 @@ impl AsName for ast::FieldKind {
     fn as_name(&self) -> Name {
         match self {
             ast::FieldKind::Name(nr) => nr.as_name(),
-            ast::FieldKind::Index(idx) => Name::new(idx.text().clone()),
+            ast::FieldKind::Index(idx) => Name::new_tuple_field(idx.text().parse().unwrap()),
         }
     }
 }
 
 impl AsName for ra_db::Dependency {
     fn as_name(&self) -> Name {
-        Name::new(self.name.clone())
+        Name::new_text(self.name.clone())
     }
 }
 
 // Primitives
-pub(crate) const ISIZE: Name = Name::new(SmolStr::new_inline_from_ascii(5, b"isize"));
-pub(crate) const I8: Name = Name::new(SmolStr::new_inline_from_ascii(2, b"i8"));
-pub(crate) const I16: Name = Name::new(SmolStr::new_inline_from_ascii(3, b"i16"));
-pub(crate) const I32: Name = Name::new(SmolStr::new_inline_from_ascii(3, b"i32"));
-pub(crate) const I64: Name = Name::new(SmolStr::new_inline_from_ascii(3, b"i64"));
-pub(crate) const I128: Name = Name::new(SmolStr::new_inline_from_ascii(4, b"i128"));
-pub(crate) const USIZE: Name = Name::new(SmolStr::new_inline_from_ascii(5, b"usize"));
-pub(crate) const U8: Name = Name::new(SmolStr::new_inline_from_ascii(2, b"u8"));
-pub(crate) const U16: Name = Name::new(SmolStr::new_inline_from_ascii(3, b"u16"));
-pub(crate) const U32: Name = Name::new(SmolStr::new_inline_from_ascii(3, b"u32"));
-pub(crate) const U64: Name = Name::new(SmolStr::new_inline_from_ascii(3, b"u64"));
-pub(crate) const U128: Name = Name::new(SmolStr::new_inline_from_ascii(4, b"u128"));
-pub(crate) const F32: Name = Name::new(SmolStr::new_inline_from_ascii(3, b"f32"));
-pub(crate) const F64: Name = Name::new(SmolStr::new_inline_from_ascii(3, b"f64"));
-pub(crate) const BOOL: Name = Name::new(SmolStr::new_inline_from_ascii(4, b"bool"));
-pub(crate) const CHAR: Name = Name::new(SmolStr::new_inline_from_ascii(4, b"char"));
-pub(crate) const STR: Name = Name::new(SmolStr::new_inline_from_ascii(3, b"str"));
+pub(crate) const ISIZE: Name = Name::new_inline_ascii(5, b"isize");
+pub(crate) const I8: Name = Name::new_inline_ascii(2, b"i8");
+pub(crate) const I16: Name = Name::new_inline_ascii(3, b"i16");
+pub(crate) const I32: Name = Name::new_inline_ascii(3, b"i32");
+pub(crate) const I64: Name = Name::new_inline_ascii(3, b"i64");
+pub(crate) const I128: Name = Name::new_inline_ascii(4, b"i128");
+pub(crate) const USIZE: Name = Name::new_inline_ascii(5, b"usize");
+pub(crate) const U8: Name = Name::new_inline_ascii(2, b"u8");
+pub(crate) const U16: Name = Name::new_inline_ascii(3, b"u16");
+pub(crate) const U32: Name = Name::new_inline_ascii(3, b"u32");
+pub(crate) const U64: Name = Name::new_inline_ascii(3, b"u64");
+pub(crate) const U128: Name = Name::new_inline_ascii(4, b"u128");
+pub(crate) const F32: Name = Name::new_inline_ascii(3, b"f32");
+pub(crate) const F64: Name = Name::new_inline_ascii(3, b"f64");
+pub(crate) const BOOL: Name = Name::new_inline_ascii(4, b"bool");
+pub(crate) const CHAR: Name = Name::new_inline_ascii(4, b"char");
+pub(crate) const STR: Name = Name::new_inline_ascii(3, b"str");
 
 // Special names
-pub(crate) const SELF_PARAM: Name = Name::new(SmolStr::new_inline_from_ascii(4, b"self"));
-pub(crate) const SELF_TYPE: Name = Name::new(SmolStr::new_inline_from_ascii(4, b"Self"));
-pub(crate) const MACRO_RULES: Name = Name::new(SmolStr::new_inline_from_ascii(11, b"macro_rules"));
+pub(crate) const SELF_PARAM: Name = Name::new_inline_ascii(4, b"self");
+pub(crate) const SELF_TYPE: Name = Name::new_inline_ascii(4, b"Self");
+pub(crate) const MACRO_RULES: Name = Name::new_inline_ascii(11, b"macro_rules");
 
 // Components of known path (value or mod name)
-pub(crate) const STD: Name = Name::new(SmolStr::new_inline_from_ascii(3, b"std"));
-pub(crate) const ITER: Name = Name::new(SmolStr::new_inline_from_ascii(4, b"iter"));
-pub(crate) const OPS: Name = Name::new(SmolStr::new_inline_from_ascii(3, b"ops"));
-pub(crate) const FUTURE: Name = Name::new(SmolStr::new_inline_from_ascii(6, b"future"));
-pub(crate) const RESULT: Name = Name::new(SmolStr::new_inline_from_ascii(6, b"result"));
-pub(crate) const BOXED: Name = Name::new(SmolStr::new_inline_from_ascii(5, b"boxed"));
+pub(crate) const STD: Name = Name::new_inline_ascii(3, b"std");
+pub(crate) const ITER: Name = Name::new_inline_ascii(4, b"iter");
+pub(crate) const OPS: Name = Name::new_inline_ascii(3, b"ops");
+pub(crate) const FUTURE: Name = Name::new_inline_ascii(6, b"future");
+pub(crate) const RESULT: Name = Name::new_inline_ascii(6, b"result");
+pub(crate) const BOXED: Name = Name::new_inline_ascii(5, b"boxed");
 
 // Components of known path (type name)
-pub(crate) const INTO_ITERATOR_TYPE: Name =
-    Name::new(SmolStr::new_inline_from_ascii(12, b"IntoIterator"));
-pub(crate) const ITEM_TYPE: Name = Name::new(SmolStr::new_inline_from_ascii(4, b"Item"));
-pub(crate) const TRY_TYPE: Name = Name::new(SmolStr::new_inline_from_ascii(3, b"Try"));
-pub(crate) const OK_TYPE: Name = Name::new(SmolStr::new_inline_from_ascii(2, b"Ok"));
-pub(crate) const FUTURE_TYPE: Name = Name::new(SmolStr::new_inline_from_ascii(6, b"Future"));
-pub(crate) const RESULT_TYPE: Name = Name::new(SmolStr::new_inline_from_ascii(6, b"Result"));
-pub(crate) const OUTPUT_TYPE: Name = Name::new(SmolStr::new_inline_from_ascii(6, b"Output"));
-pub(crate) const TARGET_TYPE: Name = Name::new(SmolStr::new_inline_from_ascii(6, b"Target"));
-pub(crate) const BOX_TYPE: Name = Name::new(SmolStr::new_inline_from_ascii(3, b"Box"));
-
-fn resolve_name(text: &SmolStr) -> SmolStr {
-    let raw_start = "r#";
-    if text.as_str().starts_with(raw_start) {
-        SmolStr::new(&text[raw_start.len()..])
-    } else {
-        text.clone()
-    }
-}
+pub(crate) const INTO_ITERATOR_TYPE: Name = Name::new_inline_ascii(12, b"IntoIterator");
+pub(crate) const ITEM_TYPE: Name = Name::new_inline_ascii(4, b"Item");
+pub(crate) const TRY_TYPE: Name = Name::new_inline_ascii(3, b"Try");
+pub(crate) const OK_TYPE: Name = Name::new_inline_ascii(2, b"Ok");
+pub(crate) const FUTURE_TYPE: Name = Name::new_inline_ascii(6, b"Future");
+pub(crate) const RESULT_TYPE: Name = Name::new_inline_ascii(6, b"Result");
+pub(crate) const OUTPUT_TYPE: Name = Name::new_inline_ascii(6, b"Output");
+pub(crate) const TARGET_TYPE: Name = Name::new_inline_ascii(6, b"Target");
+pub(crate) const BOX_TYPE: Name = Name::new_inline_ascii(3, b"Box");

--- a/crates/ra_hir/src/nameres.rs
+++ b/crates/ra_hir/src/nameres.rs
@@ -332,6 +332,20 @@ impl CrateDefMap {
     ) -> ResolvePathResult {
         let mut segments = path.segments.iter().enumerate();
         let mut curr_per_ns: PerNs = match path.kind {
+            PathKind::DollarCrate(krate) => {
+                if krate == self.krate {
+                    tested_by!(macro_dollar_crate_self);
+                    PerNs::types(Module { krate: self.krate, module_id: self.root }.into())
+                } else {
+                    match krate.root_module(db) {
+                        Some(module) => {
+                            tested_by!(macro_dollar_crate_other);
+                            PerNs::types(module.into())
+                        }
+                        None => return ResolvePathResult::empty(ReachedFixedPoint::No),
+                    }
+                }
+            }
             PathKind::Crate => {
                 PerNs::types(Module { krate: self.krate, module_id: self.root }.into())
             }

--- a/crates/ra_hir/src/nameres.rs
+++ b/crates/ra_hir/src/nameres.rs
@@ -342,7 +342,7 @@ impl CrateDefMap {
                             tested_by!(macro_dollar_crate_other);
                             PerNs::types(module.into())
                         }
-                        None => return ResolvePathResult::empty(ReachedFixedPoint::No),
+                        None => return ResolvePathResult::empty(ReachedFixedPoint::Yes),
                     }
                 }
             }

--- a/crates/ra_hir/src/nameres/collector.rs
+++ b/crates/ra_hir/src/nameres/collector.rs
@@ -662,7 +662,10 @@ where
         // Case 1: macro rules, define a macro in crate-global mutable scope
         if is_macro_rules(&mac.path) {
             if let Some(name) = &mac.name {
-                let macro_id = MacroDefId(mac.ast_id.with_file_id(self.file_id));
+                let macro_id = MacroDefId {
+                    ast_id: mac.ast_id.with_file_id(self.file_id),
+                    krate: self.def_collector.def_map.krate,
+                };
                 let macro_ = MacroDef { id: macro_id };
                 self.def_collector.define_macro(self.module_id, name.clone(), macro_, mac.export);
             }

--- a/crates/ra_hir/src/nameres/raw.rs
+++ b/crates/ra_hir/src/nameres/raw.rs
@@ -202,7 +202,7 @@ struct RawItemsCollector<DB> {
     db: DB,
 }
 
-impl<DB: AstDatabase> RawItemsCollector<&'_ DB> {
+impl<DB: AstDatabase> RawItemsCollector<&DB> {
     fn process_module(&mut self, current_module: Option<Module>, body: impl ast::ModuleItemOwner) {
         for item_or_macro in body.items_with_macros() {
             match item_or_macro {

--- a/crates/ra_hir/src/source_binder.rs
+++ b/crates/ra_hir/src/source_binder.rs
@@ -203,6 +203,7 @@ impl SourceAnalyzer {
         db: &impl HirDatabase,
         macro_call: &ast::MacroCall,
     ) -> Option<MacroDef> {
+        // This must be a normal source file rather than macro file.
         let path = macro_call.path().and_then(Path::from_ast)?;
         self.resolver.resolve_path_as_macro(db, &path)
     }
@@ -261,6 +262,7 @@ impl SourceAnalyzer {
                 return Some(PathResolution::AssocItem(assoc));
             }
         }
+        // This must be a normal source file rather than macro file.
         let hir_path = crate::Path::from_ast(path.clone())?;
         self.resolve_hir_path(db, &hir_path)
     }

--- a/crates/ra_hir/src/ty/infer.rs
+++ b/crates/ra_hir/src/ty/infer.rs
@@ -609,7 +609,7 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
 
         for (i, &subpat) in subpats.iter().enumerate() {
             let expected_ty = def
-                .and_then(|d| d.field(self.db, &Name::tuple_field_name(i)))
+                .and_then(|d| d.field(self.db, &Name::new_tuple_field(i)))
                 .map_or(Ty::Unknown, |field| field.ty(self.db))
                 .subst(&substs);
             let expected_ty = self.normalize_associated_types_in(expected_ty);
@@ -1375,10 +1375,9 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
                 )
                 .find_map(|derefed_ty| match canonicalized.decanonicalize_ty(derefed_ty.value) {
                     Ty::Apply(a_ty) => match a_ty.ctor {
-                        TypeCtor::Tuple { .. } => {
-                            let i = name.to_string().parse::<usize>().ok();
-                            i.and_then(|i| a_ty.parameters.0.get(i).cloned())
-                        }
+                        TypeCtor::Tuple { .. } => name
+                            .as_tuple_index()
+                            .and_then(|idx| a_ty.parameters.0.get(idx).cloned()),
                         TypeCtor::Adt(Adt::Struct(s)) => s.field(self.db, name).map(|field| {
                             self.write_field_resolution(tgt_expr, field);
                             field.ty(self.db).subst(&a_ty.parameters)

--- a/crates/ra_hir/src/type_ref.rs
+++ b/crates/ra_hir/src/type_ref.rs
@@ -72,6 +72,7 @@ impl TypeRef {
             }
             ast::TypeRef::NeverType(..) => TypeRef::Never,
             ast::TypeRef::PathType(inner) => {
+                // FIXME: Use `Path::from_src`
                 inner.path().and_then(Path::from_ast).map(TypeRef::Path).unwrap_or(TypeRef::Error)
             }
             ast::TypeRef::PointerType(inner) => {
@@ -141,6 +142,7 @@ impl TypeBound {
                     Some(p) => p,
                     None => return TypeBound::Error,
                 };
+                // FIXME: Use `Path::from_src`
                 let path = match Path::from_ast(path) {
                     Some(p) => p,
                     None => return TypeBound::Error,

--- a/crates/ra_mbe/src/mbe_expander/transcriber.rs
+++ b/crates/ra_mbe/src/mbe_expander/transcriber.rs
@@ -86,7 +86,7 @@ fn expand_subtree(ctx: &mut ExpandCtx, template: &tt::Subtree) -> Result<tt::Sub
 
 fn expand_var(ctx: &mut ExpandCtx, v: &SmolStr) -> Result<Fragment, ExpandError> {
     let res = if v == "crate" {
-        // FIXME: Properly handle $crate token
+        // We simply produce identifier `$crate` here. And it will be resolved when lowering ast to Path.
         let tt =
             tt::Leaf::from(tt::Ident { text: "$crate".into(), id: tt::TokenId::unspecified() })
                 .into();

--- a/crates/ra_syntax/src/ast/extensions.rs
+++ b/crates/ra_syntax/src/ast/extensions.rs
@@ -21,6 +21,16 @@ impl ast::NameRef {
     pub fn text(&self) -> &SmolStr {
         text_of_first_token(self.syntax())
     }
+
+    pub fn as_tuple_field(&self) -> Option<usize> {
+        self.syntax().children_with_tokens().find_map(|c| {
+            if c.kind() == SyntaxKind::INT_NUMBER {
+                c.as_token().and_then(|tok| tok.text().as_str().parse().ok())
+            } else {
+                None
+            }
+        })
+    }
 }
 
 fn text_of_first_token(node: &SyntaxNode) -> &SmolStr {


### PR DESCRIPTION
This PR makes normal use cases of `$crate` from macros work as expected.

It makes more macros from `std` work. Type inference works well with `panic`, `unimplemented`, `format`, and maybe more.
Sadly that `vec![1, 2, 3]` still not works, but it is not longer an issue about macro.

Screenshot:
![Screenshot_20190927_022136](https://user-images.githubusercontent.com/14816024/65714465-b4568f80-e0cd-11e9-8043-dd44c2ae8040.png)


