### PR TITLE
Handle IfLet in convert_to_guarded_return.

### DIFF
--- a/crates/ra_assists/src/assists/early_return.rs
+++ b/crates/ra_assists/src/assists/early_return.rs
@@ -38,7 +38,6 @@ use crate::{
 pub(crate) fn convert_to_guarded_return(ctx: AssistCtx<impl HirDatabase>) -> Option<Assist> {
     let if_expr: ast::IfExpr = ctx.find_node_at_offset()?;
     let cond = if_expr.condition()?;
-    let pat = &cond.pat();
     let expr = cond.expr()?;
     let then_block = if_expr.then_branch()?.block()?;
     if if_expr.else_branch().is_some() {
@@ -79,7 +78,7 @@ pub(crate) fn convert_to_guarded_return(ctx: AssistCtx<impl HirDatabase>) -> Opt
 
     ctx.add_assist(AssistId("convert_to_guarded_return"), "convert to guarded return", |edit| {
         let if_indent_level = IndentLevel::from_node(&if_expr.syntax());
-        let new_block = match pat {
+        let new_block = match cond.pat() {
             None => {
                 // If.
                 let early_expression = &(early_expression.to_owned() + ";");

--- a/crates/ra_syntax/src/ast/make.rs
+++ b/crates/ra_syntax/src/ast/make.rs
@@ -110,14 +110,15 @@ pub fn match_arm_list(arms: impl Iterator<Item = ast::MatchArm>) -> ast::MatchAr
     }
 }
 
-pub fn let_match_early(expr: ast::Expr, early_expression: &str) -> ast::LetStmt {
+pub fn let_match_early(expr: ast::Expr, path: &str, early_expression: &str) -> ast::LetStmt {
     return from_text(&format!(
         r#"let {} = match {} {{
-    Some(it) => it,
+    {}(it) => it,
     None => {},
 }};"#,
         expr.syntax().text(),
         expr.syntax().text(),
+        path,
         early_expression
     ));
 

--- a/crates/ra_syntax/src/ast/make.rs
+++ b/crates/ra_syntax/src/ast/make.rs
@@ -110,6 +110,22 @@ pub fn match_arm_list(arms: impl Iterator<Item = ast::MatchArm>) -> ast::MatchAr
     }
 }
 
+pub fn let_match_early(expr: ast::Expr, early_expression: &str) -> ast::LetStmt {
+    return from_text(&format!(
+        r#"let {} = match {} {{
+    Some(it) => it,
+    None => {},
+}};"#,
+        expr.syntax().text(),
+        expr.syntax().text(),
+        early_expression
+    ));
+
+    fn from_text(text: &str) -> ast::LetStmt {
+        ast_from_text(&format!("fn f() {{ {} }}", text))
+    }
+}
+
 pub fn where_pred(path: ast::Path, bounds: impl Iterator<Item = ast::TypeBound>) -> ast::WherePred {
     let bounds = bounds.map(|b| b.syntax().to_string()).join(" + ");
     return from_text(&format!("{}: {}", path.syntax(), bounds));


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/2124

I could not move the cursor position out of `let`:
`le<|>t` vs `let<|>`.

Also, please suggest extra test cases.