### PR TITLE
Parse const generics

### DIFF
--- a/crates/ra_parser/src/grammar/type_params.rs
+++ b/crates/ra_parser/src/grammar/type_params.rs
@@ -25,6 +25,7 @@ fn type_param_list(p: &mut Parser) {
         match p.current() {
             LIFETIME => lifetime_param(p, m),
             IDENT => type_param(p, m),
+            CONST_KW => type_const_param(p, m),
             _ => {
                 m.abandon(p);
                 p.err_and_bump("expected type parameter")
@@ -60,6 +61,16 @@ fn type_param(p: &mut Parser, m: Marker) {
         types::type_(p)
     }
     m.complete(p, TYPE_PARAM);
+}
+
+// test const_param
+// struct S<const N: u32>;
+fn type_const_param(p: &mut Parser, m: Marker) {
+    assert!(p.at(CONST_KW));
+    p.bump(T![const]);
+    name(p);
+    types::ascription(p);
+    m.complete(p, CONST_PARAM);
 }
 
 // test type_param_bounds

--- a/crates/ra_parser/src/syntax_kind/generated.rs
+++ b/crates/ra_parser/src/syntax_kind/generated.rs
@@ -227,6 +227,7 @@ pub enum SyntaxKind {
     TYPE_PARAM_LIST,
     LIFETIME_PARAM,
     TYPE_PARAM,
+    CONST_PARAM,
     TYPE_ARG_LIST,
     LIFETIME_ARG,
     TYPE_ARG,

--- a/crates/ra_syntax/src/ast/generated.rs
+++ b/crates/ra_syntax/src/ast/generated.rs
@@ -551,6 +551,36 @@ impl ConstDef {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ConstParam {
+    pub(crate) syntax: SyntaxNode,
+}
+impl AstNode for ConstParam {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            CONST_PARAM => true,
+            _ => false,
+        }
+    }
+    fn cast(syntax: SyntaxNode) -> Option<Self> {
+        if Self::can_cast(syntax.kind()) {
+            Some(Self { syntax })
+        } else {
+            None
+        }
+    }
+    fn syntax(&self) -> &SyntaxNode {
+        &self.syntax
+    }
+}
+impl ast::NameOwner for ConstParam {}
+impl ast::AttrsOwner for ConstParam {}
+impl ast::TypeAscriptionOwner for ConstParam {}
+impl ConstParam {
+    pub fn default_val(&self) -> Option<Expr> {
+        AstChildren::new(&self.syntax).next()
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ContinueExpr {
     pub(crate) syntax: SyntaxNode,
 }

--- a/crates/ra_syntax/src/grammar.ron
+++ b/crates/ra_syntax/src/grammar.ron
@@ -243,6 +243,7 @@ Grammar(
         "TYPE_PARAM_LIST",
         "LIFETIME_PARAM",
         "TYPE_PARAM",
+        "CONST_PARAM",
         "TYPE_ARG_LIST",
         "LIFETIME_ARG",
         "TYPE_ARG",
@@ -601,6 +602,10 @@ Grammar(
         "TypeParam": (
             options: [("default_type", "TypeRef")],
             traits: ["NameOwner", "AttrsOwner", "TypeBoundsOwner"],
+        ),
+        "ConstParam": (
+            options: [("default_val", "Expr")],
+            traits: ["NameOwner", "AttrsOwner", "TypeAscriptionOwner"],
         ),
         "LifetimeParam": (
             traits: ["AttrsOwner"],

--- a/crates/ra_syntax/test_data/parser/inline/ok/0147_const_param.rs
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0147_const_param.rs
@@ -1,0 +1,1 @@
+struct S<const N: u32>;

--- a/crates/ra_syntax/test_data/parser/inline/ok/0147_const_param.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0147_const_param.txt
@@ -1,0 +1,23 @@
+SOURCE_FILE@[0; 24)
+  STRUCT_DEF@[0; 23)
+    STRUCT_KW@[0; 6) "struct"
+    WHITESPACE@[6; 7) " "
+    NAME@[7; 8)
+      IDENT@[7; 8) "S"
+    TYPE_PARAM_LIST@[8; 22)
+      L_ANGLE@[8; 9) "<"
+      CONST_PARAM@[9; 21)
+        CONST_KW@[9; 14) "const"
+        WHITESPACE@[14; 15) " "
+        NAME@[15; 16)
+          IDENT@[15; 16) "N"
+        COLON@[16; 17) ":"
+        WHITESPACE@[17; 18) " "
+        PATH_TYPE@[18; 21)
+          PATH@[18; 21)
+            PATH_SEGMENT@[18; 21)
+              NAME_REF@[18; 21)
+                IDENT@[18; 21) "u32"
+      R_ANGLE@[21; 22) ">"
+    SEMI@[22; 23) ";"
+  WHITESPACE@[23; 24) "\n"


### PR DESCRIPTION
Adds very primitive support for parsing const generics (`const IDENT: TY`) so that rust-analyzer stops complaining about the syntax being invalid.

Fixes #1574
Fixes #2281 