### PR TITLE
env!("OUT_DIR") macro

### DIFF
--- a/crates/ra_db/src/input.rs
+++ b/crates/ra_db/src/input.rs
@@ -129,7 +129,7 @@ impl CrateData {
         self.dependencies.push(Dependency { name, crate_id })
     }
 
-    /// Sets environment variable available trough `env!(VARIABLE_NAME)` macro for crates in crate graph.
+    /// Sets environment variable available through `env!(VARIABLE_NAME)` macro for crates in crate graph.
     pub fn set_env(&mut self, env: &str, value: String) {
         self.env.insert(env.to_owned(), value);
     }

--- a/crates/ra_db/src/input.rs
+++ b/crates/ra_db/src/input.rs
@@ -76,6 +76,7 @@ impl SourceRoot {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CrateGraph {
     arena: FxHashMap<CrateId, CrateData>,
+    env: FxHashMap<String, String>,
 }
 
 #[derive(Debug)]
@@ -146,6 +147,11 @@ impl CrateGraph {
         let prev = self.arena.insert(crate_id, CrateData::new(file_id, edition, cfg_options));
         assert!(prev.is_none());
         crate_id
+    }
+
+    /// Sets environment variable available trough `env!(VARIABLE_NAME)` macro for crates in crate graph.
+    pub fn set_env(&mut self, env: &str, value: &str) {
+        self.env.insert(env.to_owned(), value.to_owned());
     }
 
     pub fn cfg_options(&self, crate_id: CrateId) -> &CfgOptions {

--- a/crates/ra_hir/src/mock.rs
+++ b/crates/ra_hir/src/mock.rs
@@ -77,7 +77,8 @@ impl MockDatabase {
         let mut crate_graph = CrateGraph::default();
         for (crate_name, (crate_root, edition, cfg_options, _)) in graph.0.iter() {
             let crate_root = self.file_id_of(&crate_root);
-            let crate_id = crate_graph.add_crate_root(crate_root, *edition, cfg_options.clone());
+            let crate_id =
+                crate_graph.add_crate_root(crate_root, *edition, cfg_options.clone(), None);
             Arc::make_mut(&mut self.crate_names).insert(crate_id, crate_name.clone());
             ids.insert(crate_name, crate_id);
         }
@@ -185,7 +186,7 @@ impl MockDatabase {
 
         if is_crate_root {
             let mut crate_graph = CrateGraph::default();
-            crate_graph.add_crate_root(file_id, Edition::Edition2018, CfgOptions::default());
+            crate_graph.add_crate_root(file_id, Edition::Edition2018, CfgOptions::default(), None);
             self.set_crate_graph(Arc::new(crate_graph));
         }
         file_id

--- a/crates/ra_ide_api/src/lib.rs
+++ b/crates/ra_ide_api/src/lib.rs
@@ -326,7 +326,7 @@ impl Analysis {
         // FIXME: cfg options
         // Default to enable test for single file.
         let cfg_options = CfgOptions::default().atom("test".into());
-        crate_graph.add_crate_root(file_id, Edition::Edition2018, cfg_options);
+        crate_graph.add_crate_root(file_id, Edition::Edition2018, cfg_options, None);
         change.add_file(source_root, file_id, "main.rs".into(), Arc::new(text));
         change.set_crate_graph(crate_graph);
         host.apply_change(change);

--- a/crates/ra_ide_api/src/mock_analysis.rs
+++ b/crates/ra_ide_api/src/mock_analysis.rs
@@ -96,9 +96,11 @@ impl MockAnalysis {
             let file_id = FileId(i as u32 + 1);
             let cfg_options = CfgOptions::default();
             if path == "/lib.rs" || path == "/main.rs" {
-                root_crate = Some(crate_graph.add_crate_root(file_id, Edition2018, cfg_options));
+                root_crate =
+                    Some(crate_graph.add_crate_root(file_id, Edition2018, cfg_options, None));
             } else if path.ends_with("/lib.rs") {
-                let other_crate = crate_graph.add_crate_root(file_id, Edition2018, cfg_options);
+                let other_crate =
+                    crate_graph.add_crate_root(file_id, Edition2018, cfg_options, None);
                 let crate_name = path.parent().unwrap().file_name().unwrap();
                 if let Some(root_crate) = root_crate {
                     crate_graph.add_dep(root_crate, crate_name.into(), other_crate).unwrap();

--- a/crates/ra_ide_api/src/parent_module.rs
+++ b/crates/ra_ide_api/src/parent_module.rs
@@ -89,7 +89,8 @@ mod tests {
         assert!(host.analysis().crate_for(mod_file).unwrap().is_empty());
 
         let mut crate_graph = CrateGraph::default();
-        let crate_id = crate_graph.add_crate_root(root_file, Edition2018, CfgOptions::default());
+        let crate_id =
+            crate_graph.add_crate_root(root_file, Edition2018, CfgOptions::default(), None);
         let mut change = AnalysisChange::new();
         change.set_crate_graph(crate_graph);
         host.apply_change(change);

--- a/crates/ra_project_model/src/cargo_workspace.rs
+++ b/crates/ra_project_model/src/cargo_workspace.rs
@@ -21,6 +21,7 @@ pub struct CargoWorkspace {
     packages: Arena<Package, PackageData>,
     targets: Arena<Target, TargetData>,
     pub(crate) workspace_root: PathBuf,
+    pub(crate) target_directory: PathBuf,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -172,7 +173,7 @@ impl CargoWorkspace {
             packages[source].features.extend(node.features);
         }
 
-        Ok(CargoWorkspace { packages, targets, workspace_root: meta.workspace_root })
+        Ok(CargoWorkspace { packages, targets, workspace_root: meta.workspace_root, target_directory: meta.target_directory })
     }
 
     pub fn packages<'a>(&'a self) -> impl Iterator<Item = Package> + ExactSizeIterator + 'a {

--- a/crates/ra_project_model/src/cargo_workspace.rs
+++ b/crates/ra_project_model/src/cargo_workspace.rs
@@ -173,7 +173,12 @@ impl CargoWorkspace {
             packages[source].features.extend(node.features);
         }
 
-        Ok(CargoWorkspace { packages, targets, workspace_root: meta.workspace_root, target_directory: meta.target_directory })
+        Ok(CargoWorkspace {
+            packages,
+            targets,
+            workspace_root: meta.workspace_root,
+            target_directory: meta.target_directory,
+        })
     }
 
     pub fn packages<'a>(&'a self) -> impl Iterator<Item = Package> + ExactSizeIterator + 'a {

--- a/crates/ra_project_model/src/lib.rs
+++ b/crates/ra_project_model/src/lib.rs
@@ -167,6 +167,12 @@ impl ProjectWorkspace {
                 }
             }
             ProjectWorkspace::Cargo { cargo, sysroot } => {
+                // Find workspace's OUT_DIR inside target/ directory.
+                // FIXME: should be replaced by path to OUT_DIR coming from metadata, but that would require upstream change to cargo
+                if let Some(dir) = find_out_dir(&cargo.target_directory) {
+                    crate_graph.set_env("OUT_DIR", dir);
+                }
+
                 let mut sysroot_crates = FxHashMap::default();
                 for krate in sysroot.crates() {
                     if let Some(file_id) = load(krate.root(&sysroot)) {
@@ -272,6 +278,13 @@ impl ProjectWorkspace {
                 .find(|root| path.starts_with(&root.path))
                 .map(|root| root.path.as_ref()),
         }
+    }
+
+    /// A heuristic that finds the `OUT_DIR` in the specific `target/` directory of `cargo` workspace.
+    fn find_out_dir(target_path: &PathBuf) -> Option<String> {
+        // FIXME: put heuristic here
+        // Should probably traverse the `target/<release-or-debug>/...` path and find a match
+        None
     }
 }
 

--- a/crates/ra_project_model/src/lib.rs
+++ b/crates/ra_project_model/src/lib.rs
@@ -169,8 +169,8 @@ impl ProjectWorkspace {
             ProjectWorkspace::Cargo { cargo, sysroot } => {
                 // Find workspace's OUT_DIR inside target/ directory.
                 // FIXME: should be replaced by path to OUT_DIR coming from metadata, but that would require upstream change to cargo
-                if let Some(dir) = find_out_dir(&cargo.target_directory) {
-                    crate_graph.set_env("OUT_DIR", dir);
+                if let Some(dir) = Self::find_out_dir(&cargo.target_directory) {
+                    crate_graph.set_env("OUT_DIR", &dir);
                 }
 
                 let mut sysroot_crates = FxHashMap::default();
@@ -280,8 +280,8 @@ impl ProjectWorkspace {
         }
     }
 
-    /// A heuristic that finds the `OUT_DIR` in the specific `target/` directory of `cargo` workspace.
-    fn find_out_dir(target_path: &PathBuf) -> Option<String> {
+    /// A heuristic that looks for the `OUT_DIR` in the specific `target/` directory of `cargo` workspace.
+    fn find_out_dir(_target_path: &PathBuf) -> Option<String> {
         // FIXME: put heuristic here
         // Should probably traverse the `target/<release-or-debug>/...` path and find a match
         None


### PR DESCRIPTION
Hello,

This PR is related to the #1964.

@matklad pls give a hint on how do we search for the `OUT_DIR` in the workspace given that we have a `target_path` from `cargo metadata` and can use that.