### PR TITLE
Use ES2018 for vscode extension

### DIFF
--- a/editors/code/tsconfig.json
+++ b/editors/code/tsconfig.json
@@ -1,9 +1,9 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es6",
+        "target": "es2018",
         "outDir": "out",
-        "lib": ["es6"],
+        "lib": ["es2018"],
         "sourceMap": true,
         "rootDir": "src",
         "strict": true,


### PR DESCRIPTION
Today's latest vscode v1.40 (Node.jsv12.4/V8 v7.6) supports ES2018
features natively.

We don't have to transform codes to ES6.