### PR TITLE
vscode extension: migrate from any to unknown where possible

### DIFF
--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -68,7 +68,7 @@ PATH=${process.env.PATH}
     // This also requires considering our settings strategy, which is work which needs doing
     // @ts-ignore The tracer is private to vscode-languageclient, but we need access to it to not log publishDecorations requests
     res._tracer = {
-        log: (messageOrDataObject: string | any, data?: string) => {
+        log: (messageOrDataObject: string | unknown, data?: string) => {
             if (typeof messageOrDataObject === 'string') {
                 if (
                     messageOrDataObject.includes(

--- a/editors/code/src/color_theme.ts
+++ b/editors/code/src/color_theme.ts
@@ -61,7 +61,7 @@ export class ColorTheme {
 }
 
 function loadThemeNamed(themeName: string): ColorTheme {
-    function isTheme(extension: vscode.Extension<any>): boolean {
+    function isTheme(extension: vscode.Extension<unknown>): boolean {
         return (
             extension.extensionKind === vscode.ExtensionKind.UI &&
             extension.packageJSON.contributes &&

--- a/editors/code/src/commands/syntax_tree.ts
+++ b/editors/code/src/commands/syntax_tree.ts
@@ -55,7 +55,7 @@ export function syntaxTree(ctx: Ctx): Cmd {
 
 // We need to order this after LS updates, but there's no API for that.
 // Hence, good old setTimeout.
-function afterLs(f: () => any) {
+function afterLs(f: () => unknown) {
     setTimeout(f, 10);
 }
 

--- a/editors/code/src/commands/syntax_tree.ts
+++ b/editors/code/src/commands/syntax_tree.ts
@@ -55,7 +55,7 @@ export function syntaxTree(ctx: Ctx): Cmd {
 
 // We need to order this after LS updates, but there's no API for that.
 // Hence, good old setTimeout.
-function afterLs(f: () => unknown) {
+function afterLs(f: () => void) {
     setTimeout(f, 10);
 }
 

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -86,7 +86,7 @@ export class Ctx {
     }
 }
 
-export type Cmd = (...args: unknown[]) => unknown;
+export type Cmd = (...args: any[]) => unknown;
 
 export async function sendRequestWithRetry<R>(
     client: lc.LanguageClient,

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -52,12 +52,12 @@ export class Ctx {
     overrideCommand(name: string, factory: (ctx: Ctx) => Cmd) {
         const defaultCmd = `default:${name}`;
         const override = factory(this);
-        const original = (...args: any[]) =>
+        const original = (...args: unknown[]) =>
             vscode.commands.executeCommand(defaultCmd, ...args);
         try {
             const d = vscode.commands.registerCommand(
                 name,
-                async (...args: any[]) => {
+                async (...args: unknown[]) => {
                     if (!(await override(...args))) {
                         return await original(...args);
                     }
@@ -73,11 +73,11 @@ export class Ctx {
         }
     }
 
-    get subscriptions(): { dispose(): any }[] {
+    get subscriptions(): { dispose(): unknown }[] {
         return this.extCtx.subscriptions;
     }
 
-    pushCleanup(d: { dispose(): any }) {
+    pushCleanup(d: { dispose(): unknown }) {
         this.extCtx.subscriptions.push(d);
     }
 
@@ -86,12 +86,12 @@ export class Ctx {
     }
 }
 
-export type Cmd = (...args: any[]) => any;
+export type Cmd = (...args: unknown[]) => unknown;
 
 export async function sendRequestWithRetry<R>(
     client: lc.LanguageClient,
     method: string,
-    param: any,
+    param: unknown,
     token?: vscode.CancellationToken,
 ): Promise<R> {
     for (const delay of [2, 4, 6, 8, 10, null]) {

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as lc from 'vscode-languageclient';
+
 import { Config } from './config';
 import { createClient } from './client';
 
@@ -73,11 +74,11 @@ export class Ctx {
         }
     }
 
-    get subscriptions(): { dispose(): unknown }[] {
+    get subscriptions(): Disposable[] {
         return this.extCtx.subscriptions;
     }
 
-    pushCleanup(d: { dispose(): unknown }) {
+    pushCleanup(d: Disposable) {
         this.extCtx.subscriptions.push(d);
     }
 
@@ -86,6 +87,9 @@ export class Ctx {
     }
 }
 
+export interface Disposable {
+    dispose(): void;
+}
 export type Cmd = (...args: any[]) => unknown;
 
 export async function sendRequestWithRetry<R>(

--- a/editors/code/src/status_display.ts
+++ b/editors/code/src/status_display.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-import { WorkDoneProgress, WorkDoneProgressBegin, WorkDoneProgressReport, WorkDoneProgressEnd } from 'vscode-languageclient';
+import { WorkDoneProgress, WorkDoneProgressBegin, WorkDoneProgressReport, WorkDoneProgressEnd, Disposable } from 'vscode-languageclient';
 
 import { Ctx } from './ctx';
 
@@ -14,7 +14,7 @@ export function activateStatusDisplay(ctx: Ctx) {
     });
 }
 
-class StatusDisplay implements vscode.Disposable {
+class StatusDisplay implements vscode.Disposable, Disposable {
     packageName?: string;
 
     private i: number = 0;


### PR DESCRIPTION
`unknown` type is the stricter version of `any` and it should always be prefered (like `const` over `let`).
It lets you assign any value to it, but doesn't let you carry out arbitrary operations on them without an explicit type check (like `typeof unknownValue === 'string'`).