### PR TITLE
Migrate u32::from(TextUnit) as usize to .to_usize()

### DIFF
--- a/crates/ra_hir_def/src/body/scope.rs
+++ b/crates/ra_hir_def/src/body/scope.rs
@@ -194,7 +194,7 @@ mod tests {
         let (off, code) = extract_offset(code);
         let code = {
             let mut buf = String::new();
-            let off = u32::from(off) as usize;
+            let off = off.to_usize();
             buf.push_str(&code[..off]);
             buf.push_str("marker");
             buf.push_str(&code[off..]);

--- a/crates/ra_text_edit/src/lib.rs
+++ b/crates/ra_text_edit/src/lib.rs
@@ -29,8 +29,8 @@ impl AtomTextEdit {
     }
 
     pub fn apply(&self, mut text: String) -> String {
-        let start = u32::from(self.delete.start()) as usize;
-        let end = u32::from(self.delete.end()) as usize;
+        let start = self.delete.start().to_usize();
+        let end = self.delete.end().to_usize();
         text.replace_range(start..end, &self.insert);
         text
     }

--- a/crates/ra_text_edit/src/text_edit.rs
+++ b/crates/ra_text_edit/src/text_edit.rs
@@ -66,13 +66,13 @@ impl TextEdit {
         let mut total_len = text.len();
         for atom in self.atoms.iter() {
             total_len += atom.insert.len();
-            total_len -= u32::from(atom.delete.end() - atom.delete.start()) as usize;
+            total_len -= (atom.delete.end() - atom.delete.start()).to_usize();
         }
         let mut buf = String::with_capacity(total_len);
         let mut prev = 0;
         for atom in self.atoms.iter() {
-            let start = u32::from(atom.delete.start()) as usize;
-            let end = u32::from(atom.delete.end()) as usize;
+            let start = atom.delete.start().to_usize();
+            let end = atom.delete.end().to_usize();
             if start > prev {
                 buf.push_str(&text[prev..start]);
             }


### PR DESCRIPTION
@matklad I see 29 uses of `.to_usize()` cast, wouldn't it be reasonable to change `TextUnit(u32)` to `TextUnit(usize)` ? Or do you have reasons to stick with `u32` here?