### PR TITLE
Go to declaration

### DIFF
--- a/crates/ra_lsp_server/src/caps.rs
+++ b/crates/ra_lsp_server/src/caps.rs
@@ -28,7 +28,7 @@ pub fn server_capabilities() -> ServerCapabilities {
             retrigger_characters: None,
             work_done_progress_options: WorkDoneProgressOptions { work_done_progress: None },
         }),
-        declaration_provider: None,
+        declaration_provider: Some(true),
         definition_provider: Some(true),
         type_definition_provider: Some(TypeDefinitionProviderCapability::Simple(true)),
         implementation_provider: Some(ImplementationProviderCapability::Simple(true)),

--- a/crates/ra_lsp_server/src/main_loop.rs
+++ b/crates/ra_lsp_server/src/main_loop.rs
@@ -441,6 +441,7 @@ fn on_request(
         .on::<req::OnTypeFormatting>(handlers::handle_on_type_formatting)?
         .on::<req::DocumentSymbolRequest>(handlers::handle_document_symbol)?
         .on::<req::WorkspaceSymbol>(handlers::handle_workspace_symbol)?
+        .on::<req::GotoDeclaration>(handlers::handle_goto_declaration)?
         .on::<req::GotoDefinition>(handlers::handle_goto_definition)?
         .on::<req::GotoImplementation>(handlers::handle_goto_implementation)?
         .on::<req::GotoTypeDefinition>(handlers::handle_goto_type_definition)?

--- a/crates/ra_lsp_server/src/main_loop/handlers.rs
+++ b/crates/ra_lsp_server/src/main_loop/handlers.rs
@@ -271,6 +271,22 @@ pub fn handle_workspace_symbol(
     }
 }
 
+pub fn handle_goto_declaration(
+    world: WorldSnapshot,
+    params: req::TextDocumentPositionParams,
+) -> Result<Option<req::GotoDefinitionResponse>> {
+    let _p = profile("handle_goto_declaration");
+    let position = params.try_conv_with(&world)?;
+
+    // FIXME: We should really only look for the declaration here.
+    let refs = match world.analysis().find_all_refs(position, None)? {
+        None => return Ok(None),
+        Some(refs) => refs,
+    };
+
+    Ok(Some(req::GotoDefinitionResponse::Scalar(refs.declaration().try_conv_with(&world)?)))
+}
+
 pub fn handle_goto_definition(
     world: WorldSnapshot,
     params: req::TextDocumentPositionParams,


### PR DESCRIPTION
This piggy backs off of find_all_refs which is not the most efficient.
Optimizing this would be a good first issue for someone.