### PR TITLE
Improve parameter hints a bit & add emacs support

### DIFF
--- a/crates/ra_ide/src/display/function_signature.rs
+++ b/crates/ra_ide/src/display/function_signature.rs
@@ -169,9 +169,22 @@ impl From<&'_ ast::FnDef> for FunctionSignature {
                     res.push(self_param.syntax().text().to_string())
                 }
 
-                res.extend(param_list.params().map(|param| {
-                    param.pat().map(|pat| pat.syntax().text().to_string()).unwrap_or_default()
-                }));
+                res.extend(
+                    param_list
+                        .params()
+                        .map(|param| {
+                            Some(
+                                param
+                                    .pat()?
+                                    .syntax()
+                                    .descendants()
+                                    .find_map(ast::Name::cast)?
+                                    .text()
+                                    .to_string(),
+                            )
+                        })
+                        .map(|param| param.unwrap_or_default()),
+                );
             }
             res
         }

--- a/crates/ra_ide/src/inlay_hints.rs
+++ b/crates/ra_ide/src/inlay_hints.rs
@@ -116,7 +116,7 @@ fn get_param_name_hints(
     let hints = parameters
         .zip(args)
         .filter_map(|(param, arg)| {
-            if arg.syntax().kind() == SyntaxKind::LITERAL {
+            if arg.syntax().kind() == SyntaxKind::LITERAL && !param.is_empty() {
                 Some((arg.syntax().text_range(), param))
             } else {
                 None
@@ -683,12 +683,12 @@ fn main() {
 struct Test {}
 
 impl Test {
-    fn method(&self, param: i32) -> i32 {
+    fn method(&self, mut param: i32) -> i32 {
         param * 2
     }
 }
 
-fn test_func(foo: i32, bar: i32, msg: &str, _: i32, last: i32) -> i32 {
+fn test_func(mut foo: i32, bar: i32, msg: &str, _: i32, last: i32) -> i32 {
     foo + bar
 }
 
@@ -704,37 +704,32 @@ fn main() {
         assert_debug_snapshot!(analysis.inlay_hints(file_id, None).unwrap(), @r###"
         [
             InlayHint {
-                range: [207; 218),
+                range: [215; 226),
                 kind: TypeHint,
                 label: "i32",
             },
             InlayHint {
-                range: [251; 252),
+                range: [259; 260),
                 kind: ParameterHint,
                 label: "foo",
             },
             InlayHint {
-                range: [254; 255),
+                range: [262; 263),
                 kind: ParameterHint,
                 label: "bar",
             },
             InlayHint {
-                range: [257; 264),
+                range: [265; 272),
                 kind: ParameterHint,
                 label: "msg",
             },
             InlayHint {
-                range: [266; 267),
-                kind: ParameterHint,
-                label: "_",
-            },
-            InlayHint {
-                range: [323; 326),
+                range: [331; 334),
                 kind: ParameterHint,
                 label: "param",
             },
             InlayHint {
-                range: [350; 354),
+                range: [358; 362),
                 kind: ParameterHint,
                 label: "param",
             },

--- a/editors/emacs/rust-analyzer.el
+++ b/editors/emacs/rust-analyzer.el
@@ -210,9 +210,9 @@
 ;; inlay hints
 (defun rust-analyzer--update-inlay-hints (buffer)
   (if (and (rust-analyzer--initialized?) (eq buffer (current-buffer)))
-    (lsp-send-request-async
-     (lsp-make-request "rust-analyzer/inlayHints"
-                       (list :textDocument (lsp--text-document-identifier)))
+    (lsp-request-async
+     "rust-analyzer/inlayHints"
+     (list :textDocument (lsp--text-document-identifier))
      (lambda (res)
        (remove-overlays (point-min) (point-max) 'rust-analyzer--inlay-hint t)
        (dolist (hint res)
@@ -221,9 +221,16 @@
                  (overlay (make-overlay beg end)))
            (overlay-put overlay 'rust-analyzer--inlay-hint t)
            (overlay-put overlay 'evaporate t)
-           (overlay-put overlay 'after-string (propertize (concat ": " label)
-                                                          'font-lock-face 'font-lock-comment-face)))))
-     'tick))
+           (cond
+            ((string= kind "TypeHint")
+             (overlay-put overlay 'after-string (propertize (concat ": " label)
+                                                            'font-lock-face 'font-lock-comment-face)))
+            ((string= kind "ParameterHint")
+             (overlay-put overlay 'before-string (propertize (concat label ": ")
+                                                            'font-lock-face 'font-lock-comment-face)))
+            )
+           )))
+     :mode 'tick))
   nil)
 
 (defvar-local rust-analyzer--inlay-hints-timer nil)


### PR DESCRIPTION
 - just include the name, not e.g. `mut`
 - don't return empty hints (or `_`)

CC @brotzeit for the Emacs change