### PR TITLE
Implement FromStr for enum Edition

### DIFF
--- a/crates/ra_db/src/fixture.rs
+++ b/crates/ra_db/src/fixture.rs
@@ -1,5 +1,6 @@
 //! FIXME: write short doc here
 
+use std::str::FromStr;
 use std::sync::Arc;
 
 use ra_cfg::CfgOptions;
@@ -164,7 +165,7 @@ fn parse_meta(meta: &str) -> ParsedMeta {
         match key {
             "crate" => krate = Some(value.to_string()),
             "deps" => deps = value.split(',').map(|it| it.to_string()).collect(),
-            "edition" => edition = Edition::from_string(&value),
+            "edition" => edition = Edition::from_str(&value).unwrap(),
             "cfg" => {
                 for key in value.split(',') {
                     match split1(key, '=') {

--- a/crates/ra_db/src/input.rs
+++ b/crates/ra_db/src/input.rs
@@ -13,7 +13,7 @@ use ra_syntax::SmolStr;
 use rustc_hash::FxHashSet;
 
 use crate::{RelativePath, RelativePathBuf};
-use std::{error::Error, str::FromStr};
+use std::str::FromStr;
 
 /// `FileId` is an integer which uniquely identifies a file. File paths are
 /// messy and system-dependent, so most of the code should work directly with

--- a/crates/ra_db/src/input.rs
+++ b/crates/ra_db/src/input.rs
@@ -13,7 +13,7 @@ use ra_syntax::SmolStr;
 use rustc_hash::FxHashSet;
 
 use crate::{RelativePath, RelativePathBuf};
-use std::str::FromStr;
+use std::{error::Error, str::FromStr};
 
 /// `FileId` is an integer which uniquely identifies a file. File paths are
 /// messy and system-dependent, so most of the code should work directly with
@@ -98,13 +98,18 @@ pub enum Edition {
     Edition2015,
 }
 
+#[derive(Debug)]
+pub struct ParseEditionError {
+    pub msg: String,
+}
+
 impl FromStr for Edition {
-    type Err = String;
+    type Err = ParseEditionError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "2015" => Ok(Edition::Edition2015),
             "2018" => Ok(Edition::Edition2018),
-            _ => Err(format! {"unknown edition: {}" , s}),
+            _ => Err(ParseEditionError { msg: format!("unknown edition: {}", s) }),
         }
     }
 }

--- a/crates/ra_db/src/input.rs
+++ b/crates/ra_db/src/input.rs
@@ -13,6 +13,7 @@ use ra_syntax::SmolStr;
 use rustc_hash::FxHashSet;
 
 use crate::{RelativePath, RelativePathBuf};
+use std::str::FromStr;
 
 /// `FileId` is an integer which uniquely identifies a file. File paths are
 /// messy and system-dependent, so most of the code should work directly with
@@ -97,12 +98,13 @@ pub enum Edition {
     Edition2015,
 }
 
-impl Edition {
-    //FIXME: replace with FromStr with proper error handling
-    pub fn from_string(s: &str) -> Edition {
+impl FromStr for Edition {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "2015" => Edition::Edition2015,
-            "2018" | _ => Edition::Edition2018,
+            "2015" => Ok(Edition::Edition2015),
+            "2018" => Ok(Edition::Edition2018),
+            _ => Err(format! {"unknown edition: {}" , s}),
         }
     }
 }

--- a/crates/ra_project_model/src/cargo_workspace.rs
+++ b/crates/ra_project_model/src/cargo_workspace.rs
@@ -1,6 +1,7 @@
 //! FIXME: write short doc here
 
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 
 use cargo_metadata::{CargoOpt, MetadataCommand};
 use ra_arena::{impl_arena_id, Arena, RawId};
@@ -141,12 +142,14 @@ impl CargoWorkspace {
 
         for meta_pkg in meta.packages {
             let is_member = ws_members.contains(&meta_pkg.id);
+            let name = meta_pkg.name;
             let pkg = packages.alloc(PackageData {
-                name: meta_pkg.name,
+                name: name.clone(),
                 manifest: meta_pkg.manifest_path.clone(),
                 targets: Vec::new(),
                 is_member,
-                edition: Edition::from_string(&meta_pkg.edition),
+                edition: Edition::from_str(&meta_pkg.edition)
+                    .unwrap_or_else(|e| panic!("unknown edition {} for package {:?}", e, &name)),
                 dependencies: Vec::new(),
                 features: Vec::new(),
             });


### PR DESCRIPTION
Just did this as I came across the comment in the code asking for implementing `std::str::FromStr` for `input::Edition`.
Not sure what was meant by "proper error handling" though, `panic!` with a descriptive message might not be it :sweat_smile: 