### PR TITLE
Remove inlay hint in diff views

### DIFF
--- a/editors/code/src/commands/syntax_tree.ts
+++ b/editors/code/src/commands/syntax_tree.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as ra from '../rust-analyzer-api';
 
 import { Ctx, Cmd } from '../ctx';
+import { isRustDocument } from '../util';
 
 // Opens the virtual file that will show the syntax tree
 //
@@ -19,7 +20,7 @@ export function syntaxTree(ctx: Ctx): Cmd {
     vscode.workspace.onDidChangeTextDocument(
         (event: vscode.TextDocumentChangeEvent) => {
             const doc = event.document;
-            if (doc.languageId !== 'rust') return;
+            if (!isRustDocument(doc)) return;
             afterLs(() => tdcp.eventEmitter.fire(tdcp.uri));
         },
         null,
@@ -28,7 +29,7 @@ export function syntaxTree(ctx: Ctx): Cmd {
 
     vscode.window.onDidChangeActiveTextEditor(
         (editor: vscode.TextEditor | undefined) => {
-            if (!editor || editor.document.languageId !== 'rust') return;
+            if (!editor || !isRustDocument(editor.document)) return;
             tdcp.eventEmitter.fire(tdcp.uri);
         },
         null,

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -3,6 +3,7 @@ import * as lc from 'vscode-languageclient';
 
 import { Config } from './config';
 import { createClient } from './client';
+import { isRustDocument } from './util';
 
 export class Ctx {
     private constructor(
@@ -23,9 +24,15 @@ export class Ctx {
 
     get activeRustEditor(): vscode.TextEditor | undefined {
         const editor = vscode.window.activeTextEditor;
-        return editor && editor.document.languageId === 'rust'
+        return editor && isRustDocument(editor.document)
             ? editor
             : undefined;
+    }
+
+    get visibleRustEditors(): vscode.TextEditor[] {
+        return vscode.window.visibleTextEditors.filter(
+            editor => isRustDocument(editor.document),
+        );
     }
 
     registerCommand(name: string, factory: (ctx: Ctx) => Cmd) {

--- a/editors/code/src/highlighting.ts
+++ b/editors/code/src/highlighting.ts
@@ -4,7 +4,7 @@ import * as ra from './rust-analyzer-api';
 import { ColorTheme, TextMateRuleSettings } from './color_theme';
 
 import { Ctx } from './ctx';
-import { sendRequestWithRetry } from './util';
+import { sendRequestWithRetry, isRustDocument } from './util';
 
 export function activateHighlighting(ctx: Ctx) {
     const highlighter = new Highlighter(ctx);
@@ -36,7 +36,7 @@ export function activateHighlighting(ctx: Ctx) {
 
     vscode.window.onDidChangeActiveTextEditor(
         async (editor: vscode.TextEditor | undefined) => {
-            if (!editor || editor.document.languageId !== 'rust') return;
+            if (!editor || !isRustDocument(editor.document)) return;
             if (!ctx.config.highlightingOn) return;
             const client = ctx.client;
             if (!client) return;

--- a/editors/code/src/inlay_hints.ts
+++ b/editors/code/src/inlay_hints.ts
@@ -4,6 +4,8 @@ import * as ra from './rust-analyzer-api';
 import { Ctx } from './ctx';
 import { log, sendRequestWithRetry } from './util';
 
+const noInlayUriSchemes = ['git', 'svn'];
+
 export function activateInlayHints(ctx: Ctx) {
     const hintsUpdater = new HintsUpdater(ctx);
     vscode.window.onDidChangeVisibleTextEditors(
@@ -90,7 +92,14 @@ class HintsUpdater {
 
     private get allEditors(): vscode.TextEditor[] {
         return vscode.window.visibleTextEditors.filter(
-            editor => editor.document.languageId === 'rust',
+            editor => {
+                if (editor.document.languageId !== 'rust') {
+                    return false;
+                }
+                const scheme = editor.document.uri.scheme;
+                const hasBlacklistedScheme = noInlayUriSchemes.some(s => s === scheme);
+                return !hasBlacklistedScheme;
+            },
         );
     }
 

--- a/editors/code/src/util.ts
+++ b/editors/code/src/util.ts
@@ -1,6 +1,7 @@
 import * as lc from "vscode-languageclient";
 import * as vscode from "vscode";
 import { strict as nativeAssert } from "assert";
+import { TextDocument } from "vscode";
 
 export function assert(condition: boolean, explanation: string): asserts condition {
     try {
@@ -64,4 +65,11 @@ export async function sendRequestWithRetry<TParam, TRet>(
 
 function sleep(ms: number) {
     return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export function isRustDocument(document: TextDocument) {
+    return document.languageId === 'rust'
+        // SCM diff views have the same URI as the on-disk document but not the same content
+        && document.uri.scheme !== 'git'
+        && document.uri.scheme !== 'svn';
 }


### PR DESCRIPTION
If the left side of a diff view that contain the old version of the file apply inlays they are misplaced and produce a weird display:

![image](https://user-images.githubusercontent.com/131878/75628802-b1ac1900-5bdc-11ea-8c26-6722d8e38371.png)

After the change:

![image](https://user-images.githubusercontent.com/131878/75628831-e91ac580-5bdc-11ea-9039-c6b4ffbdb2be.png)

The detection is done by blacklisting the url schemes used by git and subversion scm extensions, whitelisting `file` is also possible but neither is perfect as VSCode now support both pluggable scm extensions and pluggable remote filesystems. But I suspect that the list of scm extensions is more easily manageable.

**Note**: I can rebase on #3378 if needed as it touches the same lines of code