### PR TITLE
Fix handling of const patterns

### DIFF
--- a/crates/ra_hir_def/src/adt.rs
+++ b/crates/ra_hir_def/src/adt.rs
@@ -174,6 +174,7 @@ impl HasChildSource for VariantId {
     }
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum StructKind {
     Tuple,
     Record,

--- a/crates/ra_hir_def/src/expr.rs
+++ b/crates/ra_hir_def/src/expr.rs
@@ -48,7 +48,7 @@ pub enum Literal {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Expr {
-    /// This is produced if syntax tree does not have a required expression piece.
+    /// This is produced if the syntax tree does not have a required expression piece.
     Missing,
     Path(Path),
     If {

--- a/crates/ra_hir_ty/src/infer/pat.rs
+++ b/crates/ra_hir_ty/src/infer/pat.rs
@@ -189,7 +189,9 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
         };
         // use a new type variable if we got Ty::Unknown here
         let ty = self.insert_type_vars_shallow(ty);
-        self.unify(&ty, expected);
+        if !self.unify(&ty, expected) {
+            // FIXME record mismatch, we need to change the type of self.type_mismatches for that
+        }
         let ty = self.resolve_ty_as_possible(ty);
         self.write_pat_ty(pat, ty.clone());
         ty


### PR DESCRIPTION
E.g. in `match x { None => ... }`, `None` is a path pattern (resolving to the
option variant), not a binding. To determine this, we need to try to resolve the
name during lowering. This isn't too hard since we already need to resolve names
for macro expansion anyway (though maybe a bit hacky).

Fixes #1618.