### PR TITLE
Implement `format_args`

### DIFF
--- a/crates/ra_hir/src/source_binder.rs
+++ b/crates/ra_hir/src/source_binder.rs
@@ -76,7 +76,7 @@ fn def_with_body_from_child_node(
     db: &impl HirDatabase,
     child: InFile<&SyntaxNode>,
 ) -> Option<DefWithBody> {
-    ancestors_with_macros(db, child).find_map(|node| {
+    child.cloned().ancestors_with_macros(db).find_map(|node| {
         let n = &node.value;
         match_ast! {
             match n {
@@ -87,17 +87,6 @@ fn def_with_body_from_child_node(
             }
         }
     })
-}
-
-fn ancestors_with_macros<'a>(
-    db: &'a (impl HirDatabase),
-    node: InFile<&SyntaxNode>,
-) -> impl Iterator<Item = InFile<SyntaxNode>> + 'a {
-    let file = node.with_value(()); // keep just the file id for borrow checker purposes
-    let parent_node = node.file_id.call_node(db);
-    let parent_ancestors: Box<dyn Iterator<Item = InFile<SyntaxNode>>> =
-        Box::new(parent_node.into_iter().flat_map(move |n| ancestors_with_macros(db, n.as_ref())));
-    node.value.ancestors().map(move |n| file.with_value(n)).chain(parent_ancestors)
 }
 
 /// `SourceAnalyzer` is a convenience wrapper which exposes HIR API in terms of

--- a/crates/ra_hir_expand/src/builtin_macro.rs
+++ b/crates/ra_hir_expand/src/builtin_macro.rs
@@ -49,7 +49,11 @@ register_builtin! {
     (COMPILE_ERROR_MACRO, CompileError) => compile_error_expand,
     (FILE_MACRO, File) => file_expand,
     (LINE_MACRO, Line) => line_expand,
-    (STRINGIFY_MACRO, Stringify) => stringify_expand
+    (STRINGIFY_MACRO, Stringify) => stringify_expand,
+    (FORMAT_ARGS_MACRO, FormatArgs) => format_args_expand,
+    // format_args_nl only differs in that it adds a newline in the end,
+    // so we use the same stub expansion for now
+    (FORMAT_ARGS_NL_MACRO, FormatArgsNl) => format_args_expand
 }
 
 fn to_line_number(db: &dyn AstDatabase, file: HirFileId, pos: TextUnit) -> usize {
@@ -198,6 +202,19 @@ fn compile_error_expand(
     }
 
     Err(mbe::ExpandError::BindingError("Must be a string".into()))
+}
+
+fn format_args_expand(
+    _db: &dyn AstDatabase,
+    _id: MacroCallId,
+    _tt: &tt::Subtree,
+) -> Result<tt::Subtree, mbe::ExpandError> {
+    // FIXME this is just a stub to make format macros type-check without mismatches
+    // We should make this at least insert the arguments, so that go to def etc. work within format macros
+    let expanded = quote! {
+        std::fmt::Arguments::new_v1(&[], &[])
+    };
+    Ok(expanded)
 }
 
 #[cfg(test)]

--- a/crates/ra_hir_expand/src/db.rs
+++ b/crates/ra_hir_expand/src/db.rs
@@ -45,8 +45,8 @@ impl TokenExpander {
     pub fn map_id_up(&self, id: tt::TokenId) -> (tt::TokenId, mbe::Origin) {
         match self {
             TokenExpander::MacroRules(it) => it.map_id_up(id),
-            TokenExpander::Builtin(..) => (id, mbe::Origin::Def),
-            TokenExpander::BuiltinDerive(..) => (id, mbe::Origin::Def),
+            TokenExpander::Builtin(..) => (id, mbe::Origin::Call),
+            TokenExpander::BuiltinDerive(..) => (id, mbe::Origin::Call),
         }
     }
 }

--- a/crates/ra_hir_expand/src/lib.rs
+++ b/crates/ra_hir_expand/src/lib.rs
@@ -76,6 +76,17 @@ impl HirFileId {
         }
     }
 
+    /// If this is a macro call, returns the syntax node of the call.
+    pub fn call_node(self, db: &dyn db::AstDatabase) -> Option<InFile<SyntaxNode>> {
+        match self.0 {
+            HirFileIdRepr::FileId(_) => None,
+            HirFileIdRepr::MacroFile(macro_file) => {
+                let loc = db.lookup_intern_macro(macro_file.macro_call_id);
+                Some(loc.kind.node(db))
+            }
+        }
+    }
+
     /// Return expansion information if it is a macro-expansion file
     pub fn expansion_info(self, db: &dyn db::AstDatabase) -> Option<ExpansionInfo> {
         match self.0 {
@@ -173,6 +184,13 @@ impl MacroCallKind {
         match self {
             MacroCallKind::FnLike(ast_id) => ast_id.file_id,
             MacroCallKind::Attr(ast_id) => ast_id.file_id,
+        }
+    }
+
+    pub fn node(&self, db: &dyn db::AstDatabase) -> InFile<SyntaxNode> {
+        match self {
+            MacroCallKind::FnLike(ast_id) => ast_id.with_value(ast_id.to_node(db).syntax().clone()),
+            MacroCallKind::Attr(ast_id) => ast_id.with_value(ast_id.to_node(db).syntax().clone()),
         }
     }
 

--- a/crates/ra_hir_expand/src/name.rs
+++ b/crates/ra_hir_expand/src/name.rs
@@ -159,6 +159,8 @@ pub const COLUMN_MACRO: Name = Name::new_inline_ascii(6, b"column");
 pub const COMPILE_ERROR_MACRO: Name = Name::new_inline_ascii(13, b"compile_error");
 pub const LINE_MACRO: Name = Name::new_inline_ascii(4, b"line");
 pub const STRINGIFY_MACRO: Name = Name::new_inline_ascii(9, b"stringify");
+pub const FORMAT_ARGS_MACRO: Name = Name::new_inline_ascii(11, b"format_args");
+pub const FORMAT_ARGS_NL_MACRO: Name = Name::new_inline_ascii(14, b"format_args_nl");
 
 // Builtin derives
 pub const COPY_TRAIT: Name = Name::new_inline_ascii(4, b"Copy");

--- a/crates/ra_hir_expand/src/name.rs
+++ b/crates/ra_hir_expand/src/name.rs
@@ -38,8 +38,8 @@ impl Name {
     }
 
     /// Shortcut to create inline plain text name
-    const fn new_inline_ascii(len: usize, text: &[u8]) -> Name {
-        Name::new_text(SmolStr::new_inline_from_ascii(len, text))
+    const fn new_inline_ascii(text: &[u8]) -> Name {
+        Name::new_text(SmolStr::new_inline_from_ascii(text.len(), text))
     }
 
     /// Resolve a name from the text of token.
@@ -105,70 +105,70 @@ impl AsName for ra_db::Dependency {
 }
 
 // Primitives
-pub const ISIZE: Name = Name::new_inline_ascii(5, b"isize");
-pub const I8: Name = Name::new_inline_ascii(2, b"i8");
-pub const I16: Name = Name::new_inline_ascii(3, b"i16");
-pub const I32: Name = Name::new_inline_ascii(3, b"i32");
-pub const I64: Name = Name::new_inline_ascii(3, b"i64");
-pub const I128: Name = Name::new_inline_ascii(4, b"i128");
-pub const USIZE: Name = Name::new_inline_ascii(5, b"usize");
-pub const U8: Name = Name::new_inline_ascii(2, b"u8");
-pub const U16: Name = Name::new_inline_ascii(3, b"u16");
-pub const U32: Name = Name::new_inline_ascii(3, b"u32");
-pub const U64: Name = Name::new_inline_ascii(3, b"u64");
-pub const U128: Name = Name::new_inline_ascii(4, b"u128");
-pub const F32: Name = Name::new_inline_ascii(3, b"f32");
-pub const F64: Name = Name::new_inline_ascii(3, b"f64");
-pub const BOOL: Name = Name::new_inline_ascii(4, b"bool");
-pub const CHAR: Name = Name::new_inline_ascii(4, b"char");
-pub const STR: Name = Name::new_inline_ascii(3, b"str");
+pub const ISIZE: Name = Name::new_inline_ascii(b"isize");
+pub const I8: Name = Name::new_inline_ascii(b"i8");
+pub const I16: Name = Name::new_inline_ascii(b"i16");
+pub const I32: Name = Name::new_inline_ascii(b"i32");
+pub const I64: Name = Name::new_inline_ascii(b"i64");
+pub const I128: Name = Name::new_inline_ascii(b"i128");
+pub const USIZE: Name = Name::new_inline_ascii(b"usize");
+pub const U8: Name = Name::new_inline_ascii(b"u8");
+pub const U16: Name = Name::new_inline_ascii(b"u16");
+pub const U32: Name = Name::new_inline_ascii(b"u32");
+pub const U64: Name = Name::new_inline_ascii(b"u64");
+pub const U128: Name = Name::new_inline_ascii(b"u128");
+pub const F32: Name = Name::new_inline_ascii(b"f32");
+pub const F64: Name = Name::new_inline_ascii(b"f64");
+pub const BOOL: Name = Name::new_inline_ascii(b"bool");
+pub const CHAR: Name = Name::new_inline_ascii(b"char");
+pub const STR: Name = Name::new_inline_ascii(b"str");
 
 // Special names
-pub const SELF_PARAM: Name = Name::new_inline_ascii(4, b"self");
-pub const SELF_TYPE: Name = Name::new_inline_ascii(4, b"Self");
-pub const MACRO_RULES: Name = Name::new_inline_ascii(11, b"macro_rules");
+pub const SELF_PARAM: Name = Name::new_inline_ascii(b"self");
+pub const SELF_TYPE: Name = Name::new_inline_ascii(b"Self");
+pub const MACRO_RULES: Name = Name::new_inline_ascii(b"macro_rules");
 
 // Components of known path (value or mod name)
-pub const STD: Name = Name::new_inline_ascii(3, b"std");
-pub const ITER: Name = Name::new_inline_ascii(4, b"iter");
-pub const OPS: Name = Name::new_inline_ascii(3, b"ops");
-pub const FUTURE: Name = Name::new_inline_ascii(6, b"future");
-pub const RESULT: Name = Name::new_inline_ascii(6, b"result");
-pub const BOXED: Name = Name::new_inline_ascii(5, b"boxed");
+pub const STD: Name = Name::new_inline_ascii(b"std");
+pub const ITER: Name = Name::new_inline_ascii(b"iter");
+pub const OPS: Name = Name::new_inline_ascii(b"ops");
+pub const FUTURE: Name = Name::new_inline_ascii(b"future");
+pub const RESULT: Name = Name::new_inline_ascii(b"result");
+pub const BOXED: Name = Name::new_inline_ascii(b"boxed");
 
 // Components of known path (type name)
-pub const INTO_ITERATOR_TYPE: Name = Name::new_inline_ascii(12, b"IntoIterator");
-pub const ITEM_TYPE: Name = Name::new_inline_ascii(4, b"Item");
-pub const TRY_TYPE: Name = Name::new_inline_ascii(3, b"Try");
-pub const OK_TYPE: Name = Name::new_inline_ascii(2, b"Ok");
-pub const FUTURE_TYPE: Name = Name::new_inline_ascii(6, b"Future");
-pub const RESULT_TYPE: Name = Name::new_inline_ascii(6, b"Result");
-pub const OUTPUT_TYPE: Name = Name::new_inline_ascii(6, b"Output");
-pub const TARGET_TYPE: Name = Name::new_inline_ascii(6, b"Target");
-pub const BOX_TYPE: Name = Name::new_inline_ascii(3, b"Box");
-pub const RANGE_FROM_TYPE: Name = Name::new_inline_ascii(9, b"RangeFrom");
-pub const RANGE_FULL_TYPE: Name = Name::new_inline_ascii(9, b"RangeFull");
-pub const RANGE_INCLUSIVE_TYPE: Name = Name::new_inline_ascii(14, b"RangeInclusive");
-pub const RANGE_TO_INCLUSIVE_TYPE: Name = Name::new_inline_ascii(16, b"RangeToInclusive");
-pub const RANGE_TO_TYPE: Name = Name::new_inline_ascii(7, b"RangeTo");
-pub const RANGE_TYPE: Name = Name::new_inline_ascii(5, b"Range");
+pub const INTO_ITERATOR_TYPE: Name = Name::new_inline_ascii(b"IntoIterator");
+pub const ITEM_TYPE: Name = Name::new_inline_ascii(b"Item");
+pub const TRY_TYPE: Name = Name::new_inline_ascii(b"Try");
+pub const OK_TYPE: Name = Name::new_inline_ascii(b"Ok");
+pub const FUTURE_TYPE: Name = Name::new_inline_ascii(b"Future");
+pub const RESULT_TYPE: Name = Name::new_inline_ascii(b"Result");
+pub const OUTPUT_TYPE: Name = Name::new_inline_ascii(b"Output");
+pub const TARGET_TYPE: Name = Name::new_inline_ascii(b"Target");
+pub const BOX_TYPE: Name = Name::new_inline_ascii(b"Box");
+pub const RANGE_FROM_TYPE: Name = Name::new_inline_ascii(b"RangeFrom");
+pub const RANGE_FULL_TYPE: Name = Name::new_inline_ascii(b"RangeFull");
+pub const RANGE_INCLUSIVE_TYPE: Name = Name::new_inline_ascii(b"RangeInclusive");
+pub const RANGE_TO_INCLUSIVE_TYPE: Name = Name::new_inline_ascii(b"RangeToInclusive");
+pub const RANGE_TO_TYPE: Name = Name::new_inline_ascii(b"RangeTo");
+pub const RANGE_TYPE: Name = Name::new_inline_ascii(b"Range");
 
 // Builtin Macros
-pub const FILE_MACRO: Name = Name::new_inline_ascii(4, b"file");
-pub const COLUMN_MACRO: Name = Name::new_inline_ascii(6, b"column");
-pub const COMPILE_ERROR_MACRO: Name = Name::new_inline_ascii(13, b"compile_error");
-pub const LINE_MACRO: Name = Name::new_inline_ascii(4, b"line");
-pub const STRINGIFY_MACRO: Name = Name::new_inline_ascii(9, b"stringify");
-pub const FORMAT_ARGS_MACRO: Name = Name::new_inline_ascii(11, b"format_args");
-pub const FORMAT_ARGS_NL_MACRO: Name = Name::new_inline_ascii(14, b"format_args_nl");
+pub const FILE_MACRO: Name = Name::new_inline_ascii(b"file");
+pub const COLUMN_MACRO: Name = Name::new_inline_ascii(b"column");
+pub const COMPILE_ERROR_MACRO: Name = Name::new_inline_ascii(b"compile_error");
+pub const LINE_MACRO: Name = Name::new_inline_ascii(b"line");
+pub const STRINGIFY_MACRO: Name = Name::new_inline_ascii(b"stringify");
+pub const FORMAT_ARGS_MACRO: Name = Name::new_inline_ascii(b"format_args");
+pub const FORMAT_ARGS_NL_MACRO: Name = Name::new_inline_ascii(b"format_args_nl");
 
 // Builtin derives
-pub const COPY_TRAIT: Name = Name::new_inline_ascii(4, b"Copy");
-pub const CLONE_TRAIT: Name = Name::new_inline_ascii(5, b"Clone");
-pub const DEFAULT_TRAIT: Name = Name::new_inline_ascii(7, b"Default");
-pub const DEBUG_TRAIT: Name = Name::new_inline_ascii(5, b"Debug");
-pub const HASH_TRAIT: Name = Name::new_inline_ascii(4, b"Hash");
-pub const ORD_TRAIT: Name = Name::new_inline_ascii(3, b"Ord");
-pub const PARTIAL_ORD_TRAIT: Name = Name::new_inline_ascii(10, b"PartialOrd");
-pub const EQ_TRAIT: Name = Name::new_inline_ascii(2, b"Eq");
-pub const PARTIAL_EQ_TRAIT: Name = Name::new_inline_ascii(9, b"PartialEq");
+pub const COPY_TRAIT: Name = Name::new_inline_ascii(b"Copy");
+pub const CLONE_TRAIT: Name = Name::new_inline_ascii(b"Clone");
+pub const DEFAULT_TRAIT: Name = Name::new_inline_ascii(b"Default");
+pub const DEBUG_TRAIT: Name = Name::new_inline_ascii(b"Debug");
+pub const HASH_TRAIT: Name = Name::new_inline_ascii(b"Hash");
+pub const ORD_TRAIT: Name = Name::new_inline_ascii(b"Ord");
+pub const PARTIAL_ORD_TRAIT: Name = Name::new_inline_ascii(b"PartialOrd");
+pub const EQ_TRAIT: Name = Name::new_inline_ascii(b"Eq");
+pub const PARTIAL_EQ_TRAIT: Name = Name::new_inline_ascii(b"PartialEq");

--- a/crates/ra_ide/src/goto_definition.rs
+++ b/crates/ra_ide/src/goto_definition.rs
@@ -689,11 +689,13 @@ mod tests {
                     fo<|>o();
                 }
             }
+            mod confuse_index { fn foo(); }
             ",
             "foo FN_DEF FileId(1) [52; 63) [55; 58)",
         );
     }
 
+    #[should_panic] // currently failing because of expr mapping problems
     #[test]
     fn goto_through_format() {
         check_goto(
@@ -711,6 +713,7 @@ mod tests {
             }
             pub mod __export {
                 pub use crate::format_args;
+                fn foo() {} // for index confusion
             }
             fn foo() -> i8 {}
             fn test() {

--- a/crates/ra_ide/src/goto_definition.rs
+++ b/crates/ra_ide/src/goto_definition.rs
@@ -693,4 +693,31 @@ mod tests {
             "foo FN_DEF FileId(1) [52; 63) [55; 58)",
         );
     }
+
+    #[test]
+    fn goto_through_format() {
+        check_goto(
+            "
+            //- /lib.rs
+            #[macro_export]
+            macro_rules! format {
+                ($($arg:tt)*) => ($crate::fmt::format($crate::__export::format_args!($($arg)*)))
+            }
+            #[rustc_builtin_macro]
+            #[macro_export]
+            macro_rules! format_args {
+                ($fmt:expr) => ({ /* compiler built-in */ });
+                ($fmt:expr, $($args:tt)*) => ({ /* compiler built-in */ })
+            }
+            pub mod __export {
+                pub use crate::format_args;
+            }
+            fn foo() -> i8 {}
+            fn test() {
+                format!(\"{}\", fo<|>o())
+            }
+            ",
+            "foo FN_DEF FileId(1) [359; 376) [362; 365)",
+        );
+    }
 }


### PR DESCRIPTION
This fixes a huge amount of type mismatches (because every format call was a type mismatch so far); I also hoped to get go to def working within `format!` etc., and the test says it should, but in practice it still doesn't seem to...

Also remove the `len` parameter from `Name::new_inline_ascii`, which I'm assuming was only there because of `const fn` limitations?

cc @edwin0cheng 