### PR TITLE
Clarify installation instructions

### DIFF
--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -1,14 +1,19 @@
 The main interface to rust-analyzer is the
-[LSP](https://microsoft.github.io/language-server-protocol/) implementation. To
-install lsp server, use `cargo xtask install --server`, which is a shorthand for `cargo
-install --package ra_lsp_server`. The binary is named `ra_lsp_server`, you
-should be able to use it with any LSP-compatible editor. We use custom
-extensions to LSP, so special client-side support is required to take full
-advantage of rust-analyzer. This repository contains support code for VS Code
-and Emacs.
+[LSP](https://microsoft.github.io/language-server-protocol/)
+implementation. To install lsp server, clone the repository and
+then run `cargo xtask install --server`. This will produce a
+binary named `ra_lsp_server` which you should be able to use it
+with any LSP-compatible editor. We use custom extensions to LSP,
+so special client-side support is required to take full advantage
+of rust-analyzer. This repository contains support code for VS
+Code and Emacs. 
 
-Rust Analyzer needs sources of rust standard library to work, so you might need
-to execute
+```
+$ git clone git@github.com:rust-analyzer/rust-analyzer && cd rust-analyzer
+$ cargo xtask install --server
+```
+Rust Analyzer needs sources of rust standard library to work, so
+you might also need to execute
 
 ```
 $ rustup component add rust-src

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -1,12 +1,12 @@
 The main interface to rust-analyzer is the
-[LSP](https://microsoft.github.io/language-server-protocol/)
-implementation. To install lsp server, clone the repository and
-then run `cargo xtask install --server`. This will produce a
-binary named `ra_lsp_server` which you should be able to use it
-with any LSP-compatible editor. We use custom extensions to LSP,
-so special client-side support is required to take full advantage
-of rust-analyzer. This repository contains support code for VS
-Code and Emacs. 
+[LSP](https://microsoft.github.io/language-server-protocol/) implementation. To
+install lsp server, clone the repository and then run `cargo xtask install
+--server` (which is shorthand for `cargo install --path
+./crates/ra_lsp_server`). This will produce a binary named `ra_lsp_server` which
+you should be able to use it with any LSP-compatible editor. We use custom
+extensions to LSP, so special client-side support is required to take full
+advantage of rust-analyzer. This repository contains support code for VS Code
+and Emacs.
 
 ```
 $ git clone git@github.com:rust-analyzer/rust-analyzer && cd rust-analyzer


### PR DESCRIPTION
In particular it is necessary to clone the repository before running the other commands. I also removed the `cargo install` side note because it didn't actually work (running the command just produces an error that --package isn't a recognized flag) and added a tldr code block with the list of commands to run.