### PR TITLE
Use proper MacroFileKind in `SourceAnalyzer`

### DIFF
--- a/crates/ra_hir_expand/src/db.rs
+++ b/crates/ra_hir_expand/src/db.rs
@@ -151,6 +151,7 @@ pub(crate) fn parse_macro(
     let fragment_kind = match macro_file.macro_file_kind {
         MacroFileKind::Items => FragmentKind::Items,
         MacroFileKind::Expr => FragmentKind::Expr,
+        MacroFileKind::Statements => FragmentKind::Statements,
     };
     let (parse, rev_token_map) = mbe::token_tree_to_syntax_node(&tt, fragment_kind).ok()?;
     Some((parse, Arc::new(rev_token_map)))

--- a/crates/ra_hir_expand/src/lib.rs
+++ b/crates/ra_hir_expand/src/lib.rs
@@ -109,6 +109,7 @@ pub struct MacroFile {
 pub enum MacroFileKind {
     Items,
     Expr,
+    Statements,
 }
 
 /// `MacroCallId` identifies a particular macro invocation, like


### PR DESCRIPTION
* Add `MacroFileKind::Statements`
* Add `to_macro_file_kind` in `source_binding.rs` to set a proper `MacroFileKind` when expanding a macro. 
* Add a test for trying expanding `match_ast` which is not correct before this PR.
* Fix some spacing issues in `insert_whitespaces`