### PR TITLE
Update link to api rustdocs pt.2

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -14,7 +14,7 @@ To learn more about how rust-analyzer works, see
 
 We also publish rustdoc docs to pages:
 
-https://rust-analyzer.github.io/rust-analyzer/api-docs/ra_ide_api/
+https://rust-analyzer.github.io/rust-analyzer/ra_ide_api/
 
 Various organizational and process issues are discussed in this document.
 


### PR DESCRIPTION
After #2014, the website was updated in #2031, where the docs url changed again.
Checking, there are only two places the api rustdocs link resides currently:
the root readme.md's `# quick links` (which was updated in #2031) and this dev docs readme.