### PR TITLE
Add proc-macro crate type handling

### DIFF
--- a/crates/ra_project_model/src/lib.rs
+++ b/crates/ra_project_model/src/lib.rs
@@ -210,6 +210,8 @@ impl ProjectWorkspace {
 
                 let libcore = sysroot.core().and_then(|it| sysroot_crates.get(&it).copied());
                 let libstd = sysroot.std().and_then(|it| sysroot_crates.get(&it).copied());
+                let libproc_macro =
+                    sysroot.proc_macro().and_then(|it| sysroot_crates.get(&it).copied());
 
                 let mut pkg_to_lib_crate = FxHashMap::default();
                 let mut pkg_crates = FxHashMap::default();
@@ -236,6 +238,21 @@ impl ProjectWorkspace {
                                 lib_tgt = Some(crate_id);
                                 pkg_to_lib_crate.insert(pkg, crate_id);
                             }
+                            if tgt.is_proc_macro(&cargo) {
+                                if let Some(proc_macro) = libproc_macro {
+                                    if let Err(_) = crate_graph.add_dep(
+                                        crate_id,
+                                        "proc_macro".into(),
+                                        proc_macro,
+                                    ) {
+                                        log::error!(
+                                            "cyclic dependency on proc_macro for {}",
+                                            pkg.name(&cargo)
+                                        )
+                                    }
+                                }
+                            }
+
                             pkg_crates.entry(pkg).or_insert_with(Vec::new).push(crate_id);
                         }
                     }

--- a/crates/ra_project_model/src/sysroot.rs
+++ b/crates/ra_project_model/src/sysroot.rs
@@ -35,6 +35,10 @@ impl Sysroot {
         self.by_name("std")
     }
 
+    pub fn proc_macro(&self) -> Option<SysrootCrate> {
+        self.by_name("proc_macro")
+    }
+
     pub fn crates<'a>(&'a self) -> impl Iterator<Item = SysrootCrate> + ExactSizeIterator + 'a {
         self.crates.iter().map(|(id, _data)| id)
     }
@@ -70,7 +74,7 @@ impl Sysroot {
             }
         }
         if let Some(alloc) = sysroot.by_name("alloc") {
-            if let Some(core) = sysroot.by_name("core") {
+            if let Some(core) = sysroot.core() {
                 sysroot.crates[alloc].deps.push(core);
             }
         }


### PR DESCRIPTION
Resolves the libproc_macro crate in crates that are the proc-macro type.
This doesn't seem the ideal implementation though, since the compiler still requires you to write `extern crate proc_macro;` (even in 2018 edition).