### PR TITLE
Add `profile` calls to {Module,Function}::diagnostics

### DIFF
--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -25,6 +25,7 @@ use hir_ty::{
     TraitEnvironment, Ty, TyDefId, TypeCtor, TypeWalk,
 };
 use ra_db::{CrateId, Edition, FileId};
+use ra_prof::profile;
 use ra_syntax::ast;
 
 use crate::{
@@ -189,6 +190,7 @@ impl Module {
     }
 
     pub fn diagnostics(self, db: &impl HirDatabase, sink: &mut DiagnosticSink) {
+        let _p = profile("Module::diagnostics");
         db.crate_def_map(self.id.krate).add_diagnostics(db, self.id.local_id, sink);
         for decl in self.declarations(db) {
             match decl {
@@ -507,6 +509,7 @@ impl Function {
     }
 
     pub fn diagnostics(self, db: &impl HirDatabase, sink: &mut DiagnosticSink) {
+        let _p = profile("Function::diagnostics");
         let infer = db.infer(self.id.into());
         infer.add_diagnostics(db, self.id, sink);
         let mut validator = ExprValidator::new(self.id, infer, sink);


### PR DESCRIPTION
With this change the output `ra_prof` gives a better indication where
the time is spent. Example output:

```
  213ms - publish_diagnostics
      213ms - diagnostics
           70ms - Module::from_definition
               70ms - Module::from_file
          132ms - Module::diagnostics
               78ms - Function::diagnostics
                    0ms - body_with_source_map_query (1 calls)
                    2ms - trait_solve_query (1 calls)
                   76ms - ???
               15ms - Function::diagnostics
                    0ms - body_with_source_map_query (1 calls)
                   15ms - trait_solve_query (5 calls)
               38ms - Function::diagnostics (51 calls)
            8ms - parse_query (1 calls)
 ```

Signed-off-by: Michal Terepeta <michal.terepeta@gmail.com>