### PR TITLE
Skip trival token in original_range

### DIFF
--- a/crates/ra_hir/src/semantics.rs
+++ b/crates/ra_hir/src/semantics.rs
@@ -8,8 +8,9 @@ use hir_def::{
 };
 use ra_db::{FileId, FileRange};
 use ra_syntax::{
-    algo::find_covering_element, ast, match_ast, AstNode, NodeOrToken, SyntaxElement, SyntaxNode,
-    SyntaxToken, TextRange, TextUnit,
+    algo::{find_covering_element, skip_trivia_token},
+    ast, match_ast, AstNode, Direction, NodeOrToken, SyntaxElement, SyntaxNode, SyntaxToken,
+    TextRange, TextUnit,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -384,11 +385,12 @@ fn original_range_and_origin(
     };
 
     // the input node has only one token ?
-    let single = node.value.first_token()? == node.value.last_token()?;
+    let single = skip_trivia_token(node.value.first_token()?, Direction::Next)?
+        == skip_trivia_token(node.value.last_token()?, Direction::Prev)?;
 
     return Some(node.value.descendants().find_map(|it| {
-        let first = it.first_token()?;
-        let last = it.last_token()?;
+        let first = skip_trivia_token(it.first_token()?, Direction::Next)?;
+        let last = skip_trivia_token(it.last_token()?, Direction::Prev)?;
 
         if !single && first == last {
             return None;

--- a/crates/ra_syntax/src/algo.rs
+++ b/crates/ra_syntax/src/algo.rs
@@ -7,7 +7,8 @@ use ra_text_edit::TextEditBuilder;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
-    AstNode, Direction, NodeOrToken, SyntaxElement, SyntaxNode, SyntaxNodePtr, TextRange, TextUnit,
+    AstNode, Direction, NodeOrToken, SyntaxElement, SyntaxNode, SyntaxNodePtr, SyntaxToken,
+    TextRange, TextUnit,
 };
 
 /// Returns ancestors of the node at the offset, sorted by length. This should
@@ -35,6 +36,17 @@ pub fn ancestors_at_offset(
 /// then the shorter node will be silently preferred.
 pub fn find_node_at_offset<N: AstNode>(syntax: &SyntaxNode, offset: TextUnit) -> Option<N> {
     ancestors_at_offset(syntax, offset).find_map(N::cast)
+}
+
+/// Skip to next non `trivia` token
+pub fn skip_trivia_token(mut token: SyntaxToken, direction: Direction) -> Option<SyntaxToken> {
+    while token.kind().is_trivia() {
+        token = match direction {
+            Direction::Next => token.next_token()?,
+            Direction::Prev => token.prev_token()?,
+        }
+    }
+    Some(token)
 }
 
 /// Finds the first sibling in the given direction which is not `trivia`


### PR DESCRIPTION
There is another bug in `original_range` such that hover on the following code will popup in the wrong position:

```rust
macro_rules! arr {
    ($($tt:tt)*) => { [$($tt)*)] }
}
fn foo() {
    let mastered_for_itunes = "";
    let _ = arr!("Tr<|>acks", &mastered_for_itunes);
}
```

There are two bugs related to above code:
1. We forget to skip some white spaces such that computed range is incorrect.
2. `hover::type_of` do not support macro expansion.

This PR fixed the first bug which will turn off tooltip and I will fix the second bug in other PR in these days. 

related: #3000 , #3135 
