### PR TITLE
Display vscode message after changing cargo-watch options

### DIFF
--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -174,22 +174,19 @@ export class Config {
             requireReloadMessage = 'Changing cargo features requires a reload';
         }
         this.prevCargoFeatures = { ...this.cargoFeatures };
-        
-        if (
-            this.prevCargoWatchOptions !== null &&
-            (this.cargoWatchOptions.enable !==
-                this.prevCargoWatchOptions.enable ||
-                this.cargoWatchOptions.command !==
-                this.prevCargoWatchOptions.command ||
-                this.cargoWatchOptions.allTargets !==
-                this.prevCargoWatchOptions.allTargets ||
-                this.cargoWatchOptions.arguments.length !==
-                this.prevCargoWatchOptions.arguments.length ||
+
+        if (this.prevCargoWatchOptions !== null) {
+            const changed =
+                this.cargoWatchOptions.enable !== this.prevCargoWatchOptions.enable ||
+                this.cargoWatchOptions.command !== this.prevCargoWatchOptions.command ||
+                this.cargoWatchOptions.allTargets !== this.prevCargoWatchOptions.allTargets ||
+                this.cargoWatchOptions.arguments.length !== this.prevCargoWatchOptions.arguments.length ||
                 this.cargoWatchOptions.arguments.some(
                     (v, i) => v !== this.prevCargoWatchOptions!.arguments[i],
-                ))
-        ) {
-            requireReloadMessage = 'Changing cargo-watch options requires a reload';
+                );
+            if (changed) {
+                requireReloadMessage = 'Changing cargo-watch options requires a reload';
+            }
         }
         this.prevCargoWatchOptions = { ...this.cargoWatchOptions };
 

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -42,6 +42,7 @@ export class Config {
 
     private prevEnhancedTyping: null | boolean = null;
     private prevCargoFeatures: null | CargoFeatures = null;
+    private prevCargoWatchOptions: null | CargoWatchOptions = null;
 
     constructor(ctx: vscode.ExtensionContext) {
         vscode.workspace.onDidChangeConfiguration(_ => this.refresh(), ctx.subscriptions);
@@ -173,6 +174,24 @@ export class Config {
             requireReloadMessage = 'Changing cargo features requires a reload';
         }
         this.prevCargoFeatures = { ...this.cargoFeatures };
+        
+        if (
+            this.prevCargoWatchOptions !== null &&
+            (this.cargoWatchOptions.enable !==
+                this.prevCargoWatchOptions.enable ||
+                this.cargoWatchOptions.command !==
+                this.prevCargoWatchOptions.command ||
+                this.cargoWatchOptions.allTargets !==
+                this.prevCargoWatchOptions.allTargets ||
+                this.cargoWatchOptions.arguments.length !==
+                this.prevCargoWatchOptions.arguments.length ||
+                this.cargoWatchOptions.arguments.some(
+                    (v, i) => v !== this.prevCargoWatchOptions!.arguments[i],
+                ))
+        ) {
+            requireReloadMessage = 'Changing cargo-watch options requires a reload';
+        }
+        this.prevCargoWatchOptions = { ...this.cargoWatchOptions };
 
         if (requireReloadMessage !== null) {
             const reloadAction = 'Reload now';


### PR DESCRIPTION
Currently, changed cargo-watch settings do not go into effect until after a reload.
This PR checks for changed `cargoWatchOptions` in the same way as the current `cargoFeatures` check.

![2020-01-14_20-52-20](https://user-images.githubusercontent.com/6868531/72398362-b5f5a300-3710-11ea-9bc1-9943bef08447.gif)
