### PR TITLE
Update async unsafe fn ordering in parser

### DIFF
--- a/crates/ra_parser/src/grammar/items.rs
+++ b/crates/ra_parser/src/grammar/items.rs
@@ -91,17 +91,17 @@ pub(super) fn maybe_item(p: &mut Parser, m: Marker, flavor: ItemFlavor) -> Resul
     // modifiers
     has_mods |= p.eat(T![const]);
 
-    // test_err unsafe_block_in_mod
-    // fn foo(){} unsafe { } fn bar(){}
-    if p.at(T![unsafe]) && p.nth(1) != T!['{'] {
-        p.eat(T![unsafe]);
-        has_mods = true;
-    }
-
     // test_err async_without_semicolon
     // fn foo() { let _ = async {} }
     if p.at(T![async]) && p.nth(1) != T!['{'] && p.nth(1) != T![move] && p.nth(1) != T![|] {
         p.eat(T![async]);
+        has_mods = true;
+    }
+
+    // test_err unsafe_block_in_mod
+    // fn foo(){} unsafe { } fn bar(){}
+    if p.at(T![unsafe]) && p.nth(1) != T!['{'] {
+        p.eat(T![unsafe]);
         has_mods = true;
     }
 
@@ -157,11 +157,11 @@ pub(super) fn maybe_item(p: &mut Parser, m: Marker, flavor: ItemFlavor) -> Resul
         // unsafe fn foo() {}
 
         // test combined_fns
-        // unsafe async fn foo() {}
+        // async unsafe fn foo() {}
         // const unsafe fn bar() {}
 
         // test_err wrong_order_fns
-        // async unsafe fn foo() {}
+        // unsafe async fn foo() {}
         // unsafe const fn bar() {}
         T![fn] => {
             fn_def(p, flavor);

--- a/crates/ra_syntax/test_data/parser/inline/err/0010_wrong_order_fns.rs
+++ b/crates/ra_syntax/test_data/parser/inline/err/0010_wrong_order_fns.rs
@@ -1,2 +1,2 @@
-async unsafe fn foo() {}
+unsafe async fn foo() {}
 unsafe const fn bar() {}

--- a/crates/ra_syntax/test_data/parser/inline/err/0010_wrong_order_fns.txt
+++ b/crates/ra_syntax/test_data/parser/inline/err/0010_wrong_order_fns.txt
@@ -1,9 +1,9 @@
 SOURCE_FILE@[0; 50)
-  ERROR@[0; 5)
-    ASYNC_KW@[0; 5) "async"
-  WHITESPACE@[5; 6) " "
-  FN_DEF@[6; 24)
-    UNSAFE_KW@[6; 12) "unsafe"
+  ERROR@[0; 6)
+    UNSAFE_KW@[0; 6) "unsafe"
+  WHITESPACE@[6; 7) " "
+  FN_DEF@[7; 24)
+    ASYNC_KW@[7; 12) "async"
     WHITESPACE@[12; 13) " "
     FN_KW@[13; 15) "fn"
     WHITESPACE@[15; 16) " "
@@ -37,5 +37,5 @@ SOURCE_FILE@[0; 50)
         L_CURLY@[47; 48) "{"
         R_CURLY@[48; 49) "}"
   WHITESPACE@[49; 50) "\n"
-error 5: expected existential, fn, trait or impl
+error 6: expected existential, fn, trait or impl
 error 31: expected existential, fn, trait or impl

--- a/crates/ra_syntax/test_data/parser/inline/ok/0128_combined_fns.rs
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0128_combined_fns.rs
@@ -1,2 +1,2 @@
-unsafe async fn foo() {}
+async unsafe fn foo() {}
 const unsafe fn bar() {}

--- a/crates/ra_syntax/test_data/parser/inline/ok/0128_combined_fns.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0128_combined_fns.txt
@@ -1,8 +1,8 @@
 SOURCE_FILE@[0; 50)
   FN_DEF@[0; 24)
-    UNSAFE_KW@[0; 6) "unsafe"
-    WHITESPACE@[6; 7) " "
-    ASYNC_KW@[7; 12) "async"
+    ASYNC_KW@[0; 5) "async"
+    WHITESPACE@[5; 6) " "
+    UNSAFE_KW@[6; 12) "unsafe"
     WHITESPACE@[12; 13) " "
     FN_KW@[13; 15) "fn"
     WHITESPACE@[15; 16) " "


### PR DESCRIPTION
As of rust-lang/rust#61319 the correct order for functions that are both unsafe and async is: `async unsafe fn` and not `unsafe async fn`.

This commit updates the parser tests to reflect this, and corrects parsing behavior to accept the correct ordering.

Fixes #3025