### PR TITLE
account for impls generated by macros

### DIFF
--- a/crates/ra_hir/src/resolve.rs
+++ b/crates/ra_hir/src/resolve.rs
@@ -5,7 +5,7 @@ use rustc_hash::FxHashSet;
 
 use crate::{
     code_model::Crate,
-    db::HirDatabase,
+    db::{DefDatabase, HirDatabase},
     expr::{
         scope::{ExprScopes, ScopeId},
         PatId,
@@ -290,7 +290,7 @@ impl Resolver {
 
     pub(crate) fn resolve_path_as_macro(
         &self,
-        db: &impl HirDatabase,
+        db: &impl DefDatabase,
         path: &Path,
     ) -> Option<MacroDef> {
         let (item_map, module) = self.module()?;

--- a/crates/ra_hir/src/ty/tests.rs
+++ b/crates/ra_hir/src/ty/tests.rs
@@ -2997,6 +2997,23 @@ fn foo() {
     );
 }
 
+#[test]
+fn processes_impls_generated_by_macros() {
+    let t = type_at(
+        r#"
+//- /main.rs
+macro_rules! m {
+    ($ident:ident) => (impl Trait for $ident {})
+}
+trait Trait { fn foo(self) -> u128 {} }
+struct S;
+m!(S);
+fn test() { S.foo()<|>; }
+"#,
+    );
+    assert_eq!(t, "u128");
+}
+
 #[ignore]
 #[test]
 fn method_resolution_trait_before_autoref() {


### PR DESCRIPTION
The code is pretty horrible and is copy-pased from expressions. We really need to find a better way to lower stuff generated by macros. But it gets the job done! I've actually though that we did this ages ago, but obviously we didn't