### PR TITLE
Silence some warnings

### DIFF
--- a/crates/ra_tt/src/buffer.rs
+++ b/crates/ra_tt/src/buffer.rs
@@ -111,7 +111,7 @@ impl<'a> Cursor<'a> {
 
     /// If the cursor is pointing at the end of a subtree, returns
     /// the parent subtree
-    pub fn end(self) -> Option<(&'a Subtree)> {
+    pub fn end(self) -> Option<&'a Subtree> {
         match self.entry() {
             Some(Entry::End(Some(ptr))) => {
                 let idx = ptr.1;
@@ -127,7 +127,7 @@ impl<'a> Cursor<'a> {
         }
     }
 
-    fn entry(self) -> Option<(&'a Entry<'a>)> {
+    fn entry(self) -> Option<&'a Entry<'a>> {
         self.buffer.entry(&self.ptr)
     }
 


### PR DESCRIPTION
```
warning: unnecessary parentheses around type
   --> crates/ra_tt/src/buffer.rs:114:32
    |
114 |     pub fn end(self) -> Option<(&'a Subtree)> {
    |                                ^^^^^^^^^^^^^ help: remove these parentheses
    |
    = note: `#[warn(unused_parens)]` on by default

warning: unnecessary parentheses around type
   --> crates/ra_tt/src/buffer.rs:130:30
    |
130 |     fn entry(self) -> Option<(&'a Entry<'a>)> {
    |                              ^^^^^^^^^^^^^^^ help: remove these parentheses
```