### PR TITLE
Auto import functions

### DIFF
--- a/crates/ra_assists/src/assists/auto_import.rs
+++ b/crates/ra_assists/src/assists/auto_import.rs
@@ -211,4 +211,28 @@ mod tests {
             }",
         );
     }
+
+    #[test]
+    fn function_import() {
+        check_assist_with_imports_locator(
+            auto_import,
+            TestImportsLocator::new,
+            r"
+            test_function<|>
+
+            pub mod PubMod {
+                pub fn test_function() {};
+            }
+            ",
+            r"
+            use PubMod::test_function;
+
+            test_function<|>
+
+            pub mod PubMod {
+                pub fn test_function() {};
+            }
+            ",
+        );
+    }
 }

--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -119,7 +119,7 @@ impl_froms!(
     BuiltinType
 );
 
-pub use hir_def::{attr::Attrs, visibility::Visibility, AssocItemId};
+pub use hir_def::{attr::Attrs, item_scope::ItemInNs, visibility::Visibility, AssocItemId};
 use rustc_hash::FxHashSet;
 
 impl Module {
@@ -238,11 +238,16 @@ impl Module {
         item: ModuleDef,
     ) -> Option<hir_def::path::ModPath> {
         // FIXME expose namespace choice
-        hir_def::find_path::find_path(
-            db,
-            hir_def::item_scope::ItemInNs::Types(item.into()),
-            self.into(),
-        )
+        hir_def::find_path::find_path(db, determine_item_namespace(item), self.into())
+    }
+}
+
+fn determine_item_namespace(module_def: ModuleDef) -> ItemInNs {
+    match module_def {
+        ModuleDef::Static(_) | ModuleDef::Const(_) | ModuleDef::Function(_) => {
+            ItemInNs::Values(module_def.into())
+        }
+        _ => ItemInNs::Types(module_def.into()),
     }
 }
 


### PR DESCRIPTION
A follow up for https://github.com/rust-analyzer/rust-analyzer/pull/2887#issuecomment-577832601

I've used the logic for conversion from the https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/ra_hir_def/src/item_scope.rs#L169 method.

I'm not fond of how the conversion is implemented and for my needs, I can simply replace the `hir_def::item_scope::ItemInNs::Types(item.into())` with `hir_def::item_scope::ItemInNs::Values(item.into())` and it will work, so I can use this approach instead, if you find it a better one.