### PR TITLE
Fix format_args expansion & go to definition

### DIFF
--- a/crates/ra_hir_def/src/body/lower.rs
+++ b/crates/ra_hir_def/src/body/lower.rs
@@ -437,9 +437,7 @@ where
                     None => self.alloc_expr(Expr::Missing, syntax_ptr),
                 }
             }
-
-            // FIXME implement HIR for these:
-            ast::Expr::Label(_e) => self.alloc_expr(Expr::Missing, syntax_ptr),
+            // FIXME expand to statements in statement position
             ast::Expr::MacroCall(e) => match self.expander.enter_expand(self.db, e) {
                 Some((mark, expansion)) => {
                     let id = self.collect_expr(expansion);
@@ -448,6 +446,9 @@ where
                 }
                 None => self.alloc_expr(Expr::Missing, syntax_ptr),
             },
+
+            // FIXME implement HIR for these:
+            ast::Expr::Label(_e) => self.alloc_expr(Expr::Missing, syntax_ptr),
         }
     }
 

--- a/crates/ra_hir_expand/src/db.rs
+++ b/crates/ra_hir_expand/src/db.rs
@@ -183,8 +183,8 @@ fn to_fragment_kind(db: &dyn AstDatabase, macro_call_id: MacroCallId) -> Fragmen
             // FIXME: Handle Pattern
             FragmentKind::Expr
         }
-        EXPR_STMT => FragmentKind::Statements,
-        BLOCK => FragmentKind::Statements,
+        // FIXME: Expand to statements in appropriate positions; HIR lowering needs to handle that
+        EXPR_STMT | BLOCK => FragmentKind::Expr,
         ARG_LIST => FragmentKind::Expr,
         TRY_EXPR => FragmentKind::Expr,
         TUPLE_EXPR => FragmentKind::Expr,

--- a/crates/ra_ide/src/goto_definition.rs
+++ b/crates/ra_ide/src/goto_definition.rs
@@ -717,7 +717,7 @@ mod tests {
                 format!(\"{}\", fo<|>o())
             }
             ",
-            "foo FN_DEF FileId(1) [359; 376) [362; 365)",
+            "foo FN_DEF FileId(1) [398; 415) [401; 404)",
         );
     }
 

--- a/crates/ra_ide/src/goto_definition.rs
+++ b/crates/ra_ide/src/goto_definition.rs
@@ -693,7 +693,6 @@ mod tests {
         );
     }
 
-    #[should_panic] // currently failing because of expr mapping problems
     #[test]
     fn goto_through_format() {
         check_goto(


### PR DESCRIPTION
The expansion of format_args wasn't yet correct enough to type-check. Also make macros in statement position expand to expressions for now, since it's not handled correctly in HIR lowering yet. This finally fixes go to definition within print macros, I think :slightly_smiling_face: 