### PR TITLE
Use rustup toolchain install instead of rustup install

### DIFF
--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -79,7 +79,7 @@ pub fn run_rustfmt(mode: Mode) -> Result<()> {
 }
 
 pub fn install_rustfmt() -> Result<()> {
-    run(&format!("rustup install {}", TOOLCHAIN), ".")?;
+    run(&format!("rustup toolchain install {}", TOOLCHAIN), ".")?;
     run(&format!("rustup component add rustfmt --toolchain {}", TOOLCHAIN), ".")
 }
 
@@ -125,7 +125,7 @@ pub fn run_clippy() -> Result<()> {
 }
 
 pub fn install_clippy() -> Result<()> {
-    run(&format!("rustup install {}", TOOLCHAIN), ".")?;
+    run(&format!("rustup toolchain install {}", TOOLCHAIN), ".")?;
     run(&format!("rustup component add clippy --toolchain {}", TOOLCHAIN), ".")
 }
 


### PR DESCRIPTION
`rustup install` and `rustup uninstall` are going to be deprecated in rustup 1.21.0

See https://github.com/rust-lang/rustup/issues/2148

and https://www.reddit.com/r/rust/comments/e7rer9/we_need_your_help_before_rustup_1210_can_be/

