### PR TITLE
Skip builtin derive for goto-implementation

### DIFF
--- a/crates/ra_hir_expand/src/lib.rs
+++ b/crates/ra_hir_expand/src/lib.rs
@@ -112,6 +112,21 @@ impl HirFileId {
             }
         }
     }
+
+    /// Indicate it is macro file generated for builtin derive
+    pub fn is_builtin_derive(&self, db: &dyn db::AstDatabase) -> bool {
+        match self.0 {
+            HirFileIdRepr::FileId(_) => false,
+            HirFileIdRepr::MacroFile(macro_file) => {
+                let loc: MacroCallLoc = db.lookup_intern_macro(macro_file.macro_call_id);
+                if let MacroDefKind::BuiltInDerive(_) = loc.def.kind {
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/ra_ide/src/impls.rs
+++ b/crates/ra_ide/src/impls.rs
@@ -1,6 +1,6 @@
 //! FIXME: write short doc here
 
-use hir::{FromSource, ImplBlock};
+use hir::{FromSource, HasSource, ImplBlock};
 use ra_db::SourceDatabase;
 use ra_syntax::{algo::find_node_at_offset, ast, AstNode};
 
@@ -62,6 +62,7 @@ fn impls_for_def(
         impls
             .into_iter()
             .filter(|impl_block| ty.is_equal_for_find_impls(&impl_block.target_ty(db)))
+            .filter(|impl_block| !impl_block.source(db).file_id.is_builtin_derive(db))
             .map(|imp| imp.to_nav(db))
             .collect(),
     )


### PR DESCRIPTION
This PR skip goto implementation for Builtin Derive (`Copy`, `Default`, etc) such that it will not show in `Implementation` code lens. 

Although there is alternative solution which we could point the navigation range to the attributes itself. But I think skipping it for now is okay. 

Related to #2531

cc @kjeremy 