### PR TITLE
Buildfix

### DIFF
--- a/crates/ra_hir/src/ty/infer.rs
+++ b/crates/ra_hir/src/ty/infer.rs
@@ -1850,3 +1850,13 @@ mod diagnostics {
         }
     }
 }
+
+impl std::iter::FromIterator<Ty> for std::sync::Arc<[Ty]>{
+    fn from_iter<I:IntoIterator<Item=Ty>>(iter:I)->std::sync::Arc<[Ty]>{
+        let mut temp:Vec<Ty> = Vec::new();
+        for i in iter{
+            temp.push(i);    
+        }
+        temp.into()
+    }
+} 


### PR DESCRIPTION
cargo install-ra failed for me with "`error[E0277]:` a collection of type `std::sync::Arc<[ty::Ty]>` cannot be built from an iterator over elements of type `ty::Ty`", this fixes it.

Ps. I know rust since 5 days and never used git.