### PR TITLE
Use dedicated type for missing HIR nodes

### DIFF
--- a/crates/ra_hir_def/src/body.rs
+++ b/crates/ra_hir_def/src/body.rs
@@ -13,7 +13,7 @@ use rustc_hash::FxHashMap;
 
 use crate::{
     db::DefDatabase,
-    expr::{Expr, ExprId, Pat, PatId},
+    expr::{Expr, ExprId, ExprIdOpt, Pat, PatId, PatIdOpt},
     nameres::{BuiltinShadowMode, CrateDefMap},
     path::Path,
     src::HasSource,
@@ -112,9 +112,9 @@ pub struct Body {
     ///
     /// If this `Body` is for the body of a constant, this will just be
     /// empty.
-    pub params: Vec<PatId>,
+    pub params: Vec<PatIdOpt>,
     /// The `ExprId` of the actual body expression.
-    pub body_expr: ExprId,
+    pub body_expr: ExprIdOpt,
 }
 
 pub type ExprPtr = Either<AstPtr<ast::Expr>, AstPtr<ast::RecordField>>;

--- a/crates/ra_hir_def/src/body/lower.rs
+++ b/crates/ra_hir_def/src/body/lower.rs
@@ -105,7 +105,11 @@ where
         let id = self.body.exprs.alloc(expr);
         Ok(id)
     }
-    fn alloc_expr_field_shorthand(&mut self, expr: Expr, ptr: AstPtr<ast::RecordField>) -> ExprIdOpt {
+    fn alloc_expr_field_shorthand(
+        &mut self,
+        expr: Expr,
+        ptr: AstPtr<ast::RecordField>,
+    ) -> ExprIdOpt {
         let ptr = Either::Right(ptr);
         let id = self.body.exprs.alloc(expr);
         let src = self.expander.to_source(ptr);

--- a/crates/ra_hir_ty/src/expr.rs
+++ b/crates/ra_hir_ty/src/expr.rs
@@ -24,8 +24,9 @@ pub use hir_def::{
         Body, BodySourceMap, ExprPtr, ExprSource, PatPtr, PatSource,
     },
     expr::{
-        ArithOp, Array, BinaryOp, BindingAnnotation, CmpOp, Expr, ExprId, ExprIdOpt, Literal, LogicOp,
-        MatchArm, Ordering, Pat, PatId, PatIdOpt, RecordFieldPat, RecordLitField, Statement, UnaryOp,
+        ArithOp, Array, BinaryOp, BindingAnnotation, CmpOp, Expr, ExprId, ExprIdOpt, Literal,
+        LogicOp, MatchArm, Ordering, Pat, PatId, PatIdOpt, RecordFieldPat, RecordLitField,
+        Statement, UnaryOp,
     },
 };
 

--- a/crates/ra_hir_ty/src/infer/pat.rs
+++ b/crates/ra_hir_ty/src/infer/pat.rs
@@ -85,7 +85,7 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
             let ty = self.table.new_type_var();
             self.unify(&ty, expected);
             let ty = self.resolve_ty_as_possible(ty);
-            return ty
+            return ty;
         };
 
         let body = Arc::clone(&self.body); // avoid borrow checker problem

--- a/crates/ra_hir_ty/src/infer/pat.rs
+++ b/crates/ra_hir_ty/src/infer/pat.rs
@@ -82,10 +82,7 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
         let pat = if let Ok(pat) = pat {
             pat
         } else {
-            let ty = self.table.new_type_var();
-            self.unify(&ty, expected);
-            let ty = self.resolve_ty_as_possible(ty);
-            return ty;
+            return expected.clone();
         };
 
         let body = Arc::clone(&self.body); // avoid borrow checker problem


### PR DESCRIPTION
As we discussed, I have a prototype implementation to replace missing HIR nodes by a `Result<ExprId, MissingNode>`.

I had trouble pushing the change into ra_hir typing. Please tell me if I made a mistake.

Next stage is to leverage this change to make the HIR->AST map infaillible. I will do it in a further PR to avoid too many rebases.