### PR TITLE
Add rollup bundler for vscode extension

### DIFF
--- a/editors/code/.gitignore
+++ b/editors/code/.gitignore
@@ -2,3 +2,4 @@ out
 node_modules
 .vscode-test/
 *.vsix
+bundle

--- a/editors/code/.vscodeignore
+++ b/editors/code/.vscodeignore
@@ -1,9 +1,9 @@
 .vscode/**
 .vscode-test/**
-out/test/**
-out/**/*.map
+out/**
 src/**
 .gitignore
 tsconfig.json
 vsc-extension-quickstart.md
 tslint.json
+node_modules/**

--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -24,6 +24,12 @@
                 "js-tokens": "^4.0.0"
             }
         },
+        "@types/estree": {
+            "version": "0.0.39",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+            "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+            "dev": true
+        },
         "@types/events": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -59,6 +65,15 @@
             "integrity": "sha512-yN/FNNW1UYsRR1wwAoyOwqvDuLDtVXnaJTZ898XIw/Q5cCaeVAlVwvsmXLX5PuiScBYwZsZU4JYSHB3TvfdwvQ==",
             "dev": true
         },
+        "@types/resolve": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
+            "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/seedrandom": {
             "version": "2.4.28",
             "resolved": "https://registry.npmjs.org/@types/seedrandom/-/seedrandom-2.4.28.tgz",
@@ -69,6 +84,12 @@
             "version": "1.37.0",
             "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.37.0.tgz",
             "integrity": "sha512-PRfeuqYuzk3vjf+puzxltIUWC+AhEGYpFX29/37w30DQSQnpf5AgMVf7GDBAdmTbWTBou+EMFz/Ne6XCM/KxzQ==",
+            "dev": true
+        },
+        "acorn": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz",
+            "integrity": "sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==",
             "dev": true
         },
         "agent-base": {
@@ -424,6 +445,12 @@
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
             "dev": true
         },
+        "estree-walker": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+            "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+            "dev": true
+        },
         "esutils": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -632,6 +659,21 @@
             "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
             "dev": true
         },
+        "is-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+            "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+            "dev": true
+        },
+        "is-reference": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.1.3.tgz",
+            "integrity": "sha512-W1iHHv/oyBb2pPxkBxtaewxa1BC58Pn5J0hogyCdefwUIvb6R+TGbAcIa4qPNYLqLhb3EnOgUf2MQkkF76BcKw==",
+            "dev": true,
+            "requires": {
+                "@types/estree": "0.0.39"
+            }
+        },
         "is-regex": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
@@ -719,6 +761,15 @@
             "dev": true,
             "requires": {
                 "chalk": "^2.0.1"
+            }
+        },
+        "magic-string": {
+            "version": "0.25.3",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.3.tgz",
+            "integrity": "sha512-6QK0OpF/phMz0Q2AxILkX2mFhi7m+WMwTRg0LQKq/WBB0cDP4rYH3Wp4/d3OTXlrPLVJT/RFqj8tFeAR4nk8AA==",
+            "dev": true,
+            "requires": {
+                "sourcemap-codec": "^1.4.4"
             }
         },
         "map-age-cleaner": {
@@ -1160,6 +1211,109 @@
                 "glob": "^7.1.3"
             }
         },
+        "rollup": {
+            "version": "1.21.4",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.21.4.tgz",
+            "integrity": "sha512-Pl512XVCmVzgcBz5h/3Li4oTaoDcmpuFZ+kdhS/wLreALz//WuDAMfomD3QEYl84NkDu6Z6wV9twlcREb4qQsw==",
+            "dev": true,
+            "requires": {
+                "@types/estree": "0.0.39",
+                "@types/node": "^12.7.5",
+                "acorn": "^7.0.0"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "12.7.5",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
+                    "integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w==",
+                    "dev": true
+                }
+            }
+        },
+        "rollup-plugin-commonjs": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.1.0.tgz",
+            "integrity": "sha512-jlXbjZSQg8EIeAAvepNwhJj++qJWNJw1Cl0YnOqKtP5Djx+fFGkp3WRh+W0ASCaFG5w1jhmzDxgu3SJuVxPF4Q==",
+            "dev": true,
+            "requires": {
+                "estree-walker": "^0.6.1",
+                "is-reference": "^1.1.2",
+                "magic-string": "^0.25.2",
+                "resolve": "^1.11.0",
+                "rollup-pluginutils": "^2.8.1"
+            },
+            "dependencies": {
+                "resolve": {
+                    "version": "1.12.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+                    "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+                    "dev": true,
+                    "requires": {
+                        "path-parse": "^1.0.6"
+                    }
+                }
+            }
+        },
+        "rollup-plugin-node-resolve": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz",
+            "integrity": "sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==",
+            "dev": true,
+            "requires": {
+                "@types/resolve": "0.0.8",
+                "builtin-modules": "^3.1.0",
+                "is-module": "^1.0.0",
+                "resolve": "^1.11.1",
+                "rollup-pluginutils": "^2.8.1"
+            },
+            "dependencies": {
+                "builtin-modules": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
+                    "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
+                    "dev": true
+                },
+                "resolve": {
+                    "version": "1.12.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+                    "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+                    "dev": true,
+                    "requires": {
+                        "path-parse": "^1.0.6"
+                    }
+                }
+            }
+        },
+        "rollup-plugin-typescript": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-typescript/-/rollup-plugin-typescript-1.0.1.tgz",
+            "integrity": "sha512-rwJDNn9jv/NsKZuyBb/h0jsclP4CJ58qbvZt2Q9zDIGILF2LtdtvCqMOL+Gq9IVq5MTrTlHZNrn8h7VjQgd8tw==",
+            "dev": true,
+            "requires": {
+                "resolve": "^1.10.0",
+                "rollup-pluginutils": "^2.5.0"
+            },
+            "dependencies": {
+                "resolve": {
+                    "version": "1.12.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+                    "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+                    "dev": true,
+                    "requires": {
+                        "path-parse": "^1.0.6"
+                    }
+                }
+            }
+        },
+        "rollup-pluginutils": {
+            "version": "2.8.2",
+            "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+            "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+            "dev": true,
+            "requires": {
+                "estree-walker": "^0.6.1"
+            }
+        },
         "safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -1231,6 +1385,12 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+            "dev": true
+        },
+        "sourcemap-codec": {
+            "version": "1.4.6",
+            "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.6.tgz",
+            "integrity": "sha512-1ZooVLYFxC448piVLBbtOxFcXwnymH9oUF8nRd3CuYDVvkRBxRl6pB4Mtas5a4drtL+E8LDgFkQNcgIw6tc8Hg==",
             "dev": true
         },
         "sprintf-js": {
@@ -1414,32 +1574,32 @@
             }
         },
         "vscode-jsonrpc": {
-            "version": "4.1.0-next.2",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.1.0-next.2.tgz",
-            "integrity": "sha512-GsBLjP9DxQ42yl1mW9GEIlnSc0+R8mfzhaebwmmTPEJjezD5SPoAo3DFrIAFZha9yvQ1nzZfZlhtVpGQmgxtXg=="
+            "version": "4.1.0-next.3",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.1.0-next.3.tgz",
+            "integrity": "sha512-Z6oxBiMks2+UADV1QHXVooSakjyhI+eHTnXzDyVvVMmegvSfkXk2w6mPEdSkaNHFBdtWW7n20H1yw2nA3A17mg=="
         },
         "vscode-languageclient": {
-            "version": "5.3.0-next.6",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-5.3.0-next.6.tgz",
-            "integrity": "sha512-DxT8+gkenjCjJV6ArcP75/AQfx6HP6m6kHIbacPCpffMeoE1YMLKj6ZixA9J87yr0fMtBmqumLmDeGe7MIF2bw==",
+            "version": "5.3.0-next.4",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-5.3.0-next.4.tgz",
+            "integrity": "sha512-RODuzXErVpJRSgHv+Xei8fwQtZ/iZOWPCqlLl07NTtkzgTAepJf9r4EioZVuTviGJ5DEJ9xs0bjrit8shKtW6Q==",
             "requires": {
                 "semver": "^5.5.0",
-                "vscode-languageserver-protocol": "^3.15.0-next.6"
+                "vscode-languageserver-protocol": "3.15.0-next.4"
             }
         },
         "vscode-languageserver-protocol": {
-            "version": "3.15.0-next.6",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.0-next.6.tgz",
-            "integrity": "sha512-/yDpYlWyNs26mM23mT73xmOFsh1iRfgZfBdHmfAxwDKwpQKLoOSqVidtYfxlK/pD3IEKGcAVnT4WXTsguxxAMQ==",
+            "version": "3.15.0-next.4",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.0-next.4.tgz",
+            "integrity": "sha512-4AgisQ8GWa3irdRu3/UNr3brcSSm0oobmoV1eSOnV7JM32lYyXDnSKB7RuTTXvaAjD/0xQJLEGhkyGHS5gbywA==",
             "requires": {
-                "vscode-jsonrpc": "^4.1.0-next.2",
-                "vscode-languageserver-types": "^3.15.0-next.2"
+                "vscode-jsonrpc": "^4.1.0-next.1",
+                "vscode-languageserver-types": "3.15.0-next.1"
             }
         },
         "vscode-languageserver-types": {
-            "version": "3.15.0-next.2",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.0-next.2.tgz",
-            "integrity": "sha512-2JkrMWWUi2rlVLSo9OFR2PIGUzdiowEM8NgNYiwLKnXTjpwpjjIrJbNNxDik7Rv4oo9KtikcFQZKXbrKilL/MQ=="
+            "version": "3.15.0-next.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.0-next.1.tgz",
+            "integrity": "sha512-R0kzmaI8gOGEoU7b9huYQAzgZzRQ/5Q8HKjsIUdfz0MjXcBZ4tr1ik1So1p1O5kGrI1VTCd22Fw/wI7ECGoIPw=="
         },
         "vscode-test": {
             "version": "1.2.0",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -18,12 +18,12 @@
     "scripts": {
         "vscode:prepublish": "npm run compile",
         "package": "vsce package",
-        "compile": "tsc -p ./ && shx cp src/utils/terminateProcess.sh out/utils/terminateProcess.sh",
+        "compile": "rollup -c && shx cp src/utils/terminateProcess.sh bundle/terminateProcess.sh",
         "watch": "tsc -watch -p ./",
         "fix": "prettier **/*.{json,ts} --write && tslint --project . --fix",
         "lint": "tslint --project .",
         "prettier": "prettier **/*.{json,ts}",
-        "test": "node ./out/test/runTest.js",
+        "test": "tsc -p . && node ./out/test/runTest.js",
         "travis": "npm run compile && npm run test && npm run lint && npm run prettier -- --write && git diff --exit-code"
     },
     "prettier": {
@@ -35,14 +35,18 @@
         "vscode-languageclient": "^5.3.0-next.4"
     },
     "devDependencies": {
+        "@types/glob": "^7.1.1",
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.14.13",
         "@types/seedrandom": "^2.4.28",
-        "@types/glob": "^7.1.1",
         "@types/vscode": "^1.36.0",
         "glob": "^7.1.4",
         "mocha": "^6.2.0",
         "prettier": "^1.18.2",
+        "rollup": "^1.21.4",
+        "rollup-plugin-commonjs": "^10.1.0",
+        "rollup-plugin-node-resolve": "^5.2.0",
+        "rollup-plugin-typescript": "^1.0.1",
         "shx": "^0.3.1",
         "tslint": "^5.18.0",
         "tslint-config-prettier": "^1.18.0",
@@ -56,7 +60,7 @@
         "onCommand:rust-analyzer.collectGarbage",
         "workspaceContains:**/Cargo.toml"
     ],
-    "main": "./out/extension",
+    "main": "./bundle/extension",
     "contributes": {
         "taskDefinitions": [
             {

--- a/editors/code/rollup.config.js
+++ b/editors/code/rollup.config.js
@@ -1,0 +1,27 @@
+import typescript from 'rollup-plugin-typescript';
+import resolve from 'rollup-plugin-node-resolve';
+import commonjs from 'rollup-plugin-commonjs';
+import nodeBuiltins from 'builtin-modules';
+
+export default {
+    input: './src/extension.ts',
+    plugins: [
+        typescript(),
+        resolve(),
+        commonjs({
+            namedExports: {
+                // squelch missing import warnings
+                'vscode-languageclient': [ 'CreateFile', 'RenameFile' ]
+            }
+        }),
+    ],
+    // keep these as require() calls, bundle the rest
+    external: [
+        ...nodeBuiltins,
+        'vscode',
+    ],
+    output: {
+        file: './bundle/extension.js',
+        format: 'cjs',
+    }
+};


### PR DESCRIPTION
This is an alternative approach to #1451 - bundling should improve extension startup times as explained [here](https://code.visualstudio.com/api/working-with-extensions/bundling-extension).

I'm using [rollup.js](https://rollupjs.org/guide/en/) which is a small and light bundler as opposed to webpack. Bundling is only done for creating the final vsix package, reducing 196 files down to 7 (of which 1 javascript file).