### PR TITLE
Use attr location for builtin derive in goto-implementation

### DIFF
--- a/crates/ra_hir_expand/src/lib.rs
+++ b/crates/ra_hir_expand/src/lib.rs
@@ -112,6 +112,21 @@ impl HirFileId {
             }
         }
     }
+
+    /// Indicate it is macro file generated for builtin derive
+    pub fn is_builtin_derive(&self, db: &dyn db::AstDatabase) -> Option<InFile<ast::ModuleItem>> {
+        match self.0 {
+            HirFileIdRepr::FileId(_) => None,
+            HirFileIdRepr::MacroFile(macro_file) => {
+                let loc: MacroCallLoc = db.lookup_intern_macro(macro_file.macro_call_id);
+                let item = match loc.def.kind {
+                    MacroDefKind::BuiltInDerive(_) => loc.kind.node(db),
+                    _ => return None,
+                };
+                Some(item.with_value(ast::ModuleItem::cast(item.value.clone())?))
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/ra_ide/src/display/navigation_target.rs
+++ b/crates/ra_ide/src/display/navigation_target.rs
@@ -251,7 +251,11 @@ impl ToNav for hir::Module {
 impl ToNav for hir::ImplBlock {
     fn to_nav(&self, db: &RootDatabase) -> NavigationTarget {
         let src = self.source(db);
-        let frange = original_range(db, src.as_ref().map(|it| it.syntax()));
+        let frange = if let Some(item) = self.is_builtin_derive(db) {
+            original_range(db, item.syntax())
+        } else {
+            original_range(db, src.as_ref().map(|it| it.syntax()))
+        };
 
         NavigationTarget::from_syntax(
             frange.file_id,

--- a/crates/ra_ide/src/impls.rs
+++ b/crates/ra_ide/src/impls.rs
@@ -203,4 +203,16 @@ mod tests {
             ],
         );
     }
+
+    #[test]
+    fn goto_implementation_to_builtin_derive() {
+        check_goto(
+            "
+            //- /lib.rs
+            #[derive(Copy)]
+            struct Foo<|>;            
+            ",
+            &["impl IMPL_BLOCK FileId(1) [0; 15)"],
+        );
+    }
 }


### PR DESCRIPTION
This PR is use attribute location for builtin derive in `ImplBlock`'s NavigationTarget such that the goto-implementation will goto to a correct position. 

Related to #2531