### PR TITLE
vscode: fix binary is not functional on windows

### DIFF
--- a/editors/code/src/installation/download_file.ts
+++ b/editors/code/src/installation/download_file.ts
@@ -27,8 +27,7 @@ export async function downloadFile(
             readBytes += chunk.length;
             onProgress(readBytes, totalBytes);
         })
-        .on("end", resolve)
         .on("error", reject)
-        .pipe(fs.createWriteStream(destFilePath))
+        .pipe(fs.createWriteStream(destFilePath).on("close", resolve))
     );
 }


### PR DESCRIPTION
This is my first approach to fix this error, need to double-check this on windows still...
Fixes #3087
Fixes #3090 