### PR TITLE
Resolve core types

### DIFF
--- a/crates/ra_hir_def/src/nameres/tests.rs
+++ b/crates/ra_hir_def/src/nameres/tests.rs
@@ -464,6 +464,37 @@ fn values_dont_shadow_extern_crates() {
 }
 
 #[test]
+fn std_prelude_takes_precedence_above_core_prelude() {
+    let map = def_map(
+        r#"
+        //- /main.rs crate:main deps:core,std
+        use {Foo, Bar};
+
+        //- /std.rs crate:std deps:core
+        #[prelude_import]
+        pub use self::prelude::*;
+        mod prelude {
+            pub struct Foo;
+            pub use core::prelude::Bar;
+        }
+
+        //- /core.rs crate:core
+        #[prelude_import]
+        pub use self::prelude::*;
+        mod prelude {
+            pub struct Bar;
+        }
+        "#,
+    );
+
+    assert_snapshot!(map, @r###"
+        ⋮crate
+        ⋮Bar: t v
+        ⋮Foo: t v
+    "###);
+}
+
+#[test]
 fn cfg_not_test() {
     let map = def_map(
         r#"

--- a/crates/ra_ide_api/src/completion/complete_scope.rs
+++ b/crates/ra_ide_api/src/completion/complete_scope.rs
@@ -598,6 +598,68 @@ mod tests {
     }
 
     #[test]
+    fn completes_std_prelude_if_core_is_defined() {
+        assert_debug_snapshot!(
+            do_reference_completion(
+                "
+                //- /main.rs
+                fn foo() { let x: <|> }
+
+                //- /core/lib.rs
+                #[prelude_import]
+                use prelude::*;
+
+                mod prelude {
+                    struct Option;
+                }
+
+                //- /std/lib.rs
+                #[prelude_import]
+                use prelude::*;
+
+                mod prelude {
+                    struct String;
+                }
+                "
+            ),
+            @r###"
+        [
+            CompletionItem {
+                label: "String",
+                source_range: [18; 18),
+                delete: [18; 18),
+                insert: "String",
+                kind: Struct,
+            },
+            CompletionItem {
+                label: "core",
+                source_range: [18; 18),
+                delete: [18; 18),
+                insert: "core",
+                kind: Module,
+            },
+            CompletionItem {
+                label: "foo()",
+                source_range: [18; 18),
+                delete: [18; 18),
+                insert: "foo()$0",
+                kind: Function,
+                lookup: "foo",
+                detail: "fn foo()",
+            },
+            CompletionItem {
+                label: "std",
+                source_range: [18; 18),
+                delete: [18; 18),
+                insert: "std",
+                kind: Module,
+            },
+        ]
+        "###
+        );
+    }
+
+    #[test]
     fn completes_macros_as_value() {
         assert_debug_snapshot!(
             do_reference_completion(

--- a/crates/ra_project_model/src/lib.rs
+++ b/crates/ra_project_model/src/lib.rs
@@ -199,6 +199,7 @@ impl ProjectWorkspace {
                     }
                 }
 
+                let libcore = sysroot.core().and_then(|it| sysroot_crates.get(&it).copied());
                 let libstd = sysroot.std().and_then(|it| sysroot_crates.get(&it).copied());
 
                 let mut pkg_to_lib_crate = FxHashMap::default();
@@ -226,7 +227,7 @@ impl ProjectWorkspace {
                         }
                     }
 
-                    // Set deps to the std and to the lib target of the current package
+                    // Set deps to the core, std and to the lib target of the current package
                     for &from in pkg_crates.get(&pkg).into_iter().flatten() {
                         if let Some(to) = lib_tgt {
                             if to != from {
@@ -238,6 +239,11 @@ impl ProjectWorkspace {
                                         pkg.name(&cargo)
                                     )
                                 }
+                            }
+                        }
+                        if let Some(core) = libcore {
+                            if let Err(_) = crate_graph.add_dep(from, "core".into(), core) {
+                                log::error!("cyclic dependency on core for {}", pkg.name(&cargo))
                             }
                         }
                         if let Some(std) = libstd {

--- a/crates/ra_project_model/src/lib.rs
+++ b/crates/ra_project_model/src/lib.rs
@@ -241,6 +241,8 @@ impl ProjectWorkspace {
                                 }
                             }
                         }
+                        // core is added as a dependency before std in order to
+                        // mimic rustcs dependency order
                         if let Some(core) = libcore {
                             if let Err(_) = crate_graph.add_dep(from, "core".into(), core) {
                                 log::error!("cyclic dependency on core for {}", pkg.name(&cargo))

--- a/crates/ra_project_model/src/sysroot.rs
+++ b/crates/ra_project_model/src/sysroot.rs
@@ -27,6 +27,10 @@ struct SysrootCrateData {
 }
 
 impl Sysroot {
+    pub fn core(&self) -> Option<SysrootCrate> {
+        self.by_name("core")
+    }
+
     pub fn std(&self) -> Option<SysrootCrate> {
         self.by_name("std")
     }


### PR DESCRIPTION
This adds support for completion and goto definition of
types defined within the "core" crate. The core crate is
added as a dependency to each crate in the project.

The core crate exported it's own prelude. This caused
now all crates to inherit the core crates prelude instead
of the std crates. In order to avoid the problem the
prelude resolution has been changed to overwrite
an already resolved prelude if this was set to a crate
named core - in order to pick a better prelude like std.

Fixes #2199