### PR TITLE
Simpilfy original_range logic

### DIFF
--- a/crates/ra_ide/src/hover.rs
+++ b/crates/ra_ide/src/hover.rs
@@ -739,6 +739,30 @@ fn func(foo: i32) { if true { <|>foo; }; }
     }
 
     #[test]
+    fn test_hover_through_func_in_macro_recursive() {
+        let hover_on = check_hover_result(
+            "
+            //- /lib.rs
+            macro_rules! id_deep {
+                ($($tt:tt)*) => { $($tt)* }
+            }
+            macro_rules! id {
+                ($($tt:tt)*) => { id_deep!($($tt)*) }
+            }
+            fn bar() -> u32 {
+                0
+            }
+            fn foo() {
+                let a = id!([0u32, bar(<|>)] );
+            }
+            ",
+            &["u32"],
+        );
+
+        assert_eq!(hover_on, "bar()")
+    }
+
+    #[test]
     fn test_hover_through_literal_string_in_macro() {
         let hover_on = check_hover_result(
             r#"


### PR DESCRIPTION
This PR fixed another [bug](https://github.com/rust-analyzer/rust-analyzer/issues/3000#issuecomment-592474844) which incorrectly map the wrong range of `punct` in macro_call and simplify the logic a little bit by introducing an `ascend_call_token` function.

