### PR TITLE
Support the new deprecated tag

### DIFF
--- a/editors/code/src/test/utils/diagnotics/rust.test.ts
+++ b/editors/code/src/test/utils/diagnotics/rust.test.ts
@@ -50,7 +50,7 @@ describe('mapRustDiagnosticToVsCode', () => {
             ].join('\n')
         );
         assert.strictEqual(diagnostic.code, 'E0053');
-        assert.strictEqual(diagnostic.tags, undefined);
+        assert.deepStrictEqual(diagnostic.tags, []);
 
         // No related information
         assert.deepStrictEqual(diagnostic.relatedInformation, []);
@@ -115,7 +115,7 @@ describe('mapRustDiagnosticToVsCode', () => {
         );
         assert.strictEqual(diagnostic.code, 'E0061');
         assert.strictEqual(diagnostic.source, 'rustc');
-        assert.strictEqual(diagnostic.tags, undefined);
+        assert.deepStrictEqual(diagnostic.tags, []);
 
         // One related information for the original definition
         const relatedInformation = diagnostic.relatedInformation;
@@ -149,7 +149,7 @@ describe('mapRustDiagnosticToVsCode', () => {
             ].join('\n')
         );
         assert.strictEqual(diagnostic.code, 'trivially_copy_pass_by_ref');
-        assert.strictEqual(diagnostic.tags, undefined);
+        assert.deepStrictEqual(diagnostic.tags, []);
 
         // One related information for the lint definition
         const relatedInformation = diagnostic.relatedInformation;
@@ -189,7 +189,7 @@ describe('mapRustDiagnosticToVsCode', () => {
         );
         assert.strictEqual(diagnostic.code, 'E0308');
         assert.strictEqual(diagnostic.source, 'rustc');
-        assert.strictEqual(diagnostic.tags, undefined);
+        assert.deepStrictEqual(diagnostic.tags, []);
 
         // No related information
         assert.deepStrictEqual(diagnostic.relatedInformation, []);

--- a/editors/code/src/utils/diagnostics/rust.ts
+++ b/editors/code/src/utils/diagnostics/rust.ts
@@ -213,6 +213,7 @@ export function mapRustDiagnosticToVsCode(
     vd.source = source;
     vd.code = code;
     vd.relatedInformation = [];
+    vd.tags = [];
 
     for (const secondarySpan of secondarySpans) {
         const related = mapSecondarySpanToRelated(secondarySpan);
@@ -245,8 +246,6 @@ export function mapRustDiagnosticToVsCode(
     if (primarySpanLabel) {
         vd.message += `\n${primarySpanLabel}`;
     }
-
-    vd.tags = []
 
     if (isUnusedOrUnnecessary(rd)) {
         vd.tags.push(vscode.DiagnosticTag.Unnecessary);

--- a/editors/code/src/utils/diagnostics/rust.ts
+++ b/editors/code/src/utils/diagnostics/rust.ts
@@ -112,6 +112,19 @@ function isUnusedOrUnnecessary(rd: RustDiagnostic): boolean {
 }
 
 /**
+ * Determines if diagnostic is related to deprecated code
+ */
+function isDeprecated(rd: RustDiagnostic): boolean {
+    if (!rd.code) {
+        return false;
+    }
+
+    return [
+        'deprecated',
+    ].includes(rd.code.code);
+}
+
+/**
  * Converts a Rust child diagnostic to a VsCode related information
  *
  * This can have three outcomes:
@@ -233,8 +246,14 @@ export function mapRustDiagnosticToVsCode(
         vd.message += `\n${primarySpanLabel}`;
     }
 
+    vd.tags = []
+
     if (isUnusedOrUnnecessary(rd)) {
-        vd.tags = [vscode.DiagnosticTag.Unnecessary];
+        vd.tags.push(vscode.DiagnosticTag.Unnecessary);
+    }
+
+    if (isDeprecated(rd)) {
+        vd.tags.push(vscode.DiagnosticTag.Deprecated);
     }
 
     return {

--- a/editors/code/src/utils/diagnostics/rust.ts
+++ b/editors/code/src/utils/diagnostics/rust.ts
@@ -119,9 +119,7 @@ function isDeprecated(rd: RustDiagnostic): boolean {
         return false;
     }
 
-    return [
-        'deprecated',
-    ].includes(rd.code.code);
+    return ['deprecated'].includes(rd.code.code);
 }
 
 /**


### PR DESCRIPTION
Which is rendered as a strike-through line. Fixes #1671 .
![深度截图_选择区域_20190927162008](https://user-images.githubusercontent.com/4067473/65799714-ccb4c180-e142-11e9-8e45-ab18964605f3.png)
