### PR TITLE
Modify ordering of drops in check watcher to only ever have one cargo

### DIFF
--- a/crates/ra_cargo_watch/src/lib.rs
+++ b/crates/ra_cargo_watch/src/lib.rs
@@ -216,8 +216,10 @@ impl CheckWatcherThread {
                 self.last_update_req.take();
                 task_send.send(CheckTask::ClearDiagnostics).unwrap();
 
-                // By replacing the watcher, we drop the previous one which
-                // causes it to shut down automatically.
+                // Replace with a dummy watcher first so we drop the original and wait for completion
+                std::mem::replace(&mut self.watcher, WatchThread::dummy());
+
+                // Then create the actual new watcher
                 self.watcher = WatchThread::new(&self.options, &self.workspace_root);
             }
         }


### PR DESCRIPTION
Due to the way drops are ordered when assigning to a mutable variable we
were launching a new cargo sub-process before letting the old one quite.

By explicitly replacing the original watcher with a dummy first, we
ensure it is dropped and the process is completed, before we start the
new process.