### PR TITLE
fix install problem with global deps and ci fixes #2456

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -17,8 +17,8 @@
     },
     "scripts": {
         "vscode:prepublish": "npm run compile",
-        "package": "vsce package",
-        "compile": "rollup -c && shx cp src/utils/terminateProcess.sh bundle/terminateProcess.sh",
+        "package": "npx vsce package",
+        "compile": "npx rollup -c && npx shx cp src/utils/terminateProcess.sh bundle/terminateProcess.sh",
         "watch": "tsc -watch -p ./",
         "fix": "prettier **/*.{json,ts} --write && tslint --project . --fix",
         "lint": "tslint --project .",

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -182,7 +182,8 @@ fn install_client(ClientOpt::VsCode: ClientOpt) -> Result<()> {
         eprintln!("\nERROR: `npm --version` failed, `npm` is required to build the VS Code plugin")
     }
 
-    Cmd { unix: r"npm ci", windows: r"cmd.exe /c npm ci", work_dir: "./editors/code" }.run()?;
+    Cmd { unix: r"npm install", windows: r"cmd.exe /c npm install", work_dir: "./editors/code" }
+        .run()?;
     Cmd {
         unix: r"npm run package --scripts-prepend-node-path",
         windows: r"cmd.exe /c npm run package",


### PR DESCRIPTION
* There seems to be an assumption that I have all of these deps (vsce, rollup, shx) installed globally on my machine. I don't so it fails for me (i'm not sure why this isn't failing for others or if it changed recently).
* npx will use the ./node_modules/.bin/[binary] so that problem is solved
* I have no idea why `ci` fails for me but `install` works, install will still use `package-lock.json` as a reference so it shouldn't be a problem with reproducible dependencies.
* * It looks like ci wipes the `node_modules` directory then tries to read from the typescript directory but fails as its empty, looks like some weird npm error.

I'm using node v13.1.0 and npm v6.12.1 