### PR TITLE
Increase the trait solver size

### DIFF
--- a/crates/ra_hir/src/ty/traits.rs
+++ b/crates/ra_hir/src/ty/traits.rs
@@ -53,7 +53,7 @@ impl TraitSolver {
 /// This controls the maximum size of types Chalk considers. If we set this too
 /// high, we can run into slow edge cases; if we set it too low, Chalk won't
 /// find some solutions.
-const CHALK_SOLVER_MAX_SIZE: usize = 4;
+const CHALK_SOLVER_MAX_SIZE: usize = 5;
 
 #[derive(Debug, Copy, Clone)]
 struct ChalkContext<'a, DB> {


### PR DESCRIPTION
This is a temporary fix for #2284 and #2052. Setting the chalk solver size to 5 is (apparently...) enough to fix the specific reproductions in https://github.com/matklad/rust-analyzer/commit/d907b00f440ca0a127e6975994a54391ce5a976d and https://github.com/rust-analyzer/rust-analyzer/issues/2284. 
It doesn't seem to cause noticeable performance issues.

Maybe the trait solver size should be configurable? 🤔