### PR TITLE
Allow assists with multiple selectable actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,6 +1067,7 @@ version = "0.1.0"
 dependencies = [
  "crossbeam-channel 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jod-thread 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lsp-server 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,8 +869,8 @@ version = "0.1.0"
 name = "ra_assists"
 version = "0.1.0"
 dependencies = [
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "format-buf 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "join_to_string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ra_db 0.1.0",
  "ra_fmt 0.1.0",
@@ -1066,8 +1066,8 @@ name = "ra_lsp_server"
 version = "0.1.0"
 dependencies = [
  "crossbeam-channel 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jod-thread 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lsp-server 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crates/ra_assists/Cargo.toml
+++ b/crates/ra_assists/Cargo.toml
@@ -11,7 +11,7 @@ doctest = false
 format-buf = "1.0.0"
 join_to_string = "0.1.3"
 rustc-hash = "1.0"
-itertools = "0.8.0"
+either = "1.5"
 
 ra_syntax = { path = "../ra_syntax" }
 ra_text_edit = { path = "../ra_text_edit" }

--- a/crates/ra_assists/src/assist_ctx.rs
+++ b/crates/ra_assists/src/assist_ctx.rs
@@ -166,7 +166,7 @@ pub(crate) struct ActionBuilder {
 impl ActionBuilder {
     #[allow(dead_code)]
     /// Adds a custom label to the action, if it needs to be different from the assist label
-    pub fn label(&mut self, label: impl Into<String>) {
+    pub(crate) fn label(&mut self, label: impl Into<String>) {
         self.label = Some(label.into())
     }
 

--- a/crates/ra_assists/src/assist_ctx.rs
+++ b/crates/ra_assists/src/assist_ctx.rs
@@ -1,6 +1,6 @@
 //! This module defines `AssistCtx` -- the API surface that is exposed to assists.
+use either::Either;
 use hir::{db::HirDatabase, InFile, SourceAnalyzer};
-use itertools::Either;
 use ra_db::FileRange;
 use ra_fmt::{leading_indent, reindent};
 use ra_syntax::{

--- a/crates/ra_assists/src/assists/inline_local_variable.rs
+++ b/crates/ra_assists/src/assists/inline_local_variable.rs
@@ -4,7 +4,7 @@ use ra_syntax::{
     TextRange,
 };
 
-use crate::assist_ctx::AssistBuilder;
+use crate::assist_ctx::ActionBuilder;
 use crate::{Assist, AssistCtx, AssistId};
 
 // Assist: inline_local_variable
@@ -94,7 +94,7 @@ pub(crate) fn inline_local_varialbe(ctx: AssistCtx<impl HirDatabase>) -> Option<
     ctx.add_assist(
         AssistId("inline_local_variable"),
         "Inline variable",
-        move |edit: &mut AssistBuilder| {
+        move |edit: &mut ActionBuilder| {
             edit.delete(delete_range);
             for (desc, should_wrap) in refs.iter().zip(wrap_in_parens) {
                 if should_wrap {

--- a/crates/ra_assists/src/doc_tests.rs
+++ b/crates/ra_assists/src/doc_tests.rs
@@ -15,21 +15,21 @@ fn check(assist_id: &str, before: &str, after: &str) {
     let (db, file_id) = TestDB::with_single_file(&before);
     let frange = FileRange { file_id, range: selection.into() };
 
-    let (_assist_id, action, _) = crate::assists(&db, frange)
+    let assist = crate::assists(&db, frange)
         .into_iter()
-        .find(|(id, _, _)| id.id.0 == assist_id)
+        .find(|assist| assist.label.id.0 == assist_id)
         .unwrap_or_else(|| {
             panic!(
                 "\n\nAssist is not applicable: {}\nAvailable assists: {}",
                 assist_id,
                 crate::assists(&db, frange)
                     .into_iter()
-                    .map(|(id, _, _)| id.id.0)
+                    .map(|assist| assist.label.id.0)
                     .collect::<Vec<_>>()
                     .join(", ")
             )
         });
 
-    let actual = action.edit.apply(&before);
+    let actual = assist.get_first_action().edit.apply(&before);
     assert_eq_text!(after, &actual);
 }

--- a/crates/ra_assists/src/doc_tests.rs
+++ b/crates/ra_assists/src/doc_tests.rs
@@ -15,16 +15,16 @@ fn check(assist_id: &str, before: &str, after: &str) {
     let (db, file_id) = TestDB::with_single_file(&before);
     let frange = FileRange { file_id, range: selection.into() };
 
-    let (_assist_id, action) = crate::assists(&db, frange)
+    let (_assist_id, action, _) = crate::assists(&db, frange)
         .into_iter()
-        .find(|(id, _)| id.id.0 == assist_id)
+        .find(|(id, _, _)| id.id.0 == assist_id)
         .unwrap_or_else(|| {
             panic!(
                 "\n\nAssist is not applicable: {}\nAvailable assists: {}",
                 assist_id,
                 crate::assists(&db, frange)
                     .into_iter()
-                    .map(|(id, _)| id.id.0)
+                    .map(|(id, _, _)| id.id.0)
                     .collect::<Vec<_>>()
                     .join(", ")
             )

--- a/crates/ra_assists/src/lib.rs
+++ b/crates/ra_assists/src/lib.rs
@@ -13,8 +13,8 @@ mod doc_tests;
 mod test_db;
 pub mod ast_transform;
 
+use either::Either;
 use hir::db::HirDatabase;
-use itertools::Either;
 use ra_db::FileRange;
 use ra_syntax::{TextRange, TextUnit};
 use ra_text_edit::TextEdit;

--- a/crates/ra_assists/src/lib.rs
+++ b/crates/ra_assists/src/lib.rs
@@ -14,6 +14,7 @@ mod test_db;
 pub mod ast_transform;
 
 use hir::db::HirDatabase;
+use itertools::Either;
 use ra_db::FileRange;
 use ra_syntax::{TextRange, TextUnit};
 use ra_text_edit::TextEdit;
@@ -41,6 +42,21 @@ pub struct AssistAction {
     pub target: Option<TextRange>,
 }
 
+#[derive(Debug, Clone)]
+pub struct ResolvedAssist {
+    pub label: AssistLabel,
+    pub action_data: Either<AssistAction, Vec<AssistAction>>,
+}
+
+impl ResolvedAssist {
+    pub fn get_first_action(&self) -> AssistAction {
+        match &self.action_data {
+            Either::Left(action) => action.clone(),
+            Either::Right(actions) => actions[0].clone(),
+        }
+    }
+}
+
 /// Return all the assists applicable at the given position.
 ///
 /// Assists are returned in the "unresolved" state, that is only labels are
@@ -65,7 +81,7 @@ where
 ///
 /// Assists are returned in the "resolved" state, that is with edit fully
 /// computed.
-pub fn assists<H>(db: &H, range: FileRange) -> Vec<(AssistLabel, AssistAction, Vec<AssistAction>)>
+pub fn assists<H>(db: &H, range: FileRange) -> Vec<ResolvedAssist>
 where
     H: HirDatabase + 'static,
 {
@@ -76,13 +92,11 @@ where
             .iter()
             .filter_map(|f| f(ctx.clone()))
             .map(|a| match a {
-                Assist::Resolved { label, action, alternative_actions } => {
-                    (label, action, alternative_actions)
-                }
+                Assist::Resolved { assist } => assist,
                 Assist::Unresolved { .. } => unreachable!(),
             })
             .collect::<Vec<_>>();
-        a.sort_by(|a, b| match (a.1.target, b.1.target) {
+        a.sort_by(|a, b| match (a.get_first_action().target, b.get_first_action().target) {
             (Some(a), Some(b)) => a.len().cmp(&b.len()),
             (Some(_), None) => Ordering::Less,
             (None, Some(_)) => Ordering::Greater,
@@ -177,7 +191,7 @@ mod helpers {
             AssistCtx::with_ctx(&db, frange, true, assist).expect("code action is not applicable");
         let action = match assist {
             Assist::Unresolved { .. } => unreachable!(),
-            Assist::Resolved { action, .. } => action,
+            Assist::Resolved { assist } => assist.get_first_action(),
         };
 
         let actual = action.edit.apply(&before);
@@ -204,7 +218,7 @@ mod helpers {
             AssistCtx::with_ctx(&db, frange, true, assist).expect("code action is not applicable");
         let action = match assist {
             Assist::Unresolved { .. } => unreachable!(),
-            Assist::Resolved { action, .. } => action,
+            Assist::Resolved { assist } => assist.get_first_action(),
         };
 
         let mut actual = action.edit.apply(&before);
@@ -227,7 +241,7 @@ mod helpers {
             AssistCtx::with_ctx(&db, frange, true, assist).expect("code action is not applicable");
         let action = match assist {
             Assist::Unresolved { .. } => unreachable!(),
-            Assist::Resolved { action, .. } => action,
+            Assist::Resolved { assist } => assist.get_first_action(),
         };
 
         let range = action.target.expect("expected target on action");
@@ -246,7 +260,7 @@ mod helpers {
             AssistCtx::with_ctx(&db, frange, true, assist).expect("code action is not applicable");
         let action = match assist {
             Assist::Unresolved { .. } => unreachable!(),
-            Assist::Resolved { action, .. } => action,
+            Assist::Resolved { assist } => assist.get_first_action(),
         };
 
         let range = action.target.expect("expected target on action");
@@ -296,10 +310,10 @@ mod tests {
         let mut assists = assists.iter();
 
         assert_eq!(
-            assists.next().expect("expected assist").0.label,
+            assists.next().expect("expected assist").label.label,
             "Change visibility to pub(crate)"
         );
-        assert_eq!(assists.next().expect("expected assist").0.label, "Add `#[derive]`");
+        assert_eq!(assists.next().expect("expected assist").label.label, "Add `#[derive]`");
     }
 
     #[test]
@@ -318,7 +332,7 @@ mod tests {
         let assists = super::assists(&db, frange);
         let mut assists = assists.iter();
 
-        assert_eq!(assists.next().expect("expected assist").0.label, "Extract into variable");
-        assert_eq!(assists.next().expect("expected assist").0.label, "Replace with match");
+        assert_eq!(assists.next().expect("expected assist").label.label, "Extract into variable");
+        assert_eq!(assists.next().expect("expected assist").label.label, "Replace with match");
     }
 }

--- a/crates/ra_assists/src/lib.rs
+++ b/crates/ra_assists/src/lib.rs
@@ -35,6 +35,7 @@ pub struct AssistLabel {
 
 #[derive(Debug, Clone)]
 pub struct AssistAction {
+    pub label: Option<String>,
     pub edit: TextEdit,
     pub cursor_position: Option<TextUnit>,
     pub target: Option<TextRange>,
@@ -64,7 +65,7 @@ where
 ///
 /// Assists are returned in the "resolved" state, that is with edit fully
 /// computed.
-pub fn assists<H>(db: &H, range: FileRange) -> Vec<(AssistLabel, AssistAction)>
+pub fn assists<H>(db: &H, range: FileRange) -> Vec<(AssistLabel, AssistAction, Vec<AssistAction>)>
 where
     H: HirDatabase + 'static,
 {
@@ -75,7 +76,9 @@ where
             .iter()
             .filter_map(|f| f(ctx.clone()))
             .map(|a| match a {
-                Assist::Resolved { label, action } => (label, action),
+                Assist::Resolved { label, action, alternative_actions } => {
+                    (label, action, alternative_actions)
+                }
                 Assist::Unresolved { .. } => unreachable!(),
             })
             .collect::<Vec<_>>();

--- a/crates/ra_ide/src/assists.rs
+++ b/crates/ra_ide/src/assists.rs
@@ -2,27 +2,46 @@
 
 use ra_db::{FilePosition, FileRange};
 
-use crate::{db::RootDatabase, SourceChange, SourceFileEdit};
+use crate::{db::RootDatabase, FileId, SourceChange, SourceFileEdit};
 
 pub use ra_assists::AssistId;
+use ra_assists::{AssistAction, AssistLabel};
 
 #[derive(Debug)]
 pub struct Assist {
     pub id: AssistId,
     pub change: SourceChange,
+    pub label: String,
+    pub alternative_changes: Vec<SourceChange>,
 }
 
 pub(crate) fn assists(db: &RootDatabase, frange: FileRange) -> Vec<Assist> {
     ra_assists::assists(db, frange)
         .into_iter()
-        .map(|(label, action)| {
+        .map(|(assist_label, action, alternative_actions)| {
             let file_id = frange.file_id;
-            let file_edit = SourceFileEdit { file_id, edit: action.edit };
-            let id = label.id;
-            let change = SourceChange::source_file_edit(label.label, file_edit).with_cursor_opt(
-                action.cursor_position.map(|offset| FilePosition { offset, file_id }),
-            );
-            Assist { id, change }
+            Assist {
+                id: assist_label.id,
+                label: assist_label.label.clone(),
+                change: action_to_edit(action, file_id, &assist_label),
+                alternative_changes: alternative_actions
+                    .into_iter()
+                    .map(|action| action_to_edit(action, file_id, &assist_label))
+                    .collect(),
+            }
         })
         .collect()
+}
+
+fn action_to_edit(
+    action: AssistAction,
+    file_id: FileId,
+    assist_label: &AssistLabel,
+) -> SourceChange {
+    let file_edit = SourceFileEdit { file_id, edit: action.edit };
+    SourceChange::source_file_edit(
+        action.label.unwrap_or_else(|| assist_label.label.clone()),
+        file_edit,
+    )
+    .with_cursor_opt(action.cursor_position.map(|offset| FilePosition { offset, file_id }))
 }

--- a/crates/ra_ide/src/assists.rs
+++ b/crates/ra_ide/src/assists.rs
@@ -4,7 +4,7 @@ use ra_db::{FilePosition, FileRange};
 
 use crate::{db::RootDatabase, FileId, SourceChange, SourceFileEdit};
 
-use itertools::Either;
+use either::Either;
 pub use ra_assists::AssistId;
 use ra_assists::{AssistAction, AssistLabel};
 

--- a/crates/ra_lsp_server/Cargo.toml
+++ b/crates/ra_lsp_server/Cargo.toml
@@ -28,7 +28,7 @@ ra_prof = { path = "../ra_prof" }
 ra_vfs_glob = { path = "../ra_vfs_glob" }
 env_logger = { version = "0.7.1", default-features = false, features = ["humantime"] }
 ra_cargo_watch = { path = "../ra_cargo_watch" }
-itertools = "0.8"
+either = "1.5"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/ra_lsp_server/Cargo.toml
+++ b/crates/ra_lsp_server/Cargo.toml
@@ -28,6 +28,7 @@ ra_prof = { path = "../ra_prof" }
 ra_vfs_glob = { path = "../ra_vfs_glob" }
 env_logger = { version = "0.7.1", default-features = false, features = ["humantime"] }
 ra_cargo_watch = { path = "../ra_cargo_watch" }
+itertools = "0.8"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/ra_lsp_server/src/main_loop/handlers.rs
+++ b/crates/ra_lsp_server/src/main_loop/handlers.rs
@@ -3,7 +3,7 @@
 
 use std::{fmt::Write as _, io::Write as _};
 
-use itertools::Either;
+use either::Either;
 use lsp_server::ErrorCode;
 use lsp_types::{
     CallHierarchyIncomingCall, CallHierarchyIncomingCallsParams, CallHierarchyItem,

--- a/editors/code/src/commands/index.ts
+++ b/editors/code/src/commands/index.ts
@@ -34,8 +34,20 @@ function showReferences(ctx: Ctx): Cmd {
 }
 
 function applySourceChange(ctx: Ctx): Cmd {
-    return async (change: sourceChange.SourceChange, alternativeChanges: sourceChange.SourceChange[] | undefined) => {
-        sourceChange.applySourceChange(ctx, change, alternativeChanges);
+    return async (change: sourceChange.SourceChange) => {
+        sourceChange.applySourceChange(ctx, change);
+    };
+}
+
+function selectAndApplySourceChange(ctx: Ctx): Cmd {
+    return async (changes: sourceChange.SourceChange[]) => {
+        if (changes.length === 1) {
+            await sourceChange.applySourceChange(ctx, changes[0]);
+        } else if (changes.length > 0) {
+            const selectedChange = await vscode.window.showQuickPick(changes);
+            if (!selectedChange) return;
+            await sourceChange.applySourceChange(ctx, selectedChange);
+        }
     };
 }
 
@@ -59,5 +71,6 @@ export {
     runSingle,
     showReferences,
     applySourceChange,
+    selectAndApplySourceChange,
     reload
 };

--- a/editors/code/src/commands/index.ts
+++ b/editors/code/src/commands/index.ts
@@ -34,8 +34,8 @@ function showReferences(ctx: Ctx): Cmd {
 }
 
 function applySourceChange(ctx: Ctx): Cmd {
-    return async (change: sourceChange.SourceChange) => {
-        sourceChange.applySourceChange(ctx, change);
+    return async (change: sourceChange.SourceChange, alternativeChanges: sourceChange.SourceChange[] | undefined) => {
+        sourceChange.applySourceChange(ctx, change, alternativeChanges);
     };
 }
 

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -26,6 +26,7 @@ export async function activate(context: vscode.ExtensionContext) {
     ctx.registerCommand('runSingle', commands.runSingle);
     ctx.registerCommand('showReferences', commands.showReferences);
     ctx.registerCommand('applySourceChange', commands.applySourceChange);
+    ctx.registerCommand('selectAndApplySourceChange', commands.selectAndApplySourceChange);
 
     if (ctx.config.enableEnhancedTyping) {
         ctx.overrideCommand('type', commands.onEnter);

--- a/editors/code/src/source_change.ts
+++ b/editors/code/src/source_change.ts
@@ -9,7 +9,7 @@ export interface SourceChange {
     cursorPosition?: lc.TextDocumentPositionParams;
 }
 
-export async function applySourceChange(ctx: Ctx, change: SourceChange) {
+async function applySelectedSourceChange(ctx: Ctx, change: SourceChange) {
     const client = ctx.client;
     if (!client) return;
 
@@ -53,5 +53,15 @@ export async function applySourceChange(ctx: Ctx, change: SourceChange) {
             new vscode.Range(position, position),
             vscode.TextEditorRevealType.Default,
         );
+    }
+}
+
+export async function applySourceChange(ctx: Ctx, change: SourceChange, alternativeChanges: SourceChange[] | undefined) {
+    if (alternativeChanges !== undefined && alternativeChanges.length > 0) {
+        const selectedChange = await vscode.window.showQuickPick([change, ...alternativeChanges]);
+        if (!selectedChange) return;
+        await applySelectedSourceChange(ctx, selectedChange);
+    } else {
+        await applySelectedSourceChange(ctx, change);
     }
 }

--- a/editors/code/src/source_change.ts
+++ b/editors/code/src/source_change.ts
@@ -9,7 +9,7 @@ export interface SourceChange {
     cursorPosition?: lc.TextDocumentPositionParams;
 }
 
-async function applySelectedSourceChange(ctx: Ctx, change: SourceChange) {
+export async function applySourceChange(ctx: Ctx, change: SourceChange) {
     const client = ctx.client;
     if (!client) return;
 
@@ -53,15 +53,5 @@ async function applySelectedSourceChange(ctx: Ctx, change: SourceChange) {
             new vscode.Range(position, position),
             vscode.TextEditorRevealType.Default,
         );
-    }
-}
-
-export async function applySourceChange(ctx: Ctx, change: SourceChange, alternativeChanges: SourceChange[] | undefined) {
-    if (alternativeChanges !== undefined && alternativeChanges.length > 0) {
-        const selectedChange = await vscode.window.showQuickPick([change, ...alternativeChanges]);
-        if (!selectedChange) return;
-        await applySelectedSourceChange(ctx, selectedChange);
-    } else {
-        await applySelectedSourceChange(ctx, change);
     }
 }


### PR DESCRIPTION
This PR prepares an infra for https://github.com/rust-analyzer/rust-analyzer/issues/2180 task by adding a possibility to specify multiple actions in one assist as multiple edit parameters to the `applySourceChange` command.

When this is done, the command opens a selection dialog, allowing the user to pick the edit to be applied.

I have no working example to test in this PR, but here's a demo of an auto import feature (a separate PR coming later for that one) using this functionality:

![out](https://user-images.githubusercontent.com/2690773/71633614-f8ea4d80-2c1d-11ea-9b15-0e13611a7aa4.gif)

The PR is not that massive as it may seem: all the assist files' changes are very generic and similar.