### PR TITLE
Add note about neovim's built in language server

### DIFF
--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -133,7 +133,7 @@ to load path and require it in `init.el`
 ## Vim and NeoVim
 
 Neovim 0.5 has a built in language server. For a quick start configuration of
-rust-analyzer, use [neovim/nvim-lsp](https://github.com/neovim/nvim-lsp).
+rust-analyzer, use [neovim/nvim-lsp](https://github.com/neovim/nvim-lsp#rust_analyzer).
 Once `neovim/nvim-lsp` is installed, you can use `call nvim_lsp#setup("rust_analyzer", {})`
 or `lua require'nvim_lsp'.rust_analyzer.setup({})` to quickly get set up.
 

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -132,6 +132,11 @@ to load path and require it in `init.el`
 
 ## Vim and NeoVim
 
+Neovim 0.5 has a built in language server. For a quick start configuration of
+rust-analyzer, use [neovim/nvim-lsp](https://github.com/neovim/nvim-lsp).
+Once `neovim/nvim-lsp` is installed, you can use `call nvim_lsp#setup("rust_analyzer", {})`
+or `lua require'nvim_lsp'.rust_analyzer.setup({})` to quickly get set up.
+
 * Install coc.nvim by following the instructions at [coc.nvim]
   - You will need nodejs installed.
   - You may want to include some of the sample vim configurations [from here][coc-vim-conf]


### PR DESCRIPTION
I implemented a builtin language server client (`:h lsp.txt`) for neovim and it's been in master since 2019-11-13. We built https://github.com/neovim/nvim-lsp to contain easy configuration settings for servers which we hope to be a database that can be referenced for other editors/3rd party users as well.

Support will be merged very soon https://github.com/neovim/nvim-lsp/pull/43.