### PR TITLE
Fix a problem with `Durability` of libraries

### DIFF
--- a/crates/ra_ide/src/change.rs
+++ b/crates/ra_ide/src/change.rs
@@ -201,7 +201,7 @@ impl RootDatabase {
                 libraries.push(library.root_id);
                 self.set_source_root_with_durability(
                     library.root_id,
-                    Default::default(),
+                    Arc::new(SourceRoot::new_library()),
                     Durability::HIGH,
                 );
                 self.set_library_symbols_with_durability(


### PR DESCRIPTION
When processing a change with added libraries, we used
`Default::default` for `SourceRoot` which sets `is_library` to false.
Since we use `is_library` to decide whether to use low or high
durability, I believe that this caused us to mark many library
dependencies as having low durability and thus increased the size of the
graph that salsa needed to verify on every change.

Based on my initial tests this speeds up the `CrateDefMapQuery` on
rust-analyzer from about ~64ms to ~14ms and reduces the number of
validations for the query from over 60k to about 7k.

Signed-off-by: Michal Terepeta <michal.terepeta@gmail.com>