### PR TITLE
Move CrateDefMap to a separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,6 +956,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ra_def"
+version = "0.1.0"
+dependencies = [
+ "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ena 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "insta 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ra_arena 0.1.0",
+ "ra_cfg 0.1.0",
+ "ra_db 0.1.0",
+ "ra_mbe 0.1.0",
+ "ra_prof 0.1.0",
+ "ra_syntax 0.1.0",
+ "ra_tt 0.1.0",
+ "relative-path 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "test_utils 0.1.0",
+]
+
+[[package]]
 name = "ra_fmt"
 version = "0.1.0"
 dependencies = [
@@ -1015,6 +1036,32 @@ dependencies = [
  "superslice 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "test_utils 0.1.0",
  "unicase 2.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ra_lower"
+version = "0.1.0"
+dependencies = [
+ "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chalk-ir 0.1.0 (git+https://github.com/rust-lang/chalk.git)",
+ "chalk-rust-ir 0.1.0 (git+https://github.com/rust-lang/chalk.git)",
+ "chalk-solve 0.1.0 (git+https://github.com/rust-lang/chalk.git)",
+ "ena 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "insta 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lalrpop-intern 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ra_arena 0.1.0",
+ "ra_cfg 0.1.0",
+ "ra_db 0.1.0",
+ "ra_mbe 0.1.0",
+ "ra_prof 0.1.0",
+ "ra_syntax 0.1.0",
+ "ra_tt 0.1.0",
+ "relative-path 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "test_utils 0.1.0",
 ]
 
 [[package]]

--- a/crates/ra_def/Cargo.toml
+++ b/crates/ra_def/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+edition = "2018"
+name = "ra_def"
+version = "0.1.0"
+authors = ["rust-analyzer developers"]
+
+[dependencies]
+arrayvec = "0.4.10"
+log = "0.4.5"
+relative-path = "0.4.0"
+rustc-hash = "1.0"
+ena = "0.13"
+once_cell = "1.0.1"
+
+ra_syntax = { path = "../ra_syntax" }
+ra_arena = { path = "../ra_arena" }
+ra_cfg = { path = "../ra_cfg" }
+ra_db = { path = "../ra_db" }
+mbe = { path = "../ra_mbe", package = "ra_mbe" }
+tt = { path = "../ra_tt", package = "ra_tt" }
+test_utils = { path = "../test_utils" }
+ra_prof = { path = "../ra_prof" }
+
+[dev-dependencies]
+insta = "0.11.0"

--- a/crates/ra_def/src/adt.rs
+++ b/crates/ra_def/src/adt.rs
@@ -1,0 +1,148 @@
+//! This module contains the implementation details of the HIR for ADTs, i.e.
+//! structs and enums (and unions).
+
+use std::sync::Arc;
+
+use ra_arena::{impl_arena_id, Arena, RawId};
+use ra_syntax::ast::{self, NameOwner, StructKind, TypeAscriptionOwner};
+
+use crate::{
+    db::{AstDatabase, DefDatabase},
+    ids::{AstItemId, EnumId, StructId},
+    name::AsName,
+    type_ref::TypeRef,
+    Name,
+    // EnumVariant, FieldSource, HasSource, Module, Struct, StructField,
+};
+
+/// Note that we use `StructData` for unions as well!
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StructData {
+    pub(crate) name: Option<Name>,
+    pub(crate) variant_data: Arc<VariantData>,
+}
+
+impl StructData {
+    fn new(struct_def: &ast::StructDef) -> StructData {
+        let name = struct_def.name().map(|n| n.as_name());
+        let variant_data = VariantData::new(struct_def.kind());
+        let variant_data = Arc::new(variant_data);
+        StructData { name, variant_data }
+    }
+
+    pub(crate) fn struct_data_query(
+        db: &(impl DefDatabase + AstDatabase),
+        struct_: StructId,
+    ) -> Arc<StructData> {
+        let src = struct_.source(db);
+        Arc::new(StructData::new(&src.ast))
+    }
+}
+
+fn variants(enum_def: &ast::EnumDef) -> impl Iterator<Item = ast::EnumVariant> {
+    enum_def.variant_list().into_iter().flat_map(|it| it.variants())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnumData {
+    pub(crate) name: Option<Name>,
+    pub(crate) variants: Arena<LocalEnumVariantId, EnumVariantData>,
+}
+
+impl EnumData {
+    pub(crate) fn enum_data_query(
+        db: &(impl DefDatabase + AstDatabase),
+        e: EnumId,
+    ) -> Arc<EnumData> {
+        let src = e.source(db);
+        let name = src.ast.name().map(|n| n.as_name());
+        let variants = variants(&src.ast)
+            .map(|var| EnumVariantData {
+                name: var.name().map(|it| it.as_name()),
+                variant_data: Arc::new(VariantData::new(var.kind())),
+            })
+            .collect();
+        Arc::new(EnumData { name, variants })
+    }
+
+    pub(crate) fn lookup(&self, name: &Name) -> Option<LocalEnumVariantId> {
+        self.variants.iter().find_map(|(id, data)| {
+            if data.name.as_ref() == Some(name) {
+                Some(id)
+            } else {
+                None
+            }
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct LocalEnumVariantId(RawId);
+impl_arena_id!(LocalEnumVariantId);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EnumVariantData {
+    pub(crate) name: Option<Name>,
+    variant_data: Arc<VariantData>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct StructFieldId(RawId);
+impl_arena_id!(StructFieldId);
+
+/// A single field of an enum variant or struct
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StructFieldData {
+    pub(crate) name: Name,
+    pub(crate) type_ref: TypeRef,
+}
+
+/// Fields of an enum variant or struct
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct VariantData(VariantDataInner);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum VariantDataInner {
+    Struct(Arena<StructFieldId, StructFieldData>),
+    Tuple(Arena<StructFieldId, StructFieldData>),
+    Unit,
+}
+
+impl VariantData {
+    pub(crate) fn fields(&self) -> Option<&Arena<StructFieldId, StructFieldData>> {
+        match &self.0 {
+            VariantDataInner::Struct(fields) | VariantDataInner::Tuple(fields) => Some(fields),
+            _ => None,
+        }
+    }
+}
+
+impl VariantData {
+    fn new(flavor: StructKind) -> Self {
+        let inner = match flavor {
+            ast::StructKind::Tuple(fl) => {
+                let fields = fl
+                    .fields()
+                    .enumerate()
+                    .map(|(i, fd)| StructFieldData {
+                        name: Name::new_tuple_field(i),
+                        type_ref: TypeRef::from_ast_opt(fd.type_ref()),
+                    })
+                    .collect();
+                VariantDataInner::Tuple(fields)
+            }
+            ast::StructKind::Named(fl) => {
+                let fields = fl
+                    .fields()
+                    .map(|fd| StructFieldData {
+                        name: fd.name().map(|n| n.as_name()).unwrap_or_else(Name::missing),
+                        type_ref: TypeRef::from_ast_opt(fd.ascribed_type()),
+                    })
+                    .collect();
+                VariantDataInner::Struct(fields)
+            }
+            ast::StructKind::Unit => VariantDataInner::Unit,
+        };
+        VariantData(inner)
+    }
+}

--- a/crates/ra_def/src/attr.rs
+++ b/crates/ra_def/src/attr.rs
@@ -1,0 +1,90 @@
+//! A higher level attributes based on TokenTree, with also some shortcuts.
+
+use std::sync::Arc;
+
+use mbe::ast_to_token_tree;
+use ra_cfg::CfgOptions;
+use ra_syntax::{
+    ast::{self, AstNode, AttrsOwner},
+    SmolStr,
+};
+use tt::Subtree;
+
+use crate::{db::AstDatabase, ids::HirFileId, path::Path, Source};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Attr {
+    pub(crate) path: Path,
+    pub(crate) input: Option<AttrInput>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AttrInput {
+    Literal(SmolStr),
+    TokenTree(Subtree),
+}
+
+impl Attr {
+    pub(crate) fn from_src(
+        Source { file_id, ast }: Source<ast::Attr>,
+        db: &impl AstDatabase,
+    ) -> Option<Attr> {
+        let path = Path::from_src(Source { file_id, ast: ast.path()? }, db)?;
+        let input = match ast.input() {
+            None => None,
+            Some(ast::AttrInput::Literal(lit)) => {
+                // FIXME: escape? raw string?
+                let value = lit.syntax().first_token()?.text().trim_matches('"').into();
+                Some(AttrInput::Literal(value))
+            }
+            Some(ast::AttrInput::TokenTree(tt)) => {
+                Some(AttrInput::TokenTree(ast_to_token_tree(&tt)?.0))
+            }
+        };
+
+        Some(Attr { path, input })
+    }
+
+    pub(crate) fn from_attrs_owner(
+        file_id: HirFileId,
+        owner: &dyn AttrsOwner,
+        db: &impl AstDatabase,
+    ) -> Option<Arc<[Attr]>> {
+        let mut attrs = owner.attrs().peekable();
+        if attrs.peek().is_none() {
+            // Avoid heap allocation
+            return None;
+        }
+        Some(attrs.flat_map(|ast| Attr::from_src(Source { file_id, ast }, db)).collect())
+    }
+
+    pub(crate) fn is_simple_atom(&self, name: &str) -> bool {
+        // FIXME: Avoid cloning
+        self.path.as_ident().map_or(false, |s| s.to_string() == name)
+    }
+
+    // FIXME: handle cfg_attr :-)
+    pub(crate) fn as_cfg(&self) -> Option<&Subtree> {
+        if !self.is_simple_atom("cfg") {
+            return None;
+        }
+        match &self.input {
+            Some(AttrInput::TokenTree(subtree)) => Some(subtree),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn as_path(&self) -> Option<&SmolStr> {
+        if !self.is_simple_atom("path") {
+            return None;
+        }
+        match &self.input {
+            Some(AttrInput::Literal(it)) => Some(it),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn is_cfg_enabled(&self, cfg_options: &CfgOptions) -> Option<bool> {
+        cfg_options.is_cfg_enabled(self.as_cfg()?)
+    }
+}

--- a/crates/ra_def/src/builtin_type.rs
+++ b/crates/ra_def/src/builtin_type.rs
@@ -1,0 +1,58 @@
+use crate::name;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum Signedness {
+    Signed,
+    Unsigned,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum IntBitness {
+    Xsize,
+    X8,
+    X16,
+    X32,
+    X64,
+    X128,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum FloatBitness {
+    X32,
+    X64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BuiltinType {
+    Char,
+    Bool,
+    Str,
+    Int { signedness: Signedness, bitness: IntBitness },
+    Float { bitness: FloatBitness },
+}
+
+impl BuiltinType {
+    #[rustfmt::skip]
+    pub(crate) const ALL: &'static [(name::Name, BuiltinType)] = &[
+        (name::CHAR, BuiltinType::Char),
+        (name::BOOL, BuiltinType::Bool),
+        (name::STR, BuiltinType::Str),
+
+        (name::ISIZE, BuiltinType::Int { signedness: Signedness::Signed, bitness: IntBitness::Xsize }),
+        (name::I8,    BuiltinType::Int { signedness: Signedness::Signed, bitness: IntBitness::X8 }),
+        (name::I16,   BuiltinType::Int { signedness: Signedness::Signed, bitness: IntBitness::X16 }),
+        (name::I32,   BuiltinType::Int { signedness: Signedness::Signed, bitness: IntBitness::X32 }),
+        (name::I64,   BuiltinType::Int { signedness: Signedness::Signed, bitness: IntBitness::X64 }),
+        (name::I128,  BuiltinType::Int { signedness: Signedness::Signed, bitness: IntBitness::X128 }),
+
+        (name::USIZE, BuiltinType::Int { signedness: Signedness::Unsigned, bitness: IntBitness::Xsize }),
+        (name::U8,    BuiltinType::Int { signedness: Signedness::Unsigned, bitness: IntBitness::X8 }),
+        (name::U16,   BuiltinType::Int { signedness: Signedness::Unsigned, bitness: IntBitness::X16 }),
+        (name::U32,   BuiltinType::Int { signedness: Signedness::Unsigned, bitness: IntBitness::X32 }),
+        (name::U64,   BuiltinType::Int { signedness: Signedness::Unsigned, bitness: IntBitness::X64 }),
+        (name::U128,  BuiltinType::Int { signedness: Signedness::Unsigned, bitness: IntBitness::X128 }),
+
+        (name::F32, BuiltinType::Float { bitness: FloatBitness::X32 }),
+        (name::F64, BuiltinType::Float { bitness: FloatBitness::X64 }),
+    ];
+}

--- a/crates/ra_def/src/db.rs
+++ b/crates/ra_def/src/db.rs
@@ -1,0 +1,141 @@
+//! FIXME: write short doc here
+
+use std::sync::Arc;
+
+use ra_db::{salsa, CrateId, SourceDatabase};
+use ra_syntax::{ast, Parse, SmolStr, SyntaxNode};
+
+use crate::{
+    adt::EnumData,
+    ids,
+    ids::{EnumId, HirFileId},
+    nameres::{
+        raw::{ImportSourceMap, RawItems},
+        CrateDefMap,
+    },
+    source_id::{AstIdMap, ErasedFileAstId},
+};
+
+/// We store all interned things in the single QueryGroup.
+///
+/// This is done mainly to allow both "volatile" `AstDatabase` and "stable"
+/// `DefDatabase` to access macros, without adding hard dependencies between the
+/// two.
+#[salsa::query_group(InternDatabaseStorage)]
+pub trait InternDatabase: SourceDatabase {
+    #[salsa::interned]
+    fn intern_macro(&self, macro_call: ids::MacroCallLoc) -> ids::MacroCallId;
+    #[salsa::interned]
+    fn intern_function(&self, loc: ids::ItemLoc<ast::FnDef>) -> ids::FunctionId;
+    #[salsa::interned]
+    fn intern_struct(&self, loc: ids::ItemLoc<ast::StructDef>) -> ids::StructId;
+    #[salsa::interned]
+    fn intern_enum(&self, loc: ids::ItemLoc<ast::EnumDef>) -> ids::EnumId;
+    #[salsa::interned]
+    fn intern_const(&self, loc: ids::ItemLoc<ast::ConstDef>) -> ids::ConstId;
+    #[salsa::interned]
+    fn intern_static(&self, loc: ids::ItemLoc<ast::StaticDef>) -> ids::StaticId;
+    #[salsa::interned]
+    fn intern_trait(&self, loc: ids::ItemLoc<ast::TraitDef>) -> ids::TraitId;
+    #[salsa::interned]
+    fn intern_type_alias(&self, loc: ids::ItemLoc<ast::TypeAliasDef>) -> ids::TypeAliasId;
+
+    // // Interned IDs for Chalk integration
+    // #[salsa::interned]
+    // fn intern_type_ctor(&self, type_ctor: TypeCtor) -> ids::TypeCtorId;
+    // #[salsa::interned]
+    // fn intern_impl(&self, impl_: Impl) -> ids::GlobalImplId;
+}
+
+/// This database has access to source code, so queries here are not really
+/// incremental.
+#[salsa::query_group(AstDatabaseStorage)]
+pub trait AstDatabase: InternDatabase {
+    #[salsa::invoke(AstIdMap::ast_id_map_query)]
+    fn ast_id_map(&self, file_id: HirFileId) -> Arc<AstIdMap>;
+
+    #[salsa::transparent]
+    #[salsa::invoke(AstIdMap::file_item_query)]
+    fn ast_id_to_node(&self, file_id: HirFileId, ast_id: ErasedFileAstId) -> SyntaxNode;
+
+    #[salsa::transparent]
+    #[salsa::invoke(crate::ids::HirFileId::parse_or_expand_query)]
+    fn parse_or_expand(&self, file_id: HirFileId) -> Option<SyntaxNode>;
+
+    #[salsa::invoke(crate::ids::HirFileId::parse_macro_query)]
+    fn parse_macro(&self, macro_file: ids::MacroFile) -> Option<Parse<SyntaxNode>>;
+
+    #[salsa::invoke(crate::ids::macro_def_query)]
+    fn macro_def(&self, macro_id: ids::MacroDefId) -> Option<Arc<mbe::MacroRules>>;
+
+    #[salsa::invoke(crate::ids::macro_arg_query)]
+    fn macro_arg(&self, macro_call: ids::MacroCallId) -> Option<Arc<tt::Subtree>>;
+
+    #[salsa::invoke(crate::ids::macro_expand_query)]
+    fn macro_expand(&self, macro_call: ids::MacroCallId) -> Result<Arc<tt::Subtree>, String>;
+}
+
+// This database uses `AstDatabase` internally,
+#[salsa::query_group(DefDatabaseStorage)]
+#[salsa::requires(AstDatabase)]
+pub trait DefDatabase: InternDatabase {
+    // #[salsa::invoke(crate::adt::StructData::struct_data_query)]
+    // fn struct_data(&self, s: Struct) -> Arc<StructData>;
+
+    #[salsa::invoke(EnumData::enum_data_query)]
+    fn enum_data(&self, e: EnumId) -> Arc<EnumData>;
+
+    // #[salsa::invoke(crate::traits::TraitData::trait_data_query)]
+    // fn trait_data(&self, t: Trait) -> Arc<TraitData>;
+
+    // #[salsa::invoke(crate::traits::TraitItemsIndex::trait_items_index)]
+    // fn trait_items_index(&self, module: Module) -> crate::traits::TraitItemsIndex;
+
+    #[salsa::invoke(RawItems::raw_items_with_source_map_query)]
+    fn raw_items_with_source_map(
+        &self,
+        file_id: HirFileId,
+    ) -> (Arc<RawItems>, Arc<ImportSourceMap>);
+
+    #[salsa::invoke(RawItems::raw_items_query)]
+    fn raw_items(&self, file_id: HirFileId) -> Arc<RawItems>;
+
+    #[salsa::invoke(CrateDefMap::crate_def_map_query)]
+    fn crate_def_map(&self, krate: CrateId) -> Arc<CrateDefMap>;
+
+    // #[salsa::invoke(crate::impl_block::impls_in_module_with_source_map_query)]
+    // fn impls_in_module_with_source_map(
+    //     &self,
+    //     module: Module,
+    // ) -> (Arc<ModuleImplBlocks>, Arc<ImplSourceMap>);
+
+    // #[salsa::invoke(crate::impl_block::impls_in_module)]
+    // fn impls_in_module(&self, module: Module) -> Arc<ModuleImplBlocks>;
+
+    // #[salsa::invoke(crate::generics::GenericParams::generic_params_query)]
+    // fn generic_params(&self, def: GenericDef) -> Arc<GenericParams>;
+
+    // #[salsa::invoke(crate::FnData::fn_data_query)]
+    // fn fn_data(&self, func: Function) -> Arc<FnData>;
+
+    // #[salsa::invoke(crate::type_alias::type_alias_data_query)]
+    // fn type_alias_data(&self, typ: TypeAlias) -> Arc<TypeAliasData>;
+
+    // #[salsa::invoke(crate::ConstData::const_data_query)]
+    // fn const_data(&self, konst: Const) -> Arc<ConstData>;
+
+    // #[salsa::invoke(crate::ConstData::static_data_query)]
+    // fn static_data(&self, konst: Static) -> Arc<ConstData>;
+
+    // #[salsa::invoke(crate::lang_item::LangItems::module_lang_items_query)]
+    // fn module_lang_items(&self, module: Module) -> Option<Arc<LangItems>>;
+
+    // #[salsa::invoke(crate::lang_item::LangItems::crate_lang_items_query)]
+    // fn crate_lang_items(&self, krate: Crate) -> Arc<LangItems>;
+
+    // #[salsa::invoke(crate::lang_item::LangItems::lang_item_query)]
+    // fn lang_item(&self, start_crate: Crate, item: SmolStr) -> Option<LangItemTarget>;
+
+    // #[salsa::invoke(crate::code_model::docs::documentation_query)]
+    // fn documentation(&self, def: crate::DocDef) -> Option<crate::Documentation>;
+}

--- a/crates/ra_def/src/db_ext.rs
+++ b/crates/ra_def/src/db_ext.rs
@@ -1,0 +1,30 @@
+use ra_db::{CrateId, Edition};
+
+use crate::{db::DefDatabase, ids::ModuleId, name::AsName, Name};
+
+#[derive(Debug)]
+pub struct CrateDependency {
+    pub krate: CrateId,
+    pub name: Name,
+}
+
+pub(crate) fn crate_dependencies(db: &impl DefDatabase, crate_id: CrateId) -> Vec<CrateDependency> {
+    db.crate_graph()
+        .dependencies(crate_id)
+        .map(|dep| {
+            let krate = dep.crate_id();
+            let name = dep.as_name();
+            CrateDependency { krate, name }
+        })
+        .collect()
+}
+
+pub(crate) fn crate_root_module(db: &impl DefDatabase, crate_id: CrateId) -> Option<ModuleId> {
+    let module_id = db.crate_def_map(crate_id).root();
+    let module = ModuleId { krate: crate_id, module_id };
+    Some(module)
+}
+
+pub(crate) fn crate_edition(db: &impl DefDatabase, crate_id: CrateId) -> Edition {
+    db.crate_graph().edition(crate_id)
+}

--- a/crates/ra_def/src/diagnostics.rs
+++ b/crates/ra_def/src/diagnostics.rs
@@ -1,0 +1,108 @@
+//! FIXME: write short doc here
+
+use std::{any::Any, fmt};
+
+use ra_syntax::{ast, AstNode, AstPtr, SyntaxNode, SyntaxNodePtr, TextRange};
+use relative_path::RelativePathBuf;
+
+use crate::{ids::HirFileId, Name, Source};
+
+/// Diagnostic defines hir API for errors and warnings.
+///
+/// It is used as a `dyn` object, which you can downcast to a concrete
+/// diagnostic. DiagnosticSink are structured, meaning that they include rich
+/// information which can be used by IDE to create fixes. DiagnosticSink are
+/// expressed in terms of macro-expanded syntax tree nodes (so, it's a bad idea
+/// to diagnostic in a salsa value).
+///
+/// Internally, various subsystems of hir produce diagnostics specific to a
+/// subsystem (typically, an `enum`), which are safe to store in salsa but do not
+/// include source locations. Such internal diagnostic are transformed into an
+/// instance of `Diagnostic` on demand.
+pub trait Diagnostic: Any + Send + Sync + fmt::Debug + 'static {
+    fn message(&self) -> String;
+    fn source(&self) -> Source<SyntaxNodePtr>;
+    fn highlight_range(&self) -> TextRange {
+        self.source().ast.range()
+    }
+    fn as_any(&self) -> &(dyn Any + Send + 'static);
+}
+
+impl dyn Diagnostic {
+    pub fn downcast_ref<D: Diagnostic>(&self) -> Option<&D> {
+        self.as_any().downcast_ref()
+    }
+}
+
+pub struct DiagnosticSink<'a> {
+    callbacks: Vec<Box<dyn FnMut(&dyn Diagnostic) -> Result<(), ()> + 'a>>,
+    default_callback: Box<dyn FnMut(&dyn Diagnostic) + 'a>,
+}
+
+impl<'a> DiagnosticSink<'a> {
+    pub fn new(cb: impl FnMut(&dyn Diagnostic) + 'a) -> DiagnosticSink<'a> {
+        DiagnosticSink { callbacks: Vec::new(), default_callback: Box::new(cb) }
+    }
+
+    pub fn on<D: Diagnostic, F: FnMut(&D) + 'a>(mut self, mut cb: F) -> DiagnosticSink<'a> {
+        let cb = move |diag: &dyn Diagnostic| match diag.downcast_ref::<D>() {
+            Some(d) => {
+                cb(d);
+                Ok(())
+            }
+            None => Err(()),
+        };
+        self.callbacks.push(Box::new(cb));
+        self
+    }
+
+    pub(crate) fn push(&mut self, d: impl Diagnostic) {
+        let d: &dyn Diagnostic = &d;
+        for cb in self.callbacks.iter_mut() {
+            match cb(d) {
+                Ok(()) => return,
+                Err(()) => (),
+            }
+        }
+        (self.default_callback)(d)
+    }
+}
+
+#[derive(Debug)]
+pub struct NoSuchField {
+    pub file: HirFileId,
+    pub field: AstPtr<ast::RecordField>,
+}
+
+impl Diagnostic for NoSuchField {
+    fn message(&self) -> String {
+        "no such field".to_string()
+    }
+
+    fn source(&self) -> Source<SyntaxNodePtr> {
+        Source { file_id: self.file, ast: self.field.into() }
+    }
+
+    fn as_any(&self) -> &(dyn Any + Send + 'static) {
+        self
+    }
+}
+
+#[derive(Debug)]
+pub struct UnresolvedModule {
+    pub file: HirFileId,
+    pub decl: AstPtr<ast::Module>,
+    pub candidate: RelativePathBuf,
+}
+
+impl Diagnostic for UnresolvedModule {
+    fn message(&self) -> String {
+        "unresolved module".to_string()
+    }
+    fn source(&self) -> Source<SyntaxNodePtr> {
+        Source { file_id: self.file, ast: self.decl.into() }
+    }
+    fn as_any(&self) -> &(dyn Any + Send + 'static) {
+        self
+    }
+}

--- a/crates/ra_def/src/either.rs
+++ b/crates/ra_def/src/either.rs
@@ -1,0 +1,54 @@
+//! FIXME: write short doc here
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Either<A, B> {
+    A(A),
+    B(B),
+}
+
+impl<A, B> Either<A, B> {
+    pub fn either<R, F1, F2>(self, f1: F1, f2: F2) -> R
+    where
+        F1: FnOnce(A) -> R,
+        F2: FnOnce(B) -> R,
+    {
+        match self {
+            Either::A(a) => f1(a),
+            Either::B(b) => f2(b),
+        }
+    }
+    pub fn map<U, V, F1, F2>(self, f1: F1, f2: F2) -> Either<U, V>
+    where
+        F1: FnOnce(A) -> U,
+        F2: FnOnce(B) -> V,
+    {
+        match self {
+            Either::A(a) => Either::A(f1(a)),
+            Either::B(b) => Either::B(f2(b)),
+        }
+    }
+    pub fn map_a<U, F>(self, f: F) -> Either<U, B>
+    where
+        F: FnOnce(A) -> U,
+    {
+        self.map(f, |it| it)
+    }
+    pub fn a(self) -> Option<A> {
+        match self {
+            Either::A(it) => Some(it),
+            Either::B(_) => None,
+        }
+    }
+    pub fn b(self) -> Option<B> {
+        match self {
+            Either::A(_) => None,
+            Either::B(it) => Some(it),
+        }
+    }
+    pub fn as_ref(&self) -> Either<&A, &B> {
+        match self {
+            Either::A(it) => Either::A(it),
+            Either::B(it) => Either::B(it),
+        }
+    }
+}

--- a/crates/ra_def/src/ids.rs
+++ b/crates/ra_def/src/ids.rs
@@ -1,0 +1,458 @@
+//! FIXME: write short doc here
+
+use std::{
+    hash::{Hash, Hasher},
+    sync::Arc,
+};
+
+use mbe::MacroRules;
+use ra_db::{salsa, CrateId, FileId};
+use ra_prof::profile;
+use ra_syntax::{ast, AstNode, Parse, SyntaxNode};
+
+use crate::{
+    adt::LocalEnumVariantId,
+    db::{AstDatabase, DefDatabase, InternDatabase},
+    nameres::CrateModuleId,
+    source_id::{AstId, FileAstId},
+    BuiltinType, Source,
+};
+
+/// hir makes heavy use of ids: integer (u32) handlers to various things. You
+/// can think of id as a pointer (but without a lifetime) or a file descriptor
+/// (but for hir objects).
+///
+/// This module defines a bunch of ids we are using. The most important ones are
+/// probably `HirFileId` and `DefId`.
+
+/// Input to the analyzer is a set of files, where each file is identified by
+/// `FileId` and contains source code. However, another source of source code in
+/// Rust are macros: each macro can be thought of as producing a "temporary
+/// file". To assign an id to such a file, we use the id of the macro call that
+/// produced the file. So, a `HirFileId` is either a `FileId` (source code
+/// written by user), or a `MacroCallId` (source code produced by macro).
+///
+/// What is a `MacroCallId`? Simplifying, it's a `HirFileId` of a file
+/// containing the call plus the offset of the macro call in the file. Note that
+/// this is a recursive definition! However, the size_of of `HirFileId` is
+/// finite (because everything bottoms out at the real `FileId`) and small
+/// (`MacroCallId` uses the location interner).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct HirFileId(HirFileIdRepr);
+
+impl HirFileId {
+    /// For macro-expansion files, returns the file original source file the
+    /// expansion originated from.
+    pub fn original_file(self, db: &impl InternDatabase) -> FileId {
+        match self.0 {
+            HirFileIdRepr::File(file_id) => file_id,
+            HirFileIdRepr::Macro(macro_file) => {
+                let loc = macro_file.macro_call_id.loc(db);
+                loc.ast_id.file_id().original_file(db)
+            }
+        }
+    }
+
+    /// Get the crate which the macro lives in, if it is a macro file.
+    pub(crate) fn macro_crate(self, db: &impl AstDatabase) -> Option<CrateId> {
+        match self.0 {
+            HirFileIdRepr::File(_) => None,
+            HirFileIdRepr::Macro(macro_file) => {
+                let loc = macro_file.macro_call_id.loc(db);
+                Some(loc.def.krate)
+            }
+        }
+    }
+
+    pub(crate) fn parse_or_expand_query(
+        db: &impl AstDatabase,
+        file_id: HirFileId,
+    ) -> Option<SyntaxNode> {
+        match file_id.0 {
+            HirFileIdRepr::File(file_id) => Some(db.parse(file_id).tree().syntax().clone()),
+            HirFileIdRepr::Macro(macro_file) => {
+                db.parse_macro(macro_file).map(|it| it.syntax_node())
+            }
+        }
+    }
+
+    pub(crate) fn parse_macro_query(
+        db: &impl AstDatabase,
+        macro_file: MacroFile,
+    ) -> Option<Parse<SyntaxNode>> {
+        let _p = profile("parse_macro_query");
+        let macro_call_id = macro_file.macro_call_id;
+        let tt = db
+            .macro_expand(macro_call_id)
+            .map_err(|err| {
+                // Note:
+                // The final goal we would like to make all parse_macro success,
+                // such that the following log will not call anyway.
+                log::warn!(
+                    "fail on macro_parse: (reason: {}) {}",
+                    err,
+                    macro_call_id.debug_dump(db)
+                );
+            })
+            .ok()?;
+        match macro_file.macro_file_kind {
+            MacroFileKind::Items => mbe::token_tree_to_items(&tt).ok().map(Parse::to_syntax),
+            MacroFileKind::Expr => mbe::token_tree_to_expr(&tt).ok().map(Parse::to_syntax),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum HirFileIdRepr {
+    File(FileId),
+    Macro(MacroFile),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MacroFile {
+    macro_call_id: MacroCallId,
+    macro_file_kind: MacroFileKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum MacroFileKind {
+    Items,
+    Expr,
+}
+
+impl From<FileId> for HirFileId {
+    fn from(file_id: FileId) -> HirFileId {
+        HirFileId(HirFileIdRepr::File(file_id))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MacroDefId {
+    pub(crate) ast_id: AstId<ast::MacroCall>,
+    pub(crate) krate: CrateId,
+}
+
+pub(crate) fn macro_def_query(db: &impl AstDatabase, id: MacroDefId) -> Option<Arc<MacroRules>> {
+    let macro_call = id.ast_id.to_node(db);
+    let arg = macro_call.token_tree()?;
+    let (tt, _) = mbe::ast_to_token_tree(&arg).or_else(|| {
+        log::warn!("fail on macro_def to token tree: {:#?}", arg);
+        None
+    })?;
+    let rules = MacroRules::parse(&tt).ok().or_else(|| {
+        log::warn!("fail on macro_def parse: {:#?}", tt);
+        None
+    })?;
+    Some(Arc::new(rules))
+}
+
+pub(crate) fn macro_arg_query(db: &impl AstDatabase, id: MacroCallId) -> Option<Arc<tt::Subtree>> {
+    let loc = id.loc(db);
+    let macro_call = loc.ast_id.to_node(db);
+    let arg = macro_call.token_tree()?;
+    let (tt, _) = mbe::ast_to_token_tree(&arg)?;
+    Some(Arc::new(tt))
+}
+
+pub(crate) fn macro_expand_query(
+    db: &impl AstDatabase,
+    id: MacroCallId,
+) -> Result<Arc<tt::Subtree>, String> {
+    let loc = id.loc(db);
+    let macro_arg = db.macro_arg(id).ok_or("Fail to args in to tt::TokenTree")?;
+
+    let macro_rules = db.macro_def(loc.def).ok_or("Fail to find macro definition")?;
+    let tt = macro_rules.expand(&macro_arg).map_err(|err| format!("{:?}", err))?;
+    // Set a hard limit for the expanded tt
+    let count = tt.count();
+    if count > 65536 {
+        return Err(format!("Total tokens count exceed limit : count = {}", count));
+    }
+    Ok(Arc::new(tt))
+}
+
+macro_rules! impl_intern_key {
+    ($name:ident) => {
+        impl salsa::InternKey for $name {
+            fn from_intern_id(v: salsa::InternId) -> Self {
+                $name(v)
+            }
+            fn as_intern_id(&self) -> salsa::InternId {
+                self.0
+            }
+        }
+    };
+}
+
+/// `MacroCallId` identifies a particular macro invocation, like
+/// `println!("Hello, {}", world)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MacroCallId(salsa::InternId);
+impl_intern_key!(MacroCallId);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct MacroCallLoc {
+    pub(crate) def: MacroDefId,
+    pub(crate) ast_id: AstId<ast::MacroCall>,
+}
+
+impl MacroCallId {
+    pub(crate) fn loc(self, db: &impl InternDatabase) -> MacroCallLoc {
+        db.lookup_intern_macro(self)
+    }
+
+    pub(crate) fn as_file(self, kind: MacroFileKind) -> HirFileId {
+        let macro_file = MacroFile { macro_call_id: self, macro_file_kind: kind };
+        HirFileId(HirFileIdRepr::Macro(macro_file))
+    }
+}
+
+impl MacroCallLoc {
+    pub(crate) fn id(self, db: &impl InternDatabase) -> MacroCallId {
+        db.intern_macro(self)
+    }
+}
+
+#[derive(Debug)]
+pub struct ItemLoc<N: AstNode> {
+    pub(crate) module: ModuleId,
+    ast_id: AstId<N>,
+}
+
+impl<N: AstNode> PartialEq for ItemLoc<N> {
+    fn eq(&self, other: &Self) -> bool {
+        self.module == other.module && self.ast_id == other.ast_id
+    }
+}
+impl<N: AstNode> Eq for ItemLoc<N> {}
+impl<N: AstNode> Hash for ItemLoc<N> {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        self.module.hash(hasher);
+        self.ast_id.hash(hasher);
+    }
+}
+
+impl<N: AstNode> Clone for ItemLoc<N> {
+    fn clone(&self) -> ItemLoc<N> {
+        ItemLoc { module: self.module, ast_id: self.ast_id }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct LocationCtx<DB> {
+    db: DB,
+    module: ModuleId,
+    file_id: HirFileId,
+}
+
+impl<'a, DB: DefDatabase> LocationCtx<&'a DB> {
+    pub(crate) fn new(db: &'a DB, module: ModuleId, file_id: HirFileId) -> LocationCtx<&'a DB> {
+        LocationCtx { db, module, file_id }
+    }
+}
+
+impl<'a, DB: DefDatabase + AstDatabase> LocationCtx<&'a DB> {
+    pub(crate) fn to_def<N, DEF>(self, ast: &N) -> DEF
+    where
+        N: AstNode,
+        DEF: AstItemId<N>,
+    {
+        DEF::from_ast(self, ast)
+    }
+}
+
+pub(crate) trait AstItemId<N: AstNode>: salsa::InternKey + Clone {
+    fn intern(db: &impl DefDatabase, loc: ItemLoc<N>) -> Self;
+    fn lookup_intern(self, db: &impl DefDatabase) -> ItemLoc<N>;
+
+    fn from_ast(ctx: LocationCtx<&(impl AstDatabase + DefDatabase)>, ast: &N) -> Self {
+        let items = ctx.db.ast_id_map(ctx.file_id);
+        let item_id = items.ast_id(ast);
+        Self::from_ast_id(ctx, item_id)
+    }
+    fn from_ast_id(ctx: LocationCtx<&impl DefDatabase>, ast_id: FileAstId<N>) -> Self {
+        let loc = ItemLoc { module: ctx.module, ast_id: ast_id.with_file_id(ctx.file_id) };
+        Self::intern(ctx.db, loc)
+    }
+    fn source(self, db: &(impl AstDatabase + DefDatabase)) -> Source<N> {
+        let loc = self.lookup_intern(db);
+        let ast = loc.ast_id.to_node(db);
+        Source { file_id: loc.ast_id.file_id(), ast }
+    }
+    fn module(self, db: &impl DefDatabase) -> ModuleId {
+        let loc = self.lookup_intern(db);
+        loc.module
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ModuleId {
+    pub(crate) krate: CrateId,
+    pub(crate) module_id: CrateModuleId,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FunctionId(salsa::InternId);
+impl_intern_key!(FunctionId);
+
+impl AstItemId<ast::FnDef> for FunctionId {
+    fn intern(db: &impl DefDatabase, loc: ItemLoc<ast::FnDef>) -> Self {
+        db.intern_function(loc)
+    }
+    fn lookup_intern(self, db: &impl DefDatabase) -> ItemLoc<ast::FnDef> {
+        db.lookup_intern_function(self)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct StructId(salsa::InternId);
+impl_intern_key!(StructId);
+impl AstItemId<ast::StructDef> for StructId {
+    fn intern(db: &impl DefDatabase, loc: ItemLoc<ast::StructDef>) -> Self {
+        db.intern_struct(loc)
+    }
+    fn lookup_intern(self, db: &impl DefDatabase) -> ItemLoc<ast::StructDef> {
+        db.lookup_intern_struct(self)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct EnumId(salsa::InternId);
+impl_intern_key!(EnumId);
+impl AstItemId<ast::EnumDef> for EnumId {
+    fn intern(db: &impl DefDatabase, loc: ItemLoc<ast::EnumDef>) -> Self {
+        db.intern_enum(loc)
+    }
+    fn lookup_intern(self, db: &impl DefDatabase) -> ItemLoc<ast::EnumDef> {
+        db.lookup_intern_enum(self)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ConstId(salsa::InternId);
+impl_intern_key!(ConstId);
+impl AstItemId<ast::ConstDef> for ConstId {
+    fn intern(db: &impl DefDatabase, loc: ItemLoc<ast::ConstDef>) -> Self {
+        db.intern_const(loc)
+    }
+    fn lookup_intern(self, db: &impl DefDatabase) -> ItemLoc<ast::ConstDef> {
+        db.lookup_intern_const(self)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct StaticId(salsa::InternId);
+impl_intern_key!(StaticId);
+impl AstItemId<ast::StaticDef> for StaticId {
+    fn intern(db: &impl DefDatabase, loc: ItemLoc<ast::StaticDef>) -> Self {
+        db.intern_static(loc)
+    }
+    fn lookup_intern(self, db: &impl DefDatabase) -> ItemLoc<ast::StaticDef> {
+        db.lookup_intern_static(self)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TraitId(salsa::InternId);
+impl_intern_key!(TraitId);
+impl AstItemId<ast::TraitDef> for TraitId {
+    fn intern(db: &impl DefDatabase, loc: ItemLoc<ast::TraitDef>) -> Self {
+        db.intern_trait(loc)
+    }
+    fn lookup_intern(self, db: &impl DefDatabase) -> ItemLoc<ast::TraitDef> {
+        db.lookup_intern_trait(self)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TypeAliasId(salsa::InternId);
+impl_intern_key!(TypeAliasId);
+impl AstItemId<ast::TypeAliasDef> for TypeAliasId {
+    fn intern(db: &impl DefDatabase, loc: ItemLoc<ast::TypeAliasDef>) -> Self {
+        db.intern_type_alias(loc)
+    }
+    fn lookup_intern(self, db: &impl DefDatabase) -> ItemLoc<ast::TypeAliasDef> {
+        db.lookup_intern_type_alias(self)
+    }
+}
+
+impl MacroCallId {
+    pub fn debug_dump(self, db: &impl AstDatabase) -> String {
+        let loc = self.loc(db);
+        let node = loc.ast_id.to_node(db);
+        let syntax_str = {
+            let mut res = String::new();
+            node.syntax().text().for_each_chunk(|chunk| {
+                if !res.is_empty() {
+                    res.push(' ')
+                }
+                res.push_str(chunk)
+            });
+            res
+        };
+
+        // dump the file name
+        let file_id: HirFileId = self.loc(db).ast_id.file_id();
+        let original = file_id.original_file(db);
+        let macro_rules = db.macro_def(loc.def);
+
+        format!(
+            "macro call [file: {:?}] : {}\nhas rules: {}",
+            db.file_relative_path(original),
+            syntax_str,
+            macro_rules.is_some()
+        )
+    }
+}
+
+/// This exists just for Chalk, because Chalk just has a single `StructId` where
+/// we have different kinds of ADTs, primitive types and special type
+/// constructors like tuples and function pointers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TypeCtorId(salsa::InternId);
+impl_intern_key!(TypeCtorId);
+
+/// This exists just for Chalk, because our ImplIds are only unique per module.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct GlobalImplId(salsa::InternId);
+impl_intern_key!(GlobalImplId);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct EnumVariantId {
+    pub(crate) parent: EnumId,
+    pub(crate) local: LocalEnumVariantId,
+}
+
+/// A Data Type
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum AdtId {
+    StructId(StructId),
+    UnionId(StructId),
+    EnumId(EnumId),
+}
+
+/// The defs which can be visible in the module.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ModuleDefId {
+    ModuleId(ModuleId),
+    FunctionId(FunctionId),
+    AdtId(AdtId),
+    // // Can't be directly declared, but can be imported.
+    EnumVariantId(EnumVariantId),
+    ConstId(ConstId),
+    StaticId(StaticId),
+    TraitId(TraitId),
+    TypeAliasId(TypeAliasId),
+    BuiltinType(BuiltinType),
+}
+impl_froms!(
+    ModuleDefId: ModuleId,
+    FunctionId,
+    AdtId,
+    EnumVariantId,
+    ConstId,
+    StaticId,
+    TraitId,
+    TypeAliasId,
+    BuiltinType
+);

--- a/crates/ra_def/src/lib.rs
+++ b/crates/ra_def/src/lib.rs
@@ -1,0 +1,46 @@
+#![allow(unused)]
+#![recursion_limit = "512"]
+
+macro_rules! impl_froms {
+    ($e:ident: $($v:ident $(($($sv:ident),*))?),*) => {
+        $(
+            impl From<$v> for $e {
+                fn from(it: $v) -> $e {
+                    $e::$v(it)
+                }
+            }
+            $($(
+                impl From<$sv> for $e {
+                    fn from(it: $sv) -> $e {
+                        $e::$v($v::$sv(it))
+                    }
+                }
+            )*)?
+        )*
+    }
+}
+
+mod name;
+mod type_ref;
+mod path;
+mod attr;
+
+mod source_id;
+pub mod ids;
+mod db;
+mod db_ext;
+mod source;
+mod either;
+mod diagnostics;
+
+mod adt;
+mod builtin_type;
+mod nameres;
+
+pub use crate::{
+    builtin_type::{BuiltinType, FloatBitness, IntBitness, Signedness},
+    either::Either,
+    name::Name,
+    path::{Path, PathKind},
+    source::{ModuleSource, Source},
+};

--- a/crates/ra_def/src/name.rs
+++ b/crates/ra_def/src/name.rs
@@ -1,0 +1,142 @@
+//! FIXME: write short doc here
+
+use std::fmt;
+
+use ra_syntax::{ast, SmolStr};
+
+/// `Name` is a wrapper around string, which is used in hir for both references
+/// and declarations. In theory, names should also carry hygiene info, but we are
+/// not there yet!
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Name(Repr);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+enum Repr {
+    Text(SmolStr),
+    TupleField(usize),
+}
+
+impl fmt::Display for Name {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match &self.0 {
+            Repr::Text(text) => fmt::Display::fmt(&text, f),
+            Repr::TupleField(idx) => fmt::Display::fmt(&idx, f),
+        }
+    }
+}
+
+impl Name {
+    /// Note: this is private to make creating name from random string hard.
+    /// Hopefully, this should allow us to integrate hygiene cleaner in the
+    /// future, and to switch to interned representation of names.
+    const fn new_text(text: SmolStr) -> Name {
+        Name(Repr::Text(text))
+    }
+
+    pub(crate) fn new_tuple_field(idx: usize) -> Name {
+        Name(Repr::TupleField(idx))
+    }
+
+    /// Shortcut to create inline plain text name
+    const fn new_inline_ascii(len: usize, text: &[u8]) -> Name {
+        Name::new_text(SmolStr::new_inline_from_ascii(len, text))
+    }
+
+    /// Resolve a name from the text of token.
+    fn resolve(raw_text: &SmolStr) -> Name {
+        let raw_start = "r#";
+        if raw_text.as_str().starts_with(raw_start) {
+            Name::new_text(SmolStr::new(&raw_text[raw_start.len()..]))
+        } else {
+            Name::new_text(raw_text.clone())
+        }
+    }
+
+    pub(crate) fn missing() -> Name {
+        Name::new_text("[missing name]".into())
+    }
+
+    pub(crate) fn as_tuple_index(&self) -> Option<usize> {
+        match self.0 {
+            Repr::TupleField(idx) => Some(idx),
+            _ => None,
+        }
+    }
+}
+
+pub(crate) trait AsName {
+    fn as_name(&self) -> Name;
+}
+
+impl AsName for ast::NameRef {
+    fn as_name(&self) -> Name {
+        match self.as_tuple_field() {
+            Some(idx) => Name::new_tuple_field(idx),
+            None => Name::resolve(self.text()),
+        }
+    }
+}
+
+impl AsName for ast::Name {
+    fn as_name(&self) -> Name {
+        Name::resolve(self.text())
+    }
+}
+
+impl AsName for ast::FieldKind {
+    fn as_name(&self) -> Name {
+        match self {
+            ast::FieldKind::Name(nr) => nr.as_name(),
+            ast::FieldKind::Index(idx) => Name::new_tuple_field(idx.text().parse().unwrap()),
+        }
+    }
+}
+
+impl AsName for ra_db::Dependency {
+    fn as_name(&self) -> Name {
+        Name::new_text(self.name.clone())
+    }
+}
+
+// Primitives
+pub(crate) const ISIZE: Name = Name::new_inline_ascii(5, b"isize");
+pub(crate) const I8: Name = Name::new_inline_ascii(2, b"i8");
+pub(crate) const I16: Name = Name::new_inline_ascii(3, b"i16");
+pub(crate) const I32: Name = Name::new_inline_ascii(3, b"i32");
+pub(crate) const I64: Name = Name::new_inline_ascii(3, b"i64");
+pub(crate) const I128: Name = Name::new_inline_ascii(4, b"i128");
+pub(crate) const USIZE: Name = Name::new_inline_ascii(5, b"usize");
+pub(crate) const U8: Name = Name::new_inline_ascii(2, b"u8");
+pub(crate) const U16: Name = Name::new_inline_ascii(3, b"u16");
+pub(crate) const U32: Name = Name::new_inline_ascii(3, b"u32");
+pub(crate) const U64: Name = Name::new_inline_ascii(3, b"u64");
+pub(crate) const U128: Name = Name::new_inline_ascii(4, b"u128");
+pub(crate) const F32: Name = Name::new_inline_ascii(3, b"f32");
+pub(crate) const F64: Name = Name::new_inline_ascii(3, b"f64");
+pub(crate) const BOOL: Name = Name::new_inline_ascii(4, b"bool");
+pub(crate) const CHAR: Name = Name::new_inline_ascii(4, b"char");
+pub(crate) const STR: Name = Name::new_inline_ascii(3, b"str");
+
+// Special names
+pub(crate) const SELF_PARAM: Name = Name::new_inline_ascii(4, b"self");
+pub(crate) const SELF_TYPE: Name = Name::new_inline_ascii(4, b"Self");
+pub(crate) const MACRO_RULES: Name = Name::new_inline_ascii(11, b"macro_rules");
+
+// Components of known path (value or mod name)
+pub(crate) const STD: Name = Name::new_inline_ascii(3, b"std");
+pub(crate) const ITER: Name = Name::new_inline_ascii(4, b"iter");
+pub(crate) const OPS: Name = Name::new_inline_ascii(3, b"ops");
+pub(crate) const FUTURE: Name = Name::new_inline_ascii(6, b"future");
+pub(crate) const RESULT: Name = Name::new_inline_ascii(6, b"result");
+pub(crate) const BOXED: Name = Name::new_inline_ascii(5, b"boxed");
+
+// Components of known path (type name)
+pub(crate) const INTO_ITERATOR_TYPE: Name = Name::new_inline_ascii(12, b"IntoIterator");
+pub(crate) const ITEM_TYPE: Name = Name::new_inline_ascii(4, b"Item");
+pub(crate) const TRY_TYPE: Name = Name::new_inline_ascii(3, b"Try");
+pub(crate) const OK_TYPE: Name = Name::new_inline_ascii(2, b"Ok");
+pub(crate) const FUTURE_TYPE: Name = Name::new_inline_ascii(6, b"Future");
+pub(crate) const RESULT_TYPE: Name = Name::new_inline_ascii(6, b"Result");
+pub(crate) const OUTPUT_TYPE: Name = Name::new_inline_ascii(6, b"Output");
+pub(crate) const TARGET_TYPE: Name = Name::new_inline_ascii(6, b"Target");
+pub(crate) const BOX_TYPE: Name = Name::new_inline_ascii(3, b"Box");

--- a/crates/ra_def/src/nameres.rs
+++ b/crates/ra_def/src/nameres.rs
@@ -1,0 +1,571 @@
+//! This module implements import-resolution/macro expansion algorithm.
+//!
+//! The result of this module is `CrateDefMap`: a data structure which contains:
+//!
+//!   * a tree of modules for the crate
+//!   * for each module, a set of items visible in the module (directly declared
+//!     or imported)
+//!
+//! Note that `CrateDefMap` contains fully macro expanded code.
+//!
+//! Computing `CrateDefMap` can be partitioned into several logically
+//! independent "phases". The phases are mutually recursive though, there's no
+//! strict ordering.
+//!
+//! ## Collecting RawItems
+//!
+//!  This happens in the `raw` module, which parses a single source file into a
+//!  set of top-level items. Nested imports are desugared to flat imports in
+//!  this phase. Macro calls are represented as a triple of (Path, Option<Name>,
+//!  TokenTree).
+//!
+//! ## Collecting Modules
+//!
+//! This happens in the `collector` module. In this phase, we recursively walk
+//! tree of modules, collect raw items from submodules, populate module scopes
+//! with defined items (so, we assign item ids in this phase) and record the set
+//! of unresolved imports and macros.
+//!
+//! While we walk tree of modules, we also record macro_rules definitions and
+//! expand calls to macro_rules defined macros.
+//!
+//! ## Resolving Imports
+//!
+//! We maintain a list of currently unresolved imports. On every iteration, we
+//! try to resolve some imports from this list. If the import is resolved, we
+//! record it, by adding an item to current module scope and, if necessary, by
+//! recursively populating glob imports.
+//!
+//! ## Resolving Macros
+//!
+//! macro_rules from the same crate use a global mutable namespace. We expand
+//! them immediately, when we collect modules.
+//!
+//! Macros from other crates (including proc-macros) can be used with
+//! `foo::bar!` syntax. We handle them similarly to imports. There's a list of
+//! unexpanded macros. On every iteration, we try to resolve each macro call
+//! path and, upon success, we run macro expansion and "collect module" phase
+//! on the result
+
+mod per_ns;
+pub(crate) mod raw;
+mod collector;
+mod mod_resolution;
+
+use std::sync::Arc;
+
+use once_cell::sync::Lazy;
+use ra_arena::{impl_arena_id, Arena, RawId};
+use ra_db::{CrateId, Edition, FileId};
+use ra_prof::profile;
+use ra_syntax::ast;
+use rustc_hash::{FxHashMap, FxHashSet};
+use test_utils::tested_by;
+
+use crate::{
+    db::{AstDatabase, DefDatabase},
+    db_ext::{crate_edition, crate_root_module},
+    diagnostics::DiagnosticSink,
+    ids::{AdtId, EnumVariantId, HirFileId, MacroDefId, ModuleDefId, ModuleId, TraitId},
+    nameres::diagnostics::DefDiagnostic,
+    source_id::AstId,
+    BuiltinType, Name, Path, PathKind,
+};
+
+pub(crate) use self::raw::{ImportSourceMap, RawItems};
+
+pub use self::{
+    per_ns::{Namespace, PerNs},
+    raw::ImportId,
+};
+
+/// Contains all top-level defs from a macro-expanded crate
+#[derive(Debug, PartialEq, Eq)]
+pub struct CrateDefMap {
+    krate: CrateId,
+    edition: Edition,
+    /// The prelude module for this crate. This either comes from an import
+    /// marked with the `prelude_import` attribute, or (in the normal case) from
+    /// a dependency (`std` or `core`).
+    prelude: Option<ModuleId>,
+    extern_prelude: FxHashMap<Name, ModuleDefId>,
+    root: CrateModuleId,
+    modules: Arena<CrateModuleId, ModuleData>,
+
+    /// Some macros are not well-behavior, which leads to infinite loop
+    /// e.g. macro_rules! foo { ($ty:ty) => { foo!($ty); } }
+    /// We mark it down and skip it in collector
+    ///
+    /// FIXME:
+    /// Right now it only handle a poison macro in a single crate,
+    /// such that if other crate try to call that macro,
+    /// the whole process will do again until it became poisoned in that crate.
+    /// We should handle this macro set globally
+    /// However, do we want to put it as a global variable?
+    poison_macros: FxHashSet<MacroDefId>,
+
+    diagnostics: Vec<DefDiagnostic>,
+}
+
+impl std::ops::Index<CrateModuleId> for CrateDefMap {
+    type Output = ModuleData;
+    fn index(&self, id: CrateModuleId) -> &ModuleData {
+        &self.modules[id]
+    }
+}
+
+/// An ID of a module, **local** to a specific crate
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct CrateModuleId(RawId);
+impl_arena_id!(CrateModuleId);
+
+#[derive(Default, Debug, PartialEq, Eq)]
+pub(crate) struct ModuleData {
+    pub(crate) parent: Option<CrateModuleId>,
+    pub(crate) children: FxHashMap<Name, CrateModuleId>,
+    pub(crate) scope: ModuleScope,
+    /// None for root
+    pub(crate) declaration: Option<AstId<ast::Module>>,
+    /// None for inline modules.
+    ///
+    /// Note that non-inline modules, by definition, live inside non-macro file.
+    pub(crate) definition: Option<FileId>,
+}
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct ModuleScope {
+    items: FxHashMap<Name, Resolution>,
+    /// Macros visable in current module in legacy textual scope
+    ///
+    /// For macros invoked by an unquatified identifier like `bar!()`, `legacy_macros` will be searched in first.
+    /// If it yields no result, then it turns to module scoped `macros`.
+    /// It macros with name quatified with a path like `crate::foo::bar!()`, `legacy_macros` will be skipped,
+    /// and only normal scoped `macros` will be searched in.
+    ///
+    /// Note that this automatically inherit macros defined textually before the definition of module itself.
+    ///
+    /// Module scoped macros will be inserted into `items` instead of here.
+    // FIXME: Macro shadowing in one module is not properly handled. Non-item place macros will
+    // be all resolved to the last one defined if shadowing happens.
+    legacy_macros: FxHashMap<Name, MacroDefId>,
+}
+
+static BUILTIN_SCOPE: Lazy<FxHashMap<Name, Resolution>> = Lazy::new(|| {
+    BuiltinType::ALL
+        .iter()
+        .map(|(name, ty)| {
+            (name.clone(), Resolution { def: PerNs::types(ty.clone().into()), import: None })
+        })
+        .collect()
+});
+
+/// Legacy macros can only be accessed through special methods like `get_legacy_macros`.
+/// Other methods will only resolve values, types and module scoped macros only.
+impl ModuleScope {
+    pub fn entries<'a>(&'a self) -> impl Iterator<Item = (&'a Name, &'a Resolution)> + 'a {
+        self.items.iter().chain(BUILTIN_SCOPE.iter())
+    }
+
+    /// Iterate over all module scoped macros
+    pub fn macros<'a>(&'a self) -> impl Iterator<Item = (&'a Name, MacroDefId)> + 'a {
+        self.items
+            .iter()
+            .filter_map(|(name, res)| res.def.get_macros().map(|macro_| (name, macro_)))
+    }
+
+    /// Iterate over all legacy textual scoped macros visable at the end of the module
+    pub fn legacy_macros<'a>(&'a self) -> impl Iterator<Item = (&'a Name, MacroDefId)> + 'a {
+        self.legacy_macros.iter().map(|(name, def)| (name, *def))
+    }
+
+    /// Get a name from current module scope, legacy macros are not included
+    pub fn get(&self, name: &Name) -> Option<&Resolution> {
+        self.items.get(name).or_else(|| BUILTIN_SCOPE.get(name))
+    }
+
+    pub fn traits<'a>(&'a self) -> impl Iterator<Item = TraitId> + 'a {
+        self.items.values().filter_map(|r| match r.def.take_types() {
+            Some(ModuleDefId::TraitId(t)) => Some(t),
+            _ => None,
+        })
+    }
+
+    fn get_legacy_macro(&self, name: &Name) -> Option<MacroDefId> {
+        self.legacy_macros.get(name).copied()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Resolution {
+    /// None for unresolved
+    pub def: PerNs,
+    /// ident by which this is imported into local scope.
+    pub import: Option<ImportId>,
+}
+
+impl Resolution {
+    pub(crate) fn from_macro(macro_: MacroDefId) -> Self {
+        Resolution { def: PerNs::macros(macro_), import: None }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ResolvePathResult {
+    resolved_def: PerNs,
+    segment_index: Option<usize>,
+    reached_fixedpoint: ReachedFixedPoint,
+}
+
+impl ResolvePathResult {
+    fn empty(reached_fixedpoint: ReachedFixedPoint) -> ResolvePathResult {
+        ResolvePathResult::with(PerNs::none(), reached_fixedpoint, None)
+    }
+
+    fn with(
+        resolved_def: PerNs,
+        reached_fixedpoint: ReachedFixedPoint,
+        segment_index: Option<usize>,
+    ) -> ResolvePathResult {
+        ResolvePathResult { resolved_def, reached_fixedpoint, segment_index }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ResolveMode {
+    Import,
+    Other,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReachedFixedPoint {
+    Yes,
+    No,
+}
+
+impl CrateDefMap {
+    pub(crate) fn crate_def_map_query(
+        // Note that this doesn't have `+ AstDatabase`!
+        // This gurantess that `CrateDefMap` is stable across reparses.
+        db: &impl DefDatabase,
+        krate: CrateId,
+    ) -> Arc<CrateDefMap> {
+        let _p = profile("crate_def_map_query");
+        let def_map = {
+            let edition = crate_edition(db, krate);
+            let mut modules: Arena<CrateModuleId, ModuleData> = Arena::default();
+            let root = modules.alloc(ModuleData::default());
+            CrateDefMap {
+                krate,
+                edition,
+                extern_prelude: FxHashMap::default(),
+                prelude: None,
+                root,
+                modules,
+                poison_macros: FxHashSet::default(),
+                diagnostics: Vec::new(),
+            }
+        };
+        let def_map = collector::collect_defs(db, def_map);
+        Arc::new(def_map)
+    }
+
+    pub(crate) fn krate(&self) -> CrateId {
+        self.krate
+    }
+
+    pub(crate) fn root(&self) -> CrateModuleId {
+        self.root
+    }
+
+    pub(crate) fn prelude(&self) -> Option<ModuleId> {
+        self.prelude
+    }
+
+    pub(crate) fn extern_prelude(&self) -> &FxHashMap<Name, ModuleDefId> {
+        &self.extern_prelude
+    }
+
+    pub(crate) fn add_diagnostics(
+        &self,
+        db: &(impl DefDatabase + AstDatabase),
+        module: CrateModuleId,
+        sink: &mut DiagnosticSink,
+    ) {
+        self.diagnostics.iter().for_each(|it| it.add_to(db, module, sink))
+    }
+
+    pub(crate) fn find_module_by_source(
+        &self,
+        file_id: HirFileId,
+        decl_id: Option<AstId<ast::Module>>,
+    ) -> Option<CrateModuleId> {
+        let (module_id, _module_data) = self.modules.iter().find(|(_module_id, module_data)| {
+            if decl_id.is_some() {
+                module_data.declaration == decl_id
+            } else {
+                module_data.definition.map(|it| it.into()) == Some(file_id)
+            }
+        })?;
+        Some(module_id)
+    }
+
+    pub(crate) fn resolve_path(
+        &self,
+        db: &impl DefDatabase,
+        original_module: CrateModuleId,
+        path: &Path,
+    ) -> (PerNs, Option<usize>) {
+        let res = self.resolve_path_fp_with_macro(db, ResolveMode::Other, original_module, path);
+        (res.resolved_def, res.segment_index)
+    }
+
+    // Returns Yes if we are sure that additions to `ItemMap` wouldn't change
+    // the result.
+    fn resolve_path_fp_with_macro(
+        &self,
+        db: &impl DefDatabase,
+        mode: ResolveMode,
+        original_module: CrateModuleId,
+        path: &Path,
+    ) -> ResolvePathResult {
+        let mut segments = path.segments.iter().enumerate();
+        let mut curr_per_ns: PerNs = match path.kind {
+            PathKind::DollarCrate(krate) => {
+                if krate == self.krate {
+                    tested_by!(macro_dollar_crate_self);
+                    PerNs::types(ModuleId { krate: self.krate, module_id: self.root }.into())
+                } else {
+                    match crate_root_module(db, krate) {
+                        Some(module) => {
+                            tested_by!(macro_dollar_crate_other);
+                            PerNs::types(module.into())
+                        }
+                        None => return ResolvePathResult::empty(ReachedFixedPoint::Yes),
+                    }
+                }
+            }
+            PathKind::Crate => {
+                PerNs::types(ModuleId { krate: self.krate, module_id: self.root }.into())
+            }
+            PathKind::Self_ => {
+                PerNs::types(ModuleId { krate: self.krate, module_id: original_module }.into())
+            }
+            // plain import or absolute path in 2015: crate-relative with
+            // fallback to extern prelude (with the simplification in
+            // rust-lang/rust#57745)
+            // FIXME there must be a nicer way to write this condition
+            PathKind::Plain | PathKind::Abs
+                if self.edition == Edition::Edition2015
+                    && (path.kind == PathKind::Abs || mode == ResolveMode::Import) =>
+            {
+                let segment = match segments.next() {
+                    Some((_, segment)) => segment,
+                    None => return ResolvePathResult::empty(ReachedFixedPoint::Yes),
+                };
+                log::debug!("resolving {:?} in crate root (+ extern prelude)", segment);
+                self.resolve_name_in_crate_root_or_extern_prelude(&segment.name)
+            }
+            PathKind::Plain => {
+                let segment = match segments.next() {
+                    Some((_, segment)) => segment,
+                    None => return ResolvePathResult::empty(ReachedFixedPoint::Yes),
+                };
+                log::debug!("resolving {:?} in module", segment);
+                self.resolve_name_in_module(db, original_module, &segment.name)
+            }
+            PathKind::Super => {
+                if let Some(p) = self.modules[original_module].parent {
+                    PerNs::types(ModuleId { krate: self.krate, module_id: p }.into())
+                } else {
+                    log::debug!("super path in root module");
+                    return ResolvePathResult::empty(ReachedFixedPoint::Yes);
+                }
+            }
+            PathKind::Abs => {
+                // 2018-style absolute path -- only extern prelude
+                let segment = match segments.next() {
+                    Some((_, segment)) => segment,
+                    None => return ResolvePathResult::empty(ReachedFixedPoint::Yes),
+                };
+                if let Some(def) = self.extern_prelude.get(&segment.name) {
+                    log::debug!("absolute path {:?} resolved to crate {:?}", path, def);
+                    PerNs::types(*def)
+                } else {
+                    return ResolvePathResult::empty(ReachedFixedPoint::No); // extern crate declarations can add to the extern prelude
+                }
+            }
+            PathKind::Type(_) => {
+                // This is handled in `infer::infer_path_expr`
+                // The result returned here does not matter
+                return ResolvePathResult::empty(ReachedFixedPoint::Yes);
+            }
+        };
+
+        for (i, segment) in segments {
+            let curr = match curr_per_ns.take_types() {
+                Some(r) => r,
+                None => {
+                    // we still have path segments left, but the path so far
+                    // didn't resolve in the types namespace => no resolution
+                    // (don't break here because `curr_per_ns` might contain
+                    // something in the value namespace, and it would be wrong
+                    // to return that)
+                    return ResolvePathResult::empty(ReachedFixedPoint::No);
+                }
+            };
+            // resolve segment in curr
+
+            curr_per_ns = match curr {
+                ModuleDefId::ModuleId(module) => {
+                    if module.krate != self.krate {
+                        let path =
+                            Path { segments: path.segments[i..].to_vec(), kind: PathKind::Self_ };
+                        log::debug!("resolving {:?} in other crate", path);
+                        let defp_map = db.crate_def_map(module.krate);
+                        let (def, s) = defp_map.resolve_path(db, module.module_id, &path);
+                        return ResolvePathResult::with(
+                            def,
+                            ReachedFixedPoint::Yes,
+                            s.map(|s| s + i),
+                        );
+                    }
+
+                    // Since it is a qualified path here, it should not contains legacy macros
+                    match self[module.module_id].scope.get(&segment.name) {
+                        Some(res) => res.def,
+                        _ => {
+                            log::debug!("path segment {:?} not found", segment.name);
+                            return ResolvePathResult::empty(ReachedFixedPoint::No);
+                        }
+                    }
+                }
+                ModuleDefId::AdtId(AdtId::EnumId(e)) => {
+                    // enum variant
+                    tested_by!(can_import_enum_variant);
+                    match db.enum_data(e).lookup(&segment.name) {
+                        Some(local_id) => {
+                            let variant = EnumVariantId { parent: e, local: local_id };
+                            PerNs::both(variant.into(), variant.into())
+                        }
+                        None => {
+                            return ResolvePathResult::with(
+                                PerNs::types(ModuleDefId::AdtId(AdtId::EnumId(e))),
+                                ReachedFixedPoint::Yes,
+                                Some(i),
+                            );
+                        }
+                    }
+                }
+                s => {
+                    // could be an inherent method call in UFCS form
+                    // (`Struct::method`), or some other kind of associated item
+                    log::debug!(
+                        "path segment {:?} resolved to non-module {:?}, but is not last",
+                        segment.name,
+                        curr,
+                    );
+
+                    return ResolvePathResult::with(
+                        PerNs::types(s),
+                        ReachedFixedPoint::Yes,
+                        Some(i),
+                    );
+                }
+            };
+        }
+        ResolvePathResult::with(curr_per_ns, ReachedFixedPoint::Yes, None)
+    }
+
+    fn resolve_name_in_crate_root_or_extern_prelude(&self, name: &Name) -> PerNs {
+        let from_crate_root =
+            self[self.root].scope.get(name).map_or_else(PerNs::none, |res| res.def);
+        let from_extern_prelude = self.resolve_name_in_extern_prelude(name);
+
+        from_crate_root.or(from_extern_prelude)
+    }
+
+    pub(crate) fn resolve_name_in_module(
+        &self,
+        db: &impl DefDatabase,
+        module: CrateModuleId,
+        name: &Name,
+    ) -> PerNs {
+        // Resolve in:
+        //  - legacy scope of macro
+        //  - current module / scope
+        //  - extern prelude
+        //  - std prelude
+        let from_legacy_macro =
+            self[module].scope.get_legacy_macro(name).map_or_else(PerNs::none, PerNs::macros);
+        let from_scope = self[module].scope.get(name).map_or_else(PerNs::none, |res| res.def);
+        let from_extern_prelude =
+            self.extern_prelude.get(name).map_or(PerNs::none(), |&it| PerNs::types(it));
+        let from_prelude = self.resolve_in_prelude(db, name);
+
+        from_legacy_macro.or(from_scope).or(from_extern_prelude).or(from_prelude)
+    }
+
+    fn resolve_name_in_extern_prelude(&self, name: &Name) -> PerNs {
+        self.extern_prelude.get(name).map_or(PerNs::none(), |&it| PerNs::types(it))
+    }
+
+    fn resolve_in_prelude(&self, db: &impl DefDatabase, name: &Name) -> PerNs {
+        if let Some(prelude) = self.prelude {
+            let keep;
+            let def_map = if prelude.krate == self.krate {
+                self
+            } else {
+                // Extend lifetime
+                keep = db.crate_def_map(prelude.krate);
+                &keep
+            };
+            def_map[prelude.module_id].scope.get(name).map_or_else(PerNs::none, |res| res.def)
+        } else {
+            PerNs::none()
+        }
+    }
+}
+
+mod diagnostics {
+    use ra_syntax::{ast, AstPtr};
+    use relative_path::RelativePathBuf;
+
+    use crate::{
+        db::{AstDatabase, DefDatabase},
+        diagnostics::{DiagnosticSink, UnresolvedModule},
+        nameres::CrateModuleId,
+        source_id::AstId,
+    };
+
+    #[derive(Debug, PartialEq, Eq)]
+    pub(super) enum DefDiagnostic {
+        UnresolvedModule {
+            module: CrateModuleId,
+            declaration: AstId<ast::Module>,
+            candidate: RelativePathBuf,
+        },
+    }
+
+    impl DefDiagnostic {
+        pub(super) fn add_to(
+            &self,
+            db: &(impl DefDatabase + AstDatabase),
+            target_module: CrateModuleId,
+            sink: &mut DiagnosticSink,
+        ) {
+            match self {
+                DefDiagnostic::UnresolvedModule { module, declaration, candidate } => {
+                    if *module != target_module {
+                        return;
+                    }
+                    let decl = declaration.to_node(db);
+                    sink.push(UnresolvedModule {
+                        file: declaration.file_id(),
+                        decl: AstPtr::new(&decl),
+                        candidate: candidate.clone(),
+                    })
+                }
+            }
+        }
+    }
+}

--- a/crates/ra_def/src/nameres/collector.rs
+++ b/crates/ra_def/src/nameres/collector.rs
@@ -1,0 +1,846 @@
+//! FIXME: write short doc here
+
+use ra_cfg::CfgOptions;
+use ra_db::{CrateId, FileId};
+use ra_syntax::{ast, SmolStr};
+use rustc_hash::FxHashMap;
+use test_utils::tested_by;
+
+use crate::{
+    attr::Attr,
+    db::DefDatabase,
+    db_ext::{crate_dependencies, crate_root_module},
+    ids::{
+        AdtId, AstItemId, ConstId, EnumId, EnumVariantId, FunctionId, HirFileId, LocationCtx,
+        MacroCallId, MacroCallLoc, MacroDefId, MacroFileKind, ModuleDefId, ModuleId, StaticId,
+        StructId, TraitId, TypeAliasId,
+    },
+    name::{AsName, MACRO_RULES},
+    nameres::{
+        diagnostics::DefDiagnostic, mod_resolution::ModDir, raw, CrateDefMap, CrateModuleId,
+        ModuleData, PerNs, ReachedFixedPoint, Resolution, ResolveMode,
+    },
+    source_id::AstId,
+    Name, Path, PathKind,
+};
+
+pub(super) fn collect_defs(db: &impl DefDatabase, mut def_map: CrateDefMap) -> CrateDefMap {
+    // populate external prelude
+    for dep in crate_dependencies(db, def_map.krate) {
+        log::debug!("crate dep {:?} -> {:?}", dep.name, dep.krate);
+        if let Some(module) = crate_root_module(db, dep.krate) {
+            def_map.extern_prelude.insert(dep.name.clone(), module.into());
+        }
+        // look for the prelude
+        if def_map.prelude.is_none() {
+            let map = db.crate_def_map(dep.krate);
+            if map.prelude.is_some() {
+                def_map.prelude = map.prelude;
+            }
+        }
+    }
+
+    let crate_graph = db.crate_graph();
+    let cfg_options = crate_graph.cfg_options(def_map.krate());
+
+    let mut collector = DefCollector {
+        db,
+        def_map,
+        glob_imports: FxHashMap::default(),
+        unresolved_imports: Vec::new(),
+        unexpanded_macros: Vec::new(),
+        mod_dirs: FxHashMap::default(),
+        macro_stack_monitor: MacroStackMonitor::default(),
+        cfg_options,
+    };
+    collector.collect();
+    collector.finish()
+}
+
+#[derive(Default)]
+struct MacroStackMonitor {
+    counts: FxHashMap<MacroDefId, u32>,
+
+    /// Mainly use for test
+    validator: Option<Box<dyn Fn(u32) -> bool>>,
+}
+
+impl MacroStackMonitor {
+    fn increase(&mut self, macro_def_id: MacroDefId) {
+        *self.counts.entry(macro_def_id).or_default() += 1;
+    }
+
+    fn decrease(&mut self, macro_def_id: MacroDefId) {
+        *self.counts.entry(macro_def_id).or_default() -= 1;
+    }
+
+    fn is_poison(&self, macro_def_id: MacroDefId) -> bool {
+        let cur = *self.counts.get(&macro_def_id).unwrap_or(&0);
+
+        if let Some(validator) = &self.validator {
+            validator(cur)
+        } else {
+            cur > 100
+        }
+    }
+}
+
+/// Walks the tree of module recursively
+struct DefCollector<'a, DB> {
+    db: &'a DB,
+    def_map: CrateDefMap,
+    glob_imports: FxHashMap<CrateModuleId, Vec<(CrateModuleId, raw::ImportId)>>,
+    unresolved_imports: Vec<(CrateModuleId, raw::ImportId, raw::ImportData)>,
+    unexpanded_macros: Vec<(CrateModuleId, AstId<ast::MacroCall>, Path)>,
+    mod_dirs: FxHashMap<CrateModuleId, ModDir>,
+
+    /// Some macro use `$tt:tt which mean we have to handle the macro perfectly
+    /// To prevent stack overflow, we add a deep counter here for prevent that.
+    macro_stack_monitor: MacroStackMonitor,
+
+    cfg_options: &'a CfgOptions,
+}
+
+impl<DB> DefCollector<'_, DB>
+where
+    DB: DefDatabase,
+{
+    fn collect(&mut self) {
+        let crate_graph = self.db.crate_graph();
+        let file_id = crate_graph.crate_root(self.def_map.krate);
+        let raw_items = self.db.raw_items(file_id.into());
+        let module_id = self.def_map.root;
+        self.def_map.modules[module_id].definition = Some(file_id);
+        ModCollector {
+            def_collector: &mut *self,
+            module_id,
+            file_id: file_id.into(),
+            raw_items: &raw_items,
+            mod_dir: ModDir::root(),
+        }
+        .collect(raw_items.items());
+
+        // main name resolution fixed-point loop.
+        let mut i = 0;
+        loop {
+            self.db.check_canceled();
+            match (self.resolve_imports(), self.resolve_macros()) {
+                (ReachedFixedPoint::Yes, ReachedFixedPoint::Yes) => break,
+                _ => i += 1,
+            }
+            if i == 1000 {
+                log::error!("name resolution is stuck");
+                break;
+            }
+        }
+
+        let unresolved_imports = std::mem::replace(&mut self.unresolved_imports, Vec::new());
+        // show unresolved imports in completion, etc
+        for (module_id, import, import_data) in unresolved_imports {
+            self.record_resolved_import(module_id, PerNs::none(), import, &import_data)
+        }
+    }
+
+    /// Define a macro with `macro_rules`.
+    ///
+    /// It will define the macro in legacy textual scope, and if it has `#[macro_export]`,
+    /// then it is also defined in the root module scope.
+    /// You can `use` or invoke it by `crate::macro_name` anywhere, before or after the definition.
+    ///
+    /// It is surprising that the macro will never be in the current module scope.
+    /// These code fails with "unresolved import/macro",
+    /// ```rust,compile_fail
+    /// mod m { macro_rules! foo { () => {} } }
+    /// use m::foo as bar;
+    /// ```
+    ///
+    /// ```rust,compile_fail
+    /// macro_rules! foo { () => {} }
+    /// self::foo!();
+    /// crate::foo!();
+    /// ```
+    ///
+    /// Well, this code compiles, bacause the plain path `foo` in `use` is searched
+    /// in the legacy textual scope only.
+    /// ```rust
+    /// macro_rules! foo { () => {} }
+    /// use foo as bar;
+    /// ```
+    fn define_macro(
+        &mut self,
+        module_id: CrateModuleId,
+        name: Name,
+        macro_: MacroDefId,
+        export: bool,
+    ) {
+        // Textual scoping
+        self.define_legacy_macro(module_id, name.clone(), macro_);
+
+        // Module scoping
+        // In Rust, `#[macro_export]` macros are unconditionally visible at the
+        // crate root, even if the parent modules is **not** visible.
+        if export {
+            self.update(self.def_map.root, None, &[(name, Resolution::from_macro(macro_))]);
+        }
+    }
+
+    /// Define a legacy textual scoped macro in module
+    ///
+    /// We use a map `legacy_macros` to store all legacy textual scoped macros visable per module.
+    /// It will clone all macros from parent legacy scope, whose definition is prior to
+    /// the definition of current module.
+    /// And also, `macro_use` on a module will import all legacy macros visable inside to
+    /// current legacy scope, with possible shadowing.
+    fn define_legacy_macro(&mut self, module_id: CrateModuleId, name: Name, macro_: MacroDefId) {
+        // Always shadowing
+        self.def_map.modules[module_id].scope.legacy_macros.insert(name, macro_);
+    }
+
+    /// Import macros from `#[macro_use] extern crate`.
+    fn import_macros_from_extern_crate(
+        &mut self,
+        current_module_id: CrateModuleId,
+        import: &raw::ImportData,
+    ) {
+        log::debug!(
+            "importing macros from extern crate: {:?} ({:?})",
+            import,
+            self.def_map.edition,
+        );
+
+        let res = self.def_map.resolve_name_in_extern_prelude(
+            &import
+                .path
+                .as_ident()
+                .expect("extern crate should have been desugared to one-element path"),
+        );
+
+        if let Some(ModuleDefId::ModuleId(m)) = res.take_types() {
+            tested_by!(macro_rules_from_other_crates_are_visible_with_macro_use);
+            self.import_all_macros_exported(current_module_id, m.krate);
+        }
+    }
+
+    /// Import all exported macros from another crate
+    ///
+    /// Exported macros are just all macros in the root module scope.
+    /// Note that it contains not only all `#[macro_export]` macros, but also all aliases
+    /// created by `use` in the root module, ignoring the visibility of `use`.
+    fn import_all_macros_exported(&mut self, current_module_id: CrateModuleId, krate: CrateId) {
+        let def_map = self.db.crate_def_map(krate);
+        for (name, def) in def_map[def_map.root].scope.macros() {
+            // `macro_use` only bring things into legacy scope.
+            self.define_legacy_macro(current_module_id, name.clone(), def);
+        }
+    }
+
+    fn resolve_imports(&mut self) -> ReachedFixedPoint {
+        let mut imports = std::mem::replace(&mut self.unresolved_imports, Vec::new());
+        let mut resolved = Vec::new();
+        imports.retain(|(module_id, import, import_data)| {
+            let (def, fp) = self.resolve_import(*module_id, import_data);
+            if fp == ReachedFixedPoint::Yes {
+                resolved.push((*module_id, def, *import, import_data.clone()))
+            }
+            fp == ReachedFixedPoint::No
+        });
+        self.unresolved_imports = imports;
+        // Resolves imports, filling-in module scopes
+        let result =
+            if resolved.is_empty() { ReachedFixedPoint::Yes } else { ReachedFixedPoint::No };
+        for (module_id, def, import, import_data) in resolved {
+            self.record_resolved_import(module_id, def, import, &import_data)
+        }
+        result
+    }
+
+    fn resolve_import(
+        &self,
+        module_id: CrateModuleId,
+        import: &raw::ImportData,
+    ) -> (PerNs, ReachedFixedPoint) {
+        log::debug!("resolving import: {:?} ({:?})", import, self.def_map.edition);
+        if import.is_extern_crate {
+            let res = self.def_map.resolve_name_in_extern_prelude(
+                &import
+                    .path
+                    .as_ident()
+                    .expect("extern crate should have been desugared to one-element path"),
+            );
+            (res, ReachedFixedPoint::Yes)
+        } else {
+            let res = self.def_map.resolve_path_fp_with_macro(
+                self.db,
+                ResolveMode::Import,
+                module_id,
+                &import.path,
+            );
+
+            (res.resolved_def, res.reached_fixedpoint)
+        }
+    }
+
+    fn record_resolved_import(
+        &mut self,
+        module_id: CrateModuleId,
+        def: PerNs,
+        import_id: raw::ImportId,
+        import: &raw::ImportData,
+    ) {
+        if import.is_glob {
+            log::debug!("glob import: {:?}", import);
+            match def.take_types() {
+                Some(ModuleDefId::ModuleId(m)) => {
+                    if import.is_prelude {
+                        tested_by!(std_prelude);
+                        self.def_map.prelude = Some(m);
+                    } else if m.krate != self.def_map.krate {
+                        tested_by!(glob_across_crates);
+                        // glob import from other crate => we can just import everything once
+                        let item_map = self.db.crate_def_map(m.krate);
+                        let scope = &item_map[m.module_id].scope;
+
+                        // Module scoped macros is included
+                        let items = scope
+                            .items
+                            .iter()
+                            .map(|(name, res)| (name.clone(), res.clone()))
+                            .collect::<Vec<_>>();
+
+                        self.update(module_id, Some(import_id), &items);
+                    } else {
+                        // glob import from same crate => we do an initial
+                        // import, and then need to propagate any further
+                        // additions
+                        let scope = &self.def_map[m.module_id].scope;
+
+                        // Module scoped macros is included
+                        let items = scope
+                            .items
+                            .iter()
+                            .map(|(name, res)| (name.clone(), res.clone()))
+                            .collect::<Vec<_>>();
+
+                        self.update(module_id, Some(import_id), &items);
+                        // record the glob import in case we add further items
+                        self.glob_imports
+                            .entry(m.module_id)
+                            .or_default()
+                            .push((module_id, import_id));
+                    }
+                }
+                Some(ModuleDefId::AdtId(AdtId::EnumId(e))) => {
+                    tested_by!(glob_enum);
+                    // glob import from enum => just import all the variants
+                    let enum_data = self.db.enum_data(e);
+                    let resolutions = enum_data
+                        .variants
+                        .iter()
+                        .filter_map(|(local_id, variant_data)| {
+                            let name = variant_data.name.clone()?;
+                            let variant = EnumVariantId { parent: e, local: local_id };
+                            let res = Resolution {
+                                def: PerNs::both(variant.into(), variant.into()),
+                                import: Some(import_id),
+                            };
+                            Some((name, res))
+                        })
+                        .collect::<Vec<_>>();
+                    self.update(module_id, Some(import_id), &resolutions);
+                }
+                Some(d) => {
+                    log::debug!("glob import {:?} from non-module/enum {:?}", import, d);
+                }
+                None => {
+                    log::debug!("glob import {:?} didn't resolve as type", import);
+                }
+            }
+        } else {
+            match import.path.segments.last() {
+                Some(last_segment) => {
+                    let name = import.alias.clone().unwrap_or_else(|| last_segment.name.clone());
+                    log::debug!("resolved import {:?} ({:?}) to {:?}", name, import, def);
+
+                    // extern crates in the crate root are special-cased to insert entries into the extern prelude: rust-lang/rust#54658
+                    if import.is_extern_crate && module_id == self.def_map.root {
+                        if let Some(def) = def.take_types() {
+                            self.def_map.extern_prelude.insert(name.clone(), def);
+                        }
+                    }
+
+                    let resolution = Resolution { def, import: Some(import_id) };
+                    self.update(module_id, Some(import_id), &[(name, resolution)]);
+                }
+                None => tested_by!(bogus_paths),
+            }
+        }
+    }
+
+    fn update(
+        &mut self,
+        module_id: CrateModuleId,
+        import: Option<raw::ImportId>,
+        resolutions: &[(Name, Resolution)],
+    ) {
+        self.update_recursive(module_id, import, resolutions, 0)
+    }
+
+    fn update_recursive(
+        &mut self,
+        module_id: CrateModuleId,
+        import: Option<raw::ImportId>,
+        resolutions: &[(Name, Resolution)],
+        depth: usize,
+    ) {
+        if depth > 100 {
+            // prevent stack overflows (but this shouldn't be possible)
+            panic!("infinite recursion in glob imports!");
+        }
+        let module_items = &mut self.def_map.modules[module_id].scope;
+        let mut changed = false;
+        for (name, res) in resolutions {
+            let existing = module_items.items.entry(name.clone()).or_default();
+
+            if existing.def.types.is_none() && res.def.types.is_some() {
+                existing.def.types = res.def.types;
+                existing.import = import.or(res.import);
+                changed = true;
+            }
+            if existing.def.values.is_none() && res.def.values.is_some() {
+                existing.def.values = res.def.values;
+                existing.import = import.or(res.import);
+                changed = true;
+            }
+            if existing.def.macros.is_none() && res.def.macros.is_some() {
+                existing.def.macros = res.def.macros;
+                existing.import = import.or(res.import);
+                changed = true;
+            }
+
+            if existing.def.is_none()
+                && res.def.is_none()
+                && existing.import.is_none()
+                && res.import.is_some()
+            {
+                existing.import = res.import;
+            }
+        }
+
+        if !changed {
+            return;
+        }
+        let glob_imports = self
+            .glob_imports
+            .get(&module_id)
+            .into_iter()
+            .flat_map(|v| v.iter())
+            .cloned()
+            .collect::<Vec<_>>();
+        for (glob_importing_module, glob_import) in glob_imports {
+            // We pass the glob import so that the tracked import in those modules is that glob import
+            self.update_recursive(glob_importing_module, Some(glob_import), resolutions, depth + 1);
+        }
+    }
+
+    fn resolve_macros(&mut self) -> ReachedFixedPoint {
+        let mut macros = std::mem::replace(&mut self.unexpanded_macros, Vec::new());
+        let mut resolved = Vec::new();
+        let mut res = ReachedFixedPoint::Yes;
+        macros.retain(|(module_id, ast_id, path)| {
+            let resolved_res = self.def_map.resolve_path_fp_with_macro(
+                self.db,
+                ResolveMode::Other,
+                *module_id,
+                path,
+            );
+
+            if let Some(def) = resolved_res.resolved_def.get_macros() {
+                let call_id = MacroCallLoc { def, ast_id: *ast_id }.id(self.db);
+                resolved.push((*module_id, call_id, def));
+                res = ReachedFixedPoint::No;
+                return false;
+            }
+
+            true
+        });
+
+        self.unexpanded_macros = macros;
+
+        for (module_id, macro_call_id, macro_def_id) in resolved {
+            self.collect_macro_expansion(module_id, macro_call_id, macro_def_id);
+        }
+
+        res
+    }
+
+    fn collect_macro_expansion(
+        &mut self,
+        module_id: CrateModuleId,
+        macro_call_id: MacroCallId,
+        macro_def_id: MacroDefId,
+    ) {
+        if self.def_map.poison_macros.contains(&macro_def_id) {
+            return;
+        }
+
+        self.macro_stack_monitor.increase(macro_def_id);
+
+        if !self.macro_stack_monitor.is_poison(macro_def_id) {
+            let file_id: HirFileId = macro_call_id.as_file(MacroFileKind::Items);
+            let raw_items = self.db.raw_items(file_id);
+            let mod_dir = self.mod_dirs[&module_id].clone();
+            ModCollector {
+                def_collector: &mut *self,
+                file_id,
+                module_id,
+                raw_items: &raw_items,
+                mod_dir,
+            }
+            .collect(raw_items.items());
+        } else {
+            log::error!("Too deep macro expansion: {:?}", macro_call_id);
+            self.def_map.poison_macros.insert(macro_def_id);
+        }
+
+        self.macro_stack_monitor.decrease(macro_def_id);
+    }
+
+    fn finish(self) -> CrateDefMap {
+        self.def_map
+    }
+}
+
+/// Walks a single module, populating defs, imports and macros
+struct ModCollector<'a, D> {
+    def_collector: D,
+    module_id: CrateModuleId,
+    file_id: HirFileId,
+    raw_items: &'a raw::RawItems,
+    mod_dir: ModDir,
+}
+
+impl<DB> ModCollector<'_, &'_ mut DefCollector<'_, DB>>
+where
+    DB: DefDatabase,
+{
+    fn collect(&mut self, items: &[raw::RawItem]) {
+        // Note: don't assert that inserted value is fresh: it's simply not true
+        // for macros.
+        self.def_collector.mod_dirs.insert(self.module_id, self.mod_dir.clone());
+
+        // Prelude module is always considered to be `#[macro_use]`.
+        if let Some(prelude_module) = self.def_collector.def_map.prelude {
+            if prelude_module.krate != self.def_collector.def_map.krate {
+                tested_by!(prelude_is_macro_use);
+                self.def_collector.import_all_macros_exported(self.module_id, prelude_module.krate);
+            }
+        }
+
+        // This should be processed eagerly instead of deferred to resolving.
+        // `#[macro_use] extern crate` is hoisted to imports macros before collecting
+        // any other items.
+        for item in items {
+            if self.is_cfg_enabled(item.attrs()) {
+                if let raw::RawItemKind::Import(import_id) = item.kind {
+                    let import = self.raw_items[import_id].clone();
+                    if import.is_extern_crate && import.is_macro_use {
+                        self.def_collector.import_macros_from_extern_crate(self.module_id, &import);
+                    }
+                }
+            }
+        }
+
+        for item in items {
+            if self.is_cfg_enabled(item.attrs()) {
+                match item.kind {
+                    raw::RawItemKind::Module(m) => {
+                        self.collect_module(&self.raw_items[m], item.attrs())
+                    }
+                    raw::RawItemKind::Import(import_id) => self
+                        .def_collector
+                        .unresolved_imports
+                        .push((self.module_id, import_id, self.raw_items[import_id].clone())),
+                    raw::RawItemKind::Def(def) => self.define_def(&self.raw_items[def]),
+                    raw::RawItemKind::Macro(mac) => self.collect_macro(&self.raw_items[mac]),
+                }
+            }
+        }
+    }
+
+    fn collect_module(&mut self, module: &raw::ModuleData, attrs: &[Attr]) {
+        let path_attr = self.path_attr(attrs);
+        let is_macro_use = self.is_macro_use(attrs);
+        match module {
+            // inline module, just recurse
+            raw::ModuleData::Definition { name, items, ast_id } => {
+                let module_id =
+                    self.push_child_module(name.clone(), ast_id.with_file_id(self.file_id), None);
+
+                ModCollector {
+                    def_collector: &mut *self.def_collector,
+                    module_id,
+                    file_id: self.file_id,
+                    raw_items: self.raw_items,
+                    mod_dir: self.mod_dir.descend_into_definition(name, path_attr),
+                }
+                .collect(&*items);
+                if is_macro_use {
+                    self.import_all_legacy_macros(module_id);
+                }
+            }
+            // out of line module, resolve, parse and recurse
+            raw::ModuleData::Declaration { name, ast_id } => {
+                let ast_id = ast_id.with_file_id(self.file_id);
+                match self.mod_dir.resolve_declaration(
+                    self.def_collector.db,
+                    self.file_id,
+                    name,
+                    path_attr,
+                ) {
+                    Ok((file_id, mod_dir)) => {
+                        let module_id = self.push_child_module(name.clone(), ast_id, Some(file_id));
+                        let raw_items = self.def_collector.db.raw_items(file_id.into());
+                        ModCollector {
+                            def_collector: &mut *self.def_collector,
+                            module_id,
+                            file_id: file_id.into(),
+                            raw_items: &raw_items,
+                            mod_dir,
+                        }
+                        .collect(raw_items.items());
+                        if is_macro_use {
+                            self.import_all_legacy_macros(module_id);
+                        }
+                    }
+                    Err(candidate) => self.def_collector.def_map.diagnostics.push(
+                        DefDiagnostic::UnresolvedModule {
+                            module: self.module_id,
+                            declaration: ast_id,
+                            candidate,
+                        },
+                    ),
+                };
+            }
+        }
+    }
+
+    fn push_child_module(
+        &mut self,
+        name: Name,
+        declaration: AstId<ast::Module>,
+        definition: Option<FileId>,
+    ) -> CrateModuleId {
+        let modules = &mut self.def_collector.def_map.modules;
+        let res = modules.alloc(ModuleData::default());
+        modules[res].parent = Some(self.module_id);
+        modules[res].declaration = Some(declaration);
+        modules[res].definition = definition;
+        modules[res].scope.legacy_macros = modules[self.module_id].scope.legacy_macros.clone();
+        modules[self.module_id].children.insert(name.clone(), res);
+        let resolution = Resolution {
+            def: PerNs::types(
+                ModuleId { krate: self.def_collector.def_map.krate, module_id: res }.into(),
+            ),
+            import: None,
+        };
+        self.def_collector.update(self.module_id, None, &[(name, resolution)]);
+        res
+    }
+
+    fn define_def(&mut self, def: &raw::DefData) {
+        let module =
+            ModuleId { krate: self.def_collector.def_map.krate, module_id: self.module_id };
+        let ctx = LocationCtx::new(self.def_collector.db, module, self.file_id);
+
+        macro_rules! def {
+            ($kind:ident, $ast_id:ident) => {
+                ModuleDefId::from($kind::from_ast_id(ctx, $ast_id))
+            };
+        }
+        let name = def.name.clone();
+        let def: PerNs = match def.kind {
+            raw::DefKind::Function(ast_id) => PerNs::values(def!(FunctionId, ast_id)),
+            raw::DefKind::Struct(ast_id) => {
+                let s = AdtId::StructId(StructId::from_ast_id(ctx, ast_id)).into();
+                PerNs::both(s, s)
+            }
+            raw::DefKind::Union(ast_id) => {
+                let s = AdtId::UnionId(StructId::from_ast_id(ctx, ast_id)).into();
+                PerNs::both(s, s)
+            }
+            raw::DefKind::Enum(ast_id) => {
+                let e = AdtId::EnumId(EnumId::from_ast_id(ctx, ast_id)).into();
+                PerNs::types(e)
+            }
+            raw::DefKind::Const(ast_id) => PerNs::values(def!(ConstId, ast_id)),
+            raw::DefKind::Static(ast_id) => PerNs::values(def!(StaticId, ast_id)),
+            raw::DefKind::Trait(ast_id) => PerNs::types(def!(TraitId, ast_id)),
+            raw::DefKind::TypeAlias(ast_id) => PerNs::types(def!(TypeAliasId, ast_id)),
+        };
+        let resolution = Resolution { def, import: None };
+        self.def_collector.update(self.module_id, None, &[(name, resolution)])
+    }
+
+    fn collect_macro(&mut self, mac: &raw::MacroData) {
+        // Case 1: macro rules, define a macro in crate-global mutable scope
+        if is_macro_rules(&mac.path) {
+            if let Some(name) = &mac.name {
+                let macro_id = MacroDefId {
+                    ast_id: mac.ast_id.with_file_id(self.file_id),
+                    krate: self.def_collector.def_map.krate,
+                };
+                self.def_collector.define_macro(self.module_id, name.clone(), macro_id, mac.export);
+            }
+            return;
+        }
+
+        let ast_id = mac.ast_id.with_file_id(self.file_id);
+
+        // Case 2: try to resolve in legacy scope and expand macro_rules, triggering
+        // recursive item collection.
+        if let Some(macro_def) = mac.path.as_ident().and_then(|name| {
+            self.def_collector.def_map[self.module_id].scope.get_legacy_macro(&name)
+        }) {
+            let macro_call_id = MacroCallLoc { def: macro_def, ast_id }.id(self.def_collector.db);
+
+            self.def_collector.collect_macro_expansion(self.module_id, macro_call_id, macro_def);
+            return;
+        }
+
+        // Case 3: resolve in module scope, expand during name resolution.
+        // We rewrite simple path `macro_name` to `self::macro_name` to force resolve in module scope only.
+        let mut path = mac.path.clone();
+        if path.is_ident() {
+            path.kind = PathKind::Self_;
+        }
+        self.def_collector.unexpanded_macros.push((self.module_id, ast_id, path));
+    }
+
+    fn import_all_legacy_macros(&mut self, module_id: CrateModuleId) {
+        let macros = self.def_collector.def_map[module_id].scope.legacy_macros.clone();
+        for (name, macro_) in macros {
+            self.def_collector.define_legacy_macro(self.module_id, name.clone(), macro_);
+        }
+    }
+
+    fn is_cfg_enabled(&self, attrs: &[Attr]) -> bool {
+        attrs.iter().all(|attr| attr.is_cfg_enabled(&self.def_collector.cfg_options) != Some(false))
+    }
+
+    fn path_attr<'a>(&self, attrs: &'a [Attr]) -> Option<&'a SmolStr> {
+        attrs.iter().find_map(|attr| attr.as_path())
+    }
+
+    fn is_macro_use<'a>(&self, attrs: &'a [Attr]) -> bool {
+        attrs.iter().any(|attr| attr.is_simple_atom("macro_use"))
+    }
+}
+
+fn is_macro_rules(path: &Path) -> bool {
+    path.as_ident() == Some(&MACRO_RULES)
+}
+
+#[cfg(test)]
+mod tests {
+    use ra_db::SourceDatabase;
+
+    use super::*;
+    use crate::{db::DefDatabase, mock::MockDatabase, Crate};
+    use ra_arena::Arena;
+    use rustc_hash::FxHashSet;
+
+    fn do_collect_defs(
+        db: &impl DefDatabase,
+        def_map: CrateDefMap,
+        monitor: MacroStackMonitor,
+    ) -> CrateDefMap {
+        let mut collector = DefCollector {
+            db,
+            def_map,
+            glob_imports: FxHashMap::default(),
+            unresolved_imports: Vec::new(),
+            unexpanded_macros: Vec::new(),
+            mod_dirs: FxHashMap::default(),
+            macro_stack_monitor: monitor,
+            cfg_options: &CfgOptions::default(),
+        };
+        collector.collect();
+        collector.finish()
+    }
+
+    fn do_limited_resolve(code: &str, limit: u32, poison_limit: u32) -> CrateDefMap {
+        let (db, _source_root, _) = MockDatabase::with_single_file(&code);
+        let crate_id = db.crate_graph().iter().next().unwrap();
+        let krate = Crate { crate_id };
+
+        let def_map = {
+            let edition = krate.edition(&db);
+            let mut modules: Arena<CrateModuleId, ModuleData> = Arena::default();
+            let root = modules.alloc(ModuleData::default());
+            CrateDefMap {
+                krate,
+                edition,
+                extern_prelude: FxHashMap::default(),
+                prelude: None,
+                root,
+                modules,
+                poison_macros: FxHashSet::default(),
+                diagnostics: Vec::new(),
+            }
+        };
+
+        let mut monitor = MacroStackMonitor::default();
+        monitor.validator = Some(Box::new(move |count| {
+            assert!(count < limit);
+            count >= poison_limit
+        }));
+
+        do_collect_defs(&db, def_map, monitor)
+    }
+
+    #[test]
+    fn test_macro_expand_limit_width() {
+        do_limited_resolve(
+            r#"
+        macro_rules! foo {
+            ($($ty:ty)*) => { foo!($($ty)*, $($ty)*); }
+        }
+foo!(KABOOM);
+        "#,
+            16,
+            1000,
+        );
+    }
+
+    #[test]
+    fn test_macro_expand_poisoned() {
+        let def = do_limited_resolve(
+            r#"
+        macro_rules! foo {
+            ($ty:ty) => { foo!($ty); }
+        }
+foo!(KABOOM);
+        "#,
+            100,
+            16,
+        );
+
+        assert_eq!(def.poison_macros.len(), 1);
+    }
+
+    #[test]
+    fn test_macro_expand_normal() {
+        let def = do_limited_resolve(
+            r#"
+        macro_rules! foo {
+            ($ident:ident) => { struct $ident {} }
+        }
+foo!(Bar);
+        "#,
+            16,
+            16,
+        );
+
+        assert_eq!(def.poison_macros.len(), 0);
+    }
+}

--- a/crates/ra_def/src/nameres/mod_resolution.rs
+++ b/crates/ra_def/src/nameres/mod_resolution.rs
@@ -1,0 +1,87 @@
+//! This module resolves `mod foo;` declaration to file.
+use ra_db::FileId;
+use ra_syntax::SmolStr;
+use relative_path::RelativePathBuf;
+
+use crate::{db::DefDatabase, ids::HirFileId, Name};
+
+#[derive(Clone, Debug)]
+pub(super) struct ModDir {
+    /// `.` for `mod.rs`, `lib.rs`
+    /// `./foo` for `foo.rs`
+    /// `./foo/bar` for `mod bar { mod x; }` nested in `foo.rs`
+    path: RelativePathBuf,
+    /// inside `./foo.rs`, mods with `#[path]` should *not* be relative to `./foo/`
+    root_non_dir_owner: bool,
+}
+
+impl ModDir {
+    pub(super) fn root() -> ModDir {
+        ModDir { path: RelativePathBuf::default(), root_non_dir_owner: false }
+    }
+
+    pub(super) fn descend_into_definition(
+        &self,
+        name: &Name,
+        attr_path: Option<&SmolStr>,
+    ) -> ModDir {
+        let mut path = self.path.clone();
+        match attr_to_path(attr_path) {
+            None => path.push(&name.to_string()),
+            Some(attr_path) => {
+                if self.root_non_dir_owner {
+                    // Workaround for relative path API: turn `lib.rs` into ``.
+                    if !path.pop() {
+                        path = RelativePathBuf::default();
+                    }
+                }
+                path.push(attr_path);
+            }
+        }
+        ModDir { path, root_non_dir_owner: false }
+    }
+
+    pub(super) fn resolve_declaration(
+        &self,
+        db: &impl DefDatabase,
+        file_id: HirFileId,
+        name: &Name,
+        attr_path: Option<&SmolStr>,
+    ) -> Result<(FileId, ModDir), RelativePathBuf> {
+        let empty_path = RelativePathBuf::default();
+        let file_id = file_id.original_file(db);
+
+        let mut candidate_files = Vec::new();
+        match attr_to_path(attr_path) {
+            Some(attr_path) => {
+                let base = if self.root_non_dir_owner {
+                    self.path.parent().unwrap_or(&empty_path)
+                } else {
+                    &self.path
+                };
+                candidate_files.push(base.join(attr_path))
+            }
+            None => {
+                candidate_files.push(self.path.join(&format!("{}.rs", name)));
+                candidate_files.push(self.path.join(&format!("{}/mod.rs", name)));
+            }
+        };
+
+        for candidate in candidate_files.iter() {
+            if let Some(file_id) = db.resolve_relative_path(file_id, candidate) {
+                let mut root_non_dir_owner = false;
+                let mut mod_path = RelativePathBuf::new();
+                if !(candidate.ends_with("mod.rs") || attr_path.is_some()) {
+                    root_non_dir_owner = true;
+                    mod_path.push(&name.to_string());
+                }
+                return Ok((file_id, ModDir { path: mod_path, root_non_dir_owner }));
+            }
+        }
+        Err(candidate_files.remove(0))
+    }
+}
+
+fn attr_to_path(attr: Option<&SmolStr>) -> Option<RelativePathBuf> {
+    attr.and_then(|it| RelativePathBuf::from_path(&it.replace("\\", "/")).ok())
+}

--- a/crates/ra_def/src/nameres/per_ns.rs
+++ b/crates/ra_def/src/nameres/per_ns.rs
@@ -1,0 +1,80 @@
+//! FIXME: write short doc here
+
+use crate::ids::{MacroDefId, ModuleDefId};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Namespace {
+    Types,
+    Values,
+    // Note that only type inference uses this enum, and it doesn't care about macros.
+    // Macro,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct PerNs {
+    pub types: Option<ModuleDefId>,
+    pub values: Option<ModuleDefId>,
+    /// Since macros has different type, many methods simply ignore it.
+    /// We can only use special method like `get_macros` to access it.
+    pub macros: Option<MacroDefId>,
+}
+
+impl Default for PerNs {
+    fn default() -> Self {
+        PerNs { types: None, values: None, macros: None }
+    }
+}
+
+impl PerNs {
+    pub fn none() -> PerNs {
+        PerNs { types: None, values: None, macros: None }
+    }
+
+    pub fn values(t: ModuleDefId) -> PerNs {
+        PerNs { types: None, values: Some(t), macros: None }
+    }
+
+    pub fn types(t: ModuleDefId) -> PerNs {
+        PerNs { types: Some(t), values: None, macros: None }
+    }
+
+    pub fn both(types: ModuleDefId, values: ModuleDefId) -> PerNs {
+        PerNs { types: Some(types), values: Some(values), macros: None }
+    }
+
+    pub fn macros(macro_: MacroDefId) -> PerNs {
+        PerNs { types: None, values: None, macros: Some(macro_) }
+    }
+
+    pub fn is_none(&self) -> bool {
+        self.types.is_none() && self.values.is_none() && self.macros.is_none()
+    }
+
+    pub fn is_all(&self) -> bool {
+        self.types.is_some() && self.values.is_some() && self.macros.is_some()
+    }
+
+    pub fn take_types(self) -> Option<ModuleDefId> {
+        self.types
+    }
+
+    pub fn take_values(self) -> Option<ModuleDefId> {
+        self.values
+    }
+
+    pub fn get_macros(&self) -> Option<MacroDefId> {
+        self.macros
+    }
+
+    pub fn only_macros(&self) -> PerNs {
+        PerNs { types: None, values: None, macros: self.macros }
+    }
+
+    pub fn or(self, other: PerNs) -> PerNs {
+        PerNs {
+            types: self.types.or(other.types),
+            values: self.values.or(other.values),
+            macros: self.macros.or(other.macros),
+        }
+    }
+}

--- a/crates/ra_def/src/nameres/raw.rs
+++ b/crates/ra_def/src/nameres/raw.rs
@@ -1,0 +1,406 @@
+//! FIXME: write short doc here
+
+use std::{ops::Index, sync::Arc};
+
+use ra_arena::{impl_arena_id, map::ArenaMap, Arena, RawId};
+use ra_syntax::{
+    ast::{self, AttrsOwner, NameOwner},
+    AstNode, AstPtr, SourceFile,
+};
+use test_utils::tested_by;
+
+use crate::{
+    attr::Attr,
+    db::{AstDatabase, DefDatabase},
+    ids::HirFileId,
+    name::AsName,
+    source_id::{AstIdMap, FileAstId},
+    Either, ModuleSource, Name, Path, Source,
+};
+
+/// `RawItems` is a set of top-level items in a file (except for impls).
+///
+/// It is the input to name resolution algorithm. `RawItems` are not invalidated
+/// on most edits.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct RawItems {
+    modules: Arena<Module, ModuleData>,
+    imports: Arena<ImportId, ImportData>,
+    defs: Arena<Def, DefData>,
+    macros: Arena<Macro, MacroData>,
+    /// items for top-level module
+    items: Vec<RawItem>,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ImportSourceMap {
+    map: ArenaMap<ImportId, ImportSourcePtr>,
+}
+
+type ImportSourcePtr = Either<AstPtr<ast::UseTree>, AstPtr<ast::ExternCrateItem>>;
+type ImportSource = Either<ast::UseTree, ast::ExternCrateItem>;
+
+impl ImportSourcePtr {
+    fn to_node(self, file: &SourceFile) -> ImportSource {
+        self.map(|ptr| ptr.to_node(file.syntax()), |ptr| ptr.to_node(file.syntax()))
+    }
+}
+
+impl ImportSourceMap {
+    fn insert(&mut self, import: ImportId, ptr: ImportSourcePtr) {
+        self.map.insert(import, ptr)
+    }
+
+    pub(crate) fn get(&self, source: &ModuleSource, import: ImportId) -> ImportSource {
+        let file = match source {
+            ModuleSource::SourceFile(file) => file.clone(),
+            ModuleSource::Module(m) => m.syntax().ancestors().find_map(SourceFile::cast).unwrap(),
+        };
+
+        self.map[import].to_node(&file)
+    }
+}
+
+impl RawItems {
+    pub(crate) fn raw_items_query(
+        db: &(impl DefDatabase + AstDatabase),
+        file_id: HirFileId,
+    ) -> Arc<RawItems> {
+        db.raw_items_with_source_map(file_id).0
+    }
+
+    pub(crate) fn raw_items_with_source_map_query(
+        db: &(impl DefDatabase + AstDatabase),
+        file_id: HirFileId,
+    ) -> (Arc<RawItems>, Arc<ImportSourceMap>) {
+        let mut collector = RawItemsCollector {
+            raw_items: RawItems::default(),
+            source_ast_id_map: db.ast_id_map(file_id),
+            source_map: ImportSourceMap::default(),
+            file_id,
+            db,
+        };
+        if let Some(node) = db.parse_or_expand(file_id) {
+            if let Some(source_file) = ast::SourceFile::cast(node.clone()) {
+                collector.process_module(None, source_file);
+            } else if let Some(item_list) = ast::MacroItems::cast(node) {
+                collector.process_module(None, item_list);
+            }
+        }
+        (Arc::new(collector.raw_items), Arc::new(collector.source_map))
+    }
+
+    pub(super) fn items(&self) -> &[RawItem] {
+        &self.items
+    }
+}
+
+impl Index<Module> for RawItems {
+    type Output = ModuleData;
+    fn index(&self, idx: Module) -> &ModuleData {
+        &self.modules[idx]
+    }
+}
+
+impl Index<ImportId> for RawItems {
+    type Output = ImportData;
+    fn index(&self, idx: ImportId) -> &ImportData {
+        &self.imports[idx]
+    }
+}
+
+impl Index<Def> for RawItems {
+    type Output = DefData;
+    fn index(&self, idx: Def) -> &DefData {
+        &self.defs[idx]
+    }
+}
+
+impl Index<Macro> for RawItems {
+    type Output = MacroData;
+    fn index(&self, idx: Macro) -> &MacroData {
+        &self.macros[idx]
+    }
+}
+
+// Avoid heap allocation on items without attributes.
+type Attrs = Option<Arc<[Attr]>>;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub(super) struct RawItem {
+    attrs: Attrs,
+    pub(super) kind: RawItemKind,
+}
+
+impl RawItem {
+    pub(super) fn attrs(&self) -> &[Attr] {
+        self.attrs.as_ref().map_or(&[], |it| &*it)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub(super) enum RawItemKind {
+    Module(Module),
+    Import(ImportId),
+    Def(Def),
+    Macro(Macro),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(super) struct Module(RawId);
+impl_arena_id!(Module);
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum ModuleData {
+    Declaration { name: Name, ast_id: FileAstId<ast::Module> },
+    Definition { name: Name, ast_id: FileAstId<ast::Module>, items: Vec<RawItem> },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ImportId(RawId);
+impl_arena_id!(ImportId);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportData {
+    pub(super) path: Path,
+    pub(super) alias: Option<Name>,
+    pub(super) is_glob: bool,
+    pub(super) is_prelude: bool,
+    pub(super) is_extern_crate: bool,
+    pub(super) is_macro_use: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(super) struct Def(RawId);
+impl_arena_id!(Def);
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct DefData {
+    pub(super) name: Name,
+    pub(super) kind: DefKind,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub(super) enum DefKind {
+    Function(FileAstId<ast::FnDef>),
+    Struct(FileAstId<ast::StructDef>),
+    Union(FileAstId<ast::StructDef>),
+    Enum(FileAstId<ast::EnumDef>),
+    Const(FileAstId<ast::ConstDef>),
+    Static(FileAstId<ast::StaticDef>),
+    Trait(FileAstId<ast::TraitDef>),
+    TypeAlias(FileAstId<ast::TypeAliasDef>),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(super) struct Macro(RawId);
+impl_arena_id!(Macro);
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct MacroData {
+    pub(super) ast_id: FileAstId<ast::MacroCall>,
+    pub(super) path: Path,
+    pub(super) name: Option<Name>,
+    pub(super) export: bool,
+}
+
+struct RawItemsCollector<DB> {
+    raw_items: RawItems,
+    source_ast_id_map: Arc<AstIdMap>,
+    source_map: ImportSourceMap,
+    file_id: HirFileId,
+    db: DB,
+}
+
+impl<DB: AstDatabase> RawItemsCollector<&DB> {
+    fn process_module(&mut self, current_module: Option<Module>, body: impl ast::ModuleItemOwner) {
+        for item_or_macro in body.items_with_macros() {
+            match item_or_macro {
+                ast::ItemOrMacro::Macro(m) => self.add_macro(current_module, m),
+                ast::ItemOrMacro::Item(item) => self.add_item(current_module, item),
+            }
+        }
+    }
+
+    fn add_item(&mut self, current_module: Option<Module>, item: ast::ModuleItem) {
+        let attrs = self.parse_attrs(&item);
+        let (kind, name) = match item {
+            ast::ModuleItem::Module(module) => {
+                self.add_module(current_module, module);
+                return;
+            }
+            ast::ModuleItem::UseItem(use_item) => {
+                self.add_use_item(current_module, use_item);
+                return;
+            }
+            ast::ModuleItem::ExternCrateItem(extern_crate) => {
+                self.add_extern_crate_item(current_module, extern_crate);
+                return;
+            }
+            ast::ModuleItem::ImplBlock(_) => {
+                // impls don't participate in name resolution
+                return;
+            }
+            ast::ModuleItem::StructDef(it) => {
+                let id = self.source_ast_id_map.ast_id(&it);
+                let name = it.name();
+                if it.is_union() {
+                    (DefKind::Union(id), name)
+                } else {
+                    (DefKind::Struct(id), name)
+                }
+            }
+            ast::ModuleItem::EnumDef(it) => {
+                (DefKind::Enum(self.source_ast_id_map.ast_id(&it)), it.name())
+            }
+            ast::ModuleItem::FnDef(it) => {
+                (DefKind::Function(self.source_ast_id_map.ast_id(&it)), it.name())
+            }
+            ast::ModuleItem::TraitDef(it) => {
+                (DefKind::Trait(self.source_ast_id_map.ast_id(&it)), it.name())
+            }
+            ast::ModuleItem::TypeAliasDef(it) => {
+                (DefKind::TypeAlias(self.source_ast_id_map.ast_id(&it)), it.name())
+            }
+            ast::ModuleItem::ConstDef(it) => {
+                (DefKind::Const(self.source_ast_id_map.ast_id(&it)), it.name())
+            }
+            ast::ModuleItem::StaticDef(it) => {
+                (DefKind::Static(self.source_ast_id_map.ast_id(&it)), it.name())
+            }
+        };
+        if let Some(name) = name {
+            let name = name.as_name();
+            let def = self.raw_items.defs.alloc(DefData { name, kind });
+            self.push_item(current_module, attrs, RawItemKind::Def(def));
+        }
+    }
+
+    fn add_module(&mut self, current_module: Option<Module>, module: ast::Module) {
+        let name = match module.name() {
+            Some(it) => it.as_name(),
+            None => return,
+        };
+        let attrs = self.parse_attrs(&module);
+
+        let ast_id = self.source_ast_id_map.ast_id(&module);
+        if module.has_semi() {
+            let item = self.raw_items.modules.alloc(ModuleData::Declaration { name, ast_id });
+            self.push_item(current_module, attrs, RawItemKind::Module(item));
+            return;
+        }
+
+        if let Some(item_list) = module.item_list() {
+            let item = self.raw_items.modules.alloc(ModuleData::Definition {
+                name,
+                ast_id,
+                items: Vec::new(),
+            });
+            self.process_module(Some(item), item_list);
+            self.push_item(current_module, attrs, RawItemKind::Module(item));
+            return;
+        }
+        tested_by!(name_res_works_for_broken_modules);
+    }
+
+    fn add_use_item(&mut self, current_module: Option<Module>, use_item: ast::UseItem) {
+        // FIXME: cfg_attr
+        let is_prelude = use_item.has_atom_attr("prelude_import");
+        let attrs = self.parse_attrs(&use_item);
+
+        Path::expand_use_item(
+            Source { ast: use_item, file_id: self.file_id },
+            self.db,
+            |path, use_tree, is_glob, alias| {
+                let import_data = ImportData {
+                    path,
+                    alias,
+                    is_glob,
+                    is_prelude,
+                    is_extern_crate: false,
+                    is_macro_use: false,
+                };
+                self.push_import(
+                    current_module,
+                    attrs.clone(),
+                    import_data,
+                    Either::A(AstPtr::new(use_tree)),
+                );
+            },
+        )
+    }
+
+    fn add_extern_crate_item(
+        &mut self,
+        current_module: Option<Module>,
+        extern_crate: ast::ExternCrateItem,
+    ) {
+        if let Some(name_ref) = extern_crate.name_ref() {
+            let path = Path::from_name_ref(&name_ref);
+            let alias = extern_crate.alias().and_then(|a| a.name()).map(|it| it.as_name());
+            let attrs = self.parse_attrs(&extern_crate);
+            // FIXME: cfg_attr
+            let is_macro_use = extern_crate.has_atom_attr("macro_use");
+            let import_data = ImportData {
+                path,
+                alias,
+                is_glob: false,
+                is_prelude: false,
+                is_extern_crate: true,
+                is_macro_use,
+            };
+            self.push_import(
+                current_module,
+                attrs,
+                import_data,
+                Either::B(AstPtr::new(&extern_crate)),
+            );
+        }
+    }
+
+    fn add_macro(&mut self, current_module: Option<Module>, m: ast::MacroCall) {
+        let attrs = self.parse_attrs(&m);
+        let path = match m
+            .path()
+            .and_then(|path| Path::from_src(Source { ast: path, file_id: self.file_id }, self.db))
+        {
+            Some(it) => it,
+            _ => return,
+        };
+
+        let name = m.name().map(|it| it.as_name());
+        let ast_id = self.source_ast_id_map.ast_id(&m);
+        // FIXME: cfg_attr
+        let export = m.attrs().filter_map(|x| x.simple_name()).any(|name| name == "macro_export");
+
+        let m = self.raw_items.macros.alloc(MacroData { ast_id, path, name, export });
+        self.push_item(current_module, attrs, RawItemKind::Macro(m));
+    }
+
+    fn push_import(
+        &mut self,
+        current_module: Option<Module>,
+        attrs: Attrs,
+        data: ImportData,
+        source: ImportSourcePtr,
+    ) {
+        let import = self.raw_items.imports.alloc(data);
+        self.source_map.insert(import, source);
+        self.push_item(current_module, attrs, RawItemKind::Import(import))
+    }
+
+    fn push_item(&mut self, current_module: Option<Module>, attrs: Attrs, kind: RawItemKind) {
+        match current_module {
+            Some(module) => match &mut self.raw_items.modules[module] {
+                ModuleData::Definition { items, .. } => items,
+                ModuleData::Declaration { .. } => unreachable!(),
+            },
+            None => &mut self.raw_items.items,
+        }
+        .push(RawItem { attrs, kind })
+    }
+
+    fn parse_attrs(&self, item: &impl ast::AttrsOwner) -> Attrs {
+        Attr::from_attrs_owner(self.file_id, item, self.db)
+    }
+}

--- a/crates/ra_def/src/path.rs
+++ b/crates/ra_def/src/path.rs
@@ -1,0 +1,418 @@
+//! FIXME: write short doc here
+
+use std::{iter, sync::Arc};
+
+use ra_db::CrateId;
+use ra_syntax::{
+    ast::{self, NameOwner, TypeAscriptionOwner},
+    AstNode,
+};
+
+use crate::{db::AstDatabase, name, name::AsName, type_ref::TypeRef, Name, Source};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Path {
+    pub kind: PathKind,
+    pub segments: Vec<PathSegment>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PathSegment {
+    pub name: Name,
+    pub args_and_bindings: Option<Arc<GenericArgs>>,
+}
+
+/// Generic arguments to a path segment (e.g. the `i32` in `Option<i32>`). This
+/// can (in the future) also include bindings of associated types, like in
+/// `Iterator<Item = Foo>`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct GenericArgs {
+    pub args: Vec<GenericArg>,
+    /// This specifies whether the args contain a Self type as the first
+    /// element. This is the case for path segments like `<T as Trait>`, where
+    /// `T` is actually a type parameter for the path `Trait` specifying the
+    /// Self type. Otherwise, when we have a path `Trait<X, Y>`, the Self type
+    /// is left out.
+    pub has_self_type: bool,
+    /// Associated type bindings like in `Iterator<Item = T>`.
+    pub bindings: Vec<(Name, TypeRef)>,
+}
+
+/// A single generic argument.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum GenericArg {
+    Type(TypeRef),
+    // or lifetime...
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum PathKind {
+    Plain,
+    Self_,
+    Super,
+    Crate,
+    // Absolute path
+    Abs,
+    // Type based path like `<T>::foo`
+    Type(Box<TypeRef>),
+    // `$crate` from macro expansion
+    DollarCrate(CrateId),
+}
+
+impl Path {
+    /// Calls `cb` with all paths, represented by this use item.
+    pub fn expand_use_item(
+        item_src: Source<ast::UseItem>,
+        db: &impl AstDatabase,
+        mut cb: impl FnMut(Path, &ast::UseTree, bool, Option<Name>),
+    ) {
+        if let Some(tree) = item_src.ast.use_tree() {
+            expand_use_tree(None, tree, &|| item_src.file_id.macro_crate(db), &mut cb);
+        }
+    }
+
+    pub fn from_simple_segments(kind: PathKind, segments: impl IntoIterator<Item = Name>) -> Path {
+        Path {
+            kind,
+            segments: segments
+                .into_iter()
+                .map(|name| PathSegment { name, args_and_bindings: None })
+                .collect(),
+        }
+    }
+
+    /// Converts an `ast::Path` to `Path`. Works with use trees.
+    /// DEPRECATED: It does not handle `$crate` from macro call.
+    pub fn from_ast(path: ast::Path) -> Option<Path> {
+        Path::parse(path, &|| None)
+    }
+
+    /// Converts an `ast::Path` to `Path`. Works with use trees.
+    /// It correctly handles `$crate` based path from macro call.
+    pub fn from_src(source: Source<ast::Path>, db: &impl AstDatabase) -> Option<Path> {
+        let file_id = source.file_id;
+        Path::parse(source.ast, &|| file_id.macro_crate(db))
+    }
+
+    fn parse(mut path: ast::Path, macro_crate: &impl Fn() -> Option<CrateId>) -> Option<Path> {
+        let mut kind = PathKind::Plain;
+        let mut segments = Vec::new();
+        loop {
+            let segment = path.segment()?;
+
+            if segment.has_colon_colon() {
+                kind = PathKind::Abs;
+            }
+
+            match segment.kind()? {
+                ast::PathSegmentKind::Name(name) => {
+                    if name.text() == "$crate" {
+                        if let Some(macro_crate) = macro_crate() {
+                            kind = PathKind::DollarCrate(macro_crate);
+                            break;
+                        }
+                    }
+
+                    let args = segment
+                        .type_arg_list()
+                        .and_then(GenericArgs::from_ast)
+                        .or_else(|| {
+                            GenericArgs::from_fn_like_path_ast(
+                                segment.param_list(),
+                                segment.ret_type(),
+                            )
+                        })
+                        .map(Arc::new);
+                    let segment = PathSegment { name: name.as_name(), args_and_bindings: args };
+                    segments.push(segment);
+                }
+                ast::PathSegmentKind::Type { type_ref, trait_ref } => {
+                    assert!(path.qualifier().is_none()); // this can only occur at the first segment
+
+                    let self_type = TypeRef::from_ast(type_ref?);
+
+                    match trait_ref {
+                        // <T>::foo
+                        None => {
+                            kind = PathKind::Type(Box::new(self_type));
+                        }
+                        // <T as Trait<A>>::Foo desugars to Trait<Self=T, A>::Foo
+                        Some(trait_ref) => {
+                            let path = Path::parse(trait_ref.path()?, macro_crate)?;
+                            kind = path.kind;
+                            let mut prefix_segments = path.segments;
+                            prefix_segments.reverse();
+                            segments.extend(prefix_segments);
+                            // Insert the type reference (T in the above example) as Self parameter for the trait
+                            let mut last_segment = segments.last_mut()?;
+                            if last_segment.args_and_bindings.is_none() {
+                                last_segment.args_and_bindings =
+                                    Some(Arc::new(GenericArgs::empty()));
+                            };
+                            let args = last_segment.args_and_bindings.as_mut().unwrap();
+                            let mut args_inner = Arc::make_mut(args);
+                            args_inner.has_self_type = true;
+                            args_inner.args.insert(0, GenericArg::Type(self_type));
+                        }
+                    }
+                }
+                ast::PathSegmentKind::CrateKw => {
+                    kind = PathKind::Crate;
+                    break;
+                }
+                ast::PathSegmentKind::SelfKw => {
+                    kind = PathKind::Self_;
+                    break;
+                }
+                ast::PathSegmentKind::SuperKw => {
+                    kind = PathKind::Super;
+                    break;
+                }
+            }
+            path = match qualifier(&path) {
+                Some(it) => it,
+                None => break,
+            };
+        }
+        segments.reverse();
+        return Some(Path { kind, segments });
+
+        fn qualifier(path: &ast::Path) -> Option<ast::Path> {
+            if let Some(q) = path.qualifier() {
+                return Some(q);
+            }
+            // FIXME: this bottom up traversal is not too precise.
+            // Should we handle do a top-down analysis, recording results?
+            let use_tree_list = path.syntax().ancestors().find_map(ast::UseTreeList::cast)?;
+            let use_tree = use_tree_list.parent_use_tree();
+            use_tree.path()
+        }
+    }
+
+    /// Converts an `ast::NameRef` into a single-identifier `Path`.
+    pub fn from_name_ref(name_ref: &ast::NameRef) -> Path {
+        name_ref.as_name().into()
+    }
+
+    /// `true` is this path is a single identifier, like `foo`
+    pub fn is_ident(&self) -> bool {
+        self.kind == PathKind::Plain && self.segments.len() == 1
+    }
+
+    /// `true` if this path is just a standalone `self`
+    pub fn is_self(&self) -> bool {
+        self.kind == PathKind::Self_ && self.segments.is_empty()
+    }
+
+    /// If this path is a single identifier, like `foo`, return its name.
+    pub fn as_ident(&self) -> Option<&Name> {
+        if self.kind != PathKind::Plain || self.segments.len() > 1 {
+            return None;
+        }
+        self.segments.first().map(|s| &s.name)
+    }
+
+    pub fn expand_macro_expr(&self) -> Option<Name> {
+        self.as_ident().and_then(|name| Some(name.clone()))
+    }
+
+    pub fn is_type_relative(&self) -> bool {
+        match self.kind {
+            PathKind::Type(_) => true,
+            _ => false,
+        }
+    }
+}
+
+impl GenericArgs {
+    pub(crate) fn from_ast(node: ast::TypeArgList) -> Option<GenericArgs> {
+        let mut args = Vec::new();
+        for type_arg in node.type_args() {
+            let type_ref = TypeRef::from_ast_opt(type_arg.type_ref());
+            args.push(GenericArg::Type(type_ref));
+        }
+        // lifetimes ignored for now
+        let mut bindings = Vec::new();
+        for assoc_type_arg in node.assoc_type_args() {
+            if let Some(name_ref) = assoc_type_arg.name_ref() {
+                let name = name_ref.as_name();
+                let type_ref = TypeRef::from_ast_opt(assoc_type_arg.type_ref());
+                bindings.push((name, type_ref));
+            }
+        }
+        if args.is_empty() && bindings.is_empty() {
+            None
+        } else {
+            Some(GenericArgs { args, has_self_type: false, bindings })
+        }
+    }
+
+    /// Collect `GenericArgs` from the parts of a fn-like path, i.e. `Fn(X, Y)
+    /// -> Z` (which desugars to `Fn<(X, Y), Output=Z>`).
+    pub(crate) fn from_fn_like_path_ast(
+        params: Option<ast::ParamList>,
+        ret_type: Option<ast::RetType>,
+    ) -> Option<GenericArgs> {
+        let mut args = Vec::new();
+        let mut bindings = Vec::new();
+        if let Some(params) = params {
+            let mut param_types = Vec::new();
+            for param in params.params() {
+                let type_ref = TypeRef::from_ast_opt(param.ascribed_type());
+                param_types.push(type_ref);
+            }
+            let arg = GenericArg::Type(TypeRef::Tuple(param_types));
+            args.push(arg);
+        }
+        if let Some(ret_type) = ret_type {
+            let type_ref = TypeRef::from_ast_opt(ret_type.type_ref());
+            bindings.push((name::OUTPUT_TYPE, type_ref))
+        }
+        if args.is_empty() && bindings.is_empty() {
+            None
+        } else {
+            Some(GenericArgs { args, has_self_type: false, bindings })
+        }
+    }
+
+    pub(crate) fn empty() -> GenericArgs {
+        GenericArgs { args: Vec::new(), has_self_type: false, bindings: Vec::new() }
+    }
+}
+
+impl From<Name> for Path {
+    fn from(name: Name) -> Path {
+        Path::from_simple_segments(PathKind::Plain, iter::once(name))
+    }
+}
+
+fn expand_use_tree(
+    prefix: Option<Path>,
+    tree: ast::UseTree,
+    macro_crate: &impl Fn() -> Option<CrateId>,
+    cb: &mut impl FnMut(Path, &ast::UseTree, bool, Option<Name>),
+) {
+    if let Some(use_tree_list) = tree.use_tree_list() {
+        let prefix = match tree.path() {
+            // E.g. use something::{{{inner}}};
+            None => prefix,
+            // E.g. `use something::{inner}` (prefix is `None`, path is `something`)
+            // or `use something::{path::{inner::{innerer}}}` (prefix is `something::path`, path is `inner`)
+            Some(path) => match convert_path(prefix, path, macro_crate) {
+                Some(it) => Some(it),
+                None => return, // FIXME: report errors somewhere
+            },
+        };
+        for child_tree in use_tree_list.use_trees() {
+            expand_use_tree(prefix.clone(), child_tree, macro_crate, cb);
+        }
+    } else {
+        let alias = tree.alias().and_then(|a| a.name()).map(|a| a.as_name());
+        if let Some(ast_path) = tree.path() {
+            // Handle self in a path.
+            // E.g. `use something::{self, <...>}`
+            if ast_path.qualifier().is_none() {
+                if let Some(segment) = ast_path.segment() {
+                    if segment.kind() == Some(ast::PathSegmentKind::SelfKw) {
+                        if let Some(prefix) = prefix {
+                            cb(prefix, &tree, false, alias);
+                            return;
+                        }
+                    }
+                }
+            }
+            if let Some(path) = convert_path(prefix, ast_path, macro_crate) {
+                let is_glob = tree.has_star();
+                cb(path, &tree, is_glob, alias)
+            }
+            // FIXME: report errors somewhere
+            // We get here if we do
+        }
+    }
+}
+
+fn convert_path(
+    prefix: Option<Path>,
+    path: ast::Path,
+    macro_crate: &impl Fn() -> Option<CrateId>,
+) -> Option<Path> {
+    let prefix = if let Some(qual) = path.qualifier() {
+        Some(convert_path(prefix, qual, macro_crate)?)
+    } else {
+        prefix
+    };
+
+    let segment = path.segment()?;
+    let res = match segment.kind()? {
+        ast::PathSegmentKind::Name(name) => {
+            if name.text() == "$crate" {
+                if let Some(krate) = macro_crate() {
+                    return Some(Path::from_simple_segments(
+                        PathKind::DollarCrate(krate),
+                        iter::empty(),
+                    ));
+                }
+            }
+
+            // no type args in use
+            let mut res = prefix
+                .unwrap_or_else(|| Path { kind: PathKind::Plain, segments: Vec::with_capacity(1) });
+            res.segments.push(PathSegment {
+                name: name.as_name(),
+                args_and_bindings: None, // no type args in use
+            });
+            res
+        }
+        ast::PathSegmentKind::CrateKw => {
+            if prefix.is_some() {
+                return None;
+            }
+            Path::from_simple_segments(PathKind::Crate, iter::empty())
+        }
+        ast::PathSegmentKind::SelfKw => {
+            if prefix.is_some() {
+                return None;
+            }
+            Path::from_simple_segments(PathKind::Self_, iter::empty())
+        }
+        ast::PathSegmentKind::SuperKw => {
+            if prefix.is_some() {
+                return None;
+            }
+            Path::from_simple_segments(PathKind::Super, iter::empty())
+        }
+        ast::PathSegmentKind::Type { .. } => {
+            // not allowed in imports
+            return None;
+        }
+    };
+    Some(res)
+}
+
+pub mod known {
+    use super::{Path, PathKind};
+    use crate::name;
+
+    pub fn std_iter_into_iterator() -> Path {
+        Path::from_simple_segments(
+            PathKind::Abs,
+            vec![name::STD, name::ITER, name::INTO_ITERATOR_TYPE],
+        )
+    }
+
+    pub fn std_ops_try() -> Path {
+        Path::from_simple_segments(PathKind::Abs, vec![name::STD, name::OPS, name::TRY_TYPE])
+    }
+
+    pub fn std_result_result() -> Path {
+        Path::from_simple_segments(PathKind::Abs, vec![name::STD, name::RESULT, name::RESULT_TYPE])
+    }
+
+    pub fn std_future_future() -> Path {
+        Path::from_simple_segments(PathKind::Abs, vec![name::STD, name::FUTURE, name::FUTURE_TYPE])
+    }
+
+    pub fn std_boxed_box() -> Path {
+        Path::from_simple_segments(PathKind::Abs, vec![name::STD, name::BOXED, name::BOX_TYPE])
+    }
+}

--- a/crates/ra_def/src/source.rs
+++ b/crates/ra_def/src/source.rs
@@ -1,0 +1,14 @@
+use ra_syntax::ast;
+
+use crate::ids::HirFileId;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct Source<T> {
+    pub file_id: HirFileId,
+    pub ast: T,
+}
+
+pub enum ModuleSource {
+    SourceFile(ast::SourceFile),
+    Module(ast::Module),
+}

--- a/crates/ra_def/src/source_id.rs
+++ b/crates/ra_def/src/source_id.rs
@@ -1,0 +1,161 @@
+//! FIXME: write short doc here
+
+use std::{
+    hash::{Hash, Hasher},
+    marker::PhantomData,
+    sync::Arc,
+};
+
+use ra_arena::{impl_arena_id, Arena, RawId};
+use ra_syntax::{ast, AstNode, SyntaxNode, SyntaxNodePtr};
+
+use crate::{db::AstDatabase, ids::HirFileId};
+
+/// `AstId` points to an AST node in any file.
+///
+/// It is stable across reparses, and can be used as salsa key/value.
+#[derive(Debug)]
+pub(crate) struct AstId<N: AstNode> {
+    file_id: HirFileId,
+    file_ast_id: FileAstId<N>,
+}
+
+impl<N: AstNode> Clone for AstId<N> {
+    fn clone(&self) -> AstId<N> {
+        *self
+    }
+}
+impl<N: AstNode> Copy for AstId<N> {}
+
+impl<N: AstNode> PartialEq for AstId<N> {
+    fn eq(&self, other: &Self) -> bool {
+        (self.file_id, self.file_ast_id) == (other.file_id, other.file_ast_id)
+    }
+}
+impl<N: AstNode> Eq for AstId<N> {}
+impl<N: AstNode> Hash for AstId<N> {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        (self.file_id, self.file_ast_id).hash(hasher);
+    }
+}
+
+impl<N: AstNode> AstId<N> {
+    pub(crate) fn file_id(&self) -> HirFileId {
+        self.file_id
+    }
+
+    pub(crate) fn to_node(&self, db: &impl AstDatabase) -> N {
+        let syntax_node = db.ast_id_to_node(self.file_id, self.file_ast_id.raw);
+        N::cast(syntax_node).unwrap()
+    }
+}
+
+/// `AstId` points to an AST node in a specific file.
+#[derive(Debug)]
+pub(crate) struct FileAstId<N: AstNode> {
+    raw: ErasedFileAstId,
+    _ty: PhantomData<fn() -> N>,
+}
+
+impl<N: AstNode> Clone for FileAstId<N> {
+    fn clone(&self) -> FileAstId<N> {
+        *self
+    }
+}
+impl<N: AstNode> Copy for FileAstId<N> {}
+
+impl<N: AstNode> PartialEq for FileAstId<N> {
+    fn eq(&self, other: &Self) -> bool {
+        self.raw == other.raw
+    }
+}
+impl<N: AstNode> Eq for FileAstId<N> {}
+impl<N: AstNode> Hash for FileAstId<N> {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        self.raw.hash(hasher);
+    }
+}
+
+impl<N: AstNode> FileAstId<N> {
+    pub(crate) fn with_file_id(self, file_id: HirFileId) -> AstId<N> {
+        AstId { file_id, file_ast_id: self }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ErasedFileAstId(RawId);
+impl_arena_id!(ErasedFileAstId);
+
+/// Maps items' `SyntaxNode`s to `ErasedFileAstId`s and back.
+#[derive(Debug, PartialEq, Eq, Default)]
+pub struct AstIdMap {
+    arena: Arena<ErasedFileAstId, SyntaxNodePtr>,
+}
+
+impl AstIdMap {
+    pub(crate) fn ast_id_map_query(db: &impl AstDatabase, file_id: HirFileId) -> Arc<AstIdMap> {
+        let map = if let Some(node) = db.parse_or_expand(file_id) {
+            AstIdMap::from_source(&node)
+        } else {
+            AstIdMap::default()
+        };
+        Arc::new(map)
+    }
+
+    pub(crate) fn file_item_query(
+        db: &impl AstDatabase,
+        file_id: HirFileId,
+        ast_id: ErasedFileAstId,
+    ) -> SyntaxNode {
+        let node = db.parse_or_expand(file_id).unwrap();
+        db.ast_id_map(file_id).arena[ast_id].to_node(&node)
+    }
+
+    pub(crate) fn ast_id<N: AstNode>(&self, item: &N) -> FileAstId<N> {
+        let ptr = SyntaxNodePtr::new(item.syntax());
+        let raw = match self.arena.iter().find(|(_id, i)| **i == ptr) {
+            Some((it, _)) => it,
+            None => panic!(
+                "Can't find {:?} in AstIdMap:\n{:?}",
+                item.syntax(),
+                self.arena.iter().map(|(_id, i)| i).collect::<Vec<_>>(),
+            ),
+        };
+
+        FileAstId { raw, _ty: PhantomData }
+    }
+
+    fn from_source(node: &SyntaxNode) -> AstIdMap {
+        assert!(node.parent().is_none());
+        let mut res = AstIdMap { arena: Arena::default() };
+        // By walking the tree in bread-first order we make sure that parents
+        // get lower ids then children. That is, adding a new child does not
+        // change parent's id. This means that, say, adding a new function to a
+        // trait does not change ids of top-level items, which helps caching.
+        bfs(node, |it| {
+            if let Some(module_item) = ast::ModuleItem::cast(it.clone()) {
+                res.alloc(module_item.syntax());
+            } else if let Some(macro_call) = ast::MacroCall::cast(it) {
+                res.alloc(macro_call.syntax());
+            }
+        });
+        res
+    }
+
+    fn alloc(&mut self, item: &SyntaxNode) -> ErasedFileAstId {
+        self.arena.alloc(SyntaxNodePtr::new(item))
+    }
+}
+
+/// Walks the subtree in bfs order, calling `f` for each node.
+fn bfs(node: &SyntaxNode, mut f: impl FnMut(SyntaxNode)) {
+    let mut curr_layer = vec![node.clone()];
+    let mut next_layer = vec![];
+    while !curr_layer.is_empty() {
+        curr_layer.drain(..).for_each(|node| {
+            next_layer.extend(node.children());
+            f(node);
+        });
+        std::mem::swap(&mut curr_layer, &mut next_layer);
+    }
+}

--- a/crates/ra_def/src/type_ref.rs
+++ b/crates/ra_def/src/type_ref.rs
@@ -1,0 +1,162 @@
+//! HIR for references to types. Paths in these are not yet resolved. They can
+//! be directly created from an ast::TypeRef, without further queries.
+
+use ra_syntax::ast::{self, TypeAscriptionOwner, TypeBoundsOwner};
+
+use crate::Path;
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub enum Mutability {
+    Shared,
+    Mut,
+}
+
+impl Mutability {
+    pub fn from_mutable(mutable: bool) -> Mutability {
+        if mutable {
+            Mutability::Mut
+        } else {
+            Mutability::Shared
+        }
+    }
+
+    pub fn as_keyword_for_ref(self) -> &'static str {
+        match self {
+            Mutability::Shared => "",
+            Mutability::Mut => "mut ",
+        }
+    }
+
+    pub fn as_keyword_for_ptr(self) -> &'static str {
+        match self {
+            Mutability::Shared => "const ",
+            Mutability::Mut => "mut ",
+        }
+    }
+}
+
+/// Compare ty::Ty
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub enum TypeRef {
+    Never,
+    Placeholder,
+    Tuple(Vec<TypeRef>),
+    Path(Path),
+    RawPtr(Box<TypeRef>, Mutability),
+    Reference(Box<TypeRef>, Mutability),
+    Array(Box<TypeRef> /*, Expr*/),
+    Slice(Box<TypeRef>),
+    /// A fn pointer. Last element of the vector is the return type.
+    Fn(Vec<TypeRef>),
+    // For
+    ImplTrait(Vec<TypeBound>),
+    DynTrait(Vec<TypeBound>),
+    Error,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub enum TypeBound {
+    Path(Path),
+    // also for<> bounds
+    // also Lifetimes
+    Error,
+}
+
+impl TypeRef {
+    /// Converts an `ast::TypeRef` to a `hir::TypeRef`.
+    pub(crate) fn from_ast(node: ast::TypeRef) -> Self {
+        match node {
+            ast::TypeRef::ParenType(inner) => TypeRef::from_ast_opt(inner.type_ref()),
+            ast::TypeRef::TupleType(inner) => {
+                TypeRef::Tuple(inner.fields().map(TypeRef::from_ast).collect())
+            }
+            ast::TypeRef::NeverType(..) => TypeRef::Never,
+            ast::TypeRef::PathType(inner) => {
+                // FIXME: Use `Path::from_src`
+                inner.path().and_then(Path::from_ast).map(TypeRef::Path).unwrap_or(TypeRef::Error)
+            }
+            ast::TypeRef::PointerType(inner) => {
+                let inner_ty = TypeRef::from_ast_opt(inner.type_ref());
+                let mutability = Mutability::from_mutable(inner.is_mut());
+                TypeRef::RawPtr(Box::new(inner_ty), mutability)
+            }
+            ast::TypeRef::ArrayType(inner) => {
+                TypeRef::Array(Box::new(TypeRef::from_ast_opt(inner.type_ref())))
+            }
+            ast::TypeRef::SliceType(inner) => {
+                TypeRef::Slice(Box::new(TypeRef::from_ast_opt(inner.type_ref())))
+            }
+            ast::TypeRef::ReferenceType(inner) => {
+                let inner_ty = TypeRef::from_ast_opt(inner.type_ref());
+                let mutability = Mutability::from_mutable(inner.is_mut());
+                TypeRef::Reference(Box::new(inner_ty), mutability)
+            }
+            ast::TypeRef::PlaceholderType(_inner) => TypeRef::Placeholder,
+            ast::TypeRef::FnPointerType(inner) => {
+                let ret_ty = TypeRef::from_ast_opt(inner.ret_type().and_then(|rt| rt.type_ref()));
+                let mut params = if let Some(pl) = inner.param_list() {
+                    pl.params().map(|p| p.ascribed_type()).map(TypeRef::from_ast_opt).collect()
+                } else {
+                    Vec::new()
+                };
+                params.push(ret_ty);
+                TypeRef::Fn(params)
+            }
+            // for types are close enough for our purposes to the inner type for now...
+            ast::TypeRef::ForType(inner) => TypeRef::from_ast_opt(inner.type_ref()),
+            ast::TypeRef::ImplTraitType(inner) => {
+                TypeRef::ImplTrait(type_bounds_from_ast(inner.type_bound_list()))
+            }
+            ast::TypeRef::DynTraitType(inner) => {
+                TypeRef::DynTrait(type_bounds_from_ast(inner.type_bound_list()))
+            }
+        }
+    }
+
+    pub(crate) fn from_ast_opt(node: Option<ast::TypeRef>) -> Self {
+        if let Some(node) = node {
+            TypeRef::from_ast(node)
+        } else {
+            TypeRef::Error
+        }
+    }
+
+    pub fn unit() -> TypeRef {
+        TypeRef::Tuple(Vec::new())
+    }
+}
+
+pub(crate) fn type_bounds_from_ast(type_bounds_opt: Option<ast::TypeBoundList>) -> Vec<TypeBound> {
+    if let Some(type_bounds) = type_bounds_opt {
+        type_bounds.bounds().map(TypeBound::from_ast).collect()
+    } else {
+        vec![]
+    }
+}
+
+impl TypeBound {
+    pub(crate) fn from_ast(node: ast::TypeBound) -> Self {
+        match node.kind() {
+            ast::TypeBoundKind::PathType(path_type) => {
+                let path = match path_type.path() {
+                    Some(p) => p,
+                    None => return TypeBound::Error,
+                };
+                // FIXME: Use `Path::from_src`
+                let path = match Path::from_ast(path) {
+                    Some(p) => p,
+                    None => return TypeBound::Error,
+                };
+                TypeBound::Path(path)
+            }
+            ast::TypeBoundKind::ForType(_) | ast::TypeBoundKind::Lifetime(_) => TypeBound::Error,
+        }
+    }
+
+    pub fn as_path(&self) -> Option<&Path> {
+        match self {
+            TypeBound::Path(p) => Some(p),
+            _ => None,
+        }
+    }
+}


### PR DESCRIPTION
This is an exploratory PR to figure out what would it take to move name resolution to a separate crate. As it turns out, not much!

The biggest change here is that instead of wrapping `XId` into OOP-style wrappers, we work with `ids` directly throughout the code. For name resolution, the change turns out to be mostly cosmetic, as we don't call that many methods anyway! So, I feel pretty confident that leaving OOP wrappers only for the outer layer is the way to go.

What I am not sure is the scope of things we want to extract (the best way to access scope is to see what is commented out in [db](https://github.com/rust-analyzer/rust-analyzer/compare/master...matklad:extract-def?expand=1#diff-abec13ade7910b3e12f07f5b851b99e9)). In this PR, `EnumData` is moved, but `StructData` isn't, as we don't look at fields during name res. Should we move `StructData` as well? I would think so, but I don't have a clear justification as too why.

I also feel that we should move expression lowering and scopes: I think when we start handling local items, we'd get cyclic deps between module-level name res and block-level nameres.