### PR TITLE
Unsizing in method resolution & autoderef for indexing

### DIFF
--- a/crates/ra_hir_ty/src/infer.rs
+++ b/crates/ra_hir_ty/src/infer.rs
@@ -28,7 +28,7 @@ use hir_def::{
     path::{path, Path},
     resolver::{HasResolver, Resolver, TypeNs},
     type_ref::{Mutability, TypeRef},
-    AdtId, AssocItemId, DefWithBodyId, FunctionId, StructFieldId, TypeAliasId, VariantId,
+    AdtId, AssocItemId, DefWithBodyId, FunctionId, StructFieldId, TraitId, TypeAliasId, VariantId,
 };
 use hir_expand::{diagnostics::DiagnosticSink, name::name};
 use ra_arena::map::ArenaMap;
@@ -540,8 +540,12 @@ impl<'a, D: HirDatabase> InferenceContext<'a, D> {
         Some(struct_.into())
     }
 
+    fn resolve_ops_index(&self) -> Option<TraitId> {
+        self.resolve_lang_item("index")?.as_trait()
+    }
+
     fn resolve_ops_index_output(&self) -> Option<TypeAliasId> {
-        let trait_ = self.resolve_lang_item("index")?.as_trait()?;
+        let trait_ = self.resolve_ops_index()?;
         self.db.trait_data(trait_).associated_type_by_name(&name![Output])
     }
 }

--- a/crates/ra_hir_ty/src/tests/method_resolution.rs
+++ b/crates/ra_hir_ty/src/tests/method_resolution.rs
@@ -839,6 +839,24 @@ fn test() { (&S).foo()<|>; }
 }
 
 #[test]
+fn method_resolution_unsize_array() {
+    let t = type_at(
+        r#"
+//- /main.rs
+#[lang = "slice"]
+impl<T> [T] {
+    fn len(&self) -> usize { loop {} }
+}
+fn test() {
+    let a = [1, 2, 3];
+    a.len()<|>;
+}
+"#,
+    );
+    assert_eq!(t, "usize");
+}
+
+#[test]
 fn method_resolution_trait_from_prelude() {
     let (db, pos) = TestDB::with_position(
         r#"

--- a/crates/ra_hir_ty/src/tests/traits.rs
+++ b/crates/ra_hir_ty/src/tests/traits.rs
@@ -568,6 +568,34 @@ mod ops {
 }
 
 #[test]
+fn infer_ops_index_autoderef() {
+    let (db, pos) = TestDB::with_position(
+        r#"
+//- /main.rs crate:main deps:std
+fn test() {
+    let a = &[1u32, 2, 3];
+    let b = a[1];
+    b<|>;
+}
+
+//- /std.rs crate:std
+impl<T> ops::Index<u32> for [T] {
+    type Output = T;
+}
+
+#[prelude_import] use ops::*;
+mod ops {
+    #[lang = "index"]
+    pub trait Index<Idx> {
+        type Output;
+    }
+}
+"#,
+    );
+    assert_eq!("u32", type_at_pos(&db, pos));
+}
+
+#[test]
 fn deref_trait() {
     let t = type_at(
         r#"


### PR DESCRIPTION
 - do autoderef for indexing
 - do array unsizing (`[T; N]` -> `[T]`) in both method resolution and indexing. It turns out array unsizing is actually the only unsizing coercion that rustc does for method receivers, so this is simpler than I expected.

Sadly, this doesn't fix indexing slices/arrays yet, there are still some trait solving problems...