### PR TITLE
Gracefully handle `const _` items in `ConstData`

### DIFF
--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -782,10 +782,6 @@ impl ConstData {
         self.name.as_ref()
     }
 
-    pub fn is_unnamed(&self) -> bool {
-        self.name.is_none()
-    }
-
     pub fn type_ref(&self) -> &TypeRef {
         &self.type_ref
     }

--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -773,13 +773,17 @@ impl Const {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConstData {
-    pub(crate) name: Name,
+    pub(crate) name: Option<Name>,
     pub(crate) type_ref: TypeRef,
 }
 
 impl ConstData {
-    pub fn name(&self) -> &Name {
-        &self.name
+    pub fn name(&self) -> Option<&Name> {
+        self.name.as_ref()
+    }
+
+    pub fn is_unnamed(&self) -> bool {
+        self.name.is_none()
     }
 
     pub fn type_ref(&self) -> &TypeRef {
@@ -804,7 +808,7 @@ impl ConstData {
 }
 
 fn const_data_for<N: NameOwner + TypeAscriptionOwner>(node: &N) -> Arc<ConstData> {
-    let name = node.name().map(|n| n.as_name()).unwrap_or_else(Name::missing);
+    let name = node.name().map(|n| n.as_name());
     let type_ref = TypeRef::from_ast_opt(node.ascribed_type());
     let sig = ConstData { name, type_ref };
     Arc::new(sig)

--- a/crates/ra_hir/src/ty/infer.rs
+++ b/crates/ra_hir/src/ty/infer.rs
@@ -577,7 +577,7 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
 
                 crate::ImplItem::Const(konst) => {
                     let data = konst.data(self.db);
-                    if segment.name == *data.name() {
+                    if Some(&segment.name) == data.name() {
                         Some(ValueNs::Const(konst))
                     } else {
                         None


### PR DESCRIPTION
A follow-up to #1847.

This makes the `name` field of `ConstData` optional.