### PR TITLE
Adds config option for cargo-watch `--ignore` flag

### DIFF
--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -79,6 +79,7 @@ See [microsoft/vscode#72308](https://github.com/microsoft/vscode/issues/72308) f
 * `rust-analyzer.cargo-watch.command`: `cargo-watch` command. (e.g: `clippy` will run as `cargo watch -x clippy` )
 * `rust-analyzer.cargo-watch.arguments`: cargo-watch check arguments.
   (e.g: `--features="shumway,pdf"` will run as `cargo watch -x "check --features="shumway,pdf""` )
+* `rust-analyzer.cargo-watch.ignore`: list of patterns for cargo-watch to ignore (will be passed as `--ignore`)
 * `rust-analyzer.trace.server`: enables internal logging
 * `rust-analyzer.trace.cargo-watch`: enables cargo-watch logging
 * `RUST_SRC_PATH`: environment variable that overwrites the sysroot

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -224,6 +224,11 @@
                     "description": "`cargo-watch` command. (e.g: `clippy` will run as `cargo watch -x clippy` )",
                     "default": "check"
                 },
+                "rust-analyzer.cargo-watch.ignore": {
+                    "type": "array",
+                    "description": "A list of patterns for cargo-watch to ignore (will be passed as `--ignore`)",
+                    "default": []
+                },
                 "rust-analyzer.showWorkspaceLoadedNotification": {
                     "type": "boolean",
                     "description": "Controls whether rust-analyzer displays a notification when a project is loaded.",

--- a/editors/code/src/commands/cargo_watch.ts
+++ b/editors/code/src/commands/cargo_watch.ts
@@ -93,10 +93,15 @@ export class CargoWatchProvider implements vscode.Disposable {
             args = '"' + args + '"';
         }
 
+        const ignoreFlags = Server.config.cargoWatchOptions.ignore.reduce(
+            (flags, pattern) => [...flags, '--ignore', pattern],
+            [] as string[]
+        );
+
         // Start the cargo watch with json message
         this.cargoProcess = child_process.spawn(
             'cargo',
-            ['watch', '-x', args],
+            ['watch', '-x', args, ...ignoreFlags],
             {
                 stdio: ['ignore', 'pipe', 'pipe'],
                 cwd: vscode.workspace.rootPath,

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -12,6 +12,7 @@ export interface CargoWatchOptions {
     arguments: string;
     command: string;
     trace: CargoWatchTraceOptions;
+    ignore: string[];
 }
 
 export class Config {
@@ -29,7 +30,8 @@ export class Config {
         enableOnStartup: 'ask',
         trace: 'off',
         arguments: '',
-        command: ''
+        command: '',
+        ignore: []
     };
 
     private prevEnhancedTyping: null | boolean = null;
@@ -121,6 +123,13 @@ export class Config {
             this.cargoWatchOptions.command = config.get<string>(
                 'cargo-watch.command',
                 ''
+            );
+        }
+
+        if (config.has('cargo-watch.ignore')) {
+            this.cargoWatchOptions.ignore = config.get<string[]>(
+                'cargo-watch.ignore',
+                []
             );
         }
 


### PR DESCRIPTION
I presume this is a nice-to-have to avoid spurious watching.

* I don't know much about Windows, so I'm not sure if the extra args need some special escaping.
* I suppose we could reuse and/or integrate with `rust-analyzer.excludeGlobs`. I find this simpler, but I'm open to suggestions.