### PR TITLE
Use types from vscode-languageclient

### DIFF
--- a/editors/code/rollup.config.js
+++ b/editors/code/rollup.config.js
@@ -13,7 +13,7 @@ export default {
         commonjs({
             namedExports: {
                 // squelch missing import warnings
-                'vscode-languageclient': ['CreateFile', 'RenameFile', 'ErrorCodes']
+                'vscode-languageclient': ['CreateFile', 'RenameFile', 'ErrorCodes', 'WorkDoneProgress', 'WorkDoneProgressBegin', 'WorkDoneProgressReport', 'WorkDoneProgressEnd']
             }
         })
     ],

--- a/editors/code/src/inlay_hints.ts
+++ b/editors/code/src/inlay_hints.ts
@@ -42,7 +42,7 @@ const parameterHintDecorationType = vscode.window.createTextEditorDecorationType
     before: {
         color: new vscode.ThemeColor('rust_analyzer.inlayHint'),
     }
-})
+});
 
 class HintsUpdater {
     private pending: Map<string, vscode.CancellationTokenSource> = new Map();

--- a/editors/code/src/status_display.ts
+++ b/editors/code/src/status_display.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode';
 
+import { WorkDoneProgress, WorkDoneProgressBegin, WorkDoneProgressReport, WorkDoneProgressEnd } from 'vscode-languageclient';
+
 import { Ctx } from './ctx';
 
 const spinnerFrames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
@@ -8,7 +10,7 @@ export function activateStatusDisplay(ctx: Ctx) {
     const statusDisplay = new StatusDisplay(ctx.config.cargoWatchOptions.command);
     ctx.pushCleanup(statusDisplay);
     ctx.onDidRestart(client => {
-        client.onNotification('$/progress', params => statusDisplay.handleProgressNotification(params));
+        client.onProgress(WorkDoneProgress.type, 'rustAnalyzer/cargoWatcher', params => statusDisplay.handleProgressNotification(params));
     });
 }
 
@@ -63,20 +65,15 @@ class StatusDisplay implements vscode.Disposable {
         this.statusBarItem.dispose();
     }
 
-    handleProgressNotification(params: ProgressParams) {
-        const { token, value } = params;
-        if (token !== 'rustAnalyzer/cargoWatcher') {
-            return;
-        }
-
-        switch (value.kind) {
+    handleProgressNotification(params: WorkDoneProgressBegin | WorkDoneProgressReport | WorkDoneProgressEnd) {
+        switch (params.kind) {
             case 'begin':
                 this.show();
                 break;
 
             case 'report':
-                if (value.message) {
-                    this.packageName = value.message;
+                if (params.message) {
+                    this.packageName = params.message;
                 }
                 break;
 
@@ -89,23 +86,4 @@ class StatusDisplay implements vscode.Disposable {
     private frame() {
         return spinnerFrames[(this.i = ++this.i % spinnerFrames.length)];
     }
-}
-
-// FIXME: Replace this once vscode-languageclient is updated to LSP 3.15
-interface ProgressParams {
-    token: string;
-    value: WorkDoneProgress;
-}
-
-enum WorkDoneProgressKind {
-    Begin = 'begin',
-    Report = 'report',
-    End = 'end',
-}
-
-interface WorkDoneProgress {
-    kind: WorkDoneProgressKind;
-    message?: string;
-    cancelable?: boolean;
-    percentage?: string;
 }


### PR DESCRIPTION
Now that we're running with 3.15 of the LSP for VSCode we don't need to define these interfaces ourselves. Yay!