### PR TITLE
Show missing struct fields in the error message

### DIFF
--- a/crates/ra_hir/src/diagnostics.rs
+++ b/crates/ra_hir/src/diagnostics.rs
@@ -39,7 +39,12 @@ pub struct MissingFields {
 
 impl Diagnostic for MissingFields {
     fn message(&self) -> String {
-        "fill structure fields".to_string()
+        use std::fmt::Write;
+        let mut message = String::from("Missing structure fields:\n");
+        for field in &self.missed_fields {
+            write!(message, "- {}\n", field).unwrap();
+        }
+        message
     }
     fn source(&self) -> Source<SyntaxNodePtr> {
         Source { file_id: self.file, value: self.field_list.into() }

--- a/crates/ra_hir/src/ty/tests.rs
+++ b/crates/ra_hir/src/ty/tests.rs
@@ -4832,7 +4832,8 @@ fn no_such_field_diagnostics() {
 
     assert_snapshot!(diagnostics, @r###"
     "baz: 62": no such field
-    "{\n            foo: 92,\n            baz: 62,\n        }": fill structure fields
+    "{\n            foo: 92,\n            baz: 62,\n        }": Missing structure fields:
+    - bar
     "###
     );
 }


### PR DESCRIPTION
This provides the most interesting information about the "missing structure fields" error directly to the user.