### PR TITLE
Fix #2705

### DIFF
--- a/crates/ra_hir_ty/src/lower.rs
+++ b/crates/ra_hir_ty/src/lower.rs
@@ -331,7 +331,7 @@ pub(super) fn substs_from_path_segment(
     if let Some(generic_args) = &segment.args_and_bindings {
         // if args are provided, it should be all of them, but we can't rely on that
         let self_param_correction = if add_self_param { 1 } else { 0 };
-        let child_len = child_len + self_param_correction;
+        let child_len = child_len - self_param_correction;
         for arg in generic_args.args.iter().take(child_len) {
             match arg {
                 GenericArg::Type(type_ref) => {

--- a/crates/ra_hir_ty/src/tests/regression.rs
+++ b/crates/ra_hir_ty/src/tests/regression.rs
@@ -365,3 +365,20 @@ fn issue_2669() {
     "###
     )
 }
+
+#[test]
+fn issue_2705() {
+    assert_snapshot!(
+        infer(r#"
+trait Trait {}
+fn test() {
+    <Trait<u32>>::foo()
+}
+"#),
+        @r###"
+    [26; 53) '{     ...oo() }': ()
+    [32; 49) '<Trait...>::foo': {unknown}
+    [32; 51) '<Trait...:foo()': ()
+    "###
+    );
+}


### PR DESCRIPTION
The `-` turned into a `+` during a refactoring.

The original issue was caused by `Read` resolving wrongly to a trait without
type parameters instead of a struct with one parameter; this only fixes the
crash, not the wrong resolution.