### PR TITLE
Remove MacroFileKind

### DIFF
--- a/crates/ra_hir_def/src/body.rs
+++ b/crates/ra_hir_def/src/body.rs
@@ -6,9 +6,7 @@ pub mod scope;
 use std::{ops::Index, sync::Arc};
 
 use either::Either;
-use hir_expand::{
-    hygiene::Hygiene, AstId, HirFileId, InFile, MacroCallKind, MacroDefId, MacroFileKind,
-};
+use hir_expand::{hygiene::Hygiene, AstId, HirFileId, InFile, MacroCallKind, MacroDefId};
 use ra_arena::{map::ArenaMap, Arena};
 use ra_syntax::{ast, AstNode, AstPtr};
 use rustc_hash::FxHashMap;
@@ -49,7 +47,7 @@ impl Expander {
         if let Some(path) = macro_call.path().and_then(|path| self.parse_path(path)) {
             if let Some(def) = self.resolve_path_as_macro(db, &path) {
                 let call_id = def.as_call_id(db, MacroCallKind::FnLike(ast_id));
-                let file_id = call_id.as_file(MacroFileKind::Expr);
+                let file_id = call_id.as_file();
                 if let Some(node) = db.parse_or_expand(file_id) {
                     if let Some(expr) = ast::Expr::cast(node) {
                         log::debug!("macro expansion {:#?}", expr.syntax());

--- a/crates/ra_hir_def/src/nameres/collector.rs
+++ b/crates/ra_hir_def/src/nameres/collector.rs
@@ -7,7 +7,7 @@ use hir_expand::{
     builtin_derive::find_builtin_derive,
     builtin_macro::find_builtin_macro,
     name::{self, AsName, Name},
-    HirFileId, MacroCallId, MacroCallKind, MacroDefId, MacroDefKind, MacroFileKind,
+    HirFileId, MacroCallId, MacroCallKind, MacroDefId, MacroDefKind,
 };
 use ra_cfg::CfgOptions;
 use ra_db::{CrateId, FileId};
@@ -545,7 +545,7 @@ where
         self.macro_stack_monitor.increase(macro_def_id);
 
         if !self.macro_stack_monitor.is_poison(macro_def_id) {
-            let file_id: HirFileId = macro_call_id.as_file(MacroFileKind::Items);
+            let file_id: HirFileId = macro_call_id.as_file();
             let raw_items = self.db.raw_items(file_id);
             let mod_dir = self.mod_dirs[&module_id].clone();
             ModCollector {

--- a/crates/ra_hir_expand/src/builtin_derive.rs
+++ b/crates/ra_hir_expand/src/builtin_derive.rs
@@ -208,7 +208,7 @@ fn partial_ord_expand(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_db::TestDB, AstId, MacroCallKind, MacroCallLoc, MacroFileKind};
+    use crate::{test_db::TestDB, AstId, MacroCallKind, MacroCallLoc};
     use ra_db::{fixture::WithFixture, SourceDatabase};
 
     fn expand_builtin_derive(s: &str, expander: BuiltinDeriveExpander) -> String {
@@ -229,7 +229,7 @@ mod tests {
         };
 
         let id = db.intern_macro(loc);
-        let parsed = db.parse_or_expand(id.as_file(MacroFileKind::Items)).unwrap();
+        let parsed = db.parse_or_expand(id.as_file()).unwrap();
 
         // FIXME text() for syntax nodes parsed from token tree looks weird
         // because there's no whitespace, see below

--- a/crates/ra_hir_expand/src/builtin_macro.rs
+++ b/crates/ra_hir_expand/src/builtin_macro.rs
@@ -2,8 +2,7 @@
 use crate::db::AstDatabase;
 use crate::{
     ast::{self, AstNode},
-    name, AstId, CrateId, HirFileId, MacroCallId, MacroDefId, MacroDefKind, MacroFileKind,
-    TextUnit,
+    name, AstId, CrateId, HirFileId, MacroCallId, MacroDefId, MacroDefKind, TextUnit,
 };
 
 use crate::quote;
@@ -90,7 +89,7 @@ fn line_expand(
     let arg = loc.kind.arg(db).ok_or_else(|| mbe::ExpandError::UnexpectedToken)?;
     let arg_start = arg.text_range().start();
 
-    let file = id.as_file(MacroFileKind::Expr);
+    let file = id.as_file();
     let line_num = to_line_number(db, file, arg_start);
 
     let expanded = quote! {
@@ -158,7 +157,7 @@ fn column_expand(
     let _arg = macro_call.token_tree().ok_or_else(|| mbe::ExpandError::UnexpectedToken)?;
     let col_start = macro_call.syntax().text_range().start();
 
-    let file = id.as_file(MacroFileKind::Expr);
+    let file = id.as_file();
     let col_num = to_col_number(db, file, col_start);
 
     let expanded = quote! {
@@ -269,7 +268,7 @@ mod tests {
         };
 
         let id = db.intern_macro(loc);
-        let parsed = db.parse_or_expand(id.as_file(MacroFileKind::Expr)).unwrap();
+        let parsed = db.parse_or_expand(id.as_file()).unwrap();
 
         parsed.text().to_string()
     }

--- a/crates/ra_hir_expand/src/lib.rs
+++ b/crates/ra_hir_expand/src/lib.rs
@@ -117,14 +117,6 @@ impl HirFileId {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MacroFile {
     macro_call_id: MacroCallId,
-    macro_file_kind: MacroFileKind,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum MacroFileKind {
-    Items,
-    Expr,
-    Statements,
 }
 
 /// `MacroCallId` identifies a particular macro invocation, like
@@ -205,9 +197,8 @@ impl MacroCallKind {
 }
 
 impl MacroCallId {
-    pub fn as_file(self, kind: MacroFileKind) -> HirFileId {
-        let macro_file = MacroFile { macro_call_id: self, macro_file_kind: kind };
-        macro_file.into()
+    pub fn as_file(self) -> HirFileId {
+        MacroFile { macro_call_id: self }.into()
     }
 }
 


### PR DESCRIPTION
This PR move `to_macro_file_kind` to `hir_expand::db` and use it to get the `FragmentKind` directly, such that we can remove `MacroFileKind`.