### PR TITLE
Dropping a reference does nothing.

### DIFF
--- a/crates/ra_cli/src/analysis_stats.rs
+++ b/crates/ra_cli/src/analysis_stats.rs
@@ -183,7 +183,6 @@ pub fn run(
     println!("Total: {:?}, {}", analysis_time.elapsed(), ra_prof::memory_usage());
 
     if memory_usage {
-        drop(db);
         for (name, bytes) in host.per_query_memory_usage() {
             println!("{:>8} {}", bytes, name)
         }


### PR DESCRIPTION
Allows clippy to continue compilation