### PR TITLE
fix #2377 super::super::*

### DIFF
--- a/crates/ra_hir_def/src/nameres/tests.rs
+++ b/crates/ra_hir_def/src/nameres/tests.rs
@@ -66,6 +66,42 @@ fn crate_def_map_smoke_test() {
 }
 
 #[test]
+fn crate_def_map_super_super() {
+    let map = def_map(
+        "
+        //- /lib.rs
+        mod a {
+            const A: usize = 0;
+
+            mod b {
+                const B: usize = 0;
+
+                mod c {
+                    use super::super::*;
+                }
+            }
+        }
+        ",
+    );
+    assert_snapshot!(map, @r###"
+        ⋮crate
+        ⋮a: t
+        ⋮
+        ⋮crate::a
+        ⋮A: v
+        ⋮b: t
+        ⋮
+        ⋮crate::a::b
+        ⋮B: v
+        ⋮c: t
+        ⋮
+        ⋮crate::a::b::c
+        ⋮A: v
+        ⋮b: t
+    "###)
+}
+
+#[test]
 fn bogus_paths() {
     covers!(bogus_paths);
     let map = def_map(

--- a/crates/ra_hir_def/src/path/lower.rs
+++ b/crates/ra_hir_def/src/path/lower.rs
@@ -101,8 +101,12 @@ pub(super) fn lower_path(mut path: ast::Path, hygiene: &Hygiene) -> Option<Path>
                 break;
             }
             ast::PathSegmentKind::SuperKw => {
-                kind = PathKind::Super(1);
-                break;
+                let nested_super_count = if let PathKind::Super(n) = kind {
+                    n
+                } else {
+                    0
+                };
+                kind = PathKind::Super(nested_super_count + 1);
             }
         }
         path = match qualifier(&path) {

--- a/crates/ra_hir_def/src/path/lower/lower_use.rs
+++ b/crates/ra_hir_def/src/path/lower/lower_use.rs
@@ -103,10 +103,13 @@ fn convert_path(prefix: Option<ModPath>, path: ast::Path, hygiene: &Hygiene) -> 
             ModPath::from_segments(PathKind::Super(0), iter::empty())
         }
         ast::PathSegmentKind::SuperKw => {
-            if prefix.is_some() {
-                return None;
-            }
-            ModPath::from_segments(PathKind::Super(1), iter::empty())
+            let nested_super_count = match prefix.map(|p| p.kind) {
+                Some(PathKind::Super(n)) => n,
+                Some(_) => return None,
+                None => 0,
+            };
+
+            ModPath::from_segments(PathKind::Super(nested_super_count + 1), iter::empty())
         }
         ast::PathSegmentKind::Type { .. } => {
             // not allowed in imports

--- a/crates/ra_ide/src/completion/complete_dot.rs
+++ b/crates/ra_ide/src/completion/complete_dot.rs
@@ -545,4 +545,43 @@ mod tests {
         "###
         )
     }
+
+    #[test]
+    fn test_super_super_completion() {
+        assert_debug_snapshot!(
+        do_ref_completion(
+                r"
+                mod a {
+                    const A: usize = 0;
+
+                    mod b {
+                        const B: usize = 0;
+
+                        mod c {
+                            use super::super::<|>
+                        }
+                    }
+                }
+                ",
+        ),
+            @r###"
+        [
+            CompletionItem {
+                label: "A",
+                source_range: [217; 217),
+                delete: [217; 217),
+                insert: "A",
+                kind: Const,
+            },
+            CompletionItem {
+                label: "b",
+                source_range: [217; 217),
+                delete: [217; 217),
+                insert: "b",
+                kind: Module,
+            },
+        ]
+        "###
+        );
+    }
 }


### PR DESCRIPTION
Thanks @matklad for the detailed explanation on #2377. I believe this fixes it.

One thing I'm not sure about is you said the fix would involve changing `crates/ra_hir_def/src/path/lower/lower.rs`, but I only changed `crates/ra_hir_def/src/path/lower/lower_use.rs`. I'm not sure what kind of test code I'd have to write to expose the issue in `lower.rs`, but I'd be happy to add it if you are able to provide additional guidance. 

closes #2377