### PR TITLE
Support `#[cfg(..)]`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,6 +923,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ra_cfg"
+version = "0.1.0"
+dependencies = [
+ "ra_mbe 0.1.0",
+ "ra_syntax 0.1.0",
+ "ra_tt 0.1.0",
+ "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ra_cli"
 version = "0.1.0"
 dependencies = [
@@ -941,6 +951,7 @@ dependencies = [
 name = "ra_db"
 version = "0.1.0"
 dependencies = [
+ "ra_cfg 0.1.0",
  "ra_prof 0.1.0",
  "ra_syntax 0.1.0",
  "relative-path 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -971,6 +982,7 @@ dependencies = [
  "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ra_arena 0.1.0",
+ "ra_cfg 0.1.0",
  "ra_db 0.1.0",
  "ra_mbe 0.1.0",
  "ra_prof 0.1.0",
@@ -993,6 +1005,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ra_assists 0.1.0",
+ "ra_cfg 0.1.0",
  "ra_db 0.1.0",
  "ra_fmt 0.1.0",
  "ra_hir 0.1.0",
@@ -1075,6 +1088,7 @@ dependencies = [
  "cargo_metadata 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ra_arena 0.1.0",
+ "ra_cfg 0.1.0",
  "ra_db 0.1.0",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,6 +1032,7 @@ dependencies = [
  "lsp-server 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lsp-types 0.61.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ra_cfg 0.1.0",
  "ra_db 0.1.0",
  "ra_ide_api 0.1.0",
  "ra_prof 0.1.0",

--- a/crates/ra_cfg/Cargo.toml
+++ b/crates/ra_cfg/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+edition = "2018"
+name = "ra_cfg"
+version = "0.1.0"
+authors = ["rust-analyzer developers"]
+
+[dependencies]
+rustc-hash = "1.0.1"
+
+ra_syntax = { path = "../ra_syntax" }
+tt = { path = "../ra_tt", package = "ra_tt" }
+
+[dev-dependencies]
+mbe = { path = "../ra_mbe", package = "ra_mbe" }

--- a/crates/ra_cfg/src/cfg_expr.rs
+++ b/crates/ra_cfg/src/cfg_expr.rs
@@ -1,0 +1,128 @@
+use std::slice::Iter as SliceIter;
+
+use ra_syntax::SmolStr;
+use tt::{Leaf, Subtree, TokenTree};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CfgExpr {
+    Invalid,
+    Atom(SmolStr),
+    KeyValue { key: SmolStr, value: SmolStr },
+    All(Vec<CfgExpr>),
+    Any(Vec<CfgExpr>),
+    Not(Box<CfgExpr>),
+}
+
+impl CfgExpr {
+    /// Fold the cfg by querying all basic `Atom` and `KeyValue` predicates.
+    pub fn fold(&self, query: &impl Fn(&SmolStr, Option<&SmolStr>) -> bool) -> Option<bool> {
+        match self {
+            CfgExpr::Invalid => None,
+            CfgExpr::Atom(name) => Some(query(name, None)),
+            CfgExpr::KeyValue { key, value } => Some(query(key, Some(value))),
+            CfgExpr::All(preds) => {
+                preds.iter().try_fold(true, |s, pred| Some(s && pred.fold(query)?))
+            }
+            CfgExpr::Any(preds) => {
+                preds.iter().try_fold(false, |s, pred| Some(s || pred.fold(query)?))
+            }
+            CfgExpr::Not(pred) => pred.fold(query).map(|s| !s),
+        }
+    }
+}
+
+pub fn parse_cfg(tt: &Subtree) -> CfgExpr {
+    next_cfg_expr(&mut tt.token_trees.iter()).unwrap_or(CfgExpr::Invalid)
+}
+
+fn next_cfg_expr(it: &mut SliceIter<tt::TokenTree>) -> Option<CfgExpr> {
+    let name = match it.next() {
+        None => return None,
+        Some(TokenTree::Leaf(Leaf::Ident(ident))) => ident.text.clone(),
+        Some(_) => return Some(CfgExpr::Invalid),
+    };
+
+    // Peek
+    let ret = match it.as_slice().first() {
+        Some(TokenTree::Leaf(Leaf::Punct(punct))) if punct.char == '=' => {
+            match it.as_slice().get(1) {
+                Some(TokenTree::Leaf(Leaf::Literal(literal))) => {
+                    it.next();
+                    it.next();
+                    // FIXME: escape? raw string?
+                    let value =
+                        SmolStr::new(literal.text.trim_start_matches('"').trim_end_matches('"'));
+                    CfgExpr::KeyValue { key: name, value }
+                }
+                _ => return Some(CfgExpr::Invalid),
+            }
+        }
+        Some(TokenTree::Subtree(subtree)) => {
+            it.next();
+            let mut sub_it = subtree.token_trees.iter();
+            let mut subs = std::iter::from_fn(|| next_cfg_expr(&mut sub_it)).collect();
+            match name.as_str() {
+                "all" => CfgExpr::All(subs),
+                "any" => CfgExpr::Any(subs),
+                "not" => CfgExpr::Not(Box::new(subs.pop().unwrap_or(CfgExpr::Invalid))),
+                _ => CfgExpr::Invalid,
+            }
+        }
+        _ => CfgExpr::Atom(name),
+    };
+
+    // Eat comma separator
+    if let Some(TokenTree::Leaf(Leaf::Punct(punct))) = it.as_slice().first() {
+        if punct.char == ',' {
+            it.next();
+        }
+    }
+    Some(ret)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use mbe::ast_to_token_tree;
+    use ra_syntax::ast::{self, AstNode};
+
+    fn assert_parse_result(input: &str, expected: CfgExpr) {
+        let source_file = ast::SourceFile::parse(input).ok().unwrap();
+        let tt = source_file.syntax().descendants().find_map(ast::TokenTree::cast).unwrap();
+        let (tt, _) = ast_to_token_tree(&tt).unwrap();
+        assert_eq!(parse_cfg(&tt), expected);
+    }
+
+    #[test]
+    fn test_cfg_expr_parser() {
+        assert_parse_result("#![cfg(foo)]", CfgExpr::Atom("foo".into()));
+        assert_parse_result("#![cfg(foo,)]", CfgExpr::Atom("foo".into()));
+        assert_parse_result(
+            "#![cfg(not(foo))]",
+            CfgExpr::Not(Box::new(CfgExpr::Atom("foo".into()))),
+        );
+        assert_parse_result("#![cfg(foo(bar))]", CfgExpr::Invalid);
+
+        // Only take the first
+        assert_parse_result(r#"#![cfg(foo, bar = "baz")]"#, CfgExpr::Atom("foo".into()));
+
+        assert_parse_result(
+            r#"#![cfg(all(foo, bar = "baz"))]"#,
+            CfgExpr::All(vec![
+                CfgExpr::Atom("foo".into()),
+                CfgExpr::KeyValue { key: "bar".into(), value: "baz".into() },
+            ]),
+        );
+
+        assert_parse_result(
+            r#"#![cfg(any(not(), all(), , bar = "baz",))]"#,
+            CfgExpr::Any(vec![
+                CfgExpr::Not(Box::new(CfgExpr::Invalid)),
+                CfgExpr::All(vec![]),
+                CfgExpr::Invalid,
+                CfgExpr::KeyValue { key: "bar".into(), value: "baz".into() },
+            ]),
+        );
+    }
+}

--- a/crates/ra_cfg/src/cfg_expr.rs
+++ b/crates/ra_cfg/src/cfg_expr.rs
@@ -15,7 +15,7 @@ pub enum CfgExpr {
 
 impl CfgExpr {
     /// Fold the cfg by querying all basic `Atom` and `KeyValue` predicates.
-    pub fn fold(&self, query: &impl Fn(&SmolStr, Option<&SmolStr>) -> bool) -> Option<bool> {
+    pub fn fold(&self, query: &dyn Fn(&SmolStr, Option<&SmolStr>) -> bool) -> Option<bool> {
         match self {
             CfgExpr::Invalid => None,
             CfgExpr::Atom(name) => Some(query(name, None)),

--- a/crates/ra_cfg/src/cfg_expr.rs
+++ b/crates/ra_cfg/src/cfg_expr.rs
@@ -1,3 +1,7 @@
+//! The condition expression used in `#[cfg(..)]` attributes.
+//!
+//! See: https://doc.rust-lang.org/reference/conditional-compilation.html#conditional-compilation
+
 use std::slice::Iter as SliceIter;
 
 use ra_syntax::SmolStr;

--- a/crates/ra_cfg/src/lib.rs
+++ b/crates/ra_cfg/src/lib.rs
@@ -1,0 +1,43 @@
+//! ra_cfg defines conditional compiling options, `cfg` attibute parser and evaluator
+use ra_syntax::SmolStr;
+use rustc_hash::{FxHashMap, FxHashSet};
+
+mod cfg_expr;
+
+pub use cfg_expr::{parse_cfg, CfgExpr};
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct CfgOptions {
+    atoms: FxHashSet<SmolStr>,
+    features: FxHashSet<SmolStr>,
+    options: FxHashMap<SmolStr, SmolStr>,
+}
+
+impl CfgOptions {
+    pub fn check(&self, cfg: &CfgExpr) -> Option<bool> {
+        cfg.fold(&|key, value| match value {
+            None => self.atoms.contains(key),
+            Some(value) if key == "feature" => self.features.contains(value),
+            Some(value) => self.options.get(key).map_or(false, |v| v == value),
+        })
+    }
+
+    pub fn is_cfg_enabled(&self, attr: &tt::Subtree) -> Option<bool> {
+        self.check(&parse_cfg(attr))
+    }
+
+    pub fn atom(mut self, name: SmolStr) -> CfgOptions {
+        self.atoms.insert(name);
+        self
+    }
+
+    pub fn feature(mut self, name: SmolStr) -> CfgOptions {
+        self.features.insert(name);
+        self
+    }
+
+    pub fn option(mut self, key: SmolStr, value: SmolStr) -> CfgOptions {
+        self.options.insert(key, value);
+        self
+    }
+}

--- a/crates/ra_cfg/src/lib.rs
+++ b/crates/ra_cfg/src/lib.rs
@@ -1,24 +1,32 @@
 //! ra_cfg defines conditional compiling options, `cfg` attibute parser and evaluator
 use ra_syntax::SmolStr;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 
 mod cfg_expr;
 
 pub use cfg_expr::{parse_cfg, CfgExpr};
 
+/// Configuration options used for conditional compilition on items with `cfg` attributes.
+/// We have two kind of options in different namespaces: atomic options like `unix`, and
+/// key-value options like `target_arch="x86"`.
+///
+/// Note that for key-value options, one key can have multiple values (but not none).
+/// `feature` is an example. We have both `feature="foo"` and `feature="bar"` if features
+/// `foo` and `bar` are both enabled. And here, we store key-value options as a set of tuple
+/// of key and value in `key_values`.
+///
+/// See: https://doc.rust-lang.org/reference/conditional-compilation.html#set-configuration-options
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct CfgOptions {
     atoms: FxHashSet<SmolStr>,
-    features: FxHashSet<SmolStr>,
-    options: FxHashMap<SmolStr, SmolStr>,
+    key_values: FxHashSet<(SmolStr, SmolStr)>,
 }
 
 impl CfgOptions {
     pub fn check(&self, cfg: &CfgExpr) -> Option<bool> {
         cfg.fold(&|key, value| match value {
             None => self.atoms.contains(key),
-            Some(value) if key == "feature" => self.features.contains(value),
-            Some(value) => self.options.get(key).map_or(false, |v| v == value),
+            Some(value) => self.key_values.contains(&(key.clone(), value.clone())),
         })
     }
 
@@ -31,13 +39,13 @@ impl CfgOptions {
         self
     }
 
-    pub fn feature(mut self, name: SmolStr) -> CfgOptions {
-        self.features.insert(name);
+    pub fn key_value(mut self, key: SmolStr, value: SmolStr) -> CfgOptions {
+        self.key_values.insert((key, value));
         self
     }
 
-    pub fn option(mut self, key: SmolStr, value: SmolStr) -> CfgOptions {
-        self.options.insert(key, value);
+    pub fn remove_atom(mut self, name: &SmolStr) -> CfgOptions {
+        self.atoms.remove(name);
         self
     }
 }

--- a/crates/ra_cfg/src/lib.rs
+++ b/crates/ra_cfg/src/lib.rs
@@ -1,4 +1,6 @@
 //! ra_cfg defines conditional compiling options, `cfg` attibute parser and evaluator
+use std::iter::IntoIterator;
+
 use ra_syntax::SmolStr;
 use rustc_hash::FxHashSet;
 
@@ -41,6 +43,14 @@ impl CfgOptions {
 
     pub fn key_value(mut self, key: SmolStr, value: SmolStr) -> CfgOptions {
         self.key_values.insert((key, value));
+        self
+    }
+
+    /// Shortcut to set features
+    pub fn features(mut self, iter: impl IntoIterator<Item = SmolStr>) -> CfgOptions {
+        for feat in iter {
+            self = self.key_value("feature".into(), feat);
+        }
         self
     }
 

--- a/crates/ra_db/Cargo.toml
+++ b/crates/ra_db/Cargo.toml
@@ -10,4 +10,5 @@ relative-path = "0.4.0"
 rustc-hash = "1.0"
 
 ra_syntax = { path = "../ra_syntax" }
+ra_cfg = { path = "../ra_cfg" }
 ra_prof = { path = "../ra_prof" }

--- a/crates/ra_db/src/input.rs
+++ b/crates/ra_db/src/input.rs
@@ -9,6 +9,7 @@
 use relative_path::{RelativePath, RelativePathBuf};
 use rustc_hash::FxHashMap;
 
+use ra_cfg::CfgOptions;
 use ra_syntax::SmolStr;
 use rustc_hash::FxHashSet;
 
@@ -109,11 +110,13 @@ struct CrateData {
     file_id: FileId,
     edition: Edition,
     dependencies: Vec<Dependency>,
+    cfg_options: CfgOptions,
 }
 
 impl CrateData {
     fn new(file_id: FileId, edition: Edition) -> CrateData {
-        CrateData { file_id, edition, dependencies: Vec::new() }
+        // FIXME: cfg options
+        CrateData { file_id, edition, dependencies: Vec::new(), cfg_options: CfgOptions::default() }
     }
 
     fn add_dep(&mut self, name: SmolStr, crate_id: CrateId) {
@@ -139,6 +142,10 @@ impl CrateGraph {
         let prev = self.arena.insert(crate_id, CrateData::new(file_id, edition));
         assert!(prev.is_none());
         crate_id
+    }
+
+    pub fn cfg_options(&self, crate_id: CrateId) -> &CfgOptions {
+        &self.arena[&crate_id].cfg_options
     }
 
     pub fn add_dep(

--- a/crates/ra_db/src/input.rs
+++ b/crates/ra_db/src/input.rs
@@ -114,9 +114,8 @@ struct CrateData {
 }
 
 impl CrateData {
-    fn new(file_id: FileId, edition: Edition) -> CrateData {
-        // FIXME: cfg options
-        CrateData { file_id, edition, dependencies: Vec::new(), cfg_options: CfgOptions::default() }
+    fn new(file_id: FileId, edition: Edition, cfg_options: CfgOptions) -> CrateData {
+        CrateData { file_id, edition, dependencies: Vec::new(), cfg_options }
     }
 
     fn add_dep(&mut self, name: SmolStr, crate_id: CrateId) {
@@ -137,9 +136,14 @@ impl Dependency {
 }
 
 impl CrateGraph {
-    pub fn add_crate_root(&mut self, file_id: FileId, edition: Edition) -> CrateId {
+    pub fn add_crate_root(
+        &mut self,
+        file_id: FileId,
+        edition: Edition,
+        cfg_options: CfgOptions,
+    ) -> CrateId {
         let crate_id = CrateId(self.arena.len() as u32);
-        let prev = self.arena.insert(crate_id, CrateData::new(file_id, edition));
+        let prev = self.arena.insert(crate_id, CrateData::new(file_id, edition, cfg_options));
         assert!(prev.is_none());
         crate_id
     }
@@ -228,14 +232,14 @@ impl CrateGraph {
 
 #[cfg(test)]
 mod tests {
-    use super::{CrateGraph, Edition::Edition2018, FileId, SmolStr};
+    use super::{CfgOptions, CrateGraph, Edition::Edition2018, FileId, SmolStr};
 
     #[test]
     fn it_should_panic_because_of_cycle_dependencies() {
         let mut graph = CrateGraph::default();
-        let crate1 = graph.add_crate_root(FileId(1u32), Edition2018);
-        let crate2 = graph.add_crate_root(FileId(2u32), Edition2018);
-        let crate3 = graph.add_crate_root(FileId(3u32), Edition2018);
+        let crate1 = graph.add_crate_root(FileId(1u32), Edition2018, CfgOptions::default());
+        let crate2 = graph.add_crate_root(FileId(2u32), Edition2018, CfgOptions::default());
+        let crate3 = graph.add_crate_root(FileId(3u32), Edition2018, CfgOptions::default());
         assert!(graph.add_dep(crate1, SmolStr::new("crate2"), crate2).is_ok());
         assert!(graph.add_dep(crate2, SmolStr::new("crate3"), crate3).is_ok());
         assert!(graph.add_dep(crate3, SmolStr::new("crate1"), crate1).is_err());
@@ -244,9 +248,9 @@ mod tests {
     #[test]
     fn it_works() {
         let mut graph = CrateGraph::default();
-        let crate1 = graph.add_crate_root(FileId(1u32), Edition2018);
-        let crate2 = graph.add_crate_root(FileId(2u32), Edition2018);
-        let crate3 = graph.add_crate_root(FileId(3u32), Edition2018);
+        let crate1 = graph.add_crate_root(FileId(1u32), Edition2018, CfgOptions::default());
+        let crate2 = graph.add_crate_root(FileId(2u32), Edition2018, CfgOptions::default());
+        let crate3 = graph.add_crate_root(FileId(3u32), Edition2018, CfgOptions::default());
         assert!(graph.add_dep(crate1, SmolStr::new("crate2"), crate2).is_ok());
         assert!(graph.add_dep(crate2, SmolStr::new("crate3"), crate3).is_ok());
     }

--- a/crates/ra_hir/Cargo.toml
+++ b/crates/ra_hir/Cargo.toml
@@ -15,6 +15,7 @@ once_cell = "1.0.1"
 
 ra_syntax = { path = "../ra_syntax" }
 ra_arena = { path = "../ra_arena" }
+ra_cfg = { path = "../ra_cfg" }
 ra_db = { path = "../ra_db" }
 mbe = { path = "../ra_mbe", package = "ra_mbe" }
 tt = { path = "../ra_tt", package = "ra_tt" }

--- a/crates/ra_hir/src/attr.rs
+++ b/crates/ra_hir/src/attr.rs
@@ -1,0 +1,58 @@
+use mbe::ast_to_token_tree;
+use ra_syntax::{
+    ast::{self, AstNode},
+    SmolStr,
+};
+use tt::Subtree;
+
+use crate::{db::AstDatabase, path::Path, Source};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Attr {
+    pub(crate) path: Path,
+    pub(crate) input: Option<AttrInput>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AttrInput {
+    Literal(SmolStr),
+    TokenTree(Subtree),
+}
+
+impl Attr {
+    pub(crate) fn from_src(
+        Source { file_id, ast }: Source<ast::Attr>,
+        db: &impl AstDatabase,
+    ) -> Option<Attr> {
+        let path = Path::from_src(Source { file_id, ast: ast.path()? }, db)?;
+        let input = match ast.input() {
+            None => None,
+            Some(ast::AttrInput::Literal(lit)) => {
+                // FIXME: escape? raw string?
+                let value = lit.syntax().first_token()?.text().trim_matches('"').into();
+                Some(AttrInput::Literal(value))
+            }
+            Some(ast::AttrInput::TokenTree(tt)) => {
+                Some(AttrInput::TokenTree(ast_to_token_tree(&tt)?.0))
+            }
+        };
+
+        Some(Attr { path, input })
+    }
+
+    pub(crate) fn is_simple_atom(&self, name: &str) -> bool {
+        // FIXME: Avoid cloning
+        self.path.as_ident().map_or(false, |s| s.to_string() == name)
+    }
+
+    pub(crate) fn as_cfg(&self) -> Option<&Subtree> {
+        if self.is_simple_atom("cfg") {
+            match &self.input {
+                Some(AttrInput::TokenTree(subtree)) => Some(subtree),
+                _ => None,
+            }
+        } else {
+            None
+        }
+    }
+}

--- a/crates/ra_hir/src/attr.rs
+++ b/crates/ra_hir/src/attr.rs
@@ -1,3 +1,5 @@
+//! A higher level attributes based on TokenTree, with also some shortcuts.
+
 use std::sync::Arc;
 
 use mbe::ast_to_token_tree;

--- a/crates/ra_hir/src/impl_block.rs
+++ b/crates/ra_hir/src/impl_block.rs
@@ -213,7 +213,9 @@ impl ModuleImplBlocks {
             match item {
                 ast::ItemOrMacro::Item(ast::ModuleItem::ImplBlock(impl_block_ast)) => {
                     let attrs = Attr::from_attrs_owner(file_id, &impl_block_ast, db);
-                    if attrs.iter().any(|attr| attr.is_cfg_enabled(cfg_options) == Some(false)) {
+                    if attrs.map_or(false, |attrs| {
+                        attrs.iter().any(|attr| attr.is_cfg_enabled(cfg_options) == Some(false))
+                    }) {
                         continue;
                     }
 
@@ -228,7 +230,9 @@ impl ModuleImplBlocks {
                 ast::ItemOrMacro::Item(_) => (),
                 ast::ItemOrMacro::Macro(macro_call) => {
                     let attrs = Attr::from_attrs_owner(file_id, &macro_call, db);
-                    if attrs.iter().any(|attr| attr.is_cfg_enabled(cfg_options) == Some(false)) {
+                    if attrs.map_or(false, |attrs| {
+                        attrs.iter().any(|attr| attr.is_cfg_enabled(cfg_options) == Some(false))
+                    }) {
                         continue;
                     }
 

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -44,6 +44,7 @@ mod traits;
 mod type_alias;
 mod type_ref;
 mod ty;
+mod attr;
 mod impl_block;
 mod expr;
 mod lang_item;

--- a/crates/ra_hir/src/nameres/collector.rs
+++ b/crates/ra_hir/src/nameres/collector.rs
@@ -7,7 +7,6 @@ use rustc_hash::FxHashMap;
 use test_utils::tested_by;
 
 use crate::{
-    attr::Attr,
     db::DefDatabase,
     ids::{AstItemDef, LocationCtx, MacroCallId, MacroCallLoc, MacroDefId, MacroFileKind},
     name::MACRO_RULES,
@@ -715,8 +714,12 @@ where
         }
     }
 
-    fn is_cfg_enabled(&self, attrs: &[Attr]) -> bool {
-        attrs.iter().all(|attr| attr.is_cfg_enabled(&self.def_collector.cfg_options) != Some(false))
+    fn is_cfg_enabled(&self, attrs: &raw::Attrs) -> bool {
+        attrs.as_ref().map_or(true, |attrs| {
+            attrs
+                .iter()
+                .all(|attr| attr.is_cfg_enabled(&self.def_collector.cfg_options) != Some(false))
+        })
     }
 }
 

--- a/crates/ra_hir/src/nameres/collector.rs
+++ b/crates/ra_hir/src/nameres/collector.rs
@@ -523,7 +523,7 @@ where
         // `#[macro_use] extern crate` is hoisted to imports macros before collecting
         // any other items.
         for item in items {
-            if let raw::RawItem::Import(import_id) = *item {
+            if let raw::RawItemKind::Import(import_id) = item.kind {
                 let import = self.raw_items[import_id].clone();
                 if import.is_extern_crate && import.is_macro_use {
                     self.def_collector.import_macros_from_extern_crate(self.module_id, &import);
@@ -532,15 +532,14 @@ where
         }
 
         for item in items {
-            match *item {
-                raw::RawItem::Module(m) => self.collect_module(&self.raw_items[m]),
-                raw::RawItem::Import(import_id) => self.def_collector.unresolved_imports.push((
-                    self.module_id,
-                    import_id,
-                    self.raw_items[import_id].clone(),
-                )),
-                raw::RawItem::Def(def) => self.define_def(&self.raw_items[def]),
-                raw::RawItem::Macro(mac) => self.collect_macro(&self.raw_items[mac]),
+            match item.kind {
+                raw::RawItemKind::Module(m) => self.collect_module(&self.raw_items[m]),
+                raw::RawItemKind::Import(import_id) => self
+                    .def_collector
+                    .unresolved_imports
+                    .push((self.module_id, import_id, self.raw_items[import_id].clone())),
+                raw::RawItemKind::Def(def) => self.define_def(&self.raw_items[def]),
+                raw::RawItemKind::Macro(mac) => self.collect_macro(&self.raw_items[mac]),
             }
         }
     }

--- a/crates/ra_hir/src/nameres/collector.rs
+++ b/crates/ra_hir/src/nameres/collector.rs
@@ -716,10 +716,7 @@ where
     }
 
     fn is_cfg_enabled(&self, attrs: &[Attr]) -> bool {
-        attrs
-            .iter()
-            .flat_map(|attr| attr.as_cfg())
-            .all(|cfg| self.def_collector.cfg_options.is_cfg_enabled(cfg).unwrap_or(true))
+        attrs.iter().all(|attr| attr.is_cfg_enabled(&self.def_collector.cfg_options) != Some(false))
     }
 }
 

--- a/crates/ra_hir/src/nameres/raw.rs
+++ b/crates/ra_hir/src/nameres/raw.rs
@@ -2,6 +2,7 @@
 
 use std::{ops::Index, sync::Arc};
 
+use mbe::ast_to_token_tree;
 use ra_arena::{impl_arena_id, map::ArenaMap, Arena, RawId};
 use ra_syntax::{
     ast::{self, AttrsOwner, NameOwner},
@@ -27,6 +28,8 @@ pub struct RawItems {
     /// items for top-level module
     items: Vec<RawItem>,
 }
+
+type Attrs = Arc<[tt::Subtree]>;
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct ImportSourceMap {
@@ -119,8 +122,14 @@ impl Index<Macro> for RawItems {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub(super) struct RawItem {
+    pub(super) attrs: Attrs,
+    pub(super) kind: RawItemKind,
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub(super) enum RawItem {
+pub(super) enum RawItemKind {
     Module(Module),
     Import(ImportId),
     Def(Def),
@@ -215,6 +224,7 @@ impl<DB: AstDatabase> RawItemsCollector<&DB> {
     }
 
     fn add_item(&mut self, current_module: Option<Module>, item: ast::ModuleItem) {
+        let attrs = self.parse_attrs(&item);
         let (kind, name) = match item {
             ast::ModuleItem::Module(module) => {
                 self.add_module(current_module, module);
@@ -263,7 +273,7 @@ impl<DB: AstDatabase> RawItemsCollector<&DB> {
         if let Some(name) = name {
             let name = name.as_name();
             let def = self.raw_items.defs.alloc(DefData { name, kind });
-            self.push_item(current_module, RawItem::Def(def))
+            self.push_item(current_module, attrs, RawItemKind::Def(def));
         }
     }
 
@@ -272,6 +282,7 @@ impl<DB: AstDatabase> RawItemsCollector<&DB> {
             Some(it) => it.as_name(),
             None => return,
         };
+        let attrs = self.parse_attrs(&module);
 
         let ast_id = self.source_ast_id_map.ast_id(&module);
         let is_macro_use = module.has_atom_attr("macro_use");
@@ -283,7 +294,7 @@ impl<DB: AstDatabase> RawItemsCollector<&DB> {
                 attr_path,
                 is_macro_use,
             });
-            self.push_item(current_module, RawItem::Module(item));
+            self.push_item(current_module, attrs, RawItemKind::Module(item));
             return;
         }
 
@@ -297,7 +308,7 @@ impl<DB: AstDatabase> RawItemsCollector<&DB> {
                 is_macro_use,
             });
             self.process_module(Some(item), item_list);
-            self.push_item(current_module, RawItem::Module(item));
+            self.push_item(current_module, attrs, RawItemKind::Module(item));
             return;
         }
         tested_by!(name_res_works_for_broken_modules);
@@ -305,6 +316,7 @@ impl<DB: AstDatabase> RawItemsCollector<&DB> {
 
     fn add_use_item(&mut self, current_module: Option<Module>, use_item: ast::UseItem) {
         let is_prelude = use_item.has_atom_attr("prelude_import");
+        let attrs = self.parse_attrs(&use_item);
 
         Path::expand_use_item(
             Source { ast: use_item, file_id: self.file_id },
@@ -318,7 +330,12 @@ impl<DB: AstDatabase> RawItemsCollector<&DB> {
                     is_extern_crate: false,
                     is_macro_use: false,
                 };
-                self.push_import(current_module, import_data, Either::A(AstPtr::new(use_tree)));
+                self.push_import(
+                    current_module,
+                    attrs.clone(),
+                    import_data,
+                    Either::A(AstPtr::new(use_tree)),
+                );
             },
         )
     }
@@ -331,6 +348,7 @@ impl<DB: AstDatabase> RawItemsCollector<&DB> {
         if let Some(name_ref) = extern_crate.name_ref() {
             let path = Path::from_name_ref(&name_ref);
             let alias = extern_crate.alias().and_then(|a| a.name()).map(|it| it.as_name());
+            let attrs = self.parse_attrs(&extern_crate);
             let is_macro_use = extern_crate.has_atom_attr("macro_use");
             let import_data = ImportData {
                 path,
@@ -340,7 +358,12 @@ impl<DB: AstDatabase> RawItemsCollector<&DB> {
                 is_extern_crate: true,
                 is_macro_use,
             };
-            self.push_import(current_module, import_data, Either::B(AstPtr::new(&extern_crate)));
+            self.push_import(
+                current_module,
+                attrs,
+                import_data,
+                Either::B(AstPtr::new(&extern_crate)),
+            );
         }
     }
 
@@ -358,21 +381,22 @@ impl<DB: AstDatabase> RawItemsCollector<&DB> {
         let export = m.attrs().filter_map(|x| x.simple_name()).any(|name| name == "macro_export");
 
         let m = self.raw_items.macros.alloc(MacroData { ast_id, path, name, export });
-        self.push_item(current_module, RawItem::Macro(m));
+        self.push_item(current_module, attrs, RawItemKind::Macro(m));
     }
 
     fn push_import(
         &mut self,
         current_module: Option<Module>,
+        attrs: Attrs,
         data: ImportData,
         source: ImportSourcePtr,
     ) {
         let import = self.raw_items.imports.alloc(data);
         self.source_map.insert(import, source);
-        self.push_item(current_module, RawItem::Import(import))
+        self.push_item(current_module, attrs, RawItemKind::Import(import))
     }
 
-    fn push_item(&mut self, current_module: Option<Module>, item: RawItem) {
+    fn push_item(&mut self, current_module: Option<Module>, attrs: Attrs, kind: RawItemKind) {
         match current_module {
             Some(module) => match &mut self.raw_items.modules[module] {
                 ModuleData::Definition { items, .. } => items,
@@ -380,7 +404,15 @@ impl<DB: AstDatabase> RawItemsCollector<&DB> {
             },
             None => &mut self.raw_items.items,
         }
-        .push(item)
+        .push(RawItem { attrs, kind })
+    }
+
+    fn parse_attrs(&self, item: &impl ast::AttrsOwner) -> Attrs {
+        item.attrs()
+            .flat_map(|attr| attr.value())
+            .flat_map(|tt| ast_to_token_tree(&tt))
+            .map(|(tt, _)| tt)
+            .collect()
     }
 }
 

--- a/crates/ra_hir/src/nameres/raw.rs
+++ b/crates/ra_hir/src/nameres/raw.rs
@@ -411,9 +411,7 @@ impl<DB: AstDatabase> RawItemsCollector<&DB> {
     }
 
     fn parse_attrs(&self, item: &impl ast::AttrsOwner) -> Arc<[Attr]> {
-        item.attrs()
-            .flat_map(|ast| Attr::from_src(Source { ast, file_id: self.file_id }, self.db))
-            .collect()
+        Attr::from_attrs_owner(self.file_id, item, self.db)
     }
 }
 

--- a/crates/ra_hir/src/nameres/tests.rs
+++ b/crates/ra_hir/src/nameres/tests.rs
@@ -563,9 +563,9 @@ fn cfg_test() {
             "main": ("/main.rs", ["std"]),
             "std": ("/lib.rs", [], CfgOptions::default()
                 .atom("test".into())
-                .feature("foo".into())
-                .feature("bar".into())
-                .option("opt".into(), "42".into())
+                .key_value("feature".into(), "foo".into())
+                .key_value("feature".into(), "bar".into())
+                .key_value("opt".into(), "42".into())
             ),
         },
     );

--- a/crates/ra_ide_api/Cargo.toml
+++ b/crates/ra_ide_api/Cargo.toml
@@ -23,6 +23,7 @@ rand = { version = "0.7.0", features = ["small_rng"] }
 ra_syntax = { path = "../ra_syntax" }
 ra_text_edit = { path = "../ra_text_edit" }
 ra_db = { path = "../ra_db" }
+ra_cfg = { path = "../ra_cfg" }
 ra_fmt = { path = "../ra_fmt" }
 ra_prof = { path = "../ra_prof" }
 hir = { path = "../ra_hir", package = "ra_hir" }

--- a/crates/ra_ide_api/src/lib.rs
+++ b/crates/ra_ide_api/src/lib.rs
@@ -49,6 +49,7 @@ mod test_utils;
 
 use std::sync::Arc;
 
+use ra_cfg::CfgOptions;
 use ra_db::{
     salsa::{self, ParallelDatabase},
     CheckCanceled, SourceDatabase,
@@ -322,7 +323,10 @@ impl Analysis {
         change.add_root(source_root, true);
         let mut crate_graph = CrateGraph::default();
         let file_id = FileId(0);
-        crate_graph.add_crate_root(file_id, Edition::Edition2018);
+        // FIXME: cfg options
+        // Default to enable test for single file.
+        let cfg_options = CfgOptions::default().atom("test".into());
+        crate_graph.add_crate_root(file_id, Edition::Edition2018, cfg_options);
         change.add_file(source_root, file_id, "main.rs".into(), Arc::new(text));
         change.set_crate_graph(crate_graph);
         host.apply_change(change);

--- a/crates/ra_ide_api/src/mock_analysis.rs
+++ b/crates/ra_ide_api/src/mock_analysis.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use ra_cfg::CfgOptions;
 use relative_path::RelativePathBuf;
 use test_utils::{extract_offset, extract_range, parse_fixture, CURSOR_MARKER};
 
@@ -93,10 +94,12 @@ impl MockAnalysis {
             assert!(path.starts_with('/'));
             let path = RelativePathBuf::from_path(&path[1..]).unwrap();
             let file_id = FileId(i as u32 + 1);
+            // FIXME: cfg options
+            let cfg_options = CfgOptions::default();
             if path == "/lib.rs" || path == "/main.rs" {
-                root_crate = Some(crate_graph.add_crate_root(file_id, Edition2018));
+                root_crate = Some(crate_graph.add_crate_root(file_id, Edition2018, cfg_options));
             } else if path.ends_with("/lib.rs") {
-                let other_crate = crate_graph.add_crate_root(file_id, Edition2018);
+                let other_crate = crate_graph.add_crate_root(file_id, Edition2018, cfg_options);
                 let crate_name = path.parent().unwrap().file_name().unwrap();
                 if let Some(root_crate) = root_crate {
                     crate_graph.add_dep(root_crate, crate_name.into(), other_crate).unwrap();

--- a/crates/ra_ide_api/src/mock_analysis.rs
+++ b/crates/ra_ide_api/src/mock_analysis.rs
@@ -94,7 +94,6 @@ impl MockAnalysis {
             assert!(path.starts_with('/'));
             let path = RelativePathBuf::from_path(&path[1..]).unwrap();
             let file_id = FileId(i as u32 + 1);
-            // FIXME: cfg options
             let cfg_options = CfgOptions::default();
             if path == "/lib.rs" || path == "/main.rs" {
                 root_crate = Some(crate_graph.add_crate_root(file_id, Edition2018, cfg_options));

--- a/crates/ra_ide_api/src/parent_module.rs
+++ b/crates/ra_ide_api/src/parent_module.rs
@@ -41,6 +41,7 @@ mod tests {
         AnalysisChange, CrateGraph,
         Edition::Edition2018,
     };
+    use ra_cfg::CfgOptions;
 
     #[test]
     fn test_resolve_parent_module() {
@@ -88,7 +89,7 @@ mod tests {
         assert!(host.analysis().crate_for(mod_file).unwrap().is_empty());
 
         let mut crate_graph = CrateGraph::default();
-        let crate_id = crate_graph.add_crate_root(root_file, Edition2018);
+        let crate_id = crate_graph.add_crate_root(root_file, Edition2018, CfgOptions::default());
         let mut change = AnalysisChange::new();
         change.set_crate_graph(crate_graph);
         host.apply_change(change);

--- a/crates/ra_lsp_server/Cargo.toml
+++ b/crates/ra_lsp_server/Cargo.toml
@@ -19,6 +19,7 @@ jod-thread = "0.1.0"
 ra_vfs = "0.4.0"
 ra_syntax = { path = "../ra_syntax" }
 ra_db = { path = "../ra_db" }
+ra_cfg = { path = "../ra_cfg" }
 ra_text_edit = { path = "../ra_text_edit" }
 ra_ide_api = { path = "../ra_ide_api" }
 lsp-server = "0.2.0"

--- a/crates/ra_lsp_server/tests/heavy_tests/main.rs
+++ b/crates/ra_lsp_server/tests/heavy_tests/main.rs
@@ -286,7 +286,13 @@ fn test_missing_module_code_action_in_json_project() {
 
     let project = json!({
         "roots": [path],
-        "crates": [ { "root_module": path.join("src/lib.rs"), "deps": [], "edition": "2015" } ]
+        "crates": [ {
+            "root_module": path.join("src/lib.rs"),
+            "deps": [],
+            "edition": "2015",
+            "atom_cfgs": [],
+            "key_value_cfgs": {}
+        } ]
     });
 
     let code = format!(

--- a/crates/ra_project_model/Cargo.toml
+++ b/crates/ra_project_model/Cargo.toml
@@ -12,6 +12,7 @@ cargo_metadata = "0.8.2"
 
 ra_arena = { path = "../ra_arena" }
 ra_db = { path = "../ra_db" }
+ra_cfg = { path = "../ra_cfg" }
 
 serde = { version = "1.0.89", features = ["derive"] }
 serde_json = "1.0.39"

--- a/crates/ra_project_model/src/cargo_workspace.rs
+++ b/crates/ra_project_model/src/cargo_workspace.rs
@@ -39,6 +39,7 @@ struct PackageData {
     is_member: bool,
     dependencies: Vec<PackageDependency>,
     edition: Edition,
+    features: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -90,6 +91,9 @@ impl Package {
     }
     pub fn edition(self, ws: &CargoWorkspace) -> Edition {
         ws.packages[self].edition
+    }
+    pub fn features(self, ws: &CargoWorkspace) -> &[String] {
+        &ws.packages[self].features
     }
     pub fn targets<'a>(self, ws: &'a CargoWorkspace) -> impl Iterator<Item = Target> + 'a {
         ws.packages[self].targets.iter().cloned()
@@ -144,6 +148,7 @@ impl CargoWorkspace {
                 is_member,
                 edition: Edition::from_string(&meta_pkg.edition),
                 dependencies: Vec::new(),
+                features: Vec::new(),
             });
             let pkg_data = &mut packages[pkg];
             pkg_by_id.insert(meta_pkg.id.clone(), pkg);
@@ -164,6 +169,7 @@ impl CargoWorkspace {
                 let dep = PackageDependency { name: dep_node.name, pkg: pkg_by_id[&dep_node.pkg] };
                 packages[source].dependencies.push(dep);
             }
+            packages[source].features.extend(node.features);
         }
 
         Ok(CargoWorkspace { packages, targets, workspace_root: meta.workspace_root })

--- a/crates/ra_project_model/src/json_project.rs
+++ b/crates/ra_project_model/src/json_project.rs
@@ -19,6 +19,8 @@ pub struct Crate {
     pub(crate) root_module: PathBuf,
     pub(crate) edition: Edition,
     pub(crate) deps: Vec<Dep>,
+    #[serde(default)]
+    pub(crate) features: Vec<String>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize)]

--- a/crates/ra_project_model/src/json_project.rs
+++ b/crates/ra_project_model/src/json_project.rs
@@ -2,6 +2,7 @@
 
 use std::path::PathBuf;
 
+use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Deserialize;
 
 /// A root points to the directory which contains Rust crates. rust-analyzer watches all files in
@@ -19,8 +20,8 @@ pub struct Crate {
     pub(crate) root_module: PathBuf,
     pub(crate) edition: Edition,
     pub(crate) deps: Vec<Dep>,
-    #[serde(default)]
-    pub(crate) features: Vec<String>,
+    pub(crate) atom_cfgs: FxHashSet<String>,
+    pub(crate) key_value_cfgs: FxHashMap<String, String>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize)]

--- a/crates/ra_syntax/src/ast/generated.rs
+++ b/crates/ra_syntax/src/ast/generated.rs
@@ -1962,6 +1962,7 @@ impl AstNode for ModuleItem {
         }
     }
 }
+impl ast::AttrsOwner for ModuleItem {}
 impl ModuleItem {}
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Name {

--- a/crates/ra_syntax/src/grammar.ron
+++ b/crates/ra_syntax/src/grammar.ron
@@ -397,7 +397,8 @@ Grammar(
         ),
         "ModuleItem": (
             enum: ["StructDef", "EnumDef", "FnDef", "TraitDef", "TypeAliasDef", "ImplBlock",
-                   "UseItem", "ExternCrateItem", "ConstDef", "StaticDef", "Module" ]
+                   "UseItem", "ExternCrateItem", "ConstDef", "StaticDef", "Module" ],
+            traits: ["AttrsOwner"]
         ),
         "ImplItem": (
             enum: ["FnDef", "TypeAliasDef", "ConstDef"]


### PR DESCRIPTION
This PR implement `#[cfg(..)]` conditional compilation. It read default cfg options from `rustc --print cfg` with also hard-coded `test` and `debug_assertion` enabled.
Front-end settings are **not** included in this PR.

There is also a known issue that inner control attributes are totally ignored. I think it is **not** a part of `cfg` and create a separated issue for it. #1949

Fixes #1920 

Related: #1073 
