### PR TITLE
Refactor generic parameteres lowering

### DIFF
--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -15,7 +15,7 @@ use hir_def::{
     per_ns::PerNs,
     resolver::HasResolver,
     type_ref::{Mutability, TypeRef},
-    AdtId, AstItemDef, ConstId, ContainerId, DefWithBodyId, EnumId, FunctionId, GenericDefId,
+    AdtId, AstItemDef, ConstId, ContainerId, DefWithBodyId, EnumId, FunctionId, GenericParamId,
     HasModule, ImplId, LocalEnumVariantId, LocalImportId, LocalModuleId, LocalStructFieldId,
     Lookup, ModuleId, StaticId, StructId, TraitId, TypeAliasId, UnionId,
 };
@@ -857,8 +857,7 @@ impl Local {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct GenericParam {
-    pub(crate) parent: GenericDefId,
-    pub(crate) idx: u32,
+    pub(crate) id: GenericParamId,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/ra_hir/src/source_binder.rs
+++ b/crates/ra_hir/src/source_binder.rs
@@ -262,10 +262,7 @@ impl SourceAnalyzer {
     ) -> Option<PathResolution> {
         let types = self.resolver.resolve_path_in_type_ns_fully(db, &path).map(|ty| match ty {
             TypeNs::SelfType(it) => PathResolution::SelfType(it.into()),
-            TypeNs::GenericParam(idx) => PathResolution::GenericParam(GenericParam {
-                parent: self.resolver.generic_def().unwrap(),
-                idx,
-            }),
+            TypeNs::GenericParam(id) => PathResolution::GenericParam(GenericParam { id }),
             TypeNs::AdtSelfType(it) | TypeNs::AdtId(it) => {
                 PathResolution::Def(Adt::from(it).into())
             }
@@ -337,10 +334,7 @@ impl SourceAnalyzer {
                 resolver::ScopeDef::PerNs(it) => it.into(),
                 resolver::ScopeDef::ImplSelfType(it) => ScopeDef::ImplSelfType(it.into()),
                 resolver::ScopeDef::AdtSelfType(it) => ScopeDef::AdtSelfType(it.into()),
-                resolver::ScopeDef::GenericParam(idx) => {
-                    let parent = self.resolver.generic_def().unwrap();
-                    ScopeDef::GenericParam(GenericParam { parent, idx })
-                }
+                resolver::ScopeDef::GenericParam(id) => ScopeDef::GenericParam(GenericParam { id }),
                 resolver::ScopeDef::Local(pat_id) => {
                     let parent = self.resolver.body_owner().unwrap().into();
                     ScopeDef::Local(Local { parent, pat_id })

--- a/crates/ra_hir_def/src/generics.rs
+++ b/crates/ra_hir_def/src/generics.rs
@@ -12,14 +12,12 @@ use crate::{
     db::DefDatabase,
     src::HasSource,
     type_ref::{TypeBound, TypeRef},
-    AdtId, AstItemDef, ContainerId, GenericDefId, LocalGenericParamId, Lookup,
+    AdtId, AstItemDef, GenericDefId, LocalGenericParamId, Lookup,
 };
 
 /// Data about a generic parameter (to a function, struct, impl, ...).
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct GenericParamData {
-    // FIXME: give generic params proper IDs
-    pub idx: u32,
     pub name: Name,
     pub default: Option<TypeRef>,
 }
@@ -27,7 +25,6 @@ pub struct GenericParamData {
 /// Data about the generic parameters of a function, struct, impl, etc.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct GenericParams {
-    pub parent_params: Option<Arc<GenericParams>>,
     pub params: Arena<LocalGenericParamId, GenericParamData>,
     pub where_predicates: Vec<WherePredicate>,
 }
@@ -47,51 +44,40 @@ impl GenericParams {
         db: &impl DefDatabase,
         def: GenericDefId,
     ) -> Arc<GenericParams> {
-        let parent_generics = parent_generic_def(db, def).map(|it| db.generic_params(it));
-        Arc::new(GenericParams::new(db, def.into(), parent_generics))
+        Arc::new(GenericParams::new(db, def.into()))
     }
 
-    fn new(
-        db: &impl DefDatabase,
-        def: GenericDefId,
-        parent_params: Option<Arc<GenericParams>>,
-    ) -> GenericParams {
-        let mut generics =
-            GenericParams { params: Arena::default(), parent_params, where_predicates: Vec::new() };
-        let start = generics.parent_params.as_ref().map(|p| p.params.len()).unwrap_or(0) as u32;
+    fn new(db: &impl DefDatabase, def: GenericDefId) -> GenericParams {
+        let mut generics = GenericParams { params: Arena::default(), where_predicates: Vec::new() };
         // FIXME: add `: Sized` bound for everything except for `Self` in traits
         match def {
-            GenericDefId::FunctionId(it) => generics.fill(&it.lookup(db).source(db).value, start),
-            GenericDefId::AdtId(AdtId::StructId(it)) => generics.fill(&it.source(db).value, start),
-            GenericDefId::AdtId(AdtId::UnionId(it)) => generics.fill(&it.source(db).value, start),
-            GenericDefId::AdtId(AdtId::EnumId(it)) => generics.fill(&it.source(db).value, start),
+            GenericDefId::FunctionId(it) => generics.fill(&it.lookup(db).source(db).value),
+            GenericDefId::AdtId(AdtId::StructId(it)) => generics.fill(&it.source(db).value),
+            GenericDefId::AdtId(AdtId::UnionId(it)) => generics.fill(&it.source(db).value),
+            GenericDefId::AdtId(AdtId::EnumId(it)) => generics.fill(&it.source(db).value),
             GenericDefId::TraitId(it) => {
                 // traits get the Self type as an implicit first type parameter
-                generics.params.alloc(GenericParamData {
-                    idx: start,
-                    name: name::SELF_TYPE,
-                    default: None,
-                });
-                generics.fill(&it.source(db).value, start + 1);
+                generics.params.alloc(GenericParamData { name: name::SELF_TYPE, default: None });
+                generics.fill(&it.source(db).value);
                 // add super traits as bounds on Self
                 // i.e., trait Foo: Bar is equivalent to trait Foo where Self: Bar
                 let self_param = TypeRef::Path(name::SELF_TYPE.into());
                 generics.fill_bounds(&it.source(db).value, self_param);
             }
-            GenericDefId::TypeAliasId(it) => generics.fill(&it.lookup(db).source(db).value, start),
+            GenericDefId::TypeAliasId(it) => generics.fill(&it.lookup(db).source(db).value),
             // Note that we don't add `Self` here: in `impl`s, `Self` is not a
             // type-parameter, but rather is a type-alias for impl's target
             // type, so this is handled by the resolver.
-            GenericDefId::ImplId(it) => generics.fill(&it.source(db).value, start),
+            GenericDefId::ImplId(it) => generics.fill(&it.source(db).value),
             GenericDefId::EnumVariantId(_) | GenericDefId::ConstId(_) => {}
         }
 
         generics
     }
 
-    fn fill(&mut self, node: &impl TypeParamsOwner, start: u32) {
+    fn fill(&mut self, node: &impl TypeParamsOwner) {
         if let Some(params) = node.type_param_list() {
-            self.fill_params(params, start)
+            self.fill_params(params)
         }
         if let Some(where_clause) = node.where_clause() {
             self.fill_where_predicates(where_clause);
@@ -106,12 +92,12 @@ impl GenericParams {
         }
     }
 
-    fn fill_params(&mut self, params: ast::TypeParamList, start: u32) {
-        for (idx, type_param) in params.type_params().enumerate() {
+    fn fill_params(&mut self, params: ast::TypeParamList) {
+        for type_param in params.type_params() {
             let name = type_param.name().map_or_else(Name::missing, |it| it.as_name());
             // FIXME: Use `Path::from_src`
             let default = type_param.default_type().map(TypeRef::from_ast);
-            let param = GenericParamData { idx: idx as u32 + start, name: name.clone(), default };
+            let param = GenericParamData { name: name.clone(), default };
             self.params.alloc(param);
 
             let type_ref = TypeRef::Path(name.into());
@@ -141,45 +127,7 @@ impl GenericParams {
         self.where_predicates.push(WherePredicate { type_ref, bound });
     }
 
-    pub fn find_by_name(&self, name: &Name) -> Option<&GenericParamData> {
-        self.params.iter().map(|(_id, data)| data).find(|p| &p.name == name)
-    }
-
-    pub fn count_parent_params(&self) -> usize {
-        self.parent_params.as_ref().map(|p| p.count_params_including_parent()).unwrap_or(0)
-    }
-
-    pub fn count_params_including_parent(&self) -> usize {
-        let parent_count = self.count_parent_params();
-        parent_count + self.params.len()
-    }
-
-    fn for_each_param<'a>(&'a self, f: &mut impl FnMut(&'a GenericParamData)) {
-        if let Some(parent) = &self.parent_params {
-            parent.for_each_param(f);
-        }
-        self.params.iter().map(|(_id, data)| data).for_each(f);
-    }
-
-    pub fn params_including_parent(&self) -> Vec<&GenericParamData> {
-        let mut vec = Vec::with_capacity(self.count_params_including_parent());
-        self.for_each_param(&mut |p| vec.push(p));
-        vec
-    }
-}
-
-fn parent_generic_def(db: &impl DefDatabase, def: GenericDefId) -> Option<GenericDefId> {
-    let container = match def {
-        GenericDefId::FunctionId(it) => it.lookup(db).container,
-        GenericDefId::TypeAliasId(it) => it.lookup(db).container,
-        GenericDefId::ConstId(it) => it.lookup(db).container,
-        GenericDefId::EnumVariantId(it) => return Some(it.parent.into()),
-        GenericDefId::AdtId(_) | GenericDefId::TraitId(_) | GenericDefId::ImplId(_) => return None,
-    };
-
-    match container {
-        ContainerId::ImplId(it) => Some(it.into()),
-        ContainerId::TraitId(it) => Some(it.into()),
-        ContainerId::ModuleId(_) => None,
+    pub fn find_by_name(&self, name: &Name) -> Option<LocalGenericParamId> {
+        self.params.iter().find_map(|(id, p)| if &p.name == name { Some(id) } else { None })
     }
 }

--- a/crates/ra_hir_def/src/lib.rs
+++ b/crates/ra_hir_def/src/lib.rs
@@ -318,6 +318,16 @@ macro_rules! impl_froms {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct GenericParamId {
+    pub parent: GenericDefId,
+    pub local_id: LocalGenericParamId,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct LocalGenericParamId(RawId);
+impl_arena_id!(LocalGenericParamId);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ContainerId {
     ModuleId(ModuleId),
     ImplId(ImplId),

--- a/crates/ra_hir_def/src/resolver.rs
+++ b/crates/ra_hir_def/src/resolver.rs
@@ -18,12 +18,13 @@ use crate::{
     path::{Path, PathKind},
     per_ns::PerNs,
     AdtId, AstItemDef, ConstId, ContainerId, DefWithBodyId, EnumId, EnumVariantId, FunctionId,
-    GenericDefId, HasModule, ImplId, LocalModuleId, Lookup, ModuleDefId, ModuleId, StaticId,
-    StructId, TraitId, TypeAliasId,
+    GenericDefId, GenericParamId, HasModule, ImplId, LocalModuleId, Lookup, ModuleDefId, ModuleId,
+    StaticId, StructId, TraitId, TypeAliasId,
 };
 
 #[derive(Debug, Clone, Default)]
 pub struct Resolver {
+    // FIXME: all usages generally call `.rev`, so maybe reverse once in consturciton?
     scopes: Vec<Scope>,
 }
 
@@ -58,7 +59,7 @@ enum Scope {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TypeNs {
     SelfType(ImplId),
-    GenericParam(u32),
+    GenericParam(GenericParamId),
     AdtId(AdtId),
     AdtSelfType(AdtId),
     // Yup, enum variants are added to the types ns, but any usage of variant as
@@ -152,10 +153,13 @@ impl Resolver {
                 Scope::ExprScope(_) => continue,
                 Scope::GenericParams { .. } | Scope::ImplBlockScope(_) if skip_to_mod => continue,
 
-                Scope::GenericParams { params, .. } => {
-                    if let Some(param) = params.find_by_name(first_name) {
+                Scope::GenericParams { params, def } => {
+                    if let Some(local_id) = params.find_by_name(first_name) {
                         let idx = if path.segments.len() == 1 { None } else { Some(1) };
-                        return Some((TypeNs::GenericParam(param.idx), idx));
+                        return Some((
+                            TypeNs::GenericParam(GenericParamId { local_id, parent: *def }),
+                            idx,
+                        ));
                     }
                 }
                 Scope::ImplBlockScope(impl_) => {
@@ -246,9 +250,9 @@ impl Resolver {
                 }
                 Scope::ExprScope(_) => continue,
 
-                Scope::GenericParams { params, .. } if n_segments > 1 => {
-                    if let Some(param) = params.find_by_name(first_name) {
-                        let ty = TypeNs::GenericParam(param.idx);
+                Scope::GenericParams { params, def } if n_segments > 1 => {
+                    if let Some(local_id) = params.find_by_name(first_name) {
+                        let ty = TypeNs::GenericParam(GenericParamId { local_id, parent: *def });
                         return Some(ResolveValueResult::Partial(ty, 1));
                     }
                 }
@@ -368,6 +372,7 @@ impl Resolver {
     ) -> impl Iterator<Item = &'a crate::generics::WherePredicate> + 'a {
         self.scopes
             .iter()
+            .rev()
             .filter_map(|scope| match scope {
                 Scope::GenericParams { params, .. } => Some(params),
                 _ => None,
@@ -376,14 +381,14 @@ impl Resolver {
     }
 
     pub fn generic_def(&self) -> Option<GenericDefId> {
-        self.scopes.iter().find_map(|scope| match scope {
+        self.scopes.iter().rev().find_map(|scope| match scope {
             Scope::GenericParams { def, .. } => Some(*def),
             _ => None,
         })
     }
 
     pub fn body_owner(&self) -> Option<DefWithBodyId> {
-        self.scopes.iter().find_map(|scope| match scope {
+        self.scopes.iter().rev().find_map(|scope| match scope {
             Scope::ExprScope(it) => Some(it.owner),
             _ => None,
         })
@@ -394,7 +399,7 @@ pub enum ScopeDef {
     PerNs(PerNs),
     ImplSelfType(ImplId),
     AdtSelfType(AdtId),
-    GenericParam(u32),
+    GenericParam(GenericParamId),
     Local(PatId),
 }
 
@@ -425,9 +430,12 @@ impl Scope {
                     });
                 }
             }
-            Scope::GenericParams { params, .. } => {
-                for (_id, param) in params.params.iter() {
-                    f(param.name.clone(), ScopeDef::GenericParam(param.idx))
+            Scope::GenericParams { params, def } => {
+                for (local_id, param) in params.params.iter() {
+                    f(
+                        param.name.clone(),
+                        ScopeDef::GenericParam(GenericParamId { local_id, parent: *def }),
+                    )
                 }
             }
             Scope::ImplBlockScope(i) => {

--- a/crates/ra_hir_def/src/resolver.rs
+++ b/crates/ra_hir_def/src/resolver.rs
@@ -426,7 +426,7 @@ impl Scope {
                 }
             }
             Scope::GenericParams { params, .. } => {
-                for param in params.params.iter() {
+                for (_id, param) in params.params.iter() {
                     f(param.name.clone(), ScopeDef::GenericParam(param.idx))
                 }
             }

--- a/crates/ra_hir_ty/src/autoderef.rs
+++ b/crates/ra_hir_ty/src/autoderef.rs
@@ -55,7 +55,7 @@ fn deref_by_trait(
     let target = db.trait_data(deref_trait).associated_type_by_name(&name::TARGET_TYPE)?;
 
     let generic_params = generics(db, target.into());
-    if generic_params.count_params_including_parent() != 1 {
+    if generic_params.len() != 1 {
         // the Target type + Deref trait should only have one generic parameter,
         // namely Deref's Self type
         return None;

--- a/crates/ra_hir_ty/src/autoderef.rs
+++ b/crates/ra_hir_ty/src/autoderef.rs
@@ -10,10 +10,10 @@ use hir_expand::name;
 use log::{info, warn};
 use ra_db::CrateId;
 
-use crate::db::HirDatabase;
-
-use super::{
+use crate::{
+    db::HirDatabase,
     traits::{InEnvironment, Solution},
+    utils::generics,
     Canonical, Substs, Ty, TypeWalk,
 };
 
@@ -54,7 +54,7 @@ fn deref_by_trait(
     };
     let target = db.trait_data(deref_trait).associated_type_by_name(&name::TARGET_TYPE)?;
 
-    let generic_params = db.generic_params(target.into());
+    let generic_params = generics(db, target.into());
     if generic_params.count_params_including_parent() != 1 {
         // the Target type + Deref trait should only have one generic parameter,
         // namely Deref's Self type

--- a/crates/ra_hir_ty/src/infer/expr.rs
+++ b/crates/ra_hir_ty/src/infer/expr.rs
@@ -662,7 +662,7 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
         let mut substs = Vec::with_capacity(parent_param_count + param_count);
         // Parent arguments are unknown, except for the receiver type
         if let Some(parent_generics) = def_generics.and_then(|p| p.parent_params.clone()) {
-            for param in &parent_generics.params {
+            for (_id, param) in parent_generics.params.iter() {
                 if param.name == name::SELF_TYPE {
                     substs.push(receiver_ty.clone());
                 } else {

--- a/crates/ra_hir_ty/src/lib.rs
+++ b/crates/ra_hir_ty/src/lib.rs
@@ -44,8 +44,8 @@ use std::sync::Arc;
 use std::{fmt, iter, mem};
 
 use hir_def::{
-    expr::ExprId, type_ref::Mutability, AdtId, ContainerId, DefWithBodyId,
-    GenericDefId, HasModule, Lookup, TraitId, TypeAliasId,
+    expr::ExprId, type_ref::Mutability, AdtId, ContainerId, DefWithBodyId, GenericDefId, HasModule,
+    Lookup, TraitId, TypeAliasId,
 };
 use hir_expand::name::Name;
 use ra_db::{impl_intern_key, salsa, CrateId};

--- a/crates/ra_hir_ty/src/lib.rs
+++ b/crates/ra_hir_ty/src/lib.rs
@@ -167,15 +167,15 @@ impl TypeCtor {
             => 1,
             TypeCtor::Adt(adt) => {
                 let generic_params = generics(db, AdtId::from(adt).into());
-                generic_params.count_params_including_parent()
+                generic_params.len()
             }
             TypeCtor::FnDef(callable) => {
                 let generic_params = generics(db, callable.into());
-                generic_params.count_params_including_parent()
+                generic_params.len()
             }
             TypeCtor::AssociatedType(type_alias) => {
                 let generic_params = generics(db, type_alias.into());
-                generic_params.count_params_including_parent()
+                generic_params.len()
             }
             TypeCtor::FnPtr { num_args } => num_args as usize + 1,
             TypeCtor::Tuple { cardinality } => cardinality as usize,
@@ -378,12 +378,12 @@ impl Substs {
     pub fn build_for_def(db: &impl HirDatabase, def: impl Into<GenericDefId>) -> SubstsBuilder {
         let def = def.into();
         let params = generics(db, def);
-        let param_count = params.count_params_including_parent();
+        let param_count = params.len();
         Substs::builder(param_count)
     }
 
     pub(crate) fn build_for_generics(generic_params: &Generics) -> SubstsBuilder {
-        Substs::builder(generic_params.count_params_including_parent())
+        Substs::builder(generic_params.len())
     }
 
     pub fn build_for_type_ctor(db: &impl HirDatabase, type_ctor: TypeCtor) -> SubstsBuilder {

--- a/crates/ra_hir_ty/src/lib.rs
+++ b/crates/ra_hir_ty/src/lib.rs
@@ -44,7 +44,7 @@ use std::sync::Arc;
 use std::{fmt, iter, mem};
 
 use hir_def::{
-    expr::ExprId, generics::GenericParams, type_ref::Mutability, AdtId, ContainerId, DefWithBodyId,
+    expr::ExprId, type_ref::Mutability, AdtId, ContainerId, DefWithBodyId,
     GenericDefId, HasModule, Lookup, TraitId, TypeAliasId,
 };
 use hir_expand::name::Name;
@@ -53,7 +53,7 @@ use ra_db::{impl_intern_key, salsa, CrateId};
 use crate::{
     db::HirDatabase,
     primitive::{FloatTy, IntTy, Uncertain},
-    utils::make_mut_slice,
+    utils::{generics, make_mut_slice, Generics},
 };
 use display::{HirDisplay, HirFormatter};
 
@@ -166,15 +166,15 @@ impl TypeCtor {
             | TypeCtor::Closure { .. } // 1 param representing the signature of the closure
             => 1,
             TypeCtor::Adt(adt) => {
-                let generic_params = db.generic_params(AdtId::from(adt).into());
+                let generic_params = generics(db, AdtId::from(adt).into());
                 generic_params.count_params_including_parent()
             }
             TypeCtor::FnDef(callable) => {
-                let generic_params = db.generic_params(callable.into());
+                let generic_params = generics(db, callable.into());
                 generic_params.count_params_including_parent()
             }
             TypeCtor::AssociatedType(type_alias) => {
-                let generic_params = db.generic_params(type_alias.into());
+                let generic_params = generics(db, type_alias.into());
                 generic_params.count_params_including_parent()
             }
             TypeCtor::FnPtr { num_args } => num_args as usize + 1,
@@ -364,35 +364,25 @@ impl Substs {
     }
 
     /// Return Substs that replace each parameter by itself (i.e. `Ty::Param`).
-    pub fn identity(generic_params: &GenericParams) -> Substs {
+    pub(crate) fn identity(generic_params: &Generics) -> Substs {
         Substs(
-            generic_params
-                .params_including_parent()
-                .into_iter()
-                .map(|p| Ty::Param { idx: p.idx, name: p.name.clone() })
-                .collect(),
+            generic_params.iter().map(|(idx, p)| Ty::Param { idx, name: p.name.clone() }).collect(),
         )
     }
 
     /// Return Substs that replace each parameter by a bound variable.
-    pub fn bound_vars(generic_params: &GenericParams) -> Substs {
-        Substs(
-            generic_params
-                .params_including_parent()
-                .into_iter()
-                .map(|p| Ty::Bound(p.idx))
-                .collect(),
-        )
+    pub(crate) fn bound_vars(generic_params: &Generics) -> Substs {
+        Substs(generic_params.iter().map(|(idx, _p)| Ty::Bound(idx)).collect())
     }
 
     pub fn build_for_def(db: &impl HirDatabase, def: impl Into<GenericDefId>) -> SubstsBuilder {
         let def = def.into();
-        let params = db.generic_params(def);
+        let params = generics(db, def);
         let param_count = params.count_params_including_parent();
         Substs::builder(param_count)
     }
 
-    pub fn build_for_generics(generic_params: &GenericParams) -> SubstsBuilder {
+    pub(crate) fn build_for_generics(generic_params: &Generics) -> SubstsBuilder {
         Substs::builder(generic_params.count_params_including_parent())
     }
 

--- a/crates/ra_hir_ty/src/lower.rs
+++ b/crates/ra_hir_ty/src/lower.rs
@@ -24,7 +24,7 @@ use crate::{
     db::HirDatabase,
     primitive::{FloatTy, IntTy},
     utils::{
-        all_super_traits, associated_type_by_name_including_super_traits, make_mut_slice,
+        all_super_traits, associated_type_by_name_including_super_traits, generics, make_mut_slice,
         variant_data,
     },
     FnSig, GenericPredicate, ProjectionPredicate, ProjectionTy, Substs, TraitEnvironment, TraitRef,
@@ -111,7 +111,9 @@ impl Ty {
             Some((it, None)) => it,
             _ => return None,
         };
-        if let TypeNs::GenericParam(idx) = resolution {
+        if let TypeNs::GenericParam(param_id) = resolution {
+            let generics = generics(db, resolver.generic_def().expect("generics in scope"));
+            let idx = generics.param_idx(param_id);
             Some(idx)
         } else {
             None
@@ -174,9 +176,11 @@ impl Ty {
                     Ty::Dyn(Arc::new([GenericPredicate::Implemented(trait_ref)]))
                 };
             }
-            TypeNs::GenericParam(idx) => {
+            TypeNs::GenericParam(param_id) => {
+                let generics = generics(db, resolver.generic_def().expect("generics in scope"));
+                let idx = generics.param_idx(param_id);
                 // FIXME: maybe return name in resolution?
-                let name = resolved_segment.name.clone();
+                let name = generics.param_name(param_id);
                 Ty::Param { idx, name }
             }
             TypeNs::SelfType(impl_id) => db.impl_self_ty(impl_id).clone(),
@@ -315,10 +319,10 @@ pub(super) fn substs_from_path_segment(
     add_self_param: bool,
 ) -> Substs {
     let mut substs = Vec::new();
-    let def_generics = def_generic.map(|def| db.generic_params(def.into()));
+    let def_generics = def_generic.map(|def| generics(db, def.into()));
 
     let (parent_param_count, param_count) =
-        def_generics.map_or((0, 0), |g| (g.count_parent_params(), g.params.len()));
+        def_generics.map_or((0, 0), |g| (g.count_parent_params(), g.params.params.len()));
     substs.extend(iter::repeat(Ty::Unknown).take(parent_param_count));
     if add_self_param {
         // FIXME this add_self_param argument is kind of a hack: Traits have the
@@ -567,12 +571,11 @@ pub(crate) fn generic_predicates_query(
 /// Resolve the default type params from generics
 pub(crate) fn generic_defaults_query(db: &impl HirDatabase, def: GenericDefId) -> Substs {
     let resolver = def.resolver(db);
-    let generic_params = db.generic_params(def.into());
+    let generic_params = generics(db, def.into());
 
     let defaults = generic_params
-        .params_including_parent()
-        .into_iter()
-        .map(|p| p.default.as_ref().map_or(Ty::Unknown, |t| Ty::from_hir(db, &resolver, t)))
+        .iter()
+        .map(|(_idx, p)| p.default.as_ref().map_or(Ty::Unknown, |t| Ty::from_hir(db, &resolver, t)))
         .collect();
 
     Substs(defaults)
@@ -589,7 +592,7 @@ fn fn_sig_for_fn(db: &impl HirDatabase, def: FunctionId) -> FnSig {
 /// Build the declared type of a function. This should not need to look at the
 /// function body.
 fn type_for_fn(db: &impl HirDatabase, def: FunctionId) -> Ty {
-    let generics = db.generic_params(def.into());
+    let generics = generics(db, def.into());
     let substs = Substs::identity(&generics);
     Ty::apply(TypeCtor::FnDef(def.into()), substs)
 }
@@ -639,7 +642,7 @@ fn type_for_struct_constructor(db: &impl HirDatabase, def: StructId) -> Ty {
     if struct_data.variant_data.is_unit() {
         return type_for_adt(db, def.into()); // Unit struct
     }
-    let generics = db.generic_params(def.into());
+    let generics = generics(db, def.into());
     let substs = Substs::identity(&generics);
     Ty::apply(TypeCtor::FnDef(def.into()), substs)
 }
@@ -653,7 +656,7 @@ fn fn_sig_for_enum_variant_constructor(db: &impl HirDatabase, def: EnumVariantId
         .iter()
         .map(|(_, field)| Ty::from_hir(db, &resolver, &field.type_ref))
         .collect::<Vec<_>>();
-    let generics = db.generic_params(def.parent.into());
+    let generics = generics(db, def.parent.into());
     let substs = Substs::identity(&generics);
     let ret = type_for_adt(db, def.parent.into()).subst(&substs);
     FnSig::from_params_and_return(params, ret)
@@ -666,18 +669,18 @@ fn type_for_enum_variant_constructor(db: &impl HirDatabase, def: EnumVariantId) 
     if var_data.is_unit() {
         return type_for_adt(db, def.parent.into()); // Unit variant
     }
-    let generics = db.generic_params(def.parent.into());
+    let generics = generics(db, def.parent.into());
     let substs = Substs::identity(&generics);
     Ty::apply(TypeCtor::FnDef(EnumVariantId::from(def).into()), substs)
 }
 
 fn type_for_adt(db: &impl HirDatabase, adt: AdtId) -> Ty {
-    let generics = db.generic_params(adt.into());
+    let generics = generics(db, adt.into());
     Ty::apply(TypeCtor::Adt(adt), Substs::identity(&generics))
 }
 
 fn type_for_type_alias(db: &impl HirDatabase, t: TypeAliasId) -> Ty {
-    let generics = db.generic_params(t.into());
+    let generics = generics(db, t.into());
     let resolver = t.resolver(db);
     let type_ref = &db.type_alias_data(t).type_ref;
     let substs = Substs::identity(&generics);

--- a/crates/ra_hir_ty/src/traits/chalk.rs
+++ b/crates/ra_hir_ty/src/traits/chalk.rs
@@ -557,7 +557,7 @@ pub(crate) fn associated_ty_data_query(
         trait_id: trait_.to_chalk(db),
         id,
         name: lalrpop_intern::intern(&db.type_alias_data(type_alias).name.to_string()),
-        binders: make_binders(bound_data, generic_params.count_params_including_parent()),
+        binders: make_binders(bound_data, generic_params.len()),
     };
     Arc::new(datum)
 }

--- a/crates/ra_hir_ty/src/utils.rs
+++ b/crates/ra_hir_ty/src/utils.rs
@@ -5,9 +5,10 @@ use std::sync::Arc;
 use hir_def::{
     adt::VariantData,
     db::DefDatabase,
+    generics::{GenericParamData, GenericParams},
     resolver::{HasResolver, TypeNs},
     type_ref::TypeRef,
-    TraitId, TypeAliasId, VariantId,
+    ContainerId, GenericDefId, GenericParamId, Lookup, TraitId, TypeAliasId, VariantId,
 };
 use hir_expand::name::{self, Name};
 
@@ -81,4 +82,83 @@ pub(crate) fn make_mut_slice<T: Clone>(a: &mut Arc<[T]>) -> &mut [T] {
         *a = a.iter().cloned().collect();
     }
     Arc::get_mut(a).unwrap()
+}
+
+pub(crate) fn generics(db: &impl DefDatabase, def: GenericDefId) -> Generics {
+    let parent_generics = parent_generic_def(db, def).map(|def| Box::new(generics(db, def)));
+    Generics { def, params: db.generic_params(def), parent_generics }
+}
+
+pub(crate) struct Generics {
+    def: GenericDefId,
+    pub(crate) params: Arc<GenericParams>,
+    parent_generics: Option<Box<Generics>>,
+}
+
+impl Generics {
+    pub(crate) fn iter<'a>(&'a self) -> impl Iterator<Item = (u32, &'a GenericParamData)> + 'a {
+        self.parent_generics
+            .as_ref()
+            .into_iter()
+            .flat_map(|it| it.params.params.iter())
+            .chain(self.params.params.iter())
+            .enumerate()
+            .map(|(i, (_local_id, p))| (i as u32, p))
+    }
+
+    pub(crate) fn iter_parent<'a>(
+        &'a self,
+    ) -> impl Iterator<Item = (u32, &'a GenericParamData)> + 'a {
+        self.parent_generics
+            .as_ref()
+            .into_iter()
+            .flat_map(|it| it.params.params.iter())
+            .enumerate()
+            .map(|(i, (_local_id, p))| (i as u32, p))
+    }
+
+    pub(crate) fn count_parent_params(&self) -> usize {
+        self.parent_generics.as_ref().map_or(0, |p| p.count_params_including_parent())
+    }
+
+    pub(crate) fn count_params_including_parent(&self) -> usize {
+        let parent_count = self.count_parent_params();
+        parent_count + self.params.params.len()
+    }
+    pub(crate) fn param_idx(&self, param: GenericParamId) -> u32 {
+        self.find_param(param).0
+    }
+    pub(crate) fn param_name(&self, param: GenericParamId) -> Name {
+        self.find_param(param).1.name.clone()
+    }
+    fn find_param(&self, param: GenericParamId) -> (u32, &GenericParamData) {
+        if param.parent == self.def {
+            let (idx, (_local_id, data)) = self
+                .params
+                .params
+                .iter()
+                .enumerate()
+                .find(|(_, (idx, _))| *idx == param.local_id)
+                .unwrap();
+
+            return ((self.count_parent_params() + idx) as u32, data);
+        }
+        self.parent_generics.as_ref().unwrap().find_param(param)
+    }
+}
+
+fn parent_generic_def(db: &impl DefDatabase, def: GenericDefId) -> Option<GenericDefId> {
+    let container = match def {
+        GenericDefId::FunctionId(it) => it.lookup(db).container,
+        GenericDefId::TypeAliasId(it) => it.lookup(db).container,
+        GenericDefId::ConstId(it) => it.lookup(db).container,
+        GenericDefId::EnumVariantId(it) => return Some(it.parent.into()),
+        GenericDefId::AdtId(_) | GenericDefId::TraitId(_) | GenericDefId::ImplId(_) => return None,
+    };
+
+    match container {
+        ContainerId::ImplId(it) => Some(it.into()),
+        ContainerId::TraitId(it) => Some(it.into()),
+        ContainerId::ModuleId(_) => None,
+    }
 }

--- a/crates/ra_hir_ty/src/utils.rs
+++ b/crates/ra_hir_ty/src/utils.rs
@@ -117,13 +117,14 @@ impl Generics {
             .map(|(i, (_local_id, p))| (i as u32, p))
     }
 
-    pub(crate) fn count_parent_params(&self) -> usize {
-        self.parent_generics.as_ref().map_or(0, |p| p.count_params_including_parent())
+    pub(crate) fn len(&self) -> usize {
+        self.len_split().0
     }
-
-    pub(crate) fn count_params_including_parent(&self) -> usize {
-        let parent_count = self.count_parent_params();
-        parent_count + self.params.params.len()
+    /// (total, parents, child)
+    pub(crate) fn len_split(&self) -> (usize, usize, usize) {
+        let parent = self.parent_generics.as_ref().map_or(0, |p| p.len());
+        let child = self.params.params.len();
+        (parent + child, parent, child)
     }
     pub(crate) fn param_idx(&self, param: GenericParamId) -> u32 {
         self.find_param(param).0
@@ -140,8 +141,8 @@ impl Generics {
                 .enumerate()
                 .find(|(_, (idx, _))| *idx == param.local_id)
                 .unwrap();
-
-            return ((self.count_parent_params() + idx) as u32, data);
+            let (_total, parent_len, _child) = self.len_split();
+            return ((parent_len + idx) as u32, data);
         }
         self.parent_generics.as_ref().unwrap().find_param(param)
     }


### PR DESCRIPTION
indices and parent params seem to be concerns, specific to `hir_ty`, so move them there. 