### PR TITLE
Add dummy implementations of env! and option_env! builtins

### DIFF
--- a/crates/ra_hir_expand/src/name.rs
+++ b/crates/ra_hir_expand/src/name.rs
@@ -170,6 +170,8 @@ pub mod known {
         stringify,
         format_args,
         format_args_nl,
+        env,
+        option_env,
         // Builtin derives
         Copy,
         Clone,

--- a/crates/ra_hir_expand/src/quote.rs
+++ b/crates/ra_hir_expand/src/quote.rs
@@ -102,6 +102,8 @@ macro_rules! __quote {
     ( : ) => {$crate::__quote!(@PUNCT ':')};
     ( :: ) => {$crate::__quote!(@PUNCT ':', ':')};
     ( . ) => {$crate::__quote!(@PUNCT '.')};
+    ( < ) => {$crate::__quote!(@PUNCT '<')};
+    ( > ) => {$crate::__quote!(@PUNCT '>')};
 
     ( $first:tt $($tail:tt)+ ) => {
         {


### PR DESCRIPTION
They don't do anything except return the correct type.

Also refactor the builtin macro tests a bit.