### PR TITLE
`fold_kind`: `MATCH_ARM_LIST => FoldKind::Block`

### DIFF
--- a/crates/ra_ide_api/src/folding_ranges.rs
+++ b/crates/ra_ide_api/src/folding_ranges.rs
@@ -87,6 +87,7 @@ fn fold_kind(kind: SyntaxKind) -> Option<FoldKind> {
         | EXTERN_ITEM_LIST
         | USE_TREE_LIST
         | BLOCK
+        | MATCH_ARM_LIST
         | ENUM_VARIANT_LIST
         | TOKEN_TREE => Some(FoldKind::Block),
         _ => None,
@@ -356,6 +357,23 @@ macro_rules! foo <fold>{
 "#;
 
         let folds = &[FoldKind::Block];
+        do_check(text, folds);
+    }
+
+    #[test]
+    fn test_fold_match_arms() {
+        let text = r#"
+fn main() <fold>{
+    match 0 <fold>{
+        0 => 0,
+        _ => 1,
+    }</fold>
+}</fold>"#;
+
+        let folds = &[
+            FoldKind::Block,
+            FoldKind::Block,
+        ];
         do_check(text, folds);
     }
 }

--- a/crates/ra_ide_api/src/folding_ranges.rs
+++ b/crates/ra_ide_api/src/folding_ranges.rs
@@ -370,10 +370,7 @@ fn main() <fold>{
     }</fold>
 }</fold>"#;
 
-        let folds = &[
-            FoldKind::Block,
-            FoldKind::Block,
-        ];
+        let folds = &[FoldKind::Block, FoldKind::Block];
         do_check(text, folds);
     }
 }


### PR DESCRIPTION
As suggested by @matklad in https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Fwg-rls-2.2E0/topic/folding.20of.20.60match.60.20and.20.60if.60/near/176109093.

This should let folks fold all the arms in a `match` expression rather than just each arm individually.