### PR TITLE
Use --depth 1 in git clone command to save time

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ standard setup (`code` and `cargo` in `$PATH`, etc), use this:
 
 ```
 # clone the repo
-$ git clone https://github.com/rust-analyzer/rust-analyzer && cd rust-analyzer
+$ git clone --depth 1 https://github.com/rust-analyzer/rust-analyzer && cd rust-analyzer
 
 # install both the language server and VS Code extension
 $ cargo xtask install


### PR DESCRIPTION
It's unlikely that casual users will need the whole development history.