### PR TITLE
xtask: added handy scripts for inserting and removing test data files

### DIFF
--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -110,11 +110,9 @@ pub fn remove_test(test_path_relative_to_crates: &str) -> Result<()> {
     let (rm_test_path, test_dir, test_id) = parse_test_path(test_path_relative_to_crates)?;
 
     prompt_confirm(&format!("Going to remove file {:?}", &rm_test_path));
-
     fs::remove_file(rm_test_path)?;
 
     prompt_confirm(&format!("Going to decrease test ids in {:?}", &test_dir));
-
     update_test_ids(&test_dir, test_id, -1)?;
 
     Ok(())
@@ -133,10 +131,9 @@ pub fn insert_test(test_path_relative_to_crates: &str) -> Result<()> {
     }
 
     prompt_confirm(&format!("Going to increase tests ids in {:?}", &test_dir));
-
     update_test_ids(&test_dir, new_test_id, 1)?;
 
-    // Its safe to create new file without confirmation here
+    prompt_confirm(&format!("Going to create empty file at {:?}", &new_test_path));
     fs::File::create(&new_test_path)?;
 
     // Some IDEs can let you open the file by a link from the terminal

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -132,7 +132,7 @@ pub fn insert_test(test_path_relative_to_crates: &str) -> Result<()> {
         anyhow::bail!("Test file {:?} already exists", new_test_path);
     }
 
-    prompt_confirm(&format!("Going to increase tests in {:?}", &test_dir));
+    prompt_confirm(&format!("Going to increase tests ids in {:?}", &test_dir));
 
     update_test_ids(&test_dir, new_test_id, 1)?;
 

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -134,7 +134,7 @@ pub fn insert_test(test_path_relative_to_crates: &str) -> Result<()> {
 
     prompt_confirm(&format!("Going to increase tests in {:?}", &test_dir));
 
-    update_test_ids(&test_dir, new_test_id, -1)?;
+    update_test_ids(&test_dir, new_test_id, 1)?;
 
     // Its safe to create new file without confirmation here
     fs::File::create(&new_test_path)?;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -13,8 +13,9 @@ use std::env;
 use pico_args::Arguments;
 use xtask::{
     codegen::{self, Mode},
+    insert_test,
     install::{ClientOpt, InstallCmd, ServerOpt},
-    pre_commit, run_clippy, run_fuzzer, run_pre_cache, run_rustfmt, Result,
+    pre_commit, remove_test, run_clippy, run_fuzzer, run_pre_cache, run_rustfmt, Result,
 };
 
 fn main() -> Result<()> {
@@ -92,6 +93,20 @@ FLAGS:
             args.finish()?;
             run_pre_cache()
         }
+        "insert-test-data" => {
+            // File path is relative to `/crates` dir
+            // e.g. `ra_syntax/test_data/lexer/ok/0012_test_name.rs`
+            let new_test_file_path: String = args.value_from_str("--path")?;
+            args.finish()?;
+            insert_test(&new_test_file_path)
+        }
+        "remove-test-data" => {
+            // File path is relative to `/crates` dir
+            // e.g. `ra_syntax/test_data/lexer/ok/0012_test_name.rs`
+            let rm_test_file_path: String = args.value_from_str("--path")?;
+            args.finish()?;
+            remove_test(&rm_test_file_path)
+        }
         _ => {
             eprintln!(
                 "\
@@ -107,7 +122,9 @@ SUBCOMMANDS:
     fuzz-tests
     codegen
     install
-    lint"
+    lint
+    insert-test-data
+    remove-test-data"
             );
             Ok(())
         }


### PR DESCRIPTION
Inserting or deleting test data files in the middle of the directory gets tedious.
You always have to bookkeep the tests numbering.
I added two scripts to automatically update test file names when inserting new test data files and removing them.
@matklad proposed to do this in Python, but... Hell no!