### PR TITLE
fix goto definition when inbetween tokens

### DIFF
--- a/crates/ra_ide/src/goto_definition.rs
+++ b/crates/ra_ide/src/goto_definition.rs
@@ -447,6 +447,22 @@ mod tests {
     }
 
     #[test]
+    fn goto_for_tuple_fields() {
+        check_goto(
+            "
+            //- /lib.rs
+            struct Foo(u32);
+
+            fn bar() {
+                let foo = Foo(0);
+                foo.<|>0;
+            }
+            ",
+            "TUPLE_FIELD_DEF FileId(1) [11; 14)",
+        );
+    }
+
+    #[test]
     fn goto_definition_works_for_ufcs_inherent_methods() {
         check_goto(
             "

--- a/crates/ra_ide/src/goto_type_definition.rs
+++ b/crates/ra_ide/src/goto_type_definition.rs
@@ -1,7 +1,7 @@
 //! FIXME: write short doc here
 
 use hir::db::AstDatabase;
-use ra_syntax::{ast, AstNode};
+use ra_syntax::{ast, AstNode, SyntaxKind};
 
 use crate::{
     db::RootDatabase, display::ToNav, expand::descend_into_macros, FilePosition, NavigationTarget,
@@ -13,7 +13,7 @@ pub(crate) fn goto_type_definition(
     position: FilePosition,
 ) -> Option<RangeInfo<Vec<NavigationTarget>>> {
     let file = db.parse_or_expand(position.file_id.into())?;
-    let token = file.token_at_offset(position.offset).filter(|it| !it.kind().is_trivia()).next()?;
+    let token = file.token_at_offset(position.offset).find(|it| it.kind() == SyntaxKind::IDENT)?;
     let token = descend_into_macros(db, position.file_id, token);
 
     let node = token.value.ancestors().find_map(|token| {
@@ -100,6 +100,18 @@ mod tests {
             }
             ",
             "Foo STRUCT_DEF FileId(1) [52; 65) [59; 62)",
+        );
+    }
+
+    #[test]
+    fn goto_type_definition_works_param() {
+        check_goto(
+            "
+            //- /lib.rs
+            struct Foo;
+            fn foo(<|>f: Foo) {}
+            ",
+            "Foo STRUCT_DEF FileId(1) [0; 11) [7; 10)",
         );
     }
 }

--- a/crates/ra_ide/src/goto_type_definition.rs
+++ b/crates/ra_ide/src/goto_type_definition.rs
@@ -1,7 +1,7 @@
 //! FIXME: write short doc here
 
 use hir::db::AstDatabase;
-use ra_syntax::{ast, AstNode, SyntaxKind};
+use ra_syntax::{ast, AstNode, SyntaxKind::*, SyntaxToken, TokenAtOffset};
 
 use crate::{
     db::RootDatabase, display::ToNav, expand::descend_into_macros, FilePosition, NavigationTarget,
@@ -13,7 +13,7 @@ pub(crate) fn goto_type_definition(
     position: FilePosition,
 ) -> Option<RangeInfo<Vec<NavigationTarget>>> {
     let file = db.parse_or_expand(position.file_id.into())?;
-    let token = file.token_at_offset(position.offset).find(|it| it.kind() == SyntaxKind::IDENT)?;
+    let token = pick_best(file.token_at_offset(position.offset))?;
     let token = descend_into_macros(db, position.file_id, token);
 
     let node = token.value.ancestors().find_map(|token| {
@@ -39,6 +39,17 @@ pub(crate) fn goto_type_definition(
 
     let nav = adt_def.to_nav(db);
     Some(RangeInfo::new(node.text_range(), vec![nav]))
+}
+
+fn pick_best(tokens: TokenAtOffset<SyntaxToken>) -> Option<SyntaxToken> {
+    return tokens.max_by_key(priority);
+    fn priority(n: &SyntaxToken) -> usize {
+        match n.kind() {
+            IDENT | INT_NUMBER => 2,
+            kind if kind.is_trivia() => 0,
+            _ => 1,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/ra_ide/src/goto_type_definition.rs
+++ b/crates/ra_ide/src/goto_type_definition.rs
@@ -104,12 +104,28 @@ mod tests {
     }
 
     #[test]
-    fn goto_type_definition_works_param() {
+    fn goto_type_definition_for_param() {
         check_goto(
             "
             //- /lib.rs
             struct Foo;
             fn foo(<|>f: Foo) {}
+            ",
+            "Foo STRUCT_DEF FileId(1) [0; 11) [7; 10)",
+        );
+    }
+
+    #[test]
+    fn goto_type_definition_for_tuple_field() {
+        check_goto(
+            "
+            //- /lib.rs
+            struct Foo;
+            struct Bar(Foo);
+            fn foo() {
+                let bar = Bar(Foo);
+                bar.<|>0;
+            }
             ",
             "Foo STRUCT_DEF FileId(1) [0; 11) [7; 10)",
         );

--- a/crates/ra_ide/src/hover.rs
+++ b/crates/ra_ide/src/hover.rs
@@ -505,6 +505,13 @@ fn func(foo: i32) { if true { <|>foo; }; }
     }
 
     #[test]
+    fn hover_for_param_edge() {
+        let (analysis, position) = single_file_with_position("fn func(<|>foo: i32) {}");
+        let hover = analysis.hover(position).unwrap().unwrap();
+        assert_eq!(trim_markup_opt(hover.info.first()), Some("i32"));
+    }
+
+    #[test]
     fn test_type_of_for_function() {
         let (analysis, range) = single_file_with_range(
             "

--- a/crates/ra_ide/src/hover.rs
+++ b/crates/ra_ide/src/hover.rs
@@ -156,7 +156,7 @@ fn hover_text_from_name_kind(
 
 pub(crate) fn hover(db: &RootDatabase, position: FilePosition) -> Option<RangeInfo<HoverResult>> {
     let file = db.parse_or_expand(position.file_id.into())?;
-    let token = file.token_at_offset(position.offset).filter(|it| !it.kind().is_trivia()).next()?;
+    let token = file.token_at_offset(position.offset).find(|it| !it.kind().is_trivia())?;
     let token = descend_into_macros(db, position.file_id, token);
 
     let mut res = HoverResult::new();


### PR DESCRIPTION
fixes both goto_definition and goto_type_definition.
before, when running goto between some non-trivia token and an
identifier, goto would be attempted for the non-trivia token.
but this does not make sense for e.g. L_PAREN or COLONCOLON only for
IDENTs.

this resulted in goto actions not working when running them on the first
character of some identifier e.g. for `module::<|>method()` or
`method(<|>parameter)`.

now only IDENTs will be searched for in goto actions, though i'm not sure
if this is correct or if goto should also work for some other token types.  