### PR TITLE
Buffer reads from cargo check's stdout

### DIFF
--- a/crates/ra_cargo_watch/src/lib.rs
+++ b/crates/ra_cargo_watch/src/lib.rs
@@ -9,6 +9,7 @@ use lsp_types::{
 };
 use std::{
     collections::HashMap,
+    io::BufReader,
     path::PathBuf,
     process::{Command, Stdio},
     sync::Arc,
@@ -347,7 +348,9 @@ impl WatchThread {
             // which will break out of the loop, and continue the shutdown
             let _ = message_send.send(CheckEvent::Begin);
 
-            for message in cargo_metadata::parse_messages(command.stdout.take().unwrap()) {
+            for message in
+                cargo_metadata::parse_messages(BufReader::new(command.stdout.take().unwrap()))
+            {
                 let message = match message {
                     Ok(message) => message,
                     Err(err) => {


### PR DESCRIPTION
`Stdio::piped()` is unbuffered, which caused RA to read the output of `cargo check` one byte at a time (out of 114KB in my test).

This isn't obviously faster on my system, but making fewer syscalls sounds like a good idea.