### PR TITLE
[WIP] Add resolve_macro_as_file

### DIFF
--- a/crates/ra_hir_def/src/nameres.rs
+++ b/crates/ra_hir_def/src/nameres.rs
@@ -51,6 +51,7 @@ pub(crate) mod raw;
 mod collector;
 mod mod_resolution;
 mod path_resolution;
+mod macro_resolution;
 
 #[cfg(test)]
 mod tests;

--- a/crates/ra_hir_def/src/nameres/macro_resolution.rs
+++ b/crates/ra_hir_def/src/nameres/macro_resolution.rs
@@ -1,0 +1,49 @@
+use hir_expand::{HirFileId, MacroCallKind, MacroDefId};
+use ra_syntax::ast;
+
+use crate::{
+    db::DefDatabase,
+    nameres::{BuiltinShadowMode, CrateDefMap},
+    path::Path,
+    AstId, LocalModuleId,
+};
+
+pub struct MacroResolver<'a> {
+    crate_def_map: &'a CrateDefMap,
+    module: LocalModuleId,
+}
+
+impl<'a> MacroResolver<'a> {
+    fn resolve(
+        &self,
+        db: &impl DefDatabase,
+        ast_id: AstId<ast::MacroCall>,
+        path: &Path,
+    ) -> Option<HirFileId> {
+        let def = self.resolve_path_as_macro(db, &path)?;
+        let call_id = def.as_call_id(db, MacroCallKind::FnLike(ast_id));
+        let file_id = call_id.as_file();
+        Some(file_id)
+    }
+
+    fn resolve_path_as_macro(&self, db: &impl DefDatabase, path: &Path) -> Option<MacroDefId> {
+        self.crate_def_map
+            .resolve_path(db, self.module, path, BuiltinShadowMode::Other)
+            .0
+            .take_macros()
+    }
+}
+
+impl CrateDefMap {
+    pub(crate) fn resolve_macro_as_file(
+        &self,
+        db: &impl DefDatabase,
+        ast_id: AstId<ast::MacroCall>,
+        path: &Path,
+        module: LocalModuleId,
+    ) -> Option<HirFileId> {
+        let resolver = MacroResolver { crate_def_map: &self, module };
+
+        resolver.resolve(db, ast_id, path)
+    }
+}

--- a/crates/ra_hir_def/src/nameres/macro_resolution.rs
+++ b/crates/ra_hir_def/src/nameres/macro_resolution.rs
@@ -1,3 +1,4 @@
+//! This module resolves a macro with path to a file.
 use hir_expand::{HirFileId, MacroCallKind, MacroDefId};
 use ra_syntax::ast;
 

--- a/crates/ra_hir_expand/src/hygiene.rs
+++ b/crates/ra_hir_expand/src/hygiene.rs
@@ -12,7 +12,7 @@ use crate::{
     HirFileId, HirFileIdRepr, MacroDefKind,
 };
 
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Hygiene {
     // This is what `$crate` expands to
     def_crate: Option<CrateId>,


### PR DESCRIPTION
By adding `resolve_macro_as_file` in` CrateDefMap`, this PR reconstructs and centralizes the macro resolution logic to a single location. It will help implement the "eagar macro expansion" implementation too.