### PR TITLE
vscode: bump TypeScript version

### DIFF
--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -1575,9 +1575,9 @@
             }
         },
         "typescript": {
-            "version": "3.7.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-            "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.2.tgz",
+            "integrity": "sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==",
             "dev": true
         },
         "typescript-formatter": {

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -42,7 +42,7 @@
         "eslint": "^6.8.0",
         "rollup": "^1.31.1",
         "tslib": "^1.10.0",
-        "typescript": "^3.7.5",
+        "typescript": "^3.8.2",
         "typescript-formatter": "^7.2.2",
         "vsce": "^1.73.0"
     },


### PR DESCRIPTION
There is a new [`type-only` import and export feature](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#-type-only-imports-and-export), but let's keep our codebase as simple as it is now.
Also, top-level await :tada:, though with a caveat ))

![image](https://user-images.githubusercontent.com/36276403/75185341-93629b00-574e-11ea-8d5c-4a4293f140f7.png)
