### PR TITLE
Implement bulitin line! macro

### DIFF
--- a/crates/ra_hir/src/code_model/src.rs
+++ b/crates/ra_hir/src/code_model/src.rs
@@ -6,8 +6,8 @@ use crate::{
     adt::VariantDef,
     db::{AstDatabase, DefDatabase, HirDatabase},
     ids::AstItemDef,
-    Const, Either, Enum, EnumVariant, FieldSource, Function, HasBody, HirFileId, MacroDef,
-    MacroDefId, Module, ModuleSource, Static, Struct, StructField, Trait, TypeAlias, Union,
+    Const, Either, Enum, EnumVariant, FieldSource, Function, HasBody, HirFileId, MacroDef, Module,
+    ModuleSource, Static, Struct, StructField, Trait, TypeAlias, Union,
 };
 
 pub use hir_expand::Source;
@@ -140,15 +140,10 @@ impl HasSource for TypeAlias {
         self.id.source(db)
     }
 }
-
 impl HasSource for MacroDef {
     type Ast = ast::MacroCall;
     fn source(self, db: &(impl DefDatabase + AstDatabase)) -> Source<ast::MacroCall> {
-        let ast_id = match self.id {
-            MacroDefId::DeclarativeMacro(it) => it.ast_id,
-            MacroDefId::BuiltinMacro(it) => it.ast_id,
-        };
-        Source { file_id: ast_id.file_id(), ast: ast_id.to_node(db) }
+        Source { file_id: self.id.ast_id.file_id(), ast: self.id.ast_id.to_node(db) }
     }
 }
 

--- a/crates/ra_hir/src/code_model/src.rs
+++ b/crates/ra_hir/src/code_model/src.rs
@@ -6,8 +6,8 @@ use crate::{
     adt::VariantDef,
     db::{AstDatabase, DefDatabase, HirDatabase},
     ids::AstItemDef,
-    Const, Either, Enum, EnumVariant, FieldSource, Function, HasBody, HirFileId, MacroDef, Module,
-    ModuleSource, Static, Struct, StructField, Trait, TypeAlias, Union,
+    Const, Either, Enum, EnumVariant, FieldSource, Function, HasBody, HirFileId, MacroDef,
+    MacroDefId, Module, ModuleSource, Static, Struct, StructField, Trait, TypeAlias, Union,
 };
 
 pub use hir_expand::Source;
@@ -140,10 +140,15 @@ impl HasSource for TypeAlias {
         self.id.source(db)
     }
 }
+
 impl HasSource for MacroDef {
     type Ast = ast::MacroCall;
     fn source(self, db: &(impl DefDatabase + AstDatabase)) -> Source<ast::MacroCall> {
-        Source { file_id: self.id.ast_id.file_id(), ast: self.id.ast_id.to_node(db) }
+        let ast_id = match self.id {
+            MacroDefId::DeclarativeMacro(it) => it.ast_id,
+            MacroDefId::BuiltinMacro(it) => it.ast_id,
+        };
+        Source { file_id: ast_id.file_id(), ast: ast_id.to_node(db) }
     }
 }
 

--- a/crates/ra_hir/src/ty/tests.rs
+++ b/crates/ra_hir/src/ty/tests.rs
@@ -4810,3 +4810,22 @@ fn no_such_field_diagnostics() {
     "###
     );
 }
+
+#[test]
+fn infer_builtin_macros_line() {
+    assert_snapshot!(
+        infer(r#"
+#[rustc_builtin_macro]
+macro_rules! line {() => {}}
+
+fn main() {
+    let x = line!();
+}
+"#),
+        @r###"
+        ![0; 1) '6': i32
+        [64; 88) '{     ...!(); }': ()
+        [74; 75) 'x': i32        
+    "###
+    );
+}

--- a/crates/ra_hir_def/src/nameres/collector.rs
+++ b/crates/ra_hir_def/src/nameres/collector.rs
@@ -3,7 +3,7 @@
 use hir_expand::{
     builtin_macro::find_builtin_macro,
     name::{self, AsName, Name},
-    DeclarativeMacro, HirFileId, MacroCallId, MacroCallLoc, MacroDefId, MacroFileKind,
+    HirFileId, MacroCallId, MacroCallLoc, MacroDefId, MacroDefKind, MacroFileKind,
 };
 use ra_cfg::CfgOptions;
 use ra_db::{CrateId, FileId};
@@ -708,13 +708,12 @@ where
         // Case 1: macro rules, define a macro in crate-global mutable scope
         if is_macro_rules(&mac.path) {
             if let Some(name) = &mac.name {
-                let macro_id = DeclarativeMacro { ast_id, krate: self.def_collector.def_map.krate };
-                self.def_collector.define_macro(
-                    self.module_id,
-                    name.clone(),
-                    MacroDefId::DeclarativeMacro(macro_id),
-                    mac.export,
-                );
+                let macro_id = MacroDefId {
+                    ast_id,
+                    krate: self.def_collector.def_map.krate,
+                    kind: MacroDefKind::Declarative,
+                };
+                self.def_collector.define_macro(self.module_id, name.clone(), macro_id, mac.export);
             }
             return;
         }

--- a/crates/ra_hir_def/src/nameres/raw.rs
+++ b/crates/ra_hir_def/src/nameres/raw.rs
@@ -200,6 +200,7 @@ pub(super) struct MacroData {
     pub(super) path: Path,
     pub(super) name: Option<Name>,
     pub(super) export: bool,
+    pub(super) builtin: bool,
 }
 
 struct RawItemsCollector {
@@ -367,7 +368,11 @@ impl RawItemsCollector {
         // FIXME: cfg_attr
         let export = m.attrs().filter_map(|x| x.simple_name()).any(|name| name == "macro_export");
 
-        let m = self.raw_items.macros.alloc(MacroData { ast_id, path, name, export });
+        // FIXME: cfg_attr
+        let builtin =
+            m.attrs().filter_map(|x| x.simple_name()).any(|name| name == "rustc_builtin_macro");
+
+        let m = self.raw_items.macros.alloc(MacroData { ast_id, path, name, export, builtin });
         self.push_item(current_module, attrs, RawItemKind::Macro(m));
     }
 

--- a/crates/ra_hir_expand/src/builtin_macro.rs
+++ b/crates/ra_hir_expand/src/builtin_macro.rs
@@ -2,7 +2,7 @@
 use crate::db::AstDatabase;
 use crate::{
     ast::{self, AstNode},
-    name, AstId, BuiltinMacro, CrateId, HirFileId, MacroCallId, MacroDefId, MacroFileKind,
+    name, AstId, CrateId, HirFileId, MacroCallId, MacroDefId, MacroDefKind, MacroFileKind,
     TextUnit,
 };
 
@@ -33,11 +33,7 @@ pub fn find_builtin_macro(
 ) -> Option<MacroDefId> {
     // FIXME: Better registering method
     if ident == &name::LINE_MACRO {
-        Some(MacroDefId::BuiltinMacro(BuiltinMacro {
-            expander: BuiltinExpander::Line,
-            krate,
-            ast_id,
-        }))
+        Some(MacroDefId { krate, ast_id, kind: MacroDefKind::BuiltIn(BuiltinExpander::Line) })
     } else {
         None
     }

--- a/crates/ra_hir_expand/src/builtin_macro.rs
+++ b/crates/ra_hir_expand/src/builtin_macro.rs
@@ -1,0 +1,26 @@
+//! Builtin macro
+use crate::{ast, name, AstId, BuiltinMacro, CrateId, MacroDefId};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BuiltinExpander {
+    Line
+}
+
+impl BuiltinExpander {
+    pub fn expand(&self, _tt: &tt::Subtree) -> Result<tt::Subtree, mbe::ExpandError> {
+        Err(mbe::ExpandError::UnexpectedToken)
+    }
+}
+
+pub fn find_builtin_macro(
+    ident: &name::Name,
+    krate: CrateId,
+    ast_id: AstId<ast::MacroCall>,
+) -> Option<MacroDefId> {
+    // FIXME: Better registering method
+    if ident == &name::LINE {
+        Some(MacroDefId::BuiltinMacro(BuiltinMacro { expander: BuiltinExpander::Line, krate, ast_id }))
+    } else {
+        None
+    }
+}

--- a/crates/ra_hir_expand/src/builtin_macro.rs
+++ b/crates/ra_hir_expand/src/builtin_macro.rs
@@ -1,14 +1,28 @@
 //! Builtin macro
-use crate::{ast, name, AstId, BuiltinMacro, CrateId, MacroDefId};
+use crate::db::AstDatabase;
+use crate::{
+    ast::{self, AstNode},
+    name, AstId, BuiltinMacro, CrateId, HirFileId, MacroCallId, MacroDefId, MacroFileKind,
+    TextUnit,
+};
+
+use crate::quote;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BuiltinExpander {
-    Line
+    Line,
 }
 
 impl BuiltinExpander {
-    pub fn expand(&self, _tt: &tt::Subtree) -> Result<tt::Subtree, mbe::ExpandError> {
-        Err(mbe::ExpandError::UnexpectedToken)
+    pub fn expand(
+        &self,
+        db: &dyn AstDatabase,
+        id: MacroCallId,
+        tt: &tt::Subtree,
+    ) -> Result<tt::Subtree, mbe::ExpandError> {
+        match self {
+            BuiltinExpander::Line => line_expand(db, id, tt),
+        }
     }
 }
 
@@ -18,9 +32,53 @@ pub fn find_builtin_macro(
     ast_id: AstId<ast::MacroCall>,
 ) -> Option<MacroDefId> {
     // FIXME: Better registering method
-    if ident == &name::LINE {
-        Some(MacroDefId::BuiltinMacro(BuiltinMacro { expander: BuiltinExpander::Line, krate, ast_id }))
+    if ident == &name::LINE_MACRO {
+        Some(MacroDefId::BuiltinMacro(BuiltinMacro {
+            expander: BuiltinExpander::Line,
+            krate,
+            ast_id,
+        }))
     } else {
         None
     }
+}
+
+fn to_line_number(db: &dyn AstDatabase, file: HirFileId, pos: TextUnit) -> usize {
+    // FIXME: Use expansion info
+    let file_id = file.original_file(db);
+    let text = db.file_text(file_id);
+    let mut line_num = 1;
+
+    // Count line end
+    for (i, c) in text.chars().enumerate() {
+        if i == pos.to_usize() {
+            break;
+        }
+        if c == '\n' {
+            line_num += 1;
+        }
+    }
+
+    line_num
+}
+
+fn line_expand(
+    db: &dyn AstDatabase,
+    id: MacroCallId,
+    _tt: &tt::Subtree,
+) -> Result<tt::Subtree, mbe::ExpandError> {
+    let loc = db.lookup_intern_macro(id);
+    let macro_call = loc.ast_id.to_node(db);
+
+    let arg = macro_call.token_tree().ok_or_else(|| mbe::ExpandError::UnexpectedToken)?;
+    let arg_start = arg.syntax().text_range().start();
+
+    let file = id.as_file(MacroFileKind::Expr);
+    let line_num = to_line_number(db, file, arg_start);
+
+    let expanded = quote! {
+        #line_num
+    };
+
+    Ok(expanded)
 }

--- a/crates/ra_hir_expand/src/db.rs
+++ b/crates/ra_hir_expand/src/db.rs
@@ -28,7 +28,7 @@ impl TokenExpander {
     ) -> Result<tt::Subtree, mbe::ExpandError> {
         match self {
             TokenExpander::MacroRules(it) => it.expand(tt),
-            TokenExpander::Builtin(it) => it.expand(tt),
+            TokenExpander::Builtin(it) => it.expand(db, id, tt),
         }
     }
 

--- a/crates/ra_hir_expand/src/hygiene.rs
+++ b/crates/ra_hir_expand/src/hygiene.rs
@@ -9,7 +9,7 @@ use crate::{
     db::AstDatabase,
     either::Either,
     name::{AsName, Name},
-    HirFileId, HirFileIdRepr, MacroDefId,
+    HirFileId, HirFileIdRepr, MacroDefKind,
 };
 
 #[derive(Debug)]
@@ -24,9 +24,9 @@ impl Hygiene {
             HirFileIdRepr::FileId(_) => None,
             HirFileIdRepr::MacroFile(macro_file) => {
                 let loc = db.lookup_intern_macro(macro_file.macro_call_id);
-                match loc.def {
-                    MacroDefId::DeclarativeMacro(it) => Some(it.krate),
-                    MacroDefId::BuiltinMacro(_) => None,
+                match loc.def.kind {
+                    MacroDefKind::Declarative => Some(loc.def.krate),
+                    MacroDefKind::BuiltIn(_) => None,
                 }
             }
         };

--- a/crates/ra_hir_expand/src/hygiene.rs
+++ b/crates/ra_hir_expand/src/hygiene.rs
@@ -9,7 +9,7 @@ use crate::{
     db::AstDatabase,
     either::Either,
     name::{AsName, Name},
-    HirFileId, HirFileIdRepr,
+    HirFileId, HirFileIdRepr, MacroDefId,
 };
 
 #[derive(Debug)]
@@ -24,7 +24,10 @@ impl Hygiene {
             HirFileIdRepr::FileId(_) => None,
             HirFileIdRepr::MacroFile(macro_file) => {
                 let loc = db.lookup_intern_macro(macro_file.macro_call_id);
-                Some(loc.def.krate)
+                match loc.def {
+                    MacroDefId::DeclarativeMacro(it) => Some(it.krate),
+                    MacroDefId::BuiltinMacro(_) => None,
+                }
             }
         };
         Hygiene { def_crate }

--- a/crates/ra_hir_expand/src/lib.rs
+++ b/crates/ra_hir_expand/src/lib.rs
@@ -11,6 +11,7 @@ pub mod name;
 pub mod hygiene;
 pub mod diagnostics;
 pub mod builtin_macro;
+pub mod quote;
 
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;

--- a/crates/ra_hir_expand/src/name.rs
+++ b/crates/ra_hir_expand/src/name.rs
@@ -140,3 +140,6 @@ pub const RESULT_TYPE: Name = Name::new_inline_ascii(6, b"Result");
 pub const OUTPUT_TYPE: Name = Name::new_inline_ascii(6, b"Output");
 pub const TARGET_TYPE: Name = Name::new_inline_ascii(6, b"Target");
 pub const BOX_TYPE: Name = Name::new_inline_ascii(3, b"Box");
+
+// Builtin Macros
+pub const LINE_MACRO: Name = Name::new_inline_ascii(4, b"line");

--- a/crates/ra_hir_expand/src/quote.rs
+++ b/crates/ra_hir_expand/src/quote.rs
@@ -1,0 +1,261 @@
+//! A simplified version of quote-crate like quasi quote macro
+
+// A helper macro quote macro
+// FIXME:
+// 1. Not all puncts are handled
+// 2. #()* pattern repetition not supported now
+//    * But we can do it manually, see `test_quote_derive_copy_hack`
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __quote {
+    () => {
+        Vec::<tt::TokenTree>::new()
+    };
+
+    ( @SUBTREE $delim:ident $($tt:tt)* ) => {
+        {
+            let children = $crate::__quote!($($tt)*);
+            let subtree = tt::Subtree {
+                delimiter: tt::Delimiter::$delim,
+                token_trees: $crate::quote::IntoTt::to_tokens(children),
+            };
+            subtree
+        }
+    };
+
+    ( @PUNCT $first:literal ) => {
+        {
+            vec![
+                tt::Leaf::Punct(tt::Punct {
+                    char: $first,
+                    spacing: tt::Spacing::Alone,
+                }).into()
+            ]
+        }
+    };
+
+    ( @PUNCT $first:literal, $sec:literal ) => {
+        {
+            vec![
+                tt::Leaf::Punct(tt::Punct {
+                    char: $first,
+                    spacing: tt::Spacing::Joint,
+                }).into(),
+                tt::Leaf::Punct(tt::Punct {
+                    char: $sec,
+                    spacing: tt::Spacing::Alone,
+                }).into()
+            ]
+        }
+    };
+
+    // hash variable
+    ( # $first:ident $($tail:tt)* ) => {
+        {
+            let token = $crate::quote::ToTokenTree::to_token($first);
+            let mut tokens = vec![token.into()];
+            let mut tail_tokens = $crate::quote::IntoTt::to_tokens($crate::__quote!($($tail)*));
+            tokens.append(&mut tail_tokens);
+            tokens
+        }
+    };
+
+    // Brace
+    ( { $($tt:tt)* } ) => { $crate::__quote!(@SUBTREE Brace $($tt)*) };
+    // Bracket
+    ( [ $($tt:tt)* ] ) => { $crate::__quote!(@SUBTREE Bracket $($tt)*) };
+    // Parenthesis
+    ( ( $($tt:tt)* ) ) => { $crate::__quote!(@SUBTREE Parenthesis $($tt)*) };
+
+    // Literal
+    ( $tt:literal ) => { vec![$crate::quote::ToTokenTree::to_token($tt).into()] };
+    // Ident
+    ( $tt:ident ) => {
+        vec![ {
+            tt::Leaf::Ident(tt::Ident {
+                text: stringify!($tt).into(),
+                id: tt::TokenId::unspecified(),
+            }).into()
+        }]
+    };
+
+    // Puncts
+    // FIXME: Not all puncts are handled
+    ( -> ) => {$crate::__quote!(@PUNCT '-', '>')};
+    ( & ) => {$crate::__quote!(@PUNCT '&')};
+    ( , ) => {$crate::__quote!(@PUNCT ',')};
+    ( : ) => {$crate::__quote!(@PUNCT ':')};
+    ( . ) => {$crate::__quote!(@PUNCT '.')};
+
+    ( $first:tt $($tail:tt)+ ) => {
+        {
+            let mut tokens = $crate::quote::IntoTt::to_tokens($crate::__quote!($first));
+            let mut tail_tokens = $crate::quote::IntoTt::to_tokens($crate::__quote!($($tail)*));
+
+            tokens.append(&mut tail_tokens);
+            tokens
+        }
+    };
+}
+
+/// FIXME:
+/// It probably should implement in proc-macro
+#[macro_export]
+macro_rules! quote {
+    ( $($tt:tt)* ) => {
+        $crate::quote::IntoTt::to_subtree($crate::__quote!($($tt)*))
+    }
+}
+
+pub(crate) trait IntoTt {
+    fn to_subtree(self) -> tt::Subtree;
+    fn to_tokens(self) -> Vec<tt::TokenTree>;
+}
+
+impl IntoTt for Vec<tt::TokenTree> {
+    fn to_subtree(self) -> tt::Subtree {
+        tt::Subtree { delimiter: tt::Delimiter::None, token_trees: self }
+    }
+
+    fn to_tokens(self) -> Vec<tt::TokenTree> {
+        self
+    }
+}
+
+impl IntoTt for tt::Subtree {
+    fn to_subtree(self) -> tt::Subtree {
+        self
+    }
+
+    fn to_tokens(self) -> Vec<tt::TokenTree> {
+        vec![tt::TokenTree::Subtree(self)]
+    }
+}
+
+pub(crate) trait ToTokenTree {
+    fn to_token(self) -> tt::TokenTree;
+}
+
+impl ToTokenTree for tt::TokenTree {
+    fn to_token(self) -> tt::TokenTree {
+        self
+    }
+}
+
+impl ToTokenTree for tt::Subtree {
+    fn to_token(self) -> tt::TokenTree {
+        self.into()
+    }
+}
+
+macro_rules! impl_to_to_tokentrees {
+    ($($ty:ty => $this:ident $im:block);*) => {
+        $(
+            impl ToTokenTree for $ty {
+                fn to_token($this) -> tt::TokenTree {
+                    let leaf: tt::Leaf = $im.into();
+                    leaf.into()
+                }
+            }
+
+            impl ToTokenTree for &$ty {
+                fn to_token($this) -> tt::TokenTree {
+                    let leaf: tt::Leaf = $im.clone().into();
+                    leaf.into()
+                }
+            }
+        )*
+    }
+}
+
+impl_to_to_tokentrees! {
+    u32 => self { tt::Literal{text: self.to_string().into()} };
+    usize => self { tt::Literal{text: self.to_string().into()}};
+    i32 => self { tt::Literal{text: self.to_string().into()}};
+    &str => self { tt::Literal{text: self.to_string().into()}};
+    String => self { tt::Literal{text: self.into()}};
+    tt::Leaf => self { self };
+    tt::Literal => self { self };
+    tt::Ident => self { self };
+    tt::Punct => self { self }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_quote_delimiters() {
+        assert_eq!(quote!({}).to_string(), "{}");
+        assert_eq!(quote!(()).to_string(), "()");
+        assert_eq!(quote!([]).to_string(), "[]");
+    }
+
+    #[test]
+    fn test_quote_idents() {
+        assert_eq!(quote!(32).to_string(), "32");
+        assert_eq!(quote!(struct).to_string(), "struct");
+    }
+
+    #[test]
+    fn test_quote_hash_simple_literal() {
+        let a = 20;
+        assert_eq!(quote!(#a).to_string(), "20");
+        let s: String = "hello".into();
+        assert_eq!(quote!(#s).to_string(), "hello");
+    }
+
+    fn mk_ident(name: &str) -> tt::Ident {
+        tt::Ident { text: name.into(), id: tt::TokenId::unspecified() }
+    }
+
+    #[test]
+    fn test_quote_hash_token_tree() {
+        let a = mk_ident("hello");
+
+        let quoted = quote!(#a);
+        assert_eq!(quoted.to_string(), "hello");
+        let t = format!("{:?}", quoted);
+        assert_eq!(t, "Subtree { delimiter: None, token_trees: [Leaf(Ident(Ident { text: \"hello\", id: TokenId(4294967295) }))] }");
+    }
+
+    #[test]
+    fn test_quote_simple_derive_copy() {
+        let name = mk_ident("Foo");
+
+        let quoted = quote! {
+            impl Clone for #name {
+                fn clone(&self) -> Self {
+                    Self {}
+                }
+            }
+        };
+
+        assert_eq!(quoted.to_string(), "impl Clone for Foo {fn clone (& self) -> Self {Self {}}}");
+    }
+
+    #[test]
+    fn test_quote_derive_copy_hack() {
+        // Assume the given struct is:
+        // struct Foo {
+        //  name: String,
+        //  id: u32,
+        // }
+        let struct_name = mk_ident("Foo");
+        let fields = [mk_ident("name"), mk_ident("id")];
+        let fields = fields
+            .into_iter()
+            .map(|it| quote!(#it: self.#it.clone(), ).token_trees.clone())
+            .flatten();
+
+        let list = tt::Subtree { delimiter: tt::Delimiter::Brace, token_trees: fields.collect() };
+
+        let quoted = quote! {
+            impl Clone for #struct_name {
+                fn clone(&self) -> Self {
+                    Self #list
+                }
+            }
+        };
+
+        assert_eq!(quoted.to_string(), "impl Clone for Foo {fn clone (& self) -> Self {Self {name : self . name . clone () , id : self . id . clone () ,}}}");
+    }
+}


### PR DESCRIPTION
This PR implements bulitin macro `line!` and add basic infra-structure for other bulitin macros:

1. Extend `MacroDefId` to support builtin macros
2. Add a `quote!` macro for simple quasi quoting.

Note that for support others builtin macros, eager macro expansion have to be supported first, this PR not try to handle it. :)