### PR TITLE
Support trait auto import

### DIFF
--- a/crates/ra_assists/src/handlers/auto_import.rs
+++ b/crates/ra_assists/src/handlers/auto_import.rs
@@ -4,8 +4,8 @@ use crate::{
 };
 use hir::{
     db::{DefDatabase, HirDatabase},
-    AssocContainerId, AssocItem, Crate, Function, ModPath, Module, ModuleDef, PathResolution,
-    SourceAnalyzer, Trait, Type,
+    AsAssocItem, AssocItem, AssocItemContainer, Crate, Function, ModPath, Module, ModuleDef,
+    PathResolution, SourceAnalyzer, Trait, Type,
 };
 use ra_ide_db::{imports_locator::ImportsLocator, RootDatabase};
 use ra_prof::profile;
@@ -157,13 +157,12 @@ impl AutoImportAssets {
                                 &trait_candidates,
                                 None,
                                 |_, assoc| {
-                                    if let AssocContainerId::TraitId(trait_id) = assoc.container(db)
+                                    if let AssocItemContainer::Trait(appropriate_trait) =
+                                        assoc.container(db)
                                     {
                                         applicable_traits.push(
-                                            self.module_with_name_to_import.find_use_path(
-                                                db,
-                                                ModuleDef::Trait(trait_id.into()),
-                                            ),
+                                            self.module_with_name_to_import
+                                                .find_use_path(db, appropriate_trait.into()),
                                         );
                                     };
                                     None::<()>
@@ -187,15 +186,15 @@ impl AutoImportAssets {
                                 current_crate,
                                 &trait_candidates,
                                 None,
-                                |_, funciton| {
-                                    if let AssocContainerId::TraitId(trait_id) =
-                                        funciton.container(db)
+                                |_, function| {
+                                    if let AssocItemContainer::Trait(appropriate_trait) = function
+                                        .as_assoc_item(db)
+                                        .expect("Function is an assoc item")
+                                        .container(db)
                                     {
                                         applicable_traits.push(
-                                            self.module_with_name_to_import.find_use_path(
-                                                db,
-                                                ModuleDef::Trait(trait_id.into()),
-                                            ),
+                                            self.module_with_name_to_import
+                                                .find_use_path(db, appropriate_trait.into()),
                                         );
                                     };
                                     None::<()>

--- a/crates/ra_assists/src/handlers/auto_import.rs
+++ b/crates/ra_assists/src/handlers/auto_import.rs
@@ -1,10 +1,11 @@
-use ra_ide_db::imports_locator::ImportsLocator;
+use ra_ide_db::{imports_locator::ImportsLocator, RootDatabase};
 use ra_syntax::ast::{self, AstNode};
 
 use crate::{
     assist_ctx::{Assist, AssistCtx},
     insert_use_statement, AssistId,
 };
+use hir::{db::HirDatabase, Adt, ModPath, Module, ModuleDef, PathResolution, SourceAnalyzer};
 use std::collections::BTreeSet;
 
 // Assist: auto_import
@@ -44,29 +45,13 @@ pub(crate) fn auto_import(ctx: AssistCtx) -> Option<Assist> {
     let source_analyzer = ctx.source_analyzer(&position, None);
     let module_with_name_to_import = source_analyzer.module()?;
 
-    let name_ref_to_import =
-        path_under_caret.syntax().descendants().find_map(ast::NameRef::cast)?;
-    if source_analyzer
-        .resolve_path(ctx.db, &name_ref_to_import.syntax().ancestors().find_map(ast::Path::cast)?)
-        .is_some()
-    {
-        return None;
-    }
-
-    let name_to_import = name_ref_to_import.syntax().to_string();
-    let proposed_imports = ImportsLocator::new(ctx.db)
-        .find_imports(&name_to_import)
-        .into_iter()
-        .filter_map(|module_def| module_with_name_to_import.find_use_path(ctx.db, module_def))
-        .filter(|use_path| !use_path.segments.is_empty())
-        .take(20)
-        .collect::<BTreeSet<_>>();
-
+    let import_candidate = ImportCandidate::new(&path_under_caret, &source_analyzer, ctx.db)?;
+    let proposed_imports = import_candidate.search_for_imports(ctx.db, module_with_name_to_import);
     if proposed_imports.is_empty() {
         return None;
     }
 
-    let mut group = ctx.add_assist_group(format!("Import {}", name_to_import));
+    let mut group = ctx.add_assist_group(format!("Import {}", import_candidate.get_search_query()));
     for import in proposed_imports {
         group.add_assist(AssistId("auto_import"), format!("Import `{}`", &import), |edit| {
             edit.target(path_under_caret.syntax().text_range());
@@ -79,6 +64,92 @@ pub(crate) fn auto_import(ctx: AssistCtx) -> Option<Assist> {
         });
     }
     group.finish()
+}
+
+#[derive(Debug)]
+// TODO kb rustdocs
+enum ImportCandidate {
+    UnqualifiedName(ast::NameRef),
+    QualifierStart(ast::NameRef),
+    TraitFunction(Adt, ast::PathSegment),
+}
+
+impl ImportCandidate {
+    // TODO kb refactor this mess
+    fn new(
+        path_under_caret: &ast::Path,
+        source_analyzer: &SourceAnalyzer,
+        db: &impl HirDatabase,
+    ) -> Option<Self> {
+        if source_analyzer.resolve_path(db, path_under_caret).is_some() {
+            return None;
+        }
+
+        let segment = path_under_caret.segment()?;
+        if let Some(qualifier) = path_under_caret.qualifier() {
+            let qualifier_start = qualifier.syntax().descendants().find_map(ast::NameRef::cast)?;
+            let qualifier_start_path =
+                qualifier_start.syntax().ancestors().find_map(ast::Path::cast)?;
+            if let Some(qualifier_start_resolution) =
+                source_analyzer.resolve_path(db, &qualifier_start_path)
+            {
+                let qualifier_resolution = if &qualifier_start_path == path_under_caret {
+                    qualifier_start_resolution
+                } else {
+                    source_analyzer.resolve_path(db, &qualifier)?
+                };
+                if let PathResolution::Def(ModuleDef::Adt(function_callee)) = qualifier_resolution {
+                    Some(ImportCandidate::TraitFunction(function_callee, segment))
+                } else {
+                    None
+                }
+            } else {
+                Some(ImportCandidate::QualifierStart(qualifier_start))
+            }
+        } else {
+            if source_analyzer.resolve_path(db, path_under_caret).is_none() {
+                Some(ImportCandidate::UnqualifiedName(
+                    segment.syntax().descendants().find_map(ast::NameRef::cast)?,
+                ))
+            } else {
+                None
+            }
+        }
+    }
+
+    fn get_search_query(&self) -> String {
+        match self {
+            ImportCandidate::UnqualifiedName(name_ref)
+            | ImportCandidate::QualifierStart(name_ref) => name_ref.syntax().to_string(),
+            ImportCandidate::TraitFunction(_, trait_function) => {
+                trait_function.syntax().to_string()
+            }
+        }
+    }
+
+    fn search_for_imports(
+        &self,
+        db: &RootDatabase,
+        module_with_name_to_import: Module,
+    ) -> BTreeSet<ModPath> {
+        ImportsLocator::new(db)
+            .find_imports(&self.get_search_query())
+            .into_iter()
+            .filter_map(|module_def| match self {
+                ImportCandidate::TraitFunction(function_callee, _) => {
+                    if let ModuleDef::Function(function) = module_def {
+                        dbg!(function);
+                        todo!()
+                    } else {
+                        None
+                    }
+                }
+                _ => module_with_name_to_import.find_use_path(db, module_def),
+            })
+            .filter(|use_path| !use_path.segments.is_empty())
+            .take(20)
+            .collect::<BTreeSet<_>>()
+    }
 }
 
 #[cfg(test)]
@@ -381,6 +452,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // TODO kb
     fn trait_method() {
         check_assist(
             auto_import,

--- a/crates/ra_assists/src/handlers/auto_import.rs
+++ b/crates/ra_assists/src/handlers/auto_import.rs
@@ -46,9 +46,9 @@ pub(crate) fn auto_import(ctx: AssistCtx) -> Option<Assist> {
 
     let name_ref_to_import =
         path_under_caret.syntax().descendants().find_map(ast::NameRef::cast)?;
-    if source_analyzer
-        .resolve_path(ctx.db, &name_ref_to_import.syntax().ancestors().find_map(ast::Path::cast)?)
-        .is_some()
+    if dbg!(source_analyzer
+        .resolve_path(ctx.db, &name_ref_to_import.syntax().ancestors().find_map(ast::Path::cast)?))
+    .is_some()
     {
         return None;
     }
@@ -286,6 +286,23 @@ mod tests {
             use mod1::mod2;
             fn main() {
                 mod2::mod3::TestStruct<|>
+            }
+            ",
+        );
+    }
+
+    #[test]
+    fn not_applicable_for_imported_function() {
+        check_assist_not_applicable(
+            auto_import,
+            r"
+            pub mod test_mod {
+                pub fn test_function() {}
+            }
+
+            use test_mod::test_function;
+            fn main() {
+                test_function<|>
             }
             ",
         );

--- a/crates/ra_assists/src/handlers/auto_import.rs
+++ b/crates/ra_assists/src/handlers/auto_import.rs
@@ -13,6 +13,7 @@ use hir::{
     AssocContainerId, AssocItem, Crate, Function, ModPath, Module, ModuleDef, PathResolution,
     SourceAnalyzer, Trait, Type,
 };
+use ra_prof::profile;
 use rustc_hash::FxHashSet;
 use std::collections::BTreeSet;
 
@@ -123,6 +124,7 @@ impl AutoImportAssets {
         db: &RootDatabase,
         module_with_name_to_import: Module,
     ) -> BTreeSet<ModPath> {
+        let _p = profile("auto_import::search_for_imports");
         ImportsLocator::new(db)
             .find_imports(&self.get_search_query())
             .into_iter()
@@ -207,6 +209,7 @@ impl AutoImportAssets {
         called_function: Function,
         root_crate: Crate,
     ) -> FxHashSet<Trait> {
+        let _p = profile("auto_import::get_trait_candidates");
         root_crate
             .dependencies(db)
             .into_iter()

--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -696,7 +696,6 @@ impl AssocItem {
             AssocItem::TypeAlias(t) => t.module(db),
         }
     }
-
     pub fn container(self, db: &impl DefDatabase) -> AssocItemContainer {
         let container = match self {
             AssocItem::Function(it) => it.id.lookup(db).container,

--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -123,7 +123,7 @@ impl_froms!(
 );
 
 pub use hir_def::{
-    attr::Attrs, item_scope::ItemInNs, visibility::Visibility, AssocItemId, AssocItemLoc,
+    attr::Attrs, item_scope::ItemInNs, visibility::Visibility, AssocContainerId, AssocItemId,
 };
 use rustc_hash::FxHashSet;
 
@@ -696,16 +696,12 @@ impl AssocItem {
             AssocItem::TypeAlias(t) => t.module(db),
         }
     }
-    pub fn container(self, db: &impl DefDatabase) -> AssocItemContainer {
-        let container = match self {
-            AssocItem::Function(it) => it.id.lookup(db).container,
-            AssocItem::Const(it) => it.id.lookup(db).container,
-            AssocItem::TypeAlias(it) => it.id.lookup(db).container,
-        };
-        match container {
-            AssocContainerId::TraitId(id) => AssocItemContainer::Trait(id.into()),
-            AssocContainerId::ImplId(id) => AssocItemContainer::ImplBlock(id.into()),
-            AssocContainerId::ContainerId(_) => panic!("invalid AssocItem"),
+
+    pub fn container(self, db: &impl DefDatabase) -> AssocContainerId {
+        match self {
+            AssocItem::Function(f) => f.id.lookup(db).container,
+            AssocItem::Const(c) => c.id.lookup(db).container,
+            AssocItem::TypeAlias(t) => t.id.lookup(db).container,
         }
     }
 }

--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -548,6 +548,10 @@ impl Function {
         let mut validator = ExprValidator::new(self.id, infer, sink);
         validator.validate_body(db);
     }
+
+    pub fn container(self, db: &impl DefDatabase) -> AssocContainerId {
+        self.id.lookup(db).container
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -699,7 +703,7 @@ impl AssocItem {
 
     pub fn container(self, db: &impl DefDatabase) -> AssocContainerId {
         match self {
-            AssocItem::Function(f) => f.id.lookup(db).container,
+            AssocItem::Function(f) => f.container(db),
             AssocItem::Const(c) => c.id.lookup(db).container,
             AssocItem::TypeAlias(t) => t.id.lookup(db).container,
         }

--- a/crates/ra_hir/src/source_analyzer.rs
+++ b/crates/ra_hir/src/source_analyzer.rs
@@ -20,7 +20,10 @@ use hir_def::{
 use hir_expand::{
     hygiene::Hygiene, name::AsName, AstId, HirFileId, InFile, MacroCallId, MacroCallKind,
 };
-use hir_ty::{InEnvironment, InferenceResult, TraitEnvironment};
+use hir_ty::{
+    method_resolution::{iterate_method_candidates, LookupMode},
+    Canonical, InEnvironment, InferenceResult, TraitEnvironment,
+};
 use ra_syntax::{
     ast::{self, AstNode},
     AstPtr, SyntaxNode, SyntaxNodePtr, SyntaxToken, TextRange, TextUnit,
@@ -28,8 +31,8 @@ use ra_syntax::{
 use rustc_hash::FxHashSet;
 
 use crate::{
-    db::HirDatabase, Adt, Const, DefWithBody, EnumVariant, Function, Local, MacroDef, Name, Path,
-    ScopeDef, Static, Struct, Trait, Type, TypeAlias, TypeParam,
+    db::HirDatabase, Adt, AssocItem, Const, DefWithBody, EnumVariant, Function, Local, MacroDef,
+    ModuleDef, Name, Path, ScopeDef, Static, Struct, Trait, Type, TypeAlias, TypeParam,
 };
 
 /// `SourceAnalyzer` is a convenience wrapper which exposes HIR API in terms of
@@ -289,9 +292,11 @@ impl SourceAnalyzer {
 
     pub fn resolve_path(&self, db: &impl HirDatabase, path: &ast::Path) -> Option<PathResolution> {
         if let Some(path_expr) = path.syntax().parent().and_then(ast::PathExpr::cast) {
-            let expr_id = self.expr_id(&path_expr.into())?;
-            if let Some(assoc) = self.infer.as_ref()?.assoc_resolutions_for_expr(expr_id) {
-                return Some(PathResolution::AssocItem(assoc.into()));
+            let path_resolution = self
+                .resolve_as_full_path(path_expr.clone())
+                .or_else(|| self.resolve_as_path_to_method(db, &path_expr));
+            if path_resolution.is_some() {
+                return path_resolution;
             }
         }
         if let Some(path_pat) = path.syntax().parent().and_then(ast::PathPat::cast) {
@@ -303,6 +308,49 @@ impl SourceAnalyzer {
         // This must be a normal source file rather than macro file.
         let hir_path = crate::Path::from_ast(path.clone())?;
         self.resolve_hir_path(db, &hir_path)
+    }
+
+    fn resolve_as_full_path(&self, path_expr: ast::PathExpr) -> Option<PathResolution> {
+        let expr_id = self.expr_id(&path_expr.into())?;
+        self.infer
+            .as_ref()?
+            .assoc_resolutions_for_expr(expr_id)
+            .map(|assoc| PathResolution::AssocItem(assoc.into()))
+    }
+
+    fn resolve_as_path_to_method(
+        &self,
+        db: &impl HirDatabase,
+        path_expr: &ast::PathExpr,
+    ) -> Option<PathResolution> {
+        let full_path = path_expr.path()?;
+        let path_to_method = full_path.qualifier()?;
+        let method_name = full_path.segment()?.syntax().to_string();
+        match self.resolve_path(db, &path_to_method)? {
+            PathResolution::Def(ModuleDef::Adt(adt)) => {
+                let ty = adt.ty(db);
+                iterate_method_candidates(
+                    &Canonical { value: ty.ty.value, num_vars: 0 },
+                    db,
+                    ty.ty.environment,
+                    self.resolver.krate()?,
+                    &self.resolver.traits_in_scope(db),
+                    None,
+                    LookupMode::Path,
+                    |_, assoc_item_id| {
+                        let assoc = assoc_item_id.into();
+                        if let AssocItem::Function(function) = assoc {
+                            if function.name(db).to_string() == method_name {
+                                return Some(assoc);
+                            }
+                        }
+                        None
+                    },
+                )
+            }
+            _ => None,
+        }
+        .map(PathResolution::AssocItem)
     }
 
     fn resolve_local_name(&self, name_ref: &ast::NameRef) -> Option<ScopeEntryWithSyntax> {


### PR DESCRIPTION
Unfortunately, for real cases it does not work as spectacular as in the tests.

The main reason for that is type inference:
* The callee type [here](https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/ra_hir_ty/src/method_resolution.rs#L369) is unknown for many cases
* The trait solution [here](https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/ra_hir_ty/src/method_resolution.rs#L399) is also often ambiguous

That results in trait candidates being rejected, and some real cases not supported.
Example: no imports for `String::from_str("test")`