### PR TITLE
Improvements around `Arc<[T]>`

### DIFF
--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -51,6 +51,7 @@ mod lang_item;
 mod generics;
 mod resolve;
 pub mod diagnostics;
+mod util;
 
 mod code_model;
 

--- a/crates/ra_hir/src/ty.rs
+++ b/crates/ra_hir/src/ty.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use std::{fmt, iter, mem};
 
 use crate::{
-    db::HirDatabase, expr::ExprId, type_ref::Mutability, util::make_mut_arc_slice, Adt, Crate,
+    db::HirDatabase, expr::ExprId, type_ref::Mutability, util::make_mut_slice, Adt, Crate,
     DefWithBody, GenericParams, HasGenericParams, Name, Trait, TypeAlias,
 };
 use display::{HirDisplay, HirFormatter};
@@ -308,11 +308,9 @@ impl Substs {
     }
 
     pub fn walk_mut(&mut self, f: &mut impl FnMut(&mut Ty)) {
-        make_mut_arc_slice(&mut self.0, |s| {
-            for t in s {
-                t.walk_mut(f);
-            }
-        });
+        for t in make_mut_slice(&mut self.0) {
+            t.walk_mut(f);
+        }
     }
 
     pub fn as_single(&self) -> &Ty {
@@ -538,11 +536,9 @@ impl TypeWalk for FnSig {
     }
 
     fn walk_mut(&mut self, f: &mut impl FnMut(&mut Ty)) {
-        make_mut_arc_slice(&mut self.params_and_return, |s| {
-            for t in s {
-                t.walk_mut(f);
-            }
-        });
+        for t in make_mut_slice(&mut self.params_and_return) {
+            t.walk_mut(f);
+        }
     }
 }
 
@@ -752,11 +748,9 @@ impl TypeWalk for Ty {
                 p_ty.parameters.walk_mut(f);
             }
             Ty::Dyn(predicates) | Ty::Opaque(predicates) => {
-                make_mut_arc_slice(predicates, |s| {
-                    for p in s {
-                        p.walk_mut(f);
-                    }
-                });
+                for p in make_mut_slice(predicates) {
+                    p.walk_mut(f);
+                }
             }
             Ty::Param { .. } | Ty::Bound(_) | Ty::Infer(_) | Ty::Unknown => {}
         }

--- a/crates/ra_hir/src/ty.rs
+++ b/crates/ra_hir/src/ty.rs
@@ -329,8 +329,7 @@ impl Substs {
                 .params_including_parent()
                 .into_iter()
                 .map(|p| Ty::Param { idx: p.idx, name: p.name.clone() })
-                .collect::<Vec<_>>()
-                .into(),
+                .collect(),
         )
     }
 
@@ -341,8 +340,7 @@ impl Substs {
                 .params_including_parent()
                 .into_iter()
                 .map(|p| Ty::Bound(p.idx))
-                .collect::<Vec<_>>()
-                .into(),
+                .collect(),
         )
     }
 

--- a/crates/ra_hir/src/ty/infer/unify.rs
+++ b/crates/ra_hir/src/ty/infer/unify.rs
@@ -6,7 +6,7 @@ use crate::ty::{
     Canonical, InEnvironment, InferTy, ProjectionPredicate, ProjectionTy, Substs, TraitRef, Ty,
     TypeWalk,
 };
-use crate::util::make_mut_arc_slice;
+use crate::util::make_mut_slice;
 
 impl<'a, D: HirDatabase> InferenceContext<'a, D> {
     pub(super) fn canonicalizer<'b>(&'b mut self) -> Canonicalizer<'a, 'b, D>
@@ -76,11 +76,9 @@ where
     }
 
     fn do_canonicalize_trait_ref(&mut self, mut trait_ref: TraitRef) -> TraitRef {
-        make_mut_arc_slice(&mut trait_ref.substs.0, |tys| {
-            for ty in tys {
-                *ty = self.do_canonicalize_ty(ty.clone());
-            }
-        });
+        for ty in make_mut_slice(&mut trait_ref.substs.0) {
+            *ty = self.do_canonicalize_ty(ty.clone());
+        }
         trait_ref
     }
 
@@ -92,11 +90,9 @@ where
     }
 
     fn do_canonicalize_projection_ty(&mut self, mut projection_ty: ProjectionTy) -> ProjectionTy {
-        make_mut_arc_slice(&mut projection_ty.parameters.0, |params| {
-            for ty in params {
-                *ty = self.do_canonicalize_ty(ty.clone());
-            }
-        });
+        for ty in make_mut_slice(&mut projection_ty.parameters.0) {
+            *ty = self.do_canonicalize_ty(ty.clone());
+        }
         projection_ty
     }
 

--- a/crates/ra_hir/src/ty/lower.rs
+++ b/crates/ra_hir/src/ty/lower.rs
@@ -22,6 +22,7 @@ use crate::{
     resolve::{Resolver, TypeNs},
     ty::Adt,
     type_ref::{TypeBound, TypeRef},
+    util::make_mut_arc_slice,
     BuiltinType, Const, Enum, EnumVariant, Function, ModuleDef, Path, Static, Struct, StructField,
     Trait, TypeAlias, Union,
 };
@@ -390,7 +391,7 @@ impl TraitRef {
     ) -> Self {
         let mut substs = TraitRef::substs_from_path(db, resolver, segment, resolved);
         if let Some(self_ty) = explicit_self_ty {
-            crate::util::make_mut_arc_slice(&mut substs.0, |substs| {
+            make_mut_arc_slice(&mut substs.0, |substs| {
                 substs[0] = self_ty;
             });
         }

--- a/crates/ra_hir/src/ty/lower.rs
+++ b/crates/ra_hir/src/ty/lower.rs
@@ -22,7 +22,7 @@ use crate::{
     resolve::{Resolver, TypeNs},
     ty::Adt,
     type_ref::{TypeBound, TypeRef},
-    util::make_mut_arc_slice,
+    util::make_mut_slice,
     BuiltinType, Const, Enum, EnumVariant, Function, ModuleDef, Path, Static, Struct, StructField,
     Trait, TypeAlias, Union,
 };
@@ -391,9 +391,7 @@ impl TraitRef {
     ) -> Self {
         let mut substs = TraitRef::substs_from_path(db, resolver, segment, resolved);
         if let Some(self_ty) = explicit_self_ty {
-            make_mut_arc_slice(&mut substs.0, |substs| {
-                substs[0] = self_ty;
-            });
+            make_mut_slice(&mut substs.0)[0] = self_ty;
         }
         TraitRef { trait_: resolved, substs }
     }

--- a/crates/ra_hir/src/ty/lower.rs
+++ b/crates/ra_hir/src/ty/lower.rs
@@ -392,10 +392,9 @@ impl TraitRef {
     ) -> Self {
         let mut substs = TraitRef::substs_from_path(db, resolver, segment, resolved);
         if let Some(self_ty) = explicit_self_ty {
-            // FIXME this could be nicer
-            let mut substs_vec = substs.0.to_vec();
-            substs_vec[0] = self_ty;
-            substs.0 = substs_vec.into();
+            crate::util::make_mut_arc_slice(&mut substs.0, |substs| {
+                substs[0] = self_ty;
+            });
         }
         TraitRef { trait_: resolved, substs }
     }

--- a/crates/ra_hir/src/ty/traits.rs
+++ b/crates/ra_hir/src/ty/traits.rs
@@ -89,7 +89,7 @@ pub(crate) fn impls_for_trait_query(
     }
     let crate_impl_blocks = db.impls_in_crate(krate);
     impls.extend(crate_impl_blocks.lookup_impl_blocks_for_trait(trait_));
-    impls.into_iter().collect::<Vec<_>>().into()
+    impls.into_iter().collect()
 }
 
 /// A set of clauses that we assume to be true. E.g. if we are inside this function:

--- a/crates/ra_hir/src/ty/traits/chalk.rs
+++ b/crates/ra_hir/src/ty/traits/chalk.rs
@@ -126,8 +126,7 @@ impl ToChalk for Substs {
                 chalk_ir::Parameter(chalk_ir::ParameterKind::Ty(ty)) => from_chalk(db, ty),
                 chalk_ir::Parameter(chalk_ir::ParameterKind::Lifetime(_)) => unimplemented!(),
             })
-            .collect::<Vec<_>>()
-            .into();
+            .collect();
         Substs(tys)
     }
 }

--- a/crates/ra_hir/src/util.rs
+++ b/crates/ra_hir/src/util.rs
@@ -4,16 +4,9 @@ use std::sync::Arc;
 
 /// Helper for mutating `Arc<[T]>` (i.e. `Arc::make_mut` for Arc slices).
 /// The underlying values are cloned if there are other strong references.
-pub(crate) fn make_mut_arc_slice<T: Clone, R>(
-    a: &mut Arc<[T]>,
-    f: impl FnOnce(&mut [T]) -> R,
-) -> R {
-    if let Some(s) = Arc::get_mut(a) {
-        f(s)
-    } else {
-        let mut v = a.to_vec();
-        let r = f(&mut v);
-        *a = Arc::from(v);
-        r
+pub(crate) fn make_mut_slice<T: Clone>(a: &mut Arc<[T]>) -> &mut [T] {
+    if Arc::get_mut(a).is_none() {
+        *a = a.iter().cloned().collect();
     }
+    Arc::get_mut(a).unwrap()
 }

--- a/crates/ra_hir/src/util.rs
+++ b/crates/ra_hir/src/util.rs
@@ -1,0 +1,19 @@
+//! Internal utility functions.
+
+use std::sync::Arc;
+
+/// Helper for mutating `Arc<[T]>` (i.e. `Arc::make_mut` for Arc slices).
+/// The underlying values are cloned if there are other strong references.
+pub(crate) fn make_mut_arc_slice<T: Clone, R>(
+    a: &mut Arc<[T]>,
+    f: impl FnOnce(&mut [T]) -> R,
+) -> R {
+    if let Some(s) = Arc::get_mut(a) {
+        f(s)
+    } else {
+        let mut v = a.to_vec();
+        let r = f(&mut v);
+        *a = Arc::from(v);
+        r
+    }
+}


### PR DESCRIPTION
First commit tries to avoid cloning `Arc<[T]>` to a temporary `Vec` for mutating it, if there are no other strong references. Second commit utilizes [`FromIterator for Arc<[T]>`](https://doc.rust-lang.org/std/sync/struct.Arc.html#impl-FromIterator%3CT%3E) instead of `.collect::<Vec<_>>().into()` to avoid allocation in `From<Vec<T>> for Arc<[T]>`.