### PR TITLE
Fix #3373

### DIFF
--- a/crates/ra_hir_ty/src/lib.rs
+++ b/crates/ra_hir_ty/src/lib.rs
@@ -355,6 +355,10 @@ impl Substs {
         Substs(self.0[..std::cmp::min(self.0.len(), n)].into())
     }
 
+    pub fn suffix(&self, n: usize) -> Substs {
+        Substs(self.0[self.0.len() - std::cmp::min(self.0.len(), n)..].into())
+    }
+
     pub fn as_single(&self) -> &Ty {
         if self.0.len() != 1 {
             panic!("expected substs of len 1, got {:?}", self);

--- a/crates/ra_hir_ty/src/tests/method_resolution.rs
+++ b/crates/ra_hir_ty/src/tests/method_resolution.rs
@@ -1049,6 +1049,25 @@ where
 }
 
 #[test]
+fn method_resolution_3373() {
+    let t = type_at(
+        r#"
+//- /main.rs
+struct A<T>(T);
+
+impl A<i32> {
+    fn from(v: i32) -> A<i32> { A(v) }
+}
+
+fn main() {
+    A::from(3)<|>;
+}
+"#,
+    );
+    assert_eq!(t, "A<i32>");
+}
+
+#[test]
 fn method_resolution_slow() {
     // this can get quite slow if we set the solver size limit too high
     let t = type_at(


### PR DESCRIPTION
Basically, we need to allow variables in the caller self type to unify with the
impl's declared self type. That requires some more contortions in the variable
handling. I'm looking forward to (hopefully) handling this in a cleaner way when
we switch to Chalk's types and unification code.