### PR TITLE
Fix snapshots and tests line-ending in Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
-crates/ra_syntax/tests/data/** -text
+crates/ra_syntax/test_data/** -text eof=LF
+crates/ra_ide_api/src/snapshots/** -text eof=LF


### PR DESCRIPTION
When running `cargo test` in Windows, there are some test and snapshots generated which are `LF` line-endings. 

This PR try to force `git` to use `LF` for these files.