### PR TITLE
Make ty and ty::primitives public.

### DIFF
--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -35,7 +35,7 @@ mod ids;
 mod adt;
 mod traits;
 mod type_alias;
-mod ty;
+pub mod ty;
 mod impl_block;
 mod expr;
 mod lang_item;

--- a/crates/ra_hir/src/ty.rs
+++ b/crates/ra_hir/src/ty.rs
@@ -2,7 +2,7 @@
 //! information and various assists.
 
 mod autoderef;
-pub(crate) mod primitive;
+pub mod primitive;
 #[cfg(test)]
 mod tests;
 pub(crate) mod traits;


### PR DESCRIPTION
Expose some HIR types to fix https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Fwg-rls-2.2E0/topic/Accessing.20ra_hir.3A.3Aty.3A.3Aprimitive.3A.3A*.20.3F 