### PR TITLE
Use HashMap to replace FxHashMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,6 +1072,7 @@ dependencies = [
  "ra_db 0.1.0",
  "ra_fmt 0.1.0",
  "ra_hir 0.1.0",
+ "ra_hir_expand 0.1.0",
  "ra_prof 0.1.0",
  "ra_syntax 0.1.0",
  "ra_text_edit 0.1.0",

--- a/crates/ra_cfg/src/lib.rs
+++ b/crates/ra_cfg/src/lib.rs
@@ -2,7 +2,7 @@
 use std::iter::IntoIterator;
 
 use ra_syntax::SmolStr;
-use rustc_hash::FxHashSet;
+use std::collections::HashSet;
 
 mod cfg_expr;
 
@@ -20,8 +20,8 @@ pub use cfg_expr::{parse_cfg, CfgExpr};
 /// See: https://doc.rust-lang.org/reference/conditional-compilation.html#set-configuration-options
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct CfgOptions {
-    atoms: FxHashSet<SmolStr>,
-    key_values: FxHashSet<(SmolStr, SmolStr)>,
+    atoms: HashSet<SmolStr>,
+    key_values: HashSet<(SmolStr, SmolStr)>,
 }
 
 impl CfgOptions {

--- a/crates/ra_db/src/fixture.rs
+++ b/crates/ra_db/src/fixture.rs
@@ -3,12 +3,12 @@
 use std::sync::Arc;
 
 use ra_cfg::CfgOptions;
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 use test_utils::{extract_offset, parse_fixture, CURSOR_MARKER};
 
 use crate::{
     CrateGraph, Edition, FileId, FilePosition, RelativePathBuf, SourceDatabaseExt, SourceRoot,
-    SourceRootId,
+    SourceRootId, CrateId
 };
 
 pub const WORKSPACE: SourceRootId = SourceRootId(0);
@@ -59,7 +59,7 @@ fn with_files(db: &mut dyn SourceDatabaseExt, fixture: &str) -> Option<FilePosit
     let fixture = parse_fixture(fixture);
 
     let mut crate_graph = CrateGraph::default();
-    let mut crates = FxHashMap::default();
+    let mut crates: HashMap<String, CrateId> = HashMap::default();
     let mut crate_deps = Vec::new();
     let mut default_crate_root: Option<FileId> = None;
 

--- a/crates/ra_db/src/input.rs
+++ b/crates/ra_db/src/input.rs
@@ -6,11 +6,11 @@
 //! actual IO. See `vfs` and `project_model` in the `ra_lsp_server` crate for how
 //! actual IO is done and lowered to input.
 
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 
 use ra_cfg::CfgOptions;
 use ra_syntax::SmolStr;
-use rustc_hash::FxHashSet;
+use std::collections::HashSet;
 
 use crate::{RelativePath, RelativePathBuf};
 
@@ -39,7 +39,7 @@ pub struct SourceRoot {
     /// Libraries are considered mostly immutable, this assumption is used to
     /// optimize salsa's query structure
     pub is_library: bool,
-    files: FxHashMap<RelativePathBuf, FileId>,
+    files: HashMap<RelativePathBuf, FileId>,
 }
 
 impl SourceRoot {
@@ -76,7 +76,7 @@ impl SourceRoot {
 /// `CrateGraph` by lowering `cargo metadata` output.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CrateGraph {
-    arena: FxHashMap<CrateId, CrateData>,
+    arena: HashMap<CrateId, CrateData>,
 }
 
 #[derive(Debug)]
@@ -160,7 +160,7 @@ impl CrateGraph {
         name: SmolStr,
         to: CrateId,
     ) -> Result<(), CyclicDependencies> {
-        if self.dfs_find(from, to, &mut FxHashSet::default()) {
+        if self.dfs_find(from, to, &mut HashSet::default()) {
             return Err(CyclicDependencies);
         }
         self.arena.get_mut(&from).unwrap().add_dep(name, to);
@@ -213,7 +213,7 @@ impl CrateGraph {
         start
     }
 
-    fn dfs_find(&self, target: CrateId, from: CrateId, visited: &mut FxHashSet<CrateId>) -> bool {
+    fn dfs_find(&self, target: CrateId, from: CrateId, visited: &mut HashSet<CrateId>) -> bool {
         if !visited.insert(from) {
             return false;
         }

--- a/crates/ra_hir/src/expr.rs
+++ b/crates/ra_hir/src/expr.rs
@@ -12,7 +12,7 @@ use hir_def::{
 };
 use ra_arena::{impl_arena_id, map::ArenaMap, Arena, RawId};
 use ra_syntax::{ast, AstPtr};
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 
 use crate::{
     db::HirDatabase,
@@ -67,11 +67,11 @@ type PatSource = Source<PatPtr>;
 /// this properly for macros.
 #[derive(Default, Debug, Eq, PartialEq)]
 pub struct BodySourceMap {
-    expr_map: FxHashMap<ExprPtr, ExprId>,
+    expr_map: HashMap<ExprPtr, ExprId>,
     expr_map_back: ArenaMap<ExprId, ExprSource>,
-    pat_map: FxHashMap<PatPtr, PatId>,
+    pat_map: HashMap<PatPtr, PatId>,
     pat_map_back: ArenaMap<PatId, PatSource>,
-    field_map: FxHashMap<(ExprId, usize), AstPtr<ast::RecordField>>,
+    field_map: HashMap<(ExprId, usize), AstPtr<ast::RecordField>>,
 }
 
 impl Body {

--- a/crates/ra_hir/src/expr/scope.rs
+++ b/crates/ra_hir/src/expr/scope.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use ra_arena::{impl_arena_id, Arena, RawId};
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 
 use crate::{
     db::HirDatabase,
@@ -19,7 +19,7 @@ impl_arena_id!(ScopeId);
 pub struct ExprScopes {
     body: Arc<Body>,
     scopes: Arena<ScopeId, ScopeData>,
-    scope_by_expr: FxHashMap<ExprId, ScopeId>,
+    scope_by_expr: HashMap<ExprId, ScopeId>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -55,7 +55,7 @@ impl ExprScopes {
         let mut scopes = ExprScopes {
             body: body.clone(),
             scopes: Arena::default(),
-            scope_by_expr: FxHashMap::default(),
+            scope_by_expr: HashMap::default(),
         };
         let root = scopes.root_scope();
         scopes.add_params_bindings(root, body.params());
@@ -78,7 +78,7 @@ impl ExprScopes {
         self.scope_by_expr.get(&expr).copied()
     }
 
-    pub(crate) fn scope_by_expr(&self) -> &FxHashMap<ExprId, ScopeId> {
+    pub(crate) fn scope_by_expr(&self) -> &HashMap<ExprId, ScopeId> {
         &self.scope_by_expr
     }
 

--- a/crates/ra_hir/src/expr/validation.rs
+++ b/crates/ra_hir/src/expr/validation.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use hir_def::path::known;
 use hir_expand::diagnostics::DiagnosticSink;
 use ra_syntax::ast;
-use rustc_hash::FxHashSet;
+use std::collections::HashSet;
 
 use crate::{
     db::HirDatabase,
@@ -64,7 +64,7 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
             _ => return,
         };
 
-        let lit_fields: FxHashSet<_> = fields.iter().map(|f| &f.name).collect();
+        let lit_fields: HashSet<_> = fields.iter().map(|f| &f.name).collect();
         let missed_fields: Vec<Name> = struct_def
             .fields(db)
             .iter()

--- a/crates/ra_hir/src/impl_block.rs
+++ b/crates/ra_hir/src/impl_block.rs
@@ -1,6 +1,6 @@
 //! FIXME: write short doc here
 
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use hir_def::{attr::Attr, type_ref::TypeRef};
@@ -172,7 +172,7 @@ impl_arena_id!(ImplId);
 pub struct ModuleImplBlocks {
     pub(crate) module: Module,
     pub(crate) impls: Arena<ImplId, ImplData>,
-    impls_by_def: FxHashMap<AssocItem, ImplId>,
+    impls_by_def: HashMap<AssocItem, ImplId>,
 }
 
 impl ModuleImplBlocks {
@@ -204,7 +204,7 @@ impl ModuleImplBlocks {
         let mut m = ModuleImplBlocks {
             module,
             impls: Arena::default(),
-            impls_by_def: FxHashMap::default(),
+            impls_by_def: HashMap::default(),
         };
 
         let src = m.module.definition_source(db);

--- a/crates/ra_hir/src/lang_item.rs
+++ b/crates/ra_hir/src/lang_item.rs
@@ -1,6 +1,6 @@
 //! FIXME: write short doc here
 
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use ra_syntax::{ast::AttrsOwner, SmolStr};
@@ -35,7 +35,7 @@ impl LangItemTarget {
 
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct LangItems {
-    items: FxHashMap<SmolStr, LangItemTarget>,
+    items: HashMap<SmolStr, LangItemTarget>,
 }
 
 impl LangItems {

--- a/crates/ra_hir/src/resolve.rs
+++ b/crates/ra_hir/src/resolve.rs
@@ -8,7 +8,7 @@ use hir_def::{
     AdtId, CrateModuleId, ModuleDefId,
 };
 use hir_expand::name::{self, Name};
-use rustc_hash::FxHashSet;
+use std::collections::HashSet;
 
 use crate::{
     code_model::Crate,
@@ -331,8 +331,8 @@ impl Resolver {
         }
     }
 
-    pub(crate) fn traits_in_scope(&self, db: &impl HirDatabase) -> FxHashSet<Trait> {
-        let mut traits = FxHashSet::default();
+    pub(crate) fn traits_in_scope(&self, db: &impl HirDatabase) -> HashSet<Trait> {
+        let mut traits = HashSet::default();
         for scope in &self.scopes {
             if let Scope::ModuleScope(m) = scope {
                 if let Some(prelude) = m.crate_def_map.prelude() {

--- a/crates/ra_hir/src/source_binder.rs
+++ b/crates/ra_hir/src/source_binder.rs
@@ -8,7 +8,7 @@
 use std::sync::Arc;
 
 use hir_def::path::known;
-use hir_expand::name::AsName;
+use hir_expand::name::{AsName, Name as HirExpandName};
 use ra_db::FileId;
 use ra_syntax::{
     ast::{self, AstNode},
@@ -16,7 +16,7 @@ use ra_syntax::{
     SyntaxKind::*,
     SyntaxNode, SyntaxNodePtr, TextRange, TextUnit,
 };
-use rustc_hash::FxHashSet;
+use std::collections::HashSet;
 
 use crate::{
     db::HirDatabase,
@@ -282,11 +282,12 @@ impl SourceAnalyzer {
     }
 
     pub fn resolve_local_name(&self, name_ref: &ast::NameRef) -> Option<ScopeEntryWithSyntax> {
-        let mut shadowed = FxHashSet::default();
+        let mut shadowed: HashSet<&HirExpandName> = HashSet::default();
         let name = name_ref.as_name();
         let source_map = self.body_source_map.as_ref()?;
         let scopes = self.scopes.as_ref()?;
         let scope = scope_for(scopes, source_map, name_ref.syntax());
+        // HashMap<ExprId, ScopeId>
         let ret = scopes
             .scope_chain(scope)
             .flat_map(|scope| scopes.entries(scope).iter())

--- a/crates/ra_hir/src/traits.rs
+++ b/crates/ra_hir/src/traits.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use hir_expand::name::AsName;
 
 use ra_syntax::ast::{self, NameOwner};
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 
 use crate::{
     db::{AstDatabase, DefDatabase},
@@ -60,12 +60,12 @@ impl TraitData {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TraitItemsIndex {
-    traits_by_def: FxHashMap<AssocItem, Trait>,
+    traits_by_def: HashMap<AssocItem, Trait>,
 }
 
 impl TraitItemsIndex {
     pub(crate) fn trait_items_index(db: &impl DefDatabase, module: Module) -> TraitItemsIndex {
-        let mut index = TraitItemsIndex { traits_by_def: FxHashMap::default() };
+        let mut index = TraitItemsIndex { traits_by_def: HashMap::default() };
         for decl in module.declarations(db) {
             if let crate::ModuleDef::Trait(tr) = decl {
                 for item in tr.trait_data(db).items() {

--- a/crates/ra_hir/src/ty/infer.rs
+++ b/crates/ra_hir/src/ty/infer.rs
@@ -19,7 +19,7 @@ use std::ops::Index;
 use std::sync::Arc;
 
 use ena::unify::{InPlaceUnificationTable, NoError, UnifyKey, UnifyValue};
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 
 use hir_def::{
     path::known,
@@ -122,13 +122,13 @@ pub struct TypeMismatch {
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
 pub struct InferenceResult {
     /// For each method call expr, records the function it resolves to.
-    method_resolutions: FxHashMap<ExprId, Function>,
+    method_resolutions: HashMap<ExprId, Function>,
     /// For each field access expr, records the field it resolves to.
-    field_resolutions: FxHashMap<ExprId, StructField>,
+    field_resolutions: HashMap<ExprId, StructField>,
     /// For each struct literal, records the variant it resolves to.
-    variant_resolutions: FxHashMap<ExprOrPatId, VariantDef>,
+    variant_resolutions: HashMap<ExprOrPatId, VariantDef>,
     /// For each associated item record what it resolves to
-    assoc_resolutions: FxHashMap<ExprOrPatId, AssocItem>,
+    assoc_resolutions: HashMap<ExprOrPatId, AssocItem>,
     diagnostics: Vec<InferenceDiagnostic>,
     pub(super) type_of_expr: ArenaMap<ExprId, Ty>,
     pub(super) type_of_pat: ArenaMap<PatId, Ty>,
@@ -200,7 +200,7 @@ struct InferenceContext<'a, D: HirDatabase> {
     /// (from_ty_ctor, to_ty_ctor) => coerce_generic_index
     // FIXME: Use trait solver for this.
     // Chalk seems unable to work well with builtin impl of `Unsize` now.
-    coerce_unsized_map: FxHashMap<(TypeCtor, TypeCtor), usize>,
+    coerce_unsized_map: HashMap<(TypeCtor, TypeCtor), usize>,
 }
 
 impl<'a, D: HirDatabase> InferenceContext<'a, D> {

--- a/crates/ra_hir/src/ty/infer/coerce.rs
+++ b/crates/ra_hir/src/ty/infer/coerce.rs
@@ -4,7 +4,7 @@
 //!
 //! See: https://doc.rust-lang.org/nomicon/coercions.html
 
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 
 use test_utils::tested_by;
 
@@ -47,11 +47,11 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
     pub(super) fn init_coerce_unsized_map(
         db: &'a D,
         resolver: &Resolver,
-    ) -> FxHashMap<(TypeCtor, TypeCtor), usize> {
+    ) -> HashMap<(TypeCtor, TypeCtor), usize> {
         let krate = resolver.krate().unwrap();
         let impls = match db.lang_item(krate, "coerce_unsized".into()) {
             Some(LangItemTarget::Trait(trait_)) => db.impls_for_trait(krate, trait_),
-            _ => return FxHashMap::default(),
+            _ => return HashMap::default(),
         };
 
         impls

--- a/crates/ra_hir/src/ty/method_resolution.rs
+++ b/crates/ra_hir/src/ty/method_resolution.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use arrayvec::ArrayVec;
 use hir_def::CrateModuleId;
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 
 use super::{autoderef, lower, Canonical, InEnvironment, TraitEnvironment, TraitRef};
 use crate::{
@@ -40,8 +40,8 @@ impl TyFingerprint {
 pub struct CrateImplBlocks {
     /// To make sense of the CrateModuleIds, we need the source root.
     krate: Crate,
-    impls: FxHashMap<TyFingerprint, Vec<(CrateModuleId, ImplId)>>,
-    impls_by_trait: FxHashMap<Trait, Vec<(CrateModuleId, ImplId)>>,
+    impls: HashMap<TyFingerprint, Vec<(CrateModuleId, ImplId)>>,
+    impls_by_trait: HashMap<Trait, Vec<(CrateModuleId, ImplId)>>,
 }
 
 impl CrateImplBlocks {
@@ -112,8 +112,8 @@ impl CrateImplBlocks {
     ) -> Arc<CrateImplBlocks> {
         let mut crate_impl_blocks = CrateImplBlocks {
             krate,
-            impls: FxHashMap::default(),
-            impls_by_trait: FxHashMap::default(),
+            impls: HashMap::default(),
+            impls_by_trait: HashMap::default(),
         };
         if let Some(module) = krate.root_module(db) {
             crate_impl_blocks.collect_recursive(db, module);

--- a/crates/ra_hir/src/ty/traits.rs
+++ b/crates/ra_hir/src/ty/traits.rs
@@ -5,7 +5,7 @@ use chalk_ir::{cast::Cast, family::ChalkIr};
 use log::debug;
 use ra_db::salsa;
 use ra_prof::profile;
-use rustc_hash::FxHashSet;
+use std::collections::HashSet;
 
 use super::{Canonical, GenericPredicate, HirDisplay, ProjectionTy, TraitRef, Ty, TypeWalk};
 use crate::{db::HirDatabase, expr::ExprId, Crate, DefWithBody, ImplBlock, Trait};
@@ -78,7 +78,7 @@ pub(crate) fn impls_for_trait_query(
     krate: Crate,
     trait_: Trait,
 ) -> Arc<[ImplBlock]> {
-    let mut impls = FxHashSet::default();
+    let mut impls: HashSet<ImplBlock> = HashSet::default();
     // We call the query recursively here. On the one hand, this means we can
     // reuse results from queries for different crates; on the other hand, this
     // will only ever get called for a few crates near the root of the tree (the

--- a/crates/ra_hir_def/src/nameres.rs
+++ b/crates/ra_hir_def/src/nameres.rs
@@ -64,7 +64,7 @@ use ra_arena::Arena;
 use ra_db::{CrateId, Edition, FileId};
 use ra_prof::profile;
 use ra_syntax::ast;
-use rustc_hash::{FxHashMap, FxHashSet};
+use std::collections::{HashMap, HashSet};
 use test_utils::tested_by;
 
 use crate::{
@@ -84,7 +84,7 @@ pub struct CrateDefMap {
     /// marked with the `prelude_import` attribute, or (in the normal case) from
     /// a dependency (`std` or `core`).
     prelude: Option<ModuleId>,
-    extern_prelude: FxHashMap<Name, ModuleDefId>,
+    extern_prelude: HashMap<Name, ModuleDefId>,
     root: CrateModuleId,
     pub modules: Arena<CrateModuleId, ModuleData>,
 
@@ -98,7 +98,7 @@ pub struct CrateDefMap {
     /// the whole process will do again until it became poisoned in that crate.
     /// We should handle this macro set globally
     /// However, do we want to put it as a global variable?
-    poison_macros: FxHashSet<MacroDefId>,
+    poison_macros: HashSet<MacroDefId>,
 
     diagnostics: Vec<DefDiagnostic>,
 }
@@ -113,7 +113,7 @@ impl std::ops::Index<CrateModuleId> for CrateDefMap {
 #[derive(Default, Debug, PartialEq, Eq)]
 pub struct ModuleData {
     pub parent: Option<CrateModuleId>,
-    pub children: FxHashMap<Name, CrateModuleId>,
+    pub children: HashMap<Name, CrateModuleId>,
     pub scope: ModuleScope,
     /// None for root
     pub declaration: Option<AstId<ast::Module>>,
@@ -125,7 +125,7 @@ pub struct ModuleData {
 
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct ModuleScope {
-    pub items: FxHashMap<Name, Resolution>,
+    pub items: HashMap<Name, Resolution>,
     /// Macros visable in current module in legacy textual scope
     ///
     /// For macros invoked by an unquatified identifier like `bar!()`, `legacy_macros` will be searched in first.
@@ -138,10 +138,10 @@ pub struct ModuleScope {
     /// Module scoped macros will be inserted into `items` instead of here.
     // FIXME: Macro shadowing in one module is not properly handled. Non-item place macros will
     // be all resolved to the last one defined if shadowing happens.
-    legacy_macros: FxHashMap<Name, MacroDefId>,
+    legacy_macros: HashMap<Name, MacroDefId>,
 }
 
-static BUILTIN_SCOPE: Lazy<FxHashMap<Name, Resolution>> = Lazy::new(|| {
+static BUILTIN_SCOPE: Lazy<HashMap<Name, Resolution>> = Lazy::new(|| {
     BuiltinType::ALL
         .iter()
         .map(|(name, ty)| {
@@ -250,11 +250,11 @@ impl CrateDefMap {
             CrateDefMap {
                 krate,
                 edition,
-                extern_prelude: FxHashMap::default(),
+                extern_prelude: HashMap::default(),
                 prelude: None,
                 root,
                 modules,
-                poison_macros: FxHashSet::default(),
+                poison_macros: HashSet::default(),
                 diagnostics: Vec::new(),
             }
         };
@@ -274,7 +274,7 @@ impl CrateDefMap {
         self.prelude
     }
 
-    pub fn extern_prelude(&self) -> &FxHashMap<Name, ModuleDefId> {
+    pub fn extern_prelude(&self) -> &HashMap<Name, ModuleDefId> {
         &self.extern_prelude
     }
 

--- a/crates/ra_hir_def/src/nameres/collector.rs
+++ b/crates/ra_hir_def/src/nameres/collector.rs
@@ -7,7 +7,7 @@ use hir_expand::{
 use ra_cfg::CfgOptions;
 use ra_db::{CrateId, FileId};
 use ra_syntax::{ast, SmolStr};
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 use test_utils::tested_by;
 
 use crate::{
@@ -48,10 +48,10 @@ pub(super) fn collect_defs(db: &impl DefDatabase2, mut def_map: CrateDefMap) -> 
     let mut collector = DefCollector {
         db,
         def_map,
-        glob_imports: FxHashMap::default(),
+        glob_imports: HashMap::default(),
         unresolved_imports: Vec::new(),
         unexpanded_macros: Vec::new(),
-        mod_dirs: FxHashMap::default(),
+        mod_dirs: HashMap::default(),
         macro_stack_monitor: MacroStackMonitor::default(),
         cfg_options,
     };
@@ -61,7 +61,7 @@ pub(super) fn collect_defs(db: &impl DefDatabase2, mut def_map: CrateDefMap) -> 
 
 #[derive(Default)]
 struct MacroStackMonitor {
-    counts: FxHashMap<MacroDefId, u32>,
+    counts: HashMap<MacroDefId, u32>,
 
     /// Mainly use for test
     validator: Option<Box<dyn Fn(u32) -> bool>>,
@@ -91,10 +91,10 @@ impl MacroStackMonitor {
 struct DefCollector<'a, DB> {
     db: &'a DB,
     def_map: CrateDefMap,
-    glob_imports: FxHashMap<CrateModuleId, Vec<(CrateModuleId, raw::ImportId)>>,
+    glob_imports: HashMap<CrateModuleId, Vec<(CrateModuleId, raw::ImportId)>>,
     unresolved_imports: Vec<(CrateModuleId, raw::ImportId, raw::ImportData)>,
     unexpanded_macros: Vec<(CrateModuleId, AstId<ast::MacroCall>, Path)>,
-    mod_dirs: FxHashMap<CrateModuleId, ModDir>,
+    mod_dirs: HashMap<CrateModuleId, ModDir>,
 
     /// Some macro use `$tt:tt which mean we have to handle the macro perfectly
     /// To prevent stack overflow, we add a deep counter here for prevent that.
@@ -742,7 +742,7 @@ fn is_macro_rules(path: &Path) -> bool {
 mod tests {
     use ra_arena::Arena;
     use ra_db::{fixture::WithFixture, SourceDatabase};
-    use rustc_hash::FxHashSet;
+    use std::collections::HashSet;
 
     use crate::{db::DefDatabase2, test_db::TestDB};
 
@@ -756,10 +756,10 @@ mod tests {
         let mut collector = DefCollector {
             db,
             def_map,
-            glob_imports: FxHashMap::default(),
+            glob_imports: HashMap::default(),
             unresolved_imports: Vec::new(),
             unexpanded_macros: Vec::new(),
-            mod_dirs: FxHashMap::default(),
+            mod_dirs: HashMap::default(),
             macro_stack_monitor: monitor,
             cfg_options: &CfgOptions::default(),
         };
@@ -778,11 +778,11 @@ mod tests {
             CrateDefMap {
                 krate,
                 edition,
-                extern_prelude: FxHashMap::default(),
+                extern_prelude: HashMap::default(),
                 prelude: None,
                 root,
                 modules,
-                poison_macros: FxHashSet::default(),
+                poison_macros: HashSet::default(),
                 diagnostics: Vec::new(),
             }
         };

--- a/crates/ra_ide_api/Cargo.toml
+++ b/crates/ra_ide_api/Cargo.toml
@@ -32,6 +32,7 @@ ra_assists = { path = "../ra_assists" }
 # ra_ide_api should depend only on the top-level `hir` package. if you need
 # something from some `hir_xxx` subpackage, reexport the API via `hir`.
 hir = { path = "../ra_hir", package = "ra_hir" }
+hir_expand = { path = "../ra_hir_expand", package = "ra_hir_expand" }
 
 [dev-dependencies]
 insta = "0.12.0"

--- a/crates/ra_ide_api/src/change.rs
+++ b/crates/ra_ide_api/src/change.rs
@@ -11,7 +11,7 @@ use ra_prof::{memory_usage, profile, Bytes};
 use ra_syntax::SourceFile;
 #[cfg(not(feature = "wasm"))]
 use rayon::prelude::*;
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 
 use crate::{
     db::{DebugData, RootDatabase},
@@ -21,7 +21,7 @@ use crate::{
 #[derive(Default)]
 pub struct AnalysisChange {
     new_roots: Vec<(SourceRootId, bool)>,
-    roots_changed: FxHashMap<SourceRootId, RootChange>,
+    roots_changed: HashMap<SourceRootId, RootChange>,
     files_changed: Vec<(FileId, Arc<String>)>,
     libraries_added: Vec<LibraryData>,
     crate_graph: Option<CrateGraph>,

--- a/crates/ra_ide_api/src/completion/complete_dot.rs
+++ b/crates/ra_ide_api/src/completion/complete_dot.rs
@@ -7,7 +7,8 @@ use crate::{
     completion::{completion_context::CompletionContext, completion_item::Completions},
     CompletionItem,
 };
-use rustc_hash::FxHashSet;
+use std::collections::HashSet;
+use hir_expand::name::Name as HirExpandName;
 
 /// Complete dot accesses, i.e. fields or methods (and .await syntax).
 pub(super) fn complete_dot(acc: &mut Completions, ctx: &CompletionContext) {
@@ -57,7 +58,7 @@ fn complete_fields(acc: &mut Completions, ctx: &CompletionContext, receiver: Ty)
 }
 
 fn complete_methods(acc: &mut Completions, ctx: &CompletionContext, receiver: Ty) {
-    let mut seen_methods = FxHashSet::default();
+    let mut seen_methods: HashSet<HirExpandName> = HashSet::default();
     ctx.analyzer.iterate_method_candidates(ctx.db, receiver, None, |_ty, func| {
         let data = func.data(ctx.db);
         if data.has_self_param() && seen_methods.insert(data.name().clone()) {

--- a/crates/ra_ide_api/src/completion/complete_fn_param.rs
+++ b/crates/ra_ide_api/src/completion/complete_fn_param.rs
@@ -1,7 +1,7 @@
 //! FIXME: write short doc here
 
 use ra_syntax::{ast, match_ast, AstNode};
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 
 use crate::completion::{CompletionContext, CompletionItem, CompletionKind, Completions};
 
@@ -14,7 +14,7 @@ pub(super) fn complete_fn_param(acc: &mut Completions, ctx: &CompletionContext) 
         return;
     }
 
-    let mut params = FxHashMap::default();
+    let mut params = HashMap::default();
     for node in ctx.token.parent().ancestors() {
         match_ast! {
             match node {
@@ -40,7 +40,7 @@ pub(super) fn complete_fn_param(acc: &mut Completions, ctx: &CompletionContext) 
                 .add_to(acc)
         });
 
-    fn process<N: ast::FnDefOwner>(node: N, params: &mut FxHashMap<String, (u32, ast::Param)>) {
+    fn process<N: ast::FnDefOwner>(node: N, params: &mut HashMap<String, (u32, ast::Param)>) {
         node.functions().filter_map(|it| it.param_list()).flat_map(|it| it.params()).for_each(
             |param| {
                 let text = param.syntax().text().to_string();

--- a/crates/ra_ide_api/src/completion/complete_scope.rs
+++ b/crates/ra_ide_api/src/completion/complete_scope.rs
@@ -3,7 +3,7 @@
 use ra_assists::auto_import_text_edit;
 use ra_syntax::{ast, AstNode, SmolStr};
 use ra_text_edit::TextEditBuilder;
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 
 use crate::completion::{CompletionContext, CompletionItem, CompletionKind, Completions};
 
@@ -115,11 +115,11 @@ impl ImportResolver {
     // Returns a map of importable items filtered by name.
     // The map associates item name with its full path.
     // todo: should return Resolutions
-    pub(crate) fn all_names(&self, name: &str) -> FxHashMap<SmolStr, Vec<SmolStr>> {
+    pub(crate) fn all_names(&self, name: &str) -> HashMap<SmolStr, Vec<SmolStr>> {
         if name.len() > 1 {
             self.dummy_names.iter().filter(|(n, _)| n.contains(name)).cloned().collect()
         } else {
-            FxHashMap::default()
+            HashMap::default()
         }
     }
 }

--- a/crates/ra_ide_api/src/db.rs
+++ b/crates/ra_ide_api/src/db.rs
@@ -7,7 +7,7 @@ use ra_db::{
     Canceled, CheckCanceled, CrateId, FileId, FileLoader, FileLoaderDelegate, RelativePath,
     SourceDatabase, SourceDatabaseExt, SourceRootId,
 };
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 
 use crate::{
     symbol_index::{self, SymbolsDatabase},
@@ -130,8 +130,8 @@ fn line_index(db: &impl LineIndexDatabase, file_id: FileId) -> Arc<LineIndex> {
 
 #[derive(Debug, Default, Clone)]
 pub(crate) struct DebugData {
-    pub(crate) root_paths: FxHashMap<SourceRootId, String>,
-    pub(crate) crate_names: FxHashMap<CrateId, String>,
+    pub(crate) root_paths: HashMap<SourceRootId, String>,
+    pub(crate) crate_names: HashMap<CrateId, String>,
 }
 
 impl DebugData {

--- a/crates/ra_ide_api/src/feature_flags.rs
+++ b/crates/ra_ide_api/src/feature_flags.rs
@@ -1,6 +1,6 @@
 //! FIXME: write short doc here
 
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 
 /// Feature flags hold fine-grained toggles for all *user-visible* features of
 /// rust-analyzer.
@@ -16,7 +16,7 @@ use rustc_hash::FxHashMap;
 /// `ra_lsp_server`. This should be benign layering violation.
 #[derive(Debug)]
 pub struct FeatureFlags {
-    flags: FxHashMap<String, bool>,
+    flags: HashMap<String, bool>,
 }
 
 impl FeatureFlags {

--- a/crates/ra_ide_api/src/folding_ranges.rs
+++ b/crates/ra_ide_api/src/folding_ranges.rs
@@ -1,6 +1,6 @@
 //! FIXME: write short doc here
 
-use rustc_hash::FxHashSet;
+use std::collections::HashSet;
 
 use ra_syntax::{
     ast::{self, AstNode, AstToken, VisibilityOwner},
@@ -25,9 +25,9 @@ pub struct Fold {
 
 pub(crate) fn folding_ranges(file: &SourceFile) -> Vec<Fold> {
     let mut res = vec![];
-    let mut visited_comments = FxHashSet::default();
-    let mut visited_imports = FxHashSet::default();
-    let mut visited_mods = FxHashSet::default();
+    let mut visited_comments = HashSet::default();
+    let mut visited_imports = HashSet::default();
+    let mut visited_mods = HashSet::default();
 
     for element in file.syntax().descendants_with_tokens() {
         // Fold items that span multiple lines
@@ -102,7 +102,7 @@ fn has_visibility(node: &SyntaxNode) -> bool {
 
 fn contiguous_range_for_group(
     first: &SyntaxNode,
-    visited: &mut FxHashSet<SyntaxNode>,
+    visited: &mut HashSet<SyntaxNode>,
 ) -> Option<TextRange> {
     contiguous_range_for_group_unless(first, |_| false, visited)
 }
@@ -110,7 +110,7 @@ fn contiguous_range_for_group(
 fn contiguous_range_for_group_unless(
     first: &SyntaxNode,
     unless: impl Fn(&SyntaxNode) -> bool,
-    visited: &mut FxHashSet<SyntaxNode>,
+    visited: &mut HashSet<SyntaxNode>,
 ) -> Option<TextRange> {
     visited.insert(first.clone());
 
@@ -150,7 +150,7 @@ fn contiguous_range_for_group_unless(
 
 fn contiguous_range_for_comment(
     first: ast::Comment,
-    visited: &mut FxHashSet<ast::Comment>,
+    visited: &mut HashSet<ast::Comment>,
 ) -> Option<TextRange> {
     visited.insert(first.clone());
 

--- a/crates/ra_ide_api/src/line_index.rs
+++ b/crates/ra_ide_api/src/line_index.rs
@@ -1,13 +1,13 @@
 //! FIXME: write short doc here
 
 use crate::TextUnit;
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 use superslice::Ext;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LineIndex {
     pub(crate) newlines: Vec<TextUnit>,
-    pub(crate) utf16_lines: FxHashMap<u32, Vec<Utf16Char>>,
+    pub(crate) utf16_lines: HashMap<u32, Vec<Utf16Char>>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -32,7 +32,7 @@ impl Utf16Char {
 
 impl LineIndex {
     pub fn new(text: &str) -> LineIndex {
-        let mut utf16_lines = FxHashMap::default();
+        let mut utf16_lines = HashMap::default();
         let mut utf16_chars = Vec::new();
 
         let mut newlines = vec![0.into()];

--- a/crates/ra_ide_api/src/references/search_scope.rs
+++ b/crates/ra_ide_api/src/references/search_scope.rs
@@ -8,18 +8,18 @@ use hir::{DefWithBody, HasSource, ModuleSource};
 use ra_db::{FileId, SourceDatabase, SourceDatabaseExt};
 use ra_prof::profile;
 use ra_syntax::{AstNode, TextRange};
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 
 use crate::db::RootDatabase;
 
 use super::{NameDefinition, NameKind};
 
 pub struct SearchScope {
-    entries: FxHashMap<FileId, Option<TextRange>>,
+    entries: HashMap<FileId, Option<TextRange>>,
 }
 
 impl SearchScope {
-    fn new(entries: FxHashMap<FileId, Option<TextRange>>) -> SearchScope {
+    fn new(entries: HashMap<FileId, Option<TextRange>>) -> SearchScope {
         SearchScope { entries }
     }
     pub fn single_file(file: FileId) -> SearchScope {
@@ -72,7 +72,7 @@ impl NameDefinition {
         let file_id = module_src.file_id.original_file(db);
 
         if let NameKind::Pat((def, _)) = self.kind {
-            let mut res = FxHashMap::default();
+            let mut res = HashMap::default();
             let range = match def {
                 DefWithBody::Function(f) => f.source(db).ast.syntax().text_range(),
                 DefWithBody::Const(c) => c.source(db).ast.syntax().text_range(),
@@ -87,7 +87,7 @@ impl NameDefinition {
 
         if vis.as_str() == "pub(super)" {
             if let Some(parent_module) = self.container.parent(db) {
-                let mut res = FxHashMap::default();
+                let mut res = HashMap::default();
                 let parent_src = parent_module.definition_source(db);
                 let file_id = parent_src.file_id.original_file(db);
 
@@ -111,7 +111,7 @@ impl NameDefinition {
         if vis.as_str() != "" {
             let source_root_id = db.file_source_root(file_id);
             let source_root = db.source_root(source_root_id);
-            let mut res = source_root.walk().map(|id| (id, None)).collect::<FxHashMap<_, _>>();
+            let mut res = source_root.walk().map(|id| (id, None)).collect::<HashMap<_, _>>();
 
             // FIXME: add "pub(in path)"
 
@@ -134,7 +134,7 @@ impl NameDefinition {
             }
         }
 
-        let mut res = FxHashMap::default();
+        let mut res = HashMap::default();
         let range = match module_src.ast {
             ModuleSource::Module(m) => Some(m.syntax().text_range()),
             ModuleSource::SourceFile(_) => None,

--- a/crates/ra_ide_api/src/syntax_highlighting.rs
+++ b/crates/ra_ide_api/src/syntax_highlighting.rs
@@ -1,6 +1,6 @@
 //! FIXME: write short doc here
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use std::collections::{HashMap, HashSet};
 
 use hir::{Mutability, Ty};
 use ra_db::SourceDatabase;
@@ -79,8 +79,8 @@ pub(crate) fn highlight(db: &RootDatabase, file_id: FileId) -> Vec<HighlightedRa
 
     // Visited nodes to handle highlighting priorities
     // FIXME: retain only ranges here
-    let mut highlighted: FxHashSet<SyntaxElement> = FxHashSet::default();
-    let mut bindings_shadow_count: FxHashMap<SmolStr, u32> = FxHashMap::default();
+    let mut highlighted: HashSet<SyntaxElement> = HashSet::default();
+    let mut bindings_shadow_count: HashMap<SmolStr, u32> = HashMap::default();
 
     let mut res = Vec::new();
     for node in root.descendants_with_tokens() {

--- a/crates/ra_lsp_server/src/config.rs
+++ b/crates/ra_lsp_server/src/config.rs
@@ -7,7 +7,7 @@
 //! configure the server itself, feature flags are passed into analysis, and
 //! tweak things like automatic insertion of `()` in completions.
 
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 
 use serde::{Deserialize, Deserializer};
 
@@ -34,7 +34,7 @@ pub struct ServerConfig {
     pub with_sysroot: bool,
 
     /// Fine grained feature flags to disable specific features.
-    pub feature_flags: FxHashMap<String, bool>,
+    pub feature_flags: HashMap<String, bool>,
 }
 
 impl Default for ServerConfig {
@@ -45,7 +45,7 @@ impl Default for ServerConfig {
             use_client_watching: false,
             lru_capacity: None,
             with_sysroot: true,
-            feature_flags: FxHashMap::default(),
+            feature_flags: HashMap::default(),
         }
     }
 }

--- a/crates/ra_lsp_server/src/main_loop.rs
+++ b/crates/ra_lsp_server/src/main_loop.rs
@@ -13,7 +13,7 @@ use ra_ide_api::{Canceled, FeatureFlags, FileId, LibraryData, SourceRootId};
 use ra_prof::profile;
 use ra_vfs::{VfsTask, Watch};
 use relative_path::RelativePathBuf;
-use rustc_hash::FxHashSet;
+use std::collections::HashSet;
 use serde::{de::DeserializeOwned, Serialize};
 use threadpool::ThreadPool;
 
@@ -263,7 +263,7 @@ impl fmt::Debug for Event {
 #[derive(Debug, Default)]
 struct LoopState {
     next_request_id: u64,
-    pending_responses: FxHashSet<RequestId>,
+    pending_responses: HashSet<RequestId>,
     pending_requests: PendingRequests,
     subscriptions: Subscriptions,
     // We try not to index more than MAX_IN_FLIGHT_LIBS libraries at the same

--- a/crates/ra_lsp_server/src/main_loop/handlers.rs
+++ b/crates/ra_lsp_server/src/main_loop/handlers.rs
@@ -14,7 +14,7 @@ use ra_ide_api::{
 };
 use ra_prof::profile;
 use ra_syntax::{AstNode, SyntaxKind, TextRange, TextUnit};
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use serde_json::to_value;
 
@@ -340,7 +340,7 @@ pub fn handle_runnables(
         label,
         bin: "cargo".to_string(),
         args: check_args,
-        env: FxHashMap::default(),
+        env: HashMap::default(),
         cwd: workspace_root.map(|root| root.to_string_lossy().to_string()),
     });
     Ok(res)
@@ -839,7 +839,7 @@ fn to_lsp_runnable(
         bin: "cargo".to_string(),
         args,
         env: {
-            let mut m = FxHashMap::default();
+            let mut m = HashMap::default();
             m.insert("RUST_BACKTRACE".to_string(), "short".to_string());
             m
         },

--- a/crates/ra_lsp_server/src/main_loop/pending_requests.rs
+++ b/crates/ra_lsp_server/src/main_loop/pending_requests.rs
@@ -3,7 +3,7 @@
 use std::time::{Duration, Instant};
 
 use lsp_server::RequestId;
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 
 #[derive(Debug)]
 pub struct CompletedRequest {
@@ -31,7 +31,7 @@ impl From<PendingRequest> for CompletedRequest {
 
 #[derive(Debug, Default)]
 pub(crate) struct PendingRequests {
-    map: FxHashMap<RequestId, PendingRequest>,
+    map: HashMap<RequestId, PendingRequest>,
 }
 
 impl PendingRequests {

--- a/crates/ra_lsp_server/src/main_loop/subscriptions.rs
+++ b/crates/ra_lsp_server/src/main_loop/subscriptions.rs
@@ -1,11 +1,11 @@
 //! FIXME: write short doc here
 
 use ra_ide_api::FileId;
-use rustc_hash::FxHashSet;
+use std::collections::HashSet;
 
 #[derive(Default, Debug)]
 pub(crate) struct Subscriptions {
-    subs: FxHashSet<FileId>,
+    subs: HashSet<FileId>,
 }
 
 impl Subscriptions {

--- a/crates/ra_lsp_server/src/req.rs
+++ b/crates/ra_lsp_server/src/req.rs
@@ -1,7 +1,7 @@
 //! FIXME: write short doc here
 
 use lsp_types::{Location, Position, Range, TextDocumentIdentifier, Url};
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 pub use lsp_types::{
@@ -165,7 +165,7 @@ pub struct Runnable {
     pub label: String,
     pub bin: String,
     pub args: Vec<String>,
-    pub env: FxHashMap<String, String>,
+    pub env: HashMap<String, String>,
     pub cwd: Option<String>,
 }
 

--- a/crates/ra_mbe/src/mbe_expander.rs
+++ b/crates/ra_mbe/src/mbe_expander.rs
@@ -6,7 +6,7 @@ mod matcher;
 mod transcriber;
 
 use ra_syntax::SmolStr;
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 
 use crate::ExpandError;
 
@@ -70,7 +70,7 @@ fn expand_rule(rule: &crate::Rule, input: &tt::Subtree) -> Result<tt::Subtree, E
 /// many is not a plain `usize`, but an `&[usize]`.
 #[derive(Debug, Default)]
 struct Bindings {
-    inner: FxHashMap<SmolStr, Binding>,
+    inner: HashMap<SmolStr, Binding>,
 }
 
 #[derive(Debug)]

--- a/crates/ra_project_model/src/cargo_workspace.rs
+++ b/crates/ra_project_model/src/cargo_workspace.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use cargo_metadata::{CargoOpt, MetadataCommand};
 use ra_arena::{impl_arena_id, Arena, RawId};
 use ra_db::Edition;
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 
 use crate::Result;
 
@@ -133,7 +133,7 @@ impl CargoWorkspace {
             meta.current_dir(parent);
         }
         let meta = meta.exec().map_err(|e| format!("cargo metadata failed: {}", e))?;
-        let mut pkg_by_id = FxHashMap::default();
+        let mut pkg_by_id: HashMap<cargo_metadata::PackageId, Package> = HashMap::default();
         let mut packages = Arena::default();
         let mut targets = Arena::default();
 

--- a/crates/ra_project_model/src/json_project.rs
+++ b/crates/ra_project_model/src/json_project.rs
@@ -2,8 +2,10 @@
 
 use std::path::PathBuf;
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use std::collections::{HashMap, HashSet};
 use serde::Deserialize;
+use std::convert::From;
+use ra_db::CrateId as DbCrateId;
 
 /// A root points to the directory which contains Rust crates. rust-analyzer watches all files in
 /// all roots. Roots might be nested.
@@ -20,8 +22,8 @@ pub struct Crate {
     pub(crate) root_module: PathBuf,
     pub(crate) edition: Edition,
     pub(crate) deps: Vec<Dep>,
-    pub(crate) atom_cfgs: FxHashSet<String>,
-    pub(crate) key_value_cfgs: FxHashMap<String, String>,
+    pub(crate) atom_cfgs: HashSet<String>,
+    pub(crate) key_value_cfgs: HashMap<String, String>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize)]
@@ -37,6 +39,12 @@ pub enum Edition {
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[serde(transparent)]
 pub struct CrateId(pub usize);
+
+impl From<CrateId> for DbCrateId {
+    fn from(item: CrateId) -> Self {
+        DbCrateId(item.0 as u32)
+    }
+}
 
 /// A dependency of a crate, identified by its id in the crates array and name.
 #[derive(Clone, Debug, Deserialize)]

--- a/crates/ra_syntax/src/algo.rs
+++ b/crates/ra_syntax/src/algo.rs
@@ -4,7 +4,7 @@ use std::ops::RangeInclusive;
 
 use itertools::Itertools;
 use ra_text_edit::TextEditBuilder;
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 
 use crate::{
     AstNode, Direction, NodeOrToken, SyntaxElement, SyntaxNode, SyntaxNodePtr, TextRange, TextUnit,
@@ -65,7 +65,7 @@ pub enum InsertPosition<T> {
 }
 
 pub struct TreeDiff {
-    replacements: FxHashMap<SyntaxElement, SyntaxElement>,
+    replacements: HashMap<SyntaxElement, SyntaxElement>,
 }
 
 impl TreeDiff {
@@ -84,14 +84,14 @@ impl TreeDiff {
 /// A trivial solution is a singletom map `{ from: to }`, but this function
 /// tries to find a more fine-grained diff.
 pub fn diff(from: &SyntaxNode, to: &SyntaxNode) -> TreeDiff {
-    let mut buf = FxHashMap::default();
+    let mut buf = HashMap::default();
     // FIXME: this is both horrible inefficient and gives larger than
     // necessary diff. I bet there's a cool algorithm to diff trees properly.
     go(&mut buf, from.clone().into(), to.clone().into());
     return TreeDiff { replacements: buf };
 
     fn go(
-        buf: &mut FxHashMap<SyntaxElement, SyntaxElement>,
+        buf: &mut HashMap<SyntaxElement, SyntaxElement>,
         lhs: SyntaxElement,
         rhs: SyntaxElement,
     ) {
@@ -185,14 +185,14 @@ pub fn replace_children(
 /// to create a type-safe abstraction on top of it instead.
 pub fn replace_descendants(
     parent: &SyntaxNode,
-    map: &FxHashMap<SyntaxElement, SyntaxElement>,
+    map: &HashMap<SyntaxElement, SyntaxElement>,
 ) -> SyntaxNode {
     //  FIXME: this could be made much faster.
     let new_children = parent.children_with_tokens().map(|it| go(map, it)).collect::<Box<[_]>>();
     return with_children(parent, new_children);
 
     fn go(
-        map: &FxHashMap<SyntaxElement, SyntaxElement>,
+        map: &HashMap<SyntaxElement, SyntaxElement>,
         element: SyntaxElement,
     ) -> NodeOrToken<rowan::GreenNode, rowan::GreenToken> {
         if let Some(replacement) = map.get(&element) {

--- a/crates/ra_syntax/src/ast/edit.rs
+++ b/crates/ra_syntax/src/ast/edit.rs
@@ -4,7 +4,7 @@
 use std::{iter, ops::RangeInclusive};
 
 use arrayvec::ArrayVec;
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 
 use crate::{
     algo,
@@ -226,7 +226,7 @@ pub fn replace_descendants<N: AstNode, D: AstNode>(
 ) -> N {
     let map = replacement_map
         .map(|(from, to)| (from.syntax().clone().into(), to.syntax().clone().into()))
-        .collect::<FxHashMap<_, _>>();
+        .collect::<HashMap<_, _>>();
     let new_syntax = algo::replace_descendants(parent.syntax(), &map);
     N::cast(new_syntax).unwrap()
 }
@@ -261,7 +261,7 @@ impl IndentLevel {
     }
 
     fn _increase_indent(self, node: SyntaxNode) -> SyntaxNode {
-        let replacements: FxHashMap<SyntaxElement, SyntaxElement> = node
+        let replacements: HashMap<SyntaxElement, SyntaxElement> = node
             .descendants_with_tokens()
             .filter_map(|el| el.into_token())
             .filter_map(ast::Whitespace::cast)
@@ -290,7 +290,7 @@ impl IndentLevel {
     }
 
     fn _decrease_indent(self, node: SyntaxNode) -> SyntaxNode {
-        let replacements: FxHashMap<SyntaxElement, SyntaxElement> = node
+        let replacements: HashMap<SyntaxElement, SyntaxElement> = node
             .descendants_with_tokens()
             .filter_map(|el| el.into_token())
             .filter_map(ast::Whitespace::cast)


### PR DESCRIPTION
Today I read some words from https://github.com/tkaitchuck/aHash that says `FxHash` is not good, so I started to replace `FxHashMap` using `HashMap`, after some find and replace and some extra type declaration it builds, most test cases passed except `crates/ra_hir_def/src/nameres/tests.rs`

I tried this commit in my vscode, most functions work well, do you think change to the std `HashMap` is a good idea?