### PR TITLE
Fix clippy warnings, update Cargo.toml versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,7 @@ version = "0.1.0"
 dependencies = [
  "either",
  "format-buf",
+ "fst",
  "indexmap",
  "insta",
  "itertools",
@@ -1059,8 +1060,11 @@ dependencies = [
  "ra_syntax",
  "ra_text_edit",
  "rand",
+ "rayon",
  "rustc-hash",
+ "superslice",
  "test_utils",
+ "unicase",
 ]
 
 [[package]]
@@ -1087,6 +1091,7 @@ dependencies = [
  "rustc-hash",
  "superslice",
  "test_utils",
+ "unicase",
 ]
 
 [[package]]
@@ -1598,6 +1603,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1638,6 +1652,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 
 [[package]]
 name = "walkdir"

--- a/crates/ra_assists/Cargo.toml
+++ b/crates/ra_assists/Cargo.toml
@@ -10,8 +10,8 @@ doctest = false
 [dependencies]
 format-buf = "1.0.0"
 join_to_string = "0.1.3"
-rustc-hash = "1.0"
-either = "1.5"
+rustc-hash = "1.1.0"
+either = "1.5.3"
 
 ra_syntax = { path = "../ra_syntax" }
 ra_text_edit = { path = "../ra_text_edit" }

--- a/crates/ra_assists/src/handlers/add_custom_impl.rs
+++ b/crates/ra_assists/src/handlers/add_custom_impl.rs
@@ -45,7 +45,7 @@ pub(crate) fn add_custom_impl(ctx: AssistCtx) -> Option<Assist> {
     let trait_token =
         ctx.token_at_offset().filter(|t| t.kind() == IDENT && *t.text() != attr_name).next()?;
 
-    let annotated = attr.syntax().siblings(Direction::Next).find_map(|s| ast::Name::cast(s))?;
+    let annotated = attr.syntax().siblings(Direction::Next).find_map(ast::Name::cast)?;
     let annotated_name = annotated.syntax().text().to_string();
     let start_offset = annotated.syntax().parent()?.text_range().end();
 
@@ -62,7 +62,7 @@ pub(crate) fn add_custom_impl(ctx: AssistCtx) -> Option<Assist> {
             .filter_map(|t| t.into_token().map(|t| t.text().clone()))
             .filter(|t| t != trait_token.text())
             .collect::<Vec<SmolStr>>();
-        let has_more_derives = new_attr_input.len() > 0;
+        let has_more_derives = !new_attr_input.is_empty();
         let new_attr_input =
             join(new_attr_input.iter()).separator(", ").surround_with("(", ")").to_string();
         let new_attr_input_len = new_attr_input.len();

--- a/crates/ra_assists/src/handlers/add_custom_impl.rs
+++ b/crates/ra_assists/src/handlers/add_custom_impl.rs
@@ -43,7 +43,7 @@ pub(crate) fn add_custom_impl(ctx: AssistCtx) -> Option<Assist> {
         .clone();
 
     let trait_token =
-        ctx.token_at_offset().filter(|t| t.kind() == IDENT && *t.text() != attr_name).next()?;
+        ctx.token_at_offset().find(|t| t.kind() == IDENT && *t.text() != attr_name)?;
 
     let annotated = attr.syntax().siblings(Direction::Next).find_map(ast::Name::cast)?;
     let annotated_name = annotated.syntax().text().to_string();
@@ -86,7 +86,7 @@ pub(crate) fn add_custom_impl(ctx: AssistCtx) -> Option<Assist> {
                 .next_sibling_or_token()
                 .filter(|t| t.kind() == WHITESPACE)
                 .map(|t| t.text_range())
-                .unwrap_or(TextRange::from_to(TextUnit::from(0), TextUnit::from(0)));
+                .unwrap_or_else(|| TextRange::from_to(TextUnit::from(0), TextUnit::from(0)));
             edit.delete(line_break_range);
 
             attr_range.len() + line_break_range.len()

--- a/crates/ra_assists/src/handlers/add_new.rs
+++ b/crates/ra_assists/src/handlers/add_new.rs
@@ -53,7 +53,7 @@ pub(crate) fn add_new(ctx: AssistCtx) -> Option<Assist> {
         }
 
         let vis = strukt.visibility().map(|v| format!("{} ", v.syntax()));
-        let vis = vis.as_ref().map(String::as_str).unwrap_or("");
+        let vis = vis.as_deref().unwrap_or("");
         write!(&mut buf, "    {}fn new(", vis).unwrap();
 
         join(field_list.fields().filter_map(|f| {

--- a/crates/ra_assists/src/handlers/move_guard.rs
+++ b/crates/ra_assists/src/handlers/move_guard.rs
@@ -44,7 +44,7 @@ pub(crate) fn move_guard_to_arm_body(ctx: AssistCtx) -> Option<Assist> {
         edit.target(guard.syntax().text_range());
         let offseting_amount = match space_before_guard.and_then(|it| it.into_token()) {
             Some(tok) => {
-                if let Some(_) = ast::Whitespace::cast(tok.clone()) {
+                if ast::Whitespace::cast(tok.clone()).is_some() {
                     let ele = tok.text_range();
                     edit.delete(ele);
                     ele.len()
@@ -98,11 +98,11 @@ pub(crate) fn move_arm_cond_to_match_guard(ctx: AssistCtx) -> Option<Assist> {
     let then_block = if_expr.then_branch()?;
 
     // Not support if with else branch
-    if let Some(_) = if_expr.else_branch() {
+    if if_expr.else_branch().is_some() {
         return None;
     }
     // Not support moving if let to arm guard
-    if let Some(_) = cond.pat() {
+    if cond.pat().is_some() {
         return None;
     }
 

--- a/crates/ra_assists/src/handlers/replace_if_let_with_match.rs
+++ b/crates/ra_assists/src/handlers/replace_if_let_with_match.rs
@@ -61,7 +61,7 @@ pub(crate) fn replace_if_let_with_match(ctx: AssistCtx) -> Option<Assist> {
 
         edit.target(if_expr.syntax().text_range());
         edit.set_cursor(if_expr.syntax().text_range().start());
-        edit.replace_ast::<ast::Expr>(if_expr.into(), match_expr.into());
+        edit.replace_ast::<ast::Expr>(if_expr.into(), match_expr);
     })
 }
 

--- a/crates/ra_assists/src/lib.rs
+++ b/crates/ra_assists/src/lib.rs
@@ -38,8 +38,8 @@ pub struct GroupLabel(pub String);
 impl AssistLabel {
     pub(crate) fn new(label: String, id: AssistId) -> AssistLabel {
         // FIXME: make fields private, so that this invariant can't be broken
-        assert!(label.chars().nth(0).unwrap().is_uppercase());
-        AssistLabel { label: label.into(), id }
+        assert!(label.chars().next().unwrap().is_uppercase());
+        AssistLabel { label, id }
     }
 }
 

--- a/crates/ra_cargo_watch/Cargo.toml
+++ b/crates/ra_cargo_watch/Cargo.toml
@@ -5,14 +5,14 @@ version = "0.1.0"
 authors = ["rust-analyzer developers"]
 
 [dependencies]
-crossbeam-channel = "0.4"
-lsp-types = { version = "0.70.0", features = ["proposed"] }
-log = "0.4.3"
+crossbeam-channel = "0.4.0"
+lsp-types = { version = "0.70.1", features = ["proposed"] }
+log = "0.4.8"
 cargo_metadata = "0.9.1"
 jod-thread = "0.1.0"
 parking_lot = "0.10.0"
-serde_json = "1.0.45"
+serde_json = "1.0.48"
 
 [dev-dependencies]
-insta = "0.13.0"
-serde_json = "1.0"
+insta = "0.13.1"
+serde_json = "1.0.48"

--- a/crates/ra_cargo_watch/src/conv.rs
+++ b/crates/ra_cargo_watch/src/conv.rs
@@ -234,7 +234,7 @@ pub(crate) fn map_rust_diagnostic_to_lsp(
         let child = map_rust_child_diagnostic(&child, workspace_root);
         match child {
             MappedRustChildDiagnostic::Related(related) => related_information.push(related),
-            MappedRustChildDiagnostic::SuggestedFix(code_action) => fixes.push(code_action.into()),
+            MappedRustChildDiagnostic::SuggestedFix(code_action) => fixes.push(code_action),
             MappedRustChildDiagnostic::MessageLine(message_line) => {
                 write!(&mut message, "\n{}", message_line).unwrap();
 

--- a/crates/ra_cfg/Cargo.toml
+++ b/crates/ra_cfg/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["rust-analyzer developers"]
 doctest = false
 
 [dependencies]
-rustc-hash = "1.0.1"
+rustc-hash = "1.1.0"
 
 ra_syntax = { path = "../ra_syntax" }
 tt = { path = "../ra_tt", package = "ra_tt" }

--- a/crates/ra_db/Cargo.toml
+++ b/crates/ra_db/Cargo.toml
@@ -10,7 +10,7 @@ doctest = false
 [dependencies]
 salsa = "0.14.1"
 relative-path = "1.0.0"
-rustc-hash = "1.0"
+rustc-hash = "1.1.0"
 
 ra_syntax = { path = "../ra_syntax" }
 ra_cfg = { path = "../ra_cfg" }

--- a/crates/ra_db/src/input.rs
+++ b/crates/ra_db/src/input.rs
@@ -249,7 +249,7 @@ impl FromStr for Edition {
         let res = match s {
             "2015" => Edition::Edition2015,
             "2018" => Edition::Edition2018,
-            _ => Err(ParseEditionError { invalid_input: s.to_string() })?,
+            _ => return Err(ParseEditionError { invalid_input: s.to_string() }),
         };
         Ok(res)
     }

--- a/crates/ra_fmt/Cargo.toml
+++ b/crates/ra_fmt/Cargo.toml
@@ -9,6 +9,6 @@ publish = false
 doctest = false
 
 [dependencies]
-itertools = "0.8.0"
+itertools = "0.8.2"
 
 ra_syntax = { path = "../ra_syntax" }

--- a/crates/ra_hir/Cargo.toml
+++ b/crates/ra_hir/Cargo.toml
@@ -8,9 +8,9 @@ authors = ["rust-analyzer developers"]
 doctest = false
 
 [dependencies]
-log = "0.4.5"
-rustc-hash = "1.0"
-either = "1.5"
+log = "0.4.8"
+rustc-hash = "1.1.0"
+either = "1.5.3"
 
 ra_syntax = { path = "../ra_syntax" }
 ra_db = { path = "../ra_db" }

--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -988,20 +988,17 @@ impl Type {
 
     pub fn fields(&self, db: &impl HirDatabase) -> Vec<(StructField, Type)> {
         if let Ty::Apply(a_ty) = &self.ty.value {
-            match a_ty.ctor {
-                TypeCtor::Adt(AdtId::StructId(s)) => {
-                    let var_def = s.into();
-                    return db
-                        .field_types(var_def)
-                        .iter()
-                        .map(|(local_id, ty)| {
-                            let def = StructField { parent: var_def.into(), id: local_id };
-                            let ty = ty.clone().subst(&a_ty.parameters);
-                            (def, self.derived(ty))
-                        })
-                        .collect();
-                }
-                _ => {}
+            if let TypeCtor::Adt(AdtId::StructId(s)) = a_ty.ctor {
+                let var_def = s.into();
+                return db
+                    .field_types(var_def)
+                    .iter()
+                    .map(|(local_id, ty)| {
+                        let def = StructField { parent: var_def.into(), id: local_id };
+                        let ty = ty.clone().subst(&a_ty.parameters);
+                        (def, self.derived(ty))
+                    })
+                    .collect();
             }
         };
         Vec::new()
@@ -1010,14 +1007,11 @@ impl Type {
     pub fn tuple_fields(&self, _db: &impl HirDatabase) -> Vec<Type> {
         let mut res = Vec::new();
         if let Ty::Apply(a_ty) = &self.ty.value {
-            match a_ty.ctor {
-                TypeCtor::Tuple { .. } => {
-                    for ty in a_ty.parameters.iter() {
-                        let ty = ty.clone();
-                        res.push(self.derived(ty));
-                    }
+            if let TypeCtor::Tuple { .. } = a_ty.ctor {
+                for ty in a_ty.parameters.iter() {
+                    let ty = ty.clone();
+                    res.push(self.derived(ty));
                 }
-                _ => {}
             }
         };
         res

--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -283,7 +283,7 @@ impl StructField {
         };
         let substs = Substs::type_params(db, generic_def_id);
         let ty = db.field_types(var_id)[self.id].clone().subst(&substs);
-        Type::new(db, self.parent.module(db).id.krate.into(), var_id, ty)
+        Type::new(db, self.parent.module(db).id.krate, var_id, ty)
     }
 
     pub fn parent_def(&self, _db: &impl HirDatabase) -> VariantDef {
@@ -315,11 +315,11 @@ impl Struct {
     }
 
     pub fn name(self, db: &impl DefDatabase) -> Name {
-        db.struct_data(self.id.into()).name.clone()
+        db.struct_data(self.id).name.clone()
     }
 
     pub fn fields(self, db: &impl HirDatabase) -> Vec<StructField> {
-        db.struct_data(self.id.into())
+        db.struct_data(self.id)
             .variant_data
             .fields()
             .iter()
@@ -332,7 +332,7 @@ impl Struct {
     }
 
     fn variant_data(self, db: &impl DefDatabase) -> Arc<VariantData> {
-        db.struct_data(self.id.into()).variant_data.clone()
+        db.struct_data(self.id).variant_data.clone()
     }
 }
 
@@ -1049,7 +1049,7 @@ impl Type {
         // FIXME check that?
         let canonical = Canonical { value: self.ty.value.clone(), num_vars: 0 };
         let environment = self.ty.environment.clone();
-        let ty = InEnvironment { value: canonical, environment: environment.clone() };
+        let ty = InEnvironment { value: canonical, environment };
         autoderef(db, Some(self.krate), ty)
             .map(|canonical| canonical.value)
             .map(move |ty| self.derived(ty))

--- a/crates/ra_hir/src/source_analyzer.rs
+++ b/crates/ra_hir/src/source_analyzer.rs
@@ -361,9 +361,8 @@ impl SourceAnalyzer {
         db: &impl HirDatabase,
         macro_call: InFile<&ast::MacroCall>,
     ) -> Option<Expansion> {
-        let macro_call_id = macro_call.as_call_id(db, |path| {
-            self.resolver.resolve_path_as_macro(db, &path).map(|it| it.into())
-        })?;
+        let macro_call_id =
+            macro_call.as_call_id(db, |path| self.resolver.resolve_path_as_macro(db, &path))?;
         Some(Expansion { macro_call_id })
     }
 }

--- a/crates/ra_hir_def/Cargo.toml
+++ b/crates/ra_hir_def/Cargo.toml
@@ -8,11 +8,11 @@ authors = ["rust-analyzer developers"]
 doctest = false
 
 [dependencies]
-log = "0.4.5"
-once_cell = "1.0.1"
-rustc-hash = "1.0"
-either = "1.5"
-anymap = "0.12"
+log = "0.4.8"
+once_cell = "1.3.1"
+rustc-hash = "1.1.0"
+either = "1.5.3"
+anymap = "0.12.1"
 drop_bomb = "0.1.4"
 itertools = "0.8.2"
 
@@ -27,4 +27,4 @@ ra_cfg = { path = "../ra_cfg" }
 tt = { path = "../ra_tt", package = "ra_tt" }
 
 [dev-dependencies]
-insta = "0.13.0"
+insta = "0.13.1"

--- a/crates/ra_hir_def/src/body/lower.rs
+++ b/crates/ra_hir_def/src/body/lower.rs
@@ -448,7 +448,7 @@ where
             // FIXME expand to statements in statement position
             ast::Expr::MacroCall(e) => {
                 let macro_call = self.expander.to_source(AstPtr::new(&e));
-                match self.expander.enter_expand(self.db, e.clone()) {
+                match self.expander.enter_expand(self.db, e) {
                     Some((mark, expansion)) => {
                         self.source_map
                             .expansions

--- a/crates/ra_hir_def/src/generics.rs
+++ b/crates/ra_hir_def/src/generics.rs
@@ -71,7 +71,7 @@ impl GenericParams {
         db: &impl DefDatabase,
         def: GenericDefId,
     ) -> Arc<GenericParams> {
-        let (params, _source_map) = GenericParams::new(db, def.into());
+        let (params, _source_map) = GenericParams::new(db, def);
         Arc::new(params)
     }
 

--- a/crates/ra_hir_def/src/item_scope.rs
+++ b/crates/ra_hir_def/src/item_scope.rs
@@ -138,7 +138,7 @@ impl ItemScope {
 
     pub(crate) fn push_res(&mut self, name: Name, def: PerNs) -> bool {
         let mut changed = false;
-        let existing = self.visible.entry(name.clone()).or_default();
+        let existing = self.visible.entry(name).or_default();
 
         if existing.types.is_none() && def.types.is_some() {
             existing.types = def.types;

--- a/crates/ra_hir_def/src/item_scope.rs
+++ b/crates/ra_hir_def/src/item_scope.rs
@@ -157,7 +157,7 @@ impl ItemScope {
     }
 
     pub(crate) fn resolutions<'a>(&'a self) -> impl Iterator<Item = (Name, PerNs)> + 'a {
-        self.visible.iter().map(|(name, res)| (name.clone(), res.clone()))
+        self.visible.iter().map(|(name, res)| (name.clone(), *res))
     }
 
     pub(crate) fn collect_legacy_macros(&self) -> FxHashMap<Name, MacroDefId> {

--- a/crates/ra_hir_def/src/lib.rs
+++ b/crates/ra_hir_def/src/lib.rs
@@ -460,7 +460,7 @@ impl AsMacroCall for AstIdWithPath<ast::MacroCall> {
         resolver: impl Fn(path::ModPath) -> Option<MacroDefId>,
     ) -> Option<MacroCallId> {
         let def = resolver(self.path.clone())?;
-        Some(def.as_call_id(db, MacroCallKind::FnLike(self.ast_id.clone())))
+        Some(def.as_call_id(db, MacroCallKind::FnLike(self.ast_id)))
     }
 }
 
@@ -471,6 +471,6 @@ impl AsMacroCall for AstIdWithPath<ast::ModuleItem> {
         resolver: impl Fn(path::ModPath) -> Option<MacroDefId>,
     ) -> Option<MacroCallId> {
         let def = resolver(self.path.clone())?;
-        Some(def.as_call_id(db, MacroCallKind::Attr(self.ast_id.clone())))
+        Some(def.as_call_id(db, MacroCallKind::Attr(self.ast_id)))
     }
 }

--- a/crates/ra_hir_def/src/nameres.rs
+++ b/crates/ra_hir_def/src/nameres.rs
@@ -156,7 +156,7 @@ impl ModuleOrigin {
             ModuleOrigin::File { definition, .. } | ModuleOrigin::CrateRoot { definition } => {
                 let file_id = *definition;
                 let sf = db.parse(file_id).tree();
-                return InFile::new(file_id.into(), ModuleSource::SourceFile(sf));
+                InFile::new(file_id.into(), ModuleSource::SourceFile(sf))
             }
             ModuleOrigin::Inline { definition } => {
                 InFile::new(definition.file_id, ModuleSource::Module(definition.to_node(db)))

--- a/crates/ra_hir_def/src/nameres/raw.rs
+++ b/crates/ra_hir_def/src/nameres/raw.rs
@@ -357,9 +357,7 @@ impl RawItemsCollector {
             let visibility =
                 RawVisibility::from_ast_with_hygiene(extern_crate.visibility(), &self.hygiene);
             let alias = extern_crate.alias().map(|a| {
-                a.name()
-                    .map(|it| it.as_name())
-                    .map_or(ImportAlias::Underscore, |a| ImportAlias::Alias(a))
+                a.name().map(|it| it.as_name()).map_or(ImportAlias::Underscore, ImportAlias::Alias)
             });
             let attrs = self.parse_attrs(&extern_crate);
             // FIXME: cfg_attr

--- a/crates/ra_hir_def/src/nameres/tests/incremental.rs
+++ b/crates/ra_hir_def/src/nameres/tests/incremental.rs
@@ -116,7 +116,7 @@ fn typing_inside_a_macro_should_not_invalidate_def_map() {
         let events = db.log_executed(|| {
             let crate_def_map = db.crate_def_map(krate);
             let (_, module_data) = crate_def_map.modules.iter().last().unwrap();
-            assert_eq!(module_data.scope.resolutions().collect::<Vec<_>>().len(), 1);
+            assert_eq!(module_data.scope.resolutions().count(), 1);
         });
         assert!(format!("{:?}", events).contains("crate_def_map"), "{:#?}", events)
     }
@@ -126,7 +126,7 @@ fn typing_inside_a_macro_should_not_invalidate_def_map() {
         let events = db.log_executed(|| {
             let crate_def_map = db.crate_def_map(krate);
             let (_, module_data) = crate_def_map.modules.iter().last().unwrap();
-            assert_eq!(module_data.scope.resolutions().collect::<Vec<_>>().len(), 1);
+            assert_eq!(module_data.scope.resolutions().count(), 1);
         });
         assert!(!format!("{:?}", events).contains("crate_def_map"), "{:#?}", events)
     }

--- a/crates/ra_hir_def/src/path/lower/lower_use.rs
+++ b/crates/ra_hir_def/src/path/lower/lower_use.rs
@@ -32,9 +32,7 @@ pub(crate) fn lower_use_tree(
         }
     } else {
         let alias = tree.alias().map(|a| {
-            a.name()
-                .map(|it| it.as_name())
-                .map_or(ImportAlias::Underscore, |a| ImportAlias::Alias(a))
+            a.name().map(|it| it.as_name()).map_or(ImportAlias::Underscore, ImportAlias::Alias)
         });
         let is_glob = tree.has_star();
         if let Some(ast_path) = tree.path() {

--- a/crates/ra_hir_def/src/resolver.rs
+++ b/crates/ra_hir_def/src/resolver.rs
@@ -474,7 +474,7 @@ impl Scope {
                     f(name.clone(), ScopeDef::PerNs(PerNs::macros(macro_, Visibility::Public)));
                 });
                 m.crate_def_map.extern_prelude.iter().for_each(|(name, &def)| {
-                    f(name.clone(), ScopeDef::PerNs(PerNs::types(def.into(), Visibility::Public)));
+                    f(name.clone(), ScopeDef::PerNs(PerNs::types(def, Visibility::Public)));
                 });
                 if let Some(prelude) = m.crate_def_map.prelude {
                     let prelude_def_map = db.crate_def_map(prelude.krate);
@@ -499,10 +499,10 @@ impl Scope {
                 }
             }
             Scope::ImplBlockScope(i) => {
-                f(name![Self], ScopeDef::ImplSelfType((*i).into()));
+                f(name![Self], ScopeDef::ImplSelfType(*i));
             }
             Scope::AdtScope(i) => {
-                f(name![Self], ScopeDef::AdtSelfType((*i).into()));
+                f(name![Self], ScopeDef::AdtSelfType(*i));
             }
             Scope::ExprScope(scope) => {
                 scope.expr_scopes.entries(scope.scope_id).iter().for_each(|e| {

--- a/crates/ra_hir_expand/Cargo.toml
+++ b/crates/ra_hir_expand/Cargo.toml
@@ -8,8 +8,8 @@ authors = ["rust-analyzer developers"]
 doctest = false
 
 [dependencies]
-log = "0.4.5"
-either = "1.5"
+log = "0.4.8"
+either = "1.5.3"
 
 ra_arena = { path = "../ra_arena" }
 ra_db = { path = "../ra_db" }

--- a/crates/ra_hir_expand/src/builtin_derive.rs
+++ b/crates/ra_hir_expand/src/builtin_derive.rs
@@ -235,7 +235,7 @@ mod tests {
         let (db, file_id) = TestDB::with_single_file(&s);
         let parsed = db.parse(file_id);
         let items: Vec<_> =
-            parsed.syntax_node().descendants().filter_map(|it| ast::ModuleItem::cast(it)).collect();
+            parsed.syntax_node().descendants().filter_map(ast::ModuleItem::cast).collect();
 
         let ast_id_map = db.ast_id_map(file_id.into());
 

--- a/crates/ra_hir_expand/src/builtin_macro.rs
+++ b/crates/ra_hir_expand/src/builtin_macro.rs
@@ -155,14 +155,11 @@ fn compile_error_expand(
     tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     if tt.count() == 1 {
-        match &tt.token_trees[0] {
-            tt::TokenTree::Leaf(tt::Leaf::Literal(it)) => {
-                let s = it.text.as_str();
-                if s.contains('"') {
-                    return Ok(quote! { loop { #it }});
-                }
+        if let tt::TokenTree::Leaf(tt::Leaf::Literal(it)) = &tt.token_trees[0] {
+            let s = it.text.as_str();
+            if s.contains('"') {
+                return Ok(quote! { loop { #it }});
             }
-            _ => {}
         };
     }
 

--- a/crates/ra_hir_expand/src/builtin_macro.rs
+++ b/crates/ra_hir_expand/src/builtin_macro.rs
@@ -158,7 +158,7 @@ fn compile_error_expand(
         match &tt.token_trees[0] {
             tt::TokenTree::Leaf(tt::Leaf::Literal(it)) => {
                 let s = it.text.as_str();
-                if s.contains(r#"""#) {
+                if s.contains('"') {
                     return Ok(quote! { loop { #it }});
                 }
             }
@@ -222,7 +222,7 @@ mod tests {
         let (db, file_id) = TestDB::with_single_file(&s);
         let parsed = db.parse(file_id);
         let macro_calls: Vec<_> =
-            parsed.syntax_node().descendants().filter_map(|it| ast::MacroCall::cast(it)).collect();
+            parsed.syntax_node().descendants().filter_map(ast::MacroCall::cast).collect();
 
         let ast_id_map = db.ast_id_map(file_id.into());
 

--- a/crates/ra_hir_expand/src/quote.rs
+++ b/crates/ra_hir_expand/src/quote.rs
@@ -15,14 +15,13 @@ macro_rules! __quote {
     ( @SUBTREE $delim:ident $($tt:tt)* ) => {
         {
             let children = $crate::__quote!($($tt)*);
-            let subtree = tt::Subtree {
+            tt::Subtree {
                 delimiter: Some(tt::Delimiter {
                     kind: tt::DelimiterKind::$delim,
                     id: tt::TokenId::unspecified(),
                 }),
                 token_trees: $crate::quote::IntoTt::to_tokens(children),
-            };
-            subtree
+            }
         }
     };
 

--- a/crates/ra_hir_expand/src/quote.rs
+++ b/crates/ra_hir_expand/src/quote.rs
@@ -259,8 +259,7 @@ mod tests {
         // }
         let struct_name = mk_ident("Foo");
         let fields = [mk_ident("name"), mk_ident("id")];
-        let fields =
-            fields.iter().map(|it| quote!(#it: self.#it.clone(), ).token_trees.clone()).flatten();
+        let fields = fields.iter().map(|it| quote!(#it: self.#it.clone(), ).token_trees).flatten();
 
         let list = tt::Subtree {
             delimiter: Some(tt::Delimiter {

--- a/crates/ra_hir_ty/Cargo.toml
+++ b/crates/ra_hir_ty/Cargo.toml
@@ -9,9 +9,9 @@ doctest = false
 
 [dependencies]
 arrayvec = "0.5.1"
-ena = "0.13"
-log = "0.4.5"
-rustc-hash = "1.0"
+ena = "0.13.1"
+log = "0.4.8"
+rustc-hash = "1.1.0"
 
 hir_def = { path = "../ra_hir_def", package = "ra_hir_def" }
 hir_expand = { path = "../ra_hir_expand", package = "ra_hir_expand" }
@@ -28,4 +28,4 @@ chalk-ir =      { git = "https://github.com/rust-lang/chalk.git", rev = "af48f30
 lalrpop-intern = "0.15.1"
 
 [dev-dependencies]
-insta = "0.13.0"
+insta = "0.13.1"

--- a/crates/ra_hir_ty/src/diagnostics.rs
+++ b/crates/ra_hir_ty/src/diagnostics.rs
@@ -40,7 +40,7 @@ impl Diagnostic for MissingFields {
         use std::fmt::Write;
         let mut message = String::from("Missing structure fields:\n");
         for field in &self.missed_fields {
-            write!(message, "- {}\n", field).unwrap();
+            writeln!(message, "- {}", field).unwrap();
         }
         message
     }

--- a/crates/ra_hir_ty/src/expr.rs
+++ b/crates/ra_hir_ty/src/expr.rs
@@ -138,7 +138,7 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
             _ => return,
         };
 
-        if params.len() == 2 && &params[0] == &mismatch.actual {
+        if params.len() == 2 && params[0] == mismatch.actual {
             let (_, source_map) = db.body_with_source_map(self.func.into());
 
             if let Some(source_ptr) = source_map.expr_syntax(id) {

--- a/crates/ra_hir_ty/src/infer/coerce.rs
+++ b/crates/ra_hir_ty/src/infer/coerce.rs
@@ -44,10 +44,8 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
         resolver: &Resolver,
     ) -> FxHashMap<(TypeCtor, TypeCtor), usize> {
         let krate = resolver.krate().unwrap();
-        let impls = match db.lang_item(krate.into(), "coerce_unsized".into()) {
-            Some(LangItemTarget::TraitId(trait_)) => {
-                db.impls_for_trait(krate.into(), trait_.into())
-            }
+        let impls = match db.lang_item(krate, "coerce_unsized".into()) {
+            Some(LangItemTarget::TraitId(trait_)) => db.impls_for_trait(krate, trait_),
             _ => return FxHashMap::default(),
         };
 

--- a/crates/ra_hir_ty/src/infer/coerce.rs
+++ b/crates/ra_hir_ty/src/infer/coerce.rs
@@ -26,7 +26,7 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
     /// Note that it is only possible that one type are coerced to another.
     /// Coercing both types to another least upper bound type is not possible in rustc,
     /// which will simply result in "incompatible types" error.
-    pub(super) fn coerce_merge_branch<'t>(&mut self, ty1: &Ty, ty2: &Ty) -> Ty {
+    pub(super) fn coerce_merge_branch(&mut self, ty1: &Ty, ty2: &Ty) -> Ty {
         if self.coerce(ty1, ty2) {
             ty2.clone()
         } else if self.coerce(ty2, ty1) {
@@ -252,15 +252,14 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
                 let unsize_generic_index = {
                     let mut index = None;
                     let mut multiple_param = false;
-                    field_tys[last_field_id].value.walk(&mut |ty| match ty {
-                        &Ty::Bound(idx) => {
+                    field_tys[last_field_id].value.walk(&mut |ty| {
+                        if let &Ty::Bound(idx) = ty {
                             if index.is_none() {
                                 index = Some(idx);
                             } else if Some(idx) != index {
                                 multiple_param = true;
                             }
                         }
-                        _ => {}
                     });
 
                     if multiple_param {

--- a/crates/ra_hir_ty/src/infer/expr.rs
+++ b/crates/ra_hir_ty/src/infer/expr.rs
@@ -35,8 +35,7 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
                 TypeMismatch { expected: expected.ty.clone(), actual: ty.clone() },
             );
         }
-        let ty = self.resolve_ty_as_possible(ty);
-        ty
+        self.resolve_ty_as_possible(ty)
     }
 
     /// Infer type of expression with possibly implicit coerce to the expected type.
@@ -155,8 +154,7 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
                 };
                 self.register_obligations_for_call(&callee_ty);
                 self.check_call_arguments(args, &param_tys);
-                let ret_ty = self.normalize_associated_types_in(ret_ty);
-                ret_ty
+                self.normalize_associated_types_in(ret_ty)
             }
             Expr::MethodCall { receiver, args, method_name, generic_args } => self
                 .infer_method_call(tgt_expr, *receiver, &args, &method_name, generic_args.as_ref()),
@@ -280,14 +278,11 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
             }
             Expr::Await { expr } => {
                 let inner_ty = self.infer_expr_inner(*expr, &Expectation::none());
-                let ty =
-                    self.resolve_associated_type(inner_ty, self.resolve_future_future_output());
-                ty
+                self.resolve_associated_type(inner_ty, self.resolve_future_future_output())
             }
             Expr::Try { expr } => {
                 let inner_ty = self.infer_expr_inner(*expr, &Expectation::none());
-                let ty = self.resolve_associated_type(inner_ty, self.resolve_ops_try_ok());
-                ty
+                self.resolve_associated_type(inner_ty, self.resolve_ops_try_ok())
             }
             Expr::Cast { expr, type_ref } => {
                 let _inner_ty = self.infer_expr_inner(*expr, &Expectation::none());
@@ -611,8 +606,7 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
         self.unify(&expected_receiver_ty, &actual_receiver_ty);
 
         self.check_call_arguments(args, &param_tys);
-        let ret_ty = self.normalize_associated_types_in(ret_ty);
-        ret_ty
+        self.normalize_associated_types_in(ret_ty)
     }
 
     fn check_call_arguments(&mut self, args: &[ExprId], param_tys: &[Ty]) {

--- a/crates/ra_hir_ty/src/infer/pat.rs
+++ b/crates/ra_hir_ty/src/infer/pat.rs
@@ -28,7 +28,7 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
 
         let substs = ty.substs().unwrap_or_else(Substs::empty);
 
-        let field_tys = def.map(|it| self.db.field_types(it.into())).unwrap_or_default();
+        let field_tys = def.map(|it| self.db.field_types(it)).unwrap_or_default();
 
         for (i, &subpat) in subpats.iter().enumerate() {
             let expected_ty = var_data
@@ -60,7 +60,7 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
 
         let substs = ty.substs().unwrap_or_else(Substs::empty);
 
-        let field_tys = def.map(|it| self.db.field_types(it.into())).unwrap_or_default();
+        let field_tys = def.map(|it| self.db.field_types(it)).unwrap_or_default();
         for subpat in subpats {
             let matching_field = var_data.as_ref().and_then(|it| it.field(&subpat.name));
             let expected_ty =

--- a/crates/ra_hir_ty/src/infer/unify.rs
+++ b/crates/ra_hir_ty/src/infer/unify.rs
@@ -140,13 +140,12 @@ where
 impl<T> Canonicalized<T> {
     pub fn decanonicalize_ty(&self, mut ty: Ty) -> Ty {
         ty.walk_mut_binders(
-            &mut |ty, binders| match ty {
-                &mut Ty::Bound(idx) => {
+            &mut |ty, binders| {
+                if let &mut Ty::Bound(idx) = ty {
                     if idx as usize >= binders && (idx as usize - binders) < self.free_vars.len() {
                         *ty = Ty::Infer(self.free_vars[idx as usize - binders]);
                     }
                 }
-                _ => {}
             },
             0,
         );

--- a/crates/ra_hir_ty/src/lib.rs
+++ b/crates/ra_hir_ty/src/lib.rs
@@ -763,8 +763,8 @@ pub trait TypeWalk {
         Self: Sized,
     {
         self.walk_mut_binders(
-            &mut |ty, binders| match ty {
-                &mut Ty::Bound(idx) => {
+            &mut |ty, binders| {
+                if let &mut Ty::Bound(idx) = ty {
                     if idx as usize >= binders && (idx as usize - binders) < substs.len() {
                         *ty = substs.0[idx as usize - binders].clone();
                     } else if idx as usize >= binders + substs.len() {
@@ -772,7 +772,6 @@ pub trait TypeWalk {
                         *ty = Ty::Bound(idx - substs.len() as u32);
                     }
                 }
-                _ => {}
             },
             0,
         );

--- a/crates/ra_hir_ty/src/lib.rs
+++ b/crates/ra_hir_ty/src/lib.rs
@@ -167,7 +167,7 @@ impl TypeCtor {
             | TypeCtor::Closure { .. } // 1 param representing the signature of the closure
             => 1,
             TypeCtor::Adt(adt) => {
-                let generic_params = generics(db, AdtId::from(adt).into());
+                let generic_params = generics(db, adt.into());
                 generic_params.len()
             }
             TypeCtor::FnDef(callable) => {
@@ -247,7 +247,7 @@ pub struct ProjectionTy {
 
 impl ProjectionTy {
     pub fn trait_ref(&self, db: &impl HirDatabase) -> TraitRef {
-        TraitRef { trait_: self.trait_(db).into(), substs: self.parameters.clone() }
+        TraitRef { trait_: self.trait_(db), substs: self.parameters.clone() }
     }
 
     fn trait_(&self, db: &impl HirDatabase) -> TraitId {

--- a/crates/ra_hir_ty/src/lower.rs
+++ b/crates/ra_hir_ty/src/lower.rs
@@ -361,10 +361,8 @@ impl Ty {
         for t in traits {
             if let Some(associated_ty) = ctx.db.trait_data(t).associated_type_by_name(&segment.name)
             {
-                let substs = Substs::build_for_def(ctx.db, t)
-                    .push(self_ty.clone())
-                    .fill_with_unknown()
-                    .build();
+                let substs =
+                    Substs::build_for_def(ctx.db, t).push(self_ty).fill_with_unknown().build();
                 // FIXME handle type parameters on the segment
                 return Ty::Projection(ProjectionTy { associated_ty, parameters: substs });
             }
@@ -428,7 +426,7 @@ pub(super) fn substs_from_path_segment(
     _add_self_param: bool,
 ) -> Substs {
     let mut substs = Vec::new();
-    let def_generics = def_generic.map(|def| generics(ctx.db, def.into()));
+    let def_generics = def_generic.map(|def| generics(ctx.db, def));
 
     let (parent_params, self_params, type_params, impl_trait_params) =
         def_generics.map_or((0, 0, 0, 0), |g| g.provenance_split());
@@ -459,7 +457,7 @@ pub(super) fn substs_from_path_segment(
 
     // handle defaults
     if let Some(def_generic) = def_generic {
-        let default_substs = ctx.db.generic_defaults(def_generic.into());
+        let default_substs = ctx.db.generic_defaults(def_generic);
         assert_eq!(substs.len(), default_substs.len());
 
         for (i, default_ty) in default_substs.iter().enumerate() {
@@ -483,7 +481,7 @@ impl TraitRef {
             _ => return None,
         };
         let segment = path.segments().last().expect("path should have at least one segment");
-        Some(TraitRef::from_resolved_path(ctx, resolved.into(), segment, explicit_self_ty))
+        Some(TraitRef::from_resolved_path(ctx, resolved, segment, explicit_self_ty))
     }
 
     pub(crate) fn from_resolved_path(
@@ -728,7 +726,7 @@ pub(crate) fn generic_predicates_query(
 pub(crate) fn generic_defaults_query(db: &impl HirDatabase, def: GenericDefId) -> Substs {
     let resolver = def.resolver(db);
     let ctx = TyLoweringContext::new(db, &resolver);
-    let generic_params = generics(db, def.into());
+    let generic_params = generics(db, def);
 
     let defaults = generic_params
         .iter()
@@ -792,7 +790,7 @@ fn type_for_builtin(def: BuiltinType) -> Ty {
 }
 
 fn fn_sig_for_struct_constructor(db: &impl HirDatabase, def: StructId) -> PolyFnSig {
-    let struct_data = db.struct_data(def.into());
+    let struct_data = db.struct_data(def);
     let fields = struct_data.variant_data.fields();
     let resolver = def.resolver(db);
     let ctx =
@@ -805,7 +803,7 @@ fn fn_sig_for_struct_constructor(db: &impl HirDatabase, def: StructId) -> PolyFn
 
 /// Build the type of a tuple struct constructor.
 fn type_for_struct_constructor(db: &impl HirDatabase, def: StructId) -> Binders<Ty> {
-    let struct_data = db.struct_data(def.into());
+    let struct_data = db.struct_data(def);
     if let StructKind::Unit = struct_data.variant_data.kind() {
         return type_for_adt(db, def.into());
     }
@@ -836,7 +834,7 @@ fn type_for_enum_variant_constructor(db: &impl HirDatabase, def: EnumVariantId) 
     }
     let generics = generics(db, def.parent.into());
     let substs = Substs::bound_vars(&generics);
-    Binders::new(substs.len(), Ty::apply(TypeCtor::FnDef(EnumVariantId::from(def).into()), substs))
+    Binders::new(substs.len(), Ty::apply(TypeCtor::FnDef(def.into()), substs))
 }
 
 fn type_for_adt(db: &impl HirDatabase, adt: AdtId) -> Binders<Ty> {
@@ -964,6 +962,6 @@ pub(crate) fn impl_trait_query(
     let target_trait = impl_data.target_trait.as_ref()?;
     Some(Binders::new(
         self_ty.num_binders,
-        TraitRef::from_hir(&ctx, target_trait, Some(self_ty.value.clone()))?,
+        TraitRef::from_hir(&ctx, target_trait, Some(self_ty.value))?,
     ))
 }

--- a/crates/ra_hir_ty/src/method_resolution.rs
+++ b/crates/ra_hir_ty/src/method_resolution.rs
@@ -214,7 +214,7 @@ pub fn iterate_method_candidates<T>(
             // the methods by autoderef order of *receiver types*, not *self
             // types*.
 
-            let deref_chain: Vec<_> = autoderef::autoderef(db, Some(krate), ty.clone()).collect();
+            let deref_chain: Vec<_> = autoderef::autoderef(db, Some(krate), ty).collect();
             for i in 0..deref_chain.len() {
                 if let Some(result) = iterate_method_candidates_with_autoref(
                     &deref_chain[i..],
@@ -290,7 +290,7 @@ fn iterate_method_candidates_with_autoref<T>(
         &ref_muted,
         deref_chain,
         db,
-        env.clone(),
+        env,
         krate,
         &traits_in_scope,
         name,
@@ -391,17 +391,17 @@ fn iterate_trait_method_candidates<T>(
         // iteration
         let mut known_implemented = false;
         for (_name, item) in data.items.iter() {
-            if !is_valid_candidate(db, name, receiver_ty, (*item).into(), self_ty) {
+            if !is_valid_candidate(db, name, receiver_ty, *item, self_ty) {
                 continue;
             }
             if !known_implemented {
                 let goal = generic_implements_goal(db, env.clone(), t, self_ty.clone());
-                if db.trait_solve(krate.into(), goal).is_none() {
+                if db.trait_solve(krate, goal).is_none() {
                     continue 'traits;
                 }
             }
             known_implemented = true;
-            if let Some(result) = callback(&self_ty.value, (*item).into()) {
+            if let Some(result) = callback(&self_ty.value, *item) {
                 return Some(result);
             }
         }
@@ -521,7 +521,7 @@ pub fn implements_trait(
         return true;
     }
     let goal = generic_implements_goal(db, env, trait_, ty.clone());
-    let solution = db.trait_solve(krate.into(), goal);
+    let solution = db.trait_solve(krate, goal);
 
     solution.is_some()
 }

--- a/crates/ra_hir_ty/src/op.rs
+++ b/crates/ra_hir_ty/src/op.rs
@@ -30,20 +30,18 @@ pub(super) fn binary_op_return_ty(op: BinaryOp, lhs_ty: Ty, rhs_ty: Ty) -> Ty {
 pub(super) fn binary_op_rhs_expectation(op: BinaryOp, lhs_ty: Ty) -> Ty {
     match op {
         BinaryOp::LogicOp(..) => Ty::simple(TypeCtor::Bool),
-        BinaryOp::Assignment { op: None } | BinaryOp::CmpOp(CmpOp::Eq { negated: _ }) => {
-            match lhs_ty {
-                Ty::Apply(ApplicationTy { ctor, .. }) => match ctor {
-                    TypeCtor::Int(..)
-                    | TypeCtor::Float(..)
-                    | TypeCtor::Str
-                    | TypeCtor::Char
-                    | TypeCtor::Bool => lhs_ty,
-                    _ => Ty::Unknown,
-                },
-                Ty::Infer(InferTy::IntVar(..)) | Ty::Infer(InferTy::FloatVar(..)) => lhs_ty,
+        BinaryOp::Assignment { op: None } | BinaryOp::CmpOp(CmpOp::Eq { .. }) => match lhs_ty {
+            Ty::Apply(ApplicationTy { ctor, .. }) => match ctor {
+                TypeCtor::Int(..)
+                | TypeCtor::Float(..)
+                | TypeCtor::Str
+                | TypeCtor::Char
+                | TypeCtor::Bool => lhs_ty,
                 _ => Ty::Unknown,
-            }
-        }
+            },
+            Ty::Infer(InferTy::IntVar(..)) | Ty::Infer(InferTy::FloatVar(..)) => lhs_ty,
+            _ => Ty::Unknown,
+        },
         BinaryOp::ArithOp(ArithOp::Shl) | BinaryOp::ArithOp(ArithOp::Shr) => Ty::Unknown,
         BinaryOp::CmpOp(CmpOp::Ord { .. })
         | BinaryOp::Assignment { op: Some(_) }

--- a/crates/ra_hir_ty/src/test_db.rs
+++ b/crates/ra_hir_ty/src/test_db.rs
@@ -86,15 +86,14 @@ impl TestDB {
     pub fn diagnostics(&self) -> String {
         let mut buf = String::new();
         let crate_graph = self.crate_graph();
-        for krate in crate_graph.iter().next() {
+        for krate in crate_graph.iter() {
             let crate_def_map = self.crate_def_map(krate);
 
             let mut fns = Vec::new();
             for (module_id, _) in crate_def_map.modules.iter() {
                 for decl in crate_def_map[module_id].scope.declarations() {
-                    match decl {
-                        ModuleDefId::FunctionId(f) => fns.push(f),
-                        _ => (),
+                    if let ModuleDefId::FunctionId(f) = decl {
+                        fns.push(f)
                     }
                 }
 

--- a/crates/ra_hir_ty/src/tests.rs
+++ b/crates/ra_hir_ty/src/tests.rs
@@ -101,9 +101,9 @@ fn infer_with_mismatches(content: &str, include_mismatches: bool) -> String {
                 (src_ptr.value.range(), node.text().to_string().replace("\n", " "))
             };
             let macro_prefix = if src_ptr.file_id != file_id.into() { "!" } else { "" };
-            write!(
+            writeln!(
                 acc,
-                "{}{} '{}': {}\n",
+                "{}{} '{}': {}",
                 macro_prefix,
                 range,
                 ellipsize(text, 15),
@@ -118,9 +118,9 @@ fn infer_with_mismatches(content: &str, include_mismatches: bool) -> String {
             for (src_ptr, mismatch) in &mismatches {
                 let range = src_ptr.value.range();
                 let macro_prefix = if src_ptr.file_id != file_id.into() { "!" } else { "" };
-                write!(
+                writeln!(
                     acc,
-                    "{}{}: expected {}, got {}\n",
+                    "{}{}: expected {}, got {}",
                     macro_prefix,
                     range,
                     mismatch.expected.display(&db),

--- a/crates/ra_hir_ty/src/traits.rs
+++ b/crates/ra_hir_ty/src/traits.rs
@@ -248,12 +248,9 @@ fn solution_from_chalk(
         let value = subst
             .value
             .into_iter()
-            .map(|p| {
-                let ty = match p.ty() {
-                    Some(ty) => from_chalk(db, ty.clone()),
-                    None => unimplemented!(),
-                };
-                ty
+            .map(|p| match p.ty() {
+                Some(ty) => from_chalk(db, ty.clone()),
+                None => unimplemented!(),
             })
             .collect();
         let result = Canonical { value, num_vars: subst.binders.len() };

--- a/crates/ra_hir_ty/src/traits/builtin.rs
+++ b/crates/ra_hir_ty/src/traits/builtin.rs
@@ -122,7 +122,7 @@ fn closure_fn_trait_impl_datum(
         substs: Substs::build_for_def(db, trait_).push(self_ty).push(arg_ty).build(),
     };
 
-    let output_ty_id = AssocTyValue::ClosureFnTraitImplOutput(data.clone());
+    let output_ty_id = AssocTyValue::ClosureFnTraitImplOutput(data);
 
     BuiltinImplData {
         num_vars: num_args as usize + 1,
@@ -137,7 +137,7 @@ fn closure_fn_trait_output_assoc_ty_value(
     krate: CrateId,
     data: super::ClosureFnTraitImplData,
 ) -> BuiltinImplAssocTyValueData {
-    let impl_ = Impl::ClosureFnTraitImpl(data.clone());
+    let impl_ = Impl::ClosureFnTraitImpl(data);
 
     let num_args: u16 = match &db.body(data.def)[data.expr] {
         Expr::Lambda { args, .. } => args.len() as u16,

--- a/crates/ra_hir_ty/src/traits/builtin.rs
+++ b/crates/ra_hir_ty/src/traits/builtin.rs
@@ -98,7 +98,7 @@ fn closure_fn_trait_impl_datum(
         // the existence of the Fn trait has been checked before
         .expect("fn trait for closure impl missing");
 
-    let num_args: u16 = match &db.body(data.def.into())[data.expr] {
+    let num_args: u16 = match &db.body(data.def)[data.expr] {
         Expr::Lambda { args, .. } => args.len() as u16,
         _ => {
             log::warn!("closure for closure type {:?} not found", data);
@@ -118,7 +118,7 @@ fn closure_fn_trait_impl_datum(
     let self_ty = Ty::apply_one(TypeCtor::Closure { def: data.def, expr: data.expr }, sig_ty);
 
     let trait_ref = TraitRef {
-        trait_: trait_.into(),
+        trait_,
         substs: Substs::build_for_def(db, trait_).push(self_ty).push(arg_ty).build(),
     };
 
@@ -139,7 +139,7 @@ fn closure_fn_trait_output_assoc_ty_value(
 ) -> BuiltinImplAssocTyValueData {
     let impl_ = Impl::ClosureFnTraitImpl(data.clone());
 
-    let num_args: u16 = match &db.body(data.def.into())[data.expr] {
+    let num_args: u16 = match &db.body(data.def)[data.expr] {
         Expr::Lambda { args, .. } => args.len() as u16,
         _ => {
             log::warn!("closure for closure type {:?} not found", data);

--- a/crates/ra_hir_ty/src/traits/chalk.rs
+++ b/crates/ra_hir_ty/src/traits/chalk.rs
@@ -409,8 +409,7 @@ where
     fn to_chalk(self, db: &impl HirDatabase) -> chalk_ir::Canonical<T::Chalk> {
         let parameter = chalk_ir::ParameterKind::Ty(chalk_ir::UniverseIndex::ROOT);
         let value = self.value.to_chalk(db);
-        let canonical = chalk_ir::Canonical { value, binders: vec![parameter; self.num_vars] };
-        canonical
+        chalk_ir::Canonical { value, binders: vec![parameter; self.num_vars] }
     }
 
     fn from_chalk(db: &impl HirDatabase, canonical: chalk_ir::Canonical<T::Chalk>) -> Canonical<T> {

--- a/crates/ra_hir_ty/src/traits/chalk.rs
+++ b/crates/ra_hir_ty/src/traits/chalk.rs
@@ -565,10 +565,10 @@ where
         // and will panic if the trait can't be resolved.
         let mut result: Vec<_> = self
             .db
-            .impls_for_trait(self.krate, trait_.into())
+            .impls_for_trait(self.krate, trait_)
             .iter()
             .copied()
-            .map(|it| Impl::ImplBlock(it.into()))
+            .map(Impl::ImplBlock)
             .map(|impl_| impl_.to_chalk(self.db))
             .collect();
 
@@ -586,7 +586,7 @@ where
         false // FIXME
     }
     fn associated_ty_value(&self, id: AssociatedTyValueId) -> Arc<AssociatedTyValue> {
-        self.db.associated_ty_value(self.krate.into(), id)
+        self.db.associated_ty_value(self.krate, id)
     }
     fn custom_clauses(&self) -> Vec<chalk_ir::ProgramClause<TypeFamily>> {
         vec![]
@@ -674,7 +674,7 @@ pub(crate) fn struct_datum_query(
     let where_clauses = type_ctor
         .as_generic_def()
         .map(|generic_def| {
-            let generic_params = generics(db, generic_def.into());
+            let generic_params = generics(db, generic_def);
             let bound_vars = Substs::bound_vars(&generic_params);
             convert_where_clauses(db, generic_def, &bound_vars)
         })
@@ -805,7 +805,7 @@ fn type_alias_associated_ty_value(
     let ty = db.ty(type_alias.into());
     let value_bound = chalk_rust_ir::AssociatedTyValueBound { ty: ty.value.to_chalk(db) };
     let value = chalk_rust_ir::AssociatedTyValue {
-        impl_id: Impl::ImplBlock(impl_id.into()).to_chalk(db),
+        impl_id: Impl::ImplBlock(impl_id).to_chalk(db),
         associated_ty_id: assoc_ty.to_chalk(db),
         value: make_binders(value_bound, ty.num_binders),
     };

--- a/crates/ra_ide/Cargo.toml
+++ b/crates/ra_ide/Cargo.toml
@@ -11,15 +11,19 @@ doctest = false
 wasm = []
 
 [dependencies]
-either = "1.5"
+either = "1.5.3"
 format-buf = "1.0.0"
-indexmap = "1.3.0"
-itertools = "0.8.0"
+indexmap = "1.3.2"
+itertools = "0.8.2"
 join_to_string = "0.1.3"
-log = "0.4.5"
-rustc-hash = "1.0"
-rand = { version = "0.7.0", features = ["small_rng"] }
-once_cell = "1.2.0"
+log = "0.4.8"
+rayon = "1.3.0"
+fst = { version = "0.3.5", default-features = false }
+rustc-hash = "1.1.0"
+unicase = "2.6.0"
+superslice = "1.0.0"
+rand = { version = "0.7.3", features = ["small_rng"] }
+once_cell = "1.3.1"
 
 ra_syntax = { path = "../ra_syntax" }
 ra_text_edit = { path = "../ra_text_edit" }
@@ -36,4 +40,4 @@ ra_assists = { path = "../ra_assists" }
 hir = { path = "../ra_hir", package = "ra_hir" }
 
 [dev-dependencies]
-insta = "0.13.0"
+insta = "0.13.1"

--- a/crates/ra_ide/src/call_info.rs
+++ b/crates/ra_ide/src/call_info.rs
@@ -128,7 +128,7 @@ impl FnCallNode {
             }),
 
             FnCallNode::MethodCallExpr(call_expr) => {
-                call_expr.syntax().children().filter_map(ast::NameRef::cast).nth(0)
+                call_expr.syntax().children().filter_map(ast::NameRef::cast).next()
             }
 
             FnCallNode::MacroCallExpr(call_expr) => call_expr.path()?.segment()?.name_ref(),

--- a/crates/ra_ide/src/completion/complete_trait_impl.rs
+++ b/crates/ra_ide/src/completion/complete_trait_impl.rs
@@ -59,7 +59,7 @@ pub(crate) fn complete_trait_impl(acc: &mut Completions, ctx: &CompletionContext
         .as_ref()
         .and_then(|node| node.parent())
         .and_then(|node| node.parent())
-        .and_then(|node| ast::ImplBlock::cast(node));
+        .and_then(ast::ImplBlock::cast);
 
     if let (Some(trigger), Some(impl_block)) = (trigger, impl_block) {
         match trigger.kind() {
@@ -110,17 +110,17 @@ fn add_function_impl(
     ctx: &CompletionContext,
     func: &hir::Function,
 ) {
-    let display = FunctionSignature::from_hir(ctx.db, func.clone());
+    let display = FunctionSignature::from_hir(ctx.db, *func);
 
     let fn_name = func.name(ctx.db).to_string();
 
-    let label = if func.params(ctx.db).len() > 0 {
+    let label = if !func.params(ctx.db).is_empty() {
         format!("fn {}(..)", fn_name)
     } else {
         format!("fn {}()", fn_name)
     };
 
-    let builder = CompletionItem::new(CompletionKind::Magic, ctx.source_range(), label.clone())
+    let builder = CompletionItem::new(CompletionKind::Magic, ctx.source_range(), label)
         .lookup_by(fn_name)
         .set_documentation(func.docs(ctx.db));
 

--- a/crates/ra_ide/src/completion/completion_item.rs
+++ b/crates/ra_ide/src/completion/completion_item.rs
@@ -159,7 +159,7 @@ impl CompletionItem {
 
     /// Short one-line additional information, like a type
     pub fn detail(&self) -> Option<&str> {
-        self.detail.as_ref().map(|it| it.as_str())
+        self.detail.as_deref()
     }
     /// A doc-comment
     pub fn documentation(&self) -> Option<Documentation> {
@@ -167,7 +167,7 @@ impl CompletionItem {
     }
     /// What string is used for filtering.
     pub fn lookup(&self) -> &str {
-        self.lookup.as_ref().map(|it| it.as_str()).unwrap_or_else(|| self.label())
+        self.lookup.as_deref().unwrap_or_else(|| self.label())
     }
 
     pub fn kind(&self) -> Option<CompletionItemKind> {

--- a/crates/ra_ide/src/display/function_signature.rs
+++ b/crates/ra_ide/src/display/function_signature.rs
@@ -54,9 +54,8 @@ impl FunctionSignature {
 
     pub(crate) fn from_struct(db: &RootDatabase, st: hir::Struct) -> Option<Self> {
         let node: ast::StructDef = st.source(db).value;
-        match node.kind() {
-            ast::StructKind::Record(_) => return None,
-            _ => (),
+        if let ast::StructKind::Record(_) = node.kind() {
+            return None;
         };
 
         let params = st

--- a/crates/ra_ide/src/display/navigation_target.rs
+++ b/crates/ra_ide/src/display/navigation_target.rs
@@ -64,11 +64,11 @@ impl NavigationTarget {
     }
 
     pub fn docs(&self) -> Option<&str> {
-        self.docs.as_ref().map(String::as_str)
+        self.docs.as_deref()
     }
 
     pub fn description(&self) -> Option<&str> {
-        self.description.as_ref().map(String::as_str)
+        self.description.as_deref()
     }
 
     /// A "most interesting" range withing the `full_range`.

--- a/crates/ra_ide/src/references.rs
+++ b/crates/ra_ide/src/references.rs
@@ -268,7 +268,7 @@ fn decl_access(
     };
 
     let stmt = find_node_at_offset::<ast::LetStmt>(syntax, range.start())?;
-    if let Some(_) = stmt.initializer() {
+    if stmt.initializer().is_some() {
         let pat = stmt.pat()?;
         if let ast::Pat::BindPat(it) = pat {
             if it.name()?.text().as_str() == name {

--- a/crates/ra_ide_db/Cargo.toml
+++ b/crates/ra_ide_db/Cargo.toml
@@ -11,17 +11,18 @@ doctest = false
 wasm = []
 
 [dependencies]
-either = "1.5"
+either = "1.5.3"
 format-buf = "1.0.0"
-indexmap = "1.3.0"
-itertools = "0.8.0"
+indexmap = "1.3.2"
+itertools = "0.8.2"
 join_to_string = "0.1.3"
-log = "0.4.5"
-rayon = "1.0.2"
-fst = { version = "0.3.1", default-features = false }
-rustc-hash = "1.0"
+log = "0.4.8"
+rayon = "1.3.0"
+fst = { version = "0.3.5", default-features = false }
+rustc-hash = "1.1.0"
+unicase = "2.6.0"
 superslice = "1.0.0"
-once_cell = "1.2.0"
+once_cell = "1.3.1"
 
 ra_syntax = { path = "../ra_syntax" }
 ra_text_edit = { path = "../ra_text_edit" }
@@ -36,4 +37,4 @@ test_utils = { path = "../test_utils" }
 hir = { path = "../ra_hir", package = "ra_hir" }
 
 [dev-dependencies]
-insta = "0.13.0"
+insta = "0.13.1"

--- a/crates/ra_ide_db/src/change.rs
+++ b/crates/ra_ide_db/src/change.rs
@@ -44,7 +44,7 @@ impl fmt::Debug for AnalysisChange {
         if !self.libraries_added.is_empty() {
             d.field("libraries_added", &self.libraries_added.len());
         }
-        if !self.crate_graph.is_none() {
+        if self.crate_graph.is_some() {
             d.field("crate_graph", &self.crate_graph);
         }
         d.finish()

--- a/crates/ra_mbe/Cargo.toml
+++ b/crates/ra_mbe/Cargo.toml
@@ -11,9 +11,9 @@ doctest = false
 ra_syntax = { path = "../ra_syntax" }
 ra_parser = { path = "../ra_parser" }
 tt = { path = "../ra_tt", package = "ra_tt" }
-rustc-hash = "1.0.0"
-smallvec = "1.0.0"
-log = "0.4.5"
+rustc-hash = "1.1.0"
+smallvec = "1.2.0"
+log = "0.4.8"
 
 [dev-dependencies]
 test_utils = { path = "../test_utils" }

--- a/crates/ra_mbe/src/mbe_expander/matcher.rs
+++ b/crates/ra_mbe/src/mbe_expander/matcher.rs
@@ -101,7 +101,7 @@ fn match_subtree(
                         tt::Leaf::Literal(tt::Literal { text: lhs, .. }),
                         tt::Leaf::Literal(tt::Literal { text: rhs, .. }),
                     ) if lhs == rhs => (),
-                    _ => Err(ExpandError::UnexpectedToken)?,
+                    _ => return Err(ExpandError::UnexpectedToken),
                 }
             }
             Op::TokenTree(tt::TokenTree::Subtree(lhs)) => {

--- a/crates/ra_mbe/src/parser.rs
+++ b/crates/ra_mbe/src/parser.rs
@@ -45,15 +45,15 @@ impl PartialEq for Separator {
     }
 }
 
-pub(crate) fn parse_template<'a>(
-    template: &'a tt::Subtree,
-) -> impl Iterator<Item = Result<Op<'a>, ExpandError>> {
+pub(crate) fn parse_template(
+    template: &tt::Subtree,
+) -> impl Iterator<Item = Result<Op<'_>, ExpandError>> {
     parse_inner(template, Mode::Template)
 }
 
-pub(crate) fn parse_pattern<'a>(
-    pattern: &'a tt::Subtree,
-) -> impl Iterator<Item = Result<Op<'a>, ExpandError>> {
+pub(crate) fn parse_pattern(
+    pattern: &tt::Subtree,
+) -> impl Iterator<Item = Result<Op<'_>, ExpandError>> {
     parse_inner(pattern, Mode::Pattern)
 }
 
@@ -63,10 +63,7 @@ enum Mode {
     Template,
 }
 
-fn parse_inner<'a>(
-    src: &'a tt::Subtree,
-    mode: Mode,
-) -> impl Iterator<Item = Result<Op<'a>, ExpandError>> {
+fn parse_inner(src: &tt::Subtree, mode: Mode) -> impl Iterator<Item = Result<Op<'_>, ExpandError>> {
     let mut src = TtIter::new(src);
     std::iter::from_fn(move || {
         let first = src.next()?;

--- a/crates/ra_mbe/src/parser.rs
+++ b/crates/ra_mbe/src/parser.rs
@@ -100,7 +100,7 @@ fn next_op<'a>(
                     Op::Repeat { subtree, separator, kind }
                 }
                 tt::TokenTree::Leaf(leaf) => match leaf {
-                    tt::Leaf::Punct(..) => Err(ExpandError::UnexpectedToken)?,
+                    tt::Leaf::Punct(..) => return Err(ExpandError::UnexpectedToken),
                     tt::Leaf::Ident(ident) => {
                         let name = &ident.text;
                         let kind = eat_fragment_kind(src, mode)?;
@@ -147,15 +147,15 @@ fn parse_repeat(src: &mut TtIter) -> Result<(Option<Separator>, RepeatKind), Exp
     for tt in src {
         let tt = match tt {
             tt::TokenTree::Leaf(leaf) => leaf,
-            tt::TokenTree::Subtree(_) => Err(ExpandError::InvalidRepeat)?,
+            tt::TokenTree::Subtree(_) => return Err(ExpandError::InvalidRepeat),
         };
         let has_sep = match &separator {
-            Separator::Puncts(puncts) => puncts.len() != 0,
+            Separator::Puncts(puncts) => !puncts.is_empty(),
             _ => true,
         };
         match tt {
             tt::Leaf::Ident(_) | tt::Leaf::Literal(_) if has_sep => {
-                Err(ExpandError::InvalidRepeat)?
+                return Err(ExpandError::InvalidRepeat)
             }
             tt::Leaf::Ident(ident) => separator = Separator::Ident(ident.clone()),
             tt::Leaf::Literal(lit) => separator = Separator::Literal(lit.clone()),
@@ -168,11 +168,11 @@ fn parse_repeat(src: &mut TtIter) -> Result<(Option<Separator>, RepeatKind), Exp
                         match &mut separator {
                             Separator::Puncts(puncts) => {
                                 if puncts.len() == 3 {
-                                    Err(ExpandError::InvalidRepeat)?
+                                    return Err(ExpandError::InvalidRepeat);
                                 }
                                 puncts.push(punct.clone())
                             }
-                            _ => Err(ExpandError::InvalidRepeat)?,
+                            _ => return Err(ExpandError::InvalidRepeat),
                         }
                         continue;
                     }

--- a/crates/ra_mbe/src/subtree_source.rs
+++ b/crates/ra_mbe/src/subtree_source.rs
@@ -124,7 +124,7 @@ fn convert_delim(d: Option<tt::DelimiterKind>, closing: bool) -> TtToken {
 
     let idx = closing as usize;
     let kind = kinds[idx];
-    let text = if texts.len() > 0 { &texts[idx..texts.len() - (1 - idx)] } else { "" };
+    let text = if !texts.is_empty() { &texts[idx..texts.len() - (1 - idx)] } else { "" };
     TtToken { kind, is_joint_to_next: false, text: SmolStr::new(text) }
 }
 

--- a/crates/ra_parser/src/grammar/expressions/atom.rs
+++ b/crates/ra_parser/src/grammar/expressions/atom.rs
@@ -230,10 +230,8 @@ fn lambda_expr(p: &mut Parser) -> CompletedMarker {
     p.eat(T![async]);
     p.eat(T![move]);
     params::param_list_closure(p);
-    if opt_fn_ret_type(p) {
-        if !p.at(T!['{']) {
-            p.error("expected `{`");
-        }
+    if opt_fn_ret_type(p) && !p.at(T!['{']) {
+        p.error("expected `{`");
     }
 
     if p.at_ts(EXPR_FIRST) {

--- a/crates/ra_parser/src/grammar/items.rs
+++ b/crates/ra_parser/src/grammar/items.rs
@@ -21,7 +21,7 @@ use super::*;
 // struct S;
 pub(super) fn mod_contents(p: &mut Parser, stop_on_r_curly: bool) {
     attributes::inner_attributes(p);
-    while !p.at(EOF) && !(stop_on_r_curly && p.at(T!['}'])) {
+    while !(stop_on_r_curly && p.at(T!['}']) || p.at(EOF)) {
         item_or_macro(p, stop_on_r_curly, ItemFlavor::Mod)
     }
 }

--- a/crates/ra_parser/src/grammar/paths.rs
+++ b/crates/ra_parser/src/grammar/paths.rs
@@ -94,7 +94,7 @@ fn path_segment(p: &mut Parser, mode: Mode, first: bool) {
 
 fn opt_path_type_args(p: &mut Parser, mode: Mode) {
     match mode {
-        Mode::Use => return,
+        Mode::Use => {}
         Mode::Type => {
             // test path_fn_trait_args
             // type F = Box<Fn(i32) -> ()>;

--- a/crates/ra_parser/src/parser.rs
+++ b/crates/ra_parser/src/parser.rs
@@ -126,13 +126,13 @@ impl<'t> Parser<'t> {
     }
 
     fn at_composite2(&self, n: usize, k1: SyntaxKind, k2: SyntaxKind) -> bool {
-        let t1 = self.token_source.lookahead_nth(n + 0);
+        let t1 = self.token_source.lookahead_nth(n);
         let t2 = self.token_source.lookahead_nth(n + 1);
         t1.kind == k1 && t1.is_jointed_to_next && t2.kind == k2
     }
 
     fn at_composite3(&self, n: usize, k1: SyntaxKind, k2: SyntaxKind, k3: SyntaxKind) -> bool {
-        let t1 = self.token_source.lookahead_nth(n + 0);
+        let t1 = self.token_source.lookahead_nth(n);
         let t2 = self.token_source.lookahead_nth(n + 1);
         let t3 = self.token_source.lookahead_nth(n + 2);
         (t1.kind == k1 && t1.is_jointed_to_next)

--- a/crates/ra_prof/Cargo.toml
+++ b/crates/ra_prof/Cargo.toml
@@ -9,13 +9,13 @@ publish = false
 doctest = false
 
 [dependencies]
-once_cell = "1.0.1"
-itertools = "0.8.0"
-backtrace = "0.3.28"
+once_cell = "1.3.1"
+itertools = "0.8.2"
+backtrace = "0.3.44"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemallocator = { version = "0.3.2", optional = true }
-jemalloc-ctl = { version = "0.3.2", optional = true }
+jemalloc-ctl = { version = "0.3.3", optional = true }
 
 [features]
 jemalloc = [ "jemallocator", "jemalloc-ctl" ]

--- a/crates/ra_prof/src/lib.rs
+++ b/crates/ra_prof/src/lib.rs
@@ -214,7 +214,7 @@ impl Drop for Profiler {
                     let start = stack.starts.pop().unwrap();
                     let duration = start.elapsed();
                     let level = stack.starts.len();
-                    stack.messages.push(Message { level, duration, label: label });
+                    stack.messages.push(Message { level, duration, label });
                     if level == 0 {
                         let stdout = stderr();
                         let longer_than = stack.filter_data.longer_than;

--- a/crates/ra_project_model/Cargo.toml
+++ b/crates/ra_project_model/Cargo.toml
@@ -8,16 +8,16 @@ authors = ["rust-analyzer developers"]
 doctest = false
 
 [dependencies]
-log = "0.4.5"
-rustc-hash = "1.0"
+log = "0.4.8"
+rustc-hash = "1.1.0"
 
-cargo_metadata = "0.9.0"
+cargo_metadata = "0.9.1"
 
 ra_arena = { path = "../ra_arena" }
 ra_db = { path = "../ra_db" }
 ra_cfg = { path = "../ra_cfg" }
 
-serde = { version = "1.0.89", features = ["derive"] }
-serde_json = "1.0.39"
+serde = { version = "1.0.104", features = ["derive"] }
+serde_json = "1.0.48"
 
 anyhow = "1.0.26"

--- a/crates/ra_project_model/src/cargo_workspace.rs
+++ b/crates/ra_project_model/src/cargo_workspace.rs
@@ -164,7 +164,7 @@ impl CargoWorkspace {
             // FIXME: `NoDefaultFeatures` is mutual exclusive with `SomeFeatures`
             // https://github.com/oli-obk/cargo_metadata/issues/79
             meta.features(CargoOpt::NoDefaultFeatures);
-        } else if cargo_features.features.len() > 0 {
+        } else if !cargo_features.features.is_empty() {
             meta.features(CargoOpt::SomeFeatures(cargo_features.features.clone()));
         }
         if let Some(parent) = cargo_toml.parent() {

--- a/crates/ra_project_model/src/cargo_workspace.rs
+++ b/crates/ra_project_model/src/cargo_workspace.rs
@@ -197,7 +197,7 @@ impl CargoWorkspace {
             let pkg_data = &mut packages[pkg];
             pkg_by_id.insert(id, pkg);
             for meta_tgt in meta_pkg.targets {
-                let is_proc_macro = meta_tgt.kind.as_slice() == &["proc-macro"];
+                let is_proc_macro = meta_tgt.kind.as_slice() == ["proc-macro"];
                 let tgt = targets.alloc(TargetData {
                     pkg,
                     name: meta_tgt.name,

--- a/crates/ra_project_model/src/lib.rs
+++ b/crates/ra_project_model/src/lib.rs
@@ -409,7 +409,7 @@ fn find_cargo_toml(path: &Path) -> Result<PathBuf> {
         }
         curr = path.parent();
     }
-    Err(CargoTomlNotFoundError(path.to_path_buf()))?
+    Err(CargoTomlNotFoundError(path.to_path_buf()).into())
 }
 
 pub fn get_rustc_cfg_options() -> CfgOptions {

--- a/crates/ra_project_model/src/lib.rs
+++ b/crates/ra_project_model/src/lib.rs
@@ -197,8 +197,9 @@ impl ProjectWorkspace {
                         if let (Some(&from), Some(&to)) =
                             (crates.get(&from_crate_id), crates.get(&to_crate_id))
                         {
-                            if let Err(_) =
-                                crate_graph.add_dep(from, CrateName::new(&dep.name).unwrap(), to)
+                            if crate_graph
+                                .add_dep(from, CrateName::new(&dep.name).unwrap(), to)
+                                .is_err()
                             {
                                 log::error!(
                                     "cyclic dependency {:?} -> {:?}",
@@ -237,8 +238,7 @@ impl ProjectWorkspace {
                         if let (Some(&from), Some(&to)) =
                             (sysroot_crates.get(&from), sysroot_crates.get(&to))
                         {
-                            if let Err(_) =
-                                crate_graph.add_dep(from, CrateName::new(name).unwrap(), to)
+                            if crate_graph.add_dep(from, CrateName::new(name).unwrap(), to).is_err()
                             {
                                 log::error!("cyclic dependency between sysroot crates")
                             }
@@ -279,11 +279,14 @@ impl ProjectWorkspace {
                             }
                             if tgt.is_proc_macro(&cargo) {
                                 if let Some(proc_macro) = libproc_macro {
-                                    if let Err(_) = crate_graph.add_dep(
-                                        crate_id,
-                                        CrateName::new("proc_macro").unwrap(),
-                                        proc_macro,
-                                    ) {
+                                    if crate_graph
+                                        .add_dep(
+                                            crate_id,
+                                            CrateName::new("proc_macro").unwrap(),
+                                            proc_macro,
+                                        )
+                                        .is_err()
+                                    {
                                         log::error!(
                                             "cyclic dependency on proc_macro for {}",
                                             pkg.name(&cargo)
@@ -299,15 +302,19 @@ impl ProjectWorkspace {
                     // Set deps to the core, std and to the lib target of the current package
                     for &from in pkg_crates.get(&pkg).into_iter().flatten() {
                         if let Some(to) = lib_tgt {
-                            if to != from {
-                                if let Err(_) = crate_graph.add_dep(
-                                    from,
-                                    // For root projects with dashes in their name,
-                                    // cargo metadata does not do any normalization,
-                                    // so we do it ourselves currently
-                                    CrateName::normalize_dashes(pkg.name(&cargo)),
-                                    to,
-                                ) {
+                            if to != from
+                                && crate_graph
+                                    .add_dep(
+                                        from,
+                                        // For root projects with dashes in their name,
+                                        // cargo metadata does not do any normalization,
+                                        // so we do it ourselves currently
+                                        CrateName::normalize_dashes(pkg.name(&cargo)),
+                                        to,
+                                    )
+                                    .is_err()
+                            {
+                                {
                                     log::error!(
                                         "cyclic dependency between targets of {}",
                                         pkg.name(&cargo)
@@ -318,22 +325,25 @@ impl ProjectWorkspace {
                         // core is added as a dependency before std in order to
                         // mimic rustcs dependency order
                         if let Some(core) = libcore {
-                            if let Err(_) =
-                                crate_graph.add_dep(from, CrateName::new("core").unwrap(), core)
+                            if crate_graph
+                                .add_dep(from, CrateName::new("core").unwrap(), core)
+                                .is_err()
                             {
                                 log::error!("cyclic dependency on core for {}", pkg.name(&cargo))
                             }
                         }
                         if let Some(alloc) = liballoc {
-                            if let Err(_) =
-                                crate_graph.add_dep(from, CrateName::new("alloc").unwrap(), alloc)
+                            if crate_graph
+                                .add_dep(from, CrateName::new("alloc").unwrap(), alloc)
+                                .is_err()
                             {
                                 log::error!("cyclic dependency on alloc for {}", pkg.name(&cargo))
                             }
                         }
                         if let Some(std) = libstd {
-                            if let Err(_) =
-                                crate_graph.add_dep(from, CrateName::new("std").unwrap(), std)
+                            if crate_graph
+                                .add_dep(from, CrateName::new("std").unwrap(), std)
+                                .is_err()
                             {
                                 log::error!("cyclic dependency on std for {}", pkg.name(&cargo))
                             }
@@ -347,11 +357,10 @@ impl ProjectWorkspace {
                     for dep in pkg.dependencies(&cargo) {
                         if let Some(&to) = pkg_to_lib_crate.get(&dep.pkg) {
                             for &from in pkg_crates.get(&pkg).into_iter().flatten() {
-                                if let Err(_) = crate_graph.add_dep(
-                                    from,
-                                    CrateName::new(&dep.name).unwrap(),
-                                    to,
-                                ) {
+                                if crate_graph
+                                    .add_dep(from, CrateName::new(&dep.name).unwrap(), to)
+                                    .is_err()
+                                {
                                     log::error!(
                                         "cyclic dependency {} -> {}",
                                         pkg.name(&cargo),

--- a/crates/ra_syntax/Cargo.toml
+++ b/crates/ra_syntax/Cargo.toml
@@ -11,12 +11,12 @@ repository = "https://github.com/rust-analyzer/rust-analyzer"
 doctest = false
 
 [dependencies]
-itertools = "0.8.0"
+itertools = "0.8.2"
 rowan = "0.9.0"
 rustc_lexer = "0.1.0"
-rustc-hash = "1.0.1"
+rustc-hash = "1.1.0"
 arrayvec = "0.5.1"
-once_cell = "1.2.0"
+once_cell = "1.3.1"
 
 ra_text_edit = { path = "../ra_text_edit" }
 ra_parser = { path = "../ra_parser" }
@@ -24,9 +24,9 @@ ra_parser = { path = "../ra_parser" }
 # This crate transitively depends on `smol_str` via `rowan`.
 # ideally, `serde` should be enabled by `rust-analyzer`, but we enable it here
 # to reduce number of compilations
-smol_str = { version = "0.1.12", features = ["serde"] }
-serde = { version = "1", features = ["derive"] }
+smol_str = { version = "0.1.15", features = ["serde"] }
+serde = { version = "1.0.104", features = ["derive"] }
 
 [dev-dependencies]
 test_utils = { path = "../test_utils" }
-walkdir = "2.2.0"
+walkdir = "2.3.1"

--- a/crates/ra_syntax/src/algo.rs
+++ b/crates/ra_syntax/src/algo.rs
@@ -95,16 +95,17 @@ pub fn diff(from: &SyntaxNode, to: &SyntaxNode) -> TreeDiff {
         lhs: SyntaxElement,
         rhs: SyntaxElement,
     ) {
-        if lhs.kind() == rhs.kind() && lhs.text_range().len() == rhs.text_range().len() {
-            if match (&lhs, &rhs) {
+        if lhs.kind() == rhs.kind()
+            && lhs.text_range().len() == rhs.text_range().len()
+            && match (&lhs, &rhs) {
                 (NodeOrToken::Node(lhs), NodeOrToken::Node(rhs)) => {
                     lhs.green() == rhs.green() || lhs.text() == rhs.text()
                 }
                 (NodeOrToken::Token(lhs), NodeOrToken::Token(rhs)) => lhs.text() == rhs.text(),
                 _ => false,
-            } {
-                return;
             }
+        {
+            return;
         }
         if let (Some(lhs), Some(rhs)) = (lhs.as_node(), rhs.as_node()) {
             if lhs.children_with_tokens().count() == rhs.children_with_tokens().count() {

--- a/crates/ra_syntax/src/ast/expr_extensions.rs
+++ b/crates/ra_syntax/src/ast/expr_extensions.rs
@@ -30,7 +30,7 @@ pub enum ElseBranch {
 
 impl ast::IfExpr {
     pub fn then_branch(&self) -> Option<ast::BlockExpr> {
-        self.blocks().nth(0)
+        self.blocks().next()
     }
     pub fn else_branch(&self) -> Option<ElseBranch> {
         let res = match self.blocks().nth(1) {
@@ -208,7 +208,7 @@ impl ast::BinExpr {
     }
 
     pub fn lhs(&self) -> Option<ast::Expr> {
-        children(self).nth(0)
+        children(self).next()
     }
 
     pub fn rhs(&self) -> Option<ast::Expr> {
@@ -271,7 +271,7 @@ impl ast::RangeExpr {
 
 impl ast::IndexExpr {
     pub fn base(&self) -> Option<ast::Expr> {
-        children(self).nth(0)
+        children(self).next()
     }
     pub fn index(&self) -> Option<ast::Expr> {
         children(self).nth(1)
@@ -287,7 +287,7 @@ impl ast::ArrayExpr {
     pub fn kind(&self) -> ArrayExprKind {
         if self.is_repeat() {
             ArrayExprKind::Repeat {
-                initializer: children(self).nth(0),
+                initializer: children(self).next(),
                 repeat: children(self).nth(1),
             }
         } else {
@@ -328,10 +328,10 @@ impl ast::Literal {
     }
 
     pub fn kind(&self) -> LiteralKind {
-        const INT_SUFFIXES: [&'static str; 12] = [
+        const INT_SUFFIXES: [&str; 12] = [
             "u64", "u32", "u16", "u8", "usize", "isize", "i64", "i32", "i16", "i8", "u128", "i128",
         ];
-        const FLOAT_SUFFIXES: [&'static str; 2] = ["f32", "f64"];
+        const FLOAT_SUFFIXES: [&str; 2] = ["f32", "f64"];
 
         let token = self.token();
 

--- a/crates/ra_syntax/src/ast/make.rs
+++ b/crates/ra_syntax/src/ast/make.rs
@@ -152,7 +152,7 @@ pub fn match_arm_list(arms: impl IntoIterator<Item = ast::MatchArm>) -> ast::Mat
             format!("    {}{}\n", arm.syntax(), comma)
         })
         .collect::<String>();
-    return from_text(&format!("{}", arms_str));
+    return from_text(&arms_str);
 
     fn from_text(text: &str) -> ast::MatchArmList {
         ast_from_text(&format!("fn f() {{ match () {{\n{}}} }}", text))

--- a/crates/ra_syntax/src/parsing/text_token_source.rs
+++ b/crates/ra_syntax/src/parsing/text_token_source.rs
@@ -48,7 +48,7 @@ impl<'t> TokenSource for TextTokenSource<'t> {
 
     fn is_keyword(&self, kw: &str) -> bool {
         let pos = self.curr.1;
-        if !(pos < self.tokens.len()) {
+        if pos >= self.tokens.len() {
             return false;
         }
         let range = TextRange::offset_len(self.start_offsets[pos], self.tokens[pos].len);

--- a/crates/ra_text_edit/Cargo.toml
+++ b/crates/ra_text_edit/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 doctest = false
 
 [dependencies]
-text_unit = "0.1.6"
+text_unit = "0.1.9"
 
 [dev-dependencies]
 test_utils = { path = "../test_utils" }

--- a/crates/ra_tt/Cargo.toml
+++ b/crates/ra_tt/Cargo.toml
@@ -10,4 +10,4 @@ doctest = false
 [dependencies]
 # ideally, `serde` should be enabled by `rust-analyzer`, but we enable it here
 # to reduce number of compilations
-smol_str = { version = "0.1.12", features = ["serde"] }
+smol_str = { version = "0.1.15", features = ["serde"] }

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -13,32 +13,32 @@ name = "rust-analyzer"
 path = "./src/bin/main.rs"
 
 [dependencies]
-anyhow = "1.0"
-crossbeam-channel = "0.4"
-either = "1.5"
+anyhow = "1.0.26"
+crossbeam-channel = "0.4.0"
+either = "1.5.3"
 env_logger = { version = "0.7.1", default-features = false }
 globset = "0.4.4"
-itertools = "0.8.0"
+itertools = "0.8.2"
 jod-thread = "0.1.0"
-log = "0.4.3"
-lsp-types = { version = "0.70.0", features = ["proposed"] }
+log = "0.4.8"
+lsp-types = { version = "0.70.1", features = ["proposed"] }
 parking_lot = "0.10.0"
-pico-args = "0.3.0"
-rand = { version = "0.7.0", features = ["small_rng"] }
+pico-args = "0.3.1"
+rand = { version = "0.7.3", features = ["small_rng"] }
 relative-path = "1.0.0"
-rustc-hash = "1.0"
-serde = { version = "1.0.83", features = ["derive"] }
-serde_json = "1.0.34"
+rustc-hash = "1.1.0"
+serde = { version = "1.0.104", features = ["derive"] }
+serde_json = "1.0.48"
 threadpool = "1.7.1"
 
-lsp-server = "0.3.0"
+lsp-server = "0.3.1"
 ra_cargo_watch = { path = "../ra_cargo_watch" }
 ra_ide = { path = "../ra_ide" }
 ra_prof = { path = "../ra_prof" }
 ra_project_model = { path = "../ra_project_model" }
 ra_syntax = { path = "../ra_syntax" }
 ra_text_edit = { path = "../ra_text_edit" }
-ra_vfs = "0.5.0"
+ra_vfs = "0.5.2"
 
 # This should only be used in CLI
 ra_db = { path = "../ra_db" }
@@ -48,10 +48,10 @@ hir_ty = { path = "../ra_hir_ty", package = "ra_hir_ty" }
 
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.3"
+winapi = "0.3.8"
 
 [dev-dependencies]
-tempfile = "3"
+tempfile = "3.1.0"
 test_utils = { path = "../test_utils" }
 
 [features]

--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -4,7 +4,7 @@
 mod args;
 
 use lsp_server::Connection;
-use ra_prof;
+
 use rust_analyzer::{cli, from_json, show_message, Result, ServerConfig};
 
 use crate::args::HelpPrinted;

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -130,7 +130,7 @@ pub fn analysis_stats(
             write!(msg, " ({:?} {})", path, syntax_range).unwrap();
         }
         if verbosity.is_spammy() {
-            bar.println(format!("{}", msg));
+            bar.println(msg.to_string());
         }
         bar.set_message(&msg);
         let f_id = FunctionId::from(f);

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -206,17 +206,17 @@ pub fn main_loop(
             let event = select! {
                 recv(&connection.receiver) -> msg => match msg {
                     Ok(msg) => Event::Msg(msg),
-                    Err(RecvError) => Err("client exited without shutdown")?,
+                    Err(RecvError) => return Err("client exited without shutdown".into()),
                 },
                 recv(task_receiver) -> task => Event::Task(task.unwrap()),
                 recv(world_state.task_receiver) -> task => match task {
                     Ok(task) => Event::Vfs(task),
-                    Err(RecvError) => Err("vfs died")?,
+                    Err(RecvError) => return Err("vfs died".into()),
                 },
                 recv(libdata_receiver) -> data => Event::Lib(data.unwrap()),
                 recv(world_state.check_watcher.task_recv) -> task => match task {
                     Ok(task) => Event::CheckWatcher(task),
-                    Err(RecvError) => Err("check watcher died")?,
+                    Err(RecvError) => return Err("check watcher died".into()),
                 }
             };
             if let Event::Msg(Message::Request(req)) = &event {

--- a/crates/rust-analyzer/tests/heavy_tests/main.rs
+++ b/crates/rust-analyzer/tests/heavy_tests/main.rs
@@ -17,7 +17,7 @@ use test_utils::skip_slow_tests;
 
 use crate::support::{project, Project};
 
-const PROFILE: &'static str = "";
+const PROFILE: &str = "";
 // const PROFILE: &'static str = "*@3>100";
 
 #[test]

--- a/crates/rust-analyzer/tests/heavy_tests/support.rs
+++ b/crates/rust-analyzer/tests/heavy_tests/support.rs
@@ -52,7 +52,7 @@ impl<'a> Project<'a> {
         let tmp_dir = self.tmp_dir.unwrap_or_else(|| TempDir::new().unwrap());
         static INIT: Once = Once::new();
         INIT.call_once(|| {
-            let _ = env_logger::builder().is_test(true).try_init().unwrap();
+            env_logger::builder().is_test(true).try_init().unwrap();
             ra_prof::set_filter(if crate::PROFILE.is_empty() {
                 ra_prof::Filter::disabled()
             } else {

--- a/crates/test_utils/Cargo.toml
+++ b/crates/test_utils/Cargo.toml
@@ -9,5 +9,5 @@ doctest = false
 
 [dependencies]
 difference = "2.0.0"
-text_unit = "0.1.2"
-serde_json = "1.0.34"
+text_unit = "0.1.9"
+serde_json = "1.0.48"

--- a/crates/test_utils/src/lib.rs
+++ b/crates/test_utils/src/lib.rs
@@ -279,7 +279,7 @@ pub fn find_mismatch<'a>(expected: &'a Value, actual: &'a Value) -> Option<(&'a 
                 return Some((expected, actual));
             }
 
-            l.values().zip(r.values()).filter_map(|(l, r)| find_mismatch(l, r)).nth(0)
+            l.values().zip(r.values()).filter_map(|(l, r)| find_mismatch(l, r)).next()
         }
         (&Null, &Null) => None,
         // magic string literal "{...}" acts as wildcard for any sub-JSON

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 doctest = false
 
 [dependencies]
-walkdir = "2.1.3"
-pico-args = "0.3.0"
+walkdir = "2.3.1"
+pico-args = "0.3.1"
 quote = "1.0.2"
-proc-macro2 = "1.0.1"
-anyhow = "1.0.19"
+proc-macro2 = "1.0.8"
+anyhow = "1.0.26"

--- a/xtask/src/install.rs
+++ b/xtask/src/install.rs
@@ -94,8 +94,7 @@ fn install_client(ClientOpt::VsCode: ClientOpt) -> Result<()> {
             })
     };
 
-    let installed_extensions;
-    if cfg!(unix) {
+    let installed_extensions = if cfg!(unix) {
         run!("npm --version").context("`npm` is required to build the VS Code plugin")?;
         run!("npm install")?;
 
@@ -103,7 +102,7 @@ fn install_client(ClientOpt::VsCode: ClientOpt) -> Result<()> {
 
         let code = find_code(|bin| run!("{} --version", bin).is_ok())?;
         run!("{} --install-extension rust-analyzer.vsix --force", code)?;
-        installed_extensions = run!("{} --list-extensions", code; echo = false)?;
+        run!("{} --list-extensions", code; echo = false)?
     } else {
         run!("cmd.exe /c npm --version")
             .context("`npm` is required to build the VS Code plugin")?;
@@ -113,8 +112,8 @@ fn install_client(ClientOpt::VsCode: ClientOpt) -> Result<()> {
 
         let code = find_code(|bin| run!("cmd.exe /c {}.cmd --version", bin).is_ok())?;
         run!(r"cmd.exe /c {}.cmd --install-extension rust-analyzer.vsix --force", code)?;
-        installed_extensions = run!("cmd.exe /c {}.cmd --list-extensions", code; echo = false)?;
-    }
+        run!("cmd.exe /c {}.cmd --list-extensions", code; echo = false)?
+    };
 
     if !installed_extensions.contains("rust-analyzer") {
         bail!(


### PR DESCRIPTION
In the `cargo xtask lint` ouptut, there were two interesting Clippy warnings that might be interesting to investigate further:

* warning: this argument (4 byte) is passed by reference, but would be more efficient if passed by value (limit: 8 byte)

* warning: large size difference between variants