### PR TITLE
WIP: introduce hir::Type

### DIFF
--- a/crates/ra_assists/src/assists/add_explicit_type.rs
+++ b/crates/ra_assists/src/assists/add_explicit_type.rs
@@ -1,4 +1,4 @@
-use hir::{db::HirDatabase, HirDisplay, Ty};
+use hir::{db::HirDatabase, HirDisplay};
 use ra_syntax::{
     ast::{self, AstNode, LetStmt, NameOwner},
     T,
@@ -43,7 +43,7 @@ pub(crate) fn add_explicit_type(ctx: AssistCtx<impl HirDatabase>) -> Option<Assi
     let analyzer = ctx.source_analyzer(stmt.syntax(), None);
     let ty = analyzer.type_of(db, &expr)?;
     // Assist not applicable if the type is unknown
-    if is_unknown(&ty) {
+    if ty.contains_unknown() {
         return None;
     }
 
@@ -51,15 +51,6 @@ pub(crate) fn add_explicit_type(ctx: AssistCtx<impl HirDatabase>) -> Option<Assi
         edit.target(pat_range);
         edit.insert(name_range.end(), format!(": {}", ty.display(db)));
     })
-}
-
-/// Returns true if any type parameter is unknown
-fn is_unknown(ty: &Ty) -> bool {
-    match ty {
-        Ty::Unknown => true,
-        Ty::Apply(a_ty) => a_ty.parameters.iter().any(is_unknown),
-        _ => false,
-    }
 }
 
 #[cfg(test)]

--- a/crates/ra_assists/src/assists/fill_match_arms.rs
+++ b/crates/ra_assists/src/assists/fill_match_arms.rs
@@ -83,10 +83,11 @@ fn resolve_enum_def(
 ) -> Option<ast::EnumDef> {
     let expr_ty = analyzer.type_of(db, &expr)?;
 
-    analyzer.autoderef(db, expr_ty).find_map(|ty| match ty.as_adt() {
-        Some((Adt::Enum(e), _)) => Some(e.source(db).value),
+    let res = expr_ty.autoderef(db).find_map(|ty| match ty.as_adt() {
+        Some(Adt::Enum(e)) => Some(e.source(db).value),
         _ => None,
-    })
+    });
+    res
 }
 
 fn build_pat(var: ast::EnumVariant) -> Option<ast::Pat> {

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -51,7 +51,7 @@ pub use crate::{
         src::HasSource, Adt, AssocItem, AttrDef, Const, Container, Crate, CrateDependency,
         DefWithBody, Docs, Enum, EnumVariant, FieldSource, Function, GenericDef, GenericParam,
         HasAttrs, ImplBlock, Import, Local, MacroDef, Module, ModuleDef, ModuleSource, ScopeDef,
-        Static, Struct, StructField, Trait, TypeAlias, Union, VariantDef,
+        Static, Struct, StructField, Trait, Type, TypeAlias, Union, VariantDef,
     },
     expr::ExprScopes,
     from_source::FromSource,

--- a/crates/ra_hir_def/src/lib.rs
+++ b/crates/ra_hir_def/src/lib.rs
@@ -489,6 +489,16 @@ impl HasModule for AdtId {
     }
 }
 
+impl HasModule for DefWithBodyId {
+    fn module(&self, db: &impl db::DefDatabase) -> ModuleId {
+        match self {
+            DefWithBodyId::FunctionId(it) => it.lookup(db).module(db),
+            DefWithBodyId::StaticId(it) => it.lookup(db).module(db),
+            DefWithBodyId::ConstId(it) => it.lookup(db).module(db),
+        }
+    }
+}
+
 impl HasModule for StaticLoc {
     fn module(&self, _db: &impl db::DefDatabase) -> ModuleId {
         self.container

--- a/crates/ra_ide_api/src/call_info.rs
+++ b/crates/ra_ide_api/src/call_info.rs
@@ -26,8 +26,8 @@ pub(crate) fn call_info(db: &RootDatabase, position: FilePosition) -> Option<Cal
     );
     let (mut call_info, has_self) = match &calling_node {
         FnCallNode::CallExpr(expr) => {
-            //FIXME: don't poke into Ty
-            let (callable_def, _subst) = analyzer.type_of(db, &expr.expr()?)?.as_callable()?;
+            //FIXME: Type::as_callable is broken
+            let callable_def = analyzer.type_of(db, &expr.expr()?)?.as_callable()?;
             match callable_def {
                 hir::CallableDef::FunctionId(it) => {
                     let fn_def = it.into();

--- a/crates/ra_ide_api/src/completion/complete_record_literal.rs
+++ b/crates/ra_ide_api/src/completion/complete_record_literal.rs
@@ -1,7 +1,5 @@
 //! FIXME: write short doc here
 
-use hir::Substs;
-
 use crate::completion::{CompletionContext, Completions};
 
 /// Complete fields in fields literals.
@@ -15,10 +13,9 @@ pub(super) fn complete_record_literal(acc: &mut Completions, ctx: &CompletionCon
         Some(it) => it,
         _ => return,
     };
-    let substs = &ty.substs().unwrap_or_else(Substs::empty);
 
-    for field in variant.fields(ctx.db) {
-        acc.add_field(ctx, field, substs);
+    for (field, field_ty) in ty.variant_fields(ctx.db, variant) {
+        acc.add_field(ctx, field, &field_ty);
     }
 }
 

--- a/crates/ra_ide_api/src/completion/complete_record_pattern.rs
+++ b/crates/ra_ide_api/src/completion/complete_record_pattern.rs
@@ -1,7 +1,5 @@
 //! FIXME: write short doc here
 
-use hir::Substs;
-
 use crate::completion::{CompletionContext, Completions};
 
 pub(super) fn complete_record_pattern(acc: &mut Completions, ctx: &CompletionContext) {
@@ -14,10 +12,9 @@ pub(super) fn complete_record_pattern(acc: &mut Completions, ctx: &CompletionCon
         Some(it) => it,
         _ => return,
     };
-    let substs = &ty.substs().unwrap_or_else(Substs::empty);
 
-    for field in variant.fields(ctx.db) {
-        acc.add_field(ctx, field, substs);
+    for (field, field_ty) in ty.variant_fields(ctx.db, variant) {
+        acc.add_field(ctx, field, &field_ty);
     }
 }
 

--- a/crates/ra_ide_api/src/goto_type_definition.rs
+++ b/crates/ra_ide_api/src/goto_type_definition.rs
@@ -24,7 +24,7 @@ pub(crate) fn goto_type_definition(
 
     let analyzer = hir::SourceAnalyzer::new(db, token.with_value(&node), None);
 
-    let ty: hir::Ty = if let Some(ty) =
+    let ty: hir::Type = if let Some(ty) =
         ast::Expr::cast(node.clone()).and_then(|e| analyzer.type_of(db, &e))
     {
         ty
@@ -35,7 +35,7 @@ pub(crate) fn goto_type_definition(
         return None;
     };
 
-    let adt_def = analyzer.autoderef(db, ty).find_map(|ty| ty.as_adt().map(|adt| adt.0))?;
+    let adt_def = ty.autoderef(db).find_map(|ty| ty.as_adt())?;
 
     let nav = adt_def.to_nav(db);
     Some(RangeInfo::new(node.text_range(), vec![nav]))

--- a/crates/ra_ide_api/src/syntax_highlighting.rs
+++ b/crates/ra_ide_api/src/syntax_highlighting.rs
@@ -2,7 +2,7 @@
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use hir::{Mutability, Name, Source};
+use hir::{Name, Source};
 use ra_db::SourceDatabase;
 use ra_prof::profile;
 use ra_syntax::{ast, AstNode, Direction, SyntaxElement, SyntaxKind, SyntaxKind::*, TextRange, T};
@@ -230,11 +230,10 @@ fn highlight_name(db: &RootDatabase, name_kind: NameKind) -> &'static str {
         Local(local) => {
             if local.is_mut(db) {
                 "variable.mut"
+            } else if local.ty(db).is_mutable_reference() {
+                "variable.mut"
             } else {
-                match local.ty(db).as_reference() {
-                    Some((_, Mutability::Mut)) => "variable.mut",
-                    _ => "variable",
-                }
+                "variable"
             }
         }
     }


### PR DESCRIPTION
This introduces `hir::Type` wrapper over `hir::Ty`, with two purposes:

* bind `Ty` and it's corresponding environment
  * Am I correct that `Ty` without an env doesn't make much sense, because the meaning of type parameters is unclear
  * Am I correct that we can safely re-use the same environment for all types derived from the given type? 
* hide representation defails of `Ty`. Specifically, I want to change `Ty::Adt` to use `hir_def::AdtId` instead of `hir::Adt`, but IDE doesn't know about underlying IDs. More generally, I feel like IDE shouldn't know that `Ty` is enum.

@flodiebold what do you think about this?