### PR TITLE
Add suggestion for failed path resolution

### DIFF
--- a/crates/ra_project_model/src/lib.rs
+++ b/crates/ra_project_model/src/lib.rs
@@ -103,7 +103,7 @@ impl ProjectWorkspace {
                 let sysroot = if with_sysroot {
                     Sysroot::discover(&cargo_toml).with_context(|| {
                         format!(
-                            "Failed to find sysroot for Cargo.toml file {}",
+                            "Failed to find sysroot for Cargo.toml file {}. Is rust-src installed?",
                             cargo_toml.display()
                         )
                     })?


### PR DESCRIPTION
This adds https://github.com/rust-analyzer/rust-analyzer/issues/3245 as an inline help text for when path resolution fails. I saw this error, but also `"Failed to read Cargo metadata from Cargo.toml file"` several times while trying to debug what was failing.

There's probably a more structured way of displaying help texts in VS Code popups. But this would've saved me 20 mins of debugging when installing `rust-analyzer` under WSL today. Thanks!