### PR TITLE
Fix unused import for windows in cargo_watch test

### DIFF
--- a/crates/ra_cargo_watch/src/conv/test.rs
+++ b/crates/ra_cargo_watch/src/conv/test.rs
@@ -1,7 +1,9 @@
 //! This module contains the large and verbose snapshot tests for the
 //! conversions between `cargo check` json and LSP diagnostics.
+#[cfg(not(windows))]
 use crate::*;
 
+#[cfg(not(windows))]
 fn parse_diagnostic(val: &str) -> cargo_metadata::diagnostic::Diagnostic {
     serde_json::from_str::<cargo_metadata::diagnostic::Diagnostic>(val).unwrap()
 }


### PR DESCRIPTION
This PR fixed some unused import in ra_cargo_watch test which are not used in Windows. 