### PR TITLE
add note in vscode instructions for vim plugin users

### DIFF
--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -44,6 +44,10 @@ $ cargo xtask install
 The automatic installation is expected to *just work* for common cases, if it
 doesn't, report bugs!
 
+**Note** [#1831](https://github.com/rust-analyzer/rust-analyzer/issues/1831): If you are using the popular 
+[Vim emulation plugin](https://github.com/VSCodeVim/Vim), you will likely
+need to turn off the `rust-analyzer.enableEnhancedTyping` setting.
+
 If you have an unusual setup (for example, `code` is not in the `PATH`), you
 should adapt these manual installation instructions:
 


### PR DESCRIPTION
Fixes #2746 

As the issue mentions, this is already mentioned below in the setting docs. However, it ended up taking me a long time to figure this out, so a note in the instructions for Vscode specifically is helpful