### PR TITLE
Fix file_structure()  to recognize macro_rules!

### DIFF
--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -58,6 +58,7 @@ pub use hir_def::{
     type_ref::Mutability,
 };
 pub use hir_expand::{
-    name::Name, HirFileId, InFile, MacroCallId, MacroCallLoc, MacroDefId, MacroFile, Origin,
+    name::name, name::AsName, name::Name, HirFileId, InFile, MacroCallId, MacroCallLoc, MacroDefId,
+    MacroFile, Origin,
 };
 pub use hir_ty::{display::HirDisplay, CallableDef};

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -58,7 +58,6 @@ pub use hir_def::{
     type_ref::Mutability,
 };
 pub use hir_expand::{
-    name::name, name::AsName, name::Name, HirFileId, InFile, MacroCallId, MacroCallLoc, MacroDefId,
-    MacroFile, Origin,
+    name::Name, HirFileId, InFile, MacroCallId, MacroCallLoc, MacroDefId, MacroFile, Origin,
 };
 pub use hir_ty::{display::HirDisplay, CallableDef};

--- a/crates/ra_ide/src/display/structure.rs
+++ b/crates/ra_ide/src/display/structure.rs
@@ -151,10 +151,24 @@ fn structure_node(node: &SyntaxNode) -> Option<StructureNode> {
                 Some(node)
             },
             ast::MacroCall(it) => {
-                let first_token = it.syntax().first_token().unwrap();
-                if first_token.text().as_str() != "macro_rules" {
-                    return None;
+                let macro_name = it.syntax()
+                    .children()
+                    .find(|c|
+                        ![
+                            SyntaxKind::COMMENT,
+                            SyntaxKind::WHITESPACE,
+                            SyntaxKind::ATTR
+                        ].iter()
+                        .any(|&k| k == c.kind())
+                    );
+
+                match macro_name {
+                    None => return None,
+                    Some(n) => if n.first_token().unwrap().text().as_str() != "macro_rules" {
+                        return None;
+                    }
                 }
+
                 decl(it)
             },
             _ => None,

--- a/crates/ra_ide/src/display/structure.rs
+++ b/crates/ra_ide/src/display/structure.rs
@@ -212,6 +212,11 @@ macro_rules! mc {
     () => {}
 }
 
+#[macro_export]
+macro_rules! mcexp {
+    () => {}
+}
+
 #[deprecated]
 fn obsolete() {}
 
@@ -388,9 +393,18 @@ fn very_obsolete() {}
             },
             StructureNode {
                 parent: None,
+                label: "mcexp",
+                navigation_range: [334; 339),
+                node_range: [305; 356),
+                kind: MACRO_CALL,
+                detail: None,
+                deprecated: false,
+            },
+            StructureNode {
+                parent: None,
                 label: "obsolete",
-                navigation_range: [322; 330),
-                node_range: [305; 335),
+                navigation_range: [375; 383),
+                node_range: [358; 388),
                 kind: FN_DEF,
                 detail: Some(
                     "fn()",
@@ -400,8 +414,8 @@ fn very_obsolete() {}
             StructureNode {
                 parent: None,
                 label: "very_obsolete",
-                navigation_range: [375; 388),
-                node_range: [337; 393),
+                navigation_range: [428; 441),
+                node_range: [390; 446),
                 kind: FN_DEF,
                 detail: Some(
                     "fn()",

--- a/crates/ra_ide/src/display/structure.rs
+++ b/crates/ra_ide/src/display/structure.rs
@@ -2,7 +2,6 @@
 
 use crate::TextRange;
 
-use hir::{name, AsName, Path};
 use ra_syntax::{
     ast::{self, AttrsOwner, NameOwner, TypeAscriptionOwner, TypeParamsOwner},
     match_ast, AstNode, SourceFile, SyntaxKind, SyntaxNode, WalkEvent,
@@ -152,9 +151,8 @@ fn structure_node(node: &SyntaxNode) -> Option<StructureNode> {
                 Some(node)
             },
             ast::MacroCall(it) => {
-                match it.path().and_then(|p| Path::from_ast(p)) {
-                    Some(path) if path.mod_path().segments.as_slice() == [name![macro_rules]]
-                        && it.name().map(|n| n.as_name()).is_some()
+                match it.path().and_then(|it| it.segment()).and_then(|it| it.name_ref()) {
+                    Some(path_segment) if path_segment.text() == "macro_rules"
                     => decl(it),
                     _ => None,
                 }


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/2774.

Not sure what to do about classifying macro definitions. Maybe make all macro invocations a function invocation?