### PR TITLE
Add alloc to the crate graph

### DIFF
--- a/crates/ra_project_model/src/lib.rs
+++ b/crates/ra_project_model/src/lib.rs
@@ -209,6 +209,7 @@ impl ProjectWorkspace {
                 }
 
                 let libcore = sysroot.core().and_then(|it| sysroot_crates.get(&it).copied());
+                let liballoc = sysroot.alloc().and_then(|it| sysroot_crates.get(&it).copied());
                 let libstd = sysroot.std().and_then(|it| sysroot_crates.get(&it).copied());
 
                 let mut pkg_to_lib_crate = FxHashMap::default();
@@ -259,6 +260,11 @@ impl ProjectWorkspace {
                         if let Some(core) = libcore {
                             if let Err(_) = crate_graph.add_dep(from, "core".into(), core) {
                                 log::error!("cyclic dependency on core for {}", pkg.name(&cargo))
+                            }
+                        }
+                        if let Some(alloc) = liballoc {
+                            if let Err(_) = crate_graph.add_dep(from, "alloc".into(), alloc) {
+                                log::error!("cyclic dependency on alloc for {}", pkg.name(&cargo))
                             }
                         }
                         if let Some(std) = libstd {

--- a/crates/ra_project_model/src/sysroot.rs
+++ b/crates/ra_project_model/src/sysroot.rs
@@ -31,6 +31,10 @@ impl Sysroot {
         self.by_name("core")
     }
 
+    pub fn alloc(&self) -> Option<SysrootCrate> {
+        self.by_name("alloc")
+    }
+
     pub fn std(&self) -> Option<SysrootCrate> {
         self.by_name("std")
     }


### PR DESCRIPTION
`alloc` has been added to the crate graph.

Completions work, but they are available even when the user has **not** declared an `extern crate alloc`. Is this the correct approach?

Fixes #2376.