### PR TITLE
vscode: update exclusiveMinimum validation according to JSONSchemaV4

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -233,10 +233,7 @@
                     "description": "Trace requests to the ra_lsp_server"
                 },
                 "rust-analyzer.lruCapacity": {
-                    "type": [
-                        "number",
-                        "null"
-                    ],
+                    "type": [ "null", "integer" ],
                     "default": null,
                     "description": "Number of syntax trees rust-analyzer keeps in memory"
                 },
@@ -246,7 +243,7 @@
                     "description": "Display additional type and parameter information in the editor"
                 },
                 "rust-analyzer.maxInlayHintLength": {
-                    "type": "number",
+                    "type": [ "null", "integer" ],
                     "default": 20,
                     "minimum": 0,
                     "exclusiveMinimum": true,

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -235,6 +235,8 @@
                 "rust-analyzer.lruCapacity": {
                     "type": [ "null", "integer" ],
                     "default": null,
+                    "minimum": 0,
+                    "exclusiveMinimum": true,
                     "description": "Number of syntax trees rust-analyzer keeps in memory"
                 },
                 "rust-analyzer.displayInlayHints": {

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -248,7 +248,8 @@
                 "rust-analyzer.maxInlayHintLength": {
                     "type": "number",
                     "default": 20,
-                    "exclusiveMinimum": 0,
+                    "minimum": 0,
+                    "exclusiveMinimum": true,
                     "description": "Maximum length for inlay hints"
                 },
                 "rust-analyzer.cargoFeatures.noDefaultFeatures": {


### PR DESCRIPTION
It seems that vscode uses 4+ version of json schema where `exclusiveMinimum` [was changed to be a boolean](http://json-schema.org/understanding-json-schema/reference/numeric.html#7f93d6925e80_Draft%204)