### PR TITLE
Fix npm vulnerability warning

### DIFF
--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -598,9 +598,9 @@
             }
         },
         "https-proxy-agent": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
-            "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+            "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
             "dev": true,
             "requires": {
                 "agent-base": "^4.3.0",


### PR DESCRIPTION
I see a warning in `npm` when I try to install RA:

```
found 1 high severity vulnerability
```

This PR update package-lock.json by run `npm audit fix` 