### PR TITLE
sublime: hint where feature flags would go

### DIFF
--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -182,7 +182,11 @@ Installation:
     "syntaxes": [
         "Packages/Rust/Rust.sublime-syntax",
         "Packages/Rust Enhanced/RustEnhanced.sublime-syntax"
-    ]
+    ],
+    "initializationOptions": {
+      "featureFlags": {
+      }
+    },
 }
 ```
 


### PR DESCRIPTION
It would appear feature flags need to be under initializationOptions for sublime

```
// LSP Settings - User
{
  "clients": {
    "rust-analyzer": {
      "command": [
        "ra_lsp_server"
      ],
      "enabled": true,
      "initializationOptions": {
        "featureFlags": {
          "notifications.workspace-loaded": false
        }
      },
      "languageId": "rust",
      "scopes": [
        "source.rust"
      ],
      "syntaxes": [
        "Packages/Rust/Rust.sublime-syntax",
        "Packages/Rust Enhanced/RustEnhanced.sublime-syntax"
      ]
    }
  }
}
```