### PR TITLE
Switch to variant-granularity field type inference

### DIFF
--- a/crates/ra_arena/src/lib.rs
+++ b/crates/ra_arena/src/lib.rs
@@ -85,7 +85,7 @@ impl<ID: ArenaId, T> Arena<ID, T> {
         self.data.push(value);
         ID::from_raw(id)
     }
-    pub fn iter(&self) -> impl Iterator<Item = (ID, &T)> + ExactSizeIterator {
+    pub fn iter(&self) -> impl Iterator<Item = (ID, &T)> + ExactSizeIterator + DoubleEndedIterator {
         self.data.iter().enumerate().map(|(idx, value)| (ID::from_raw(RawId(idx as u32)), value))
     }
 }

--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -305,7 +305,7 @@ impl StructField {
     }
 
     pub fn ty(&self, db: &impl HirDatabase) -> Ty {
-        db.type_for_field(*self)
+        db.field_types(self.parent.into())[self.id].clone()
     }
 
     pub fn parent_def(&self, _db: &impl HirDatabase) -> VariantDef {

--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use ra_arena::map::ArenaMap;
 use ra_db::salsa;
 
 use crate::{
@@ -11,15 +12,19 @@ use crate::{
         CallableDef, FnSig, GenericPredicate, InferenceResult, Namespace, Substs, Ty, TypableDef,
         TypeCtor,
     },
-    Crate, DefWithBody, GenericDef, ImplBlock, StructField, Trait,
+    Crate, DefWithBody, GenericDef, ImplBlock, Trait,
 };
 
-pub use hir_def::db::{
-    BodyQuery, BodyWithSourceMapQuery, ConstDataQuery, CrateDefMapQuery, CrateLangItemsQuery,
-    DefDatabase, DefDatabaseStorage, DocumentationQuery, EnumDataQuery, ExprScopesQuery,
-    FunctionDataQuery, GenericParamsQuery, ImplDataQuery, InternDatabase, InternDatabaseStorage,
-    LangItemQuery, ModuleLangItemsQuery, RawItemsQuery, RawItemsWithSourceMapQuery,
-    StaticDataQuery, StructDataQuery, TraitDataQuery, TypeAliasDataQuery,
+pub use hir_def::{
+    db::{
+        BodyQuery, BodyWithSourceMapQuery, ConstDataQuery, CrateDefMapQuery, CrateLangItemsQuery,
+        DefDatabase, DefDatabaseStorage, DocumentationQuery, EnumDataQuery, ExprScopesQuery,
+        FunctionDataQuery, GenericParamsQuery, ImplDataQuery, InternDatabase,
+        InternDatabaseStorage, LangItemQuery, ModuleLangItemsQuery, RawItemsQuery,
+        RawItemsWithSourceMapQuery, StaticDataQuery, StructDataQuery, TraitDataQuery,
+        TypeAliasDataQuery,
+    },
+    LocalStructFieldId, VariantId,
 };
 pub use hir_expand::db::{
     AstDatabase, AstDatabaseStorage, AstIdMapQuery, MacroArgQuery, MacroDefQuery, MacroExpandQuery,
@@ -35,8 +40,8 @@ pub trait HirDatabase: DefDatabase {
     #[salsa::invoke(crate::ty::type_for_def)]
     fn type_for_def(&self, def: TypableDef, ns: Namespace) -> Ty;
 
-    #[salsa::invoke(crate::ty::type_for_field)]
-    fn type_for_field(&self, field: StructField) -> Ty;
+    #[salsa::invoke(crate::ty::field_types_query)]
+    fn field_types(&self, var: VariantId) -> Arc<ArenaMap<LocalStructFieldId, Ty>>;
 
     #[salsa::invoke(crate::ty::callable_item_sig)]
     fn callable_item_signature(&self, def: CallableDef) -> FnSig;

--- a/crates/ra_hir/src/ty.rs
+++ b/crates/ra_hir/src/ty.rs
@@ -30,8 +30,9 @@ pub(crate) use autoderef::autoderef;
 pub(crate) use infer::{infer_query, InferTy, InferenceResult};
 pub use lower::CallableDef;
 pub(crate) use lower::{
-    callable_item_sig, generic_defaults_query, generic_predicates_for_param_query,
-    generic_predicates_query, type_for_def, type_for_field, Namespace, TypableDef,
+    callable_item_sig, field_types_query, generic_defaults_query,
+    generic_predicates_for_param_query, generic_predicates_query, type_for_def, Namespace,
+    TypableDef,
 };
 pub(crate) use traits::{InEnvironment, Obligation, ProjectionPredicate, TraitEnvironment};
 

--- a/crates/ra_hir/src/ty/infer/expr.rs
+++ b/crates/ra_hir/src/ty/infer/expr.rs
@@ -214,6 +214,8 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
                 self.unify(&ty, &expected.ty);
 
                 let substs = ty.substs().unwrap_or_else(Substs::empty);
+                let field_types =
+                    def_id.map(|it| self.db.field_types(it.into())).unwrap_or_default();
                 for (field_idx, field) in fields.iter().enumerate() {
                     let field_def = def_id.and_then(|it| match it.field(self.db, &field.name) {
                         Some(field) => Some(field),
@@ -228,8 +230,9 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
                     if let Some(field_def) = field_def {
                         self.result.record_field_resolutions.insert(field.expr, field_def);
                     }
-                    let field_ty =
-                        field_def.map_or(Ty::Unknown, |field| field.ty(self.db)).subst(&substs);
+                    let field_ty = field_def
+                        .map_or(Ty::Unknown, |it| field_types[it.id].clone())
+                        .subst(&substs);
                     self.infer_expr_coerce(field.expr, &Expectation::has_type(field_ty));
                 }
                 if let Some(expr) = spread {
@@ -252,7 +255,9 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
                             .and_then(|idx| a_ty.parameters.0.get(idx).cloned()),
                         TypeCtor::Adt(Adt::Struct(s)) => s.field(self.db, name).map(|field| {
                             self.write_field_resolution(tgt_expr, field);
-                            field.ty(self.db).subst(&a_ty.parameters)
+                            self.db.field_types(s.id.into())[field.id]
+                                .clone()
+                                .subst(&a_ty.parameters)
                         }),
                         _ => None,
                     },

--- a/crates/ra_hir_def/src/lib.rs
+++ b/crates/ra_hir_def/src/lib.rs
@@ -192,12 +192,6 @@ pub struct LocalEnumVariantId(RawId);
 impl_arena_id!(LocalEnumVariantId);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum VariantId {
-    EnumVariantId(EnumVariantId),
-    StructId(StructId),
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct StructFieldId {
     pub parent: VariantId,
     pub local_id: LocalStructFieldId,
@@ -436,6 +430,13 @@ impl_froms!(
     MacroDefId,
     ImplId
 );
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum VariantId {
+    EnumVariantId(EnumVariantId),
+    StructId(StructId),
+}
+impl_froms!(VariantId: EnumVariantId, StructId);
 
 trait Intern {
     type ID;

--- a/crates/ra_ide_api/src/change.rs
+++ b/crates/ra_ide_api/src/change.rs
@@ -324,7 +324,7 @@ impl RootDatabase {
             hir::db::ExprScopesQuery
             hir::db::InferQuery
             hir::db::TypeForDefQuery
-            hir::db::TypeForFieldQuery
+            hir::db::FieldTypesQuery
             hir::db::CallableItemSignatureQuery
             hir::db::GenericPredicatesQuery
             hir::db::GenericDefaultsQuery


### PR DESCRIPTION
r? @flodiebold 

Previously, we had a `ty` query for each field. This PR switcthes to a query per struct, which returns an `ArenaMap` with `Ty`s. 

I don't know which approach is better. What is bugging me about the original approach is that, if we do all queries on the "leaf" defs, in practice we get a ton of queries which repeatedly reach into the parent definition to compute module, resolver, etc. This *seems* wasteful (but I don't think this is really what causes any perf problems for us). 

At the same time, I've been looking at Kotlin, and they seem to use the general pattern of analyzing the *parent* definition, and storing info about children into a `BindingContext`. 

I don't really which way is preferable. I think I want to try this approach, where query granularity generally mirrors the data granularity. The primary motivation for me here is probably just hope that we can avoid adding a ton of helpers to a `StructField`, and maybe in general avoid the need to switch to a global `StructField`, using `LocalStructFieldId` most of the time internally. 

For external API (ie, for `ra_ide_api`), I think we should continue with fine-grained `StructField::ty` approach, which internally fetches the table for the whole struct and indexes into it.

In terms of actual memory savings, the results are as follows:

```
This PR:
   142kb FieldTypesQuery (deps)
    38kb FieldTypesQuery

Status Quo:
   208kb TypeForFieldQuery (deps)
    18kb TypeForFieldQuery
```

Note how the table itself occupies more than twice as much space! I don't have an explanation for this: a plausible hypothesis is that single-field structs are very common and for them the table is a pessimisation. 

THere's noticiable wallclock time difference.