### PR TITLE
Support open source version of vscode as well

### DIFF
--- a/crates/ra_tools/src/main.rs
+++ b/crates/ra_tools/src/main.rs
@@ -167,7 +167,7 @@ fn install_client(ClientOpt::VsCode: ClientOpt) -> Result<()> {
     }
     .run()?;
 
-    let code_binary = ["code", "code-insiders"].iter().find(|bin| {
+    let code_binary = ["code", "code-insiders", "codium"].iter().find(|bin| {
         Cmd {
             unix: &format!("{} --version", bin),
             windows: &format!("cmd.exe /c {}.cmd --version", bin),


### PR DESCRIPTION
This patch adds support for https://github.com/VSCodium/vscodium - an truly open source version of vscode.