### PR TITLE
Hide MacroCallLoc outside hir_expand 

### DIFF
--- a/crates/ra_hir/src/source_binder.rs
+++ b/crates/ra_hir/src/source_binder.rs
@@ -14,8 +14,7 @@ use hir_def::{
     DefWithBodyId,
 };
 use hir_expand::{
-    hygiene::Hygiene, name::AsName, AstId, HirFileId, MacroCallId, MacroCallLoc, MacroFileKind,
-    Source,
+    hygiene::Hygiene, name::AsName, AstId, HirFileId, MacroCallId, MacroFileKind, Source,
 };
 use ra_syntax::{
     ast::{self, AstNode},
@@ -451,9 +450,8 @@ impl SourceAnalyzer {
             macro_call.file_id,
             db.ast_id_map(macro_call.file_id).ast_id(macro_call.value),
         );
-        let macro_call_loc = MacroCallLoc { def, ast_id };
         Some(Expansion {
-            macro_call_id: db.intern_macro(macro_call_loc),
+            macro_call_id: def.as_call_id(db, ast_id),
             macro_file_kind: to_macro_file_kind(macro_call.value),
         })
     }

--- a/crates/ra_hir_def/src/body.rs
+++ b/crates/ra_hir_def/src/body.rs
@@ -6,8 +6,7 @@ pub mod scope;
 use std::{ops::Index, sync::Arc};
 
 use hir_expand::{
-    either::Either, hygiene::Hygiene, AstId, HirFileId, MacroCallLoc, MacroDefId, MacroFileKind,
-    Source,
+    either::Either, hygiene::Hygiene, AstId, HirFileId, MacroDefId, MacroFileKind, Source,
 };
 use ra_arena::{map::ArenaMap, Arena};
 use ra_syntax::{ast, AstNode, AstPtr};
@@ -47,7 +46,7 @@ impl Expander {
 
         if let Some(path) = macro_call.path().and_then(|path| self.parse_path(path)) {
             if let Some(def) = self.resolve_path_as_macro(db, &path) {
-                let call_id = db.intern_macro(MacroCallLoc { def, ast_id });
+                let call_id = def.as_call_id(db, ast_id);
                 let file_id = call_id.as_file(MacroFileKind::Expr);
                 if let Some(node) = db.parse_or_expand(file_id) {
                     if let Some(expr) = ast::Expr::cast(node) {

--- a/crates/ra_hir_def/src/nameres/collector.rs
+++ b/crates/ra_hir_def/src/nameres/collector.rs
@@ -6,7 +6,7 @@
 use hir_expand::{
     builtin_macro::find_builtin_macro,
     name::{self, AsName, Name},
-    HirFileId, MacroCallId, MacroCallLoc, MacroDefId, MacroDefKind, MacroFileKind,
+    HirFileId, MacroCallId, MacroDefId, MacroDefKind, MacroFileKind,
 };
 use ra_cfg::CfgOptions;
 use ra_db::{CrateId, FileId};
@@ -480,7 +480,7 @@ where
             );
 
             if let Some(def) = resolved_res.resolved_def.take_macros() {
-                let call_id = self.db.intern_macro(MacroCallLoc { def, ast_id: *ast_id });
+                let call_id = def.as_call_id(self.db, *ast_id);
                 resolved.push((*module_id, call_id, def));
                 res = ReachedFixedPoint::No;
                 return false;
@@ -773,8 +773,7 @@ where
         if let Some(macro_def) = mac.path.as_ident().and_then(|name| {
             self.def_collector.def_map[self.module_id].scope.get_legacy_macro(&name)
         }) {
-            let macro_call_id =
-                self.def_collector.db.intern_macro(MacroCallLoc { def: macro_def, ast_id });
+            let macro_call_id = macro_def.as_call_id(self.def_collector.db, ast_id);
 
             self.def_collector.collect_macro_expansion(self.module_id, macro_call_id, macro_def);
             return;

--- a/crates/ra_hir_expand/src/lib.rs
+++ b/crates/ra_hir_expand/src/lib.rs
@@ -135,6 +135,16 @@ pub struct MacroDefId {
     pub kind: MacroDefKind,
 }
 
+impl MacroDefId {
+    pub fn as_call_id(
+        self,
+        db: &dyn db::AstDatabase,
+        ast_id: AstId<ast::MacroCall>,
+    ) -> MacroCallId {
+        db.intern_macro(MacroCallLoc { def: self, ast_id })
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum MacroDefKind {
     Declarative,
@@ -143,8 +153,8 @@ pub enum MacroDefKind {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct MacroCallLoc {
-    pub def: MacroDefId,
-    pub ast_id: AstId<ast::MacroCall>,
+    pub(crate) def: MacroDefId,
+    pub(crate) ast_id: AstId<ast::MacroCall>,
 }
 
 impl MacroCallId {


### PR DESCRIPTION
This PR refactor `MacroCallLoc` such that it  be hided to become implementation details of hir_expand. 