### PR TITLE
Fix array element attribute position

### DIFF
--- a/crates/ra_parser/src/grammar/attributes.rs
+++ b/crates/ra_parser/src/grammar/attributes.rs
@@ -8,6 +8,28 @@ pub(super) fn inner_attributes(p: &mut Parser) {
     }
 }
 
+pub(super) fn with_outer_attributes(
+    p: &mut Parser,
+    f: impl Fn(&mut Parser) -> Option<CompletedMarker>,
+) -> bool {
+    let am = p.start();
+    let has_attrs = p.at(T![#]);
+    attributes::outer_attributes(p);    
+    let cm = f(p);
+    let success = cm.is_some();
+
+    match (has_attrs, cm) {
+        (true, Some(cm)) => {
+            let kind = cm.kind();
+            cm.undo_completion(p).abandon(p);
+            am.complete(p, kind);
+        }
+        _ => am.abandon(p),
+    }
+
+    success
+}
+
 pub(super) fn outer_attributes(p: &mut Parser) {
     while p.at(T![#]) {
         attribute(p, false)

--- a/crates/ra_parser/src/grammar/attributes.rs
+++ b/crates/ra_parser/src/grammar/attributes.rs
@@ -14,7 +14,7 @@ pub(super) fn with_outer_attributes(
 ) -> bool {
     let am = p.start();
     let has_attrs = p.at(T![#]);
-    attributes::outer_attributes(p);    
+    attributes::outer_attributes(p);
     let cm = f(p);
     let success = cm.is_some();
 

--- a/crates/ra_parser/src/grammar/expressions.rs
+++ b/crates/ra_parser/src/grammar/expressions.rs
@@ -14,9 +14,9 @@ pub(super) enum StmtWithSemi {
 
 const EXPR_FIRST: TokenSet = LHS_FIRST;
 
-pub(super) fn expr(p: &mut Parser) -> BlockLike {
+pub(super) fn expr(p: &mut Parser) -> (Option<CompletedMarker>, BlockLike) {
     let r = Restrictions { forbid_structs: false, prefer_stmt: false };
-    expr_bp(p, r, 1).1
+    expr_bp(p, r, 1)
 }
 
 pub(super) fn expr_stmt(p: &mut Parser) -> (Option<CompletedMarker>, BlockLike) {

--- a/crates/ra_parser/src/grammar/expressions/atom.rs
+++ b/crates/ra_parser/src/grammar/expressions/atom.rs
@@ -192,9 +192,8 @@ fn array_expr(p: &mut Parser) -> CompletedMarker {
     //    1,
     //    2,
     // ];
-    attributes::outer_attributes(p);
+    attributes::with_outer_attributes(p, |p| expr(p).0);
 
-    expr(p);
     if p.eat(T![;]) {
         expr(p);
         p.expect(T![']']);
@@ -212,12 +211,15 @@ fn array_expr(p: &mut Parser) -> CompletedMarker {
         //    #[cfg(test)]
         //    2,
         // ];
-        attributes::outer_attributes(p);
-        if !p.at_ts(EXPR_FIRST) {
-            p.error("expected expression");
+        if !attributes::with_outer_attributes(p, |p| {
+            if !p.at_ts(EXPR_FIRST) {
+                p.error("expected expression");
+                return None;
+            }
+            expr(p).0
+        }) {
             break;
         }
-        expr(p);
     }
     p.expect(T![']']);
     m.complete(p, ARRAY_EXPR)

--- a/crates/ra_syntax/test_data/parser/inline/ok/0135_first_array_member_attributes.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0135_first_array_member_attributes.txt
@@ -27,20 +27,20 @@ SOURCE_FILE@[0; 56)
       ARRAY_EXPR@[23; 54)
         L_BRACK@[23; 24) "["
         WHITESPACE@[24; 28) "\n   "
-        ATTR@[28; 40)
-          POUND@[28; 29) "#"
-          L_BRACK@[29; 30) "["
-          PATH@[30; 33)
-            PATH_SEGMENT@[30; 33)
-              NAME_REF@[30; 33)
-                IDENT@[30; 33) "cfg"
-          TOKEN_TREE@[33; 39)
-            L_PAREN@[33; 34) "("
-            IDENT@[34; 38) "test"
-            R_PAREN@[38; 39) ")"
-          R_BRACK@[39; 40) "]"
-        WHITESPACE@[40; 44) "\n   "
-        LITERAL@[44; 45)
+        LITERAL@[28; 45)
+          ATTR@[28; 40)
+            POUND@[28; 29) "#"
+            L_BRACK@[29; 30) "["
+            PATH@[30; 33)
+              PATH_SEGMENT@[30; 33)
+                NAME_REF@[30; 33)
+                  IDENT@[30; 33) "cfg"
+            TOKEN_TREE@[33; 39)
+              L_PAREN@[33; 34) "("
+              IDENT@[34; 38) "test"
+              R_PAREN@[38; 39) ")"
+            R_BRACK@[39; 40) "]"
+          WHITESPACE@[40; 44) "\n   "
           INT_NUMBER@[44; 45) "1"
         COMMA@[45; 46) ","
         WHITESPACE@[46; 50) "\n   "

--- a/crates/ra_syntax/test_data/parser/inline/ok/0136_subsequent_array_member_attributes.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0136_subsequent_array_member_attributes.txt
@@ -31,20 +31,20 @@ SOURCE_FILE@[0; 56)
           INT_NUMBER@[28; 29) "1"
         COMMA@[29; 30) ","
         WHITESPACE@[30; 34) "\n   "
-        ATTR@[34; 46)
-          POUND@[34; 35) "#"
-          L_BRACK@[35; 36) "["
-          PATH@[36; 39)
-            PATH_SEGMENT@[36; 39)
-              NAME_REF@[36; 39)
-                IDENT@[36; 39) "cfg"
-          TOKEN_TREE@[39; 45)
-            L_PAREN@[39; 40) "("
-            IDENT@[40; 44) "test"
-            R_PAREN@[44; 45) ")"
-          R_BRACK@[45; 46) "]"
-        WHITESPACE@[46; 50) "\n   "
-        LITERAL@[50; 51)
+        LITERAL@[34; 51)
+          ATTR@[34; 46)
+            POUND@[34; 35) "#"
+            L_BRACK@[35; 36) "["
+            PATH@[36; 39)
+              PATH_SEGMENT@[36; 39)
+                NAME_REF@[36; 39)
+                  IDENT@[36; 39) "cfg"
+            TOKEN_TREE@[39; 45)
+              L_PAREN@[39; 40) "("
+              IDENT@[40; 44) "test"
+              R_PAREN@[44; 45) ")"
+            R_BRACK@[45; 46) "]"
+          WHITESPACE@[46; 50) "\n   "
           INT_NUMBER@[50; 51) "2"
         COMMA@[51; 52) ","
         WHITESPACE@[52; 53) "\n"


### PR DESCRIPTION
This PR fixed a bug which an ATTR node insert in the wrong place in array element. ~~And introduce `precede_next` for allow outer attributes to insert into a parsed `expr`.~~  

related #2783