### PR TITLE
Resolve symbolic links before trying to load a file.

### DIFF
--- a/crates/ra_lsp_server/src/world.rs
+++ b/crates/ra_lsp_server/src/world.rs
@@ -225,7 +225,7 @@ impl WorldSnapshot {
     }
 
     pub fn uri_to_file_id(&self, uri: &Url) -> Result<FileId> {
-        let path = uri.to_file_path().map_err(|()| format!("invalid uri: {}", uri))?;
+        let path = uri.to_file_path().map_err(|()| format!("invalid uri: {}", uri))?.canonicalize()?;
         let file = self.vfs.read().path2file(&path).ok_or_else(|| {
             // Show warning as this file is outside current workspace
             LspError {


### PR DESCRIPTION
This prevents errors when a file is in fact local but looks
like it's outside the current workspace because it is accessed
via a symbolic link path.