### PR TITLE
Use `original_file` instead of `as_original_file`

### DIFF
--- a/crates/ra_hir/src/ids.rs
+++ b/crates/ra_hir/src/ids.rs
@@ -50,16 +50,6 @@ impl HirFileId {
         }
     }
 
-    /// XXX: this is a temporary function, which should go away when we implement the
-    /// nameresolution+macro expansion combo. Prefer using `original_file` if
-    /// possible.
-    pub fn as_original_file(self) -> FileId {
-        match self.0 {
-            HirFileIdRepr::File(file_id) => file_id,
-            HirFileIdRepr::Macro(_r) => panic!("macro generated file: {:?}", self),
-        }
-    }
-
     /// Get the crate which the macro lives in, if it is a macro file.
     pub(crate) fn macro_crate(self, db: &impl AstDatabase) -> Option<Crate> {
         match self.0 {

--- a/crates/ra_ide_api/src/display/navigation_target.rs
+++ b/crates/ra_ide_api/src/display/navigation_target.rs
@@ -119,7 +119,7 @@ impl NavigationTarget {
 
     pub(crate) fn from_module(db: &RootDatabase, module: hir::Module) -> NavigationTarget {
         let src = module.definition_source(db);
-        let file_id = src.file_id.as_original_file();
+        let file_id = src.file_id.original_file(db);
         let name = module.name(db).map(|it| it.to_string().into()).unwrap_or_default();
         match src.ast {
             ModuleSource::SourceFile(node) => {
@@ -139,7 +139,7 @@ impl NavigationTarget {
     pub(crate) fn from_module_to_decl(db: &RootDatabase, module: hir::Module) -> NavigationTarget {
         let name = module.name(db).map(|it| it.to_string().into()).unwrap_or_default();
         if let Some(src) = module.declaration_source(db) {
-            let file_id = src.file_id.as_original_file();
+            let file_id = src.file_id.original_file(db);
             return NavigationTarget::from_syntax(
                 file_id,
                 name,
@@ -213,7 +213,7 @@ impl NavigationTarget {
     ) -> NavigationTarget {
         let src = impl_block.source(db);
         NavigationTarget::from_syntax(
-            src.file_id.as_original_file(),
+            src.file_id.original_file(db),
             "impl".into(),
             None,
             src.ast.syntax(),

--- a/crates/ra_ide_api/src/references.rs
+++ b/crates/ra_ide_api/src/references.rs
@@ -140,7 +140,7 @@ fn rename_mod(
     let module_src = hir::Source { file_id: position.file_id.into(), ast: ast_module.clone() };
     if let Some(module) = hir::Module::from_declaration(db, module_src) {
         let src = module.definition_source(db);
-        let file_id = src.file_id.as_original_file();
+        let file_id = src.file_id.original_file(db);
         match src.ast {
             ModuleSource::SourceFile(..) => {
                 let mod_path: RelativePathBuf = db.file_relative_path(file_id);


### PR DESCRIPTION
I saw ra_lsp_server panics originating from `as_original_file`, though I have not been able to reproduce.