### PR TITLE
Fix wrong path parsing for macro call in pattern position

### DIFF
--- a/crates/ra_ide/src/goto_definition.rs
+++ b/crates/ra_ide/src/goto_definition.rs
@@ -425,6 +425,42 @@ mod tests {
     }
 
     #[test]
+    fn goto_definition_works_for_macro_inside_pattern() {
+        check_goto(
+            "
+            //- /lib.rs
+            macro_rules! foo {() => {0}}
+
+            fn bar() {
+                match (0,1) {
+                    (<|>foo!(), _) => {}
+                }
+            }
+            ",
+            "foo MACRO_CALL FileId(1) [0; 28) [13; 16)",
+            "macro_rules! foo {() => {0}}|foo",
+        );
+    }
+
+    #[test]
+    fn goto_definition_works_for_macro_inside_match_arm_lhs() {
+        check_goto(
+            "
+            //- /lib.rs
+            macro_rules! foo {() => {0}}
+
+            fn bar() {
+                match 0 {
+                    <|>foo!() => {}
+                }
+            }
+            ",
+            "foo MACRO_CALL FileId(1) [0; 28) [13; 16)",
+            "macro_rules! foo {() => {0}}|foo",
+        );
+    }
+
+    #[test]
     fn goto_def_for_methods() {
         covers!(goto_def_for_methods);
         check_goto(

--- a/crates/ra_parser/src/grammar/patterns.rs
+++ b/crates/ra_parser/src/grammar/patterns.rs
@@ -50,7 +50,7 @@ pub(super) fn pattern_r(p: &mut Parser, recovery_set: TokenSet) {
         //     let m!(x) = 0;
         // }
         if lhs.kind() == PATH_PAT && p.at(T![!]) {
-            let m = lhs.precede(p);
+            let m = lhs.undo_completion(p);
             items::macro_call_after_excl(p);
             m.complete(p, MACRO_CALL);
         }

--- a/crates/ra_syntax/test_data/parser/inline/ok/0129_marco_pat.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0129_marco_pat.txt
@@ -16,11 +16,10 @@ SOURCE_FILE@[0; 33)
           LET_KW@[16; 19) "let"
           WHITESPACE@[19; 20) " "
           MACRO_CALL@[20; 25)
-            PATH_PAT@[20; 21)
-              PATH@[20; 21)
-                PATH_SEGMENT@[20; 21)
-                  NAME_REF@[20; 21)
-                    IDENT@[20; 21) "m"
+            PATH@[20; 21)
+              PATH_SEGMENT@[20; 21)
+                NAME_REF@[20; 21)
+                  IDENT@[20; 21) "m"
             EXCL@[21; 22) "!"
             TOKEN_TREE@[22; 25)
               L_PAREN@[22; 23) "("


### PR DESCRIPTION
The parser incorrectly insert a `PathPat` inside `MacroCall` syntax node when parsing inside a pattern position, for example : 

```rust
let foo!() = 0;
```

become:

```
 MACRO_CALL@[60; 66)
    PATH_PAT@[60; 63)     <------------- It should not exist
      PATH@[60; 63)
        PATH_SEGMENT@[60; 63)
          NAME_REF@[60; 63)
            IDENT@[60; 63) "foo"
    EXCL@[63; 64) "!"
    TOKEN_TREE@[64; 66)
      L_PAREN@[64; 65) "("
      R_PAREN@[65; 66) ")"
```

This PR fix this bug and add some test to make sure goto-defintion works for macro inside pattern.
