### PR TITLE
Add support macros in impl blocks

### DIFF
--- a/crates/ra_hir_def/src/lib.rs
+++ b/crates/ra_hir_def/src/lib.rs
@@ -47,6 +47,7 @@ use ra_arena::{impl_arena_id, RawId};
 use ra_db::{impl_intern_key, salsa, CrateId};
 use ra_syntax::{ast, AstNode};
 
+use crate::body::Expander;
 use crate::builtin_type::BuiltinType;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/ra_hir_expand/src/db.rs
+++ b/crates/ra_hir_expand/src/db.rs
@@ -188,6 +188,7 @@ fn to_fragment_kind(db: &dyn AstDatabase, macro_call_id: MacroCallId) -> Fragmen
         ARG_LIST => FragmentKind::Expr,
         TRY_EXPR => FragmentKind::Expr,
         TUPLE_EXPR => FragmentKind::Expr,
+        ITEM_LIST => FragmentKind::Items,
         _ => {
             // Unknown , Just guess it is `Items`
             FragmentKind::Items

--- a/crates/ra_hir_ty/src/tests/macros.rs
+++ b/crates/ra_hir_ty/src/tests/macros.rs
@@ -183,6 +183,25 @@ fn test() { S.foo()<|>; }
 }
 
 #[test]
+fn infer_impl_items_generated_by_macros() {
+    let t = type_at(
+        r#"
+//- /main.rs
+macro_rules! m {
+    () => (fn foo(&self) -> u128 {0})
+}
+struct S;
+impl S {
+    m!();
+}
+
+fn test() { S.foo()<|>; }
+"#,
+    );
+    assert_eq!(t, "u128");
+}
+
+#[test]
 fn infer_macro_with_dollar_crate_is_correct_in_expr() {
     let (db, pos) = TestDB::with_position(
         r#"


### PR DESCRIPTION
This PR add support for macros in impl blocks, which reuse `Expander` for macro expansion.

see also: #2459 