### PR TITLE
Remove the custom impl of AttrsOwner for ImplItem

### DIFF
--- a/crates/ra_syntax/src/ast/extensions.rs
+++ b/crates/ra_syntax/src/ast/extensions.rs
@@ -2,7 +2,7 @@
 //! Extensions for various expressions live in a sibling `expr_extensions` module.
 
 use crate::{
-    ast::{self, child_opt, children, AstChildren, AstNode, AttrInput, SyntaxNode},
+    ast::{self, child_opt, children, AstNode, AttrInput, SyntaxNode},
     SmolStr, SyntaxElement,
     SyntaxKind::*,
     SyntaxToken, T,
@@ -173,16 +173,6 @@ impl ast::ImplBlock {
 
     pub fn is_negative(&self) -> bool {
         self.syntax().children_with_tokens().any(|t| t.kind() == T![!])
-    }
-}
-
-impl ast::AttrsOwner for ast::ImplItem {
-    fn attrs(&self) -> AstChildren<ast::Attr> {
-        match self {
-            ast::ImplItem::FnDef(it) => it.attrs(),
-            ast::ImplItem::TypeAliasDef(it) => it.attrs(),
-            ast::ImplItem::ConstDef(it) => it.attrs(),
-        }
     }
 }
 

--- a/crates/ra_syntax/src/ast/generated.rs
+++ b/crates/ra_syntax/src/ast/generated.rs
@@ -1298,6 +1298,7 @@ impl AstNode for ImplItem {
         }
     }
 }
+impl ast::AttrsOwner for ImplItem {}
 impl ImplItem {}
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ImplTraitType {

--- a/crates/ra_syntax/src/grammar.ron
+++ b/crates/ra_syntax/src/grammar.ron
@@ -401,7 +401,8 @@ Grammar(
             traits: ["AttrsOwner"]
         ),
         "ImplItem": (
-            enum: ["FnDef", "TypeAliasDef", "ConstDef"]
+            enum: ["FnDef", "TypeAliasDef", "ConstDef"],
+            traits: ["AttrsOwner"]
         ),
 
         "TupleExpr": (


### PR DESCRIPTION
The default impl should have the same behaviour, and it can be generated by codegen.
See also `ModuleItem` and `NominalDef`.

Also see https://github.com/rust-analyzer/rust-analyzer/commit/5dbbfda34ae423229487595fd0ae9e727ae42906#r36011245