### PR TITLE
Update lsp-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.70.2"
+version = "0.71.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6743fb3902ab3dfa6ce030daeac6ff492e20bb0fee840739d16f6bfb0efaf91c"
+checksum = "efa6b75633b0c3412ee36fc416e6d9c1e4ff576b536217f4ac3f34ac83d9e564"
 dependencies = [
  "base64",
  "bitflags",

--- a/crates/ra_cargo_watch/Cargo.toml
+++ b/crates/ra_cargo_watch/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["rust-analyzer developers"]
 
 [dependencies]
 crossbeam-channel = "0.4.0"
-lsp-types = { version = "0.70.1", features = ["proposed"] }
+lsp-types = { version = "0.71.0", features = ["proposed"] }
 log = "0.4.8"
 cargo_metadata = "0.9.1"
 jod-thread = "0.1.0"

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -21,7 +21,7 @@ globset = "0.4.4"
 itertools = "0.8.2"
 jod-thread = "0.1.0"
 log = "0.4.8"
-lsp-types = { version = "0.70.1", features = ["proposed"] }
+lsp-types = { version = "0.71.0", features = ["proposed"] }
 parking_lot = "0.10.0"
 pico-args = "0.3.1"
 rand = { version = "0.7.3", features = ["small_rng"] }


### PR DESCRIPTION
Uses the correct type for the currently unused `SemanticTokensEditsRequest::Return`