### PR TITLE
MBE: Add TokenId shift in macro_rules

### DIFF
--- a/crates/ra_mbe/src/lib.rs
+++ b/crates/ra_mbe/src/lib.rs
@@ -108,7 +108,7 @@ impl MacroRules {
 
         // Note that TokenId is started from zero,
         // We have to add 1 to prevent duplication.
-        let shift = max_id(tt).unwrap_or(0) + 1;
+        let shift = max_id(tt).map_or(0, |it| it + 1);
         Ok(MacroRules { rules, shift })
     }
 

--- a/crates/ra_mbe/src/lib.rs
+++ b/crates/ra_mbe/src/lib.rs
@@ -72,7 +72,7 @@ fn find_subtree_shift(tt: &tt::Subtree, mut cur: Option<u32>) -> Option<u32> {
 }
 
 /// Shift given TokenTree token id
-fn shift_token_tree(tt: &mut tt::Subtree, shift: u32) {
+fn shift_subtree(tt: &mut tt::Subtree, shift: u32) {
     for t in tt.token_trees.iter_mut() {
         match t {
             tt::TokenTree::Leaf(leaf) => match leaf {
@@ -83,7 +83,7 @@ fn shift_token_tree(tt: &mut tt::Subtree, shift: u32) {
                 }
                 _ => (),
             },
-            tt::TokenTree::Subtree(tt) => shift_token_tree(tt, shift),
+            tt::TokenTree::Subtree(tt) => shift_subtree(tt, shift),
         }
     }
 }
@@ -117,7 +117,7 @@ impl MacroRules {
         // apply shift
         let mut tt = tt.clone();
         if let Some(shift) = self.shift {
-            shift_token_tree(&mut tt, shift)
+            shift_subtree(&mut tt, shift)
         }
 
         mbe_expander::expand(self, &tt)


### PR DESCRIPTION
As discussed in #2169 , for fixing duplication TokenId during expansion :

> What we can do here is to re-number the tokens during expansion. Specifically:
> * when we create macro_rules, we note the highest id of the token we have as shift>
> * when we expand macro rules, if we need to output a token from definition, we just re-use its id
> * if we need to output a token from the argument, we increase its id by shift (so it's guaranteed to not to collide with anything from the definition)
> * finally, when we have a HirFileId of the expansion, we can look up the original value of shift and classify node to the arg/def by comparing it's id with shift.
> 

This PR implement first 3 points of above solution. 