### PR TITLE
Show record field names in Enum completion

### DIFF
--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use either::Either;
 use hir_def::{
+    adt::StructKind,
     adt::VariantData,
     builtin_type::BuiltinType,
     docs::Documentation,
@@ -422,6 +423,10 @@ impl EnumVariant {
             .iter()
             .map(|(id, _)| StructField { parent: self.into(), id })
             .collect()
+    }
+
+    pub fn kind(self, db: &impl HirDatabase) -> StructKind {
+        self.variant_data(db).kind()
     }
 
     pub(crate) fn variant_data(self, db: &impl DefDatabase) -> Arc<VariantData> {

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -50,6 +50,7 @@ pub use crate::{
 };
 
 pub use hir_def::{
+    adt::StructKind,
     body::scope::ExprScopes,
     builtin_type::BuiltinType,
     docs::Documentation,

--- a/crates/ra_hir_def/src/adt.rs
+++ b/crates/ra_hir_def/src/adt.rs
@@ -147,12 +147,6 @@ impl VariantData {
             VariantData::Unit => StructKind::Unit,
         }
     }
-    pub fn is_unit(&self) -> bool {
-        match self {
-            VariantData::Unit => true,
-            _ => false,
-        }
-    }
 }
 
 impl HasChildSource for VariantId {

--- a/crates/ra_hir_def/src/adt.rs
+++ b/crates/ra_hir_def/src/adt.rs
@@ -140,6 +140,13 @@ impl VariantData {
         self.fields().iter().find_map(|(id, data)| if &data.name == name { Some(id) } else { None })
     }
 
+    pub fn kind(&self) -> StructKind {
+        match self {
+            VariantData::Record(_) => StructKind::Record,
+            VariantData::Tuple(_) => StructKind::Tuple,
+            VariantData::Unit => StructKind::Unit,
+        }
+    }
     pub fn is_unit(&self) -> bool {
         match self {
             VariantData::Unit => true,
@@ -173,7 +180,7 @@ impl HasChildSource for VariantId {
     }
 }
 
-enum StructKind {
+pub enum StructKind {
     Tuple,
     Record,
     Unit,

--- a/crates/ra_hir_ty/src/lower.rs
+++ b/crates/ra_hir_ty/src/lower.rs
@@ -806,9 +806,8 @@ fn fn_sig_for_struct_constructor(db: &impl HirDatabase, def: StructId) -> PolyFn
 /// Build the type of a tuple struct constructor.
 fn type_for_struct_constructor(db: &impl HirDatabase, def: StructId) -> Binders<Ty> {
     let struct_data = db.struct_data(def.into());
-    match struct_data.variant_data.kind() {
-        StructKind::Unit => return type_for_adt(db, def.into()),
-        StructKind::Tuple | StructKind::Record => (),
+    if let StructKind::Unit = struct_data.variant_data.kind() {
+        return type_for_adt(db, def.into());
     }
     let generics = generics(db, def.into());
     let substs = Substs::bound_vars(&generics);
@@ -832,9 +831,8 @@ fn fn_sig_for_enum_variant_constructor(db: &impl HirDatabase, def: EnumVariantId
 fn type_for_enum_variant_constructor(db: &impl HirDatabase, def: EnumVariantId) -> Binders<Ty> {
     let enum_data = db.enum_data(def.parent);
     let var_data = &enum_data.variants[def.local_id].variant_data;
-    match var_data.kind() {
-        StructKind::Unit => return type_for_adt(db, def.parent.into()),
-        StructKind::Record | StructKind::Tuple => (),
+    if let StructKind::Unit = var_data.kind() {
+        return type_for_adt(db, def.parent.into());
     }
     let generics = generics(db, def.parent.into());
     let substs = Substs::bound_vars(&generics);

--- a/crates/ra_hir_ty/src/lower.rs
+++ b/crates/ra_hir_ty/src/lower.rs
@@ -9,6 +9,7 @@ use std::iter;
 use std::sync::Arc;
 
 use hir_def::{
+    adt::StructKind,
     builtin_type::BuiltinType,
     generics::{TypeParamProvenance, WherePredicate, WherePredicateTarget},
     path::{GenericArg, Path, PathSegment, PathSegments},
@@ -805,8 +806,9 @@ fn fn_sig_for_struct_constructor(db: &impl HirDatabase, def: StructId) -> PolyFn
 /// Build the type of a tuple struct constructor.
 fn type_for_struct_constructor(db: &impl HirDatabase, def: StructId) -> Binders<Ty> {
     let struct_data = db.struct_data(def.into());
-    if struct_data.variant_data.is_unit() {
-        return type_for_adt(db, def.into()); // Unit struct
+    match struct_data.variant_data.kind() {
+        StructKind::Unit => return type_for_adt(db, def.into()),
+        StructKind::Tuple | StructKind::Record => (),
     }
     let generics = generics(db, def.into());
     let substs = Substs::bound_vars(&generics);
@@ -830,8 +832,9 @@ fn fn_sig_for_enum_variant_constructor(db: &impl HirDatabase, def: EnumVariantId
 fn type_for_enum_variant_constructor(db: &impl HirDatabase, def: EnumVariantId) -> Binders<Ty> {
     let enum_data = db.enum_data(def.parent);
     let var_data = &enum_data.variants[def.local_id].variant_data;
-    if var_data.is_unit() {
-        return type_for_adt(db, def.parent.into()); // Unit variant
+    match var_data.kind() {
+        StructKind::Unit => return type_for_adt(db, def.parent.into()),
+        StructKind::Record | StructKind::Tuple => (),
     }
     let generics = generics(db, def.parent.into());
     let substs = Substs::bound_vars(&generics);

--- a/crates/ra_ide/src/completion/presentation.rs
+++ b/crates/ra_ide/src/completion/presentation.rs
@@ -280,7 +280,7 @@ impl Completions {
             StructKind::Record => {
                 join(detail_types.map(|(n, t)| format!("{}: {}", n, t.display(ctx.db).to_string())))
                     .separator(", ")
-                    .surround_with("{", "}")
+                    .surround_with("{ ", " }")
                     .to_string()
             }
         };
@@ -328,7 +328,7 @@ mod tests {
                 delete: [121; 123),
                 insert: "Foo",
                 kind: EnumVariant,
-                detail: "{x: i32, y: i32}",
+                detail: "{ x: i32, y: i32 }",
             },
         ]"###
         );


### PR DESCRIPTION
Adresses https://github.com/rust-analyzer/rust-analyzer/issues/2947.
Previously the details shown when autocompleting an Enum variant would look like the variant was a tuple even if it was a record:
![2020-02-16-15:59:32_crop](https://user-images.githubusercontent.com/16367467/74607233-64f21980-50d7-11ea-99db-e973e29c71d7.png)

This change will show the names of the fields for a record and use curly braces instead of parentheses:
![2020-02-16-15:33:00_crop](https://user-images.githubusercontent.com/16367467/74607251-8ce17d00-50d7-11ea-9d4d-38d198a4aec0.png)

This required exposing the type `adt::StructKind` from `ra_hir` and adding a function 
```
kind(self, db: &impl HirDatabase) -> StructKind
```
in the `impl` of `EnumVariant`. 

There was also a previously existing function `is_unit(self, db: &impl HirDatabase) -> bool` for `EnumVariant` which I removed because it seemed redundant after adding `kind`.