### PR TITLE
Fixed a typo in settings

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -524,7 +524,7 @@
             },
             {
                 "id": "ralsp.type.lifetime",
-                "description": "Color for `Self` param type",
+                "description": "Color for lifetimes parameters",
                 "defaults": {
                     "dark": "#4EC9B0",
                     "light": "#267F99",


### PR DESCRIPTION
@lnicola found a typo in the description for one of the settings introduced in #2559.