### PR TITLE
Handle `cargo watch` errors caused by `cargo-watch` itself

### DIFF
--- a/editors/code/src/commands/runnables.ts
+++ b/editors/code/src/commands/runnables.ts
@@ -161,7 +161,7 @@ export async function startCargoWatch(
 ): Promise<CargoWatchProvider | undefined> {
     const execPromise = util.promisify(child_process.exec);
 
-    const { stderr } = await execPromise('cargo watch --version').catch(e => e);
+    const { stderr, code = 0 } = await execPromise('cargo watch --version').catch(e => e);
 
     if (stderr.includes('no such subcommand: `watch`')) {
         const msg =
@@ -201,9 +201,9 @@ export async function startCargoWatch(
             );
             return;
         }
-    } else if (stderr !== '') {
+    } else if (code !== 0) {
         vscode.window.showErrorMessage(
-            `Couldn't run \`cargo watch\`: ${stderr}`
+            `\`cargo watch\` failed with ${code}: ${stderr}`
         );
         return;
     }

--- a/editors/code/src/commands/runnables.ts
+++ b/editors/code/src/commands/runnables.ts
@@ -161,7 +161,9 @@ export async function startCargoWatch(
 ): Promise<CargoWatchProvider | undefined> {
     const execPromise = util.promisify(child_process.exec);
 
-    const { stderr, code = 0 } = await execPromise('cargo watch --version').catch(e => e);
+    const { stderr, code = 0 } = await execPromise(
+        'cargo watch --version'
+    ).catch(e => e);
 
     if (stderr.includes('no such subcommand: `watch`')) {
         const msg =

--- a/editors/code/src/commands/runnables.ts
+++ b/editors/code/src/commands/runnables.ts
@@ -201,6 +201,11 @@ export async function startCargoWatch(
             );
             return;
         }
+    } else if (stderr !== '') {
+        vscode.window.showErrorMessage(
+            `Couldn't run \`cargo watch\`: ${stderr}`
+        );
+        return;
     }
 
     const provider = await registerCargoWatchProvider(context.subscriptions);


### PR DESCRIPTION
Currently, it silently fails when `cargo-watch` is installed but broken.

This PR handles missing cases and prompt the error message when failed.
