### PR TITLE
fix 2190; add test for "replace if let with match"

### DIFF
--- a/crates/ra_assists/src/assists/replace_if_let_with_match.rs
+++ b/crates/ra_assists/src/assists/replace_if_let_with_match.rs
@@ -66,8 +66,8 @@ fn build_match_expr(
 
 fn format_arm(block: &ast::BlockExpr) -> String {
     match extract_trivial_expression(block) {
-        None => block.syntax().text().to_string(),
-        Some(e) => format!("{},", e.syntax().text()),
+        Some(e) if !e.syntax().text().contains_char('\n') => format!("{},", e.syntax().text()),
+        _ => block.syntax().text().to_string(),
     }
 }
 
@@ -97,6 +97,34 @@ impl VariantData {
             VariantData::Struct(..) => true,
             _ => false,
         }
+    }
+}           ",
+        )
+    }
+
+    #[test]
+    fn test_replace_if_let_with_match_doesnt_unwrap_multiline_expressions() {
+        check_assist(
+            replace_if_let_with_match,
+            "
+fn foo() {
+    if <|>let VariantData::Struct(..) = a {
+        bar(
+            123
+        )
+    } else {
+        false
+    }
+}           ",
+            "
+fn foo() {
+    <|>match a {
+        VariantData::Struct(..) => {
+            bar(
+                123
+            )
+        }
+        _ => false,
     }
 }           ",
         )

--- a/crates/ra_fmt/src/lib.rs
+++ b/crates/ra_fmt/src/lib.rs
@@ -38,9 +38,6 @@ fn prev_tokens(token: SyntaxToken) -> impl Iterator<Item = SyntaxToken> {
 pub fn extract_trivial_expression(expr: &ast::BlockExpr) -> Option<ast::Expr> {
     let block = expr.block()?;
     let expr = block.expr()?;
-    if expr.syntax().text().contains_char('\n') {
-        return None;
-    }
     let non_trivial_children = block.syntax().children().filter(|it| match it.kind() {
         WHITESPACE | T!['{'] | T!['}'] => false,
         _ => it != expr.syntax(),

--- a/crates/ra_ide_api/src/join_lines.rs
+++ b/crates/ra_ide_api/src/join_lines.rs
@@ -244,6 +244,34 @@ fn foo(e: Result<U, V>) {
     }
 
     #[test]
+    fn join_lines_multiline_in_block() {
+        check_join_lines(
+            r"
+fn foo() {
+    match ty {
+        <|> Some(ty) => {
+            match ty {
+                _ => false,
+            }
+        }
+        _ => true,
+    }
+}
+",
+            r"
+fn foo() {
+    match ty {
+        <|> Some(ty) => match ty {
+                _ => false,
+            },
+        _ => true,
+    }
+}
+",
+        );
+    }
+
+    #[test]
     fn join_lines_keeps_comma_for_block_in_match_arm() {
         // We already have a comma
         check_join_lines(


### PR DESCRIPTION
Fixes #2190.

Check that the expression doesn't contain newlines only for "replace if let with match". For "join lines", enclosing blocks for multiline expressions should be removed. 