### PR TITLE
Make `SourceMap` infaillible

### DIFF
--- a/crates/ra_cli/src/analysis_stats.rs
+++ b/crates/ra_cli/src/analysis_stats.rs
@@ -123,7 +123,7 @@ pub fn run(
                 num_type_mismatches += 1;
                 if verbosity.is_verbose() {
                     let src = f.body_source_map(db).expr_syntax(expr_id);
-                    if let Some(src) = src {
+                    if let Some(src) = src.a() {
                         // FIXME: it might be nice to have a function (on Analysis?) that goes from Source<T> -> (LineCol, LineCol) directly
                         let original_file = src.file_id.original_file(db);
                         let path = db.file_relative_path(original_file);

--- a/crates/ra_cli/src/analysis_stats.rs
+++ b/crates/ra_cli/src/analysis_stats.rs
@@ -128,10 +128,7 @@ pub fn run(
                         let original_file = src.file_id.original_file(db);
                         let path = db.file_relative_path(original_file);
                         let line_index = host.analysis().file_line_index(original_file).unwrap();
-                        let text_range = src.value.either(
-                            |it| it.syntax_node_ptr().range(),
-                            |it| it.syntax_node_ptr().range(),
-                        );
+                        let text_range = src.value.range();
                         let (start, end) = (
                             line_index.line_col(text_range.start()),
                             line_index.line_col(text_range.end()),

--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -30,7 +30,7 @@ use crate::{
     db::{DefDatabase, HirDatabase},
     ty::display::HirFormatter,
     ty::{self, InEnvironment, InferenceResult, TraitEnvironment, Ty, TyDefId, TypeCtor, TypeWalk},
-    CallableDef, Either, HirDisplay, InFile, Name,
+    CallableDef, HirDisplay, InFile, Name,
 };
 
 /// hir::Crate describes a single crate. It's the main interface with which
@@ -901,11 +901,11 @@ impl Local {
         Type { krate, ty: InEnvironment { value: ty, environment } }
     }
 
-    pub fn source(self, db: &impl HirDatabase) -> InFile<Either<ast::BindPat, ast::SelfParam>> {
+    pub fn source(self, db: &impl HirDatabase) -> InFile<SyntaxNode> {
         let (_body, source_map) = db.body_with_source_map(self.parent.into());
         let src = source_map.pat_syntax(self.pat_id).unwrap(); // Hmm...
         let root = src.file_syntax(db);
-        src.map(|ast| ast.map(|it| it.cast().unwrap().to_node(&root), |it| it.to_node(&root)))
+        src.map(|ast| ast.to_node(&root))
     }
 }
 

--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -903,7 +903,7 @@ impl Local {
 
     pub fn source(self, db: &impl HirDatabase) -> InFile<SyntaxNode> {
         let (_body, source_map) = db.body_with_source_map(self.parent.into());
-        let src = source_map.pat_syntax(self.pat_id).unwrap(); // Hmm...
+        let src = source_map.pat_syntax(self.pat_id).a().unwrap(); // Hmm...
         let root = src.file_syntax(db);
         src.map(|ast| ast.to_node(&root))
     }

--- a/crates/ra_hir/src/source_binder.rs
+++ b/crates/ra_hir/src/source_binder.rs
@@ -33,8 +33,8 @@ use crate::{
         method_resolution::{self, implements_trait},
         InEnvironment, TraitEnvironment, Ty,
     },
-    Adt, AssocItem, Const, DefWithBody, Enum, EnumVariant, FromSource, Function,
-    GenericParam, Local, MacroDef, Name, Path, ScopeDef, Static, Struct, Trait, Type, TypeAlias,
+    Adt, AssocItem, Const, DefWithBody, Enum, EnumVariant, FromSource, Function, GenericParam,
+    Local, MacroDef, Name, Path, ScopeDef, Static, Struct, Trait, Type, TypeAlias,
 };
 
 fn try_get_resolver_for_node(db: &impl HirDatabase, node: InFile<&SyntaxNode>) -> Option<Resolver> {

--- a/crates/ra_hir/src/source_binder.rs
+++ b/crates/ra_hir/src/source_binder.rs
@@ -322,7 +322,7 @@ impl SourceAnalyzer {
         let entry = scopes.resolve_name_in_scope(scope, &name)?;
         Some(ScopeEntryWithSyntax {
             name: entry.name().clone(),
-            ptr: source_map.pat_syntax(entry.pat())?.value,
+            ptr: source_map.pat_syntax(entry.pat()).a()?.value,
         })
     }
 
@@ -481,7 +481,7 @@ fn scope_for_offset(
         .scope_by_expr()
         .iter()
         .filter_map(|(id, scope)| {
-            let source = source_map.expr_syntax(*id)?;
+            let source = source_map.expr_syntax(*id).a()?;
             // FIXME: correctly handle macro expansion
             if source.file_id != offset.file_id {
                 return None;
@@ -515,7 +515,7 @@ fn adjust(
         .scope_by_expr()
         .iter()
         .filter_map(|(id, scope)| {
-            let source = source_map.expr_syntax(*id)?;
+            let source = source_map.expr_syntax(*id).a()?;
             // FIXME: correctly handle macro expansion
             if source.file_id != file_id {
                 return None;

--- a/crates/ra_hir_def/src/body.rs
+++ b/crates/ra_hir_def/src/body.rs
@@ -6,9 +6,7 @@ pub mod scope;
 
 use std::{ops::Index, sync::Arc};
 
-use hir_expand::{
-    hygiene::Hygiene, AstId, HirFileId, InFile, MacroDefId, MacroFileKind,
-};
+use hir_expand::{hygiene::Hygiene, AstId, HirFileId, InFile, MacroDefId, MacroFileKind};
 use ra_arena::Arena;
 use ra_syntax::{ast, AstNode};
 
@@ -19,11 +17,8 @@ use crate::{
     path::Path,
     DefWithBodyId, ModuleId,
 };
-pub use source_map::{
-    ExprPtr, ExprSource, PatPtr, PatSource,
-    BodySourceMap,
-};
 pub(crate) use source_map::BodyWithSourceMap;
+pub use source_map::{BodySourceMap, ExprPtr, ExprSource, PatPtr, PatSource};
 
 struct Expander {
     crate_def_map: Arc<CrateDefMap>,

--- a/crates/ra_hir_def/src/body.rs
+++ b/crates/ra_hir_def/src/body.rs
@@ -17,7 +17,6 @@ use crate::{
     path::Path,
     DefWithBodyId, ModuleId,
 };
-pub(crate) use source_map::BodyWithSourceMap;
 pub use source_map::{BodySourceMap, ExprPtr, ExprSource, PatPtr, PatSource};
 
 struct Expander {

--- a/crates/ra_hir_def/src/body.rs
+++ b/crates/ra_hir_def/src/body.rs
@@ -1,16 +1,16 @@
 //! Defines `Body`: a lowered representation of bodies of functions, statics and
 //! consts.
 mod lower;
+mod source_map;
 pub mod scope;
 
 use std::{ops::Index, sync::Arc};
 
 use hir_expand::{
-    either::Either, hygiene::Hygiene, AstId, HirFileId, InFile, MacroDefId, MacroFileKind,
+    hygiene::Hygiene, AstId, HirFileId, InFile, MacroDefId, MacroFileKind,
 };
-use ra_arena::{map::ArenaMap, Arena};
-use ra_syntax::{ast, AstNode, AstPtr};
-use rustc_hash::FxHashMap;
+use ra_arena::Arena;
+use ra_syntax::{ast, AstNode};
 
 use crate::{
     db::DefDatabase,
@@ -20,6 +20,11 @@ use crate::{
     src::HasSource,
     DefWithBodyId, HasModule, Lookup, ModuleId,
 };
+pub use source_map::{
+    ExprPtr, ExprSource, PatPtr, PatSource,
+    BodySourceMap,
+};
+pub(crate) use source_map::BodyWithSourceMap;
 
 struct Expander {
     crate_def_map: Arc<CrateDefMap>,
@@ -115,32 +120,6 @@ pub struct Body {
     pub body_expr: ExprId,
 }
 
-pub type ExprPtr = Either<AstPtr<ast::Expr>, AstPtr<ast::RecordField>>;
-pub type ExprSource = InFile<ExprPtr>;
-
-pub type PatPtr = Either<AstPtr<ast::Pat>, AstPtr<ast::SelfParam>>;
-pub type PatSource = InFile<PatPtr>;
-
-/// An item body together with the mapping from syntax nodes to HIR expression
-/// IDs. This is needed to go from e.g. a position in a file to the HIR
-/// expression containing it; but for type inference etc., we want to operate on
-/// a structure that is agnostic to the actual positions of expressions in the
-/// file, so that we don't recompute types whenever some whitespace is typed.
-///
-/// One complication here is that, due to macro expansion, a single `Body` might
-/// be spread across several files. So, for each ExprId and PatId, we record
-/// both the HirFileId and the position inside the file. However, we only store
-/// AST -> ExprId mapping for non-macro files, as it is not clear how to handle
-/// this properly for macros.
-#[derive(Default, Debug, Eq, PartialEq)]
-pub struct BodySourceMap {
-    expr_map: FxHashMap<ExprSource, ExprId>,
-    expr_map_back: ArenaMap<ExprId, ExprSource>,
-    pat_map: FxHashMap<PatSource, PatId>,
-    pat_map_back: ArenaMap<PatId, PatSource>,
-    field_map: FxHashMap<(ExprId, usize), AstPtr<ast::RecordField>>,
-}
-
 impl Body {
     pub(crate) fn body_with_source_map_query(
         db: &impl DefDatabase,
@@ -198,29 +177,5 @@ impl Index<PatId> for Body {
 
     fn index(&self, pat: PatId) -> &Pat {
         &self.pats[pat]
-    }
-}
-
-impl BodySourceMap {
-    pub fn expr_syntax(&self, expr: ExprId) -> Option<ExprSource> {
-        self.expr_map_back.get(expr).copied()
-    }
-
-    pub fn node_expr(&self, node: InFile<&ast::Expr>) -> Option<ExprId> {
-        let src = node.map(|it| Either::A(AstPtr::new(it)));
-        self.expr_map.get(&src).cloned()
-    }
-
-    pub fn pat_syntax(&self, pat: PatId) -> Option<PatSource> {
-        self.pat_map_back.get(pat).copied()
-    }
-
-    pub fn node_pat(&self, node: InFile<&ast::Pat>) -> Option<PatId> {
-        let src = node.map(|it| Either::A(AstPtr::new(it)));
-        self.pat_map.get(&src).cloned()
-    }
-
-    pub fn field_syntax(&self, expr: ExprId, field: usize) -> AstPtr<ast::RecordField> {
-        self.field_map[&(expr, field)]
     }
 }

--- a/crates/ra_hir_def/src/body/lower.rs
+++ b/crates/ra_hir_def/src/body/lower.rs
@@ -157,9 +157,9 @@ where
         self.body.alloc_pat(pat, src)
     }
 
-    fn empty_block(&mut self) -> ExprId {
+    fn empty_block(&mut self, ptr: AstPtr<ast::Expr>) -> ExprId {
         let block = Expr::Block { statements: Vec::new(), tail: None };
-        self.body.body.exprs.alloc(block)
+        self.alloc_expr(block, ptr)
     }
 
     fn missing_expr(&mut self) -> ExprId {
@@ -197,7 +197,7 @@ where
                                 MatchArm { pats: vec![pat], expr: then_branch, guard: None },
                                 MatchArm {
                                     pats: vec![placeholder_pat],
-                                    expr: else_branch.unwrap_or_else(|| self.empty_block()),
+                                    expr: else_branch.unwrap_or_else(|| self.empty_block(syntax_ptr)),
                                     guard: None,
                                 },
                             ];

--- a/crates/ra_hir_def/src/body/lower.rs
+++ b/crates/ra_hir_def/src/body/lower.rs
@@ -15,7 +15,7 @@ use ra_syntax::{
 use test_utils::tested_by;
 
 use crate::{
-    body::{Body, BodySourceMap, BodyWithSourceMap, Expander, PatPtr},
+    body::{source_map::BodyWithSourceMap, Body, BodySourceMap, Expander, PatPtr},
     builtin_type::{BuiltinFloat, BuiltinInt},
     db::DefDatabase,
     expr::{

--- a/crates/ra_hir_def/src/body/lower.rs
+++ b/crates/ra_hir_def/src/body/lower.rs
@@ -91,22 +91,28 @@ where
     fn alloc_expr(&mut self, expr: Expr, ptr: AstPtr<ast::Expr>) -> ExprId {
         let ptr = Either::A(ptr);
         let src = self.expander.to_source(ptr);
+        let ast_src = src.map(|a| a.either(Into::into, Into::into));
+        let expr = self.body.alloc_expr(expr, ast_src);
+        self.body.map_expr(src, expr);
+        expr
+    }
+
+    fn alloc_expr_desugared(&mut self, expr: Expr, ptr: AstPtr<ast::Expr>) -> ExprId {
+        let src = self.expander.to_source(ptr.syntax_node_ptr());
         self.body.alloc_expr(expr, src)
     }
 
-    fn alloc_expr_desugared(&mut self, expr: Expr) -> ExprId {
-        self.body.alloc_expr_desugared(expr)
-    }
-
     fn alloc_expr_field_shorthand(&mut self, expr: Expr, ptr: AstPtr<ast::RecordField>) -> ExprId {
-        let ptr = Either::B(ptr);
-        let src = self.expander.to_source(ptr);
+        let src = self.expander.to_source(ptr.syntax_node_ptr());
         self.body.alloc_expr(expr, src)
     }
 
     fn alloc_pat(&mut self, pat: Pat, ptr: PatPtr) -> PatId {
         let src = self.expander.to_source(ptr);
-        self.body.alloc_pat(pat, src)
+        let ast_src = src.map(|a| a.either(Into::into, Into::into));
+        let pat = self.body.alloc_pat(pat, ast_src);
+        self.body.map_pat(src, pat);
+        pat
     }
 
     fn empty_block(&mut self, ptr: AstPtr<ast::Expr>) -> ExprId {
@@ -183,13 +189,17 @@ where
                             let pat = self.collect_pat(pat);
                             let match_expr = self.collect_expr_opt(condition.expr());
                             let placeholder_pat = self.missing_pat();
-                            let break_ = self.alloc_expr_desugared(Expr::Break { expr: None });
+                            let break_ = self.alloc_expr_desugared(
+                                Expr::Break { expr: None }, syntax_ptr
+                            );
                             let arms = vec![
                                 MatchArm { pats: vec![pat], expr: body, guard: None },
                                 MatchArm { pats: vec![placeholder_pat], expr: break_, guard: None },
                             ];
-                            let match_expr =
-                                self.alloc_expr_desugared(Expr::Match { expr: match_expr, arms });
+                            let match_expr = self.alloc_expr_desugared(
+                                Expr::Match { expr: match_expr, arms },
+                                syntax_ptr
+                            );
                             return self.alloc_expr(Expr::Loop { body: match_expr }, syntax_ptr);
                         }
                     },

--- a/crates/ra_hir_def/src/body/lower.rs
+++ b/crates/ra_hir_def/src/body/lower.rs
@@ -155,11 +155,15 @@ where
     }
 
     fn missing_expr(&mut self) -> ExprId {
-        self.body.missing_expr()
+        let ptr = self.parent;
+        let src = self.expander.to_source(ptr);
+        self.body.missing_expr(src)
     }
 
     fn missing_pat(&mut self) -> PatId {
-        self.body.missing_pat()
+        let ptr = self.parent;
+        let src = self.expander.to_source(ptr);
+        self.body.missing_pat(src)
     }
 
     fn with_parent<F, T>(&mut self, parent: SyntaxNodePtr, f: F) -> T

--- a/crates/ra_hir_def/src/body/scope.rs
+++ b/crates/ra_hir_def/src/body/scope.rs
@@ -325,7 +325,7 @@ mod tests {
         let resolved = scopes.resolve_name_in_scope(expr_scope, &name_ref.as_name()).unwrap();
         let pat_src = source_map.pat_syntax(resolved.pat()).unwrap();
 
-        let local_name = pat_src.value.either(|it| it.syntax_node_ptr(), |it| it.syntax_node_ptr());
+        let local_name = pat_src.value;
         assert_eq!(local_name.range(), expected_name.syntax().text_range());
     }
 

--- a/crates/ra_hir_def/src/body/scope.rs
+++ b/crates/ra_hir_def/src/body/scope.rs
@@ -323,7 +323,7 @@ mod tests {
         };
 
         let resolved = scopes.resolve_name_in_scope(expr_scope, &name_ref.as_name()).unwrap();
-        let pat_src = source_map.pat_syntax(resolved.pat()).unwrap();
+        let pat_src = source_map.pat_syntax(resolved.pat());
 
         let local_name = pat_src.value;
         assert_eq!(local_name.range(), expected_name.syntax().text_range());

--- a/crates/ra_hir_def/src/body/scope.rs
+++ b/crates/ra_hir_def/src/body/scope.rs
@@ -325,7 +325,7 @@ mod tests {
         let resolved = scopes.resolve_name_in_scope(expr_scope, &name_ref.as_name()).unwrap();
         let pat_src = source_map.pat_syntax(resolved.pat());
 
-        let local_name = pat_src.value;
+        let local_name = pat_src.a().unwrap().value;
         assert_eq!(local_name.range(), expected_name.syntax().text_range());
     }
 

--- a/crates/ra_hir_def/src/body/source_map.rs
+++ b/crates/ra_hir_def/src/body/source_map.rs
@@ -1,0 +1,136 @@
+use hir_expand::{
+    either::Either,
+    InFile,
+};
+use ra_arena::{map::ArenaMap, Arena};
+use ra_syntax::{ast, AstPtr};
+use rustc_hash::FxHashMap;
+
+use crate::{
+    expr::{Expr, ExprId, Pat, PatId},
+    body::Body,
+};
+
+pub type ExprPtr = Either<AstPtr<ast::Expr>, AstPtr<ast::RecordField>>;
+pub type ExprSource = InFile<ExprPtr>;
+
+pub type PatPtr = Either<AstPtr<ast::Pat>, AstPtr<ast::SelfParam>>;
+pub type PatSource = InFile<PatPtr>;
+
+/// An item body together with the mapping from syntax nodes to HIR expression
+/// IDs. This is needed to go from e.g. a position in a file to the HIR
+/// expression containing it; but for type inference etc., we want to operate on
+/// a structure that is agnostic to the actual positions of expressions in the
+/// file, so that we don't recompute types whenever some whitespace is typed.
+///
+/// One complication here is that, due to macro expansion, a single `Body` might
+/// be spread across several files. So, for each ExprId and PatId, we record
+/// both the HirFileId and the position inside the file. However, we only store
+/// AST -> ExprId mapping for non-macro files, as it is not clear how to handle
+/// this properly for macros.
+#[derive(Debug, Eq, PartialEq)]
+pub struct BodySourceMap {
+    expr_map: FxHashMap<ExprSource, ExprId>,
+    expr_map_back: ArenaMap<ExprId, ExprSource>,
+    pat_map: FxHashMap<PatSource, PatId>,
+    pat_map_back: ArenaMap<PatId, PatSource>,
+    field_map: FxHashMap<(ExprId, usize), AstPtr<ast::RecordField>>,
+}
+
+impl BodySourceMap {
+    fn new() -> BodySourceMap {
+        BodySourceMap {
+            expr_map: FxHashMap::default(),
+            expr_map_back: ArenaMap::default(),
+            pat_map: FxHashMap::default(),
+            pat_map_back: ArenaMap::default(),
+            field_map: FxHashMap::default(),
+        }
+    }
+
+    pub fn expr_syntax(&self, expr: ExprId) -> Option<ExprSource> {
+        self.expr_map_back.get(expr).copied()
+    }
+
+    pub fn node_expr(&self, node: InFile<&ast::Expr>) -> Option<ExprId> {
+        let src = node.map(|it| Either::A(AstPtr::new(it)));
+        self.expr_map.get(&src).cloned()
+    }
+
+    pub fn pat_syntax(&self, pat: PatId) -> Option<PatSource> {
+        self.pat_map_back.get(pat).copied()
+    }
+
+    pub fn node_pat(&self, node: InFile<&ast::Pat>) -> Option<PatId> {
+        let src = node.map(|it| Either::A(AstPtr::new(it)));
+        self.pat_map.get(&src).cloned()
+    }
+
+    pub fn field_syntax(&self, expr: ExprId, field: usize) -> AstPtr<ast::RecordField> {
+        self.field_map[&(expr, field)]
+    }
+}
+
+/// This structure is used to enforce HIR nodes allocation discipline.
+/// All allocated Ids must be associated to a source pointer.
+pub(crate) struct BodyWithSourceMap {
+    body: Body,
+    source_map: BodySourceMap,
+}
+
+impl BodyWithSourceMap {
+    pub fn new() -> BodyWithSourceMap {
+        BodyWithSourceMap {
+            body: Body {
+                exprs: Arena::default(),
+                pats: Arena::default(),
+                params: Vec::new(),
+                body_expr: ExprId::dummy(),
+            },
+            source_map: BodySourceMap::new(),
+        }
+    }
+
+    pub fn split(self) -> (Body, BodySourceMap) {
+        (self.body, self.source_map)
+    }
+
+    pub fn push_param(&mut self, pat: PatId) {
+        self.body.params.push(pat)
+    }
+
+    pub fn map_expr(&mut self, src: ExprSource, to: ExprId) {
+        self.source_map.expr_map.insert(src, to);
+    }
+
+    pub fn map_field(&mut self, src: AstPtr<ast::RecordField>, res: ExprId, i: usize) {
+        self.source_map.field_map.insert((res, i), src);
+    }
+
+    pub fn alloc_expr(&mut self, expr: Expr, src: ExprSource) -> ExprId {
+        let id = self.body.exprs.alloc(expr);
+        self.source_map.expr_map.insert(src, id);
+        self.source_map.expr_map_back.insert(id, src);
+        id
+    }
+
+    pub fn alloc_expr_desugared(&mut self, expr: Expr) -> ExprId {
+        let id = self.body.exprs.alloc(expr);
+        id
+    }
+
+    pub fn alloc_pat(&mut self, pat: Pat, src: PatSource) -> PatId {
+        let id = self.body.pats.alloc(pat);
+        self.source_map.pat_map.insert(src, id);
+        self.source_map.pat_map_back.insert(id, src);
+        id
+    }
+
+    pub fn missing_expr(&mut self) -> ExprId {
+        self.body.exprs.alloc(Expr::Missing)
+    }
+
+    pub fn missing_pat(&mut self) -> PatId {
+        self.body.pats.alloc(Pat::Missing)
+    }
+}

--- a/crates/ra_hir_def/src/body/source_map.rs
+++ b/crates/ra_hir_def/src/body/source_map.rs
@@ -1,3 +1,4 @@
+//! Definition of the HIR <-> AST mapping.
 use hir_expand::{either::Either, InFile};
 use ra_arena::{map::ArenaMap, Arena};
 use ra_syntax::{ast, AstPtr, SyntaxNodePtr};
@@ -48,24 +49,33 @@ impl BodySourceMap {
         }
     }
 
+    /// Get AST from HIR Expr.
+    /// The `A` case corresponds to the real AST node.
+    /// The `B` case corresponds to the parent node if missing.
     pub fn expr_syntax(&self, expr: ExprId) -> AstBackSource {
         self.expr_map_back[expr]
     }
 
+    /// Get HIR from AST Expr.
     pub fn node_expr(&self, node: InFile<&ast::Expr>) -> Option<ExprId> {
         let src = node.map(|it| Either::A(AstPtr::new(it)));
         self.expr_map.get(&src).cloned()
     }
 
+    /// Get AST from HIR Pat.
+    /// The `A` case corresponds to the real AST node.
+    /// The `B` case corresponds to the parent node if missing.
     pub fn pat_syntax(&self, pat: PatId) -> AstBackSource {
         self.pat_map_back[pat]
     }
 
+    /// Get HIR from AST Pat.
     pub fn node_pat(&self, node: InFile<&ast::Pat>) -> Option<PatId> {
         let src = node.map(|it| Either::A(AstPtr::new(it)));
         self.pat_map.get(&src).cloned()
     }
 
+    /// Get AST node associated to Field expression.
     pub fn field_syntax(&self, expr: ExprId, field: usize) -> AstPtr<ast::RecordField> {
         self.field_map[&(expr, field)]
     }
@@ -73,7 +83,7 @@ impl BodySourceMap {
 
 /// This structure is used to enforce HIR nodes allocation discipline.
 /// All allocated Ids must be associated to a source pointer.
-pub(crate) struct BodyWithSourceMap {
+pub(super) struct BodyWithSourceMap {
     body: Body,
     source_map: BodySourceMap,
 }

--- a/crates/ra_hir_def/src/body/source_map.rs
+++ b/crates/ra_hir_def/src/body/source_map.rs
@@ -1,14 +1,11 @@
-use hir_expand::{
-    either::Either,
-    InFile,
-};
+use hir_expand::{either::Either, InFile};
 use ra_arena::{map::ArenaMap, Arena};
 use ra_syntax::{ast, AstPtr, SyntaxNodePtr};
 use rustc_hash::FxHashMap;
 
 use crate::{
-    expr::{Expr, ExprId, Pat, PatId},
     body::Body,
+    expr::{Expr, ExprId, Pat, PatId},
 };
 
 pub type ExprPtr = Either<AstPtr<ast::Expr>, AstPtr<ast::RecordField>>;

--- a/crates/ra_hir_def/src/body/source_map.rs
+++ b/crates/ra_hir_def/src/body/source_map.rs
@@ -109,23 +109,18 @@ impl BodyWithSourceMap {
         self.source_map.field_map.insert((res, i), src);
     }
 
-    pub fn alloc_expr(&mut self, expr: Expr, src: ExprSource) -> ExprId {
+    pub fn map_pat(&mut self, src: PatSource, to: PatId) {
+        self.source_map.pat_map.insert(src, to);
+    }
+
+    pub fn alloc_expr(&mut self, expr: Expr, src: AstSource) -> ExprId {
         let id = self.body.exprs.alloc(expr);
-        self.source_map.expr_map.insert(src, id);
-        let src = src.map(|a| a.either(Into::into, Into::into));
         self.source_map.expr_map_back.insert(id, src);
         id
     }
 
-    pub fn alloc_expr_desugared(&mut self, expr: Expr) -> ExprId {
-        let id = self.body.exprs.alloc(expr);
-        id
-    }
-
-    pub fn alloc_pat(&mut self, pat: Pat, src: PatSource) -> PatId {
+    pub fn alloc_pat(&mut self, pat: Pat, src: AstSource) -> PatId {
         let id = self.body.pats.alloc(pat);
-        self.source_map.pat_map.insert(src, id);
-        let src = src.map(|a| a.either(Into::into, Into::into));
         self.source_map.pat_map_back.insert(id, src);
         id
     }

--- a/crates/ra_hir_ty/src/expr.rs
+++ b/crates/ra_hir_ty/src/expr.rs
@@ -97,7 +97,7 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
         let (_, source_map) = db.body_with_source_map(self.func.into());
 
         if let Some(source_ptr) = source_map.expr_syntax(id) {
-            if let Some(expr) = source_ptr.value.a() {
+            if let Some(expr) = source_ptr.value.cast() {
                 let root = source_ptr.file_syntax(db);
                 if let ast::Expr::RecordLit(record_lit) = expr.to_node(&root) {
                     if let Some(field_list) = record_lit.record_field_list() {
@@ -142,7 +142,7 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
             let (_, source_map) = db.body_with_source_map(self.func.into());
 
             if let Some(source_ptr) = source_map.expr_syntax(id) {
-                if let Some(expr) = source_ptr.value.a() {
+                if let Some(expr) = source_ptr.value.cast() {
                     self.sink.push(MissingOkInTailExpr { file: source_ptr.file_id, expr });
                 }
             }

--- a/crates/ra_hir_ty/src/expr.rs
+++ b/crates/ra_hir_ty/src/expr.rs
@@ -7,7 +7,7 @@ use hir_def::{
     resolver::HasResolver,
     AdtId, FunctionId,
 };
-use hir_expand::{diagnostics::DiagnosticSink, name::Name, either::Either};
+use hir_expand::{diagnostics::DiagnosticSink, either::Either, name::Name};
 use ra_syntax::ast;
 use ra_syntax::AstPtr;
 use rustc_hash::FxHashSet;

--- a/crates/ra_hir_ty/src/expr.rs
+++ b/crates/ra_hir_ty/src/expr.rs
@@ -7,7 +7,7 @@ use hir_def::{
     resolver::HasResolver,
     AdtId, FunctionId,
 };
-use hir_expand::{diagnostics::DiagnosticSink, name::Name};
+use hir_expand::{diagnostics::DiagnosticSink, name::Name, either::Either};
 use ra_syntax::ast;
 use ra_syntax::AstPtr;
 use rustc_hash::FxHashSet;
@@ -96,7 +96,7 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
         }
         let (_, source_map) = db.body_with_source_map(self.func.into());
 
-        if let Some(source_ptr) = source_map.expr_syntax(id) {
+        if let Either::A(source_ptr) = source_map.expr_syntax(id) {
             if let Some(expr) = source_ptr.value.cast() {
                 let root = source_ptr.file_syntax(db);
                 if let ast::Expr::RecordLit(record_lit) = expr.to_node(&root) {
@@ -141,7 +141,7 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
         if params.len() == 2 && &params[0] == &mismatch.actual {
             let (_, source_map) = db.body_with_source_map(self.func.into());
 
-            if let Some(source_ptr) = source_map.expr_syntax(id) {
+            if let Either::A(source_ptr) = source_map.expr_syntax(id) {
                 if let Some(expr) = source_ptr.value.cast() {
                     self.sink.push(MissingOkInTailExpr { file: source_ptr.file_id, expr });
                 }

--- a/crates/ra_hir_ty/src/tests.rs
+++ b/crates/ra_hir_ty/src/tests.rs
@@ -8,7 +8,7 @@ use hir_def::{
     body::BodySourceMap, db::DefDatabase, nameres::CrateDefMap, AssocItemId, DefWithBodyId,
     LocalModuleId, Lookup, ModuleDefId,
 };
-use hir_expand::InFile;
+use hir_expand::{InFile, either::Either};
 use insta::assert_snapshot;
 use ra_db::{fixture::WithFixture, salsa::Database, FilePosition, SourceDatabase};
 use ra_syntax::{
@@ -1363,6 +1363,8 @@ fn test(x: &i32) {
     [126; 152) '{     ...     }': ()
     [140; 141) 'g': {unknown}
     [144; 145) 'e': {unknown}
+    [158; 205) 'if let...     }': {unknown}
+    [158; 205) 'if let...     }': ()
     [158; 205) 'if let...     }': ()
     [165; 170) '[val]': {unknown}
     [173; 176) 'opt': {unknown}
@@ -4756,12 +4758,16 @@ fn infer(content: &str) -> String {
 
         for (pat, ty) in inference_result.type_of_pat.iter() {
             let syntax_ptr = body_source_map.pat_syntax(pat);
-            types.push((syntax_ptr, ty));
+            if let Either::A(syntax_ptr) = syntax_ptr {
+                types.push((syntax_ptr, ty));
+            }
         }
 
         for (expr, ty) in inference_result.type_of_expr.iter() {
             let syntax_ptr = body_source_map.expr_syntax(expr);
-            types.push((syntax_ptr, ty));
+            if let Either::A(syntax_ptr) = syntax_ptr {
+                types.push((syntax_ptr, ty));
+            }
         }
 
         // sort ranges for consistency

--- a/crates/ra_hir_ty/src/tests.rs
+++ b/crates/ra_hir_ty/src/tests.rs
@@ -8,7 +8,7 @@ use hir_def::{
     body::BodySourceMap, db::DefDatabase, nameres::CrateDefMap, AssocItemId, DefWithBodyId,
     LocalModuleId, Lookup, ModuleDefId,
 };
-use hir_expand::{InFile, either::Either};
+use hir_expand::{either::Either, InFile};
 use insta::assert_snapshot;
 use ra_db::{fixture::WithFixture, salsa::Database, FilePosition, SourceDatabase};
 use ra_syntax::{

--- a/crates/ra_hir_ty/src/tests.rs
+++ b/crates/ra_hir_ty/src/tests.rs
@@ -4755,18 +4755,12 @@ fn infer(content: &str) -> String {
         let mut types = Vec::new();
 
         for (pat, ty) in inference_result.type_of_pat.iter() {
-            let syntax_ptr = match body_source_map.pat_syntax(pat) {
-                Some(sp) => sp,
-                None => continue,
-            };
+            let syntax_ptr = body_source_map.pat_syntax(pat);
             types.push((syntax_ptr, ty));
         }
 
         for (expr, ty) in inference_result.type_of_expr.iter() {
-            let syntax_ptr = match body_source_map.expr_syntax(expr) {
-                Some(sp) => sp,
-                None => continue,
-            };
+            let syntax_ptr = body_source_map.expr_syntax(expr);
             types.push((syntax_ptr, ty));
         }
 

--- a/crates/ra_hir_ty/src/tests.rs
+++ b/crates/ra_hir_ty/src/tests.rs
@@ -4756,9 +4756,7 @@ fn infer(content: &str) -> String {
 
         for (pat, ty) in inference_result.type_of_pat.iter() {
             let syntax_ptr = match body_source_map.pat_syntax(pat) {
-                Some(sp) => {
-                    sp.map(|ast| ast.either(|it| it.syntax_node_ptr(), |it| it.syntax_node_ptr()))
-                }
+                Some(sp) => sp,
                 None => continue,
             };
             types.push((syntax_ptr, ty));
@@ -4766,9 +4764,7 @@ fn infer(content: &str) -> String {
 
         for (expr, ty) in inference_result.type_of_expr.iter() {
             let syntax_ptr = match body_source_map.expr_syntax(expr) {
-                Some(sp) => {
-                    sp.map(|ast| ast.either(|it| it.syntax_node_ptr(), |it| it.syntax_node_ptr()))
-                }
+                Some(sp) => sp,
                 None => continue,
             };
             types.push((syntax_ptr, ty));


### PR DESCRIPTION
This is based on the work done in #2405.

By specifically marking the missing AST nodes and with a bit of refactoring, I was able to make the HIR->AST map infallible.
This required to remove the typing of AST nodes in the HIR->AST map. I believe this is a good thing, because it allows to record more precise information when desugaring.