### PR TITLE
Use HirDatabase to compute `is_deprecated`

### DIFF
--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod src;
 pub(crate) mod docs;
+pub(crate) mod attrs;
 
 use std::sync::Arc;
 

--- a/crates/ra_hir/src/code_model/attrs.rs
+++ b/crates/ra_hir/src/code_model/attrs.rs
@@ -1,0 +1,92 @@
+//! FIXME: write short doc here
+
+use crate::{
+    db::{AstDatabase, DefDatabase, HirDatabase},
+    Adt, Const, Enum, EnumVariant, FieldSource, Function, HasSource, MacroDef, Module, Static,
+    Struct, StructField, Trait, TypeAlias, Union,
+};
+use hir_def::attr::Attr;
+use hir_expand::hygiene::Hygiene;
+use ra_syntax::ast;
+use std::sync::Arc;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum AttrDef {
+    Module(Module),
+    StructField(StructField),
+    Adt(Adt),
+    Function(Function),
+    EnumVariant(EnumVariant),
+    Static(Static),
+    Const(Const),
+    Trait(Trait),
+    TypeAlias(TypeAlias),
+    MacroDef(MacroDef),
+}
+
+impl_froms!(
+    AttrDef: Module,
+    StructField,
+    Adt(Struct, Enum, Union),
+    EnumVariant,
+    Static,
+    Const,
+    Function,
+    Trait,
+    TypeAlias,
+    MacroDef
+);
+
+pub trait Attrs {
+    fn attrs(&self, db: &impl HirDatabase) -> Option<Arc<[Attr]>>;
+}
+
+pub(crate) fn attributes_query(
+    db: &(impl DefDatabase + AstDatabase),
+    def: AttrDef,
+) -> Option<Arc<[Attr]>> {
+    match def {
+        AttrDef::Module(it) => {
+            let src = it.declaration_source(db)?;
+            let hygiene = Hygiene::new(db, src.file_id);
+            Attr::from_attrs_owner(&src.ast, &hygiene)
+        }
+        AttrDef::StructField(it) => match it.source(db).ast {
+            FieldSource::Named(named) => {
+                let src = it.source(db);
+                let hygiene = Hygiene::new(db, src.file_id);
+                Attr::from_attrs_owner(&named, &hygiene)
+            }
+            FieldSource::Pos(..) => None,
+        },
+        AttrDef::Adt(it) => match it {
+            Adt::Struct(it) => attrs_from_ast(it, db),
+            Adt::Enum(it) => attrs_from_ast(it, db),
+            Adt::Union(it) => attrs_from_ast(it, db),
+        },
+        AttrDef::EnumVariant(it) => attrs_from_ast(it, db),
+        AttrDef::Static(it) => attrs_from_ast(it, db),
+        AttrDef::Const(it) => attrs_from_ast(it, db),
+        AttrDef::Function(it) => attrs_from_ast(it, db),
+        AttrDef::Trait(it) => attrs_from_ast(it, db),
+        AttrDef::TypeAlias(it) => attrs_from_ast(it, db),
+        AttrDef::MacroDef(it) => attrs_from_ast(it, db),
+    }
+}
+
+fn attrs_from_ast<T, D>(node: T, db: &D) -> Option<Arc<[Attr]>>
+where
+    T: HasSource,
+    T::Ast: ast::AttrsOwner,
+    D: DefDatabase + AstDatabase,
+{
+    let src = node.source(db);
+    let hygiene = Hygiene::new(db, src.file_id);
+    Attr::from_attrs_owner(&src.ast, &hygiene)
+}
+
+impl<T: Into<AttrDef> + Copy> Attrs for T {
+    fn attrs(&self, db: &impl HirDatabase) -> Option<Arc<[Attr]>> {
+        db.attrs((*self).into())
+    }
+}

--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use hir_def::attr::Attr;
 use ra_db::salsa;
 use ra_syntax::SmolStr;
 
@@ -75,6 +76,9 @@ pub trait DefDatabase: HirDebugDatabase + DefDatabase2 {
 
     #[salsa::invoke(crate::code_model::docs::documentation_query)]
     fn documentation(&self, def: crate::DocDef) -> Option<crate::Documentation>;
+
+    #[salsa::invoke(crate::code_model::attrs::attributes_query)]
+    fn attrs(&self, def: crate::AttrDef) -> Option<Arc<[Attr]>>;
 }
 
 #[salsa::query_group(HirDatabaseStorage)]

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -61,6 +61,7 @@ use crate::{ids::MacroFileKind, resolve::Resolver};
 pub use crate::{
     adt::VariantDef,
     code_model::{
+        attrs::{AttrDef, Attrs},
         docs::{DocDef, Docs, Documentation},
         src::{HasBodySource, HasSource},
         Adt, AssocItem, Const, ConstData, Container, Crate, CrateDependency, DefWithBody, Enum,


### PR DESCRIPTION
This PR fixes #2167 by introducing `attributes_query` and adding `fn attrs(&self, def: crate::AttrDef) -> Option<Arc<[Attr]>>;`  to the `DefDatabase` trait.

I'm a little concerned about the two spots in `attributes_query` where code is repeated, but I couldn't figure out a way to avoid that, so.. I welcome suggestions :smile: 

