### PR TITLE
Don't do check progress update for fresh crates

### DIFF
--- a/crates/ra_cargo_watch/src/lib.rs
+++ b/crates/ra_cargo_watch/src/lib.rs
@@ -359,6 +359,14 @@ impl WatchThread {
                     }
                 };
 
+                // Skip certain kinds of messages to only spend time on what's useful
+                match &message {
+                    Message::CompilerArtifact(artifact) if artifact.fresh => continue,
+                    Message::BuildScriptExecuted(_) => continue,
+                    Message::Unknown => continue,
+                    _ => {}
+                }
+
                 match message_send.send(CheckEvent::Msg(message)) {
                     Ok(()) => {}
                     Err(_err) => {


### PR DESCRIPTION
Skip sending progress updates for crates that aren't getting checked.