### PR TITLE
Fix coercion of &T to itself

### DIFF
--- a/crates/ra_hir_ty/src/infer/unify.rs
+++ b/crates/ra_hir_ty/src/infer/unify.rs
@@ -249,6 +249,8 @@ impl InferenceTable {
         match (ty1, ty2) {
             (Ty::Unknown, _) | (_, Ty::Unknown) => true,
 
+            (Ty::Placeholder(p1), Ty::Placeholder(p2)) if *p1 == *p2 => true,
+
             (Ty::Infer(InferTy::TypeVar(tv1)), Ty::Infer(InferTy::TypeVar(tv2)))
             | (Ty::Infer(InferTy::IntVar(tv1)), Ty::Infer(InferTy::IntVar(tv2)))
             | (Ty::Infer(InferTy::FloatVar(tv1)), Ty::Infer(InferTy::FloatVar(tv2)))

--- a/crates/ra_hir_ty/src/tests/coercion.rs
+++ b/crates/ra_hir_ty/src/tests/coercion.rs
@@ -526,3 +526,25 @@ fn test() {
     "###
     );
 }
+
+#[test]
+fn coerce_placeholder_ref() {
+    // placeholders should unify, even behind references
+    assert_snapshot!(
+        infer_with_mismatches(r#"
+struct S<T> { t: T }
+impl<TT> S<TT> {
+    fn get(&self) -> &TT {
+        &self.t
+    }
+}
+"#, true),
+        @r###"
+    [51; 55) 'self': &S<TT>
+    [64; 87) '{     ...     }': &TT
+    [74; 81) '&self.t': &TT
+    [75; 79) 'self': &S<TT>
+    [75; 81) 'self.t': TT
+    "###
+    );
+}


### PR DESCRIPTION
The autoderef coercion logic did not handle matching placeholders. This led to
some type mismatches.