### PR TITLE
Implement unsizing coercions using Chalk

### DIFF
--- a/crates/ra_hir_ty/src/infer.rs
+++ b/crates/ra_hir_ty/src/infer.rs
@@ -206,12 +206,6 @@ struct InferenceContext<'a, D: HirDatabase> {
     /// closures, but currently this is the only field that will change there,
     /// so it doesn't make sense.
     return_ty: Ty,
-
-    /// Impls of `CoerceUnsized` used in coercion.
-    /// (from_ty_ctor, to_ty_ctor) => coerce_generic_index
-    // FIXME: Use trait solver for this.
-    // Chalk seems unable to work well with builtin impl of `Unsize` now.
-    coerce_unsized_map: FxHashMap<(TypeCtor, TypeCtor), usize>,
 }
 
 impl<'a, D: HirDatabase> InferenceContext<'a, D> {
@@ -222,7 +216,6 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
             obligations: Vec::default(),
             return_ty: Ty::Unknown, // set in collect_fn_signature
             trait_env: TraitEnvironment::lower(db, &resolver),
-            coerce_unsized_map: Self::init_coerce_unsized_map(db, &resolver),
             db,
             owner,
             body: db.body(owner),

--- a/crates/ra_hir_ty/src/lib.rs
+++ b/crates/ra_hir_ty/src/lib.rs
@@ -814,13 +814,13 @@ pub trait TypeWalk {
     where
         Self: Sized,
     {
-        self.fold(&mut |ty| match ty {
-            Ty::Bound(idx) => {
+        self.fold_binders(&mut |ty, binders| match ty {
+            Ty::Bound(idx) if idx as usize >= binders => {
                 assert!(idx as i32 >= -n);
                 Ty::Bound((idx as i32 + n) as u32)
             }
             ty => ty,
-        })
+        }, 0)
     }
 }
 

--- a/crates/ra_hir_ty/src/lib.rs
+++ b/crates/ra_hir_ty/src/lib.rs
@@ -661,6 +661,17 @@ impl Ty {
         }
     }
 
+    /// If this is a `dyn Trait` type, this returns the `Trait` part.
+    pub fn dyn_trait_ref(&self) -> Option<&TraitRef> {
+        match self {
+            Ty::Dyn(bounds) => bounds.get(0).and_then(|b| match b {
+                GenericPredicate::Implemented(trait_ref) => Some(trait_ref),
+                _ => None,
+            }),
+            _ => None,
+        }
+    }
+
     fn builtin_deref(&self) -> Option<Ty> {
         match self {
             Ty::Apply(a_ty) => match a_ty.ctor {

--- a/crates/ra_hir_ty/src/lib.rs
+++ b/crates/ra_hir_ty/src/lib.rs
@@ -814,13 +814,16 @@ pub trait TypeWalk {
     where
         Self: Sized,
     {
-        self.fold_binders(&mut |ty, binders| match ty {
-            Ty::Bound(idx) if idx as usize >= binders => {
-                assert!(idx as i32 >= -n);
-                Ty::Bound((idx as i32 + n) as u32)
-            }
-            ty => ty,
-        }, 0)
+        self.fold_binders(
+            &mut |ty, binders| match ty {
+                Ty::Bound(idx) if idx as usize >= binders => {
+                    assert!(idx as i32 >= -n);
+                    Ty::Bound((idx as i32 + n) as u32)
+                }
+                ty => ty,
+            },
+            0,
+        )
     }
 }
 

--- a/crates/ra_hir_ty/src/lower.rs
+++ b/crates/ra_hir_ty/src/lower.rs
@@ -241,7 +241,8 @@ impl Ty {
             TypeNs::TraitId(trait_) => {
                 // if this is a bare dyn Trait, we'll directly put the required ^0 for the self type in there
                 let self_ty = if remaining_segments.len() == 0 { Some(Ty::Bound(0)) } else { None };
-                let trait_ref = TraitRef::from_resolved_path(ctx, trait_, resolved_segment, self_ty);
+                let trait_ref =
+                    TraitRef::from_resolved_path(ctx, trait_, resolved_segment, self_ty);
                 return if remaining_segments.len() == 1 {
                     let segment = remaining_segments.first().unwrap();
                     let associated_ty = associated_type_by_name_including_super_traits(

--- a/crates/ra_hir_ty/src/lower.rs
+++ b/crates/ra_hir_ty/src/lower.rs
@@ -239,7 +239,9 @@ impl Ty {
     ) -> Ty {
         let ty = match resolution {
             TypeNs::TraitId(trait_) => {
-                let trait_ref = TraitRef::from_resolved_path(ctx, trait_, resolved_segment, None);
+                // if this is a bare dyn Trait, we'll directly put the required ^0 for the self type in there
+                let self_ty = if remaining_segments.len() == 0 { Some(Ty::Bound(0)) } else { None };
+                let trait_ref = TraitRef::from_resolved_path(ctx, trait_, resolved_segment, self_ty);
                 return if remaining_segments.len() == 1 {
                     let segment = remaining_segments.first().unwrap();
                     let associated_ty = associated_type_by_name_including_super_traits(

--- a/crates/ra_hir_ty/src/tests/coercion.rs
+++ b/crates/ra_hir_ty/src/tests/coercion.rs
@@ -576,7 +576,6 @@ fn test() {
     );
 }
 
-#[ignore]
 #[test]
 fn coerce_unsize_trait_object() {
     assert_snapshot!(
@@ -600,6 +599,13 @@ fn test() {
 }
 "#, true),
         @r###"
+    [240; 300) '{     ...obj; }': ()
+    [250; 253) 'obj': &dyn Bar
+    [266; 268) '&S': &S
+    [267; 268) 'S': S
+    [278; 281) 'obj': &dyn Foo
+    [294; 297) 'obj': &dyn Bar
+    [294; 297): expected &dyn Foo, got &dyn Bar
     "###
     );
 }

--- a/crates/ra_hir_ty/src/traits.rs
+++ b/crates/ra_hir_ty/src/traits.rs
@@ -335,6 +335,12 @@ pub struct ClosureFnTraitImplData {
     fn_trait: FnTrait,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UnsizeToSuperTraitObjectData {
+    trait_: TraitId,
+    super_trait: TraitId,
+}
+
 /// An impl. Usually this comes from an impl block, but some built-in types get
 /// synthetic impls.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -345,6 +351,10 @@ pub enum Impl {
     ClosureFnTraitImpl(ClosureFnTraitImplData),
     /// [T; n]: Unsize<[T]>
     UnsizeArray,
+    /// T: Unsize<dyn Trait> where T: Trait
+    UnsizeToTraitObject(TraitId),
+    /// dyn Trait: Unsize<dyn SuperTrait> if Trait: SuperTrait
+    UnsizeToSuperTraitObject(UnsizeToSuperTraitObjectData),
 }
 /// This exists just for Chalk, because our ImplIds are only unique per module.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/ra_hir_ty/src/traits.rs
+++ b/crates/ra_hir_ty/src/traits.rs
@@ -343,6 +343,8 @@ pub enum Impl {
     ImplBlock(ImplId),
     /// Closure types implement the Fn traits synthetically.
     ClosureFnTraitImpl(ClosureFnTraitImplData),
+    /// [T; n]: Unsize<[T]>
+    UnsizeArray,
 }
 /// This exists just for Chalk, because our ImplIds are only unique per module.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/ra_hir_ty/src/traits/builtin.rs
+++ b/crates/ra_hir_ty/src/traits/builtin.rs
@@ -316,12 +316,10 @@ fn super_trait_object_unsize_impl_datum(
     let self_bounds = vec![GenericPredicate::Implemented(self_trait_ref.clone())];
 
     // we need to go from our trait to the super trait, substituting type parameters
-    let mut path = crate::utils::find_super_trait_path(db, data.super_trait, data.trait_);
-    path.pop(); // the last one is our current trait, we don't need that
-    path.reverse(); // we want to go from trait to super trait
+    let path = crate::utils::find_super_trait_path(db, data.trait_, data.super_trait);
 
     let mut current_trait_ref = self_trait_ref;
-    for t in path {
+    for t in path.into_iter().skip(1) {
         let bounds = db.generic_predicates(current_trait_ref.trait_.into());
         let super_trait_ref = bounds
             .iter()

--- a/crates/ra_hir_ty/src/traits/builtin.rs
+++ b/crates/ra_hir_ty/src/traits/builtin.rs
@@ -230,10 +230,7 @@ fn check_unsize_impl_prerequisites(db: &impl HirDatabase, krate: CrateId) -> boo
         None => return false,
     };
     let generic_params = generics(db, unsize_trait.into());
-    if generic_params.len() != 2 {
-        return false;
-    }
-    true
+    generic_params.len() == 2
 }
 
 fn array_unsize_impl_datum(db: &impl HirDatabase, krate: CrateId) -> BuiltinImplData {

--- a/crates/ra_hir_ty/src/traits/chalk.rs
+++ b/crates/ra_hir_ty/src/traits/chalk.rs
@@ -572,8 +572,10 @@ where
             .collect();
 
         let ty: Ty = from_chalk(self.db, parameters[0].assert_ty_ref().clone());
+        let arg: Option<Ty> =
+            parameters.get(1).map(|p| from_chalk(self.db, p.assert_ty_ref().clone()));
 
-        builtin::get_builtin_impls(self.db, self.krate, &ty, trait_, |i| {
+        builtin::get_builtin_impls(self.db, self.krate, &ty, &arg, trait_, |i| {
             result.push(i.to_chalk(self.db))
         });
 

--- a/crates/ra_hir_ty/src/utils.rs
+++ b/crates/ra_hir_ty/src/utils.rs
@@ -62,6 +62,27 @@ pub(super) fn all_super_traits(db: &impl DefDatabase, trait_: TraitId) -> Vec<Tr
     result
 }
 
+/// Finds a path from a trait to one of its descendant traits. Returns an empty
+/// vector if there is no path.
+pub(super) fn find_super_trait_path(
+    db: &impl DefDatabase,
+    super_trait: TraitId,
+    trait_: TraitId,
+) -> Vec<TraitId> {
+    if trait_ == super_trait {
+        return vec![trait_];
+    }
+
+    for tt in direct_super_traits(db, trait_) {
+        let mut path = find_super_trait_path(db, super_trait, tt);
+        if !path.is_empty() {
+            path.push(trait_);
+            return path;
+        }
+    }
+    Vec::new()
+}
+
 pub(super) fn associated_type_by_name_including_super_traits(
     db: &impl DefDatabase,
     trait_: TraitId,


### PR DESCRIPTION
These are coercions like `&[T; n] -> &[T]`, which are handled by the `Unsize` and `CoerceUnsized` traits. The impls for `Unsize` are all built in to the compiler and require special handling, so we need to provide them to Chalk.

This adds the following `Unsize` impls:
 - `Unsize<[T]> for [T; _]`
 - `Unsize<dyn Trait> for T where T: Trait`
 - `Unsize<dyn SuperTrait> for dyn SubTrait`

Hence we are still missing the 'unsizing the last field of a generic struct' case.