### PR TITLE
LSP 3.15 supports the deprecated tag on completions

### DIFF
--- a/crates/ra_lsp_server/src/conv.rs
+++ b/crates/ra_lsp_server/src/conv.rs
@@ -130,6 +130,11 @@ impl ConvWith<(&LineIndex, LineEndings)> for CompletionItem {
             deprecated: Some(self.deprecated()),
             ..Default::default()
         };
+
+        if self.deprecated() {
+            res.tags = Some(vec![lsp_types::CompletionItemTag::Deprecated])
+        }
+
         res.insert_text_format = Some(match self.insert_text_format() {
             InsertTextFormat::Snippet => lsp_types::InsertTextFormat::Snippet,
             InsertTextFormat::PlainText => lsp_types::InsertTextFormat::PlainText,


### PR DESCRIPTION
So let's set it.