### PR TITLE
Enable tsc builtin lint options  for vscode/extension

### DIFF
--- a/editors/code/src/commands/analyzer_status.ts
+++ b/editors/code/src/commands/analyzer_status.ts
@@ -9,7 +9,7 @@ export class TextDocumentContentProvider
     public syntaxTree: string = 'Not available';
 
     public provideTextDocumentContent(
-        uri: vscode.Uri,
+        _uri: vscode.Uri,
     ): vscode.ProviderResult<string> {
         const editor = vscode.window.activeTextEditor;
         if (editor == null) {

--- a/editors/code/src/commands/expand_macro.ts
+++ b/editors/code/src/commands/expand_macro.ts
@@ -11,7 +11,7 @@ export class ExpandMacroContentProvider
     public eventEmitter = new vscode.EventEmitter<vscode.Uri>();
 
     public provideTextDocumentContent(
-        uri: vscode.Uri,
+        _uri: vscode.Uri,
     ): vscode.ProviderResult<string> {
         async function handle() {
             const editor = vscode.window.activeTextEditor;

--- a/editors/code/src/commands/runnables.ts
+++ b/editors/code/src/commands/runnables.ts
@@ -73,7 +73,7 @@ function createTask(spec: Runnable): vscode.Task {
 }
 
 let prevRunnable: RunnableQuickPick | undefined;
-export async function handle() {
+export async function handle(): Promise<vscode.TaskExecution | undefined> {
     const editor = vscode.window.activeTextEditor;
     if (editor == null || editor.document.languageId !== 'rust') {
         return;
@@ -105,12 +105,14 @@ export async function handle() {
         items.push(new RunnableQuickPick(r));
     }
     const item = await vscode.window.showQuickPick(items);
-    if (item) {
-        item.detail = 'rerun';
-        prevRunnable = item;
-        const task = createTask(item.runnable);
-        return await vscode.tasks.executeTask(task);
+    if (!item) {
+        return;
     }
+
+    item.detail = 'rerun';
+    prevRunnable = item;
+    const task = createTask(item.runnable);
+    return await vscode.tasks.executeTask(task);
 }
 
 export async function handleSingle(runnable: Runnable) {

--- a/editors/code/src/commands/runnables.ts
+++ b/editors/code/src/commands/runnables.ts
@@ -178,7 +178,7 @@ export async function startCargoWatch(
         }
 
         const label = 'install-cargo-watch';
-        const taskFinished = new Promise((resolve, reject) => {
+        const taskFinished = new Promise((resolve, _reject) => {
             const disposable = vscode.tasks.onDidEndTask(({ execution }) => {
                 if (execution.task.name === label) {
                     disposable.dispose();

--- a/editors/code/src/test/utils/diagnotics/SuggestedFix.test.ts
+++ b/editors/code/src/test/utils/diagnotics/SuggestedFix.test.ts
@@ -114,7 +114,8 @@ describe('SuggestedFix', () => {
 
             const edit = codeAction.edit;
             if (!edit) {
-                return assert.fail('Code Action edit unexpectedly missing');
+                assert.fail('Code Action edit unexpectedly missing');
+                return;
             }
 
             const editEntries = edit.entries();

--- a/editors/code/src/test/utils/diagnotics/SuggestedFixCollection.test.ts
+++ b/editors/code/src/test/utils/diagnotics/SuggestedFixCollection.test.ts
@@ -53,7 +53,8 @@ describe('SuggestedFixCollection', () => {
 
         const { diagnostics } = codeAction;
         if (!diagnostics) {
-            return assert.fail('Diagnostics unexpectedly missing');
+            assert.fail('Diagnostics unexpectedly missing');
+            return;
         }
 
         assert.strictEqual(diagnostics.length, 1);
@@ -114,7 +115,8 @@ describe('SuggestedFixCollection', () => {
         const { diagnostics } = codeAction;
 
         if (!diagnostics) {
-            return assert.fail('Diagnostics unexpectedly missing');
+            assert.fail('Diagnostics unexpectedly missing');
+            return;
         }
 
         // We should be associated with both diagnostics

--- a/editors/code/src/test/utils/diagnotics/rust.test.ts
+++ b/editors/code/src/test/utils/diagnotics/rust.test.ts
@@ -120,7 +120,8 @@ describe('mapRustDiagnosticToVsCode', () => {
         // One related information for the original definition
         const relatedInformation = diagnostic.relatedInformation;
         if (!relatedInformation) {
-            return assert.fail('Related information unexpectedly undefined');
+            assert.fail('Related information unexpectedly undefined');
+            return;
         }
         assert.strictEqual(relatedInformation.length, 1);
         const [related] = relatedInformation;
@@ -154,7 +155,8 @@ describe('mapRustDiagnosticToVsCode', () => {
         // One related information for the lint definition
         const relatedInformation = diagnostic.relatedInformation;
         if (!relatedInformation) {
-            return assert.fail('Related information unexpectedly undefined');
+            assert.fail('Related information unexpectedly undefined');
+            return;
         }
         assert.strictEqual(relatedInformation.length, 1);
         const [related] = relatedInformation;

--- a/editors/code/tsconfig.json
+++ b/editors/code/tsconfig.json
@@ -9,7 +9,8 @@
         "strict": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,
-        "noImplicitReturns": true
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": true
     },
     "exclude": ["node_modules", ".vscode-test"]
 }

--- a/editors/code/tsconfig.json
+++ b/editors/code/tsconfig.json
@@ -8,7 +8,8 @@
         "rootDir": "src",
         "strict": true,
         "noUnusedLocals": true,
-        "noUnusedParameters": true
+        "noUnusedParameters": true,
+        "noImplicitReturns": true
     },
     "exclude": ["node_modules", ".vscode-test"]
 }

--- a/editors/code/tsconfig.json
+++ b/editors/code/tsconfig.json
@@ -7,7 +7,8 @@
         "sourceMap": true,
         "rootDir": "src",
         "strict": true,
-        "noUnusedLocals": true
+        "noUnusedLocals": true,
+        "noUnusedParameters": true
     },
     "exclude": ["node_modules", ".vscode-test"]
 }

--- a/editors/code/tslint.json
+++ b/editors/code/tslint.json
@@ -4,6 +4,8 @@
     "rules": {
         "quotemark": [true, "single"],
         "interface-name": false,
-        "object-literal-sort-keys": false
+        "object-literal-sort-keys": false,
+        // Allow `_bar` to sort with tsc's `noUnusedParameters` option
+        "variable-name": [true, "allow-leading-underscore"]
     }
 }


### PR DESCRIPTION
* These options are not enabled by `--strict` option and these options make a code more solid.
    * https://www.typescriptlang.org/docs/handbook/compiler-options.html
* For `noUnusedParameters` , we need to tweak tslint option to allow `_bar` style.