### PR TITLE
Extend analysis-stats a bit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,6 +1015,7 @@ name = "ra_cli"
 version = "0.1.0"
 dependencies = [
  "env_logger",
+ "itertools",
  "pico-args",
  "ra_batch",
  "ra_db",
@@ -1024,6 +1025,7 @@ dependencies = [
  "ra_ide",
  "ra_prof",
  "ra_syntax",
+ "rand 0.7.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,8 @@ opt-level = 0
 
 [patch.'crates-io']
 # rowan = { path = "../rowan" }
+
+[patch.'https://github.com/rust-lang/chalk.git']
+# chalk-solve = { path = "../chalk/chalk-solve" }
+# chalk-rust-ir = { path = "../chalk/chalk-rust-ir" }
+# chalk-ir = { path = "../chalk/chalk-ir" }

--- a/crates/ra_cli/Cargo.toml
+++ b/crates/ra_cli/Cargo.toml
@@ -6,8 +6,10 @@ authors = ["rust-analyzer developers"]
 publish = false
 
 [dependencies]
+itertools = "0.8.0"
 pico-args = "0.3.0"
 env_logger = { version = "0.7.1", default-features = false }
+rand = { version = "0.7.0", features = ["small_rng"] }
 
 ra_syntax = { path = "../ra_syntax" }
 ra_ide = { path = "../ra_ide" }

--- a/crates/ra_hir_ty/src/traits.rs
+++ b/crates/ra_hir_ty/src/traits.rs
@@ -60,6 +60,9 @@ impl TraitSolver {
                     context.0.db.check_canceled();
                     let remaining = fuel.get();
                     fuel.set(remaining - 1);
+                    if remaining == 0 {
+                        log::debug!("fuel exhausted");
+                    }
                     remaining > 0
                 })
             }


### PR DESCRIPTION
This adds some tools helpful when debugging nondeterminism in analysis-stats:
 - a `--randomize` option that analyses everything in random order
 - a `-vv` option that prints even more detail

Also add a debug log if Chalk fuel is exhausted (which would be a source of
nondeterminism, but didn't happen in my tests).

I found one source of nondeterminism (rust-lang/chalk#331), but there are still
other cases remaining.