### PR TITLE
Remove rollup-typescript

### DIFF
--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -61,16 +61,6 @@
                 }
             }
         },
-        "@rollup/plugin-typescript": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-2.1.0.tgz",
-            "integrity": "sha512-7lXKGY06aofrceVez/YnN2axttFdHSqlUBpCJ6ebzDfxwLDKMgSV5lD4ykBcdgE7aK3egxuLkD/HKyRB5L8Log==",
-            "dev": true,
-            "requires": {
-                "@rollup/pluginutils": "^3.0.0",
-                "resolve": "^1.13.1"
-            }
-        },
         "@rollup/pluginutils": {
             "version": "3.0.8",
             "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.0.8.tgz",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -18,9 +18,9 @@
         "vscode": "^1.41.0"
     },
     "scripts": {
-        "vscode:prepublish": "tsc -p ./ && rollup -c",
+        "vscode:prepublish": "tsc && rollup -c",
         "package": "vsce package",
-        "watch": "tsc -watch -p ./",
+        "watch": "tsc --watch",
         "fmt": "tsfmt -r && tslint -c tslint.json 'src/**/*.ts' --fix"
     },
     "dependencies": {

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -18,7 +18,7 @@
         "vscode": "^1.41.0"
     },
     "scripts": {
-        "vscode:prepublish": "rollup -c",
+        "vscode:prepublish": "tsc -p ./ && rollup -c",
         "package": "vsce package",
         "watch": "tsc -watch -p ./",
         "fmt": "tsfmt -r && tslint -c tslint.json 'src/**/*.ts' --fix"
@@ -30,7 +30,6 @@
     "devDependencies": {
         "@rollup/plugin-commonjs": "^11.0.2",
         "@rollup/plugin-node-resolve": "^7.1.1",
-        "@rollup/plugin-typescript": "^2.0.0",
         "@types/node": "^12.12.25",
         "@types/vscode": "^1.41.0",
         "rollup": "^1.31.0",

--- a/editors/code/rollup.config.js
+++ b/editors/code/rollup.config.js
@@ -1,12 +1,10 @@
-import typescript from '@rollup/plugin-typescript';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import nodeBuiltins from 'builtin-modules';
 
 export default {
-    input: 'src/main.ts',
+    input: 'out/main.js',
     plugins: [
-        typescript(),
         resolve({
             preferBuiltins: true
         }),


### PR DESCRIPTION
It seems like just calling typescript directly is simpler and more reliable?


@Veetaha what do you think about this approach?