### PR TITLE
Reset fontStyle for inlay hints

### DIFF
--- a/editors/code/src/inlay_hints.ts
+++ b/editors/code/src/inlay_hints.ts
@@ -42,12 +42,14 @@ export function activateInlayHints(ctx: Ctx) {
 const typeHintDecorationType = vscode.window.createTextEditorDecorationType({
     after: {
         color: new vscode.ThemeColor('rust_analyzer.inlayHint'),
+        fontStyle: "normal",
     },
 });
 
 const parameterHintDecorationType = vscode.window.createTextEditorDecorationType({
     before: {
         color: new vscode.ThemeColor('rust_analyzer.inlayHint'),
+        fontStyle: "normal",
     },
 });
 


### PR DESCRIPTION
Otherwise, we get bold hints on `true` and `false`



bors r+
🤖