### PR TITLE
Remove the Default impl for SourceRoot

### DIFF
--- a/crates/ra_db/src/fixture.rs
+++ b/crates/ra_db/src/fixture.rs
@@ -49,7 +49,7 @@ fn with_single_file(db: &mut dyn SourceDatabaseExt, text: &str) -> FileId {
     let file_id = FileId(0);
     let rel_path: RelativePathBuf = "/main.rs".into();
 
-    let mut source_root = SourceRoot::default();
+    let mut source_root = SourceRoot::new_local();
     source_root.insert_file(rel_path.clone(), file_id);
 
     let mut crate_graph = CrateGraph::default();
@@ -77,7 +77,7 @@ fn with_files(db: &mut dyn SourceDatabaseExt, fixture: &str) -> Option<FilePosit
     let mut crate_deps = Vec::new();
     let mut default_crate_root: Option<FileId> = None;
 
-    let mut source_root = SourceRoot::default();
+    let mut source_root = SourceRoot::new_local();
     let mut source_root_id = WORKSPACE;
     let mut source_root_prefix: RelativePathBuf = "/".into();
     let mut file_id = FileId(0);
@@ -87,7 +87,7 @@ fn with_files(db: &mut dyn SourceDatabaseExt, fixture: &str) -> Option<FilePosit
     for entry in fixture.iter() {
         let meta = match parse_meta(&entry.meta) {
             ParsedMeta::Root { path } => {
-                let source_root = std::mem::replace(&mut source_root, SourceRoot::default());
+                let source_root = std::mem::replace(&mut source_root, SourceRoot::new_local());
                 db.set_source_root(source_root_id, Arc::new(source_root));
                 source_root_id.0 += 1;
                 source_root_prefix = path;

--- a/crates/ra_db/src/input.rs
+++ b/crates/ra_db/src/input.rs
@@ -33,7 +33,7 @@ pub struct FileId(pub u32);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct SourceRootId(pub u32);
 
-#[derive(Default, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SourceRoot {
     /// Sysroot or crates.io library.
     ///
@@ -44,11 +44,11 @@ pub struct SourceRoot {
 }
 
 impl SourceRoot {
-    pub fn new() -> SourceRoot {
-        Default::default()
+    pub fn new_local() -> SourceRoot {
+        SourceRoot { is_library: false, files: Default::default() }
     }
     pub fn new_library() -> SourceRoot {
-        SourceRoot { is_library: true, ..SourceRoot::new() }
+        SourceRoot { is_library: true, files: Default::default() }
     }
     pub fn insert_file(&mut self, path: RelativePathBuf, file_id: FileId) {
         self.files.insert(path, file_id);

--- a/crates/ra_ide/src/change.rs
+++ b/crates/ra_ide/src/change.rs
@@ -176,7 +176,8 @@ impl RootDatabase {
         if !change.new_roots.is_empty() {
             let mut local_roots = Vec::clone(&self.local_roots());
             for (root_id, is_local) in change.new_roots {
-                let root = if is_local { SourceRoot::new() } else { SourceRoot::new_library() };
+                let root =
+                    if is_local { SourceRoot::new_local() } else { SourceRoot::new_library() };
                 let durability = durability(&root);
                 self.set_source_root_with_durability(root_id, Arc::new(root), durability);
                 if is_local {


### PR DESCRIPTION
Let's be always explicit whether we create a library (i.e., an immutable
dependency) or a local `SourceRoot`, since it can have a large impact on
the validation performance in salsa. (we found it the hard way recently,
where the `Default` instance made it quite tricky to spot a bug)

Signed-off-by: Michal Terepeta <michal.terepeta@gmail.com>