### PR TITLE
Guess macro braces from docs

### DIFF
--- a/crates/ra_ide_api/src/completion/complete_macro_in_item_position.rs
+++ b/crates/ra_ide_api/src/completion/complete_macro_in_item_position.rs
@@ -56,6 +56,16 @@ mod tests {
             do_reference_completion(
                 "
                 //- /main.rs
+                /// Creates a [`Vec`] containing the arguments.
+                ///
+                /// - Create a [`Vec`] containing a given list of elements:
+                ///
+                /// ```
+                /// let v = vec![1, 2, 3];
+                /// assert_eq!(v[0], 1);
+                /// assert_eq!(v[1], 2);
+                /// assert_eq!(v[2], 3);
+                /// ```
                 macro_rules! vec {
                     () => {}
                 }
@@ -68,13 +78,61 @@ mod tests {
             @r##"[
     CompletionItem {
         label: "vec!",
-        source_range: [46; 46),
-        delete: [46; 46),
+        source_range: [280; 280),
+        delete: [280; 280),
         insert: "vec![$0]",
         kind: Macro,
         detail: "macro_rules! vec",
+        documentation: Documentation(
+            "Creates a [`Vec`] containing the arguments.\n\n- Create a [`Vec`] containing a given list of elements:\n\n```\nlet v = vec![1, 2, 3];\nassert_eq!(v[0], 1);\nassert_eq!(v[1], 2);\nassert_eq!(v[2], 3);\n```",
+        ),
     },
 ]"##
+        );
+    }
+
+    #[test]
+    fn completes_macros_braces_guessing() {
+        assert_debug_snapshot!(
+            do_reference_completion(
+                "
+                //- /main.rs
+                /// Foo
+                ///
+                /// Not call `fooo!()` `fooo!()`, or `_foo![]` `_foo![]`.
+                /// Call as `let _=foo!  { hello world };`
+                macro_rules! foo {
+                    () => {}
+                }
+
+                fn main() {
+                    <|>
+                }
+                "
+            ),
+            @r###"[
+    CompletionItem {
+        label: "foo!",
+        source_range: [163; 163),
+        delete: [163; 163),
+        insert: "foo! {$0}",
+        kind: Macro,
+        detail: "macro_rules! foo",
+        documentation: Documentation(
+            "Foo\n\nNot call `fooo!()` `fooo!()`, or `_foo![]` `_foo![]`.\nCall as `let _=foo!  { hello world };`",
+        ),
+    },
+    CompletionItem {
+        label: "main()",
+        source_range: [163; 163),
+        delete: [163; 163),
+        insert: "main()$0",
+        kind: Function,
+        lookup: "main",
+        detail: "fn main()",
+    },
+]
+        "###
         );
     }
 }


### PR DESCRIPTION
Instead of hard-code `vec` to have snippet with bracket `vec![]`, 
we try to find the "most common used brace kind" from documentation of the macro, 
which usually contains some example code.
It also works better with extern macros.

We can suggest braces for `thread_local! {}` now.
