### PR TITLE
Fix #2467

### DIFF
--- a/crates/ra_hir_ty/src/infer/unify.rs
+++ b/crates/ra_hir_ty/src/infer/unify.rs
@@ -167,12 +167,12 @@ impl<T> Canonicalized<T> {
     }
 }
 
-pub fn unify(ty1: Canonical<&Ty>, ty2: &Ty) -> Option<Substs> {
+pub fn unify(ty1: &Canonical<Ty>, ty2: &Canonical<Ty>) -> Option<Substs> {
     let mut table = InferenceTable::new();
     let vars =
         Substs::builder(ty1.num_vars).fill(std::iter::repeat_with(|| table.new_type_var())).build();
     let ty_with_vars = ty1.value.clone().subst_bound_vars(&vars);
-    if !table.unify(&ty_with_vars, ty2) {
+    if !table.unify(&ty_with_vars, &ty2.value) {
         return None;
     }
     Some(

--- a/crates/ra_hir_ty/src/method_resolution.rs
+++ b/crates/ra_hir_ty/src/method_resolution.rs
@@ -437,12 +437,12 @@ fn is_valid_candidate(
 pub(crate) fn inherent_impl_substs(
     db: &impl HirDatabase,
     impl_id: ImplId,
-    self_ty: &Ty,
+    self_ty: &Canonical<Ty>,
 ) -> Option<Substs> {
     let vars = Substs::build_for_def(db, impl_id).fill_with_bound_vars(0).build();
     let self_ty_with_vars = db.impl_self_ty(impl_id).subst(&vars);
-    let self_ty_with_vars = Canonical { num_vars: vars.len(), value: &self_ty_with_vars };
-    super::infer::unify(self_ty_with_vars, self_ty)
+    let self_ty_with_vars = Canonical { num_vars: vars.len(), value: self_ty_with_vars };
+    super::infer::unify(&self_ty_with_vars, self_ty)
 }
 
 fn transform_receiver_ty(
@@ -455,7 +455,7 @@ fn transform_receiver_ty(
             .push(self_ty.value.clone())
             .fill_with_unknown()
             .build(),
-        hir_def::ContainerId::ImplId(impl_id) => inherent_impl_substs(db, impl_id, &self_ty.value)?,
+        hir_def::ContainerId::ImplId(impl_id) => inherent_impl_substs(db, impl_id, &self_ty)?,
         hir_def::ContainerId::ModuleId(_) => unreachable!(),
     };
     let sig = db.callable_item_signature(function_id.into());


### PR DESCRIPTION
The stand-alone `unify` requires that the type doesn't contain any type
variables. So we can't share the code here for now (without more refactoring)...