### PR TITLE
Disable rollup warning

### DIFF
--- a/editors/code/rollup.config.js
+++ b/editors/code/rollup.config.js
@@ -18,6 +18,7 @@ export default {
     external: [...nodeBuiltins, 'vscode'],
     output: {
         file: './out/main.js',
-        format: 'cjs'
+        format: 'cjs',
+        exports: 'named'
     }
 };


### PR DESCRIPTION
In https://rollupjs.org/guide/en/#output-exports

```
As with regular entry points, files that mix default and named exports will produce warnings. You can avoid the warnings by forcing all files to use named export mode via output.exports: "named".
```

This PR try added `output.exports: "named"` and disabe this warning. It is because vscode consume our plugins only by named functions such that it should be safe to disable it.

cc @Veetaha 