### PR TITLE
Improve RA version display

### DIFF
--- a/crates/rust-analyzer/build.rs
+++ b/crates/rust-analyzer/build.rs
@@ -3,7 +3,7 @@
 use std::{env, path::PathBuf, process::Command};
 
 fn main() {
-    let _ = set_rerun();
+    set_rerun();
 
     let rev = rev().unwrap_or_else(|| "???????".to_string());
     println!("cargo:rustc-env=REV={}", rev)

--- a/crates/rust-analyzer/build.rs
+++ b/crates/rust-analyzer/build.rs
@@ -1,10 +1,38 @@
 //! Just embed git-hash to `--version`
 
-use std::process::Command;
+use std::{env, path::PathBuf, process::Command};
 
 fn main() {
+    let _ = set_rerun();
+
     let rev = rev().unwrap_or_else(|| "???????".to_string());
     println!("cargo:rustc-env=REV={}", rev)
+}
+
+fn set_rerun() {
+    let mut manifest_dir = PathBuf::from(
+        env::var("CARGO_MANIFEST_DIR").expect("`CARGO_MANIFEST_DIR` is always set by cargo."),
+    );
+
+    while manifest_dir.parent().is_some() {
+        if manifest_dir.join(".git/HEAD").exists() {
+            let git_dir = manifest_dir.join(".git");
+
+            println!("cargo:rerun-if-changed={}", git_dir.join("HEAD").display());
+            // current branch ref
+            if let Ok(output) =
+                Command::new("git").args(&["rev-parse", "--symbolic-full-name", "HEAD"]).output()
+            {
+                if let Ok(ref_link) = String::from_utf8(output.stdout) {
+                    println!("cargo:rerun-if-changed={}", git_dir.join(ref_link).display());
+                }
+            }
+            return;
+        }
+
+        manifest_dir.pop();
+    }
+    println!("cargo:warning=Could not find `.git/HEAD` from manifest dir!");
 }
 
 fn rev() -> Option<String> {

--- a/docs/user/features.md
+++ b/docs/user/features.md
@@ -89,6 +89,10 @@ Shows the full macro expansion of the macro at current cursor.
 
 Shows internal statistic about memory usage of rust-analyzer
 
+#### Show RA Version
+
+Show current rust-analyzer version
+
 #### Run garbage collection
 
 Manually triggers GC

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -131,6 +131,11 @@
                 "command": "rust-analyzer.ssr",
                 "title": "Structural Search Replace",
                 "category": "Rust Analyzer"
+            },
+            {
+                "command": "rust-analyzer.serverVersion",
+                "title": "Show RA Version",
+                "category": "Rust Analyzer"
             }
         ],
         "keybindings": [

--- a/editors/code/src/commands/index.ts
+++ b/editors/code/src/commands/index.ts
@@ -13,6 +13,7 @@ export * from './syntax_tree';
 export * from './expand_macro';
 export * from './runnables';
 export * from './ssr';
+export * from './server_version';
 
 export function collectGarbage(ctx: Ctx): Cmd {
     return async () => {

--- a/editors/code/src/commands/server_version.ts
+++ b/editors/code/src/commands/server_version.ts
@@ -1,0 +1,9 @@
+import * as vscode from 'vscode';
+import { ServerVersion } from '../installation/server';
+import { Cmd } from '../ctx';
+
+export function serverVersion(): Cmd {
+    return () => {
+        vscode.window.showInformationMessage('rust-analyzer version : ' + ServerVersion);
+    };
+}

--- a/editors/code/src/commands/server_version.ts
+++ b/editors/code/src/commands/server_version.ts
@@ -7,3 +7,4 @@ export function serverVersion(): Cmd {
         vscode.window.showInformationMessage('rust-analyzer version : ' + ServerVersion);
     };
 }
+

--- a/editors/code/src/commands/server_version.ts
+++ b/editors/code/src/commands/server_version.ts
@@ -14,8 +14,7 @@ export function serverVersion(ctx: Ctx): Cmd {
             );
         }
 
-        const res = spawnSync(binaryPath, ["--version"]);
-        const version = res.output?.filter(x => x !== null).map(String).join(" ");
+        const version = spawnSync(binaryPath, ["--version"], { encoding: "utf8" }).stdout;
         vscode.window.showInformationMessage('rust-analyzer version : ' + version);
     };
 }

--- a/editors/code/src/commands/server_version.ts
+++ b/editors/code/src/commands/server_version.ts
@@ -1,10 +1,22 @@
 import * as vscode from 'vscode';
-import { ServerVersion } from '../installation/server';
-import { Cmd } from '../ctx';
+import { ensureServerBinary } from '../installation/server';
+import { Ctx, Cmd } from '../ctx';
+import { spawnSync } from 'child_process';
 
-export function serverVersion(): Cmd {
-    return () => {
-        vscode.window.showInformationMessage('rust-analyzer version : ' + ServerVersion);
+export function serverVersion(ctx: Ctx): Cmd {
+    return async () => {
+        const binaryPath = await ensureServerBinary(ctx.config.serverSource);
+
+        if (binaryPath == null) {
+            throw new Error(
+                "Rust Analyzer Language Server is not available. " +
+                "Please, ensure its [proper installation](https://rust-analyzer.github.io/manual.html#installation)."
+            );
+        }
+
+        const res = spawnSync(binaryPath, ["--version"]);
+        const version = res.output?.filter(x => x !== null).map(String).join(" ");
+        vscode.window.showInformationMessage('rust-analyzer version : ' + version);
     };
 }
 

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -55,6 +55,7 @@ export async function activate(context: vscode.ExtensionContext) {
     ctx.registerCommand('run', commands.run);
     ctx.registerCommand('onEnter', commands.onEnter);
     ctx.registerCommand('ssr', commands.ssr);
+    ctx.registerCommand('serverVersion', commands.serverVersion);
 
     // Internal commands which are invoked by the server.
     ctx.registerCommand('runSingle', commands.runSingle);


### PR DESCRIPTION
There are 2 problems of current implementation for displaying current version of RA binary:

1. If that binary is coming from built by source, the `REV` may not be updated somehow. (See discussion in [Zuilp](https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Fwg-rls-2.2E0/topic/vscode.20version.20in.20console))

2. We must go through the VSCode debugger console to see the output of `console.log`.

This PR implemented a new VSCode command "Show RA Version" to display the version, which  fixed the first problem.  And added some `rerun-if` flags in `build.rs` to fix the second one.