### PR TITLE
Omit closure parameters in closure type display strings

### DIFF
--- a/crates/ra_hir_ty/src/display.rs
+++ b/crates/ra_hir_ty/src/display.rs
@@ -10,7 +10,7 @@ pub struct HirFormatter<'a, 'b, DB> {
     buf: String,
     curr_size: usize,
     max_size: Option<usize>,
-    should_display_default_types: bool,
+    omit_verbose_types: bool,
 }
 
 pub trait HirDisplay {
@@ -20,7 +20,7 @@ pub trait HirDisplay {
     where
         Self: Sized,
     {
-        HirDisplayWrapper(db, self, None, true)
+        HirDisplayWrapper(db, self, None, false)
     }
 
     fn display_truncated<'a, DB>(
@@ -31,7 +31,7 @@ pub trait HirDisplay {
     where
         Self: Sized,
     {
-        HirDisplayWrapper(db, self, max_size, false)
+        HirDisplayWrapper(db, self, max_size, true)
     }
 }
 
@@ -74,8 +74,8 @@ where
         }
     }
 
-    pub fn should_display_default_types(&self) -> bool {
-        self.should_display_default_types
+    pub fn omit_verbose_types(&self) -> bool {
+        self.omit_verbose_types
     }
 }
 
@@ -93,7 +93,7 @@ where
             buf: String::with_capacity(20),
             curr_size: 0,
             max_size: self.2,
-            should_display_default_types: self.3,
+            omit_verbose_types: self.3,
         })
     }
 }

--- a/crates/ra_ide/src/inlay_hints.rs
+++ b/crates/ra_ide/src/inlay_hints.rs
@@ -293,7 +293,7 @@ fn main() {
     }
 
     #[test]
-    fn closure_parameter() {
+    fn closure_parameters() {
         let (analysis, file_id) = single_file(
             r#"
 fn main() {
@@ -301,6 +301,11 @@ fn main() {
     (0..2).for_each(|increment| {
         start += increment;
     })
+
+    let multiply = |a, b, c, d| a * b * c * d;
+    let _: i32 = multiply(1, 2, 3, 4);
+
+    let return_42 = || 42;
 }"#,
         );
 
@@ -315,6 +320,36 @@ fn main() {
                 range: [57; 66),
                 kind: TypeHint,
                 label: "i32",
+            },
+            InlayHint {
+                range: [114; 122),
+                kind: TypeHint,
+                label: "|…| -> i32",
+            },
+            InlayHint {
+                range: [126; 127),
+                kind: TypeHint,
+                label: "i32",
+            },
+            InlayHint {
+                range: [129; 130),
+                kind: TypeHint,
+                label: "i32",
+            },
+            InlayHint {
+                range: [132; 133),
+                kind: TypeHint,
+                label: "i32",
+            },
+            InlayHint {
+                range: [135; 136),
+                kind: TypeHint,
+                label: "i32",
+            },
+            InlayHint {
+                range: [201; 210),
+                kind: TypeHint,
+                label: "|| -> i32",
             },
         ]
         "###


### PR DESCRIPTION
Part of https://github.com/rust-analyzer/rust-analyzer/issues/1946

I wonder, should we display the the closure trait (Fn/FnMut/FnOnce) in inlay hints instead of `|...|` at all?