### PR TITLE
Remove ImportResolver-related stubs

### DIFF
--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -58,7 +58,6 @@ pub use hir_def::{
     type_ref::Mutability,
 };
 pub use hir_expand::{
-    name::{name, Name},
-    HirFileId, InFile, MacroCallId, MacroCallLoc, MacroDefId, MacroFile, Origin,
+    name::Name, HirFileId, InFile, MacroCallId, MacroCallLoc, MacroDefId, MacroFile, Origin,
 };
 pub use hir_ty::{display::HirDisplay, CallableDef};

--- a/crates/ra_hir_expand/src/name.rs
+++ b/crates/ra_hir_expand/src/name.rs
@@ -187,13 +187,6 @@ pub mod known {
         PartialOrd,
         Eq,
         PartialEq,
-        // FIXME delete those after `ImportResolver` is removed.
-        hash,
-        fmt,
-        io,
-        Display,
-        Iterator,
-        Hasher,
     );
 
     // self/Self cannot be used as an identifier


### PR DESCRIPTION
A follow-up for https://github.com/rust-analyzer/rust-analyzer/pull/3063/, removes the FIXME added during the https://github.com/rust-analyzer/rust-analyzer/pull/2982#issuecomment-581130028 changes.