### PR TITLE
vscode: fix vscode-vim keybindings conflict

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -162,7 +162,7 @@
             {
                 "command": "rust-analyzer.onEnter",
                 "key": "enter",
-                "when": "editorTextFocus && !suggestWidgetVisible && editorLangId == rust"
+                "when": "editorTextFocus && !suggestWidgetVisible && editorLangId == rust && !vim.active || vim.mode == 'Insert' && editorTextFocus && !suggestWidgetVisible && editorLangId == rust"
             }
         ],
         "configuration": {


### PR DESCRIPTION
Closes #3013 I hope

vscode-vim extension overrides the `type` command so that it prevents
some keypresses to reach the text document editor.
It conflicts with our `onEnter` keybinding
that is used to support automatic doc comments extending and
indentation insertion.

The VSCode-native way to implement this would be
to use regular expressions, but as per matklad it is
considered not acceptable for the language server.

Thus we implement it via a `Enter` keybinding that
invokes our `onEnter` command which does it via the language-server.

At the end of the day we may only apply
ad hoc workarounds for conflicting extensions.
But vscode has another bug for that. You
either cannot use parantheses in `when` condition
of a keybinding or it just malfunctions.

See an issue about that here: https://github.com/microsoft/vscode/issues/91473
To get the ultimate context, follow this [zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Fwg-rls-2.2E0/topic/Enhanced.20typing)