### PR TITLE
Split `crate_def_map` into two methods

### DIFF
--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -1,11 +1,11 @@
 //! FIXME: write short doc here
 
 pub use hir_def::db::{
-    BodyQuery, BodyWithSourceMapQuery, ConstDataQuery, CrateDefMapQuery, CrateLangItemsQuery,
-    DefDatabase, DefDatabaseStorage, DocumentationQuery, EnumDataQuery, ExprScopesQuery,
-    FunctionDataQuery, GenericParamsQuery, ImplDataQuery, InternDatabase, InternDatabaseStorage,
-    LangItemQuery, ModuleLangItemsQuery, RawItemsQuery, StaticDataQuery, StructDataQuery,
-    TraitDataQuery, TypeAliasDataQuery,
+    BodyQuery, BodyWithSourceMapQuery, ComputeCrateDefMapQuery, ConstDataQuery,
+    CrateLangItemsQuery, DefDatabase, DefDatabaseStorage, DocumentationQuery, EnumDataQuery,
+    ExprScopesQuery, FunctionDataQuery, GenericParamsQuery, ImplDataQuery, InternDatabase,
+    InternDatabaseStorage, LangItemQuery, ModuleLangItemsQuery, RawItemsQuery, StaticDataQuery,
+    StructDataQuery, TraitDataQuery, TypeAliasDataQuery,
 };
 pub use hir_expand::db::{
     AstDatabase, AstDatabaseStorage, AstIdMapQuery, MacroArgQuery, MacroDefQuery, MacroExpandQuery,

--- a/crates/ra_hir_def/src/db.rs
+++ b/crates/ra_hir_def/src/db.rs
@@ -50,7 +50,7 @@ pub trait DefDatabase: InternDatabase + AstDatabase {
     #[salsa::transparent]
     fn crate_def_map(&self, krate: CrateId) -> Arc<CrateDefMap>;
 
-    #[salsa::invoke(CrateDefMap::compute_crate_def_map)]
+    #[salsa::invoke(CrateDefMap::compute_crate_def_map_query)]
     fn compute_crate_def_map(&self, krate: CrateId) -> Arc<CrateDefMap>;
 
     #[salsa::invoke(StructData::struct_data_query)]

--- a/crates/ra_hir_def/src/nameres.rs
+++ b/crates/ra_hir_def/src/nameres.rs
@@ -172,13 +172,13 @@ pub struct ModuleData {
 }
 
 impl CrateDefMap {
-    pub(crate) fn crate_def_map_query(
+    pub(crate) fn compute_crate_def_map(
         // Note that this doesn't have `+ AstDatabase`!
         // This gurantess that `CrateDefMap` is stable across reparses.
         db: &impl DefDatabase,
         krate: CrateId,
     ) -> Arc<CrateDefMap> {
-        let _p = profile("crate_def_map_query");
+        let _p = profile("compute_crate_def_map");
         let def_map = {
             let crate_graph = db.crate_graph();
             let edition = crate_graph.edition(krate);

--- a/crates/ra_hir_def/src/nameres.rs
+++ b/crates/ra_hir_def/src/nameres.rs
@@ -172,7 +172,7 @@ pub struct ModuleData {
 }
 
 impl CrateDefMap {
-    pub(crate) fn compute_crate_def_map(
+    pub(crate) fn compute_crate_def_map_query(
         // Note that this doesn't have `+ AstDatabase`!
         // This gurantess that `CrateDefMap` is stable across reparses.
         db: &impl DefDatabase,

--- a/crates/ra_ide/src/change.rs
+++ b/crates/ra_ide/src/change.rs
@@ -309,7 +309,7 @@ impl RootDatabase {
             hir::db::EnumDataQuery
             hir::db::TraitDataQuery
             hir::db::RawItemsQuery
-            hir::db::CrateDefMapQuery
+            hir::db::ComputeCrateDefMapQuery
             hir::db::GenericParamsQuery
             hir::db::FunctionDataQuery
             hir::db::TypeAliasDataQuery


### PR DESCRIPTION
This change:

  - introduces `compute_crate_def_map` query and renames
    `CrateDefMap::crate_def_map_query` for consistency,

  - annotates `crate_def_map` as `salsa::transparent` and adds a
    top-level `crate_def_map` wrapper function around that starts the
    profiler and immediately calls into `compute_crate_def_map` query.

This allows us to better understand where we spent the time, in
particular, how much is spent in the recomputaiton and how much in
salsa.

Example output (where we don't actually re-compute anything, but the
query still takes a non-trivial amount of time):

```
  211ms - handle_inlay_hints
      150ms - get_inlay_hints
          150ms - SourceAnalyzer::new
               65ms - def_with_body_from_child_node
                   65ms - analyze_container
                       65ms - analyze_container
                           65ms - Module::from_definition
                               65ms - Module::from_file
                                   65ms - crate_def_map
                                        1ms - parse_macro_query (6 calls)
                                        0ms - raw_items_query (1 calls)
                                       64ms - ???
```

Signed-off-by: Michal Terepeta <michal.terepeta@gmail.com>