### PR TITLE
Parse cargo output a line at a time.

### DIFF
--- a/crates/ra_cargo_watch/Cargo.toml
+++ b/crates/ra_cargo_watch/Cargo.toml
@@ -11,6 +11,7 @@ log = "0.4.3"
 cargo_metadata = "0.9.1"
 jod-thread = "0.1.0"
 parking_lot = "0.10.0"
+serde_json = "1.0.45"
 
 [dev-dependencies]
 insta = "0.13.0"

--- a/crates/ra_cargo_watch/src/lib.rs
+++ b/crates/ra_cargo_watch/src/lib.rs
@@ -363,7 +363,7 @@ impl WatchThread {
                 let line = match line {
                     Ok(line) => line,
                     Err(err) => {
-                        log::error!("Couldn't read line from cargo: {:?}", err);
+                        log::error!("Couldn't read line from cargo: {}", err);
                         continue;
                     }
                 };
@@ -372,7 +372,11 @@ impl WatchThread {
                 let message = match message {
                     Ok(message) => message,
                     Err(err) => {
-                        log::error!("Invalid json from cargo check, ignoring ({}): {} ", err, line);
+                        log::error!(
+                            "Invalid json from cargo check, ignoring ({}): {:?} ",
+                            err,
+                            line
+                        );
                         continue;
                     }
                 };


### PR DESCRIPTION
We previously used serde's stream deserializer to read json blobs from
the cargo output. It has an issue though: If the deserializer encounters
invalid input, it gets stuck reporting the same error again and again
because it is unable to foward over the input until it reaches a new
valid object.

Reading a line at a time and manually deserializing fixes this issue,
because cargo makes sure to only outpu one json blob per line, so should
we encounter invalid input, we can just skip a line and continue.

The main reason this would happen is stray printf-debugging in
procedural macros, so we still report that an error occured, but we
handle it gracefully now.

Fixes #2935