### PR TITLE
Add rust-analyzer.showWorkspaceLoadedNotification to package.json

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -224,6 +224,11 @@
                     "description": "`cargo-watch` command. (e.g: `clippy` will run as `cargo watch -x clippy` )",
                     "default": "check"
                 },
+                "rust-analyzer.showWorkspaceLoadedNotification": {
+                    "type": "boolean",
+                    "description": "Controls whether rust-analyzer displays a notification when a project is loaded.",
+                    "default": false
+                },
                 "rust-analyzer.trace.server": {
                     "type": "string",
                     "scope": "window",


### PR DESCRIPTION
Fixes #2016 

I still believe the option has no effect, but...