### PR TITLE
Visibility

### DIFF
--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -1053,8 +1053,8 @@ impl<T: Into<AttrDef> + Copy> Docs for T {
 
 pub trait HasVisibility {
     fn visibility(&self, db: &impl HirDatabase) -> Visibility;
-    fn visible_from(&self, db: &impl HirDatabase, module: Module) -> bool {
+    fn is_visible_from(&self, db: &impl HirDatabase, module: Module) -> bool {
         let vis = self.visibility(db);
-        vis.visible_from(db, module.id)
+        vis.is_visible_from(db, module.id)
     }
 }

--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -257,8 +257,8 @@ impl StructField {
 
 impl HasVisibility for StructField {
     fn visibility(&self, db: &impl HirDatabase) -> Visibility {
-        let struct_field_id: hir_def::StructFieldId = (*self).into();
-        let visibility = db.visibility(struct_field_id.into());
+        let variant_data = self.parent.variant_data(db);
+        let visibility = &variant_data.fields()[self.id].visibility;
         let parent_id: hir_def::VariantId = self.parent.into();
         visibility.resolve(db, &parent_id.resolver(db))
     }

--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -118,7 +118,7 @@ impl_froms!(
     BuiltinType
 );
 
-pub use hir_def::attr::Attrs;
+pub use hir_def::{attr::Attrs, visibility::ResolvedVisibility};
 
 impl Module {
     pub(crate) fn new(krate: Crate, crate_module_id: LocalModuleId) -> Module {
@@ -252,6 +252,15 @@ impl StructField {
 
     pub fn parent_def(&self, _db: &impl HirDatabase) -> VariantDef {
         self.parent
+    }
+}
+
+impl HasVisibility for StructField {
+    fn visibility(&self, db: &impl HirDatabase) -> ResolvedVisibility {
+        let struct_field_id: hir_def::StructFieldId = (*self).into();
+        let visibility = db.visibility(struct_field_id.into());
+        let parent_id: hir_def::VariantId = self.parent.into();
+        visibility.resolve(db, &parent_id.resolver(db))
     }
 }
 
@@ -1039,5 +1048,13 @@ impl<T: Into<AttrDef> + Copy> Docs for T {
     fn docs(&self, db: &impl HirDatabase) -> Option<Documentation> {
         let def: AttrDef = (*self).into();
         db.documentation(def.into())
+    }
+}
+
+pub trait HasVisibility {
+    fn visibility(&self, db: &impl HirDatabase) -> ResolvedVisibility;
+    fn visible_from(&self, db: &impl HirDatabase, module: Module) -> bool {
+        let vis = self.visibility(db);
+        vis.visible_from(db, module.id)
     }
 }

--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -118,7 +118,7 @@ impl_froms!(
     BuiltinType
 );
 
-pub use hir_def::{attr::Attrs, visibility::ResolvedVisibility};
+pub use hir_def::{attr::Attrs, visibility::Visibility};
 
 impl Module {
     pub(crate) fn new(krate: Crate, crate_module_id: LocalModuleId) -> Module {
@@ -256,7 +256,7 @@ impl StructField {
 }
 
 impl HasVisibility for StructField {
-    fn visibility(&self, db: &impl HirDatabase) -> ResolvedVisibility {
+    fn visibility(&self, db: &impl HirDatabase) -> Visibility {
         let struct_field_id: hir_def::StructFieldId = (*self).into();
         let visibility = db.visibility(struct_field_id.into());
         let parent_id: hir_def::VariantId = self.parent.into();
@@ -1052,7 +1052,7 @@ impl<T: Into<AttrDef> + Copy> Docs for T {
 }
 
 pub trait HasVisibility {
-    fn visibility(&self, db: &impl HirDatabase) -> ResolvedVisibility;
+    fn visibility(&self, db: &impl HirDatabase) -> Visibility;
     fn visible_from(&self, db: &impl HirDatabase, module: Module) -> bool {
         let vis = self.visibility(db);
         vis.visible_from(db, module.id)

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -40,8 +40,8 @@ mod from_source;
 pub use crate::{
     code_model::{
         Adt, AssocItem, AttrDef, Const, Crate, CrateDependency, DefWithBody, Docs, Enum,
-        EnumVariant, FieldSource, Function, GenericDef, HasAttrs, ImplBlock, Local, MacroDef,
-        Module, ModuleDef, ScopeDef, Static, Struct, StructField, Trait, Type, TypeAlias,
+        EnumVariant, FieldSource, Function, GenericDef, HasAttrs, HasVisibility, ImplBlock, Local,
+        MacroDef, Module, ModuleDef, ScopeDef, Static, Struct, StructField, Trait, Type, TypeAlias,
         TypeParam, Union, VariantDef,
     },
     from_source::FromSource,

--- a/crates/ra_hir_def/src/body/lower.rs
+++ b/crates/ra_hir_def/src/body/lower.rs
@@ -543,7 +543,10 @@ where
             };
             self.body.item_scope.define_def(def);
             if let Some(name) = name {
-                self.body.item_scope.push_res(name.as_name(), def.into());
+                let vis = crate::visibility::ResolvedVisibility::Public; // FIXME determine correctly
+                self.body
+                    .item_scope
+                    .push_res(name.as_name(), crate::per_ns::PerNs::from_def(def, vis));
             }
         }
     }

--- a/crates/ra_hir_def/src/body/lower.rs
+++ b/crates/ra_hir_def/src/body/lower.rs
@@ -543,7 +543,7 @@ where
             };
             self.body.item_scope.define_def(def);
             if let Some(name) = name {
-                let vis = crate::visibility::ResolvedVisibility::Public; // FIXME determine correctly
+                let vis = crate::visibility::Visibility::Public; // FIXME determine correctly
                 self.body
                     .item_scope
                     .push_res(name.as_name(), crate::per_ns::PerNs::from_def(def, vis));

--- a/crates/ra_hir_def/src/db.rs
+++ b/crates/ra_hir_def/src/db.rs
@@ -14,9 +14,10 @@ use crate::{
     generics::GenericParams,
     lang_item::{LangItemTarget, LangItems},
     nameres::{raw::RawItems, CrateDefMap},
+    visibility::Visibility,
     AttrDefId, ConstId, ConstLoc, DefWithBodyId, EnumId, EnumLoc, FunctionId, FunctionLoc,
     GenericDefId, ImplId, ImplLoc, ModuleId, StaticId, StaticLoc, StructId, StructLoc, TraitId,
-    TraitLoc, TypeAliasId, TypeAliasLoc, UnionId, UnionLoc,
+    TraitLoc, TypeAliasId, TypeAliasLoc, UnionId, UnionLoc, VisibilityDefId,
 };
 
 #[salsa::query_group(InternDatabaseStorage)]
@@ -89,6 +90,9 @@ pub trait DefDatabase: InternDatabase + AstDatabase {
 
     #[salsa::invoke(Attrs::attrs_query)]
     fn attrs(&self, def: AttrDefId) -> Attrs;
+
+    #[salsa::invoke(Visibility::visibility_query)]
+    fn visibility(&self, def: VisibilityDefId) -> Visibility;
 
     #[salsa::invoke(LangItems::module_lang_items_query)]
     fn module_lang_items(&self, module: ModuleId) -> Option<Arc<LangItems>>;

--- a/crates/ra_hir_def/src/db.rs
+++ b/crates/ra_hir_def/src/db.rs
@@ -14,7 +14,7 @@ use crate::{
     generics::GenericParams,
     lang_item::{LangItemTarget, LangItems},
     nameres::{raw::RawItems, CrateDefMap},
-    visibility::Visibility,
+    visibility::RawVisibility,
     AttrDefId, ConstId, ConstLoc, DefWithBodyId, EnumId, EnumLoc, FunctionId, FunctionLoc,
     GenericDefId, ImplId, ImplLoc, ModuleId, StaticId, StaticLoc, StructId, StructLoc, TraitId,
     TraitLoc, TypeAliasId, TypeAliasLoc, UnionId, UnionLoc, VisibilityDefId,
@@ -91,8 +91,8 @@ pub trait DefDatabase: InternDatabase + AstDatabase {
     #[salsa::invoke(Attrs::attrs_query)]
     fn attrs(&self, def: AttrDefId) -> Attrs;
 
-    #[salsa::invoke(Visibility::visibility_query)]
-    fn visibility(&self, def: VisibilityDefId) -> Visibility;
+    #[salsa::invoke(RawVisibility::visibility_query)]
+    fn visibility(&self, def: VisibilityDefId) -> RawVisibility;
 
     #[salsa::invoke(LangItems::module_lang_items_query)]
     fn module_lang_items(&self, module: ModuleId) -> Option<Arc<LangItems>>;

--- a/crates/ra_hir_def/src/db.rs
+++ b/crates/ra_hir_def/src/db.rs
@@ -14,10 +14,9 @@ use crate::{
     generics::GenericParams,
     lang_item::{LangItemTarget, LangItems},
     nameres::{raw::RawItems, CrateDefMap},
-    visibility::RawVisibility,
     AttrDefId, ConstId, ConstLoc, DefWithBodyId, EnumId, EnumLoc, FunctionId, FunctionLoc,
     GenericDefId, ImplId, ImplLoc, ModuleId, StaticId, StaticLoc, StructId, StructLoc, TraitId,
-    TraitLoc, TypeAliasId, TypeAliasLoc, UnionId, UnionLoc, VisibilityDefId,
+    TraitLoc, TypeAliasId, TypeAliasLoc, UnionId, UnionLoc,
 };
 
 #[salsa::query_group(InternDatabaseStorage)]
@@ -90,9 +89,6 @@ pub trait DefDatabase: InternDatabase + AstDatabase {
 
     #[salsa::invoke(Attrs::attrs_query)]
     fn attrs(&self, def: AttrDefId) -> Attrs;
-
-    #[salsa::invoke(RawVisibility::visibility_query)]
-    fn visibility(&self, def: VisibilityDefId) -> RawVisibility;
 
     #[salsa::invoke(LangItems::module_lang_items_query)]
     fn module_lang_items(&self, module: ModuleId) -> Option<Arc<LangItems>>;

--- a/crates/ra_hir_def/src/item_scope.rs
+++ b/crates/ra_hir_def/src/item_scope.rs
@@ -149,16 +149,8 @@ impl ItemScope {
         changed
     }
 
-    #[cfg(test)]
-    pub(crate) fn collect_resolutions(&self) -> Vec<(Name, PerNs)> {
-        self.visible.iter().map(|(name, res)| (name.clone(), res.clone())).collect()
-    }
-
-    pub(crate) fn collect_resolutions_with_vis(
-        &self,
-        vis: ResolvedVisibility,
-    ) -> Vec<(Name, PerNs)> {
-        self.visible.iter().map(|(name, res)| (name.clone(), res.with_visibility(vis))).collect()
+    pub(crate) fn resolutions<'a>(&'a self) -> impl Iterator<Item = (Name, PerNs)> + 'a {
+        self.visible.iter().map(|(name, res)| (name.clone(), res.clone()))
     }
 
     pub(crate) fn collect_legacy_macros(&self) -> FxHashMap<Name, MacroDefId> {

--- a/crates/ra_hir_def/src/item_scope.rs
+++ b/crates/ra_hir_def/src/item_scope.rs
@@ -6,8 +6,8 @@ use once_cell::sync::Lazy;
 use rustc_hash::FxHashMap;
 
 use crate::{
-    per_ns::PerNs, visibility::ResolvedVisibility, AdtId, BuiltinType, ImplId, MacroDefId,
-    ModuleDefId, TraitId,
+    per_ns::PerNs, visibility::Visibility, AdtId, BuiltinType, ImplId, MacroDefId, ModuleDefId,
+    TraitId,
 };
 
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -33,9 +33,7 @@ pub struct ItemScope {
 static BUILTIN_SCOPE: Lazy<FxHashMap<Name, PerNs>> = Lazy::new(|| {
     BuiltinType::ALL
         .iter()
-        .map(|(name, ty)| {
-            (name.clone(), PerNs::types(ty.clone().into(), ResolvedVisibility::Public))
-        })
+        .map(|(name, ty)| (name.clone(), PerNs::types(ty.clone().into(), Visibility::Public)))
         .collect()
 });
 
@@ -159,7 +157,7 @@ impl ItemScope {
 }
 
 impl PerNs {
-    pub(crate) fn from_def(def: ModuleDefId, v: ResolvedVisibility) -> PerNs {
+    pub(crate) fn from_def(def: ModuleDefId, v: Visibility) -> PerNs {
         match def {
             ModuleDefId::ModuleId(_) => PerNs::types(def, v),
             ModuleDefId::FunctionId(_) => PerNs::values(def, v),

--- a/crates/ra_hir_def/src/item_scope.rs
+++ b/crates/ra_hir_def/src/item_scope.rs
@@ -5,7 +5,10 @@ use hir_expand::name::Name;
 use once_cell::sync::Lazy;
 use rustc_hash::FxHashMap;
 
-use crate::{per_ns::PerNs, AdtId, BuiltinType, ImplId, MacroDefId, ModuleDefId, TraitId};
+use crate::{
+    per_ns::PerNs, visibility::ResolvedVisibility, AdtId, BuiltinType, ImplId, MacroDefId,
+    ModuleDefId, TraitId,
+};
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct ItemScope {
@@ -30,7 +33,9 @@ pub struct ItemScope {
 static BUILTIN_SCOPE: Lazy<FxHashMap<Name, PerNs>> = Lazy::new(|| {
     BuiltinType::ALL
         .iter()
-        .map(|(name, ty)| (name.clone(), PerNs::types(ty.clone().into())))
+        .map(|(name, ty)| {
+            (name.clone(), PerNs::types(ty.clone().into(), ResolvedVisibility::Public))
+        })
         .collect()
 });
 
@@ -144,8 +149,16 @@ impl ItemScope {
         changed
     }
 
+    #[cfg(test)]
     pub(crate) fn collect_resolutions(&self) -> Vec<(Name, PerNs)> {
         self.visible.iter().map(|(name, res)| (name.clone(), res.clone())).collect()
+    }
+
+    pub(crate) fn collect_resolutions_with_vis(
+        &self,
+        vis: ResolvedVisibility,
+    ) -> Vec<(Name, PerNs)> {
+        self.visible.iter().map(|(name, res)| (name.clone(), res.with_visibility(vis))).collect()
     }
 
     pub(crate) fn collect_legacy_macros(&self) -> FxHashMap<Name, MacroDefId> {
@@ -153,20 +166,20 @@ impl ItemScope {
     }
 }
 
-impl From<ModuleDefId> for PerNs {
-    fn from(def: ModuleDefId) -> PerNs {
+impl PerNs {
+    pub(crate) fn from_def(def: ModuleDefId, v: ResolvedVisibility) -> PerNs {
         match def {
-            ModuleDefId::ModuleId(_) => PerNs::types(def),
-            ModuleDefId::FunctionId(_) => PerNs::values(def),
+            ModuleDefId::ModuleId(_) => PerNs::types(def, v),
+            ModuleDefId::FunctionId(_) => PerNs::values(def, v),
             ModuleDefId::AdtId(adt) => match adt {
-                AdtId::StructId(_) | AdtId::UnionId(_) => PerNs::both(def, def),
-                AdtId::EnumId(_) => PerNs::types(def),
+                AdtId::StructId(_) | AdtId::UnionId(_) => PerNs::both(def, def, v),
+                AdtId::EnumId(_) => PerNs::types(def, v),
             },
-            ModuleDefId::EnumVariantId(_) => PerNs::both(def, def),
-            ModuleDefId::ConstId(_) | ModuleDefId::StaticId(_) => PerNs::values(def),
-            ModuleDefId::TraitId(_) => PerNs::types(def),
-            ModuleDefId::TypeAliasId(_) => PerNs::types(def),
-            ModuleDefId::BuiltinType(_) => PerNs::types(def),
+            ModuleDefId::EnumVariantId(_) => PerNs::both(def, def, v),
+            ModuleDefId::ConstId(_) | ModuleDefId::StaticId(_) => PerNs::values(def, v),
+            ModuleDefId::TraitId(_) => PerNs::types(def, v),
+            ModuleDefId::TypeAliasId(_) => PerNs::types(def, v),
+            ModuleDefId::BuiltinType(_) => PerNs::types(def, v),
         }
     }
 }

--- a/crates/ra_hir_def/src/lib.rs
+++ b/crates/ra_hir_def/src/lib.rs
@@ -36,6 +36,8 @@ pub mod nameres;
 pub mod src;
 pub mod child_by_source;
 
+pub mod visibility;
+
 #[cfg(test)]
 mod test_db;
 #[cfg(test)]
@@ -321,6 +323,29 @@ impl_froms!(
     TypeAliasId,
     MacroDefId,
     ImplId
+);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum VisibilityDefId {
+    ModuleId(ModuleId),
+    StructFieldId(StructFieldId),
+    AdtId(AdtId),
+    FunctionId(FunctionId),
+    StaticId(StaticId),
+    ConstId(ConstId),
+    TraitId(TraitId),
+    TypeAliasId(TypeAliasId),
+}
+
+impl_froms!(
+    VisibilityDefId: ModuleId,
+    StructFieldId,
+    AdtId(StructId, EnumId, UnionId),
+    StaticId,
+    ConstId,
+    FunctionId,
+    TraitId,
+    TypeAliasId
 );
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/ra_hir_def/src/lib.rs
+++ b/crates/ra_hir_def/src/lib.rs
@@ -325,29 +325,6 @@ impl_froms!(
     ImplId
 );
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum VisibilityDefId {
-    ModuleId(ModuleId),
-    StructFieldId(StructFieldId),
-    AdtId(AdtId),
-    FunctionId(FunctionId),
-    StaticId(StaticId),
-    ConstId(ConstId),
-    TraitId(TraitId),
-    TypeAliasId(TypeAliasId),
-}
-
-impl_froms!(
-    VisibilityDefId: ModuleId,
-    StructFieldId,
-    AdtId(StructId, EnumId, UnionId),
-    StaticId,
-    ConstId,
-    FunctionId,
-    TraitId,
-    TypeAliasId
-);
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum VariantId {
     EnumVariantId(EnumVariantId),

--- a/crates/ra_hir_def/src/nameres/collector.rs
+++ b/crates/ra_hir_def/src/nameres/collector.rs
@@ -743,7 +743,7 @@ where
         name: Name,
         declaration: AstId<ast::Module>,
         definition: Option<FileId>,
-        visibility: &crate::visibility::Visibility,
+        visibility: &crate::visibility::RawVisibility,
     ) -> LocalModuleId {
         let vis = self
             .def_collector

--- a/crates/ra_hir_def/src/nameres/collector.rs
+++ b/crates/ra_hir_def/src/nameres/collector.rs
@@ -378,12 +378,7 @@ where
                             .resolutions()
                             // only keep visible names...
                             .map(|(n, res)| {
-                                (
-                                    n,
-                                    res.filter_visibility(|v| {
-                                        v.visible_from_def_map(&self.def_map, module_id)
-                                    }),
-                                )
+                                (n, res.filter_visibility(|v| v.visible_from_other_crate()))
                             })
                             .filter(|(_, res)| !res.is_none())
                             .collect::<Vec<_>>();

--- a/crates/ra_hir_def/src/nameres/collector.rs
+++ b/crates/ra_hir_def/src/nameres/collector.rs
@@ -378,7 +378,7 @@ where
                             .resolutions()
                             // only keep visible names...
                             .map(|(n, res)| {
-                                (n, res.filter_visibility(|v| v.visible_from_other_crate()))
+                                (n, res.filter_visibility(|v| v.is_visible_from_other_crate()))
                             })
                             .filter(|(_, res)| !res.is_none())
                             .collect::<Vec<_>>();
@@ -398,7 +398,7 @@ where
                                 (
                                     n,
                                     res.filter_visibility(|v| {
-                                        v.visible_from_def_map(&self.def_map, module_id)
+                                        v.is_visible_from_def_map(&self.def_map, module_id)
                                     }),
                                 )
                             })
@@ -492,7 +492,7 @@ where
         for (glob_importing_module, glob_import_vis) in glob_imports {
             // we know all resolutions have the same visibility (`vis`), so we
             // just need to check that once
-            if !vis.visible_from_def_map(&self.def_map, glob_importing_module) {
+            if !vis.is_visible_from_def_map(&self.def_map, glob_importing_module) {
                 continue;
             }
             self.update_recursive(glob_importing_module, resolutions, glob_import_vis, depth + 1);

--- a/crates/ra_hir_def/src/nameres/collector.rs
+++ b/crates/ra_hir_def/src/nameres/collector.rs
@@ -109,7 +109,7 @@ struct MacroDirective {
 struct DefCollector<'a, DB> {
     db: &'a DB,
     def_map: CrateDefMap,
-    glob_imports: FxHashMap<LocalModuleId, Vec<(LocalModuleId, raw::Import)>>,
+    glob_imports: FxHashMap<LocalModuleId, Vec<(LocalModuleId, ResolvedVisibility)>>,
     unresolved_imports: Vec<ImportDirective>,
     resolved_imports: Vec<ImportDirective>,
     unexpanded_macros: Vec<MacroDirective>,
@@ -218,6 +218,7 @@ where
             self.update(
                 self.def_map.root,
                 &[(name, PerNs::macros(macro_, ResolvedVisibility::Public))],
+                ResolvedVisibility::Public,
             );
         }
     }
@@ -352,7 +353,6 @@ where
 
     fn record_resolved_import(&mut self, directive: &ImportDirective) {
         let module_id = directive.module_id;
-        let import_id = directive.import_id;
         let import = &directive.import;
         let def = directive.status.namespaces();
         let vis = self
@@ -373,28 +373,48 @@ where
                         let item_map = self.db.crate_def_map(m.krate);
                         let scope = &item_map[m.local_id].scope;
 
-                        // TODO: only use names we can see
-
                         // Module scoped macros is included
-                        let items = scope.collect_resolutions_with_vis(vis);
+                        let items = scope
+                            .resolutions()
+                            // only keep visible names...
+                            .map(|(n, res)| {
+                                (
+                                    n,
+                                    res.filter_visibility(|v| {
+                                        v.visible_from_def_map(&self.def_map, module_id)
+                                    }),
+                                )
+                            })
+                            .filter(|(_, res)| !res.is_none())
+                            .collect::<Vec<_>>();
 
-                        self.update(module_id, &items);
+                        self.update(module_id, &items, vis);
                     } else {
                         // glob import from same crate => we do an initial
                         // import, and then need to propagate any further
                         // additions
                         let scope = &self.def_map[m.local_id].scope;
 
-                        // TODO: only use names we can see
-
                         // Module scoped macros is included
-                        let items = scope.collect_resolutions_with_vis(vis);
+                        let items = scope
+                            .resolutions()
+                            // only keep visible names...
+                            .map(|(n, res)| {
+                                (
+                                    n,
+                                    res.filter_visibility(|v| {
+                                        v.visible_from_def_map(&self.def_map, module_id)
+                                    }),
+                                )
+                            })
+                            .filter(|(_, res)| !res.is_none())
+                            .collect::<Vec<_>>();
 
-                        self.update(module_id, &items);
+                        self.update(module_id, &items, vis);
                         // record the glob import in case we add further items
                         let glob = self.glob_imports.entry(m.local_id).or_default();
-                        if !glob.iter().any(|it| *it == (module_id, import_id)) {
-                            glob.push((module_id, import_id));
+                        if !glob.iter().any(|(mid, _)| *mid == module_id) {
+                            glob.push((module_id, vis));
                         }
                     }
                 }
@@ -412,7 +432,7 @@ where
                             (name, res)
                         })
                         .collect::<Vec<_>>();
-                    self.update(module_id, &resolutions);
+                    self.update(module_id, &resolutions, vis);
                 }
                 Some(d) => {
                     log::debug!("glob import {:?} from non-module/enum {:?}", import, d);
@@ -434,21 +454,29 @@ where
                         }
                     }
 
-                    self.update(module_id, &[(name, def.with_visibility(vis))]);
+                    self.update(module_id, &[(name, def)], vis);
                 }
                 None => tested_by!(bogus_paths),
             }
         }
     }
 
-    fn update(&mut self, module_id: LocalModuleId, resolutions: &[(Name, PerNs)]) {
-        self.update_recursive(module_id, resolutions, 0)
+    fn update(
+        &mut self,
+        module_id: LocalModuleId,
+        resolutions: &[(Name, PerNs)],
+        vis: ResolvedVisibility,
+    ) {
+        self.update_recursive(module_id, resolutions, vis, 0)
     }
 
     fn update_recursive(
         &mut self,
         module_id: LocalModuleId,
         resolutions: &[(Name, PerNs)],
+        // All resolutions are imported with this visibility; the visibilies in
+        // the `PerNs` values are ignored and overwritten
+        vis: ResolvedVisibility,
         depth: usize,
     ) {
         if depth > 100 {
@@ -458,7 +486,7 @@ where
         let scope = &mut self.def_map.modules[module_id].scope;
         let mut changed = false;
         for (name, res) in resolutions {
-            changed |= scope.push_res(name.clone(), *res);
+            changed |= scope.push_res(name.clone(), res.with_visibility(vis));
         }
 
         if !changed {
@@ -471,9 +499,13 @@ where
             .flat_map(|v| v.iter())
             .cloned()
             .collect::<Vec<_>>();
-        for (glob_importing_module, _glob_import) in glob_imports {
-            // We pass the glob import so that the tracked import in those modules is that glob import
-            self.update_recursive(glob_importing_module, resolutions, depth + 1);
+        for (glob_importing_module, glob_import_vis) in glob_imports {
+            // we know all resolutions have the same visibility (`vis`), so we
+            // just need to check that once
+            if !vis.visible_from_def_map(&self.def_map, glob_importing_module) {
+                continue;
+            }
+            self.update_recursive(glob_importing_module, resolutions, glob_import_vis, depth + 1);
         }
     }
 
@@ -715,7 +747,7 @@ where
         let def: ModuleDefId = module.into();
         let vis = ResolvedVisibility::Public; // TODO handle module visibility
         self.def_collector.def_map.modules[self.module_id].scope.define_def(def);
-        self.def_collector.update(self.module_id, &[(name, PerNs::from_def(def, vis))]);
+        self.def_collector.update(self.module_id, &[(name, PerNs::from_def(def, vis))], vis);
         res
     }
 
@@ -780,7 +812,7 @@ where
             .def_map
             .resolve_visibility(self.def_collector.db, self.module_id, vis)
             .unwrap_or(ResolvedVisibility::Public);
-        self.def_collector.update(self.module_id, &[(name, PerNs::from_def(def, vis))])
+        self.def_collector.update(self.module_id, &[(name, PerNs::from_def(def, vis))], vis)
     }
 
     fn collect_derives(&mut self, attrs: &Attrs, def: &raw::DefData) {

--- a/crates/ra_hir_def/src/nameres/path_resolution.rs
+++ b/crates/ra_hir_def/src/nameres/path_resolution.rs
@@ -21,7 +21,7 @@ use crate::{
     nameres::{BuiltinShadowMode, CrateDefMap},
     path::{ModPath, PathKind},
     per_ns::PerNs,
-    visibility::{ResolvedVisibility, Visibility},
+    visibility::{RawVisibility, ResolvedVisibility},
     AdtId, CrateId, EnumVariantId, LocalModuleId, ModuleDefId, ModuleId,
 };
 
@@ -71,10 +71,10 @@ impl CrateDefMap {
         &self,
         db: &impl DefDatabase,
         original_module: LocalModuleId,
-        visibility: &Visibility,
+        visibility: &RawVisibility,
     ) -> Option<ResolvedVisibility> {
         match visibility {
-            Visibility::Module(path) => {
+            RawVisibility::Module(path) => {
                 let (result, remaining) =
                     self.resolve_path(db, original_module, &path, BuiltinShadowMode::Module);
                 if remaining.is_some() {
@@ -89,7 +89,7 @@ impl CrateDefMap {
                     }
                 }
             }
-            Visibility::Public => Some(ResolvedVisibility::Public),
+            RawVisibility::Public => Some(ResolvedVisibility::Public),
         }
     }
 

--- a/crates/ra_hir_def/src/nameres/raw.rs
+++ b/crates/ra_hir_def/src/nameres/raw.rs
@@ -16,12 +16,15 @@ use hir_expand::{
 use ra_arena::{impl_arena_id, Arena, RawId};
 use ra_prof::profile;
 use ra_syntax::{
-    ast::{self, AttrsOwner, NameOwner},
+    ast::{self, AttrsOwner, NameOwner, VisibilityOwner},
     AstNode,
 };
 use test_utils::tested_by;
 
-use crate::{attr::Attrs, db::DefDatabase, path::ModPath, FileAstId, HirFileId, InFile};
+use crate::{
+    attr::Attrs, db::DefDatabase, path::ModPath, visibility::Visibility, FileAstId, HirFileId,
+    InFile,
+};
 
 /// `RawItems` is a set of top-level items in a file (except for impls).
 ///
@@ -138,6 +141,7 @@ pub struct ImportData {
     pub(super) is_prelude: bool,
     pub(super) is_extern_crate: bool,
     pub(super) is_macro_use: bool,
+    pub(super) visibility: Visibility,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -148,6 +152,7 @@ impl_arena_id!(Def);
 pub(super) struct DefData {
     pub(super) name: Name,
     pub(super) kind: DefKind,
+    pub(super) visibility: Visibility,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -218,6 +223,7 @@ impl RawItemsCollector {
 
     fn add_item(&mut self, current_module: Option<Module>, item: ast::ModuleItem) {
         let attrs = self.parse_attrs(&item);
+        let visibility = Visibility::from_ast_with_hygiene(item.visibility(), &self.hygiene);
         let (kind, name) = match item {
             ast::ModuleItem::Module(module) => {
                 self.add_module(current_module, module);
@@ -266,7 +272,7 @@ impl RawItemsCollector {
         };
         if let Some(name) = name {
             let name = name.as_name();
-            let def = self.raw_items.defs.alloc(DefData { name, kind });
+            let def = self.raw_items.defs.alloc(DefData { name, kind, visibility });
             self.push_item(current_module, attrs, RawItemKind::Def(def));
         }
     }
@@ -302,6 +308,7 @@ impl RawItemsCollector {
         // FIXME: cfg_attr
         let is_prelude = use_item.has_atom_attr("prelude_import");
         let attrs = self.parse_attrs(&use_item);
+        let visibility = Visibility::from_ast_with_hygiene(use_item.visibility(), &self.hygiene);
 
         let mut buf = Vec::new();
         ModPath::expand_use_item(
@@ -315,6 +322,7 @@ impl RawItemsCollector {
                     is_prelude,
                     is_extern_crate: false,
                     is_macro_use: false,
+                    visibility: visibility.clone(),
                 };
                 buf.push(import_data);
             },
@@ -331,6 +339,8 @@ impl RawItemsCollector {
     ) {
         if let Some(name_ref) = extern_crate.name_ref() {
             let path = ModPath::from_name_ref(&name_ref);
+            let visibility =
+                Visibility::from_ast_with_hygiene(extern_crate.visibility(), &self.hygiene);
             let alias = extern_crate.alias().and_then(|a| a.name()).map(|it| it.as_name());
             let attrs = self.parse_attrs(&extern_crate);
             // FIXME: cfg_attr
@@ -342,6 +352,7 @@ impl RawItemsCollector {
                 is_prelude: false,
                 is_extern_crate: true,
                 is_macro_use,
+                visibility,
             };
             self.push_import(current_module, attrs, import_data);
         }

--- a/crates/ra_hir_def/src/nameres/tests.rs
+++ b/crates/ra_hir_def/src/nameres/tests.rs
@@ -12,8 +12,8 @@ use test_utils::covers;
 
 use crate::{db::DefDatabase, nameres::*, test_db::TestDB, LocalModuleId};
 
-fn def_map(fixtute: &str) -> String {
-    let dm = compute_crate_def_map(fixtute);
+fn def_map(fixture: &str) -> String {
+    let dm = compute_crate_def_map(fixture);
     render_crate_def_map(&dm)
 }
 
@@ -32,7 +32,7 @@ fn render_crate_def_map(map: &CrateDefMap) -> String {
         *buf += path;
         *buf += "\n";
 
-        let mut entries = map.modules[module].scope.collect_resolutions();
+        let mut entries: Vec<_> = map.modules[module].scope.resolutions().collect();
         entries.sort_by_key(|(name, _)| name.clone());
 
         for (name, def) in entries {

--- a/crates/ra_hir_def/src/nameres/tests/globs.rs
+++ b/crates/ra_hir_def/src/nameres/tests/globs.rs
@@ -170,6 +170,26 @@ fn glob_across_crates() {
 }
 
 #[test]
+fn glob_privacy_across_crates() {
+    covers!(glob_across_crates);
+    let map = def_map(
+        "
+        //- /main.rs crate:main deps:test_crate
+        use test_crate::*;
+
+        //- /lib.rs crate:test_crate
+        pub struct Baz;
+        struct Foo;
+        ",
+    );
+    assert_snapshot!(map, @r###"
+   ⋮crate
+   ⋮Baz: t v
+    "###
+    );
+}
+
+#[test]
 fn glob_enum() {
     covers!(glob_enum);
     let map = def_map(

--- a/crates/ra_hir_def/src/nameres/tests/globs.rs
+++ b/crates/ra_hir_def/src/nameres/tests/globs.rs
@@ -122,7 +122,7 @@ fn glob_privacy_2() {
         use foo::bar::*;
 
         //- /foo/mod.rs
-        pub mod bar;
+        mod bar;
         fn Foo() {};
         pub struct Foo {};
 
@@ -136,7 +136,6 @@ fn glob_privacy_2() {
     crate
     Foo: t
     PubCrateStruct: t v
-    bar: t
     foo: t
     
     crate::foo

--- a/crates/ra_hir_def/src/nameres/tests/incremental.rs
+++ b/crates/ra_hir_def/src/nameres/tests/incremental.rs
@@ -116,7 +116,7 @@ fn typing_inside_a_macro_should_not_invalidate_def_map() {
         let events = db.log_executed(|| {
             let crate_def_map = db.crate_def_map(krate);
             let (_, module_data) = crate_def_map.modules.iter().last().unwrap();
-            assert_eq!(module_data.scope.collect_resolutions().len(), 1);
+            assert_eq!(module_data.scope.resolutions().collect::<Vec<_>>().len(), 1);
         });
         assert!(format!("{:?}", events).contains("crate_def_map"), "{:#?}", events)
     }
@@ -126,7 +126,7 @@ fn typing_inside_a_macro_should_not_invalidate_def_map() {
         let events = db.log_executed(|| {
             let crate_def_map = db.crate_def_map(krate);
             let (_, module_data) = crate_def_map.modules.iter().last().unwrap();
-            assert_eq!(module_data.scope.collect_resolutions().len(), 1);
+            assert_eq!(module_data.scope.resolutions().collect::<Vec<_>>().len(), 1);
         });
         assert!(!format!("{:?}", events).contains("crate_def_map"), "{:#?}", events)
     }

--- a/crates/ra_hir_def/src/per_ns.rs
+++ b/crates/ra_hir_def/src/per_ns.rs
@@ -61,6 +61,14 @@ impl PerNs {
         self.macros.map(|it| it.0)
     }
 
+    pub fn filter_visibility(self, mut f: impl FnMut(ResolvedVisibility) -> bool) -> PerNs {
+        PerNs {
+            types: self.types.filter(|(_, v)| f(*v)),
+            values: self.values.filter(|(_, v)| f(*v)),
+            macros: self.macros.filter(|(_, v)| f(*v)),
+        }
+    }
+
     pub fn with_visibility(self, vis: ResolvedVisibility) -> PerNs {
         PerNs {
             types: self.types.map(|(it, _)| (it, vis)),

--- a/crates/ra_hir_def/src/per_ns.rs
+++ b/crates/ra_hir_def/src/per_ns.rs
@@ -5,13 +5,13 @@
 
 use hir_expand::MacroDefId;
 
-use crate::{visibility::ResolvedVisibility, ModuleDefId};
+use crate::{visibility::Visibility, ModuleDefId};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct PerNs {
-    pub types: Option<(ModuleDefId, ResolvedVisibility)>,
-    pub values: Option<(ModuleDefId, ResolvedVisibility)>,
-    pub macros: Option<(MacroDefId, ResolvedVisibility)>,
+    pub types: Option<(ModuleDefId, Visibility)>,
+    pub values: Option<(ModuleDefId, Visibility)>,
+    pub macros: Option<(MacroDefId, Visibility)>,
 }
 
 impl Default for PerNs {
@@ -25,19 +25,19 @@ impl PerNs {
         PerNs { types: None, values: None, macros: None }
     }
 
-    pub fn values(t: ModuleDefId, v: ResolvedVisibility) -> PerNs {
+    pub fn values(t: ModuleDefId, v: Visibility) -> PerNs {
         PerNs { types: None, values: Some((t, v)), macros: None }
     }
 
-    pub fn types(t: ModuleDefId, v: ResolvedVisibility) -> PerNs {
+    pub fn types(t: ModuleDefId, v: Visibility) -> PerNs {
         PerNs { types: Some((t, v)), values: None, macros: None }
     }
 
-    pub fn both(types: ModuleDefId, values: ModuleDefId, v: ResolvedVisibility) -> PerNs {
+    pub fn both(types: ModuleDefId, values: ModuleDefId, v: Visibility) -> PerNs {
         PerNs { types: Some((types, v)), values: Some((values, v)), macros: None }
     }
 
-    pub fn macros(macro_: MacroDefId, v: ResolvedVisibility) -> PerNs {
+    pub fn macros(macro_: MacroDefId, v: Visibility) -> PerNs {
         PerNs { types: None, values: None, macros: Some((macro_, v)) }
     }
 
@@ -49,7 +49,7 @@ impl PerNs {
         self.types.map(|it| it.0)
     }
 
-    pub fn take_types_vis(self) -> Option<(ModuleDefId, ResolvedVisibility)> {
+    pub fn take_types_vis(self) -> Option<(ModuleDefId, Visibility)> {
         self.types
     }
 
@@ -61,7 +61,7 @@ impl PerNs {
         self.macros.map(|it| it.0)
     }
 
-    pub fn filter_visibility(self, mut f: impl FnMut(ResolvedVisibility) -> bool) -> PerNs {
+    pub fn filter_visibility(self, mut f: impl FnMut(Visibility) -> bool) -> PerNs {
         PerNs {
             types: self.types.filter(|(_, v)| f(*v)),
             values: self.values.filter(|(_, v)| f(*v)),
@@ -69,7 +69,7 @@ impl PerNs {
         }
     }
 
-    pub fn with_visibility(self, vis: ResolvedVisibility) -> PerNs {
+    pub fn with_visibility(self, vis: Visibility) -> PerNs {
         PerNs {
             types: self.types.map(|(it, _)| (it, vis)),
             values: self.values.map(|(it, _)| (it, vis)),

--- a/crates/ra_hir_def/src/per_ns.rs
+++ b/crates/ra_hir_def/src/per_ns.rs
@@ -5,13 +5,13 @@
 
 use hir_expand::MacroDefId;
 
-use crate::ModuleDefId;
+use crate::{visibility::ResolvedVisibility, ModuleDefId};
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct PerNs {
-    pub types: Option<ModuleDefId>,
-    pub values: Option<ModuleDefId>,
-    pub macros: Option<MacroDefId>,
+    pub types: Option<(ModuleDefId, ResolvedVisibility)>,
+    pub values: Option<(ModuleDefId, ResolvedVisibility)>,
+    pub macros: Option<(MacroDefId, ResolvedVisibility)>,
 }
 
 impl Default for PerNs {
@@ -25,20 +25,20 @@ impl PerNs {
         PerNs { types: None, values: None, macros: None }
     }
 
-    pub fn values(t: ModuleDefId) -> PerNs {
-        PerNs { types: None, values: Some(t), macros: None }
+    pub fn values(t: ModuleDefId, v: ResolvedVisibility) -> PerNs {
+        PerNs { types: None, values: Some((t, v)), macros: None }
     }
 
-    pub fn types(t: ModuleDefId) -> PerNs {
-        PerNs { types: Some(t), values: None, macros: None }
+    pub fn types(t: ModuleDefId, v: ResolvedVisibility) -> PerNs {
+        PerNs { types: Some((t, v)), values: None, macros: None }
     }
 
-    pub fn both(types: ModuleDefId, values: ModuleDefId) -> PerNs {
-        PerNs { types: Some(types), values: Some(values), macros: None }
+    pub fn both(types: ModuleDefId, values: ModuleDefId, v: ResolvedVisibility) -> PerNs {
+        PerNs { types: Some((types, v)), values: Some((values, v)), macros: None }
     }
 
-    pub fn macros(macro_: MacroDefId) -> PerNs {
-        PerNs { types: None, values: None, macros: Some(macro_) }
+    pub fn macros(macro_: MacroDefId, v: ResolvedVisibility) -> PerNs {
+        PerNs { types: None, values: None, macros: Some((macro_, v)) }
     }
 
     pub fn is_none(&self) -> bool {
@@ -46,15 +46,27 @@ impl PerNs {
     }
 
     pub fn take_types(self) -> Option<ModuleDefId> {
+        self.types.map(|it| it.0)
+    }
+
+    pub fn take_types_vis(self) -> Option<(ModuleDefId, ResolvedVisibility)> {
         self.types
     }
 
     pub fn take_values(self) -> Option<ModuleDefId> {
-        self.values
+        self.values.map(|it| it.0)
     }
 
     pub fn take_macros(self) -> Option<MacroDefId> {
-        self.macros
+        self.macros.map(|it| it.0)
+    }
+
+    pub fn with_visibility(self, vis: ResolvedVisibility) -> PerNs {
+        PerNs {
+            types: self.types.map(|(it, _)| (it, vis)),
+            values: self.values.map(|(it, _)| (it, vis)),
+            macros: self.macros.map(|(it, _)| (it, vis)),
+        }
     }
 
     pub fn or(self, other: PerNs) -> PerNs {

--- a/crates/ra_hir_def/src/resolver.rs
+++ b/crates/ra_hir_def/src/resolver.rs
@@ -466,10 +466,16 @@ impl Scope {
                     f(name.clone(), ScopeDef::PerNs(def));
                 });
                 m.crate_def_map[m.module_id].scope.legacy_macros().for_each(|(name, macro_)| {
-                    f(name.clone(), ScopeDef::PerNs(PerNs::macros(macro_)));
+                    f(
+                        name.clone(),
+                        ScopeDef::PerNs(PerNs::macros(macro_, ResolvedVisibility::Public)),
+                    );
                 });
                 m.crate_def_map.extern_prelude.iter().for_each(|(name, &def)| {
-                    f(name.clone(), ScopeDef::PerNs(PerNs::types(def.into())));
+                    f(
+                        name.clone(),
+                        ScopeDef::PerNs(PerNs::types(def.into(), ResolvedVisibility::Public)),
+                    );
                 });
                 if let Some(prelude) = m.crate_def_map.prelude {
                     let prelude_def_map = db.crate_def_map(prelude.krate);

--- a/crates/ra_hir_def/src/resolver.rs
+++ b/crates/ra_hir_def/src/resolver.rs
@@ -19,7 +19,7 @@ use crate::{
     nameres::CrateDefMap,
     path::{ModPath, PathKind},
     per_ns::PerNs,
-    visibility::{RawVisibility, ResolvedVisibility},
+    visibility::{RawVisibility, Visibility},
     AdtId, AssocContainerId, ConstId, ContainerId, DefWithBodyId, EnumId, EnumVariantId,
     FunctionId, GenericDefId, HasModule, ImplId, LocalModuleId, Lookup, ModuleDefId, ModuleId,
     StaticId, StructId, TraitId, TypeAliasId, TypeParamId, VariantId,
@@ -236,7 +236,7 @@ impl Resolver {
         &self,
         db: &impl DefDatabase,
         visibility: &RawVisibility,
-    ) -> Option<ResolvedVisibility> {
+    ) -> Option<Visibility> {
         match visibility {
             RawVisibility::Module(_) => {
                 let (item_map, module) = match self.module() {
@@ -245,7 +245,7 @@ impl Resolver {
                 };
                 item_map.resolve_visibility(db, module, visibility)
             }
-            RawVisibility::Public => Some(ResolvedVisibility::Public),
+            RawVisibility::Public => Some(Visibility::Public),
         }
     }
 
@@ -466,16 +466,10 @@ impl Scope {
                     f(name.clone(), ScopeDef::PerNs(def));
                 });
                 m.crate_def_map[m.module_id].scope.legacy_macros().for_each(|(name, macro_)| {
-                    f(
-                        name.clone(),
-                        ScopeDef::PerNs(PerNs::macros(macro_, ResolvedVisibility::Public)),
-                    );
+                    f(name.clone(), ScopeDef::PerNs(PerNs::macros(macro_, Visibility::Public)));
                 });
                 m.crate_def_map.extern_prelude.iter().for_each(|(name, &def)| {
-                    f(
-                        name.clone(),
-                        ScopeDef::PerNs(PerNs::types(def.into(), ResolvedVisibility::Public)),
-                    );
+                    f(name.clone(), ScopeDef::PerNs(PerNs::types(def.into(), Visibility::Public)));
                 });
                 if let Some(prelude) = m.crate_def_map.prelude {
                     let prelude_def_map = db.crate_def_map(prelude.krate);

--- a/crates/ra_hir_def/src/resolver.rs
+++ b/crates/ra_hir_def/src/resolver.rs
@@ -238,15 +238,12 @@ impl Resolver {
         visibility: &Visibility,
     ) -> Option<ResolvedVisibility> {
         match visibility {
-            Visibility::Module(mod_path) => {
-                let resolved = self.resolve_module_path_in_items(db, &mod_path).take_types()?;
-                match resolved {
-                    ModuleDefId::ModuleId(m) => Some(ResolvedVisibility::Module(m)),
-                    _ => {
-                        // error: visibility needs to refer to module
-                        None
-                    }
-                }
+            Visibility::Module(_) => {
+                let (item_map, module) = match self.module() {
+                    Some(it) => it,
+                    None => return None,
+                };
+                item_map.resolve_visibility(db, module, visibility)
             }
             Visibility::Public => Some(ResolvedVisibility::Public),
         }

--- a/crates/ra_hir_def/src/resolver.rs
+++ b/crates/ra_hir_def/src/resolver.rs
@@ -19,7 +19,7 @@ use crate::{
     nameres::CrateDefMap,
     path::{ModPath, PathKind},
     per_ns::PerNs,
-    visibility::{ResolvedVisibility, Visibility},
+    visibility::{RawVisibility, ResolvedVisibility},
     AdtId, AssocContainerId, ConstId, ContainerId, DefWithBodyId, EnumId, EnumVariantId,
     FunctionId, GenericDefId, HasModule, ImplId, LocalModuleId, Lookup, ModuleDefId, ModuleId,
     StaticId, StructId, TraitId, TypeAliasId, TypeParamId, VariantId,
@@ -235,17 +235,17 @@ impl Resolver {
     pub fn resolve_visibility(
         &self,
         db: &impl DefDatabase,
-        visibility: &Visibility,
+        visibility: &RawVisibility,
     ) -> Option<ResolvedVisibility> {
         match visibility {
-            Visibility::Module(_) => {
+            RawVisibility::Module(_) => {
                 let (item_map, module) = match self.module() {
                     Some(it) => it,
                     None => return None,
                 };
                 item_map.resolve_visibility(db, module, visibility)
             }
-            Visibility::Public => Some(ResolvedVisibility::Public),
+            RawVisibility::Public => Some(ResolvedVisibility::Public),
         }
     }
 

--- a/crates/ra_hir_def/src/visibility.rs
+++ b/crates/ra_hir_def/src/visibility.rs
@@ -109,26 +109,26 @@ impl RawVisibility {
         &self,
         db: &impl DefDatabase,
         resolver: &crate::resolver::Resolver,
-    ) -> ResolvedVisibility {
+    ) -> Visibility {
         // we fall back to public visibility (i.e. fail open) if the path can't be resolved
-        resolver.resolve_visibility(db, self).unwrap_or(ResolvedVisibility::Public)
+        resolver.resolve_visibility(db, self).unwrap_or(Visibility::Public)
     }
 }
 
 /// Visibility of an item, with the path resolved.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum ResolvedVisibility {
+pub enum Visibility {
     /// Visibility is restricted to a certain module.
     Module(ModuleId),
     /// Visibility is unrestricted.
     Public,
 }
 
-impl ResolvedVisibility {
+impl Visibility {
     pub fn visible_from(self, db: &impl DefDatabase, from_module: ModuleId) -> bool {
         let to_module = match self {
-            ResolvedVisibility::Module(m) => m,
-            ResolvedVisibility::Public => return true,
+            Visibility::Module(m) => m,
+            Visibility::Public => return true,
         };
         // if they're not in the same crate, it can't be visible
         if from_module.krate != to_module.krate {
@@ -144,8 +144,8 @@ impl ResolvedVisibility {
         from_module: crate::LocalModuleId,
     ) -> bool {
         let to_module = match self {
-            ResolvedVisibility::Module(m) => m,
-            ResolvedVisibility::Public => return true,
+            Visibility::Module(m) => m,
+            Visibility::Public => return true,
         };
         // from_module needs to be a descendant of to_module
         let mut ancestors = std::iter::successors(Some(from_module), |m| {

--- a/crates/ra_hir_def/src/visibility.rs
+++ b/crates/ra_hir_def/src/visibility.rs
@@ -81,7 +81,7 @@ pub enum Visibility {
 }
 
 impl Visibility {
-    pub fn visible_from(self, db: &impl DefDatabase, from_module: ModuleId) -> bool {
+    pub fn is_visible_from(self, db: &impl DefDatabase, from_module: ModuleId) -> bool {
         let to_module = match self {
             Visibility::Module(m) => m,
             Visibility::Public => return true,
@@ -91,17 +91,17 @@ impl Visibility {
             return false;
         }
         let def_map = db.crate_def_map(from_module.krate);
-        self.visible_from_def_map(&def_map, from_module.local_id)
+        self.is_visible_from_def_map(&def_map, from_module.local_id)
     }
 
-    pub(crate) fn visible_from_other_crate(self) -> bool {
+    pub(crate) fn is_visible_from_other_crate(self) -> bool {
         match self {
             Visibility::Module(_) => false,
             Visibility::Public => true,
         }
     }
 
-    pub(crate) fn visible_from_def_map(
+    pub(crate) fn is_visible_from_def_map(
         self,
         def_map: &crate::nameres::CrateDefMap,
         from_module: crate::LocalModuleId,

--- a/crates/ra_hir_def/src/visibility.rs
+++ b/crates/ra_hir_def/src/visibility.rs
@@ -99,6 +99,13 @@ impl Visibility {
         self.visible_from_def_map(&def_map, from_module.local_id)
     }
 
+    pub(crate) fn visible_from_other_crate(self) -> bool {
+        match self {
+            Visibility::Module(_) => false,
+            Visibility::Public => true,
+        }
+    }
+
     pub(crate) fn visible_from_def_map(
         self,
         def_map: &crate::nameres::CrateDefMap,

--- a/crates/ra_hir_def/src/visibility.rs
+++ b/crates/ra_hir_def/src/visibility.rs
@@ -1,0 +1,101 @@
+use std::sync::Arc;
+
+use either::Either;
+
+use hir_expand::InFile;
+use ra_syntax::ast::{self, VisibilityOwner};
+
+use crate::{
+    db::DefDatabase,
+    path::{ModPath, PathKind},
+    src::{HasChildSource, HasSource},
+    AdtId, Lookup, VisibilityDefId,
+};
+
+/// Visibility of an item, not yet resolved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Visibility {
+    // FIXME: We could avoid the allocation in many cases by special-casing
+    // pub(crate), pub(super) and private. Alternatively, `ModPath` could be
+    // made to contain an Arc<[Segment]> instead of a Vec?
+    /// `pub(in module)`, `pub(crate)` or `pub(super)`. Also private, which is
+    /// equivalent to `pub(self)`.
+    Module(Arc<ModPath>),
+    /// `pub`.
+    Public,
+}
+
+impl Visibility {
+    pub(crate) fn visibility_query(db: &impl DefDatabase, def: VisibilityDefId) -> Visibility {
+        match def {
+            VisibilityDefId::ModuleId(module) => {
+                let def_map = db.crate_def_map(module.krate);
+                let src = match def_map[module.local_id].declaration_source(db) {
+                    Some(it) => it,
+                    None => return Visibility::private(),
+                };
+                Visibility::from_ast(db, src.map(|it| it.visibility()))
+            }
+            VisibilityDefId::StructFieldId(it) => {
+                let src = it.parent.child_source(db);
+                // TODO: enum variant fields should be public by default
+                let vis_node = src.map(|m| match &m[it.local_id] {
+                    Either::Left(tuple) => tuple.visibility(),
+                    Either::Right(record) => record.visibility(),
+                });
+                Visibility::from_ast(db, vis_node)
+            }
+            VisibilityDefId::AdtId(it) => match it {
+                AdtId::StructId(it) => visibility_from_loc(it.lookup(db), db),
+                AdtId::EnumId(it) => visibility_from_loc(it.lookup(db), db),
+                AdtId::UnionId(it) => visibility_from_loc(it.lookup(db), db),
+            },
+            VisibilityDefId::TraitId(it) => visibility_from_loc(it.lookup(db), db),
+            VisibilityDefId::ConstId(it) => visibility_from_loc(it.lookup(db), db),
+            VisibilityDefId::StaticId(it) => visibility_from_loc(it.lookup(db), db),
+            VisibilityDefId::FunctionId(it) => visibility_from_loc(it.lookup(db), db),
+            VisibilityDefId::TypeAliasId(it) => visibility_from_loc(it.lookup(db), db),
+        }
+    }
+
+    fn private() -> Visibility {
+        let path = ModPath { kind: PathKind::Super(0), segments: Vec::new() };
+        Visibility::Module(Arc::new(path))
+    }
+
+    fn from_ast(db: &impl DefDatabase, node: InFile<Option<ast::Visibility>>) -> Visibility {
+        let file_id = node.file_id;
+        let node = match node.value {
+            None => return Visibility::private(),
+            Some(node) => node,
+        };
+        match node.kind() {
+            ast::VisibilityKind::In(path) => {
+                let path = ModPath::from_src(path, &hir_expand::hygiene::Hygiene::new(db, file_id));
+                let path = match path {
+                    None => return Visibility::private(),
+                    Some(path) => path,
+                };
+                Visibility::Module(Arc::new(path))
+            }
+            ast::VisibilityKind::PubCrate => {
+                let path = ModPath { kind: PathKind::Crate, segments: Vec::new() };
+                Visibility::Module(Arc::new(path))
+            }
+            ast::VisibilityKind::PubSuper => {
+                let path = ModPath { kind: PathKind::Super(1), segments: Vec::new() };
+                Visibility::Module(Arc::new(path))
+            }
+            ast::VisibilityKind::Pub => Visibility::Public,
+        }
+    }
+}
+
+fn visibility_from_loc<T>(node: T, db: &impl DefDatabase) -> Visibility
+where
+    T: HasSource,
+    T::Value: ast::VisibilityOwner,
+{
+    let src = node.source(db);
+    Visibility::from_ast(db, src.map(|n| n.visibility()))
+}

--- a/crates/ra_hir_def/src/visibility.rs
+++ b/crates/ra_hir_def/src/visibility.rs
@@ -1,3 +1,5 @@
+//! Defines hir-level representation of visibility (e.g. `pub` and `pub(crate)`).
+
 use std::sync::Arc;
 
 use either::Either;

--- a/crates/ra_ide/src/completion/complete_dot.rs
+++ b/crates/ra_ide/src/completion/complete_dot.rs
@@ -38,7 +38,7 @@ pub(super) fn complete_dot(acc: &mut Completions, ctx: &CompletionContext) {
 fn complete_fields(acc: &mut Completions, ctx: &CompletionContext, receiver: &Type) {
     for receiver in receiver.autoderef(ctx.db) {
         for (field, ty) in receiver.fields(ctx.db) {
-            if ctx.module.map_or(false, |m| !field.visible_from(ctx.db, m)) {
+            if ctx.module.map_or(false, |m| !field.is_visible_from(ctx.db, m)) {
                 // Skip private field. FIXME: If the definition location of the
                 // field is editable, we should show the completion
                 continue;

--- a/crates/ra_ide/src/completion/complete_dot.rs
+++ b/crates/ra_ide/src/completion/complete_dot.rs
@@ -1,6 +1,6 @@
 //! FIXME: write short doc here
 
-use hir::Type;
+use hir::{HasVisibility, Type};
 
 use crate::completion::completion_item::CompletionKind;
 use crate::{
@@ -38,9 +38,15 @@ pub(super) fn complete_dot(acc: &mut Completions, ctx: &CompletionContext) {
 fn complete_fields(acc: &mut Completions, ctx: &CompletionContext, receiver: &Type) {
     for receiver in receiver.autoderef(ctx.db) {
         for (field, ty) in receiver.fields(ctx.db) {
+            if ctx.module.map_or(false, |m| !field.visible_from(ctx.db, m)) {
+                // Skip private field. FIXME: If the definition location of the
+                // field is editable, we should show the completion
+                continue;
+            }
             acc.add_field(ctx, field, &ty);
         }
         for (i, ty) in receiver.tuple_fields(ctx.db).into_iter().enumerate() {
+            // FIXME: Handle visibility
             acc.add_tuple_field(ctx, i, &ty);
         }
     }
@@ -183,6 +189,55 @@ mod tests {
             ",
         ),
         @"[]"
+        );
+    }
+
+    #[test]
+    fn test_struct_field_visibility_private() {
+        assert_debug_snapshot!(
+            do_ref_completion(
+                r"
+            mod inner {
+                struct A {
+                    private_field: u32,
+                    pub pub_field: u32,
+                    pub(crate) crate_field: u32,
+                    pub(super) super_field: u32,
+                }
+            }
+            fn foo(a: inner::A) {
+               a.<|>
+            }
+            ",
+            ),
+            @r###"
+        [
+            CompletionItem {
+                label: "crate_field",
+                source_range: [313; 313),
+                delete: [313; 313),
+                insert: "crate_field",
+                kind: Field,
+                detail: "u32",
+            },
+            CompletionItem {
+                label: "pub_field",
+                source_range: [313; 313),
+                delete: [313; 313),
+                insert: "pub_field",
+                kind: Field,
+                detail: "u32",
+            },
+            CompletionItem {
+                label: "super_field",
+                source_range: [313; 313),
+                delete: [313; 313),
+                insert: "super_field",
+                kind: Field,
+                detail: "u32",
+            },
+        ]
+        "###
         );
     }
 

--- a/crates/ra_syntax/src/ast.rs
+++ b/crates/ra_syntax/src/ast.rs
@@ -17,7 +17,9 @@ use crate::{
 
 pub use self::{
     expr_extensions::{ArrayExprKind, BinOp, ElseBranch, LiteralKind, PrefixOp, RangeOp},
-    extensions::{FieldKind, PathSegmentKind, SelfParamKind, StructKind, TypeBoundKind},
+    extensions::{
+        FieldKind, PathSegmentKind, SelfParamKind, StructKind, TypeBoundKind, VisibilityKind,
+    },
     generated::*,
     tokens::*,
     traits::*,

--- a/crates/ra_syntax/src/ast/extensions.rs
+++ b/crates/ra_syntax/src/ast/extensions.rs
@@ -413,3 +413,32 @@ impl ast::TraitDef {
         self.syntax().children_with_tokens().any(|t| t.kind() == T![auto])
     }
 }
+
+pub enum VisibilityKind {
+    In(ast::Path),
+    PubCrate,
+    PubSuper,
+    Pub,
+}
+
+impl ast::Visibility {
+    pub fn kind(&self) -> VisibilityKind {
+        if let Some(path) = children(self).next() {
+            VisibilityKind::In(path)
+        } else if self.is_pub_crate() {
+            VisibilityKind::PubCrate
+        } else if self.is_pub_super() {
+            VisibilityKind::PubSuper
+        } else {
+            VisibilityKind::Pub
+        }
+    }
+
+    fn is_pub_crate(&self) -> bool {
+        self.syntax().children_with_tokens().any(|it| it.kind() == T![crate])
+    }
+
+    fn is_pub_super(&self) -> bool {
+        self.syntax().children_with_tokens().any(|it| it.kind() == T![super])
+    }
+}

--- a/crates/ra_syntax/src/ast/generated.rs
+++ b/crates/ra_syntax/src/ast/generated.rs
@@ -1064,6 +1064,7 @@ impl AstNode for ExternCrateItem {
     }
 }
 impl ast::AttrsOwner for ExternCrateItem {}
+impl ast::VisibilityOwner for ExternCrateItem {}
 impl ExternCrateItem {
     pub fn name_ref(&self) -> Option<NameRef> {
         AstChildren::new(&self.syntax).next()
@@ -2006,6 +2007,7 @@ impl AstNode for ModuleItem {
     }
 }
 impl ast::AttrsOwner for ModuleItem {}
+impl ast::VisibilityOwner for ModuleItem {}
 impl ModuleItem {}
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Name {
@@ -3893,6 +3895,7 @@ impl AstNode for UseItem {
     }
 }
 impl ast::AttrsOwner for UseItem {}
+impl ast::VisibilityOwner for UseItem {}
 impl UseItem {
     pub fn use_tree(&self) -> Option<UseTree> {
         AstChildren::new(&self.syntax).next()

--- a/crates/ra_syntax/src/grammar.ron
+++ b/crates/ra_syntax/src/grammar.ron
@@ -412,7 +412,7 @@ Grammar(
         "ModuleItem": (
             enum: ["StructDef", "UnionDef", "EnumDef", "FnDef", "TraitDef", "TypeAliasDef", "ImplBlock",
                    "UseItem", "ExternCrateItem", "ConstDef", "StaticDef", "Module" ],
-            traits: ["AttrsOwner"],
+            traits: ["AttrsOwner", "VisibilityOwner"],
         ),
         "ImplItem": (
             enum: ["FnDef", "TypeAliasDef", "ConstDef"],
@@ -683,7 +683,7 @@ Grammar(
             ]
         ),
         "UseItem": (
-            traits: ["AttrsOwner"],
+            traits: ["AttrsOwner", "VisibilityOwner"],
             options: [ "UseTree" ],
         ),
         "UseTree": (
@@ -696,7 +696,7 @@ Grammar(
             collections: [("use_trees", "UseTree")]
         ),
         "ExternCrateItem": (
-            traits: ["AttrsOwner"],
+            traits: ["AttrsOwner", "VisibilityOwner"],
             options: ["NameRef", "Alias"],
         ),
         "ArgList": (

--- a/xtask/tests/tidy-tests/cli.rs
+++ b/xtask/tests/tidy-tests/cli.rs
@@ -43,7 +43,7 @@ fn no_todo() {
             return;
         }
         let text = std::fs::read_to_string(e.path()).unwrap();
-        if text.contains("TODO") || text.contains("TOOD") {
+        if text.contains("TODO") || text.contains("TOOD") || text.contains("todo!") {
             panic!(
                 "\nTODO markers should not be committed to the master branch,\n\
                  use FIXME instead\n\


### PR DESCRIPTION
This adds the infrastructure for handling visibility (for fields and methods, not in name resolution) in the HIR and code model, and as a first application hides struct fields from completions if they're not visible from the current module. (We might want to relax this again later, but I think it's ok for now?)