### PR TITLE
Actually test references

### DIFF
--- a/crates/ra_ide/src/lib.rs
+++ b/crates/ra_ide/src/lib.rs
@@ -75,7 +75,7 @@ pub use crate::{
     inlay_hints::{InlayHint, InlayKind},
     line_index::{LineCol, LineIndex},
     line_index_utils::translate_offset_with_edit,
-    references::{ReferenceSearchResult, SearchScope},
+    references::{Reference, ReferenceKind, ReferenceSearchResult, SearchScope},
     runnables::{Runnable, RunnableKind},
     source_change::{FileSystemEdit, SourceChange, SourceFileEdit},
     syntax_highlighting::HighlightedRange,

--- a/crates/ra_ide/src/references.rs
+++ b/crates/ra_ide/src/references.rs
@@ -534,11 +534,11 @@ mod tests {
     }
 
     impl Reference {
-        pub fn debug_render(&self) -> String {
+        fn debug_render(&self) -> String {
             format!("{:?} {:?} {:?}", self.file_range.file_id, self.file_range.range, self.kind)
         }
 
-        pub fn assert_match(&self, expected: &str) {
+        fn assert_match(&self, expected: &str) {
             let actual = self.debug_render();
             test_utils::assert_eq_text!(expected.trim(), actual.trim(),);
         }


### PR DESCRIPTION
This will be a little more work when `ReferenceSearchResults` change but I think it's easier to maintain in the end. It also follows a similar pattern to navigation targets and call hierarchy.