### PR TITLE
vscode: fix the default value for withSysroot

### DIFF
--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -153,5 +153,5 @@ export class Config {
     }
 
     // for internal use
-    get withSysroot() { return this.cfg.get("withSysroot", false); }
+    get withSysroot() { return this.cfg.get("withSysroot", true) as boolean; }
 }


### PR DESCRIPTION
See [zulip](https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Fwg-rls-2.2E0/topic/withSysroot.20is.20false.20.3F)
cc @edwin0cheng 