### PR TITLE
Slightly more robust cargo watcher root search

### DIFF
--- a/crates/ra_cargo_watch/src/lib.rs
+++ b/crates/ra_cargo_watch/src/lib.rs
@@ -58,6 +58,12 @@ impl CheckWatcher {
         CheckWatcher { task_recv, cmd_send: Some(cmd_send), handle: Some(handle), shared }
     }
 
+    /// Returns a CheckWatcher that doesn't actually do anything
+    pub fn dummy() -> CheckWatcher {
+        let shared = Arc::new(RwLock::new(CheckWatcherSharedState::new()));
+        CheckWatcher { task_recv: never(), cmd_send: None, handle: None, shared }
+    }
+
     /// Schedule a re-start of the cargo check worker.
     pub fn update(&self) {
         if let Some(cmd_send) = &self.cmd_send {

--- a/crates/ra_lsp_server/src/world.rs
+++ b/crates/ra_lsp_server/src/world.rs
@@ -135,7 +135,7 @@ impl WorldState {
         let check_watcher = {
             let first_workspace = workspaces.first().unwrap();
             let cargo_project_root = match first_workspace {
-                ProjectWorkspace::Cargo { cargo, .. } => cargo.workspace_root.clone(),
+                ProjectWorkspace::Cargo { cargo, .. } => cargo.workspace_root().to_path_buf(),
                 ProjectWorkspace::Json { .. } => {
                     log::warn!(
                         "Cargo check watching only supported for cargo workspaces, disabling"

--- a/crates/ra_lsp_server/src/world.rs
+++ b/crates/ra_lsp_server/src/world.rs
@@ -74,7 +74,7 @@ impl WorldState {
         lru_capacity: Option<usize>,
         exclude_globs: &[Glob],
         watch: Watch,
-        mut options: Options,
+        options: Options,
         feature_flags: FeatureFlags,
     ) -> WorldState {
         let mut change = AnalysisChange::new();

--- a/crates/ra_project_model/src/cargo_workspace.rs
+++ b/crates/ra_project_model/src/cargo_workspace.rs
@@ -21,7 +21,7 @@ use crate::Result;
 pub struct CargoWorkspace {
     packages: Arena<Package, PackageData>,
     targets: Arena<Target, TargetData>,
-    pub workspace_root: PathBuf,
+    workspace_root: PathBuf,
 }
 
 #[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -224,5 +224,9 @@ impl CargoWorkspace {
 
     pub fn target_by_root(&self, root: &Path) -> Option<Target> {
         self.packages().filter_map(|pkg| pkg.targets(self).find(|it| it.root(self) == root)).next()
+    }
+
+    pub fn workspace_root(&self) -> &Path {
+        &self.workspace_root
     }
 }

--- a/crates/ra_project_model/src/cargo_workspace.rs
+++ b/crates/ra_project_model/src/cargo_workspace.rs
@@ -21,7 +21,7 @@ use crate::Result;
 pub struct CargoWorkspace {
     packages: Arena<Package, PackageData>,
     targets: Arena<Target, TargetData>,
-    pub(crate) workspace_root: PathBuf,
+    pub workspace_root: PathBuf,
 }
 
 #[derive(Deserialize, Clone, Debug, PartialEq, Eq)]

--- a/crates/ra_project_model/src/lib.rs
+++ b/crates/ra_project_model/src/lib.rs
@@ -333,7 +333,7 @@ impl ProjectWorkspace {
     pub fn workspace_root_for(&self, path: &Path) -> Option<&Path> {
         match self {
             ProjectWorkspace::Cargo { cargo, .. } => {
-                Some(cargo.workspace_root.as_ref()).filter(|root| path.starts_with(root))
+                Some(cargo.workspace_root()).filter(|root| path.starts_with(root))
             }
             ProjectWorkspace::Json { project: JsonProject { roots, .. } } => roots
                 .iter()


### PR DESCRIPTION
Fixes #2780 (hopefully).

Use the already painstakingly found `workspaces` instead of naively using `folder_roots` from editor.