### PR TITLE
Preserve whitespace at the end of doc comments

### DIFF
--- a/crates/ra_syntax/src/ast.rs
+++ b/crates/ra_syntax/src/ast.rs
@@ -173,7 +173,7 @@ fn test_doc_comment_single_line_block_strips_suffix_whitespace() {
     .ok()
     .unwrap();
     let module = file.syntax().descendants().find_map(Module::cast).unwrap();
-    assert_eq!("this is mod foo", module.doc_comment_text().unwrap());
+    assert_eq!("this is mod foo ", module.doc_comment_text().unwrap());
 }
 
 #[test]
@@ -191,7 +191,27 @@ fn test_doc_comment_multi_line_block_strips_suffix() {
     .ok()
     .unwrap();
     let module = file.syntax().descendants().find_map(Module::cast).unwrap();
-    assert_eq!("        this\n        is\n        mod foo", module.doc_comment_text().unwrap());
+    assert_eq!(
+        "        this\n        is\n        mod foo\n        ",
+        module.doc_comment_text().unwrap()
+    );
+}
+
+#[test]
+fn test_comments_preserve_trailing_whitespace() {
+    let file = SourceFile::parse(
+        r#"
+/// Representation of a Realm.   
+/// In the specification these are called Realm Records.
+struct Realm {}"#,
+    )
+    .ok()
+    .unwrap();
+    let def = file.syntax().descendants().find_map(StructDef::cast).unwrap();
+    assert_eq!(
+        "Representation of a Realm.   \nIn the specification these are called Realm Records.",
+        def.doc_comment_text().unwrap()
+    );
 }
 
 #[test]

--- a/crates/ra_syntax/src/ast/traits.rs
+++ b/crates/ra_syntax/src/ast/traits.rs
@@ -120,7 +120,7 @@ pub trait DocCommentsOwner: AstNode {
                 has_comments = true;
                 let prefix_len = comment.prefix().len();
 
-                let line = comment.text().as_str();
+                let line: &str = comment.text().as_str();
 
                 // Determine if the prefix or prefix + 1 char is stripped
                 let pos =
@@ -136,7 +136,10 @@ pub trait DocCommentsOwner: AstNode {
                     line.len()
                 };
 
-                line[pos..end].trim_end().to_owned()
+                // Note that we do not trim the end of the line here
+                // since whitespace can have special meaning at the end
+                // of a line in markdown.
+                line[pos..end].to_owned()
             })
             .join("\n");
 


### PR DESCRIPTION
Whitespace can have special meaning in markdown. For instance ending a line with three spaces will render a new line.

Note that this behavior diverges from RLS.

Fixes #1997