### PR TITLE
Normalize dashes in crate names

### DIFF
--- a/crates/ra_db/src/fixture.rs
+++ b/crates/ra_db/src/fixture.rs
@@ -8,8 +8,8 @@ use rustc_hash::FxHashMap;
 use test_utils::{extract_offset, parse_fixture, CURSOR_MARKER};
 
 use crate::{
-    CrateGraph, CrateId, Edition, Env, FileId, FilePosition, RelativePathBuf, SourceDatabaseExt,
-    SourceRoot, SourceRootId,
+    input::CrateName, CrateGraph, CrateId, Edition, Env, FileId, FilePosition, RelativePathBuf,
+    SourceDatabaseExt, SourceRoot, SourceRootId,
 };
 
 pub const WORKSPACE: SourceRootId = SourceRootId(0);
@@ -139,7 +139,7 @@ fn with_files(db: &mut dyn SourceDatabaseExt, fixture: &str) -> Option<FilePosit
         for (from, to) in crate_deps {
             let from_id = crates[&from];
             let to_id = crates[&to];
-            crate_graph.add_dep(from_id, to.into(), to_id).unwrap();
+            crate_graph.add_dep(from_id, CrateName::new(&to).unwrap(), to_id).unwrap();
         }
     }
 

--- a/crates/ra_db/src/lib.rs
+++ b/crates/ra_db/src/lib.rs
@@ -10,7 +10,9 @@ use ra_syntax::{ast, Parse, SourceFile, TextRange, TextUnit};
 
 pub use crate::{
     cancellation::Canceled,
-    input::{CrateGraph, CrateId, Dependency, Edition, Env, FileId, SourceRoot, SourceRootId},
+    input::{
+        CrateGraph, CrateId, CrateName, Dependency, Edition, Env, FileId, SourceRoot, SourceRootId,
+    },
 };
 pub use relative_path::{RelativePath, RelativePathBuf};
 pub use salsa;

--- a/crates/ra_ide/src/mock_analysis.rs
+++ b/crates/ra_ide/src/mock_analysis.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use ra_cfg::CfgOptions;
-use ra_db::{Env, RelativePathBuf};
+use ra_db::{CrateName, Env, RelativePathBuf};
 use test_utils::{extract_offset, extract_range, parse_fixture, CURSOR_MARKER};
 
 use crate::{
@@ -107,7 +107,9 @@ impl MockAnalysis {
                     crate_graph.add_crate_root(file_id, Edition2018, cfg_options, Env::default());
                 let crate_name = path.parent().unwrap().file_name().unwrap();
                 if let Some(root_crate) = root_crate {
-                    crate_graph.add_dep(root_crate, crate_name.into(), other_crate).unwrap();
+                    crate_graph
+                        .add_dep(root_crate, CrateName::new(crate_name).unwrap(), other_crate)
+                        .unwrap();
                 }
             }
             change.add_file(source_root, file_id, path, Arc::new(contents));


### PR DESCRIPTION
A follow-up for https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Fwg-rls-2.2E0/topic/Yet.20another.20auto.20import.20bug

In theory, I could have used the same new type in the `Dependency` `name`  field, but since the `add_dep` method that actually adds a dependency is private, it seems like an unnecessary change now.