### PR TITLE
Remove AnalysisHost::type_of 

### DIFF
--- a/crates/ra_ide/src/hover.rs
+++ b/crates/ra_ide/src/hover.rs
@@ -176,7 +176,7 @@ pub(crate) fn hover(db: &RootDatabase, position: FilePosition) -> Option<RangeIn
     let ty = match_ast! {
         match node {
             ast::MacroCall(_it) => {
-                // if this node is a MACRO_CALL, it means that `descend_into_macros` is failed to resolve.
+                // If this node is a MACRO_CALL, it means that `descend_into_macros` failed to resolve.
                 // (e.g expanding a builtin macro). So we give up here.
                 return None;
             },

--- a/crates/ra_ide/src/lib.rs
+++ b/crates/ra_ide/src/lib.rs
@@ -455,11 +455,6 @@ impl Analysis {
         self.with_db(|db| diagnostics::diagnostics(db, file_id))
     }
 
-    /// Computes the type of the expression at the given position.
-    pub fn type_of(&self, frange: FileRange) -> Cancelable<Option<String>> {
-        self.with_db(|db| hover::type_of(db, frange))
-    }
-
     /// Returns the edit required to rename reference at the position to the new
     /// name.
     pub fn rename(


### PR DESCRIPTION
This PR remove ` AnalysisHost::type_of` (It is subsume by hover now) and use `Semantics::type_of_x` to infer the type inside `hover` directly. 

And this also solved a bug : Right now hovering on a string literal inside a macro will show up a `&str` popup correctly. (Except if that involved builtin macro, e.g. `println`)