### PR TITLE
Fixed syntax highlighting not refreshing on windows.

### DIFF
--- a/crates/ra_lsp_server/src/world.rs
+++ b/crates/ra_lsp_server/src/world.rs
@@ -22,7 +22,6 @@ use crate::{
     main_loop::pending_requests::{CompletedRequest, LatestRequests},
     LspError, Result,
 };
-use std::str::FromStr;
 
 #[derive(Debug, Clone)]
 pub struct Options {
@@ -286,6 +285,8 @@ impl WorldSnapshot {
 
 #[cfg(target_os = "windows")]
 fn lowercase_drive_letter(url: &Url) -> Url {
+    use std::str::FromStr;
+
     let s = url.to_string();
     let drive_partition: Vec<&str> = s.rsplitn(2, ':').collect::<Vec<&str>>();
 

--- a/crates/ra_lsp_server/src/world.rs
+++ b/crates/ra_lsp_server/src/world.rs
@@ -306,8 +306,7 @@ fn url_from_path_with_drive_lowercasing(path: impl AsRef<Path>) -> Result<Url> {
         let url_original = Url::from_file_path(&path)
             .map_err(|_| format!("can't convert path to url: {}", path.as_ref().display()))?;
 
-        let drive_partition: Vec<&str> =
-            url_original.as_str().rsplitn(2, ':').collect::<Vec<&str>>();
+        let drive_partition: Vec<&str> = url_original.as_str().rsplitn(2, ':').collect();
 
         // There is a drive partition, but we never found a colon.
         // This should not happen, but in this case we just pass it through.

--- a/crates/ra_lsp_server/src/world.rs
+++ b/crates/ra_lsp_server/src/world.rs
@@ -325,16 +325,22 @@ fn url_from_path_with_drive_lowercasing(path: impl AsRef<Path>) -> Result<Url> {
     }
 }
 
-#[test]
-fn test_lowercase_drive_letter_with_drive() {
-    let url = url_from_path_with_drive_lowercasing("C:\\Test").unwrap();
+// `Url` is not able to parse windows paths on unix machines.
+#[cfg(target_os = "windows")]
+#[cfg(test)]
+mod path_conversion_windows_tests {
+    use super::url_from_path_with_drive_lowercasing;
+    #[test]
+    fn test_lowercase_drive_letter_with_drive() {
+        let url = url_from_path_with_drive_lowercasing("C:\\Test").unwrap();
 
-    assert_eq!(url.to_string(), "file:///c:/Test");
-}
+        assert_eq!(url.to_string(), "file:///c:/Test");
+    }
 
-#[test]
-fn test_drive_without_colon_passthrough() {
-    let url = url_from_path_with_drive_lowercasing(r#"\\localhost\C$\my_dir"#).unwrap();
+    #[test]
+    fn test_drive_without_colon_passthrough() {
+        let url = url_from_path_with_drive_lowercasing(r#"\\localhost\C$\my_dir"#).unwrap();
 
-    assert_eq!(url.to_string(), "file://localhost/C$/my_dir");
+        assert_eq!(url.to_string(), "file://localhost/C$/my_dir");
+    }
 }

--- a/editors/code/src/notifications/publish_decorations.ts
+++ b/editors/code/src/notifications/publish_decorations.ts
@@ -12,9 +12,8 @@ export function handle(params: PublishDecorationsParams) {
     const targetEditor = vscode.window.visibleTextEditors.find(
         editor => {
             const unescapedUri = unescape(editor.document.uri.toString());
-            // Unescaped URI should be something like:
+            // Unescaped URI looks like:
             // file:///c:/Workspace/ra-test/src/main.rs
-            // RA server might send it with the drive letter uppercased, so we force only the drive letter to lowercase.
             return unescapedUri === params.uri
         }
     );

--- a/editors/code/src/notifications/publish_decorations.ts
+++ b/editors/code/src/notifications/publish_decorations.ts
@@ -15,8 +15,7 @@ export function handle(params: PublishDecorationsParams) {
             // Unescaped URI should be something like:
             // file:///c:/Workspace/ra-test/src/main.rs
             // RA server might send it with the drive letter uppercased, so we force only the drive letter to lowercase.
-            const uriWithLowercasedDrive = params.uri.substr(0, 8) + params.uri[8].toLowerCase() + params.uri.substr(9);
-            return unescapedUri === uriWithLowercasedDrive
+            return unescapedUri === params.uri
         }
     );
 

--- a/editors/code/src/notifications/publish_decorations.ts
+++ b/editors/code/src/notifications/publish_decorations.ts
@@ -10,10 +10,19 @@ export interface PublishDecorationsParams {
 
 export function handle(params: PublishDecorationsParams) {
     const targetEditor = vscode.window.visibleTextEditors.find(
-        editor => editor.document.uri.toString() === params.uri,
+        editor => {
+            const unescapedUri = unescape(editor.document.uri.toString());
+            // Unescaped URI should be something like:
+            // file:///c:/Workspace/ra-test/src/main.rs
+            // RA server might send it with the drive letter uppercased, so we force only the drive letter to lowercase.
+            const uriWithLowercasedDrive = params.uri.substr(0, 8) + params.uri[8].toLowerCase() + params.uri.substr(9);
+            return unescapedUri === uriWithLowercasedDrive
+        }
     );
+
     if (!Server.config.highlightingOn || !targetEditor) {
         return;
     }
+
     Server.highlighter.setHighlights(targetEditor, params.decorations);
 }

--- a/editors/code/src/notifications/publish_decorations.ts
+++ b/editors/code/src/notifications/publish_decorations.ts
@@ -9,14 +9,12 @@ export interface PublishDecorationsParams {
 }
 
 export function handle(params: PublishDecorationsParams) {
-    const targetEditor = vscode.window.visibleTextEditors.find(
-        editor => {
-            const unescapedUri = unescape(editor.document.uri.toString());
-            // Unescaped URI looks like:
-            // file:///c:/Workspace/ra-test/src/main.rs
-            return unescapedUri === params.uri
-        }
-    );
+    const targetEditor = vscode.window.visibleTextEditors.find(editor => {
+        const unescapedUri = unescape(editor.document.uri.toString());
+        // Unescaped URI looks like:
+        // file:///c:/Workspace/ra-test/src/main.rs
+        return unescapedUri === params.uri;
+    });
 
     if (!Server.config.highlightingOn || !targetEditor) {
         return;


### PR DESCRIPTION
I was encoutering the same probelm described in #1690.

It seems that events initiated by the frontend with `rust-analyzer/decorationsRequest` would go through.
So whenever a user switches tabs, highlighting will update.

However, when decorations are initiated by a notification with `rust-analyzer/publishDecorations`, it would fail on this check here https://github.com/rust-analyzer/rust-analyzer/blob/6cbd8a4a4bbca8a7656df9f3ef849acebbf9ef9b/editors/code/src/notifications/publish_decorations.ts#L15 (`targetEditor` will always be `undefined`).

This is because it's trying to match the uri `rust-analyzer` sends (which uses an uppercase drive letter) to the uri provided at `editor.document.uri.toString()`, which is both escaped (uses `%3a` for `:`), and uses a lowercase letter drive.

Aparrently this was an issue for some other extensions aswell - https://github.com/Microsoft/vscode/issues/68325.

But this is the defined behavior - https://github.com/microsoft/vscode/blob/c110d84460b3e45842a8fe753562341003595e1d/src/vs/vscode.d.ts#L1304

This fix is only relevant for windows.
I've opted for a server-side fix, since rust will always return uppercase letters for drives, there seems to be no other easy solution than manipulating the Url string before sending it to the frontend.


Closes #1690.