### PR TITLE
Add std::ops::Index support for infering

### DIFF
--- a/crates/ra_hir_def/src/path.rs
+++ b/crates/ra_hir_def/src/path.rs
@@ -254,6 +254,7 @@ macro_rules! __known_path {
     (std::ops::Try) => {};
     (std::ops::Neg) => {};
     (std::ops::Not) => {};
+    (std::ops::Index) => {};
     ($path:path) => {
         compile_error!("Please register your known path in the path module")
     };

--- a/crates/ra_hir_expand/src/name.rs
+++ b/crates/ra_hir_expand/src/name.rs
@@ -161,6 +161,7 @@ pub mod known {
         Range,
         Neg,
         Not,
+        Index,
         // Builtin macros
         file,
         column,

--- a/crates/ra_hir_ty/src/infer.rs
+++ b/crates/ra_hir_ty/src/infer.rs
@@ -375,7 +375,7 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
         match assoc_ty {
             Some(res_assoc_ty) => {
                 let ty = self.table.new_type_var();
-                let mut builder = Substs::builder(1 + params.len()).push(inner_ty);
+                let mut builder = Substs::build_for_def(self.db, res_assoc_ty).push(inner_ty);
                 for ty in params {
                     builder = builder.push(ty.clone());
                 }

--- a/crates/ra_hir_ty/src/infer.rs
+++ b/crates/ra_hir_ty/src/infer.rs
@@ -375,11 +375,9 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
         match assoc_ty {
             Some(res_assoc_ty) => {
                 let ty = self.table.new_type_var();
-                let mut builder = Substs::build_for_def(self.db, res_assoc_ty).push(inner_ty);
-                for ty in params {
-                    builder = builder.push(ty.clone());
-                }
-
+                let builder = Substs::build_for_def(self.db, res_assoc_ty)
+                    .push(inner_ty)
+                    .fill(params.iter().cloned());
                 let projection = ProjectionPredicate {
                     ty: ty.clone(),
                     projection_ty: ProjectionTy {

--- a/crates/ra_hir_ty/src/infer/expr.rs
+++ b/crates/ra_hir_ty/src/infer/expr.rs
@@ -422,10 +422,14 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
                 }
             }
             Expr::Index { base, index } => {
-                let _base_ty = self.infer_expr_inner(*base, &Expectation::none());
-                let _index_ty = self.infer_expr(*index, &Expectation::none());
-                // FIXME: use `std::ops::Index::Output` to figure out the real return type
-                Ty::Unknown
+                let base_ty = self.infer_expr_inner(*base, &Expectation::none());
+                let index_ty = self.infer_expr(*index, &Expectation::none());
+
+                self.resolve_associated_type_with_params(
+                    base_ty,
+                    self.resolve_ops_index_output(),
+                    &[index_ty],
+                )
             }
             Expr::Tuple { exprs } => {
                 let mut tys = match &expected.ty {

--- a/crates/ra_hir_ty/src/tests/traits.rs
+++ b/crates/ra_hir_ty/src/tests/traits.rs
@@ -427,6 +427,38 @@ fn indexing_arrays() {
 }
 
 #[test]
+fn infer_ops_index() {
+    let (db, pos) = TestDB::with_position(
+        r#"
+//- /main.rs crate:main deps:std
+
+struct Bar;
+struct Foo;
+
+impl std::ops::Index<u32> for Bar {
+    type Output = Foo;
+}
+
+fn test() {
+    let a = Bar;
+    let b = a[1];
+    b<|>;
+}
+
+//- /std.rs crate:std
+
+#[prelude_import] use ops::*;
+mod ops {
+    pub trait Index<Idx> {
+        type Output;
+    }
+}
+"#,
+    );
+    assert_eq!("Foo", type_at_pos(&db, pos));
+}
+
+#[test]
 fn deref_trait() {
     let t = type_at(
         r#"


### PR DESCRIPTION
see also #2534

Seem like this can't fix #2534 for this case:

```rust
fn foo3(bar: [usize; 2]) {
    let baz = bar[1];   // <--- baz is still unknown ?
    println!("{}", baz);
}
```