### PR TITLE
Improve responsiveness of the cargo check status label

### DIFF
--- a/editors/code/src/status_display.ts
+++ b/editors/code/src/status_display.ts
@@ -17,7 +17,7 @@ export function activateStatusDisplay(ctx: Ctx) {
 class StatusDisplay implements vscode.Disposable {
     packageName?: string;
 
-    private i = 0;
+    private i: number = 0;
     private statusBarItem: vscode.StatusBarItem;
     private command: string;
     private timer?: NodeJS.Timeout;
@@ -37,11 +37,8 @@ class StatusDisplay implements vscode.Disposable {
         this.timer =
             this.timer ||
             setInterval(() => {
-                if (this.packageName) {
-                    this.statusBarItem!.text = `${this.frame()} cargo ${this.command} [${this.packageName}]`;
-                } else {
-                    this.statusBarItem!.text = `${this.frame()} cargo ${this.command}`;
-                }
+                this.tick();
+                this.refreshLabel();
             }, 300);
 
         this.statusBarItem.show();
@@ -65,6 +62,14 @@ class StatusDisplay implements vscode.Disposable {
         this.statusBarItem.dispose();
     }
 
+    refreshLabel() {
+        if (this.packageName) {
+            this.statusBarItem!.text = `${spinnerFrames[this.i]} cargo ${this.command} [${this.packageName}]`;
+        } else {
+            this.statusBarItem!.text = `${spinnerFrames[this.i]} cargo ${this.command}`;
+        }
+    }
+
     handleProgressNotification(params: WorkDoneProgressBegin | WorkDoneProgressReport | WorkDoneProgressEnd) {
         switch (params.kind) {
             case 'begin':
@@ -74,6 +79,7 @@ class StatusDisplay implements vscode.Disposable {
             case 'report':
                 if (params.message) {
                     this.packageName = params.message;
+                    this.refreshLabel();
                 }
                 break;
 
@@ -83,7 +89,7 @@ class StatusDisplay implements vscode.Disposable {
         }
     }
 
-    private frame() {
-        return spinnerFrames[(this.i = ++this.i % spinnerFrames.length)];
+    private tick() {
+        this.i = (this.i + 1) % spinnerFrames.length;
     }
 }


### PR DESCRIPTION
This is still not ideal because the label displays the crate that was just checked, not the one that's currently being checked. But it should give the impression of being faster.