### PR TITLE
Rework value parameter parsing

### DIFF
--- a/crates/ra_parser/src/grammar/expressions/atom.rs
+++ b/crates/ra_parser/src/grammar/expressions/atom.rs
@@ -229,7 +229,7 @@ fn lambda_expr(p: &mut Parser) -> CompletedMarker {
     let m = p.start();
     p.eat(T![async]);
     p.eat(T![move]);
-    params::param_list_opt_types(p);
+    params::param_list_closure(p);
     if opt_fn_ret_type(p) {
         if !p.at(T!['{']) {
             p.error("expected `{`");

--- a/crates/ra_parser/src/grammar/items.rs
+++ b/crates/ra_parser/src/grammar/items.rs
@@ -164,7 +164,7 @@ pub(super) fn maybe_item(p: &mut Parser, m: Marker, flavor: ItemFlavor) -> Resul
         // async unsafe fn foo() {}
         // unsafe const fn bar() {}
         T![fn] => {
-            fn_def(p, flavor);
+            fn_def(p);
             m.complete(p, FN_DEF);
         }
 
@@ -301,7 +301,7 @@ pub(crate) fn extern_item_list(p: &mut Parser) {
     m.complete(p, EXTERN_ITEM_LIST);
 }
 
-fn fn_def(p: &mut Parser, flavor: ItemFlavor) {
+fn fn_def(p: &mut Parser) {
     assert!(p.at(T![fn]));
     p.bump(T![fn]);
 
@@ -311,10 +311,7 @@ fn fn_def(p: &mut Parser, flavor: ItemFlavor) {
     type_params::opt_type_param_list(p);
 
     if p.at(T!['(']) {
-        match flavor {
-            ItemFlavor::Mod => params::param_list(p),
-            ItemFlavor::Trait => params::param_list_opt_patterns(p),
-        }
+        params::param_list_fn(p);
     } else {
         p.error("expected function arguments");
     }

--- a/crates/ra_parser/src/grammar/items.rs
+++ b/crates/ra_parser/src/grammar/items.rs
@@ -311,7 +311,7 @@ fn fn_def(p: &mut Parser) {
     type_params::opt_type_param_list(p);
 
     if p.at(T!['(']) {
-        params::param_list_fn(p);
+        params::param_list_fn_def(p);
     } else {
         p.error("expected function arguments");
     }

--- a/crates/ra_parser/src/grammar/params.rs
+++ b/crates/ra_parser/src/grammar/params.rs
@@ -125,6 +125,10 @@ fn value_parameter(p: &mut Parser, flavor: Flavor) {
                 types::type_(p);
             }
         }
+        // test closure_params
+        // fn main() {
+        //    let foo = |bar, baz: Baz, qux: Qux::Quux| ();
+        // }
         Flavor::Closure => {
             patterns::pattern(p);
             if p.at(T![:]) && !p.at(T![::]) {

--- a/crates/ra_parser/src/grammar/params.rs
+++ b/crates/ra_parser/src/grammar/params.rs
@@ -30,7 +30,7 @@ enum Flavor {
     Function, // Includes trait fn params; omitted param idents are not supported
     ImplFn,
     FnPointer,
-    Closure
+    Closure,
 }
 
 fn list_(p: &mut Parser, flavor: Flavor) {
@@ -38,7 +38,7 @@ fn list_(p: &mut Parser, flavor: Flavor) {
 
     let (bra, ket) = match flavor {
         Closure => (T![|], T![|]),
-        Function | ImplFn | FnPointer => (T!['('], T![')'])
+        Function | ImplFn | FnPointer => (T!['('], T![')']),
     };
 
     let m = p.start();

--- a/crates/ra_parser/src/grammar/paths.rs
+++ b/crates/ra_parser/src/grammar/paths.rs
@@ -99,7 +99,7 @@ fn opt_path_type_args(p: &mut Parser, mode: Mode) {
             // test path_fn_trait_args
             // type F = Box<Fn(i32) -> ()>;
             if p.at(T!['(']) {
-                params::param_list_impl_fn(p);
+                params::param_list_fn_trait(p);
                 opt_fn_ret_type(p);
             } else {
                 type_args::opt_type_arg_list(p, false)

--- a/crates/ra_parser/src/grammar/paths.rs
+++ b/crates/ra_parser/src/grammar/paths.rs
@@ -97,9 +97,9 @@ fn opt_path_type_args(p: &mut Parser, mode: Mode) {
         Mode::Use => return,
         Mode::Type => {
             // test path_fn_trait_args
-            // type F = Box<Fn(x: i32) -> ()>;
+            // type F = Box<Fn(i32) -> ()>;
             if p.at(T!['(']) {
-                params::param_list_opt_patterns(p);
+                params::param_list_impl_fn(p);
                 opt_fn_ret_type(p);
             } else {
                 type_args::opt_type_arg_list(p, false)

--- a/crates/ra_parser/src/grammar/types.rs
+++ b/crates/ra_parser/src/grammar/types.rs
@@ -183,7 +183,7 @@ fn fn_pointer_type(p: &mut Parser) {
         return;
     }
     if p.at(T!['(']) {
-        params::param_list_opt_patterns(p);
+        params::param_list_fn_ptr(p);
     } else {
         p.error("expected parameters")
     }

--- a/crates/ra_syntax/test_data/parser/inline/ok/0004_value_parameters_no_patterns.rs
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0004_value_parameters_no_patterns.rs
@@ -1,1 +1,1 @@
-type F = Box<Fn(a: i32, &b: &i32, &mut c: &i32, ())>;
+type F = Box<Fn(i32, &i32, &i32, ())>;

--- a/crates/ra_syntax/test_data/parser/inline/ok/0004_value_parameters_no_patterns.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0004_value_parameters_no_patterns.txt
@@ -1,5 +1,5 @@
-SOURCE_FILE@[0; 54)
-  TYPE_ALIAS_DEF@[0; 53)
+SOURCE_FILE@[0; 39)
+  TYPE_ALIAS_DEF@[0; 38)
     TYPE_KW@[0; 4) "type"
     WHITESPACE@[4; 5) " "
     NAME@[5; 6)
@@ -7,75 +7,54 @@ SOURCE_FILE@[0; 54)
     WHITESPACE@[6; 7) " "
     EQ@[7; 8) "="
     WHITESPACE@[8; 9) " "
-    PATH_TYPE@[9; 52)
-      PATH@[9; 52)
-        PATH_SEGMENT@[9; 52)
+    PATH_TYPE@[9; 37)
+      PATH@[9; 37)
+        PATH_SEGMENT@[9; 37)
           NAME_REF@[9; 12)
             IDENT@[9; 12) "Box"
-          TYPE_ARG_LIST@[12; 52)
+          TYPE_ARG_LIST@[12; 37)
             L_ANGLE@[12; 13) "<"
-            TYPE_ARG@[13; 51)
-              PATH_TYPE@[13; 51)
-                PATH@[13; 51)
-                  PATH_SEGMENT@[13; 51)
+            TYPE_ARG@[13; 36)
+              PATH_TYPE@[13; 36)
+                PATH@[13; 36)
+                  PATH_SEGMENT@[13; 36)
                     NAME_REF@[13; 15)
                       IDENT@[13; 15) "Fn"
-                    PARAM_LIST@[15; 51)
+                    PARAM_LIST@[15; 36)
                       L_PAREN@[15; 16) "("
-                      PARAM@[16; 22)
-                        BIND_PAT@[16; 17)
-                          NAME@[16; 17)
-                            IDENT@[16; 17) "a"
-                        COLON@[17; 18) ":"
-                        WHITESPACE@[18; 19) " "
-                        PATH_TYPE@[19; 22)
-                          PATH@[19; 22)
-                            PATH_SEGMENT@[19; 22)
-                              NAME_REF@[19; 22)
-                                IDENT@[19; 22) "i32"
-                      COMMA@[22; 23) ","
-                      WHITESPACE@[23; 24) " "
-                      PARAM@[24; 32)
-                        REF_PAT@[24; 26)
-                          AMP@[24; 25) "&"
-                          BIND_PAT@[25; 26)
-                            NAME@[25; 26)
-                              IDENT@[25; 26) "b"
-                        COLON@[26; 27) ":"
-                        WHITESPACE@[27; 28) " "
-                        REFERENCE_TYPE@[28; 32)
-                          AMP@[28; 29) "&"
-                          PATH_TYPE@[29; 32)
-                            PATH@[29; 32)
-                              PATH_SEGMENT@[29; 32)
-                                NAME_REF@[29; 32)
-                                  IDENT@[29; 32) "i32"
-                      COMMA@[32; 33) ","
-                      WHITESPACE@[33; 34) " "
-                      PARAM@[34; 46)
-                        REF_PAT@[34; 40)
-                          AMP@[34; 35) "&"
-                          MUT_KW@[35; 38) "mut"
-                          WHITESPACE@[38; 39) " "
-                          BIND_PAT@[39; 40)
-                            NAME@[39; 40)
-                              IDENT@[39; 40) "c"
-                        COLON@[40; 41) ":"
-                        WHITESPACE@[41; 42) " "
-                        REFERENCE_TYPE@[42; 46)
-                          AMP@[42; 43) "&"
-                          PATH_TYPE@[43; 46)
-                            PATH@[43; 46)
-                              PATH_SEGMENT@[43; 46)
-                                NAME_REF@[43; 46)
-                                  IDENT@[43; 46) "i32"
-                      COMMA@[46; 47) ","
-                      WHITESPACE@[47; 48) " "
-                      PARAM@[48; 50)
-                        TUPLE_TYPE@[48; 50)
-                          L_PAREN@[48; 49) "("
-                          R_PAREN@[49; 50) ")"
-                      R_PAREN@[50; 51) ")"
-            R_ANGLE@[51; 52) ">"
-    SEMI@[52; 53) ";"
-  WHITESPACE@[53; 54) "\n"
+                      PARAM@[16; 19)
+                        PATH_TYPE@[16; 19)
+                          PATH@[16; 19)
+                            PATH_SEGMENT@[16; 19)
+                              NAME_REF@[16; 19)
+                                IDENT@[16; 19) "i32"
+                      COMMA@[19; 20) ","
+                      WHITESPACE@[20; 21) " "
+                      PARAM@[21; 25)
+                        REFERENCE_TYPE@[21; 25)
+                          AMP@[21; 22) "&"
+                          PATH_TYPE@[22; 25)
+                            PATH@[22; 25)
+                              PATH_SEGMENT@[22; 25)
+                                NAME_REF@[22; 25)
+                                  IDENT@[22; 25) "i32"
+                      COMMA@[25; 26) ","
+                      WHITESPACE@[26; 27) " "
+                      PARAM@[27; 31)
+                        REFERENCE_TYPE@[27; 31)
+                          AMP@[27; 28) "&"
+                          PATH_TYPE@[28; 31)
+                            PATH@[28; 31)
+                              PATH_SEGMENT@[28; 31)
+                                NAME_REF@[28; 31)
+                                  IDENT@[28; 31) "i32"
+                      COMMA@[31; 32) ","
+                      WHITESPACE@[32; 33) " "
+                      PARAM@[33; 35)
+                        TUPLE_TYPE@[33; 35)
+                          L_PAREN@[33; 34) "("
+                          R_PAREN@[34; 35) ")"
+                      R_PAREN@[35; 36) ")"
+            R_ANGLE@[36; 37) ">"
+    SEMI@[37; 38) ";"
+  WHITESPACE@[38; 39) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0104_path_fn_trait_args.rs
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0104_path_fn_trait_args.rs
@@ -1,1 +1,1 @@
-type F = Box<Fn(x: i32) -> ()>;
+type F = Box<Fn(i32) -> ()>;

--- a/crates/ra_syntax/test_data/parser/inline/ok/0104_path_fn_trait_args.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0104_path_fn_trait_args.txt
@@ -1,5 +1,5 @@
-SOURCE_FILE@[0; 32)
-  TYPE_ALIAS_DEF@[0; 31)
+SOURCE_FILE@[0; 29)
+  TYPE_ALIAS_DEF@[0; 28)
     TYPE_KW@[0; 4) "type"
     WHITESPACE@[4; 5) " "
     NAME@[5; 6)
@@ -7,40 +7,35 @@ SOURCE_FILE@[0; 32)
     WHITESPACE@[6; 7) " "
     EQ@[7; 8) "="
     WHITESPACE@[8; 9) " "
-    PATH_TYPE@[9; 30)
-      PATH@[9; 30)
-        PATH_SEGMENT@[9; 30)
+    PATH_TYPE@[9; 27)
+      PATH@[9; 27)
+        PATH_SEGMENT@[9; 27)
           NAME_REF@[9; 12)
             IDENT@[9; 12) "Box"
-          TYPE_ARG_LIST@[12; 30)
+          TYPE_ARG_LIST@[12; 27)
             L_ANGLE@[12; 13) "<"
-            TYPE_ARG@[13; 29)
-              PATH_TYPE@[13; 29)
-                PATH@[13; 29)
-                  PATH_SEGMENT@[13; 29)
+            TYPE_ARG@[13; 26)
+              PATH_TYPE@[13; 26)
+                PATH@[13; 26)
+                  PATH_SEGMENT@[13; 26)
                     NAME_REF@[13; 15)
                       IDENT@[13; 15) "Fn"
-                    PARAM_LIST@[15; 23)
+                    PARAM_LIST@[15; 20)
                       L_PAREN@[15; 16) "("
-                      PARAM@[16; 22)
-                        BIND_PAT@[16; 17)
-                          NAME@[16; 17)
-                            IDENT@[16; 17) "x"
-                        COLON@[17; 18) ":"
-                        WHITESPACE@[18; 19) " "
-                        PATH_TYPE@[19; 22)
-                          PATH@[19; 22)
-                            PATH_SEGMENT@[19; 22)
-                              NAME_REF@[19; 22)
-                                IDENT@[19; 22) "i32"
-                      R_PAREN@[22; 23) ")"
-                    WHITESPACE@[23; 24) " "
-                    RET_TYPE@[24; 29)
-                      THIN_ARROW@[24; 26) "->"
-                      WHITESPACE@[26; 27) " "
-                      TUPLE_TYPE@[27; 29)
-                        L_PAREN@[27; 28) "("
-                        R_PAREN@[28; 29) ")"
-            R_ANGLE@[29; 30) ">"
-    SEMI@[30; 31) ";"
-  WHITESPACE@[31; 32) "\n"
+                      PARAM@[16; 19)
+                        PATH_TYPE@[16; 19)
+                          PATH@[16; 19)
+                            PATH_SEGMENT@[16; 19)
+                              NAME_REF@[16; 19)
+                                IDENT@[16; 19) "i32"
+                      R_PAREN@[19; 20) ")"
+                    WHITESPACE@[20; 21) " "
+                    RET_TYPE@[21; 26)
+                      THIN_ARROW@[21; 23) "->"
+                      WHITESPACE@[23; 24) " "
+                      TUPLE_TYPE@[24; 26)
+                        L_PAREN@[24; 25) "("
+                        R_PAREN@[25; 26) ")"
+            R_ANGLE@[26; 27) ">"
+    SEMI@[27; 28) ";"
+  WHITESPACE@[28; 29) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0152_fn_patterns.rs
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0152_fn_patterns.rs
@@ -1,0 +1,6 @@
+impl U {
+    fn f1((a, b): (usize, usize)) {}
+    fn f2(S { a, b }: S) {}
+    fn f3(NewType(a): NewType) {}
+    fn f4(&&a: &&usize) {}
+}

--- a/crates/ra_syntax/test_data/parser/inline/ok/0152_fn_patterns.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0152_fn_patterns.txt
@@ -1,0 +1,164 @@
+SOURCE_FILE@[0; 137)
+  IMPL_BLOCK@[0; 136)
+    IMPL_KW@[0; 4) "impl"
+    WHITESPACE@[4; 5) " "
+    PATH_TYPE@[5; 6)
+      PATH@[5; 6)
+        PATH_SEGMENT@[5; 6)
+          NAME_REF@[5; 6)
+            IDENT@[5; 6) "U"
+    WHITESPACE@[6; 7) " "
+    ITEM_LIST@[7; 136)
+      L_CURLY@[7; 8) "{"
+      WHITESPACE@[8; 13) "\n    "
+      FN_DEF@[13; 45)
+        FN_KW@[13; 15) "fn"
+        WHITESPACE@[15; 16) " "
+        NAME@[16; 18)
+          IDENT@[16; 18) "f1"
+        PARAM_LIST@[18; 42)
+          L_PAREN@[18; 19) "("
+          PARAM@[19; 41)
+            TUPLE_PAT@[19; 25)
+              L_PAREN@[19; 20) "("
+              BIND_PAT@[20; 21)
+                NAME@[20; 21)
+                  IDENT@[20; 21) "a"
+              COMMA@[21; 22) ","
+              WHITESPACE@[22; 23) " "
+              BIND_PAT@[23; 24)
+                NAME@[23; 24)
+                  IDENT@[23; 24) "b"
+              R_PAREN@[24; 25) ")"
+            COLON@[25; 26) ":"
+            WHITESPACE@[26; 27) " "
+            TUPLE_TYPE@[27; 41)
+              L_PAREN@[27; 28) "("
+              PATH_TYPE@[28; 33)
+                PATH@[28; 33)
+                  PATH_SEGMENT@[28; 33)
+                    NAME_REF@[28; 33)
+                      IDENT@[28; 33) "usize"
+              COMMA@[33; 34) ","
+              WHITESPACE@[34; 35) " "
+              PATH_TYPE@[35; 40)
+                PATH@[35; 40)
+                  PATH_SEGMENT@[35; 40)
+                    NAME_REF@[35; 40)
+                      IDENT@[35; 40) "usize"
+              R_PAREN@[40; 41) ")"
+          R_PAREN@[41; 42) ")"
+        WHITESPACE@[42; 43) " "
+        BLOCK_EXPR@[43; 45)
+          BLOCK@[43; 45)
+            L_CURLY@[43; 44) "{"
+            R_CURLY@[44; 45) "}"
+      WHITESPACE@[45; 50) "\n    "
+      FN_DEF@[50; 73)
+        FN_KW@[50; 52) "fn"
+        WHITESPACE@[52; 53) " "
+        NAME@[53; 55)
+          IDENT@[53; 55) "f2"
+        PARAM_LIST@[55; 70)
+          L_PAREN@[55; 56) "("
+          PARAM@[56; 69)
+            RECORD_PAT@[56; 66)
+              PATH@[56; 57)
+                PATH_SEGMENT@[56; 57)
+                  NAME_REF@[56; 57)
+                    IDENT@[56; 57) "S"
+              WHITESPACE@[57; 58) " "
+              RECORD_FIELD_PAT_LIST@[58; 66)
+                L_CURLY@[58; 59) "{"
+                WHITESPACE@[59; 60) " "
+                BIND_PAT@[60; 61)
+                  NAME@[60; 61)
+                    IDENT@[60; 61) "a"
+                COMMA@[61; 62) ","
+                WHITESPACE@[62; 63) " "
+                BIND_PAT@[63; 64)
+                  NAME@[63; 64)
+                    IDENT@[63; 64) "b"
+                WHITESPACE@[64; 65) " "
+                R_CURLY@[65; 66) "}"
+            COLON@[66; 67) ":"
+            WHITESPACE@[67; 68) " "
+            PATH_TYPE@[68; 69)
+              PATH@[68; 69)
+                PATH_SEGMENT@[68; 69)
+                  NAME_REF@[68; 69)
+                    IDENT@[68; 69) "S"
+          R_PAREN@[69; 70) ")"
+        WHITESPACE@[70; 71) " "
+        BLOCK_EXPR@[71; 73)
+          BLOCK@[71; 73)
+            L_CURLY@[71; 72) "{"
+            R_CURLY@[72; 73) "}"
+      WHITESPACE@[73; 78) "\n    "
+      FN_DEF@[78; 107)
+        FN_KW@[78; 80) "fn"
+        WHITESPACE@[80; 81) " "
+        NAME@[81; 83)
+          IDENT@[81; 83) "f3"
+        PARAM_LIST@[83; 104)
+          L_PAREN@[83; 84) "("
+          PARAM@[84; 103)
+            TUPLE_STRUCT_PAT@[84; 94)
+              PATH@[84; 91)
+                PATH_SEGMENT@[84; 91)
+                  NAME_REF@[84; 91)
+                    IDENT@[84; 91) "NewType"
+              L_PAREN@[91; 92) "("
+              BIND_PAT@[92; 93)
+                NAME@[92; 93)
+                  IDENT@[92; 93) "a"
+              R_PAREN@[93; 94) ")"
+            COLON@[94; 95) ":"
+            WHITESPACE@[95; 96) " "
+            PATH_TYPE@[96; 103)
+              PATH@[96; 103)
+                PATH_SEGMENT@[96; 103)
+                  NAME_REF@[96; 103)
+                    IDENT@[96; 103) "NewType"
+          R_PAREN@[103; 104) ")"
+        WHITESPACE@[104; 105) " "
+        BLOCK_EXPR@[105; 107)
+          BLOCK@[105; 107)
+            L_CURLY@[105; 106) "{"
+            R_CURLY@[106; 107) "}"
+      WHITESPACE@[107; 112) "\n    "
+      FN_DEF@[112; 134)
+        FN_KW@[112; 114) "fn"
+        WHITESPACE@[114; 115) " "
+        NAME@[115; 117)
+          IDENT@[115; 117) "f4"
+        PARAM_LIST@[117; 131)
+          L_PAREN@[117; 118) "("
+          PARAM@[118; 130)
+            REF_PAT@[118; 121)
+              AMP@[118; 119) "&"
+              REF_PAT@[119; 121)
+                AMP@[119; 120) "&"
+                BIND_PAT@[120; 121)
+                  NAME@[120; 121)
+                    IDENT@[120; 121) "a"
+            COLON@[121; 122) ":"
+            WHITESPACE@[122; 123) " "
+            REFERENCE_TYPE@[123; 130)
+              AMP@[123; 124) "&"
+              REFERENCE_TYPE@[124; 130)
+                AMP@[124; 125) "&"
+                PATH_TYPE@[125; 130)
+                  PATH@[125; 130)
+                    PATH_SEGMENT@[125; 130)
+                      NAME_REF@[125; 130)
+                        IDENT@[125; 130) "usize"
+          R_PAREN@[130; 131) ")"
+        WHITESPACE@[131; 132) " "
+        BLOCK_EXPR@[132; 134)
+          BLOCK@[132; 134)
+            L_CURLY@[132; 133) "{"
+            R_CURLY@[133; 134) "}"
+      WHITESPACE@[134; 135) "\n"
+      R_CURLY@[135; 136) "}"
+  WHITESPACE@[136; 137) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0153_trait_fn_patterns.rs
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0153_trait_fn_patterns.rs
@@ -1,0 +1,6 @@
+trait T {
+    fn f1((a, b): (usize, usize)) {}
+    fn f2(S { a, b }: S) {}
+    fn f3(NewType(a): NewType) {}
+    fn f4(&&a: &&usize) {}
+}

--- a/crates/ra_syntax/test_data/parser/inline/ok/0153_trait_fn_patterns.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0153_trait_fn_patterns.txt
@@ -1,0 +1,161 @@
+SOURCE_FILE@[0; 138)
+  TRAIT_DEF@[0; 137)
+    TRAIT_KW@[0; 5) "trait"
+    WHITESPACE@[5; 6) " "
+    NAME@[6; 7)
+      IDENT@[6; 7) "T"
+    WHITESPACE@[7; 8) " "
+    ITEM_LIST@[8; 137)
+      L_CURLY@[8; 9) "{"
+      WHITESPACE@[9; 14) "\n    "
+      FN_DEF@[14; 46)
+        FN_KW@[14; 16) "fn"
+        WHITESPACE@[16; 17) " "
+        NAME@[17; 19)
+          IDENT@[17; 19) "f1"
+        PARAM_LIST@[19; 43)
+          L_PAREN@[19; 20) "("
+          PARAM@[20; 42)
+            TUPLE_PAT@[20; 26)
+              L_PAREN@[20; 21) "("
+              BIND_PAT@[21; 22)
+                NAME@[21; 22)
+                  IDENT@[21; 22) "a"
+              COMMA@[22; 23) ","
+              WHITESPACE@[23; 24) " "
+              BIND_PAT@[24; 25)
+                NAME@[24; 25)
+                  IDENT@[24; 25) "b"
+              R_PAREN@[25; 26) ")"
+            COLON@[26; 27) ":"
+            WHITESPACE@[27; 28) " "
+            TUPLE_TYPE@[28; 42)
+              L_PAREN@[28; 29) "("
+              PATH_TYPE@[29; 34)
+                PATH@[29; 34)
+                  PATH_SEGMENT@[29; 34)
+                    NAME_REF@[29; 34)
+                      IDENT@[29; 34) "usize"
+              COMMA@[34; 35) ","
+              WHITESPACE@[35; 36) " "
+              PATH_TYPE@[36; 41)
+                PATH@[36; 41)
+                  PATH_SEGMENT@[36; 41)
+                    NAME_REF@[36; 41)
+                      IDENT@[36; 41) "usize"
+              R_PAREN@[41; 42) ")"
+          R_PAREN@[42; 43) ")"
+        WHITESPACE@[43; 44) " "
+        BLOCK_EXPR@[44; 46)
+          BLOCK@[44; 46)
+            L_CURLY@[44; 45) "{"
+            R_CURLY@[45; 46) "}"
+      WHITESPACE@[46; 51) "\n    "
+      FN_DEF@[51; 74)
+        FN_KW@[51; 53) "fn"
+        WHITESPACE@[53; 54) " "
+        NAME@[54; 56)
+          IDENT@[54; 56) "f2"
+        PARAM_LIST@[56; 71)
+          L_PAREN@[56; 57) "("
+          PARAM@[57; 70)
+            RECORD_PAT@[57; 67)
+              PATH@[57; 58)
+                PATH_SEGMENT@[57; 58)
+                  NAME_REF@[57; 58)
+                    IDENT@[57; 58) "S"
+              WHITESPACE@[58; 59) " "
+              RECORD_FIELD_PAT_LIST@[59; 67)
+                L_CURLY@[59; 60) "{"
+                WHITESPACE@[60; 61) " "
+                BIND_PAT@[61; 62)
+                  NAME@[61; 62)
+                    IDENT@[61; 62) "a"
+                COMMA@[62; 63) ","
+                WHITESPACE@[63; 64) " "
+                BIND_PAT@[64; 65)
+                  NAME@[64; 65)
+                    IDENT@[64; 65) "b"
+                WHITESPACE@[65; 66) " "
+                R_CURLY@[66; 67) "}"
+            COLON@[67; 68) ":"
+            WHITESPACE@[68; 69) " "
+            PATH_TYPE@[69; 70)
+              PATH@[69; 70)
+                PATH_SEGMENT@[69; 70)
+                  NAME_REF@[69; 70)
+                    IDENT@[69; 70) "S"
+          R_PAREN@[70; 71) ")"
+        WHITESPACE@[71; 72) " "
+        BLOCK_EXPR@[72; 74)
+          BLOCK@[72; 74)
+            L_CURLY@[72; 73) "{"
+            R_CURLY@[73; 74) "}"
+      WHITESPACE@[74; 79) "\n    "
+      FN_DEF@[79; 108)
+        FN_KW@[79; 81) "fn"
+        WHITESPACE@[81; 82) " "
+        NAME@[82; 84)
+          IDENT@[82; 84) "f3"
+        PARAM_LIST@[84; 105)
+          L_PAREN@[84; 85) "("
+          PARAM@[85; 104)
+            TUPLE_STRUCT_PAT@[85; 95)
+              PATH@[85; 92)
+                PATH_SEGMENT@[85; 92)
+                  NAME_REF@[85; 92)
+                    IDENT@[85; 92) "NewType"
+              L_PAREN@[92; 93) "("
+              BIND_PAT@[93; 94)
+                NAME@[93; 94)
+                  IDENT@[93; 94) "a"
+              R_PAREN@[94; 95) ")"
+            COLON@[95; 96) ":"
+            WHITESPACE@[96; 97) " "
+            PATH_TYPE@[97; 104)
+              PATH@[97; 104)
+                PATH_SEGMENT@[97; 104)
+                  NAME_REF@[97; 104)
+                    IDENT@[97; 104) "NewType"
+          R_PAREN@[104; 105) ")"
+        WHITESPACE@[105; 106) " "
+        BLOCK_EXPR@[106; 108)
+          BLOCK@[106; 108)
+            L_CURLY@[106; 107) "{"
+            R_CURLY@[107; 108) "}"
+      WHITESPACE@[108; 113) "\n    "
+      FN_DEF@[113; 135)
+        FN_KW@[113; 115) "fn"
+        WHITESPACE@[115; 116) " "
+        NAME@[116; 118)
+          IDENT@[116; 118) "f4"
+        PARAM_LIST@[118; 132)
+          L_PAREN@[118; 119) "("
+          PARAM@[119; 131)
+            REF_PAT@[119; 122)
+              AMP@[119; 120) "&"
+              REF_PAT@[120; 122)
+                AMP@[120; 121) "&"
+                BIND_PAT@[121; 122)
+                  NAME@[121; 122)
+                    IDENT@[121; 122) "a"
+            COLON@[122; 123) ":"
+            WHITESPACE@[123; 124) " "
+            REFERENCE_TYPE@[124; 131)
+              AMP@[124; 125) "&"
+              REFERENCE_TYPE@[125; 131)
+                AMP@[125; 126) "&"
+                PATH_TYPE@[126; 131)
+                  PATH@[126; 131)
+                    PATH_SEGMENT@[126; 131)
+                      NAME_REF@[126; 131)
+                        IDENT@[126; 131) "usize"
+          R_PAREN@[131; 132) ")"
+        WHITESPACE@[132; 133) " "
+        BLOCK_EXPR@[133; 135)
+          BLOCK@[133; 135)
+            L_CURLY@[133; 134) "{"
+            R_CURLY@[134; 135) "}"
+      WHITESPACE@[135; 136) "\n"
+      R_CURLY@[136; 137) "}"
+  WHITESPACE@[137; 138) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0154_fn_pointer_param_ident_path.rs
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0154_fn_pointer_param_ident_path.rs
@@ -1,0 +1,2 @@
+type Foo = fn(Bar::Baz);
+type Qux = fn(baz: Bar::Baz);

--- a/crates/ra_syntax/test_data/parser/inline/ok/0154_fn_pointer_param_ident_path.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0154_fn_pointer_param_ident_path.txt
@@ -1,0 +1,58 @@
+SOURCE_FILE@[0; 55)
+  TYPE_ALIAS_DEF@[0; 24)
+    TYPE_KW@[0; 4) "type"
+    WHITESPACE@[4; 5) " "
+    NAME@[5; 8)
+      IDENT@[5; 8) "Foo"
+    WHITESPACE@[8; 9) " "
+    EQ@[9; 10) "="
+    WHITESPACE@[10; 11) " "
+    FN_POINTER_TYPE@[11; 23)
+      FN_KW@[11; 13) "fn"
+      PARAM_LIST@[13; 23)
+        L_PAREN@[13; 14) "("
+        PARAM@[14; 22)
+          PATH_TYPE@[14; 22)
+            PATH@[14; 22)
+              PATH@[14; 17)
+                PATH_SEGMENT@[14; 17)
+                  NAME_REF@[14; 17)
+                    IDENT@[14; 17) "Bar"
+              COLONCOLON@[17; 19) "::"
+              PATH_SEGMENT@[19; 22)
+                NAME_REF@[19; 22)
+                  IDENT@[19; 22) "Baz"
+        R_PAREN@[22; 23) ")"
+    SEMI@[23; 24) ";"
+  WHITESPACE@[24; 25) "\n"
+  TYPE_ALIAS_DEF@[25; 54)
+    TYPE_KW@[25; 29) "type"
+    WHITESPACE@[29; 30) " "
+    NAME@[30; 33)
+      IDENT@[30; 33) "Qux"
+    WHITESPACE@[33; 34) " "
+    EQ@[34; 35) "="
+    WHITESPACE@[35; 36) " "
+    FN_POINTER_TYPE@[36; 53)
+      FN_KW@[36; 38) "fn"
+      PARAM_LIST@[38; 53)
+        L_PAREN@[38; 39) "("
+        PARAM@[39; 52)
+          BIND_PAT@[39; 42)
+            NAME@[39; 42)
+              IDENT@[39; 42) "baz"
+          COLON@[42; 43) ":"
+          WHITESPACE@[43; 44) " "
+          PATH_TYPE@[44; 52)
+            PATH@[44; 52)
+              PATH@[44; 47)
+                PATH_SEGMENT@[44; 47)
+                  NAME_REF@[44; 47)
+                    IDENT@[44; 47) "Bar"
+              COLONCOLON@[47; 49) "::"
+              PATH_SEGMENT@[49; 52)
+                NAME_REF@[49; 52)
+                  IDENT@[49; 52) "Baz"
+        R_PAREN@[52; 53) ")"
+    SEMI@[53; 54) ";"
+  WHITESPACE@[54; 55) "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0155_closure_params.rs
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0155_closure_params.rs
@@ -1,0 +1,3 @@
+fn main() {
+   let foo = |bar, baz: Baz, qux: Qux::Quux| ();
+}

--- a/crates/ra_syntax/test_data/parser/inline/ok/0155_closure_params.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0155_closure_params.txt
@@ -1,0 +1,70 @@
+SOURCE_FILE@[0; 63)
+  FN_DEF@[0; 62)
+    FN_KW@[0; 2) "fn"
+    WHITESPACE@[2; 3) " "
+    NAME@[3; 7)
+      IDENT@[3; 7) "main"
+    PARAM_LIST@[7; 9)
+      L_PAREN@[7; 8) "("
+      R_PAREN@[8; 9) ")"
+    WHITESPACE@[9; 10) " "
+    BLOCK_EXPR@[10; 62)
+      BLOCK@[10; 62)
+        L_CURLY@[10; 11) "{"
+        WHITESPACE@[11; 15) "\n   "
+        LET_STMT@[15; 60)
+          LET_KW@[15; 18) "let"
+          WHITESPACE@[18; 19) " "
+          BIND_PAT@[19; 22)
+            NAME@[19; 22)
+              IDENT@[19; 22) "foo"
+          WHITESPACE@[22; 23) " "
+          EQ@[23; 24) "="
+          WHITESPACE@[24; 25) " "
+          LAMBDA_EXPR@[25; 59)
+            PARAM_LIST@[25; 56)
+              PIPE@[25; 26) "|"
+              PARAM@[26; 29)
+                BIND_PAT@[26; 29)
+                  NAME@[26; 29)
+                    IDENT@[26; 29) "bar"
+              COMMA@[29; 30) ","
+              WHITESPACE@[30; 31) " "
+              PARAM@[31; 39)
+                BIND_PAT@[31; 34)
+                  NAME@[31; 34)
+                    IDENT@[31; 34) "baz"
+                COLON@[34; 35) ":"
+                WHITESPACE@[35; 36) " "
+                PATH_TYPE@[36; 39)
+                  PATH@[36; 39)
+                    PATH_SEGMENT@[36; 39)
+                      NAME_REF@[36; 39)
+                        IDENT@[36; 39) "Baz"
+              COMMA@[39; 40) ","
+              WHITESPACE@[40; 41) " "
+              PARAM@[41; 55)
+                BIND_PAT@[41; 44)
+                  NAME@[41; 44)
+                    IDENT@[41; 44) "qux"
+                COLON@[44; 45) ":"
+                WHITESPACE@[45; 46) " "
+                PATH_TYPE@[46; 55)
+                  PATH@[46; 55)
+                    PATH@[46; 49)
+                      PATH_SEGMENT@[46; 49)
+                        NAME_REF@[46; 49)
+                          IDENT@[46; 49) "Qux"
+                    COLONCOLON@[49; 51) "::"
+                    PATH_SEGMENT@[51; 55)
+                      NAME_REF@[51; 55)
+                        IDENT@[51; 55) "Quux"
+              PIPE@[55; 56) "|"
+            WHITESPACE@[56; 57) " "
+            TUPLE_EXPR@[57; 59)
+              L_PAREN@[57; 58) "("
+              R_PAREN@[58; 59) ")"
+          SEMI@[59; 60) ";"
+        WHITESPACE@[60; 61) "\n"
+        R_CURLY@[61; 62) "}"
+  WHITESPACE@[62; 63) "\n"

--- a/crates/ra_syntax/test_data/parser/ok/0030_traits.rs
+++ b/crates/ra_syntax/test_data/parser/ok/0030_traits.rs
@@ -1,7 +1,3 @@
-pub trait WriteMessage {
-    fn write_message(&FrontendMessage);
-}
-
 trait Runnable {
     fn handler();
 }

--- a/crates/ra_syntax/test_data/parser/ok/0030_traits.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0030_traits.txt
@@ -1,93 +1,61 @@
-SOURCE_FILE@[0; 164)
-  TRAIT_DEF@[0; 66)
-    VISIBILITY@[0; 3)
-      PUB_KW@[0; 3) "pub"
-    WHITESPACE@[3; 4) " "
-    TRAIT_KW@[4; 9) "trait"
-    WHITESPACE@[9; 10) " "
-    NAME@[10; 22)
-      IDENT@[10; 22) "WriteMessage"
-    WHITESPACE@[22; 23) " "
-    ITEM_LIST@[23; 66)
-      L_CURLY@[23; 24) "{"
-      WHITESPACE@[24; 29) "\n    "
-      FN_DEF@[29; 64)
-        FN_KW@[29; 31) "fn"
-        WHITESPACE@[31; 32) " "
-        NAME@[32; 45)
-          IDENT@[32; 45) "write_message"
-        PARAM_LIST@[45; 63)
-          L_PAREN@[45; 46) "("
-          PARAM@[46; 62)
-            REFERENCE_TYPE@[46; 62)
-              AMP@[46; 47) "&"
-              PATH_TYPE@[47; 62)
-                PATH@[47; 62)
-                  PATH_SEGMENT@[47; 62)
-                    NAME_REF@[47; 62)
-                      IDENT@[47; 62) "FrontendMessage"
-          R_PAREN@[62; 63) ")"
-        SEMI@[63; 64) ";"
-      WHITESPACE@[64; 65) "\n"
-      R_CURLY@[65; 66) "}"
-  WHITESPACE@[66; 68) "\n\n"
-  TRAIT_DEF@[68; 104)
-    TRAIT_KW@[68; 73) "trait"
-    WHITESPACE@[73; 74) " "
-    NAME@[74; 82)
-      IDENT@[74; 82) "Runnable"
-    WHITESPACE@[82; 83) " "
-    ITEM_LIST@[83; 104)
-      L_CURLY@[83; 84) "{"
-      WHITESPACE@[84; 89) "\n    "
-      FN_DEF@[89; 102)
-        FN_KW@[89; 91) "fn"
-        WHITESPACE@[91; 92) " "
-        NAME@[92; 99)
-          IDENT@[92; 99) "handler"
-        PARAM_LIST@[99; 101)
-          L_PAREN@[99; 100) "("
-          R_PAREN@[100; 101) ")"
-        SEMI@[101; 102) ";"
-      WHITESPACE@[102; 103) "\n"
-      R_CURLY@[103; 104) "}"
-  WHITESPACE@[104; 106) "\n\n"
-  TRAIT_DEF@[106; 163)
-    TRAIT_KW@[106; 111) "trait"
-    WHITESPACE@[111; 112) " "
-    NAME@[112; 125)
-      IDENT@[112; 125) "TraitWithExpr"
-    WHITESPACE@[125; 126) " "
-    ITEM_LIST@[126; 163)
-      L_CURLY@[126; 127) "{"
-      WHITESPACE@[127; 132) "\n    "
-      FN_DEF@[132; 161)
-        FN_KW@[132; 134) "fn"
-        WHITESPACE@[134; 135) " "
-        NAME@[135; 147)
-          IDENT@[135; 147) "fn_with_expr"
-        PARAM_LIST@[147; 160)
-          L_PAREN@[147; 148) "("
-          PARAM@[148; 159)
-            BIND_PAT@[148; 149)
-              NAME@[148; 149)
-                IDENT@[148; 149) "x"
-            COLON@[149; 150) ":"
-            WHITESPACE@[150; 151) " "
-            ARRAY_TYPE@[151; 159)
-              L_BRACK@[151; 152) "["
-              PATH_TYPE@[152; 155)
-                PATH@[152; 155)
-                  PATH_SEGMENT@[152; 155)
-                    NAME_REF@[152; 155)
-                      IDENT@[152; 155) "i32"
-              SEMI@[155; 156) ";"
-              WHITESPACE@[156; 157) " "
-              LITERAL@[157; 158)
-                INT_NUMBER@[157; 158) "1"
-              R_BRACK@[158; 159) "]"
-          R_PAREN@[159; 160) ")"
-        SEMI@[160; 161) ";"
-      WHITESPACE@[161; 162) "\n"
-      R_CURLY@[162; 163) "}"
-  WHITESPACE@[163; 164) "\n"
+SOURCE_FILE@[0; 96)
+  TRAIT_DEF@[0; 36)
+    TRAIT_KW@[0; 5) "trait"
+    WHITESPACE@[5; 6) " "
+    NAME@[6; 14)
+      IDENT@[6; 14) "Runnable"
+    WHITESPACE@[14; 15) " "
+    ITEM_LIST@[15; 36)
+      L_CURLY@[15; 16) "{"
+      WHITESPACE@[16; 21) "\n    "
+      FN_DEF@[21; 34)
+        FN_KW@[21; 23) "fn"
+        WHITESPACE@[23; 24) " "
+        NAME@[24; 31)
+          IDENT@[24; 31) "handler"
+        PARAM_LIST@[31; 33)
+          L_PAREN@[31; 32) "("
+          R_PAREN@[32; 33) ")"
+        SEMI@[33; 34) ";"
+      WHITESPACE@[34; 35) "\n"
+      R_CURLY@[35; 36) "}"
+  WHITESPACE@[36; 38) "\n\n"
+  TRAIT_DEF@[38; 95)
+    TRAIT_KW@[38; 43) "trait"
+    WHITESPACE@[43; 44) " "
+    NAME@[44; 57)
+      IDENT@[44; 57) "TraitWithExpr"
+    WHITESPACE@[57; 58) " "
+    ITEM_LIST@[58; 95)
+      L_CURLY@[58; 59) "{"
+      WHITESPACE@[59; 64) "\n    "
+      FN_DEF@[64; 93)
+        FN_KW@[64; 66) "fn"
+        WHITESPACE@[66; 67) " "
+        NAME@[67; 79)
+          IDENT@[67; 79) "fn_with_expr"
+        PARAM_LIST@[79; 92)
+          L_PAREN@[79; 80) "("
+          PARAM@[80; 91)
+            BIND_PAT@[80; 81)
+              NAME@[80; 81)
+                IDENT@[80; 81) "x"
+            COLON@[81; 82) ":"
+            WHITESPACE@[82; 83) " "
+            ARRAY_TYPE@[83; 91)
+              L_BRACK@[83; 84) "["
+              PATH_TYPE@[84; 87)
+                PATH@[84; 87)
+                  PATH_SEGMENT@[84; 87)
+                    NAME_REF@[84; 87)
+                      IDENT@[84; 87) "i32"
+              SEMI@[87; 88) ";"
+              WHITESPACE@[88; 89) " "
+              LITERAL@[89; 90)
+                INT_NUMBER@[89; 90) "1"
+              R_BRACK@[90; 91) "]"
+          R_PAREN@[91; 92) ")"
+        SEMI@[92; 93) ";"
+      WHITESPACE@[93; 94) "\n"
+      R_CURLY@[94; 95) "}"
+  WHITESPACE@[95; 96) "\n"


### PR DESCRIPTION
Fixes #2847.

- `Fn__(...)` parameters with idents/patterns no longer parse
- Trait function parameters with arbitrary patterns parse
- Trait function parameters without idents/patterns no longer parse
- `fn(...)` parameters no longer parse with patterns other than a single ident

__Question__: The pre-existing test `param_list_opt_patterns` has been kept as-is, although the name no longer makes sense (it's testing `Fn__(...)` params, which aren't allowed patterns any more). What would be best to do about this?