### PR TITLE
Remove RWLock from check watcher.

### DIFF
--- a/crates/ra_cargo_watch/src/conv.rs
+++ b/crates/ra_cargo_watch/src/conv.rs
@@ -117,7 +117,7 @@ fn is_deprecated(rd: &RustDiagnostic) -> bool {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SuggestedFix {
     pub title: String,
     pub location: Location,

--- a/crates/ra_lsp_server/src/main_loop/handlers.rs
+++ b/crates/ra_lsp_server/src/main_loop/handlers.rs
@@ -674,8 +674,7 @@ pub fn handle_code_action(
         res.push(action.into());
     }
 
-    for fix in world.check_watcher.read().fixes_for(&params.text_document.uri).into_iter().flatten()
-    {
+    for fix in world.check_watcher.fixes_for(&params.text_document.uri).into_iter().flatten() {
         let fix_range = fix.location.range.conv_with(&line_index);
         if fix_range.intersection(&range).is_none() {
             continue;
@@ -895,7 +894,7 @@ pub fn publish_diagnostics(
             tags: None,
         })
         .collect();
-    if let Some(check_diags) = world.check_watcher.read().diagnostics_for(&uri) {
+    if let Some(check_diags) = world.check_watcher.diagnostics_for(&uri) {
         diagnostics.extend(check_diags.iter().cloned());
     }
     Ok(req::PublishDiagnosticsParams { uri, diagnostics, version: None })

--- a/crates/ra_lsp_server/src/world.rs
+++ b/crates/ra_lsp_server/src/world.rs
@@ -63,7 +63,7 @@ pub struct WorldSnapshot {
     pub workspaces: Arc<Vec<ProjectWorkspace>>,
     pub analysis: Analysis,
     pub latest_requests: Arc<RwLock<LatestRequests>>,
-    pub check_watcher: Arc<RwLock<CheckState>>,
+    pub check_watcher: CheckState,
     vfs: Arc<RwLock<Vfs>>,
 }
 
@@ -220,7 +220,7 @@ impl WorldState {
             analysis: self.analysis_host.analysis(),
             vfs: Arc::clone(&self.vfs),
             latest_requests: Arc::clone(&self.latest_requests),
-            check_watcher: self.check_watcher.state.clone(),
+            check_watcher: (*self.check_watcher.state).clone(),
         }
     }
 


### PR DESCRIPTION
@matklad mentioned this might be a good idea.

So the general idea is that we don't really need the lock, as we can
just clone the check watcher state when creating a snapshot. We can then
use `Arc::get_mut` to get mutable access to the state from `WorldState`
when needed.

Running with this it seems to improve responsiveness a bit while cargo
is running, but I have no hard numbers to prove it. In any case, a
serialization point less is always better when we're trying to be
responsive.