### PR TITLE
vscode: removed unnecessary awaits feature

### DIFF
--- a/editors/code/src/installation/language_server.ts
+++ b/editors/code/src/installation/language_server.ts
@@ -105,10 +105,13 @@ export async function ensureLanguageServerBinary(
                     `GitHub repository: ${err.message}`
                 );
 
-                dns.resolve('www.google.com').catch(err => {
-                    console.error("DNS resolution failed, there might be an issue with Internet availability");
-                    console.error(err);
-                });
+                dns.resolve('www.google.com').then(
+                    addrs => console.log("DNS resolution was successful", addrs),
+                    err => {
+                        console.error("DNS resolution failed, there might be an issue with Internet availability");
+                        console.error(err);
+                    }
+                );
 
                 return null;
             }

--- a/editors/code/src/installation/language_server.ts
+++ b/editors/code/src/installation/language_server.ts
@@ -105,10 +105,13 @@ export async function ensureLanguageServerBinary(
                     `GitHub repository: ${err.message}`
                 );
 
-                dns.resolve('www.google.com').then(
-                    addrs => console.log("DNS resolution was successful", addrs),
+                dns.resolve('example.com').then(
+                    addrs => console.log("DNS resolution for example.com was successful", addrs),
                     err => {
-                        console.error("DNS resolution failed, there might be an issue with Internet availability");
+                        console.error(
+                            "DNS resolution for example.com failed, " +
+                            "there might be an issue with Internet availability"
+                        );
                         console.error(err);
                     }
                 );

--- a/editors/code/src/installation/language_server.ts
+++ b/editors/code/src/installation/language_server.ts
@@ -100,12 +100,12 @@ export async function ensureLanguageServerBinary(
             try {
                 await downloadLatestLanguageServer(langServerSource);
             } catch (err) {
-                await vscode.window.showErrorMessage(
+                vscode.window.showErrorMessage(
                     `Failed to download language server from ${langServerSource.repo.name} ` +
                     `GitHub repository: ${err.message}`
                 );
 
-                await dns.resolve('www.google.com').catch(err => {
+                dns.resolve('www.google.com').catch(err => {
                     console.error("DNS resolution failed, there might be an issue with Internet availability");
                     console.error(err);
                 });


### PR DESCRIPTION
Found a feature that when the user has no internet connection the whole extension is blocked by waiting for the user to dismiss the error message and for making a sanity-check dns resolution.