### PR TITLE
ra_syntax: removed code duplication and token reevaluation

### DIFF
--- a/crates/ra_parser/src/lib.rs
+++ b/crates/ra_parser/src/lib.rs
@@ -27,7 +27,7 @@ pub use syntax_kind::SyntaxKind;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ParseError(pub String);
 
-/// `TokenSource` abstracts the source of the tokens parser operates one.
+/// `TokenSource` abstracts the source of the tokens parser operates on.
 ///
 /// Hopefully this will allow us to treat text and token trees in the same way!
 pub trait TokenSource {
@@ -43,7 +43,7 @@ pub trait TokenSource {
     fn is_keyword(&self, kw: &str) -> bool;
 }
 
-/// `TokenCursor` abstracts the cursor of `TokenSource` operates one.
+/// `Token` abstracts the cursor of `TokenSource` operates on.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Token {
     /// What is the current token?

--- a/crates/ra_syntax/src/ast/expr_extensions.rs
+++ b/crates/ra_syntax/src/ast/expr_extensions.rs
@@ -322,7 +322,7 @@ impl ast::Literal {
 
         match token.kind() {
             INT_NUMBER => {
-                // FYI: there was a bug here previously, thus an if statement here is necessary.
+                // FYI: there was a bug here previously, thus an if statement bellow is necessary.
                 // The lexer treats e.g. `1f64` as an integer literal. See
                 // https://github.com/rust-analyzer/rust-analyzer/issues/1592
                 // and the comments on the linked PR.

--- a/crates/ra_syntax/src/ast/expr_extensions.rs
+++ b/crates/ra_syntax/src/ast/expr_extensions.rs
@@ -322,6 +322,11 @@ impl ast::Literal {
 
         match token.kind() {
             INT_NUMBER => {
+                // FYI: there was a bug here previously, thus an if statement here is necessary.
+                // The lexer treated e.g. `1f64` as an integer literal. See
+                // https://github.com/rust-analyzer/rust-analyzer/issues/1592
+                // and the comments on the linked PR.
+
                 let text = token.text();
 
                 if let suffix @ Some(_) = Self::find_suffix(&text, &FLOAT_SUFFIXES) {

--- a/crates/ra_syntax/src/ast/expr_extensions.rs
+++ b/crates/ra_syntax/src/ast/expr_extensions.rs
@@ -323,7 +323,7 @@ impl ast::Literal {
         match token.kind() {
             INT_NUMBER => {
                 // FYI: there was a bug here previously, thus an if statement here is necessary.
-                // The lexer treated e.g. `1f64` as an integer literal. See
+                // The lexer treats e.g. `1f64` as an integer literal. See
                 // https://github.com/rust-analyzer/rust-analyzer/issues/1592
                 // and the comments on the linked PR.
 

--- a/crates/ra_syntax/src/ast/expr_extensions.rs
+++ b/crates/ra_syntax/src/ast/expr_extensions.rs
@@ -305,44 +305,34 @@ impl ast::Literal {
             .unwrap()
     }
 
+    fn find_suffix(text: &str, possible_suffixes: &[&str]) -> Option<SmolStr> {
+        possible_suffixes
+            .iter()
+            .find(|&suffix| text.ends_with(suffix))
+            .map(|&suffix| SmolStr::new(suffix))
+    }
+
     pub fn kind(&self) -> LiteralKind {
-        match self.token().kind() {
+        const INT_SUFFIXES: [&'static str; 12] = [
+            "u64", "u32", "u16", "u8", "usize", "isize", "i64", "i32", "i16", "i8", "u128", "i128",
+        ];
+        const FLOAT_SUFFIXES: [&'static str; 2] = ["f32", "f64"];
+
+        let token = self.token();
+
+        match token.kind() {
             INT_NUMBER => {
-                let int_suffix_list = [
-                    "isize", "i128", "i64", "i32", "i16", "i8", "usize", "u128", "u64", "u32",
-                    "u16", "u8",
-                ];
+                let text = token.text();
 
-                // The lexer treats e.g. `1f64` as an integer literal. See
-                // https://github.com/rust-analyzer/rust-analyzer/issues/1592
-                // and the comments on the linked PR.
-                let float_suffix_list = ["f32", "f64"];
-
-                let text = self.token().text().to_string();
-
-                let float_suffix = float_suffix_list
-                    .iter()
-                    .find(|&s| text.ends_with(s))
-                    .map(|&suf| SmolStr::new(suf));
-
-                if float_suffix.is_some() {
-                    LiteralKind::FloatNumber { suffix: float_suffix }
+                if let suffix @ Some(_) = Self::find_suffix(&text, &FLOAT_SUFFIXES) {
+                    LiteralKind::FloatNumber { suffix }
                 } else {
-                    let suffix = int_suffix_list
-                        .iter()
-                        .find(|&s| text.ends_with(s))
-                        .map(|&suf| SmolStr::new(suf));
-                    LiteralKind::IntNumber { suffix }
+                    LiteralKind::IntNumber { suffix: Self::find_suffix(&text, &INT_SUFFIXES) }
                 }
             }
             FLOAT_NUMBER => {
-                let allowed_suffix_list = ["f64", "f32"];
-                let text = self.token().text().to_string();
-                let suffix = allowed_suffix_list
-                    .iter()
-                    .find(|&s| text.ends_with(s))
-                    .map(|&suf| SmolStr::new(suf));
-                LiteralKind::FloatNumber { suffix }
+                let text = token.text();
+                LiteralKind::FloatNumber { suffix: Self::find_suffix(&text, &FLOAT_SUFFIXES) }
             }
             STRING | RAW_STRING => LiteralKind::String,
             T![true] | T![false] => LiteralKind::Bool,


### PR DESCRIPTION
Just a small refactoring along the way of reading the codebase