### PR TITLE
Use prettier settings in ts-lint

### DIFF
--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -466,6 +466,16 @@
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
             "dev": true
         },
+        "eslint-plugin-prettier": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.7.0.tgz",
+            "integrity": "sha512-CStQYJgALoQBw3FsBzH0VOVDRnJ/ZimUlpLm226U8qgqYJfPOY/CPK6wyRInMxh73HSKg5wyRwdS4BVYYHwokA==",
+            "dev": true,
+            "requires": {
+                "fast-diff": "^1.1.1",
+                "jest-docblock": "^21.0.0"
+            }
+        },
         "esprima": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -482,6 +492,12 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+            "dev": true
+        },
+        "fast-diff": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+            "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
             "dev": true
         },
         "fd-slicer": {
@@ -712,6 +728,12 @@
             "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
             "dev": true
         },
+        "jest-docblock": {
+            "version": "21.2.0",
+            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
+            "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
+            "dev": true
+        },
         "js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -727,6 +749,12 @@
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
             }
+        },
+        "lines-and-columns": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+            "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+            "dev": true
         },
         "linkify-it": {
             "version": "2.2.0",
@@ -1412,6 +1440,17 @@
             "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz",
             "integrity": "sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==",
             "dev": true
+        },
+        "tslint-plugin-prettier": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/tslint-plugin-prettier/-/tslint-plugin-prettier-2.0.1.tgz",
+            "integrity": "sha512-4FX9JIx/1rKHIPJNfMb+ooX1gPk5Vg3vNi7+dyFYpLO+O57F4g+b/fo1+W/G0SUOkBLHB/YKScxjX/P+7ZT/Tw==",
+            "dev": true,
+            "requires": {
+                "eslint-plugin-prettier": "^2.2.0",
+                "lines-and-columns": "^1.1.6",
+                "tslib": "^1.7.1"
+            }
         },
         "tsutils": {
             "version": "2.29.0",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -48,11 +48,12 @@
         "rollup": "^1.27.9",
         "rollup-plugin-commonjs": "^10.1.0",
         "rollup-plugin-node-resolve": "^5.2.0",
-        "rollup-plugin-typescript": "^1.0.1",
         "rollup-plugin-sourcemaps": "^0.4.2",
+        "rollup-plugin-typescript": "^1.0.1",
         "shx": "^0.3.1",
         "tslint": "^5.20.1",
         "tslint-config-prettier": "^1.18.0",
+        "tslint-plugin-prettier": "^2.0.1",
         "typescript": "^3.7.3",
         "vsce": "^1.70.0",
         "vscode-test": "^1.2.3"

--- a/editors/code/tslint.json
+++ b/editors/code/tslint.json
@@ -1,9 +1,13 @@
 {
     "defaultSeverity": "error",
-    "extends": ["tslint:recommended", "tslint-config-prettier"],
+    "extends": [
+        "tslint:recommended",
+        "tslint-config-prettier",
+        "tslint-plugin-prettier"
+    ],
     "rules": {
-        "quotemark": [true, "single"],
         "interface-name": false,
+        "prettier": true,
         "object-literal-sort-keys": false,
         // Allow `_bar` to sort with tsc's `noUnusedParameters` option
         "variable-name": [true, "allow-leading-underscore"]


### PR DESCRIPTION
This PR add `tslint-plugin-prettier` extension in ts-lint, which "runs prettier rules as tslint rules." and remove  `quotemark` from ts-lint and let prettier to handle it. 

And also fix #2515