### PR TITLE
MBE: Mapping spans for goto definition

### DIFF
--- a/crates/ra_hir_expand/src/db.rs
+++ b/crates/ra_hir_expand/src/db.rs
@@ -8,9 +8,15 @@ use ra_prof::profile;
 use ra_syntax::{AstNode, Parse, SyntaxNode};
 
 use crate::{
-    ast_id_map::AstIdMap, HirFileId, HirFileIdRepr, MacroCallId, MacroCallLoc, MacroDefId,
-    MacroFile, MacroFileKind,
+    ast_id_map::AstIdMap, ExpansionInfo, HirFileId, HirFileIdRepr, MacroCallId, MacroCallLoc,
+    MacroDefId, MacroFile, MacroFileKind,
 };
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct ParseMacroWithInfo {
+    pub parsed: Parse<SyntaxNode>,
+    pub expansion_info: Arc<ExpansionInfo>,
+}
 
 // FIXME: rename to ExpandDatabase
 #[salsa::query_group(AstDatabaseStorage)]
@@ -22,10 +28,16 @@ pub trait AstDatabase: SourceDatabase {
 
     #[salsa::interned]
     fn intern_macro(&self, macro_call: MacroCallLoc) -> MacroCallId;
-    fn macro_arg(&self, id: MacroCallId) -> Option<Arc<tt::Subtree>>;
-    fn macro_def(&self, id: MacroDefId) -> Option<Arc<mbe::MacroRules>>;
+    fn macro_arg(&self, id: MacroCallId) -> Option<(Arc<tt::Subtree>, Arc<mbe::TokenMap>)>;
+    fn macro_def(&self, id: MacroDefId) -> Option<(Arc<mbe::MacroRules>, Arc<mbe::TokenMap>)>;
     fn parse_macro(&self, macro_file: MacroFile) -> Option<Parse<SyntaxNode>>;
-    fn macro_expand(&self, macro_call: MacroCallId) -> Result<Arc<tt::Subtree>, String>;
+    fn parse_macro_with_info(&self, macro_file: MacroFile) -> Option<ParseMacroWithInfo>;
+    fn macro_expand(
+        &self,
+        macro_call: MacroCallId,
+    ) -> Result<(Arc<tt::Subtree>, (Arc<mbe::TokenMap>, Arc<mbe::TokenMap>)), String>;
+
+    fn macro_expansion_info(&self, macro_file: MacroFile) -> Option<Arc<ExpansionInfo>>;
 }
 
 pub(crate) fn ast_id_map(db: &dyn AstDatabase, file_id: HirFileId) -> Arc<AstIdMap> {
@@ -34,10 +46,13 @@ pub(crate) fn ast_id_map(db: &dyn AstDatabase, file_id: HirFileId) -> Arc<AstIdM
     Arc::new(map)
 }
 
-pub(crate) fn macro_def(db: &dyn AstDatabase, id: MacroDefId) -> Option<Arc<MacroRules>> {
+pub(crate) fn macro_def(
+    db: &dyn AstDatabase,
+    id: MacroDefId,
+) -> Option<(Arc<mbe::MacroRules>, Arc<mbe::TokenMap>)> {
     let macro_call = id.ast_id.to_node(db);
     let arg = macro_call.token_tree()?;
-    let (tt, _) = mbe::ast_to_token_tree(&arg).or_else(|| {
+    let (tt, tmap) = mbe::ast_to_token_tree(&arg).or_else(|| {
         log::warn!("fail on macro_def to token tree: {:#?}", arg);
         None
     })?;
@@ -45,32 +60,36 @@ pub(crate) fn macro_def(db: &dyn AstDatabase, id: MacroDefId) -> Option<Arc<Macr
         log::warn!("fail on macro_def parse: {:#?}", tt);
         None
     })?;
-    Some(Arc::new(rules))
+    Some((Arc::new(rules), Arc::new(tmap)))
 }
 
-pub(crate) fn macro_arg(db: &dyn AstDatabase, id: MacroCallId) -> Option<Arc<tt::Subtree>> {
+pub(crate) fn macro_arg(
+    db: &dyn AstDatabase,
+    id: MacroCallId,
+) -> Option<(Arc<tt::Subtree>, Arc<mbe::TokenMap>)> {
     let loc = db.lookup_intern_macro(id);
     let macro_call = loc.ast_id.to_node(db);
     let arg = macro_call.token_tree()?;
-    let (tt, _) = mbe::ast_to_token_tree(&arg)?;
-    Some(Arc::new(tt))
+    let (tt, tmap) = mbe::ast_to_token_tree(&arg)?;
+    Some((Arc::new(tt), Arc::new(tmap)))
 }
 
 pub(crate) fn macro_expand(
     db: &dyn AstDatabase,
     id: MacroCallId,
-) -> Result<Arc<tt::Subtree>, String> {
+) -> Result<(Arc<tt::Subtree>, (Arc<mbe::TokenMap>, Arc<mbe::TokenMap>)), String> {
     let loc = db.lookup_intern_macro(id);
     let macro_arg = db.macro_arg(id).ok_or("Fail to args in to tt::TokenTree")?;
 
     let macro_rules = db.macro_def(loc.def).ok_or("Fail to find macro definition")?;
-    let tt = macro_rules.expand(&macro_arg).map_err(|err| format!("{:?}", err))?;
+    let tt = macro_rules.0.expand(&macro_arg.0).map_err(|err| format!("{:?}", err))?;
     // Set a hard limit for the expanded tt
     let count = tt.count();
     if count > 65536 {
         return Err(format!("Total tokens count exceed limit : count = {}", count));
     }
-    Ok(Arc::new(tt))
+
+    Ok((Arc::new(tt), (macro_arg.1.clone(), macro_rules.1.clone())))
 }
 
 pub(crate) fn parse_or_expand(db: &dyn AstDatabase, file_id: HirFileId) -> Option<SyntaxNode> {
@@ -87,6 +106,13 @@ pub(crate) fn parse_macro(
     macro_file: MacroFile,
 ) -> Option<Parse<SyntaxNode>> {
     let _p = profile("parse_macro_query");
+    db.parse_macro_with_info(macro_file).map(|r| r.parsed)
+}
+
+pub(crate) fn parse_macro_with_info(
+    db: &dyn AstDatabase,
+    macro_file: MacroFile,
+) -> Option<ParseMacroWithInfo> {
     let macro_call_id = macro_file.macro_call_id;
     let tt = db
         .macro_expand(macro_call_id)
@@ -97,8 +123,39 @@ pub(crate) fn parse_macro(
             log::warn!("fail on macro_parse: (reason: {})", err,);
         })
         .ok()?;
-    match macro_file.macro_file_kind {
-        MacroFileKind::Items => mbe::token_tree_to_items(&tt).ok().map(Parse::to_syntax),
-        MacroFileKind::Expr => mbe::token_tree_to_expr(&tt).ok().map(Parse::to_syntax),
-    }
+    let res = match macro_file.macro_file_kind {
+        MacroFileKind::Items => {
+            mbe::token_tree_to_items(&tt.0).ok().map(|(p, map)| (Parse::to_syntax(p), map))
+        }
+        MacroFileKind::Expr => {
+            mbe::token_tree_to_expr(&tt.0).ok().map(|(p, map)| (Parse::to_syntax(p), map))
+        }
+    };
+
+    res.map(|(parsed, exp_map)| {
+        let (arg_map, def_map) = tt.1;
+        let loc: MacroCallLoc = db.lookup_intern_macro(macro_call_id);
+
+        let def_start =
+            loc.def.ast_id.to_node(db).token_tree().map(|t| t.syntax().text_range().start());
+        let arg_start =
+            loc.ast_id.to_node(db).token_tree().map(|t| t.syntax().text_range().start());
+
+        let arg_map =
+            arg_start.map(|start| exp_map.ranges(&arg_map, start)).unwrap_or_else(|| Vec::new());
+
+        let def_map =
+            def_start.map(|start| exp_map.ranges(&def_map, start)).unwrap_or_else(|| Vec::new());
+
+        let info = ExpansionInfo { arg_map, def_map };
+
+        ParseMacroWithInfo { parsed, expansion_info: Arc::new(info) }
+    })
+}
+
+pub(crate) fn macro_expansion_info(
+    db: &dyn AstDatabase,
+    macro_file: MacroFile,
+) -> Option<Arc<ExpansionInfo>> {
+    db.parse_macro_with_info(macro_file).map(|res| res.expansion_info.clone())
 }

--- a/crates/ra_hir_expand/src/db.rs
+++ b/crates/ra_hir_expand/src/db.rs
@@ -151,10 +151,15 @@ pub(crate) fn parse_macro_with_info(
     let arg_start = arg_tt.map(|t| t.syntax().text_range().start());
     let def_start = def_tt.map(|t| t.syntax().text_range().start());
 
-    let arg_map =
-        arg_start.map(|start| exp_map.ranges(&expand_info.arg_map, start)).unwrap_or_default();
-    let def_map =
-        def_start.map(|start| exp_map.ranges(&expand_info.def_map, start)).unwrap_or_default();
+    let macro_rules = db.macro_def(loc.def).ok_or("Fail to find macro definition").ok()?.0;
+    let shift = macro_rules.shift();
+
+    let arg_map = arg_start
+        .map(|start| exp_map.map_ranges(&expand_info.arg_map, start, shift))
+        .unwrap_or_default();
+    let def_map = def_start
+        .map(|start| exp_map.map_ranges(&expand_info.def_map, start, 0))
+        .unwrap_or_default();
 
     let info = ExpansionInfo { arg_map, def_map };
 

--- a/crates/ra_hir_expand/src/db.rs
+++ b/crates/ra_hir_expand/src/db.rs
@@ -148,17 +148,15 @@ pub(crate) fn parse_macro_with_info(
     let arg_tt = loc.ast_id.to_node(db).token_tree();
     let def_tt = loc.def.ast_id.to_node(db).token_tree();
 
-    let arg_start = arg_tt.map(|t| t.syntax().text_range().start());
-    let def_start = def_tt.map(|t| t.syntax().text_range().start());
+    let arg_range = arg_tt.map(|t| t.syntax().text_range());
+    let def_range = def_tt.map(|t| t.syntax().text_range());
 
     let shift = db.macro_def(loc.def)?.0.shift();
 
-    let arg_map = arg_start
-        .map(|start| exp_map.map_ranges(&expand_info.arg_map, start, shift))
-        .unwrap_or_default();
-    let def_map = def_start
-        .map(|start| exp_map.map_ranges(&expand_info.def_map, start, 0))
-        .unwrap_or_default();
+    let arg_map =
+        arg_range.map(|it| exp_map.map_ranges(&expand_info.arg_map, it, shift)).unwrap_or_default();
+    let def_map =
+        def_range.map(|it| exp_map.map_ranges(&expand_info.def_map, it, 0)).unwrap_or_default();
 
     let info = ExpansionInfo { arg_map, def_map };
 

--- a/crates/ra_hir_expand/src/db.rs
+++ b/crates/ra_hir_expand/src/db.rs
@@ -151,8 +151,7 @@ pub(crate) fn parse_macro_with_info(
     let arg_start = arg_tt.map(|t| t.syntax().text_range().start());
     let def_start = def_tt.map(|t| t.syntax().text_range().start());
 
-    let macro_rules = db.macro_def(loc.def).ok_or("Fail to find macro definition").ok()?.0;
-    let shift = macro_rules.shift();
+    let shift = db.macro_def(loc.def)?.0.shift();
 
     let arg_map = arg_start
         .map(|start| exp_map.map_ranges(&expand_info.arg_map, start, shift))

--- a/crates/ra_hir_expand/src/lib.rs
+++ b/crates/ra_hir_expand/src/lib.rs
@@ -132,7 +132,7 @@ impl MacroCallId {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-/// ExpansionInfo mainly describle how to map text range between src and expaned macro
+/// ExpansionInfo mainly describes how to map text range between src and expanded macro
 pub struct ExpansionInfo {
     pub arg_map: Vec<(TextRange, TextRange)>,
     pub def_map: Vec<(TextRange, TextRange)>,

--- a/crates/ra_hir_expand/src/lib.rs
+++ b/crates/ra_hir_expand/src/lib.rs
@@ -145,17 +145,13 @@ impl ExpansionInfo {
         (arg_file_id, def_file_id): (HirFileId, HirFileId),
     ) -> Option<(HirFileId, TextRange)> {
         for (src, dest) in &self.arg_map {
-            dbg!((src, *dest, "arg_map"));
             if src.is_subrange(&from) {
-                dbg!((arg_file_id, *dest));
                 return Some((arg_file_id, *dest));
             }
         }
 
         for (src, dest) in &self.def_map {
-            dbg!((src, *dest, "def_map"));
             if src.is_subrange(&from) {
-                dbg!((arg_file_id, *dest));
                 return Some((def_file_id, *dest));
             }
         }

--- a/crates/ra_ide_api/src/display/navigation_target.rs
+++ b/crates/ra_ide_api/src/display/navigation_target.rs
@@ -37,7 +37,7 @@ fn find_range_from_node(
     let text_range = node.text_range();
     let (file_id, text_range) = src
         .parent_expansion(db)
-        .and_then(|(files, expansion_info)| expansion_info.find_range(text_range, files))
+        .and_then(|expansion_info| expansion_info.find_range(text_range))
         .unwrap_or((src, text_range));
 
     // FIXME: handle recursive macro generated macro
@@ -139,7 +139,6 @@ impl NavigationTarget {
     pub(crate) fn from_module(db: &RootDatabase, module: hir::Module) -> NavigationTarget {
         let src = module.definition_source(db);
         let name = module.name(db).map(|it| it.to_string().into()).unwrap_or_default();
-
         match src.ast {
             ModuleSource::SourceFile(node) => {
                 let (file_id, text_range) = find_range_from_node(db, src.file_id, node.syntax());
@@ -324,9 +323,7 @@ impl NavigationTarget {
     ) -> NavigationTarget {
         //FIXME: use `_` instead of empty string
         let name = node.name().map(|it| it.text().clone()).unwrap_or_default();
-
         let focus_range = node.name().map(|it| find_range_from_node(db, file_id, it.syntax()).1);
-
         let (file_id, full_range) = find_range_from_node(db, file_id, node.syntax());
 
         NavigationTarget::from_syntax(

--- a/crates/ra_ide_api/src/display/navigation_target.rs
+++ b/crates/ra_ide_api/src/display/navigation_target.rs
@@ -36,7 +36,7 @@ fn find_range_from_node(
 ) -> (FileId, TextRange) {
     let text_range = node.text_range();
     let (file_id, text_range) = src
-        .parent_expansion(db)
+        .expansion_info(db)
         .and_then(|expansion_info| expansion_info.find_range(text_range))
         .unwrap_or((src, text_range));
 

--- a/crates/ra_ide_api/src/display/navigation_target.rs
+++ b/crates/ra_ide_api/src/display/navigation_target.rs
@@ -40,6 +40,7 @@ fn find_range_from_node(
         .and_then(|(files, expansion_info)| expansion_info.find_range(text_range, files))
         .unwrap_or((src, text_range));
 
+    // FIXME: handle recursive macro generated macro
     (file_id.original_file(db), text_range)
 }
 

--- a/crates/ra_ide_api/src/goto_definition.rs
+++ b/crates/ra_ide_api/src/goto_definition.rs
@@ -101,19 +101,20 @@ pub(crate) fn name_definition(
         }
     }
 
-    if let Some(nav) = named_target(file_id, &parent) {
+    if let Some(nav) = named_target(db, file_id, &parent) {
         return Some(vec![nav]);
     }
 
     None
 }
 
-fn named_target(file_id: FileId, node: &SyntaxNode) -> Option<NavigationTarget> {
+fn named_target(db: &RootDatabase, file_id: FileId, node: &SyntaxNode) -> Option<NavigationTarget> {
     match_ast! {
         match node {
             ast::StructDef(it) => {
                 Some(NavigationTarget::from_named(
-                    file_id,
+                    db,
+                    file_id.into(),
                     &it,
                     it.doc_comment_text(),
                     it.short_label(),
@@ -121,7 +122,8 @@ fn named_target(file_id: FileId, node: &SyntaxNode) -> Option<NavigationTarget> 
             },
             ast::EnumDef(it) => {
                 Some(NavigationTarget::from_named(
-                    file_id,
+                    db,
+                    file_id.into(),
                     &it,
                     it.doc_comment_text(),
                     it.short_label(),
@@ -129,7 +131,8 @@ fn named_target(file_id: FileId, node: &SyntaxNode) -> Option<NavigationTarget> 
             },
             ast::EnumVariant(it) => {
                 Some(NavigationTarget::from_named(
-                    file_id,
+                    db,
+                    file_id.into(),
                     &it,
                     it.doc_comment_text(),
                     it.short_label(),
@@ -137,7 +140,8 @@ fn named_target(file_id: FileId, node: &SyntaxNode) -> Option<NavigationTarget> 
             },
             ast::FnDef(it) => {
                 Some(NavigationTarget::from_named(
-                    file_id,
+                    db,
+                    file_id.into(),
                     &it,
                     it.doc_comment_text(),
                     it.short_label(),
@@ -145,7 +149,8 @@ fn named_target(file_id: FileId, node: &SyntaxNode) -> Option<NavigationTarget> 
             },
             ast::TypeAliasDef(it) => {
                 Some(NavigationTarget::from_named(
-                    file_id,
+                    db,
+                    file_id.into(),
                     &it,
                     it.doc_comment_text(),
                     it.short_label(),
@@ -153,7 +158,8 @@ fn named_target(file_id: FileId, node: &SyntaxNode) -> Option<NavigationTarget> 
             },
             ast::ConstDef(it) => {
                 Some(NavigationTarget::from_named(
-                    file_id,
+                    db,
+                    file_id.into(),
                     &it,
                     it.doc_comment_text(),
                     it.short_label(),
@@ -161,7 +167,8 @@ fn named_target(file_id: FileId, node: &SyntaxNode) -> Option<NavigationTarget> 
             },
             ast::StaticDef(it) => {
                 Some(NavigationTarget::from_named(
-                    file_id,
+                    db,
+                    file_id.into(),
                     &it,
                     it.doc_comment_text(),
                     it.short_label(),
@@ -169,7 +176,8 @@ fn named_target(file_id: FileId, node: &SyntaxNode) -> Option<NavigationTarget> 
             },
             ast::TraitDef(it) => {
                 Some(NavigationTarget::from_named(
-                    file_id,
+                    db,
+                    file_id.into(),
                     &it,
                     it.doc_comment_text(),
                     it.short_label(),
@@ -177,7 +185,8 @@ fn named_target(file_id: FileId, node: &SyntaxNode) -> Option<NavigationTarget> 
             },
             ast::RecordFieldDef(it) => {
                 Some(NavigationTarget::from_named(
-                    file_id,
+                    db,
+                    file_id.into(),
                     &it,
                     it.doc_comment_text(),
                     it.short_label(),
@@ -185,7 +194,8 @@ fn named_target(file_id: FileId, node: &SyntaxNode) -> Option<NavigationTarget> 
             },
             ast::Module(it) => {
                 Some(NavigationTarget::from_named(
-                    file_id,
+                    db,
+                    file_id.into(),
                     &it,
                     it.doc_comment_text(),
                     it.short_label(),
@@ -193,7 +203,8 @@ fn named_target(file_id: FileId, node: &SyntaxNode) -> Option<NavigationTarget> 
             },
             ast::MacroCall(it) => {
                 Some(NavigationTarget::from_named(
-                    file_id,
+                    db,
+                    file_id.into(),
                     &it,
                     it.doc_comment_text(),
                     None,

--- a/crates/ra_ide_api/src/goto_definition.rs
+++ b/crates/ra_ide_api/src/goto_definition.rs
@@ -346,6 +346,46 @@ mod tests {
     }
 
     #[test]
+    fn goto_definition_works_for_macro_defined_fn_with_arg() {
+        check_goto(
+            "
+            //- /lib.rs
+            macro_rules! define_fn {
+                ($name:ident) => (fn $name() {})
+            }
+
+            define_fn!(
+                foo
+            )
+
+            fn bar() {
+               <|>foo();
+            }
+            ",
+            "foo FN_DEF FileId(1) [80; 83) [80; 83)",
+        );
+    }
+
+    #[test]
+    fn goto_definition_works_for_macro_defined_fn_no_arg() {
+        check_goto(
+            "
+            //- /lib.rs
+            macro_rules! define_fn {
+                () => (fn foo() {})
+            }
+
+            define_fn!();
+
+            fn bar() {
+               <|>foo();
+            }
+            ",
+            "foo FN_DEF FileId(1) [39; 42) [39; 42)",
+        );
+    }
+
+    #[test]
     fn goto_definition_works_for_methods() {
         covers!(goto_definition_works_for_methods);
         check_goto(

--- a/crates/ra_ide_api/src/status.rs
+++ b/crates/ra_ide_api/src/status.rs
@@ -94,10 +94,10 @@ impl FromIterator<TableEntry<FileId, Parse<ast::SourceFile>>> for SyntaxTreeStat
     }
 }
 
-impl FromIterator<TableEntry<MacroFile, Option<Parse<SyntaxNode>>>> for SyntaxTreeStats {
+impl<M> FromIterator<TableEntry<MacroFile, Option<(Parse<SyntaxNode>, M)>>> for SyntaxTreeStats {
     fn from_iter<T>(iter: T) -> SyntaxTreeStats
     where
-        T: IntoIterator<Item = TableEntry<MacroFile, Option<Parse<SyntaxNode>>>>,
+        T: IntoIterator<Item = TableEntry<MacroFile, Option<(Parse<SyntaxNode>, M)>>>,
     {
         let mut res = SyntaxTreeStats::default();
         for entry in iter {

--- a/crates/ra_mbe/src/lib.rs
+++ b/crates/ra_mbe/src/lib.rs
@@ -118,6 +118,10 @@ impl MacroRules {
         shift_subtree(&mut tt, self.shift);
         mbe_expander::expand(self, &tt)
     }
+
+    pub fn shift(&self) -> u32 {
+        self.shift
+    }
 }
 
 impl Rule {

--- a/crates/ra_mbe/src/lib.rs
+++ b/crates/ra_mbe/src/lib.rs
@@ -32,7 +32,7 @@ pub enum ExpandError {
 
 pub use crate::syntax_bridge::{
     ast_to_token_tree, syntax_node_to_token_tree, token_tree_to_expr, token_tree_to_items,
-    token_tree_to_macro_stmts, token_tree_to_pat, token_tree_to_ty,
+    token_tree_to_macro_stmts, token_tree_to_pat, token_tree_to_ty, TokenMap,
 };
 
 /// This struct contains AST for a single `macro_rules` definition. What might

--- a/crates/ra_mbe/src/lib.rs
+++ b/crates/ra_mbe/src/lib.rs
@@ -32,7 +32,7 @@ pub enum ExpandError {
 
 pub use crate::syntax_bridge::{
     ast_to_token_tree, syntax_node_to_token_tree, token_tree_to_expr, token_tree_to_items,
-    token_tree_to_macro_stmts, token_tree_to_pat, token_tree_to_ty, TokenMap,
+    token_tree_to_macro_stmts, token_tree_to_pat, token_tree_to_ty, RevTokenMap, TokenMap,
 };
 
 /// This struct contains AST for a single `macro_rules` definition. What might

--- a/crates/ra_mbe/src/syntax_bridge.rs
+++ b/crates/ra_mbe/src/syntax_bridge.rs
@@ -23,7 +23,7 @@ pub struct TokenMap {
 /// Maps relative range of the expanded syntax node to `tt::TokenId`
 #[derive(Debug, PartialEq, Eq, Default)]
 pub struct RevTokenMap {
-    ranges: Vec<(TextRange, tt::TokenId)>,
+    pub ranges: Vec<(TextRange, tt::TokenId)>,
 }
 
 /// Convert the syntax tree (what user has written) to a `TokenTree` (what macro
@@ -120,36 +120,6 @@ impl TokenMap {
 impl RevTokenMap {
     fn add(&mut self, relative_range: TextRange, token_id: tt::TokenId) {
         self.ranges.push((relative_range, token_id.clone()))
-    }
-
-    /// Map a given token map to (Expanded syntax node, Input tokens) text-ranges pair
-    ///
-    /// This function do the following things:
-    ///
-    /// 1. Undo the increment of token-id `shift`:
-    ///     When we output a token from from macro argument, we increased its id
-    ///     by `shift` (so it's guaranteed to not to collide with anything from the definition)
-    ///     We undo the increment here to rollback to its original token id.
-    /// 2. Offset the input tokens (`to`) by `parent` text-range:
-    ///     We transforms the input tokens text-ranges from relative to original first token
-    ///     to parent text-range
-    /// 3. Maps expanded tokens text-ranges to parent text-ranges
-    ///
-    pub fn map_ranges(
-        &self,
-        to: &TokenMap,
-        parent: TextRange,
-        shift: u32,
-    ) -> Vec<(TextRange, TextRange)> {
-        self.ranges
-            .iter()
-            .filter_map(|(r, tid)| {
-                let adjusted_id = tt::TokenId(tid.0.checked_sub(shift)?);
-                let to_range = to.relative_range_of(adjusted_id)?;
-
-                Some((*r, TextRange::offset_len(to_range.start() + parent.start(), to_range.len())))
-            })
-            .collect()
     }
 }
 

--- a/crates/ra_mbe/src/syntax_bridge.rs
+++ b/crates/ra_mbe/src/syntax_bridge.rs
@@ -158,7 +158,6 @@ impl ExpandedRangeMap {
     }
 
     pub fn ranges(&self, to: &TokenMap, start: TextUnit) -> Vec<(TextRange, TextRange)> {
-        dbg!(&self.ranges);
         self.ranges
             .iter()
             .filter_map(|(r, tid)| {

--- a/crates/ra_mbe/src/syntax_bridge.rs
+++ b/crates/ra_mbe/src/syntax_bridge.rs
@@ -148,7 +148,7 @@ impl ExpandedRangeMap {
             .filter_map(|(r, tid)| {
                 let adjusted_id = tt::TokenId(tid.0.checked_sub(shift)?);
                 let to_range = to.relative_range_of(adjusted_id)?;
-                
+
                 Some((*r, TextRange::offset_len(to_range.start() + start, to_range.len())))
             })
             .collect()

--- a/crates/ra_mbe/src/tests.rs
+++ b/crates/ra_mbe/src/tests.rs
@@ -126,7 +126,7 @@ fn test_expr_order() {
 "#,
     );
     let expanded = expand(&rules, "foo! { 1 + 1}");
-    let tree = token_tree_to_items(&expanded).unwrap().tree();
+    let tree = token_tree_to_items(&expanded).unwrap().0.tree();
 
     let dump = format!("{:#?}", tree.syntax());
     assert_eq_text!(
@@ -383,7 +383,7 @@ fn test_expand_to_item_list() {
             ",
     );
     let expansion = expand(&rules, "structs!(Foo, Bar);");
-    let tree = token_tree_to_items(&expansion).unwrap().tree();
+    let tree = token_tree_to_items(&expansion).unwrap().0.tree();
     assert_eq!(
         format!("{:#?}", tree.syntax()).trim(),
         r#"
@@ -501,7 +501,7 @@ fn test_tt_to_stmts() {
     );
 
     let expanded = expand(&rules, "foo!{}");
-    let stmts = token_tree_to_macro_stmts(&expanded).unwrap().tree();
+    let stmts = token_tree_to_macro_stmts(&expanded).unwrap().0.tree();
 
     assert_eq!(
         format!("{:#?}", stmts.syntax()).trim(),
@@ -946,7 +946,7 @@ fn test_vec() {
     );
 
     let expansion = expand(&rules, r#"vec![1u32,2];"#);
-    let tree = token_tree_to_expr(&expansion).unwrap().tree();
+    let tree = token_tree_to_expr(&expansion).unwrap().0.tree();
 
     assert_eq!(
         format!("{:#?}", tree.syntax()).trim(),
@@ -1436,8 +1436,8 @@ pub(crate) fn assert_expansion(
     };
     let (expanded_tree, expected_tree) = match kind {
         MacroKind::Items => {
-            let expanded_tree = token_tree_to_items(&expanded).unwrap().tree();
-            let expected_tree = token_tree_to_items(&expected).unwrap().tree();
+            let expanded_tree = token_tree_to_items(&expanded).unwrap().0.tree();
+            let expected_tree = token_tree_to_items(&expected).unwrap().0.tree();
 
             (
                 debug_dump_ignore_spaces(expanded_tree.syntax()).trim().to_string(),
@@ -1446,8 +1446,8 @@ pub(crate) fn assert_expansion(
         }
 
         MacroKind::Stmts => {
-            let expanded_tree = token_tree_to_macro_stmts(&expanded).unwrap().tree();
-            let expected_tree = token_tree_to_macro_stmts(&expected).unwrap().tree();
+            let expanded_tree = token_tree_to_macro_stmts(&expanded).unwrap().0.tree();
+            let expected_tree = token_tree_to_macro_stmts(&expected).unwrap().0.tree();
 
             (
                 debug_dump_ignore_spaces(expanded_tree.syntax()).trim().to_string(),

--- a/crates/ra_tt/src/lib.rs
+++ b/crates/ra_tt/src/lib.rs
@@ -25,26 +25,11 @@ use smol_str::SmolStr;
 /// source token and making sure that identities are preserved during macro
 /// expansion.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct TokenId {
-    token_id: u32,
-    map_id: u32,
-}
+pub struct TokenId(pub u32);
 
 impl TokenId {
-    pub fn new(token_id: u32, map_id: u32) -> TokenId {
-        TokenId { token_id, map_id }
-    }
-
     pub const fn unspecified() -> TokenId {
-        TokenId { token_id: !0, map_id: !0 }
-    }
-
-    pub fn token_id(&self) -> u32 {
-        self.token_id
-    }
-
-    pub fn map_id(&self) -> u32 {
-        self.map_id
+        TokenId(!0)
     }
 }
 

--- a/crates/ra_tt/src/lib.rs
+++ b/crates/ra_tt/src/lib.rs
@@ -25,23 +25,26 @@ use smol_str::SmolStr;
 /// source token and making sure that identities are preserved during macro
 /// expansion.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct TokenId(u32, u32);
+pub struct TokenId {
+    token_id: u32,
+    map_id: u32,
+}
 
 impl TokenId {
     pub fn new(token_id: u32, map_id: u32) -> TokenId {
-        TokenId(token_id, map_id)
+        TokenId { token_id, map_id }
     }
 
     pub const fn unspecified() -> TokenId {
-        TokenId(!0, !0)
+        TokenId { token_id: !0, map_id: !0 }
     }
 
     pub fn token_id(&self) -> u32 {
-        self.0
+        self.token_id
     }
 
     pub fn map_id(&self) -> u32 {
-        self.1
+        self.map_id
     }
 }
 

--- a/crates/ra_tt/src/lib.rs
+++ b/crates/ra_tt/src/lib.rs
@@ -25,11 +25,23 @@ use smol_str::SmolStr;
 /// source token and making sure that identities are preserved during macro
 /// expansion.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct TokenId(pub u32);
+pub struct TokenId(u32, u32);
 
 impl TokenId {
+    pub fn new(token_id: u32, map_id: u32) -> TokenId {
+        TokenId(token_id, map_id)
+    }
+
     pub const fn unspecified() -> TokenId {
-        TokenId(!0)
+        TokenId(!0, !0)
+    }
+
+    pub fn token_id(&self) -> u32 {
+        self.0
+    }
+
+    pub fn map_id(&self) -> u32 {
+        self.1
     }
 }
 


### PR DESCRIPTION
Currently, go to definition gives the wrong span in MBE.  This PR implement a mapping mechanism to fix it and it could be used for future MBE hygiene implementation.

The basic idea of the mapping is:
1. When expanding the macro, generated 2 `TokenMap` which maps the macro args and macro defs between tokens and input text-ranges.
2. Before converting generated `TokenTree` to `SyntaxNode`, generated a `ExpandedRangeMap` which is a mapping between token and output text-ranges.
3. Using these 3 mappings to construct an `ExpansionInfo`  which can map between input text ranges and output text ranges.
