### PR TITLE
Remove the leftovers after ImportLocator removal

### DIFF
--- a/crates/ra_assists/src/assists/auto_import.rs
+++ b/crates/ra_assists/src/assists/auto_import.rs
@@ -8,7 +8,7 @@ use crate::{
     assist_ctx::{ActionBuilder, Assist, AssistCtx},
     auto_import_text_edit, AssistId,
 };
-use ra_ide_db::imports_locator::ImportsLocatorIde;
+use ra_ide_db::imports_locator::ImportsLocator;
 
 // Assist: auto_import
 //
@@ -52,7 +52,7 @@ pub(crate) fn auto_import(ctx: AssistCtx) -> Option<Assist> {
         return None;
     }
 
-    let mut imports_locator = ImportsLocatorIde::new(ctx.db);
+    let mut imports_locator = ImportsLocator::new(ctx.db);
 
     let proposed_imports = imports_locator
         .find_imports(&name_to_import)

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -56,7 +56,6 @@ pub use hir_def::{
     nameres::ModuleSource,
     path::{ModPath, Path, PathKind},
     type_ref::Mutability,
-    ModuleDefId, // FIXME this is exposed and should be used for implementing the `TestImportsLocator` in `ra_assists` only, should be removed later along with the trait and the implementation.
 };
 pub use hir_expand::{
     name::{name, Name},

--- a/crates/ra_ide_db/src/imports_locator.rs
+++ b/crates/ra_ide_db/src/imports_locator.rs
@@ -12,11 +12,11 @@ use crate::{
     RootDatabase,
 };
 
-pub struct ImportsLocatorIde<'a> {
+pub struct ImportsLocator<'a> {
     source_binder: SourceBinder<'a, RootDatabase>,
 }
 
-impl<'a> ImportsLocatorIde<'a> {
+impl<'a> ImportsLocator<'a> {
     pub fn new(db: &'a RootDatabase) -> Self {
         Self { source_binder: SourceBinder::new(db) }
     }


### PR DESCRIPTION
Follow the FIXME's suggestion (https://github.com/rust-analyzer/rust-analyzer/pull/3034/files#diff-001b3b1412c33fee802c22b0f848dcd7L237) and remove the `ModuleDefId` reexport.

Also rename `ImportsLocatorIde` into plain `ImportsLocator`