### PR TITLE
vscode: redesign inlay hints to be capable of handling multiple editors for one source file

### DIFF
--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -3,7 +3,7 @@ import * as lc from 'vscode-languageclient';
 
 import { Config } from './config';
 import { createClient } from './client';
-import { isRustDocument } from './util';
+import { isRustEditor, RustEditor } from './util';
 
 export class Ctx {
     private constructor(
@@ -22,17 +22,15 @@ export class Ctx {
         return res;
     }
 
-    get activeRustEditor(): vscode.TextEditor | undefined {
+    get activeRustEditor(): RustEditor | undefined {
         const editor = vscode.window.activeTextEditor;
-        return editor && isRustDocument(editor.document)
+        return editor && isRustEditor(editor)
             ? editor
             : undefined;
     }
 
-    get visibleRustEditors(): vscode.TextEditor[] {
-        return vscode.window.visibleTextEditors.filter(
-            editor => isRustDocument(editor.document),
-        );
+    get visibleRustEditors(): RustEditor[] {
+        return vscode.window.visibleTextEditors.filter(isRustEditor);
     }
 
     registerCommand(name: string, factory: (ctx: Ctx) => Cmd) {

--- a/editors/code/src/inlay_hints.ts
+++ b/editors/code/src/inlay_hints.ts
@@ -101,12 +101,8 @@ class HintsUpdater {
     clearHints() {
         for (const file of this.sourceFiles) {
             file.inlaysRequest?.cancel();
-            this.renderHints(file, []);
+            file.renderHints([], this.client.protocol2CodeConverter)
         }
-    }
-
-    private renderHints(file: RustSourceFile, hints: ra.InlayHint[]) {
-        file.renderHints(hints, this.client.protocol2CodeConverter);
     }
 
     refreshRustDocument(document: RustTextDocument) {

--- a/editors/code/src/inlay_hints.ts
+++ b/editors/code/src/inlay_hints.ts
@@ -101,7 +101,7 @@ class HintsUpdater {
     clearHints() {
         for (const file of this.sourceFiles) {
             file.inlaysRequest?.cancel();
-            file.renderHints([], this.client.protocol2CodeConverter)
+            file.renderHints([], this.client.protocol2CodeConverter);
         }
     }
 

--- a/editors/code/src/inlay_hints.ts
+++ b/editors/code/src/inlay_hints.ts
@@ -1,156 +1,323 @@
+import * as lc from "vscode-languageclient";
 import * as vscode from 'vscode';
 import * as ra from './rust-analyzer-api';
 
 import { Ctx } from './ctx';
-import { log, sendRequestWithRetry, isRustDocument } from './util';
+import { sendRequestWithRetry, assert } from './util';
 
 export function activateInlayHints(ctx: Ctx) {
-    const hintsUpdater = new HintsUpdater(ctx);
+    const hintsUpdater = new HintsUpdater(ctx.client);
+
     vscode.window.onDidChangeVisibleTextEditors(
-        async _ => hintsUpdater.refresh(),
+        visibleEditors => hintsUpdater.refreshVisibleRustEditors(
+            visibleEditors.filter(isRustTextEditor)
+        ),
         null,
         ctx.subscriptions
     );
 
     vscode.workspace.onDidChangeTextDocument(
-        async event => {
-            if (event.contentChanges.length === 0) return;
-            if (!isRustDocument(event.document)) return;
-            await hintsUpdater.refresh();
+        ({ contentChanges, document }) => {
+            if (contentChanges.length === 0) return;
+            if (!isRustTextDocument(document)) return;
+
+            hintsUpdater.refreshRustDocument(document);
         },
         null,
         ctx.subscriptions
     );
 
     vscode.workspace.onDidChangeConfiguration(
-        async _ => hintsUpdater.setEnabled(ctx.config.displayInlayHints),
+        async _ => {
+            // FIXME: ctx.config may have not been refreshed at this point of time, i.e.
+            // it's on onDidChangeConfiguration() handler may've not executed yet
+            // (order of invokation is unspecified)
+            // To fix this we should expose an event emitter from our `Config` itself.
+            await hintsUpdater.setEnabled(ctx.config.displayInlayHints);
+        },
         null,
         ctx.subscriptions
     );
 
     ctx.pushCleanup({
         dispose() {
-            hintsUpdater.clear();
+            hintsUpdater.clearHints();
         }
     });
 
-    // XXX: we don't await this, thus Promise rejections won't be handled, but
-    // this should never throw in fact...
-    void hintsUpdater.setEnabled(ctx.config.displayInlayHints);
+    hintsUpdater.setEnabled(ctx.config.displayInlayHints);
 }
 
-const typeHintDecorationType = vscode.window.createTextEditorDecorationType({
-    after: {
-        color: new vscode.ThemeColor('rust_analyzer.inlayHint'),
-        fontStyle: "normal",
-    },
-});
 
-const parameterHintDecorationType = vscode.window.createTextEditorDecorationType({
-    before: {
-        color: new vscode.ThemeColor('rust_analyzer.inlayHint'),
-        fontStyle: "normal",
-    },
-});
+const typeHints = {
+    decorationType: vscode.window.createTextEditorDecorationType({
+        after: {
+            color: new vscode.ThemeColor('rust_analyzer.inlayHint'),
+            fontStyle: "normal",
+        }
+    }),
+
+    toDecoration(hint: ra.InlayHint.TypeHint, conv: lc.Protocol2CodeConverter): vscode.DecorationOptions {
+        return {
+            range: conv.asRange(hint.range),
+            renderOptions: { after: { contentText: `: ${hint.label}` } }
+        };
+    }
+};
+
+const paramHints = {
+    decorationType: vscode.window.createTextEditorDecorationType({
+        before: {
+            color: new vscode.ThemeColor('rust_analyzer.inlayHint'),
+            fontStyle: "normal",
+        }
+    }),
+
+    toDecoration(hint: ra.InlayHint.ParamHint, conv: lc.Protocol2CodeConverter): vscode.DecorationOptions {
+        return {
+            range: conv.asRange(hint.range),
+            renderOptions: { before: { contentText: `${hint.label}: ` } }
+        };
+    }
+};
 
 class HintsUpdater {
-    private pending = new Map<string, vscode.CancellationTokenSource>();
-    private ctx: Ctx;
-    private enabled: boolean;
+    private sourceFiles = new RustSourceFiles();
+    private enabled = false;
 
-    constructor(ctx: Ctx) {
-        this.ctx = ctx;
-        this.enabled = false;
-    }
+    constructor(readonly client: lc.LanguageClient) { }
 
-    async setEnabled(enabled: boolean): Promise<void> {
-        log.debug({ enabled, prev: this.enabled });
-
+    setEnabled(enabled: boolean) {
         if (this.enabled === enabled) return;
         this.enabled = enabled;
 
         if (this.enabled) {
-            return await this.refresh();
+            this.refreshVisibleRustEditors(vscode.window.visibleTextEditors.filter(isRustTextEditor));
         } else {
-            return this.clear();
+            this.clearHints();
         }
     }
 
-    clear() {
-        this.ctx.visibleRustEditors.forEach(it => {
-            this.setTypeDecorations(it, []);
-            this.setParameterDecorations(it, []);
-        });
+    clearHints() {
+        for (const file of this.sourceFiles) {
+            file.inlaysRequest?.cancel();
+            this.renderHints(file, []);
+        }
     }
 
-    async refresh() {
+    private renderHints(file: RustSourceFile, hints: ra.InlayHint[]) {
+        file.renderHints(hints, this.client.protocol2CodeConverter);
+    }
+
+    refreshRustDocument(document: RustTextDocument) {
         if (!this.enabled) return;
-        await Promise.all(this.ctx.visibleRustEditors.map(it => this.refreshEditor(it)));
+
+        const file = this.sourceFiles.getSourceFile(document.uri.toString());
+
+        assert(!!file, "Document must be opened in some text editor!");
+
+        void file.fetchAndRenderHints(this.client);
     }
 
-    private async refreshEditor(editor: vscode.TextEditor): Promise<void> {
-        const newHints = await this.queryHints(editor.document.uri.toString());
-        if (newHints == null) return;
+    refreshVisibleRustEditors(visibleEditors: RustTextEditor[]) {
+        if (!this.enabled) return;
 
-        const newTypeDecorations = newHints
-            .filter(hint => hint.kind === ra.InlayKind.TypeHint)
-            .map(hint => ({
-                range: this.ctx.client.protocol2CodeConverter.asRange(hint.range),
-                renderOptions: {
-                    after: {
-                        contentText: `: ${hint.label}`,
-                    },
-                },
-            }));
-        this.setTypeDecorations(editor, newTypeDecorations);
+        const visibleSourceFiles = this.sourceFiles.drainEditors(visibleEditors);
 
-        const newParameterDecorations = newHints
-            .filter(hint => hint.kind === ra.InlayKind.ParameterHint)
-            .map(hint => ({
-                range: this.ctx.client.protocol2CodeConverter.asRange(hint.range),
-                renderOptions: {
-                    before: {
-                        contentText: `${hint.label}: `,
-                    },
-                },
-            }));
-        this.setParameterDecorations(editor, newParameterDecorations);
+        // Cancel requests for source files whose editors were disposed (leftovers after drain).
+        for (const { inlaysRequest } of this.sourceFiles) inlaysRequest?.cancel();
+
+        this.sourceFiles = visibleSourceFiles;
+
+        for (const file of this.sourceFiles) {
+            if (!file.rerenderHints()) {
+                void file.fetchAndRenderHints(this.client);
+            }
+        }
+    }
+}
+
+
+/**
+ * This class encapsulates a map of file uris to respective inlay hints
+ * request cancellation token source (cts) and an array of editors.
+ * E.g.
+ * ```
+ * {
+ *    file1.rs -> (cts, (typeDecor, paramDecor), [editor1, editor2])
+ *                  ^-- there is a cts to cancel the in-flight request
+ *    file2.rs -> (cts, null, [editor3])
+ *                       ^-- no decorations are applied to this source file yet
+ *    file3.rs -> (null, (typeDecor, paramDecor), [editor4])
+ * }                ^-- there is no inflight request
+ * ```
+ *
+ * Invariants: each stored source file has at least 1 editor.
+ */
+class RustSourceFiles {
+    private files = new Map<string, RustSourceFile>();
+
+    /**
+     * Removes `editors` from `this` source files and puts them into a returned
+     * source files object. cts and decorations are moved to the returned source files.
+     */
+    drainEditors(editors: RustTextEditor[]): RustSourceFiles {
+        const result = new RustSourceFiles;
+
+        for (const editor of editors) {
+            const oldFile = this.removeEditor(editor);
+            const newFile = result.addEditor(editor);
+
+            if (oldFile) newFile.stealCacheFrom(oldFile);
+        }
+
+        return result;
     }
 
-    private setTypeDecorations(
-        editor: vscode.TextEditor,
-        decorations: vscode.DecorationOptions[],
-    ) {
-        editor.setDecorations(
-            typeHintDecorationType,
-            this.enabled ? decorations : [],
-        );
+    /**
+     * Remove the editor and if it was the only editor for a source file,
+     * the source file is removed altogether.
+     *
+     * @returns A reference to the source file for this editor or
+     *          null if no such source file was not found.
+     */
+    private removeEditor(editor: RustTextEditor): null | RustSourceFile {
+        const uri = editor.document.uri.toString();
+
+        const file = this.files.get(uri);
+        if (!file) return null;
+
+        const editorIndex = file.editors.findIndex(suspect => areEditorsEqual(suspect, editor));
+
+        if (editorIndex >= 0) {
+            file.editors.splice(editorIndex, 1);
+
+            if (file.editors.length === 0) this.files.delete(uri);
+        }
+
+        return file;
     }
 
-    private setParameterDecorations(
-        editor: vscode.TextEditor,
-        decorations: vscode.DecorationOptions[],
-    ) {
-        editor.setDecorations(
-            parameterHintDecorationType,
-            this.enabled ? decorations : [],
-        );
+    /**
+     * @returns A reference to an existing source file or newly created one for the editor.
+     */
+    private addEditor(editor: RustTextEditor): RustSourceFile {
+        const uri = editor.document.uri.toString();
+        const file = this.files.get(uri);
+
+        if (!file) {
+            const newFile = new RustSourceFile([editor]);
+            this.files.set(uri, newFile);
+            return newFile;
+        }
+
+        if (!file.editors.find(suspect => areEditorsEqual(suspect, editor))) {
+            file.editors.push(editor);
+        }
+        return file;
     }
 
-    private async queryHints(documentUri: string): Promise<ra.InlayHint[] | null> {
-        this.pending.get(documentUri)?.cancel();
+    getSourceFile(uri: string): undefined | RustSourceFile {
+        return this.files.get(uri);
+    }
+
+    [Symbol.iterator](): IterableIterator<RustSourceFile> {
+        return this.files.values();
+    }
+}
+class RustSourceFile {
+    constructor(
+        /**
+         * Editors for this source file (one text document may be opened in multiple editors).
+         * We keep this just an array, because most of the time we have 1 editor for 1 source file.
+         */
+        readonly editors: RustTextEditor[],
+        /**
+         * Source of the token to cancel in-flight inlay hints request if any.
+         */
+        public inlaysRequest: null | vscode.CancellationTokenSource = null,
+
+        public decorations: null | {
+            type: vscode.DecorationOptions[];
+            param: vscode.DecorationOptions[];
+        } = null
+    ) { }
+
+    stealCacheFrom(other: RustSourceFile) {
+        if (other.inlaysRequest) this.inlaysRequest = other.inlaysRequest;
+        if (other.decorations) this.decorations = other.decorations;
+
+        other.inlaysRequest = null;
+        other.decorations = null;
+    }
+
+    rerenderHints(): boolean {
+        if (!this.decorations) return false;
+
+        for (const editor of this.editors) {
+            editor.setDecorations(typeHints.decorationType, this.decorations.type);
+            editor.setDecorations(paramHints.decorationType, this.decorations.param);
+        }
+        return true;
+    }
+
+    renderHints(hints: ra.InlayHint[], conv: lc.Protocol2CodeConverter) {
+        this.decorations = { type: [], param: [] };
+
+        for (const hint of hints) {
+            switch (hint.kind) {
+                case ra.InlayHint.Kind.TypeHint: {
+                    this.decorations.type.push(typeHints.toDecoration(hint, conv));
+                    continue;
+                }
+                case ra.InlayHint.Kind.ParamHint: {
+                    this.decorations.param.push(paramHints.toDecoration(hint, conv));
+                    continue;
+                }
+            }
+        }
+        this.rerenderHints();
+    }
+
+    async fetchAndRenderHints(client: lc.LanguageClient): Promise<void> {
+        this.inlaysRequest?.cancel();
 
         const tokenSource = new vscode.CancellationTokenSource();
-        this.pending.set(documentUri, tokenSource);
+        this.inlaysRequest = tokenSource;
 
-        const request = { textDocument: { uri: documentUri } };
+        const request = { textDocument: { uri: this.editors[0].document.uri.toString() } };
 
-        return sendRequestWithRetry(this.ctx.client, ra.inlayHints, request, tokenSource.token)
-            .catch(_ => null)
-            .finally(() => {
-                if (!tokenSource.token.isCancellationRequested) {
-                    this.pending.delete(documentUri);
-                }
-            });
+        try {
+            const hints = await sendRequestWithRetry(client, ra.inlayHints, request, tokenSource.token);
+            this.renderHints(hints, client.protocol2CodeConverter);
+        } catch {
+            /* ignore */
+        } finally {
+            if (this.inlaysRequest === tokenSource) {
+                this.inlaysRequest = null;
+            }
+        }
     }
+}
+
+type RustTextDocument = vscode.TextDocument & { languageId: "rust" };
+type RustTextEditor = vscode.TextEditor & { document: RustTextDocument; id: string };
+
+function areEditorsEqual(a: RustTextEditor, b: RustTextEditor): boolean {
+    return a.id === b.id;
+}
+
+function isRustTextEditor(suspect: vscode.TextEditor & { id?: unknown }): suspect is RustTextEditor {
+    // Dirty hack, we need to access private vscode editor id,
+    // see https://github.com/microsoft/vscode/issues/91788
+    assert(
+        typeof suspect.id === "string",
+        "Private text editor id is no longer available, please update the workaround!"
+    );
+
+    return isRustTextDocument(suspect.document);
+}
+
+function isRustTextDocument(suspect: vscode.TextDocument): suspect is RustTextDocument {
+    return suspect.languageId === "rust";
 }

--- a/editors/code/src/inlay_hints.ts
+++ b/editors/code/src/inlay_hints.ts
@@ -13,7 +13,7 @@ export function activateInlayHints(ctx: Ctx) {
             if (!ctx.config.displayInlayHints) {
                 return this.dispose();
             }
-            if (!this.updater) this.updater = HintsUpdater.create(ctx);
+            if (!this.updater) this.updater = new HintsUpdater(ctx);
         },
         dispose() {
             this.updater?.dispose();
@@ -67,25 +67,21 @@ class HintsUpdater implements Disposable {
     private sourceFiles = new Map<string, RustSourceFile>(); // map Uri -> RustSourceFile
     private readonly disposables: Disposable[] = [];
 
-    private constructor(private readonly ctx: Ctx) { }
-
-    static create(ctx: Ctx) {
-        const self = new HintsUpdater(ctx);
-
+    constructor(private readonly ctx: Ctx) {
         vscode.window.onDidChangeVisibleTextEditors(
-            self.onDidChangeVisibleTextEditors,
-            self,
-            self.disposables
+            this.onDidChangeVisibleTextEditors,
+            this,
+            this.disposables
         );
 
         vscode.workspace.onDidChangeTextDocument(
-            self.onDidChangeTextDocument,
-            self,
-            self.disposables
+            this.onDidChangeTextDocument,
+            this,
+            this.disposables
         );
 
         // Set up initial cache shape
-        ctx.visibleRustEditors.forEach(editor => self.sourceFiles.set(
+        ctx.visibleRustEditors.forEach(editor => this.sourceFiles.set(
             editor.document.uri.toString(),
             {
                 document: editor.document,
@@ -94,9 +90,7 @@ class HintsUpdater implements Disposable {
             }
         ));
 
-        self.syncCacheAndRenderHints();
-
-        return self;
+        this.syncCacheAndRenderHints();
     }
 
     dispose() {

--- a/editors/code/src/inlay_hints.ts
+++ b/editors/code/src/inlay_hints.ts
@@ -67,7 +67,7 @@ class HintsUpdater implements Disposable {
     private sourceFiles = new Map<string, RustSourceFile>(); // map Uri -> RustSourceFile
     private readonly disposables: Disposable[] = [];
 
-    private constructor(readonly ctx: Ctx) { }
+    private constructor(private readonly ctx: Ctx) { }
 
     static create(ctx: Ctx) {
         const self = new HintsUpdater(ctx);

--- a/editors/code/src/rust-analyzer-api.ts
+++ b/editors/code/src/rust-analyzer-api.ts
@@ -86,14 +86,20 @@ export interface Runnable {
 export const runnables = request<RunnablesParams, Vec<Runnable>>("runnables");
 
 
-export const enum InlayKind {
-    TypeHint = "TypeHint",
-    ParameterHint = "ParameterHint",
-}
-export interface InlayHint {
-    range: lc.Range;
-    kind: InlayKind;
-    label: string;
+
+export type InlayHint = InlayHint.TypeHint | InlayHint.ParamHint;
+
+export namespace InlayHint {
+    export const enum Kind {
+        TypeHint = "TypeHint",
+        ParamHint = "ParameterHint",
+    }
+    interface Common {
+        range: lc.Range;
+        label: string;
+    }
+    export type TypeHint = Common & { kind: Kind.TypeHint; }
+    export type ParamHint = Common & { kind: Kind.ParamHint; }
 }
 export interface InlayHintsParams {
     textDocument: lc.TextDocumentIdentifier;

--- a/editors/code/src/rust-analyzer-api.ts
+++ b/editors/code/src/rust-analyzer-api.ts
@@ -98,8 +98,8 @@ export namespace InlayHint {
         range: lc.Range;
         label: string;
     }
-    export type TypeHint = Common & { kind: Kind.TypeHint; }
-    export type ParamHint = Common & { kind: Kind.ParamHint; }
+    export type TypeHint = Common & { kind: Kind.TypeHint };
+    export type ParamHint = Common & { kind: Kind.ParamHint };
 }
 export interface InlayHintsParams {
     textDocument: lc.TextDocumentIdentifier;

--- a/editors/code/src/util.ts
+++ b/editors/code/src/util.ts
@@ -1,7 +1,6 @@
 import * as lc from "vscode-languageclient";
 import * as vscode from "vscode";
 import { strict as nativeAssert } from "assert";
-import { TextDocument } from "vscode";
 
 export function assert(condition: boolean, explanation: string): asserts condition {
     try {
@@ -67,9 +66,16 @@ function sleep(ms: number) {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-export function isRustDocument(document: TextDocument) {
+export type RustDocument = vscode.TextDocument & { languageId: "rust" };
+export type RustEditor = vscode.TextEditor & { document: RustDocument; id: string };
+
+export function isRustDocument(document: vscode.TextDocument): document is RustDocument {
     return document.languageId === 'rust'
         // SCM diff views have the same URI as the on-disk document but not the same content
         && document.uri.scheme !== 'git'
         && document.uri.scheme !== 'svn';
+}
+
+export function isRustEditor(editor: vscode.TextEditor): editor is RustEditor {
+    return isRustDocument(editor.document);
 }


### PR DESCRIPTION
Fixes: #3008 (inlay corruption with multiple editors for one file).
Fixes: #3319 (unnecessary requests for inlay hints when switching unrelated source files or output/log/console windows)
Also, I don't know how, but the problem described in #3057 doesn't appear for me anymore (maybe it was some fix on the server-side, idk), the inlay hints are displaying right away. Though the last time I checked this it was caused by the server returning an empty array of hints and responding with a very big latency, I am not sure that this redesign actually fixed #3057....

We didn't handle the case when one rust source file is open in multiple editors in vscode (e.g. by manually adding another editor for the same file or by opening an inline git diff view or just any kind of preview within the same file).

The git diff preview is actually quite special because it causes memory leaks in vscode (https://github.com/microsoft/vscode/issues/91782). It is not removed from `visibleEditors` once it is closed. However, this bug doesn't affect the inlay hints anymore, because we don't issue a request and set inlay hints for each editor in isolation. Editors are grouped by their respective files and we issue requests only for files and then update all duplicate editors using the results (so we just update the decorations for already closed git diff preview read-only editors).

Also, note on a hack I had to use. `vscode.TextEdtior` identity is not actually public, its `id` field is not exposed to us. I created a dedicated upstream issue for this (https://github.com/microsoft/vscode/issues/91788).

Regarding #3319: the newly designed hints client doesn't issue requests for type hints when switching the visible editors if it has them already cached (though it does rerender things anyway, but this could be optimized in future if so wanted).

<details>
<summary>Before</summary>

![bug_demo](https://user-images.githubusercontent.com/36276403/75613171-3cd0d480-5b33-11ea-9066-954fb2fb18a5.gif)


</details>

<details>
<summary> After </summary>

![multi-cursor-replace](https://user-images.githubusercontent.com/36276403/75612710-d5b12100-5b2e-11ea-99ba-214b4219e6d3.gif)

</details>