### PR TITLE
Improve integration with token color configuration

### DIFF
--- a/editors/code/src/color_theme.ts
+++ b/editors/code/src/color_theme.ts
@@ -83,8 +83,12 @@ function loadThemeNamed(themeName: string): ColorTheme {
         res.mergeFrom(loadThemeFile(themePath));
     }
 
-    const customizations: any = vscode.workspace.getConfiguration('editor').get('tokenColorCustomizations');
-    res.mergeFrom(ColorTheme.fromRules(customizations?.textMateRules ?? []));
+    const global_customizations: any = vscode.workspace.getConfiguration('editor').get('tokenColorCustomizations');
+    res.mergeFrom(ColorTheme.fromRules(global_customizations?.textMateRules ?? []));
+
+    const theme_customizations: any = vscode.workspace.getConfiguration('editor.tokenColorCustomizations').get(`[${themeName}]`);
+    res.mergeFrom(ColorTheme.fromRules(theme_customizations?.textMateRules ?? []));
+
 
     return res;
 }

--- a/editors/code/src/highlighting.ts
+++ b/editors/code/src/highlighting.ts
@@ -233,16 +233,16 @@ const TAG_TO_SCOPES = new Map<string, string[]>([
     ["type", ["entity.name.type"]],
     ["type.builtin", ["entity.name.type", "support.type.primitive"]],
     ["type.self", ["entity.name.type.parameter.self"]],
-    ["type.param", ["entity.name.type.parameter"]],
-    ["type.lifetime", ["entity.name.type.lifetime"]],
+    ["type.param", ["entity.name.type.parameter", "entity.name.type.param.rust"]],
+    ["type.lifetime", ["entity.name.type.lifetime", "entity.name.lifetime.rust"]],
 
     ["literal.byte", ["constant.character.byte"]],
-    ["literal.char", ["constant.character"]],
+    ["literal.char", ["constant.character.rust"]],
     ["literal.numeric", ["constant.numeric"]],
 
     ["comment", ["comment"]],
     ["string", ["string.quoted"]],
-    ["attribute", ["meta.attribute"]],
+    ["attribute", ["meta.attribute.rust"]],
 
     ["keyword", ["keyword"]],
     ["keyword.unsafe", ["keyword.other.unsafe"]],


### PR DESCRIPTION
First, the extension now checks theme token color customizations as well as global token color customizations when determining what colors to highlight syntax with. Theme token color customizations take precedence over both global token color customizations and the theme token colors. 

Second, a few additional token color customization keys used by other themes are added. The original paths still take precedence, but now turning on rust analyzer syntax highlighting should now not unexpectedly homogenize token colors when custom themes are used. 