### PR TITLE
Remove owner from Body

### DIFF
--- a/crates/ra_hir/src/expr/lower.rs
+++ b/crates/ra_hir/src/expr/lower.rs
@@ -20,8 +20,8 @@ use ra_syntax::{
 use test_utils::tested_by;
 
 use crate::{
-    db::HirDatabase, AstId, DefWithBody, Either, HirFileId, MacroCallLoc, MacroFileKind,
-    Mutability, Path, Resolver, Source,
+    db::HirDatabase, AstId, Either, HirFileId, MacroCallLoc, MacroFileKind, Mutability, Path,
+    Resolver, Source,
 };
 
 use super::{
@@ -33,7 +33,6 @@ pub(super) fn lower(
     db: &impl HirDatabase,
     resolver: Resolver,
     file_id: HirFileId,
-    owner: DefWithBody,
     params: Option<ast::ParamList>,
     body: Option<ast::Expr>,
 ) -> (Body, BodySourceMap) {
@@ -44,7 +43,6 @@ pub(super) fn lower(
         current_file_id: file_id,
         source_map: BodySourceMap::default(),
         body: Body {
-            owner,
             exprs: Arena::default(),
             pats: Arena::default(),
             params: Vec::new(),

--- a/crates/ra_hir/src/source_binder.rs
+++ b/crates/ra_hir/src/source_binder.rs
@@ -150,7 +150,7 @@ impl SourceAnalyzer {
                 None => scope_for(&scopes, &source_map, &node),
                 Some(offset) => scope_for_offset(&scopes, &source_map, file_id.into(), offset),
             };
-            let resolver = expr::resolver_for_scope(def.body(db), db, scope);
+            let resolver = expr::resolver_for_scope(db, def, scope);
             SourceAnalyzer {
                 resolver,
                 body_owner: Some(def),

--- a/crates/ra_hir/src/ty/infer/expr.rs
+++ b/crates/ra_hir/src/ty/infer/expr.rs
@@ -130,10 +130,8 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
                     TypeCtor::FnPtr { num_args: sig_tys.len() as u16 - 1 },
                     Substs(sig_tys.into()),
                 );
-                let closure_ty = Ty::apply_one(
-                    TypeCtor::Closure { def: self.body.owner(), expr: tgt_expr },
-                    sig_ty,
-                );
+                let closure_ty =
+                    Ty::apply_one(TypeCtor::Closure { def: self.owner, expr: tgt_expr }, sig_ty);
 
                 // Eagerly try to relate the closure type with the expected
                 // type, otherwise we often won't have enough information to
@@ -184,7 +182,7 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
             }
             Expr::Path(p) => {
                 // FIXME this could be more efficient...
-                let resolver = expr::resolver_for_expr(self.body.clone(), self.db, tgt_expr);
+                let resolver = expr::resolver_for_expr(self.db, self.owner, tgt_expr);
                 self.infer_path(&resolver, p, tgt_expr.into()).unwrap_or(Ty::Unknown)
             }
             Expr::Continue => Ty::simple(TypeCtor::Never),


### PR DESCRIPTION
cc @flodiebold 

I do this so that it's easier to move lowering code to another crate (owner is the only thing that tethers Body to the rest of the code), but it's interesting that this is a net reduction of lines. I think this might be considered an evidence that it's a good idea to not add "parent pointers" / parent ids to data structures, and instead add them to `ctx` objects which are used when building data structures

bors r+