### PR TITLE
Disable enhanced typing by default

### DIFF
--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -18,7 +18,7 @@ export interface CargoFeatures {
 export class Config {
     highlightingOn = true;
     rainbowHighlightingOn = false;
-    enableEnhancedTyping = true;
+    enableEnhancedTyping = false;
     raLspServerPath = RA_LSP_DEBUG || 'ra_lsp_server';
     lruCapacity: null | number = null;
     displayInlayHints = true;


### PR DESCRIPTION
Enhanced typing makes typing laggy. Disable this feature until that is fixed. See #2331.