### PR TITLE
Only add features flags if non-empty

### DIFF
--- a/crates/ra_project_model/src/cargo_workspace.rs
+++ b/crates/ra_project_model/src/cargo_workspace.rs
@@ -165,7 +165,7 @@ impl CargoWorkspace {
             // FIXME: `NoDefaultFeatures` is mutual exclusive with `SomeFeatures`
             // https://github.com/oli-obk/cargo_metadata/issues/79
             meta.features(CargoOpt::NoDefaultFeatures);
-        } else {
+        } else if cargo_features.features.len() > 0 {
             meta.features(CargoOpt::SomeFeatures(cargo_features.features.clone()));
         }
         if let Some(parent) = cargo_toml.parent() {


### PR DESCRIPTION
This prevent error when disabled  `all-features` in a cargo workspace, because of `--features is not allowed in the root of a virtual workspace` when running `cargo metadata`.