### PR TITLE
Split `infer` query into two for better profiling

### DIFF
--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -12,10 +12,10 @@ pub use hir_expand::db::{
     ParseMacroQuery,
 };
 pub use hir_ty::db::{
-    AssociatedTyDataQuery, CallableItemSignatureQuery, FieldTypesQuery, GenericDefaultsQuery,
-    GenericPredicatesQuery, HirDatabase, HirDatabaseStorage, ImplDatumQuery, ImplsForTraitQuery,
-    ImplsInCrateQuery, InferQuery, StructDatumQuery, TraitDatumQuery, TraitSolveQuery, TyQuery,
-    ValueTyQuery,
+    AssociatedTyDataQuery, CallableItemSignatureQuery, DoInferQuery, FieldTypesQuery,
+    GenericDefaultsQuery, GenericPredicatesQuery, HirDatabase, HirDatabaseStorage, ImplDatumQuery,
+    ImplsForTraitQuery, ImplsInCrateQuery, StructDatumQuery, TraitDatumQuery, TraitSolveQuery,
+    TyQuery, ValueTyQuery,
 };
 
 #[test]

--- a/crates/ra_hir_ty/src/infer.rs
+++ b/crates/ra_hir_ty/src/infer.rs
@@ -62,8 +62,8 @@ mod pat;
 mod coerce;
 
 /// The entry point of type inference.
-pub fn infer_query(db: &impl HirDatabase, def: DefWithBodyId) -> Arc<InferenceResult> {
-    let _p = profile("infer_query");
+pub fn do_infer_query(db: &impl HirDatabase, def: DefWithBodyId) -> Arc<InferenceResult> {
+    let _p = profile("do_infer");
     let resolver = def.resolver(db);
     let mut ctx = InferenceContext::new(db, def, resolver);
 

--- a/crates/ra_hir_ty/src/lib.rs
+++ b/crates/ra_hir_ty/src/lib.rs
@@ -58,7 +58,7 @@ use crate::{
 use display::{HirDisplay, HirFormatter};
 
 pub use autoderef::autoderef;
-pub use infer::{infer_query, InferTy, InferenceResult};
+pub use infer::{do_infer_query, InferTy, InferenceResult};
 pub use lower::CallableDef;
 pub use lower::{callable_item_sig, TyDefId, ValueTyDefId};
 pub use traits::{InEnvironment, Obligation, ProjectionPredicate, TraitEnvironment};

--- a/crates/ra_ide/src/change.rs
+++ b/crates/ra_ide/src/change.rs
@@ -273,7 +273,7 @@ impl RootDatabase {
         self.query(hir::db::BodyWithSourceMapQuery).sweep(sweep);
 
         self.query(hir::db::ExprScopesQuery).sweep(sweep);
-        self.query(hir::db::InferQuery).sweep(sweep);
+        self.query(hir::db::DoInferQuery).sweep(sweep);
         self.query(hir::db::BodyQuery).sweep(sweep);
     }
 
@@ -320,7 +320,7 @@ impl RootDatabase {
             hir::db::LangItemQuery
             hir::db::DocumentationQuery
             hir::db::ExprScopesQuery
-            hir::db::InferQuery
+            hir::db::DoInferQuery
             hir::db::TyQuery
             hir::db::ValueTyQuery
             hir::db::FieldTypesQuery


### PR DESCRIPTION
This is the same change as we did with `crate_def_map` and it does seem
that we mostly spend time in salsa, without recomputing much on
rust-analyzer side.

Example output:

```
 233ms - handle_inlay_hints
      163ms - get_inlay_hints
          163ms - SourceAnalyzer::new
               67ms - def_with_body_from_child_node
                   67ms - analyze_container
                       67ms - analyze_container
                           67ms - Module::from_definition
                               67ms - Module::from_file
                                   67ms - crate_def_map
                                        0ms - parse_macro_query (6 calls)
                                        0ms - raw_items_query (1 calls)
                                       66ms - ???
                            0ms - crate_def_map (1 calls)
                        0ms - crate_def_map (1 calls)
               96ms - infer
                    2ms - trait_solve_query (2 calls)
                   94ms - ???
                0ms - body_with_source_map_query (1 calls)
                0ms - crate_def_map (1 calls)
      [...]
```

Signed-off-by: Michal Terepeta <michal.terepeta@gmail.com>