### PR TITLE
Mark Path::from_ast as deprecated

### DIFF
--- a/crates/ra_hir/src/path.rs
+++ b/crates/ra_hir/src/path.rs
@@ -82,6 +82,7 @@ impl Path {
 
     /// Converts an `ast::Path` to `Path`. Works with use trees.
     /// DEPRECATED: It does not handle `$crate` from macro call.
+    #[deprecated(note = "Use from_src")]
     pub fn from_ast(path: ast::Path) -> Option<Path> {
         Path::parse(path, &|| None)
     }


### PR DESCRIPTION
This does spawn warnings so we may not want this change right now.