### PR TITLE
Enable SemanticTokens on the client

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -18,6 +18,7 @@
     "engines": {
         "vscode": "^1.42.0"
     },
+    "enableProposedApi": true,
     "scripts": {
         "vscode:prepublish": "tsc && rollup -c",
         "package": "vsce package -o rust-analyzer.vsix",

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 
 import { Config } from './config';
 import { CallHierarchyFeature } from 'vscode-languageclient/lib/callHierarchy.proposed';
+import { SemanticTokensFeature } from 'vscode-languageclient/lib/semanticTokens.proposed';
 
 export async function createClient(config: Config, serverPath: string): Promise<lc.LanguageClient> {
     // '.' Is the fallback if no folder is open
@@ -83,5 +84,7 @@ export async function createClient(config: Config, serverPath: string): Promise<
     // Here we want to just enable CallHierarchyFeature since it is available on stable.
     // Note that while the CallHierarchyFeature is stable the LSP protocol is not.
     res.registerFeature(new CallHierarchyFeature(res));
+    res.registerFeature(new SemanticTokensFeature(res));
+
     return res;
 }


### PR DESCRIPTION
This will crash the extension on stable and insiders without the "--enable-proposed-api matklad.rust-analyzer" command line switch.

See https://github.com/rust-analyzer/rust-analyzer/pull/3159#issuecomment-591430261