### PR TITLE
Note vscode remote limitation when client install fails

### DIFF
--- a/xtask/src/install.rs
+++ b/xtask/src/install.rs
@@ -121,8 +121,7 @@ fn install_client(ClientOpt::VsCode: ClientOpt) -> Result<()> {
 
     if !installed_extensions.contains("rust-analyzer") {
         bail!(
-            "Could not install the Visual Studio Code extension. \
-             Please make sure you have at least NodeJS 12.x together with the latest version of VS Code installed and try again."
+            "Could not install the Visual Studio Code extension. Please make sure you have at least NodeJS 12.x together with the latest version of VS Code installed and try again. Note that installing via xtask install does not work for VS Code Remote, instead you’ll need to install the .vsix manually."
         );
     }
 

--- a/xtask/src/install.rs
+++ b/xtask/src/install.rs
@@ -121,7 +121,9 @@ fn install_client(ClientOpt::VsCode: ClientOpt) -> Result<()> {
 
     if !installed_extensions.contains("rust-analyzer") {
         bail!(
-            "Could not install the Visual Studio Code extension. Please make sure you have at least NodeJS 12.x together with the latest version of VS Code installed and try again. Note that installing via xtask install does not work for VS Code Remote, instead you’ll need to install the .vsix manually."
+            "Could not install the Visual Studio Code extension. \
+            Please make sure you have at least NodeJS 12.x together with the latest version of VS Code installed and try again. \
+            Note that installing via xtask install does not work for VS Code Remote, instead you’ll need to install the .vsix manually."
         );
     }
 


### PR DESCRIPTION
Just adding a note about the limitation referenced in https://github.com/rust-analyzer/rust-analyzer/issues/2522/ 

Considered checking if this message is relevant in the context (is this remote?) but decided against it because of return on investment - seeing how fast vscode iterates this limitation might just disappear in the near future.

Also checked if there is a way to already do this which lead me to leaving a specifing question at https://github.com/microsoft/vscode-remote-release/issues/385 