### PR TITLE
Find cargo toml up the fs

### DIFF
--- a/crates/ra_project_model/src/lib.rs
+++ b/crates/ra_project_model/src/lib.rs
@@ -421,19 +421,14 @@ fn find_cargo_toml_down_the_fs(path: &Path) -> Option<PathBuf> {
 }
 
 fn find_cargo_toml_up_the_fs(path: &Path) -> Option<PathBuf> {
-    log::info!("find_cargo_toml_up_the_fs()");
     let entities = match read_dir(path) {
         Ok(entities) => entities,
-        Err(e) => {
-            log::info!("err {}", e);
-            return None
-        }
+        Err(_) => return None
     };
 
-    log::info!("entities: {:?}", entities);
+    // Only one level up to avoid cycles the easy way and stop a runaway scan with large projects
     for entity in entities.filter_map(Result::ok) {
         let candidate = entity.path().join("Cargo.toml");
-        log::info!("candidate: {:?}, exists: {}", candidate, candidate.exists());
         if candidate.exists() {
             return Some(candidate);
         }

--- a/crates/ra_project_model/src/lib.rs
+++ b/crates/ra_project_model/src/lib.rs
@@ -462,7 +462,7 @@ fn find_cargo_toml(path: &Path) -> Result<PathBuf> {
         return Ok(p);
     }
 
-    let entities = match read_dir(path.join("does_not_exist")) {
+    let entities = match read_dir(path) {
         Ok(entities) => entities,
         Err(e) => return Err(CargoTomlSearchFileSystemError(path_as_buf, e.to_string()).into()),
     };

--- a/crates/ra_project_model/src/lib.rs
+++ b/crates/ra_project_model/src/lib.rs
@@ -463,12 +463,8 @@ fn find_cargo_toml(path: &Path) -> Result<PathBuf> {
     }
 
     let entities = match read_dir(path.join("does_not_exist")) {
-        Ok(entities) => {
-            entities
-        },
-        Err(e) => {
-            return Err(CargoTomlSearchFileSystemError(path_as_buf, e.to_string()).into())
-        },
+        Ok(entities) => entities,
+        Err(e) => return Err(CargoTomlSearchFileSystemError(path_as_buf, e.to_string()).into()),
     };
 
     let mut valid_canditates = find_cargo_toml_in_child_dir(entities);

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -116,10 +116,8 @@ pub fn main_loop(
                     Err(e) => {
                         log::error!("loading workspace failed: {:?}", e);
 
-                        if let Some(ra_project_model::CargoTomlNotFoundError {
-                            searched_at: _,
-                            reason: _,
-                        }) = e.downcast_ref()
+                        if let Some(ra_project_model::CargoTomlNotFoundError { .. }) =
+                            e.downcast_ref()
                         {
                             if !feature_flags.get("notifications.cargo-toml-not-found") {
                                 continue;

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -115,12 +115,17 @@ pub fn main_loop(
                     Ok(workspace) => loaded_workspaces.push(workspace),
                     Err(e) => {
                         log::error!("loading workspace failed: {:?}", e);
-                        if let Some(ra_project_model::CargoTomlNoneFoundError(_)) = e.downcast_ref()
+
+                        if let Some(ra_project_model::CargoTomlNotFoundError {
+                            searched_at: _,
+                            reason: _,
+                        }) = e.downcast_ref()
                         {
                             if !feature_flags.get("notifications.cargo-toml-not-found") {
                                 continue;
                             }
                         }
+
                         show_message(
                             req::MessageType::Error,
                             format!("rust-analyzer failed to load workspace: {:?}", e),

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -115,7 +115,7 @@ pub fn main_loop(
                     Ok(workspace) => loaded_workspaces.push(workspace),
                     Err(e) => {
                         log::error!("loading workspace failed: {:?}", e);
-                        if let Some(ra_project_model::CargoTomlNotFoundError(_)) = e.downcast_ref()
+                        if let Some(ra_project_model::CargoTomlNoneFoundError(_)) = e.downcast_ref()
                         {
                             if !feature_flags.get("notifications.cargo-toml-not-found") {
                                 continue;


### PR DESCRIPTION
Currently rust-analyzer will look for Cargo.toml in the root of the project and if failing that then go down the filesystem until root.

This unfortunately wouldn't work automatically with (what I imagine is) a fairly common project structure. As an example with multiple languages like:
```
js/
  ..
rust/
  Cargo.toml
  ...
```

Added this small change so rust-analyzer would glance one level up if not found in root or down the filesystem.

## Why not go deeper?

Could be problematic with large project vendored dependencies etc.

## Why not add a Cargo.toml manual setting option?

Loosely related and a good idea, however the convenience of having this automated also is hard to pass up. 

## Testing?

Build a binary with various logs and checked it in a project with such a structure:

```
[ERROR ra_project_model] find_cargo_toml()
[ERROR ra_project_model] find_cargo_toml_up_the_fs()
[ERROR ra_project_model] entities: ReadDir("/workspaces/my-project")
[ERROR ra_project_model] candidate: "/workspaces/my-project/rust/Cargo.toml", exists: true
```

## Edge Cases?

If you have multiple Cargo.toml files one level deeper AND not in the root, will get whatever comes first (order undefined), example:
```
crate1/
    Cargo.toml
crate2/
     Cargo.toml
... (no root Cargo.toml)
```

However this is quite unusual and wouldn't have worked before either. This is only resolvable via manually choosing.