### PR TITLE
vscode: fix bundling by switching to es2015 target modules system

### DIFF
--- a/editors/code/tsconfig.json
+++ b/editors/code/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "es2015",
         "target": "es2018",
         "outDir": "out",
         "lib": [


### PR DESCRIPTION
Quick fix