### PR TITLE
EXPERIMENT: port to rowan#34

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1165,7 +1165,7 @@ dependencies = [
  "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ra_parser 0.1.0",
  "ra_text_edit 0.1.0",
- "rowan 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rowan 0.6.2 (git+https://github.com/cad97/rowan?branch=boxed-tokens)",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_lexer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smol_str 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1431,10 +1431,11 @@ dependencies = [
 [[package]]
 name = "rowan"
 version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/cad97/rowan?branch=boxed-tokens#c03a3bb4e41583f485234da055643a8b8fd84b02"
 dependencies = [
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smol_str 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "static_assertions 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "text_unit 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1601,9 +1602,14 @@ dependencies = [
  "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "psm 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "psm 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "superslice"
@@ -1939,7 +1945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cf147e022eacf0c8a054ab864914a7602618adba841d800a9a9868a5237a529f"
-"checksum psm 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "54639efee26275dfadc49644039c31c73673edde0ef2815acf25a8db526ee193"
+"checksum psm 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b14fc68b454f875abc8354c2555e1d56596f74833ddc0f77f87f4871ed6a30e0"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum ra_vfs 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc8f508bc7a9871b81b6ee75e15d0bbc9f81a96698364a090a8d10b0f8b970b7"
@@ -1967,7 +1973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum relative-path 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bedde000f40f2921ce439ea165c9c53fd629bfa115140c72e22aceacb4a21954"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum ron 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2ece421e0c4129b90e4a35b6f625e472e96c552136f5093a2f4fa2bbb75a62d5"
-"checksum rowan 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dc2b79612dedc9004083a61448eb669d336d56690aab29fbd7249e8c8ab41d8c"
+"checksum rowan 0.6.2 (git+https://github.com/cad97/rowan?branch=boxed-tokens)" = "<none>"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"
 "checksum rustc_lexer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c86aae0c77166108c01305ee1a36a1e77289d7dc6ca0a3cd91ff4992de2d16a5"
@@ -1988,6 +1994,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum smallvec 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "533e29e15d0748f28afbaf4ff7cab44d73e483a8e50b38c40bd13b7f3d48f542"
 "checksum smol_str 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "34836c9a295c62c2ce3514471117c5cb269891e8421b2aafdd910050576c4d8b"
 "checksum stacker 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d96fc4f13a0ac088e9a3cd9af1cc8c5cc1ab5deb2145cef661267dfc9c542f8a"
+"checksum static_assertions 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0fa13613355688665b68639b1c378a62dbedea78aff0fc59a4fa656cbbdec657"
 "checksum superslice 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ab16ced94dbd8a46c82fd81e3ed9a8727dac2977ea869d217bcc4ea1f122e81f"
 "checksum syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0e7bedb3320d0f3035594b0b723c8a28d7d336a3eda3881db79e61d676fb644c"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ incremental = true
 debug = 1 # only line info
 
 [patch.'crates-io']
+rowan = { git = "https://github.com/cad97/rowan", branch = "boxed-tokens" }

--- a/crates/ra_syntax/src/lib.rs
+++ b/crates/ra_syntax/src/lib.rs
@@ -58,7 +58,7 @@ pub use rowan::{SmolStr, SyntaxText, TextRange, TextUnit, TokenAtOffset, WalkEve
 /// files.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Parse<T> {
-    green: GreenNode,
+    green: Arc<GreenNode>,
     errors: Arc<Vec<SyntaxError>>,
     _ty: PhantomData<fn() -> T>,
 }
@@ -70,7 +70,7 @@ impl<T> Clone for Parse<T> {
 }
 
 impl<T> Parse<T> {
-    fn new(green: GreenNode, errors: Vec<SyntaxError>) -> Parse<T> {
+    fn new(green: Arc<GreenNode>, errors: Vec<SyntaxError>) -> Parse<T> {
         Parse { green, errors: Arc::new(errors), _ty: PhantomData }
     }
 

--- a/crates/ra_syntax/src/parsing.rs
+++ b/crates/ra_syntax/src/parsing.rs
@@ -6,13 +6,15 @@ mod text_token_source;
 mod text_tree_sink;
 mod reparsing;
 
+use std::sync::Arc;
+
 use crate::{syntax_node::GreenNode, SyntaxError};
 
 pub use self::lexer::{classify_literal, tokenize, Token};
 
 pub(crate) use self::reparsing::incremental_reparse;
 
-pub(crate) fn parse_text(text: &str) -> (GreenNode, Vec<SyntaxError>) {
+pub(crate) fn parse_text(text: &str) -> (Arc<GreenNode>, Vec<SyntaxError>) {
     let tokens = tokenize(&text);
     let mut token_source = text_token_source::TextTokenSource::new(text, &tokens);
     let mut tree_sink = text_tree_sink::TextTreeSink::new(text, &tokens);

--- a/crates/ra_syntax/src/parsing/text_tree_sink.rs
+++ b/crates/ra_syntax/src/parsing/text_tree_sink.rs
@@ -1,6 +1,6 @@
 //! FIXME: write short doc here
 
-use std::mem;
+use std::{mem, sync::Arc};
 
 use ra_parser::{ParseError, TreeSink};
 
@@ -103,7 +103,7 @@ impl<'a> TextTreeSink<'a> {
         }
     }
 
-    pub(super) fn finish(mut self) -> (GreenNode, Vec<SyntaxError>) {
+    pub(super) fn finish(mut self) -> (Arc<GreenNode>, Vec<SyntaxError>) {
         match mem::replace(&mut self.state, State::Normal) {
             State::PendingFinish => {
                 self.eat_trivias();

--- a/crates/ra_syntax/src/syntax_node.rs
+++ b/crates/ra_syntax/src/syntax_node.rs
@@ -6,6 +6,8 @@
 //! The *real* implementation is in the (language-agnostic) `rowan` crate, this
 //! modules just wraps its API.
 
+use std::sync::Arc;
+
 use ra_parser::ParseError;
 use rowan::{GreenNodeBuilder, Language};
 
@@ -50,7 +52,7 @@ impl Default for SyntaxTreeBuilder {
 }
 
 impl SyntaxTreeBuilder {
-    pub(crate) fn finish_raw(self) -> (GreenNode, Vec<SyntaxError>) {
+    pub(crate) fn finish_raw(self) -> (Arc<GreenNode>, Vec<SyntaxError>) {
         let green = self.inner.finish();
         (green, self.errors)
     }
@@ -61,7 +63,7 @@ impl SyntaxTreeBuilder {
         if cfg!(debug_assertions) {
             crate::validation::validate_block_structure(&node);
         }
-        Parse::new(node.green().clone(), errors)
+        Parse::new(node.green().to_owned(), errors)
     }
 
     pub fn token(&mut self, kind: SyntaxKind, text: SmolStr) {


### PR DESCRIPTION
<details><summary>With this branch</summary>

```powershell
PS D:\usr\Documents\Code\Rust\rust-analyzer> cargo run --bin ra_cli --release -- analysis-stats .
    Finished release [optimized + debuginfo] target(s) in 0.46s
     Running `target\release\ra_cli.exe analysis-stats .`
Database loaded, 221 roots, 1.0601376s
Crates in this dir: 27
Total modules found: 331
Total declarations: 11135
Total functions: 3839
Item Collection: 11.8499283s, 0b allocated 0b resident
Total expressions: 89244
Expressions of unknown type: 6960 (7%)
Expressions of partially unknown type: 3522 (3%)
Type mismatches: 3568
Inference: 36.3460289s, 0b allocated 0b resident
Total: 48.1964408s, 0b allocated 0b resident
PS D:\usr\Documents\Code\Rust\rust-analyzer> Measure-Command { type "D:\rust-lang\src\libcore\unicode\tables.rs" | cargo run --bin ra_cli --release -- symbols }
    Finished release [optimized + debuginfo] target(s) in 0.45s


Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 738
Ticks             : 7380228
TotalDays         : 8.54193055555555E-06
TotalHours        : 0.000205006333333333
TotalMinutes      : 0.01230038
TotalSeconds      : 0.7380228
TotalMilliseconds : 738.0228



PS D:\usr\Documents\Code\Rust\rust-analyzer> Measure-Command { type "D:\rust-lang\src\libcore\unicode\tables.rs" | cargo run --bin ra_cli --release -- parse --no-dump } 
    Finished release [optimized + debuginfo] target(s) in 0.44s
     Running `target\release\ra_cli.exe parse --no-dump`


Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 603
Ticks             : 6035426
TotalDays         : 6.98544675925926E-06
TotalHours        : 0.000167650722222222
TotalMinutes      : 0.0100590433333333
TotalSeconds      : 0.6035426
TotalMilliseconds : 603.5426



```
</details>

<details><summary>Without this branch (<a href="https://github.com/rust-analyzer/rust-analyzer/commit/5451bfb9">5451bfb9</a>)</summary>

```powershell
PS D:\usr\Documents\Code\Rust\rust-analyzer> cargo run --bin ra_cli --release -- analysis-stats .
    Finished release [optimized + debuginfo] target(s) in 0.45s
     Running `target\release\ra_cli.exe analysis-stats .`
Database loaded, 220 roots, 1.0174838s
Crates in this dir: 27
Total modules found: 331
Total declarations: 11135
Total functions: 3839
Item Collection: 10.509602s, 0b allocated 0b resident
Total expressions: 89241                                                                                                                                                 
Expressions of unknown type: 6959 (7%)
Expressions of partially unknown type: 3522 (3%)
Type mismatches: 3569
Inference: 34.963529s, 0b allocated 0b resident
Total: 45.4737377s, 0b allocated 0b resident
PS D:\usr\Documents\Code\Rust\rust-analyzer> Measure-Command { type "D:\rust-lang\src\libcore\unicode\tables.rs" | cargo run --bin ra_cli --release -- symbols }         
    Finished release [optimized + debuginfo] target(s) in 0.44s


Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 587
Ticks             : 5875475
TotalDays         : 6.80031828703704E-06
TotalHours        : 0.000163207638888889
TotalMinutes      : 0.00979245833333333
TotalSeconds      : 0.5875475
TotalMilliseconds : 587.5475



PS D:\usr\Documents\Code\Rust\rust-analyzer> Measure-Command { type "D:\rust-lang\src\libcore\unicode\tables.rs" | cargo run --bin ra_cli --release -- parse --no-dump } 
    Finished release [optimized + debuginfo] target(s) in 0.44s
     Running `target\release\ra_cli.exe parse --no-dump`


Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 573
Ticks             : 5737453
TotalDays         : 6.64057060185185E-06
TotalHours        : 0.000159373694444444
TotalMinutes      : 0.00956242166666667
TotalSeconds      : 0.5737453
TotalMilliseconds : 573.7453



```
</details>

I'm not able to do test `--features jemalloc`/`--memory-usage` on Windows, so if someone could do that for me, I'd be appreciative.

Based on the unscientific test runs above, this seems like a net loss. However, this is not necessarily the end state of this avenue of `rowan` size optimization.