### PR TITLE
vscode: now we are actually using tslib

### DIFF
--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -749,8 +749,7 @@
         "tslib": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-            "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-            "dev": true
+            "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
         },
         "tslint": {
             "version": "5.20.1",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -25,7 +25,8 @@
     "dependencies": {
         "jsonc-parser": "^2.1.0",
         "seedrandom": "^3.0.5",
-        "vscode-languageclient": "^6.1.0"
+        "vscode-languageclient": "^6.1.0",
+        "tslib": "^1.10.0"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^11.0.1",
@@ -35,7 +36,6 @@
         "@types/seedrandom": "^2.4.28",
         "@types/vscode": "^1.41.0",
         "rollup": "^1.30.1",
-        "tslib": "^1.10.0",
         "tslint": "^5.20.1",
         "typescript": "^3.7.5",
         "typescript-formatter": "^7.2.2",

--- a/editors/code/tsconfig.json
+++ b/editors/code/tsconfig.json
@@ -15,6 +15,7 @@
         "noFallthroughCasesInSwitch": true,
         "newLine": "LF",
         "esModuleInterop": true,
+        "importHelpers": true
     },
     "exclude": [
         "node_modules"


### PR DESCRIPTION
We had an incorrect setup where `tslib` was in `devDependencies`.
FYI:
tslib is a runtime dependency, it contains functions that are used by transpiled JavaScript in order not to inline them in each file.
For example:
```ts
// foo.ts (source code)
import * as foo from "foo";
// ---------------------------
// foo.js (compiled output)
"use strict";
var __importStar = (this && this.__importStar) || function (mod) {
    if (mod && mod.__esModule) return mod;
    var result = {};
    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
    result["default"] = mod;
    return result;
};
Object.defineProperty(exports, "__esModule", { value: true });
const foo = __importStar(require("foo"));
```
As you see, `tsc` generated that `__importStar` helper function in compiled output. And it generates it per each file if you don't enable `"importHelpers": true`. Now with `importHelpers` enabled we get the following picture:
```ts
// foo.ts (source code)
import * as foo from "foo";
// ---------------------------
// foo.js (compiled output)
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
const tslib_1 = require("tslib");
const foo = tslib_1.__importStar(require("foo"));
```
It saves some bundle size, but I am not entirely sure wheter we want that. Discussions are welcome!