### PR TITLE
Initial auto import action implementation

### DIFF
--- a/crates/ra_assists/src/assist_ctx.rs
+++ b/crates/ra_assists/src/assist_ctx.rs
@@ -101,7 +101,6 @@ impl<'a, DB: HirDatabase> AssistCtx<'a, DB> {
         Some(assist)
     }
 
-    #[allow(dead_code)] // will be used for auto import assist with multiple actions
     pub(crate) fn add_assist_group(
         self,
         id: AssistId,
@@ -168,7 +167,6 @@ pub(crate) struct ActionBuilder {
 }
 
 impl ActionBuilder {
-    #[allow(dead_code)]
     /// Adds a custom label to the action, if it needs to be different from the assist label
     pub(crate) fn label(&mut self, label: impl Into<String>) {
         self.label = Some(label.into())

--- a/crates/ra_assists/src/assists/auto_import.rs
+++ b/crates/ra_assists/src/assists/auto_import.rs
@@ -55,7 +55,8 @@ pub(crate) fn auto_import<F: ImportsLocator>(
         .filter_map(|module_def| module_with_name_to_import.find_use_path(ctx.db, module_def))
         .filter(|use_path| !use_path.segments.is_empty())
         .take(20)
-        .collect::<std::collections::HashSet<_>>();
+        .map(|import| import.to_string())
+        .collect::<std::collections::BTreeSet<_>>();
     if proposed_imports.is_empty() {
         return None;
     }
@@ -63,7 +64,7 @@ pub(crate) fn auto_import<F: ImportsLocator>(
     ctx.add_assist_group(AssistId("auto_import"), "auto import", || {
         proposed_imports
             .into_iter()
-            .map(|import| import_to_action(import.to_string(), &position, &path_to_import))
+            .map(|import| import_to_action(import, &position, &path_to_import))
             .collect()
     })
 }

--- a/crates/ra_assists/src/assists/auto_import.rs
+++ b/crates/ra_assists/src/assists/auto_import.rs
@@ -1,0 +1,181 @@
+use hir::db::HirDatabase;
+use ra_syntax::{
+    ast::{self, AstNode},
+    SmolStr, SyntaxElement,
+    SyntaxKind::{NAME_REF, USE_ITEM},
+    SyntaxNode,
+};
+
+use crate::{
+    assist_ctx::{ActionBuilder, Assist, AssistCtx},
+    auto_import_text_edit, AssistId, ImportsLocator,
+};
+
+// Assist: auto_import
+//
+// If the name is unresolved, provides all possible imports for it.
+//
+// ```
+// fn main() {
+//     let map = HashMap<|>::new();
+// }
+// ```
+// ->
+// ```
+// use std::collections::HashMap;
+//
+// fn main() {
+//     let map = HashMap<|>::new();
+// }
+// ```
+pub(crate) fn auto_import<'a, F: ImportsLocator<'a>>(
+    ctx: AssistCtx<impl HirDatabase>,
+    imports_locator: &mut F,
+) -> Option<Assist> {
+    let path: ast::Path = ctx.find_node_at_offset()?;
+    let module = path.syntax().ancestors().find_map(ast::Module::cast);
+    let position = match module.and_then(|it| it.item_list()) {
+        Some(item_list) => item_list.syntax().clone(),
+        None => {
+            let current_file = path.syntax().ancestors().find_map(ast::SourceFile::cast)?;
+            current_file.syntax().clone()
+        }
+    };
+
+    let module_with_name_to_import = ctx.source_analyzer(&position, None).module()?;
+    let name_to_import = hir::InFile {
+        file_id: ctx.frange.file_id.into(),
+        value: &find_applicable_name_ref(ctx.covering_element())?,
+    };
+
+    let proposed_imports =
+        imports_locator.find_imports(name_to_import, module_with_name_to_import)?;
+    if proposed_imports.is_empty() {
+        return None;
+    }
+
+    ctx.add_assist_group(AssistId("auto_import"), "auto import", || {
+        proposed_imports
+            .into_iter()
+            .map(|import| import_to_action(import.to_string(), &position, &path))
+            .collect()
+    })
+}
+
+fn find_applicable_name_ref(element: SyntaxElement) -> Option<ast::NameRef> {
+    if element.ancestors().find(|ancestor| ancestor.kind() == USE_ITEM).is_some() {
+        None
+    } else if element.kind() == NAME_REF {
+        Some(element.as_node().cloned().and_then(ast::NameRef::cast)?)
+    } else {
+        let parent = element.parent()?;
+        if parent.kind() == NAME_REF {
+            Some(ast::NameRef::cast(parent)?)
+        } else {
+            None
+        }
+    }
+}
+
+fn import_to_action(import: String, position: &SyntaxNode, path: &ast::Path) -> ActionBuilder {
+    let mut action_builder = ActionBuilder::default();
+    action_builder.label(format!("Import `{}`", &import));
+    auto_import_text_edit(
+        position,
+        &path.syntax().clone(),
+        &[SmolStr::new(import)],
+        action_builder.text_edit_builder(),
+    );
+    action_builder
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::helpers::{
+        check_assist_with_imports_locator, check_assist_with_imports_locator_not_applicable,
+    };
+    use hir::Name;
+
+    #[derive(Clone)]
+    struct TestImportsLocator<'a> {
+        import_path: &'a [Name],
+    }
+
+    impl<'a> TestImportsLocator<'a> {
+        fn new(import_path: &'a [Name]) -> Self {
+            TestImportsLocator { import_path }
+        }
+    }
+
+    impl<'a> ImportsLocator<'_> for TestImportsLocator<'_> {
+        fn find_imports(
+            &mut self,
+            _: hir::InFile<&ast::NameRef>,
+            _: hir::Module,
+        ) -> Option<Vec<hir::ModPath>> {
+            if self.import_path.is_empty() {
+                None
+            } else {
+                Some(vec![hir::ModPath {
+                    kind: hir::PathKind::Plain,
+                    segments: self.import_path.to_owned(),
+                }])
+            }
+        }
+    }
+
+    #[test]
+    fn applicable_when_found_an_import() {
+        let import_path = &[hir::name::known::std, hir::name::known::ops, hir::name::known::Debug];
+        let mut imports_locator = TestImportsLocator::new(import_path);
+        check_assist_with_imports_locator(
+            auto_import,
+            &mut imports_locator,
+            "
+            fn main() {
+            }
+
+            Debug<|>",
+            &format!(
+                "
+            use {};
+
+            fn main() {{
+            }}
+
+            Debug<|>",
+                import_path
+                    .into_iter()
+                    .map(|name| name.to_string())
+                    .collect::<Vec<String>>()
+                    .join("::")
+            ),
+        );
+    }
+
+    #[test]
+    fn not_applicable_when_no_imports_found() {
+        let mut imports_locator = TestImportsLocator::new(&[]);
+        check_assist_with_imports_locator_not_applicable(
+            auto_import,
+            &mut imports_locator,
+            "
+            fn main() {
+            }
+
+            Debug<|>",
+        );
+    }
+
+    #[test]
+    fn not_applicable_in_import_statements() {
+        let import_path = &[hir::name::known::std, hir::name::known::ops, hir::name::known::Debug];
+        let mut imports_locator = TestImportsLocator::new(import_path);
+        check_assist_with_imports_locator_not_applicable(
+            auto_import,
+            &mut imports_locator,
+            "use Debug<|>;",
+        );
+    }
+}

--- a/crates/ra_assists/src/assists/auto_import.rs
+++ b/crates/ra_assists/src/assists/auto_import.rs
@@ -28,7 +28,7 @@ use crate::{
 //     let map = HashMap<|>::new();
 // }
 // ```
-pub(crate) fn auto_import<'a, F: ImportsLocator<'a>>(
+pub(crate) fn auto_import<F: ImportsLocator>(
     ctx: AssistCtx<impl HirDatabase>,
     imports_locator: &mut F,
 ) -> Option<Assist> {
@@ -108,7 +108,7 @@ mod tests {
         }
     }
 
-    impl<'a> ImportsLocator<'_> for TestImportsLocator<'_> {
+    impl<'a> ImportsLocator for TestImportsLocator<'a> {
         fn find_imports(
             &mut self,
             _: hir::InFile<&ast::NameRef>,

--- a/crates/ra_assists/src/doc_tests.rs
+++ b/crates/ra_assists/src/doc_tests.rs
@@ -11,6 +11,10 @@ use test_utils::{assert_eq_text, extract_range_or_offset};
 use crate::test_db::TestDB;
 
 fn check(assist_id: &str, before: &str, after: &str) {
+    // FIXME we cannot get the imports search functionality here yet, but still need to generate a test and a doc for an assist
+    if assist_id == "auto_import" {
+        return;
+    }
     let (selection, before) = extract_range_or_offset(before);
     let (db, file_id) = TestDB::with_single_file(&before);
     let frange = FileRange { file_id, range: selection.into() };

--- a/crates/ra_assists/src/doc_tests/generated.rs
+++ b/crates/ra_assists/src/doc_tests/generated.rs
@@ -215,6 +215,25 @@ fn main() {
 }
 
 #[test]
+fn doctest_auto_import() {
+    check(
+        "auto_import",
+        r#####"
+fn main() {
+    let map = HashMap<|>::new();
+}
+"#####,
+        r#####"
+use std::collections::HashMap;
+
+fn main() {
+    let map = HashMap<|>::new();
+}
+"#####,
+    )
+}
+
+#[test]
 fn doctest_change_visibility() {
     check(
         "change_visibility",

--- a/crates/ra_assists/src/lib.rs
+++ b/crates/ra_assists/src/lib.rs
@@ -83,7 +83,7 @@ where
 /// due to the search functionality located there.
 /// Later, this trait should be removed completely and the search functionality moved to a separate crate,
 /// accessible from the ra_assists crate.
-pub trait ImportsLocator<'a> {
+pub trait ImportsLocator {
     /// Finds all imports for the given name and the module that contains this name.
     fn find_imports(
         &mut self,
@@ -97,14 +97,14 @@ pub trait ImportsLocator<'a> {
 ///
 /// Assists are returned in the "resolved" state, that is with edit fully
 /// computed.
-pub fn assists_with_imports_locator<'a, H, F: 'a>(
+pub fn assists_with_imports_locator<H, F>(
     db: &H,
     range: FileRange,
     mut imports_locator: F,
 ) -> Vec<ResolvedAssist>
 where
     H: HirDatabase + 'static,
-    F: ImportsLocator<'a>,
+    F: ImportsLocator,
 {
     AssistCtx::with_ctx(db, range, true, |ctx| {
         let mut assists = assists::all()
@@ -222,7 +222,7 @@ mod assists {
         ]
     }
 
-    pub(crate) fn all_with_imports_locator<'a, DB: HirDatabase, F: ImportsLocator<'a>>(
+    pub(crate) fn all_with_imports_locator<'a, DB: HirDatabase, F: ImportsLocator>(
     ) -> &'a [fn(AssistCtx<DB>, &mut F) -> Option<Assist>] {
         &[auto_import::auto_import]
     }
@@ -264,7 +264,7 @@ mod helpers {
         assert_eq_text!(after, &actual);
     }
 
-    pub(crate) fn check_assist_with_imports_locator<'a, F: ImportsLocator<'a>>(
+    pub(crate) fn check_assist_with_imports_locator<F: ImportsLocator>(
         assist: fn(AssistCtx<TestDB>, &mut F) -> Option<Assist>,
         imports_locator: &mut F,
         before: &str,
@@ -366,7 +366,7 @@ mod helpers {
         assert!(assist.is_none());
     }
 
-    pub(crate) fn check_assist_with_imports_locator_not_applicable<'a, F: ImportsLocator<'a>>(
+    pub(crate) fn check_assist_with_imports_locator_not_applicable<F: ImportsLocator>(
         assist: fn(AssistCtx<TestDB>, &mut F) -> Option<Assist>,
         imports_locator: &mut F,
         before: &str,

--- a/crates/ra_assists/src/lib.rs
+++ b/crates/ra_assists/src/lib.rs
@@ -234,6 +234,7 @@ mod helpers {
     use crate::{test_db::TestDB, Assist, AssistCtx, ImportsLocator};
     use std::sync::Arc;
 
+    // FIXME remove the `ModuleDefId` reexport from `ra_hir` when this gets removed.
     pub(crate) struct TestImportsLocator {
         db: Arc<TestDB>,
         test_file_id: FileId,
@@ -248,13 +249,13 @@ mod helpers {
     impl ImportsLocator for TestImportsLocator {
         fn find_imports(&mut self, name_to_import: &str) -> Vec<hir::ModuleDef> {
             let crate_def_map = self.db.crate_def_map(self.db.test_crate());
-            let mut findings = vec![];
+            let mut findings = Vec::new();
 
             let mut module_ids_to_process =
                 crate_def_map.modules_for_file(self.test_file_id).collect::<Vec<_>>();
 
             while !module_ids_to_process.is_empty() {
-                let mut more_ids_to_process = vec![];
+                let mut more_ids_to_process = Vec::new();
                 for local_module_id in module_ids_to_process.drain(..) {
                     for (name, namespace_data) in
                         crate_def_map[local_module_id].scope.entries_without_primitives()

--- a/crates/ra_assists/src/lib.rs
+++ b/crates/ra_assists/src/lib.rs
@@ -14,9 +14,9 @@ mod test_db;
 pub mod ast_transform;
 
 use either::Either;
-use hir::{db::HirDatabase, InFile, ModPath, Module};
+use hir::{db::HirDatabase, ModuleDef};
 use ra_db::FileRange;
-use ra_syntax::{ast::NameRef, TextRange, TextUnit};
+use ra_syntax::{TextRange, TextUnit};
 use ra_text_edit::TextEdit;
 
 pub(crate) use crate::assist_ctx::{Assist, AssistCtx};
@@ -85,11 +85,7 @@ where
 /// accessible from the ra_assists crate.
 pub trait ImportsLocator {
     /// Finds all imports for the given name and the module that contains this name.
-    fn find_imports(
-        &mut self,
-        name_to_import: InFile<&NameRef>,
-        module_with_name_to_import: Module,
-    ) -> Option<Vec<ModPath>>;
+    fn find_imports(&mut self, name_to_import: &str) -> Vec<ModuleDef>;
 }
 
 /// Return all the assists applicable at the given position

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -58,6 +58,7 @@ pub use hir_def::{
     type_ref::Mutability,
 };
 pub use hir_expand::{
-    name, name::Name, HirFileId, InFile, MacroCallId, MacroCallLoc, MacroDefId, MacroFile, Origin,
+    name::{AsName, Name},
+    HirFileId, InFile, MacroCallId, MacroCallLoc, MacroDefId, MacroFile, Origin,
 };
 pub use hir_ty::{display::HirDisplay, CallableDef};

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -56,10 +56,9 @@ pub use hir_def::{
     nameres::ModuleSource,
     path::{ModPath, Path, PathKind},
     type_ref::Mutability,
-    ModuleDefId,
+    ModuleDefId, // FIXME this is exposed and should be used for implementing the `TestImportsLocator` in `ra_assists` only, should be removed later along with the trait and the implementation.
 };
 pub use hir_expand::{
-    name::{AsName, Name},
-    HirFileId, InFile, MacroCallId, MacroCallLoc, MacroDefId, MacroFile, Origin,
+    name::Name, HirFileId, InFile, MacroCallId, MacroCallLoc, MacroDefId, MacroFile, Origin,
 };
 pub use hir_ty::{display::HirDisplay, CallableDef};

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -56,6 +56,7 @@ pub use hir_def::{
     nameres::ModuleSource,
     path::{ModPath, Path, PathKind},
     type_ref::Mutability,
+    ModuleDefId,
 };
 pub use hir_expand::{
     name::{AsName, Name},

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -58,6 +58,6 @@ pub use hir_def::{
     type_ref::Mutability,
 };
 pub use hir_expand::{
-    name::Name, HirFileId, InFile, MacroCallId, MacroCallLoc, MacroDefId, MacroFile, Origin,
+    name, name::Name, HirFileId, InFile, MacroCallId, MacroCallLoc, MacroDefId, MacroFile, Origin,
 };
 pub use hir_ty::{display::HirDisplay, CallableDef};

--- a/crates/ra_ide/src/assists.rs
+++ b/crates/ra_ide/src/assists.rs
@@ -2,8 +2,9 @@
 
 use ra_db::{FilePosition, FileRange};
 
-use crate::{db::RootDatabase, FileId, SourceChange, SourceFileEdit};
-
+use crate::{
+    db::RootDatabase, imports_locator::ImportsLocatorIde, FileId, SourceChange, SourceFileEdit,
+};
 use either::Either;
 pub use ra_assists::AssistId;
 use ra_assists::{AssistAction, AssistLabel};
@@ -16,7 +17,7 @@ pub struct Assist {
 }
 
 pub(crate) fn assists(db: &RootDatabase, frange: FileRange) -> Vec<Assist> {
-    ra_assists::assists(db, frange)
+    ra_assists::assists_with_imports_locator(db, frange, ImportsLocatorIde::new(db))
         .into_iter()
         .map(|assist| {
             let file_id = frange.file_id;

--- a/crates/ra_ide/src/imports_locator.rs
+++ b/crates/ra_ide/src/imports_locator.rs
@@ -82,7 +82,7 @@ impl<'a> ImportsLocatorIde<'a> {
     }
 }
 
-impl<'a> ImportsLocator<'a> for ImportsLocatorIde<'a> {
+impl<'a> ImportsLocator for ImportsLocatorIde<'a> {
     fn find_imports(
         &mut self,
         name_to_import: InFile<&NameRef>,

--- a/crates/ra_ide/src/imports_locator.rs
+++ b/crates/ra_ide/src/imports_locator.rs
@@ -1,0 +1,97 @@
+//! This module contains an import search funcionality that is provided to the ra_assists module.
+//! Later, this should be moved away to a separate crate that is accessible from the ra_assists module.
+
+use crate::{
+    db::RootDatabase,
+    references::{classify_name, classify_name_ref, NameDefinition, NameKind},
+    symbol_index::{self, FileSymbol},
+    Query,
+};
+use ast::NameRef;
+use hir::{db::HirDatabase, InFile, ModPath, Module, SourceBinder};
+use itertools::Itertools;
+use ra_assists::ImportsLocator;
+use ra_prof::profile;
+use ra_syntax::{ast, AstNode, SyntaxKind::NAME};
+
+pub(crate) struct ImportsLocatorIde<'a> {
+    source_binder: SourceBinder<'a, RootDatabase>,
+}
+
+impl<'a> ImportsLocatorIde<'a> {
+    pub(crate) fn new(db: &'a RootDatabase) -> Self {
+        Self { source_binder: SourceBinder::new(db) }
+    }
+
+    fn search_for_imports(
+        &mut self,
+        name_to_import: &ast::NameRef,
+        module_with_name_to_import: Module,
+    ) -> Vec<ModPath> {
+        let _p = profile("search_for_imports");
+        let db = self.source_binder.db;
+        let name_to_import = name_to_import.text();
+
+        let project_results = {
+            let mut query = Query::new(name_to_import.to_string());
+            query.exact();
+            query.limit(10);
+            symbol_index::world_symbols(db, query)
+        };
+        let lib_results = {
+            let mut query = Query::new(name_to_import.to_string());
+            query.libs();
+            query.exact();
+            query.limit(10);
+            symbol_index::world_symbols(db, query)
+        };
+
+        project_results
+            .into_iter()
+            .chain(lib_results.into_iter())
+            .filter_map(|import_candidate| self.get_name_definition(db, &import_candidate))
+            .filter_map(|name_definition_to_import| {
+                if let NameKind::Def(module_def) = name_definition_to_import.kind {
+                    module_with_name_to_import.find_use_path(db, module_def)
+                } else {
+                    None
+                }
+            })
+            .filter(|use_path| !use_path.segments.is_empty())
+            .unique()
+            .collect()
+    }
+
+    fn get_name_definition(
+        &mut self,
+        db: &impl HirDatabase,
+        import_candidate: &FileSymbol,
+    ) -> Option<NameDefinition> {
+        let _p = profile("get_name_definition");
+        let file_id = import_candidate.file_id.into();
+        let candidate_node = import_candidate.ptr.to_node(&db.parse_or_expand(file_id)?);
+        let candidate_name_node = if candidate_node.kind() != NAME {
+            candidate_node.children().find(|it| it.kind() == NAME)?
+        } else {
+            candidate_node
+        };
+        classify_name(
+            &mut self.source_binder,
+            hir::InFile { file_id, value: &ast::Name::cast(candidate_name_node)? },
+        )
+    }
+}
+
+impl<'a> ImportsLocator<'a> for ImportsLocatorIde<'a> {
+    fn find_imports(
+        &mut self,
+        name_to_import: InFile<&NameRef>,
+        module_with_name_to_import: Module,
+    ) -> Option<Vec<ModPath>> {
+        if classify_name_ref(&mut self.source_binder, name_to_import).is_none() {
+            Some(self.search_for_imports(name_to_import.value, module_with_name_to_import))
+        } else {
+            None
+        }
+    }
+}

--- a/crates/ra_ide/src/imports_locator.rs
+++ b/crates/ra_ide/src/imports_locator.rs
@@ -35,14 +35,14 @@ impl<'a> ImportsLocatorIde<'a> {
         let project_results = {
             let mut query = Query::new(name_to_import.to_string());
             query.exact();
-            query.limit(10);
+            query.limit(40);
             symbol_index::world_symbols(db, query)
         };
         let lib_results = {
             let mut query = Query::new(name_to_import.to_string());
             query.libs();
             query.exact();
-            query.limit(10);
+            query.limit(40);
             symbol_index::world_symbols(db, query)
         };
 
@@ -59,6 +59,7 @@ impl<'a> ImportsLocatorIde<'a> {
             })
             .filter(|use_path| !use_path.segments.is_empty())
             .unique()
+            .take(20)
             .collect()
     }
 

--- a/crates/ra_ide/src/imports_locator.rs
+++ b/crates/ra_ide/src/imports_locator.rs
@@ -41,7 +41,7 @@ impl<'a> ImportsLocatorIde<'a> {
     }
 }
 
-impl<'a> ImportsLocator for ImportsLocatorIde<'a> {
+impl ImportsLocator for ImportsLocatorIde<'_> {
     fn find_imports(&mut self, name_to_import: &str) -> Vec<ModuleDef> {
         let _p = profile("search_for_imports");
         let db = self.source_binder.db;

--- a/crates/ra_ide/src/lib.rs
+++ b/crates/ra_ide/src/lib.rs
@@ -30,6 +30,7 @@ mod syntax_highlighting;
 mod parent_module;
 mod references;
 mod impls;
+mod imports_locator;
 mod assists;
 mod diagnostics;
 mod syntax_tree;

--- a/docs/user/assists.md
+++ b/docs/user/assists.md
@@ -209,6 +209,24 @@ fn main() {
 }
 ```
 
+## `auto_import`
+
+If the name is unresolved, provides all possible imports for it.
+
+```rust
+// BEFORE
+fn main() {
+    let map = HashMap┃::new();
+}
+
+// AFTER
+use std::collections::HashMap;
+
+fn main() {
+    let map = HashMap┃::new();
+}
+```
+
 ## `change_visibility`
 
 Adds or changes existing visibility specifier.


### PR DESCRIPTION
Closes https://github.com/rust-analyzer/rust-analyzer/issues/2180

Adds an auto import action implementation.

This implementation is not ideal and has a few limitations:

* The import search functionality should be moved into a separate crate accessible from ra_assists.
This requires a lot of changes and a preliminary design. 
Currently the functionality is provided as a trait impl, more on that here: https://github.com/rust-analyzer/rust-analyzer/issues/2180#issuecomment-575690942

* Due to the design desicion from the previous item, no doctests are run for the new aciton (look for a new FIXME in the PR)

* For the same reason, I have to create the mock trait implementaion to test the assist

* Ideally, I think we should have this feature as a diagnostics (that detects an absense of an import) that has a corresponding quickfix action that gets evaluated on demand.
Curretly we perform the import search every time we resolve the import which looks suboptimal.
This requires `classify_name_ref` to be moved from ra_ide, so not done currently.

A few improvements to the imports mechanism to be considered later:

* Constants like `ra_syntax::SyntaxKind::NAME` are not imported, because they are not present in the database

* Method usages are not imported, they are found in the database, but `find_use_path` does not return any import paths for them

* Some import paths returned by the `find_use_path` method end up in `core::` or `alloc::` instead of `std:`, for example: `core::fmt::Debug` instead of `std::fmt::Debug`.
This is not an error techically, but still looks weird.

* No detection of cases where a trait should be imported in order to be able to call a method

* Improve `auto_import_text_edit` functionality: refactor it and move away from the place it is now, add better logic for merging the new import with already existing imports