### PR TITLE
Remove index resolving from hover

### DIFF
--- a/crates/ra_ide/src/display.rs
+++ b/crates/ra_ide/src/display.rs
@@ -15,7 +15,7 @@ pub use function_signature::FunctionSignature;
 pub use navigation_target::NavigationTarget;
 pub use structure::{file_structure, StructureNode};
 
-pub(crate) use navigation_target::{description_from_symbol, docs_from_symbol, ToNav};
+pub(crate) use navigation_target::ToNav;
 pub(crate) use short_label::ShortLabel;
 
 pub(crate) fn function_label(node: &ast::FnDef) -> String {


### PR DESCRIPTION
I have left in `HoverResult`'s support for multiple entries because we may still want that at some point.

Per https://github.com/rust-analyzer/rust-analyzer/issues/2542#issuecomment-565238142