### PR TITLE
vscode: a couple of more intuitive names and shortening languageServer to langServer

### DIFF
--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -2,7 +2,7 @@ import * as lc from 'vscode-languageclient';
 import * as vscode from 'vscode';
 
 import { Config } from './config';
-import { ensureLangServerBinary } from './installation/lang_server';
+import { ensureServerBinary } from './installation/server';
 import { CallHierarchyFeature } from 'vscode-languageclient/lib/callHierarchy.proposed';
 
 export async function createClient(config: Config): Promise<null | lc.LanguageClient> {
@@ -11,11 +11,11 @@ export async function createClient(config: Config): Promise<null | lc.LanguageCl
     // It might be a good idea to test if the uri points to a file.
     const workspaceFolderPath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? '.';
 
-    const langServerPath = await ensureLangServerBinary(config.langServerBinarySource);
-    if (!langServerPath) return null;
+    const serverPath = await ensureServerBinary(config.serverBinarySource);
+    if (!serverPath) return null;
 
     const run: lc.Executable = {
-        command: langServerPath,
+        command: serverPath,
         options: { cwd: workspaceFolderPath },
     };
     const serverOptions: lc.ServerOptions = {

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -2,7 +2,7 @@ import * as lc from 'vscode-languageclient';
 import * as vscode from 'vscode';
 
 import { Config } from './config';
-import { ensureLanguageServerBinary } from './installation/language_server';
+import { ensureLangServerBinary } from './installation/lang_server';
 import { CallHierarchyFeature } from 'vscode-languageclient/lib/callHierarchy.proposed';
 
 export async function createClient(config: Config): Promise<null | lc.LanguageClient> {
@@ -11,7 +11,7 @@ export async function createClient(config: Config): Promise<null | lc.LanguageCl
     // It might be a good idea to test if the uri points to a file.
     const workspaceFolderPath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? '.';
 
-    const langServerPath = await ensureLanguageServerBinary(config.langServerBinarySource);
+    const langServerPath = await ensureLangServerBinary(config.langServerBinarySource);
     if (!langServerPath) return null;
 
     const run: lc.Executable = {

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -68,7 +68,7 @@ export class Config {
      * `platform` on GitHub releases. (It is also stored under the same name when
      * downloaded by the extension).
      */
-    get prebuiltLangServerFileName(): null | string {
+    get prebuiltServerFileName(): null | string {
         // See possible `arch` values here:
         // https://nodejs.org/api/process.html#process_process_arch
 
@@ -98,17 +98,17 @@ export class Config {
         }
     }
 
-    get langServerBinarySource(): null | BinarySource {
-        const langServerPath = RA_LSP_DEBUG ?? this.cfg.get<null | string>("raLspServerPath");
+    get serverBinarySource(): null | BinarySource {
+        const serverPath = RA_LSP_DEBUG ?? this.cfg.get<null | string>("raLspServerPath");
 
-        if (langServerPath) {
+        if (serverPath) {
             return {
                 type: BinarySource.Type.ExplicitPath,
-                path: Config.replaceTildeWithHomeDir(langServerPath)
+                path: Config.replaceTildeWithHomeDir(serverPath)
             };
         }
 
-        const prebuiltBinaryName = this.prebuiltLangServerFileName;
+        const prebuiltBinaryName = this.prebuiltServerFileName;
 
         if (!prebuiltBinaryName) return null;
 

--- a/editors/code/src/installation/fetch_latest_artifact_release_info.ts
+++ b/editors/code/src/installation/fetch_latest_artifact_release_info.ts
@@ -1,5 +1,5 @@
 import fetch from "node-fetch";
-import { GithubRepo, ArtifactMetadata } from "./interfaces";
+import { GithubRepo, ArtifactReleaseInfo } from "./interfaces";
 
 const GITHUB_API_ENDPOINT_URL = "https://api.github.com";
 
@@ -7,9 +7,9 @@ const GITHUB_API_ENDPOINT_URL = "https://api.github.com";
  * Fetches the latest release from GitHub `repo` and returns metadata about
  * `artifactFileName` shipped with this release or `null` if no such artifact was published.
  */
-export async function fetchLatestArtifactMetadata(
+export async function fetchLatestArtifactReleaseInfo(
     repo: GithubRepo, artifactFileName: string
-): Promise<null | ArtifactMetadata> {
+): Promise<null | ArtifactReleaseInfo> {
 
     const repoOwner = encodeURIComponent(repo.owner);
     const repoName  = encodeURIComponent(repo.name);

--- a/editors/code/src/installation/interfaces.ts
+++ b/editors/code/src/installation/interfaces.ts
@@ -6,7 +6,7 @@ export interface GithubRepo {
 /**
  * Metadata about particular artifact retrieved from GitHub releases.
  */
-export interface ArtifactMetadata {
+export interface ArtifactReleaseInfo {
     releaseName: string;
     downloadUrl: string;
 }

--- a/editors/code/src/installation/lang_server.ts
+++ b/editors/code/src/installation/lang_server.ts
@@ -7,13 +7,13 @@ import { spawnSync } from "child_process";
 import { throttle } from "throttle-debounce";
 
 import { BinarySource } from "./interfaces";
-import { fetchLatestArtifactMetadata } from "./fetch_latest_artifact_metadata";
+import { fetchLatestArtifactReleaseInfo } from "./fetch_latest_artifact_release_info";
 import { downloadFile } from "./download_file";
 
-export async function downloadLatestLanguageServer(
+export async function downloadLatestLangServer(
     {file: artifactFileName, dir: installationDir, repo}: BinarySource.GithubRelease
 ) {
-    const { releaseName, downloadUrl } = (await fetchLatestArtifactMetadata(
+    const { releaseName, downloadUrl } = (await fetchLatestArtifactReleaseInfo(
         repo, artifactFileName
     ))!;
 
@@ -53,7 +53,7 @@ export async function downloadLatestLanguageServer(
     );
     console.timeEnd("Downloading ra_lsp_server");
 }
-export async function ensureLanguageServerBinary(
+export async function ensureLangServerBinary(
     langServerSource: null | BinarySource
 ): Promise<null | string> {
 
@@ -97,7 +97,7 @@ export async function ensureLanguageServerBinary(
             if (userResponse !== "Download now") return null;
 
             try {
-                await downloadLatestLanguageServer(langServerSource);
+                await downloadLatestLangServer(langServerSource);
             } catch (err) {
                 vscode.window.showErrorMessage(
                     `Failed to download language server from ${langServerSource.repo.name} ` +

--- a/editors/code/src/installation/server.ts
+++ b/editors/code/src/installation/server.ts
@@ -10,7 +10,7 @@ import { BinarySource } from "./interfaces";
 import { fetchLatestArtifactReleaseInfo } from "./fetch_latest_artifact_release_info";
 import { downloadFile } from "./download_file";
 
-export async function downloadLatestLangServer(
+export async function downloadLatestServer(
     {file: artifactFileName, dir: installationDir, repo}: BinarySource.GithubRelease
 ) {
     const { releaseName, downloadUrl } = (await fetchLatestArtifactReleaseInfo(
@@ -53,11 +53,11 @@ export async function downloadLatestLangServer(
     );
     console.timeEnd("Downloading ra_lsp_server");
 }
-export async function ensureLangServerBinary(
-    langServerSource: null | BinarySource
+export async function ensureServerBinary(
+    serverSource: null | BinarySource
 ): Promise<null | string> {
 
-    if (!langServerSource) {
+    if (!serverSource) {
         vscode.window.showErrorMessage(
             "Unfortunately we don't ship binaries for your platform yet. " +
             "You need to manually clone rust-analyzer repository and " +
@@ -69,21 +69,21 @@ export async function ensureLangServerBinary(
         return null;
     }
 
-    switch (langServerSource.type) {
+    switch (serverSource.type) {
         case BinarySource.Type.ExplicitPath: {
-            if (isBinaryAvailable(langServerSource.path)) {
-                return langServerSource.path;
+            if (isBinaryAvailable(serverSource.path)) {
+                return serverSource.path;
             }
 
             vscode.window.showErrorMessage(
-                `Unable to run ${langServerSource.path} binary. ` +
+                `Unable to run ${serverSource.path} binary. ` +
                 `To use the pre-built language server, set "rust-analyzer.raLspServerPath" ` +
                 "value to `null` or remove it from the settings to use it by default."
             );
             return null;
         }
         case BinarySource.Type.GithubRelease: {
-            const prebuiltBinaryPath = path.join(langServerSource.dir, langServerSource.file);
+            const prebuiltBinaryPath = path.join(serverSource.dir, serverSource.file);
 
             if (isBinaryAvailable(prebuiltBinaryPath)) {
                 return prebuiltBinaryPath;
@@ -97,10 +97,10 @@ export async function ensureLangServerBinary(
             if (userResponse !== "Download now") return null;
 
             try {
-                await downloadLatestLangServer(langServerSource);
+                await downloadLatestServer(serverSource);
             } catch (err) {
                 vscode.window.showErrorMessage(
-                    `Failed to download language server from ${langServerSource.repo.name} ` +
+                    `Failed to download language server from ${serverSource.repo.name} ` +
                     `GitHub repository: ${err.message}`
                 );
 
@@ -122,7 +122,7 @@ export async function ensureLangServerBinary(
 
             if (!isBinaryAvailable(prebuiltBinaryPath)) assert(false,
                 `Downloaded language server binary is not functional.` +
-                `Downloaded from: ${JSON.stringify(langServerSource)}`
+                `Downloaded from: ${JSON.stringify(serverSource)}`
             );
 
 


### PR DESCRIPTION
God, naming is so hard. I'd like to extract this change from upcomming "Download latest language server" command PR.