### PR TITLE
Fix various names, e.g. Iterator not resolving in core prelude

### DIFF
--- a/crates/ra_hir_def/src/nameres/collector.rs
+++ b/crates/ra_hir_def/src/nameres/collector.rs
@@ -328,7 +328,7 @@ where
             );
 
             let def = res.resolved_def;
-            if res.reached_fixedpoint == ReachedFixedPoint::No {
+            if res.reached_fixedpoint == ReachedFixedPoint::No || def.is_none() {
                 return PartialResolvedImport::Unresolved;
             }
 

--- a/crates/ra_hir_def/src/nameres/tests/mod_resolution.rs
+++ b/crates/ra_hir_def/src/nameres/tests/mod_resolution.rs
@@ -53,6 +53,51 @@ fn nested_module_resolution() {
 }
 
 #[test]
+fn nested_module_resolution_2() {
+    let map = def_map(
+        "
+        //- /lib.rs
+        mod prelude;
+        mod iter;
+
+        //- /prelude.rs
+        pub use crate::iter::Iterator;
+
+        //- /iter.rs
+        pub use self::traits::Iterator;
+        mod traits;
+
+        //- /iter/traits.rs
+        pub use self::iterator::Iterator;
+        mod iterator;
+
+        //- /iter/traits/iterator.rs
+        pub trait Iterator;
+        ",
+    );
+
+    assert_snapshot!(map, @r###"
+    crate
+    iter: t
+    prelude: t
+    
+    crate::iter
+    Iterator: t
+    traits: t
+    
+    crate::iter::traits
+    Iterator: t
+    iterator: t
+    
+    crate::iter::traits::iterator
+    Iterator: t
+    
+    crate::prelude
+    Iterator: t
+    "###);
+}
+
+#[test]
 fn module_resolution_works_for_non_standard_filenames() {
     let map = def_map(
         "


### PR DESCRIPTION
Basically, `Iterator` is re-exported via several steps, which happened to not be
resolved yet when we got to the prelude import, but since the name resolved to
the reexport from `core::iter` (just to no actual items), we gave up trying to
resolve it further.

Maybe part of the problem is that we can have
`PartialResolvedImport::Unresolved` or `PartialResolvedImport::Indeterminate`
with `None` in all namespaces, and handle them differently.

Fixes #2683.