### PR TITLE
Fix panic on raw string assist

### DIFF
--- a/crates/ra_assists/src/assists/raw_string.rs
+++ b/crates/ra_assists/src/assists/raw_string.rs
@@ -159,10 +159,17 @@ fn count_hashes(s: &str) -> usize {
 }
 
 fn find_usual_string_range(s: &str) -> Option<TextRange> {
-    Some(TextRange::from_to(
-        TextUnit::from(s.find('"')? as u32),
-        TextUnit::from(s.rfind('"')? as u32),
-    ))
+    let left_quote = s.find('"')?;
+    let right_quote = s.rfind('"')?;
+    if left_quote == right_quote {
+        // `s` only contains one quote
+        None
+    } else {
+        Some(TextRange::from_to(
+            TextUnit::from(left_quote as u32),
+            TextUnit::from(right_quote as u32),
+        ))
+    }
 }
 
 #[cfg(test)]
@@ -268,6 +275,30 @@ string"###;
                 let s = <|>r#"random string"#;
             }
             "##,
+        )
+    }
+
+    #[test]
+    fn make_raw_string_not_works_on_partial_string() {
+        check_assist_not_applicable(
+            make_raw_string,
+            r#"
+            fn f() {
+                let s = "foo<|>
+            }
+            "#,
+        )
+    }
+
+    #[test]
+    fn make_usual_string_not_works_on_partial_string() {
+        check_assist_not_applicable(
+            make_usual_string,
+            r#"
+            fn main() {
+                let s = r#"bar<|>
+            }
+            "#,
         )
     }
 


### PR DESCRIPTION
Strings that do not contain two quotation marks would cause a slice indexing panic because `find_usual_string_range` would return a range that only contained a single quotation mark.
Panic example:
```
fn main() {
    let s = "<|>
}
```

I noticed a lot of panics from the `make_raw_string` assist while working on another issue today.