### PR TITLE
Basic DocumentHighlightKind support for assignments

### DIFF
--- a/crates/ra_ide/src/lib.rs
+++ b/crates/ra_ide/src/lib.rs
@@ -75,7 +75,7 @@ pub use crate::{
     inlay_hints::{InlayHint, InlayKind},
     line_index::{LineCol, LineIndex},
     line_index_utils::translate_offset_with_edit,
-    references::{Reference, ReferenceKind, ReferenceSearchResult, SearchScope},
+    references::{Reference, ReferenceAccess, ReferenceKind, ReferenceSearchResult, SearchScope},
     runnables::{Runnable, RunnableKind},
     source_change::{FileSystemEdit, SourceChange, SourceFileEdit},
     syntax_highlighting::HighlightedRange,

--- a/crates/ra_ide/src/lib.rs
+++ b/crates/ra_ide/src/lib.rs
@@ -75,7 +75,9 @@ pub use crate::{
     inlay_hints::{InlayHint, InlayKind},
     line_index::{LineCol, LineIndex},
     line_index_utils::translate_offset_with_edit,
-    references::{Reference, ReferenceAccess, ReferenceKind, ReferenceSearchResult, SearchScope},
+    references::{
+        Declaration, Reference, ReferenceAccess, ReferenceKind, ReferenceSearchResult, SearchScope,
+    },
     runnables::{Runnable, RunnableKind},
     source_change::{FileSystemEdit, SourceChange, SourceFileEdit},
     syntax_highlighting::HighlightedRange,

--- a/crates/ra_ide/src/references.rs
+++ b/crates/ra_ide/src/references.rs
@@ -37,9 +37,15 @@ pub use self::search_scope::SearchScope;
 
 #[derive(Debug, Clone)]
 pub struct ReferenceSearchResult {
-    declaration: NavigationTarget,
-    declaration_kind: ReferenceKind,
+    declaration: Declaration,
     references: Vec<Reference>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Declaration {
+    pub nav: NavigationTarget,
+    pub kind: ReferenceKind,
+    pub access: Option<ReferenceAccess>,
 }
 
 #[derive(Debug, Clone)]
@@ -62,8 +68,12 @@ pub enum ReferenceAccess {
 }
 
 impl ReferenceSearchResult {
-    pub fn declaration(&self) -> &NavigationTarget {
+    pub fn declaration(&self) -> &Declaration {
         &self.declaration
+    }
+
+    pub fn decl_target(&self) -> &NavigationTarget {
+        &self.declaration.nav
     }
 
     pub fn references(&self) -> &[Reference] {
@@ -88,11 +98,11 @@ impl IntoIterator for ReferenceSearchResult {
         let mut v = Vec::with_capacity(self.len());
         v.push(Reference {
             file_range: FileRange {
-                file_id: self.declaration.file_id(),
-                range: self.declaration.range(),
+                file_id: self.declaration.nav.file_id(),
+                range: self.declaration.nav.range(),
             },
-            kind: self.declaration_kind,
-            access: None,
+            kind: self.declaration.kind,
+            access: self.declaration.access,
         });
         v.append(&mut self.references);
         v.into_iter()
@@ -139,15 +149,14 @@ pub(crate) fn find_all_refs(
         }
     };
 
+    let declaration = Declaration { nav: declaration, kind: ReferenceKind::Other, access: None };
+
     let references = process_definition(db, def, name, search_scope)
         .into_iter()
         .filter(|r| search_kind == ReferenceKind::Other || search_kind == r.kind)
         .collect();
 
-    Some(RangeInfo::new(
-        range,
-        ReferenceSearchResult { declaration, references, declaration_kind: ReferenceKind::Other },
-    ))
+    Some(RangeInfo::new(range, ReferenceSearchResult { declaration, references }))
 }
 
 fn find_name<'a>(
@@ -259,7 +268,7 @@ fn access_mode(kind: NameKind, name_ref: &ast::NameRef) -> Option<ReferenceAcces
 mod tests {
     use crate::{
         mock_analysis::{analysis_and_position, single_file_with_position, MockAnalysis},
-        Reference, ReferenceKind, ReferenceSearchResult, SearchScope,
+        Declaration, Reference, ReferenceSearchResult, SearchScope,
     };
 
     #[test]
@@ -279,8 +288,7 @@ mod tests {
         let refs = get_all_refs(code);
         check_result(
             refs,
-            "Foo STRUCT_DEF FileId(1) [5; 39) [12; 15)",
-            ReferenceKind::Other,
+            "Foo STRUCT_DEF FileId(1) [5; 39) [12; 15) Other",
             &["FileId(1) [142; 145) StructLiteral"],
         );
     }
@@ -303,8 +311,7 @@ mod tests {
         let refs = get_all_refs(code);
         check_result(
             refs,
-            "i BIND_PAT FileId(1) [33; 34)",
-            ReferenceKind::Other,
+            "i BIND_PAT FileId(1) [33; 34) Other",
             &[
                 "FileId(1) [67; 68) Other Write",
                 "FileId(1) [71; 72) Other Read",
@@ -324,8 +331,7 @@ mod tests {
         let refs = get_all_refs(code);
         check_result(
             refs,
-            "i BIND_PAT FileId(1) [12; 13)",
-            ReferenceKind::Other,
+            "i BIND_PAT FileId(1) [12; 13) Other",
             &["FileId(1) [38; 39) Other Read"],
         );
     }
@@ -340,8 +346,7 @@ mod tests {
         let refs = get_all_refs(code);
         check_result(
             refs,
-            "i BIND_PAT FileId(1) [12; 13)",
-            ReferenceKind::Other,
+            "i BIND_PAT FileId(1) [12; 13) Other",
             &["FileId(1) [38; 39) Other Read"],
         );
     }
@@ -362,8 +367,7 @@ mod tests {
         let refs = get_all_refs(code);
         check_result(
             refs,
-            "spam RECORD_FIELD_DEF FileId(1) [66; 79) [70; 74)",
-            ReferenceKind::Other,
+            "spam RECORD_FIELD_DEF FileId(1) [66; 79) [70; 74) Other",
             &["FileId(1) [152; 156) Other Read"],
         );
     }
@@ -379,7 +383,7 @@ mod tests {
         "#;
 
         let refs = get_all_refs(code);
-        check_result(refs, "f FN_DEF FileId(1) [88; 104) [91; 92)", ReferenceKind::Other, &[]);
+        check_result(refs, "f FN_DEF FileId(1) [88; 104) [91; 92) Other", &[]);
     }
 
     #[test]
@@ -394,7 +398,7 @@ mod tests {
         "#;
 
         let refs = get_all_refs(code);
-        check_result(refs, "B ENUM_VARIANT FileId(1) [83; 84) [83; 84)", ReferenceKind::Other, &[]);
+        check_result(refs, "B ENUM_VARIANT FileId(1) [83; 84) [83; 84) Other", &[]);
     }
 
     #[test]
@@ -435,8 +439,7 @@ mod tests {
         let refs = analysis.find_all_refs(pos, None).unwrap().unwrap();
         check_result(
             refs,
-            "Foo STRUCT_DEF FileId(2) [16; 50) [27; 30)",
-            ReferenceKind::Other,
+            "Foo STRUCT_DEF FileId(2) [16; 50) [27; 30) Other",
             &["FileId(1) [52; 55) StructLiteral", "FileId(3) [77; 80) StructLiteral"],
         );
     }
@@ -466,8 +469,7 @@ mod tests {
         let refs = analysis.find_all_refs(pos, None).unwrap().unwrap();
         check_result(
             refs,
-            "foo SOURCE_FILE FileId(2) [0; 35)",
-            ReferenceKind::Other,
+            "foo SOURCE_FILE FileId(2) [0; 35) Other",
             &["FileId(1) [13; 16) Other"],
         );
     }
@@ -496,8 +498,7 @@ mod tests {
         let refs = analysis.find_all_refs(pos, None).unwrap().unwrap();
         check_result(
             refs,
-            "Foo STRUCT_DEF FileId(3) [0; 41) [18; 21)",
-            ReferenceKind::Other,
+            "Foo STRUCT_DEF FileId(3) [0; 41) [18; 21) Other",
             &["FileId(2) [20; 23) Other", "FileId(2) [46; 49) StructLiteral"],
         );
     }
@@ -525,8 +526,7 @@ mod tests {
         let refs = analysis.find_all_refs(pos, None).unwrap().unwrap();
         check_result(
             refs,
-            "quux FN_DEF FileId(1) [18; 34) [25; 29)",
-            ReferenceKind::Other,
+            "quux FN_DEF FileId(1) [18; 34) [25; 29) Other",
             &["FileId(2) [16; 20) Other", "FileId(3) [16; 20) Other"],
         );
 
@@ -534,8 +534,7 @@ mod tests {
             analysis.find_all_refs(pos, Some(SearchScope::single_file(bar))).unwrap().unwrap();
         check_result(
             refs,
-            "quux FN_DEF FileId(1) [18; 34) [25; 29)",
-            ReferenceKind::Other,
+            "quux FN_DEF FileId(1) [18; 34) [25; 29) Other",
             &["FileId(3) [16; 20) Other"],
         );
     }
@@ -554,8 +553,7 @@ mod tests {
         let refs = get_all_refs(code);
         check_result(
             refs,
-            "m1 MACRO_CALL FileId(1) [9; 63) [46; 48)",
-            ReferenceKind::Other,
+            "m1 MACRO_CALL FileId(1) [9; 63) [46; 48) Other",
             &["FileId(1) [96; 98) Other", "FileId(1) [114; 116) Other"],
         );
     }
@@ -571,8 +569,7 @@ mod tests {
         let refs = get_all_refs(code);
         check_result(
             refs,
-            "i BIND_PAT FileId(1) [36; 37)",
-            ReferenceKind::Other,
+            "i BIND_PAT FileId(1) [36; 37) Other",
             &["FileId(1) [55; 56) Other Write", "FileId(1) [59; 60) Other Read"],
         );
     }
@@ -592,8 +589,7 @@ mod tests {
         let refs = get_all_refs(code);
         check_result(
             refs,
-            "f RECORD_FIELD_DEF FileId(1) [32; 38) [32; 33)",
-            ReferenceKind::Other,
+            "f RECORD_FIELD_DEF FileId(1) [32; 38) [32; 33) Other",
             &["FileId(1) [96; 97) Other Read", "FileId(1) [117; 118) Other Write"],
         );
     }
@@ -603,17 +599,25 @@ mod tests {
         analysis.find_all_refs(position, None).unwrap().unwrap()
     }
 
-    fn check_result(
-        res: ReferenceSearchResult,
-        expected_decl: &str,
-        decl_kind: ReferenceKind,
-        expected_refs: &[&str],
-    ) {
+    fn check_result(res: ReferenceSearchResult, expected_decl: &str, expected_refs: &[&str]) {
         res.declaration().assert_match(expected_decl);
-        assert_eq!(res.declaration_kind, decl_kind);
-
         assert_eq!(res.references.len(), expected_refs.len());
         res.references().iter().enumerate().for_each(|(i, r)| r.assert_match(expected_refs[i]));
+    }
+
+    impl Declaration {
+        fn debug_render(&self) -> String {
+            let mut s = format!("{} {:?}", self.nav.debug_render(), self.kind);
+            if let Some(access) = self.access {
+                s.push_str(&format!(" {:?}", access));
+            }
+            s
+        }
+
+        fn assert_match(&self, expected: &str) {
+            let actual = self.debug_render();
+            test_utils::assert_eq_text!(expected.trim(), actual.trim(),);
+        }
     }
 
     impl Reference {

--- a/crates/ra_lsp_server/src/conv.rs
+++ b/crates/ra_lsp_server/src/conv.rs
@@ -9,7 +9,7 @@ use lsp_types::{
 use ra_ide::{
     translate_offset_with_edit, CompletionItem, CompletionItemKind, FileId, FilePosition,
     FileRange, FileSystemEdit, Fold, FoldKind, InsertTextFormat, LineCol, LineIndex,
-    NavigationTarget, RangeInfo, Severity, SourceChange, SourceFileEdit,
+    NavigationTarget, RangeInfo, ReferenceAccess, Severity, SourceChange, SourceFileEdit,
 };
 use ra_syntax::{SyntaxKind, TextRange, TextUnit};
 use ra_text_edit::{AtomTextEdit, TextEdit};
@@ -49,6 +49,18 @@ impl Conv for SyntaxKind {
             SyntaxKind::CONST_DEF => SymbolKind::Constant,
             SyntaxKind::IMPL_BLOCK => SymbolKind::Object,
             _ => SymbolKind::Variable,
+        }
+    }
+}
+
+impl Conv for ReferenceAccess {
+    type Output = ::lsp_types::DocumentHighlightKind;
+
+    fn conv(self) -> Self::Output {
+        use lsp_types::DocumentHighlightKind::*;
+        match self {
+            ReferenceAccess::Read => Read,
+            ReferenceAccess::Write => Write,
         }
     }
 }

--- a/crates/ra_lsp_server/src/conv.rs
+++ b/crates/ra_lsp_server/src/conv.rs
@@ -57,10 +57,10 @@ impl Conv for ReferenceAccess {
     type Output = ::lsp_types::DocumentHighlightKind;
 
     fn conv(self) -> Self::Output {
-        use lsp_types::DocumentHighlightKind::*;
+        use lsp_types::DocumentHighlightKind;
         match self {
-            ReferenceAccess::Read => Read,
-            ReferenceAccess::Write => Write,
+            ReferenceAccess::Read => DocumentHighlightKind::Read,
+            ReferenceAccess::Write => DocumentHighlightKind::Write,
         }
     }
 }

--- a/crates/ra_lsp_server/src/main_loop/handlers.rs
+++ b/crates/ra_lsp_server/src/main_loop/handlers.rs
@@ -536,18 +536,32 @@ pub fn handle_references(
 
     let locations = if params.context.include_declaration {
         refs.into_iter()
-            .filter_map(|r| {
-                let line_index = world.analysis().file_line_index(r.file_range.file_id).ok()?;
-                to_location(r.file_range.file_id, r.file_range.range, &world, &line_index).ok()
+            .filter_map(|reference| {
+                let line_index =
+                    world.analysis().file_line_index(reference.file_range.file_id).ok()?;
+                to_location(
+                    reference.file_range.file_id,
+                    reference.file_range.range,
+                    &world,
+                    &line_index,
+                )
+                .ok()
             })
             .collect()
     } else {
         // Only iterate over the references if include_declaration was false
         refs.references()
             .iter()
-            .filter_map(|r| {
-                let line_index = world.analysis().file_line_index(r.file_range.file_id).ok()?;
-                to_location(r.file_range.file_id, r.file_range.range, &world, &line_index).ok()
+            .filter_map(|reference| {
+                let line_index =
+                    world.analysis().file_line_index(reference.file_range.file_id).ok()?;
+                to_location(
+                    reference.file_range.file_id,
+                    reference.file_range.range,
+                    &world,
+                    &line_index,
+                )
+                .ok()
             })
             .collect()
     };
@@ -836,10 +850,10 @@ pub fn handle_document_highlight(
 
     Ok(Some(
         refs.into_iter()
-            .filter(|r| r.file_range.file_id == file_id)
-            .map(|r| DocumentHighlight {
-                range: r.file_range.range.conv_with(&line_index),
-                kind: None,
+            .filter(|reference| reference.file_range.file_id == file_id)
+            .map(|reference| DocumentHighlight {
+                range: reference.file_range.range.conv_with(&line_index),
+                kind: reference.access.map(|it| it.conv()),
             })
             .collect(),
     ))

--- a/crates/ra_syntax/src/ast/expr_extensions.rs
+++ b/crates/ra_syntax/src/ast/expr_extensions.rs
@@ -144,6 +144,7 @@ impl BinOp {
         }
     }
 }
+
 impl ast::BinExpr {
     pub fn op_details(&self) -> Option<(SyntaxToken, BinOp)> {
         self.syntax().children_with_tokens().filter_map(|it| it.into_token()).find_map(|c| {


### PR DESCRIPTION
Wraps references per #2738 and adds limited support for DocumentHighlightKind Read/Write for simple binops assignments.

I think I need some help with determining reads/writes.

Towards #2560 