### PR TITLE
Add macro_rules item snippet

### DIFF
--- a/crates/ra_ide/src/completion/complete_snippet.rs
+++ b/crates/ra_ide/src/completion/complete_snippet.rs
@@ -36,6 +36,7 @@ fn ${1:feature}() {
     .lookup_by("tfn")
     .add_to(acc);
 
+    snippet(ctx, "macro_rules", "macro_rules! $1 {\n\t($2) => {\n\t\t$0\n\t};\n}").add_to(acc);
     snippet(ctx, "pub(crate)", "pub(crate) $0").add_to(acc);
 }
 
@@ -105,6 +106,13 @@ mod tests {
                 insert: "#[test]\nfn ${1:feature}() {\n    $0\n}",
                 kind: Snippet,
                 lookup: "tfn",
+            },
+            CompletionItem {
+                label: "macro_rules",
+                source_range: [78; 78),
+                delete: [78; 78),
+                insert: "macro_rules! $1 {\n\t($2) => {\n\t\t$0\n\t};\n}",
+                kind: Snippet,
             },
             CompletionItem {
                 label: "pub(crate)",


### PR DESCRIPTION
An user trying out rust-analyzer mentioned to me that they missed `rls-vscode`'s [macro_rules snippet](https://github.com/rust-lang/rls-vscode/blob/c2293a63d4adc76ab714a5c6d0a2e9c7b7be77ed/snippets/rust.json#L60)

![2020-01-12_17-47-34](https://user-images.githubusercontent.com/6868531/72227227-fcf46480-3567-11ea-9e3b-2f7319d127f7.gif)
