### PR TITLE
vscode: Add ability to call onEnter without overriding "type".

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -141,6 +141,11 @@
                 "command": "rust-analyzer.run",
                 "key": "ctrl+r",
                 "when": "editorTextFocus && editorLangId == rust"
+            },
+            {
+                "command": "rust-analyzer.onEnter",
+                "key": "enter",
+                "when": "editorTextFocus && editorLangId == rust"
             }
         ],
         "configuration": {
@@ -164,7 +169,7 @@
                 },
                 "rust-analyzer.enableEnhancedTyping": {
                     "type": "boolean",
-                    "default": true,
+                    "default": false,
                     "description": "Enables enhanced typing. NOTE: If using a VIM extension, you should set this to false"
                 },
                 "rust-analyzer.raLspServerPath": {

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -145,7 +145,7 @@
             {
                 "command": "rust-analyzer.onEnter",
                 "key": "enter",
-                "when": "editorTextFocus && editorLangId == rust"
+                "when": "editorTextFocus && !suggestWidgetVisible && editorLangId == rust"
             }
         ],
         "configuration": {

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -114,6 +114,11 @@
                 "command": "rust-analyzer.reload",
                 "title": "Restart server",
                 "category": "Rust Analyzer"
+            },
+            {
+                "command": "rust-analyzer.onEnter",
+                "title": "Enhanced enter key",
+                "category": "Rust Analyzer"
             }
         ],
         "keybindings": [

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -167,11 +167,6 @@
                     "default": {},
                     "description": "Fine grained feature flags to disable annoying features"
                 },
-                "rust-analyzer.enableEnhancedTyping": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Enables enhanced typing. NOTE: If using a VIM extension, you should set this to false"
-                },
                 "rust-analyzer.raLspServerPath": {
                     "type": [
                         "string"

--- a/editors/code/src/commands/on_enter.ts
+++ b/editors/code/src/commands/on_enter.ts
@@ -8,7 +8,7 @@ async function handleKeypress(ctx: Ctx) {
     const editor = ctx.activeRustEditor;
     const client = ctx.client;
     if (!editor) return false;
-    if (!client) return false;
+    if (!editor || !client) return false;
 
     const request: lc.TextDocumentPositionParams = {
         textDocument: { uri: editor.document.uri.toString() },

--- a/editors/code/src/commands/on_enter.ts
+++ b/editors/code/src/commands/on_enter.ts
@@ -26,17 +26,9 @@ async function handleKeypress(ctx: Ctx) {
     return true;
 }
 
-export function onEnterOverride(ctx: Ctx): Cmd {
-    return async (event: { text: string }) => {
-        if (event.text === '\n') {
-            handleKeypress(ctx);
-        }
-    };
-}
-
 export function onEnter(ctx: Ctx): Cmd {
     return async () => {
-        if (handleKeypress(ctx)) return;
+        if (await handleKeypress(ctx)) return;
 
         await vscode.commands.executeCommand('default:type', { text: '\n' });
     };

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -50,30 +50,6 @@ export class Ctx {
         this.pushCleanup(d);
     }
 
-    overrideCommand(name: string, factory: (ctx: Ctx) => Cmd) {
-        const defaultCmd = `default:${name}`;
-        const override = factory(this);
-        const original = (...args: unknown[]) =>
-            vscode.commands.executeCommand(defaultCmd, ...args);
-        try {
-            const d = vscode.commands.registerCommand(
-                name,
-                async (...args: unknown[]) => {
-                    if (!(await override(...args))) {
-                        return await original(...args);
-                    }
-                },
-            );
-            this.pushCleanup(d);
-        } catch (_) {
-            vscode.window.showWarningMessage(
-                'Enhanced typing feature is disabled because of incompatibility ' +
-                'with VIM extension, consider turning off rust-analyzer.enableEnhancedTyping: ' +
-                'https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/user/README.md#settings',
-            );
-        }
-    }
-
     get subscriptions(): Disposable[] {
         return this.extCtx.subscriptions;
     }

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -21,6 +21,7 @@ export async function activate(context: vscode.ExtensionContext) {
     ctx.registerCommand('expandMacro', commands.expandMacro);
     ctx.registerCommand('run', commands.run);
     ctx.registerCommand('reload', commands.reload);
+    ctx.registerCommand('onEnter', commands.onEnter);
 
     // Internal commands which are invoked by the server.
     ctx.registerCommand('runSingle', commands.runSingle);
@@ -29,7 +30,7 @@ export async function activate(context: vscode.ExtensionContext) {
     ctx.registerCommand('selectAndApplySourceChange', commands.selectAndApplySourceChange);
 
     if (ctx.config.enableEnhancedTyping) {
-        ctx.overrideCommand('type', commands.onEnter);
+        ctx.overrideCommand('type', commands.onEnterOverride);
     }
     activateStatusDisplay(ctx);
 

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -29,9 +29,6 @@ export async function activate(context: vscode.ExtensionContext) {
     ctx.registerCommand('applySourceChange', commands.applySourceChange);
     ctx.registerCommand('selectAndApplySourceChange', commands.selectAndApplySourceChange);
 
-    if (ctx.config.enableEnhancedTyping) {
-        ctx.overrideCommand('type', commands.onEnterOverride);
-    }
     activateStatusDisplay(ctx);
 
     activateHighlighting(ctx);


### PR DESCRIPTION
Before this PR, the only way to get enhanced typing (right now, only with `onEnter`) was to override VS Code's `type` command. This leads to issues with extensions like [VsCodeVim](https://github.com/VSCodeVim/Vim) that need to override `type` as well.

This PR adds an additional command, `onEnter`. This command can be used with the following keybinding, which allows the user to get smart `onEnter` behavior without overriding `type`.

```json
{
    "key": "enter",
    "command": "rust-analyzer.onEnter",
    "when": "editorTextFocus && editorLangId == rust"
}
```