### PR TITLE
Rename module references

### DIFF
--- a/crates/ra_ide/src/references/rename.rs
+++ b/crates/ra_ide/src/references/rename.rs
@@ -99,17 +99,13 @@ fn rename_mod(
     source_file_edits.push(edit);
 
     if let Some(RangeInfo { range: _, info: refs }) = find_all_refs(db, position, None) {
-        let ref_edits = refs
-            .references
-            .into_iter()
-            .map(|reference| {
-                source_edit_from_file_id_range(
-                    reference.file_range.file_id,
-                    reference.file_range.range,
-                    new_name,
-                )
-            })
-            .collect::<Vec<_>>();
+        let ref_edits = refs.references.into_iter().map(|reference| {
+            source_edit_from_file_id_range(
+                reference.file_range.file_id,
+                reference.file_range.range,
+                new_name,
+            )
+        });
         source_file_edits.extend(ref_edits);
     }
 

--- a/crates/ra_ide/src/references/rename.rs
+++ b/crates/ra_ide/src/references/rename.rs
@@ -110,9 +110,7 @@ fn rename_mod(
                 )
             })
             .collect::<Vec<_>>();
-        for ref_edit in ref_edits {
-            source_file_edits.push(ref_edit);
-        }
+        source_file_edits.extend(ref_edits);
     }
 
     Some(SourceChange::from_edits("rename", source_file_edits, file_system_edits))

--- a/crates/ra_ide/src/references/rename.rs
+++ b/crates/ra_ide/src/references/rename.rs
@@ -98,6 +98,23 @@ fn rename_mod(
     };
     source_file_edits.push(edit);
 
+    if let Some(RangeInfo { range: _, info: refs }) = find_all_refs(db, position, None) {
+        let ref_edits = refs
+            .references
+            .into_iter()
+            .map(|reference| {
+                source_edit_from_file_id_range(
+                    reference.file_range.file_id,
+                    reference.file_range.range,
+                    new_name,
+                )
+            })
+            .collect::<Vec<_>>();
+        for ref_edit in ref_edits {
+            source_file_edits.push(ref_edit);
+        }
+    }
+
     Some(SourceChange::from_edits("rename", source_file_edits, file_system_edits))
 }
 
@@ -381,6 +398,101 @@ mod tests {
         )
         "###
                );
+    }
+
+    #[test]
+    fn test_module_rename_in_path() {
+        test_rename(
+            r#"
+    mod <|>foo {
+        pub fn bar() {}
+    }
+
+    fn main() {
+        foo::bar();
+    }"#,
+            "baz",
+            r#"
+    mod baz {
+        pub fn bar() {}
+    }
+
+    fn main() {
+        baz::bar();
+    }"#,
+        );
+    }
+
+    #[test]
+    fn test_rename_mod_filename_and_path() {
+        let (analysis, position) = analysis_and_position(
+            "
+            //- /lib.rs
+            mod bar;
+            fn f() {
+                bar::foo::fun()
+            }
+
+            //- /bar.rs
+            pub mod foo<|>;
+
+            //- /bar/foo.rs
+            // pub fn fun() {}
+            ",
+        );
+        let new_name = "foo2";
+        let source_change = analysis.rename(position, new_name).unwrap();
+        assert_debug_snapshot!(&source_change,
+@r###"
+        Some(
+            RangeInfo {
+                range: [8; 11),
+                info: SourceChange {
+                    label: "rename",
+                    source_file_edits: [
+                        SourceFileEdit {
+                            file_id: FileId(
+                                2,
+                            ),
+                            edit: TextEdit {
+                                atoms: [
+                                    AtomTextEdit {
+                                        delete: [8; 11),
+                                        insert: "foo2",
+                                    },
+                                ],
+                            },
+                        },
+                        SourceFileEdit {
+                            file_id: FileId(
+                                1,
+                            ),
+                            edit: TextEdit {
+                                atoms: [
+                                    AtomTextEdit {
+                                        delete: [27; 30),
+                                        insert: "foo2",
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                    file_system_edits: [
+                        MoveFile {
+                            src: FileId(
+                                3,
+                            ),
+                            dst_source_root: SourceRootId(
+                                0,
+                            ),
+                            dst_path: "bar/foo2.rs",
+                        },
+                    ],
+                    cursor_position: None,
+                },
+            },
+        )
+        "###);
     }
 
     fn test_rename(text: &str, new_name: &str, expected: &str) {


### PR DESCRIPTION
Rename references to a module when the module is renamed. This fixes some missing renames in the existing implementation. For example, renaming the module `foo` to `foo2` in this case:
```rust
mod foo {
    pub fn bar() {}
}

fn main() {
    foo::bar()
}
```
previously would not change the call `foo::bar()` to `foo2::bar()`, but now it will. 