### PR TITLE
Fix lruCapacity config key in VSCode

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -217,7 +217,10 @@
                     "description": "Trace requests to the ra_lsp_server"
                 },
                 "rust-analyzer.lruCapacity": {
-                    "type": "number",
+                    "type": [
+                        "number",
+                        "null"
+                    ],
                     "default": null,
                     "description": "Number of syntax trees rust-analyzer keeps in memory"
                 },


### PR DESCRIPTION
Closes #2789.

This simply adds `null` as a valid value for the configuration key. 

We could use the server-side default value (128) instead, but in that case every time we change its value on the server side we would have to update it on the client side too.