### PR TITLE
Implement concat eager macro 

### DIFF
--- a/crates/ra_hir_expand/src/builtin_derive.rs
+++ b/crates/ra_hir_expand/src/builtin_derive.rs
@@ -9,7 +9,7 @@ use ra_syntax::{
 };
 
 use crate::db::AstDatabase;
-use crate::{name, quote, MacroCallId, MacroDefId, MacroDefKind};
+use crate::{name, quote, LazyMacroId, MacroDefId, MacroDefKind};
 
 macro_rules! register_builtin {
     ( $($trait:ident => $expand:ident),* ) => {
@@ -22,7 +22,7 @@ macro_rules! register_builtin {
             pub fn expand(
                 &self,
                 db: &dyn AstDatabase,
-                id: MacroCallId,
+                id: LazyMacroId,
                 tt: &tt::Subtree,
             ) -> Result<tt::Subtree, mbe::ExpandError> {
                 let expander = match *self {
@@ -155,7 +155,7 @@ fn expand_simple_derive(
 
 fn copy_expand(
     _db: &dyn AstDatabase,
-    _id: MacroCallId,
+    _id: LazyMacroId,
     tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     expand_simple_derive(tt, quote! { std::marker::Copy })
@@ -163,7 +163,7 @@ fn copy_expand(
 
 fn clone_expand(
     _db: &dyn AstDatabase,
-    _id: MacroCallId,
+    _id: LazyMacroId,
     tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     expand_simple_derive(tt, quote! { std::clone::Clone })
@@ -171,7 +171,7 @@ fn clone_expand(
 
 fn default_expand(
     _db: &dyn AstDatabase,
-    _id: MacroCallId,
+    _id: LazyMacroId,
     tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     expand_simple_derive(tt, quote! { std::default::Default })
@@ -179,7 +179,7 @@ fn default_expand(
 
 fn debug_expand(
     _db: &dyn AstDatabase,
-    _id: MacroCallId,
+    _id: LazyMacroId,
     tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     expand_simple_derive(tt, quote! { std::fmt::Debug })
@@ -187,7 +187,7 @@ fn debug_expand(
 
 fn hash_expand(
     _db: &dyn AstDatabase,
-    _id: MacroCallId,
+    _id: LazyMacroId,
     tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     expand_simple_derive(tt, quote! { std::hash::Hash })
@@ -195,7 +195,7 @@ fn hash_expand(
 
 fn eq_expand(
     _db: &dyn AstDatabase,
-    _id: MacroCallId,
+    _id: LazyMacroId,
     tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     expand_simple_derive(tt, quote! { std::cmp::Eq })
@@ -203,7 +203,7 @@ fn eq_expand(
 
 fn partial_eq_expand(
     _db: &dyn AstDatabase,
-    _id: MacroCallId,
+    _id: LazyMacroId,
     tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     expand_simple_derive(tt, quote! { std::cmp::PartialEq })
@@ -211,7 +211,7 @@ fn partial_eq_expand(
 
 fn ord_expand(
     _db: &dyn AstDatabase,
-    _id: MacroCallId,
+    _id: LazyMacroId,
     tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     expand_simple_derive(tt, quote! { std::cmp::Ord })
@@ -219,7 +219,7 @@ fn ord_expand(
 
 fn partial_ord_expand(
     _db: &dyn AstDatabase,
-    _id: MacroCallId,
+    _id: LazyMacroId,
     tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     expand_simple_derive(tt, quote! { std::cmp::PartialOrd })
@@ -228,7 +228,7 @@ fn partial_ord_expand(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_db::TestDB, AstId, MacroCallKind, MacroCallLoc};
+    use crate::{test_db::TestDB, AstId, MacroCallId, MacroCallKind, MacroCallLoc};
     use ra_db::{fixture::WithFixture, SourceDatabase};
 
     fn expand_builtin_derive(s: &str, expander: BuiltinDeriveExpander) -> String {

--- a/crates/ra_hir_expand/src/builtin_derive.rs
+++ b/crates/ra_hir_expand/src/builtin_derive.rs
@@ -248,7 +248,7 @@ mod tests {
             kind: MacroCallKind::Attr(AstId::new(file_id.into(), ast_id_map.ast_id(&items[0]))),
         };
 
-        let id = db.intern_macro(loc);
+        let id: MacroCallId = db.intern_macro(loc).into();
         let parsed = db.parse_or_expand(id.as_file()).unwrap();
 
         // FIXME text() for syntax nodes parsed from token tree looks weird

--- a/crates/ra_hir_expand/src/builtin_macro.rs
+++ b/crates/ra_hir_expand/src/builtin_macro.rs
@@ -1,24 +1,31 @@
 //! Builtin macro
 use crate::db::AstDatabase;
 use crate::{
-    ast::{self},
-    name, AstId, CrateId, MacroCallId, MacroDefId, MacroDefKind, TextUnit,
+    ast::{self, AstToken, HasStringValue},
+    name, AstId, CrateId, MacroDefId, MacroDefKind, TextUnit,
 };
 
-use crate::quote;
+use crate::{quote, LazyMacroId};
+use either::Either;
+use ra_parser::FragmentKind;
 
 macro_rules! register_builtin {
-    ( $(($name:ident, $kind: ident) => $expand:ident),* ) => {
+    ( LAZY: $(($name:ident, $kind: ident) => $expand:ident),* , EAGER: $(($e_name:ident, $e_kind: ident) => $e_expand:ident),*  ) => {
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         pub enum BuiltinFnLikeExpander {
             $($kind),*
+        }
+
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        pub enum EagerExpander {
+            $($e_kind),*
         }
 
         impl BuiltinFnLikeExpander {
             pub fn expand(
                 &self,
                 db: &dyn AstDatabase,
-                id: MacroCallId,
+                id: LazyMacroId,
                 tt: &tt::Subtree,
             ) -> Result<tt::Subtree, mbe::ExpandError> {
                 let expander = match *self {
@@ -26,28 +33,54 @@ macro_rules! register_builtin {
                 };
                 expander(db, id, tt)
             }
+        }
 
-            fn by_name(ident: &name::Name) -> Option<BuiltinFnLikeExpander> {
-                match ident {
-                    $( id if id == &name::name![$name] => Some(BuiltinFnLikeExpander::$kind), )*
-                    _ => return None,
-                }
+        impl EagerExpander {
+            pub fn expand(
+                &self,
+                tt: &tt::Subtree,
+            ) -> Result<(tt::Subtree, FragmentKind), mbe::ExpandError> {
+                let expander = match *self {
+                    $( EagerExpander::$e_kind => $e_expand, )*
+                };
+                expander(tt)
             }
         }
 
-        pub fn find_builtin_macro(
-            ident: &name::Name,
-            krate: CrateId,
-            ast_id: AstId<ast::MacroCall>,
-        ) -> Option<MacroDefId> {
-            let kind = BuiltinFnLikeExpander::by_name(ident)?;
-
-            Some(MacroDefId { krate: Some(krate), ast_id: Some(ast_id), kind: MacroDefKind::BuiltIn(kind) })
+        fn find_by_name(ident: &name::Name) -> Option<Either<BuiltinFnLikeExpander, EagerExpander>> {
+            match ident {
+                $( id if id == &name::name![$name] => Some(Either::Left(BuiltinFnLikeExpander::$kind)), )*
+                $( id if id == &name::name![$e_name] => Some(Either::Right(EagerExpander::$e_kind)), )*
+                _ => return None,
+            }
         }
     };
 }
 
+pub fn find_builtin_macro(
+    ident: &name::Name,
+    krate: CrateId,
+    ast_id: AstId<ast::MacroCall>,
+) -> Option<MacroDefId> {
+    let kind = find_by_name(ident)?;
+
+    match kind {
+        Either::Left(kind) => Some(MacroDefId {
+            krate: Some(krate),
+            ast_id: Some(ast_id),
+            kind: MacroDefKind::BuiltIn(kind),
+        }),
+        Either::Right(kind) => Some(MacroDefId {
+            krate: Some(krate),
+            ast_id: Some(ast_id),
+            kind: MacroDefKind::BuiltInEager(kind),
+        }),
+    }
+}
+
 register_builtin! {
+    LAZY:
+
     (column, Column) => column_expand,
     (compile_error, CompileError) => compile_error_expand,
     (file, File) => file_expand,
@@ -58,12 +91,16 @@ register_builtin! {
     (option_env, OptionEnv) => option_env_expand,
     // format_args_nl only differs in that it adds a newline in the end,
     // so we use the same stub expansion for now
-    (format_args_nl, FormatArgsNl) => format_args_expand
+    (format_args_nl, FormatArgsNl) => format_args_expand,
+
+    EAGER:
+    // eagers
+    (concat, Concat) => concat_expand
 }
 
 fn line_expand(
     _db: &dyn AstDatabase,
-    _id: MacroCallId,
+    _id: LazyMacroId,
     _tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     // dummy implementation for type-checking purposes
@@ -77,13 +114,9 @@ fn line_expand(
 
 fn stringify_expand(
     db: &dyn AstDatabase,
-    id: MacroCallId,
+    id: LazyMacroId,
     _tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
-    let id = match id {
-        MacroCallId::LazyMacro(id) => id,
-    };
-
     let loc = db.lookup_intern_macro(id);
 
     let macro_content = {
@@ -103,7 +136,7 @@ fn stringify_expand(
 
 fn env_expand(
     _db: &dyn AstDatabase,
-    _id: MacroCallId,
+    _id: LazyMacroId,
     _tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     // dummy implementation for type-checking purposes
@@ -114,7 +147,7 @@ fn env_expand(
 
 fn option_env_expand(
     _db: &dyn AstDatabase,
-    _id: MacroCallId,
+    _id: LazyMacroId,
     _tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     // dummy implementation for type-checking purposes
@@ -125,7 +158,7 @@ fn option_env_expand(
 
 fn column_expand(
     _db: &dyn AstDatabase,
-    _id: MacroCallId,
+    _id: LazyMacroId,
     _tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     // dummy implementation for type-checking purposes
@@ -139,7 +172,7 @@ fn column_expand(
 
 fn file_expand(
     _db: &dyn AstDatabase,
-    _id: MacroCallId,
+    _id: LazyMacroId,
     _tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     // FIXME: RA purposefully lacks knowledge of absolute file names
@@ -155,7 +188,7 @@ fn file_expand(
 
 fn compile_error_expand(
     _db: &dyn AstDatabase,
-    _id: MacroCallId,
+    _id: LazyMacroId,
     tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     if tt.count() == 1 {
@@ -172,7 +205,7 @@ fn compile_error_expand(
 
 fn format_args_expand(
     _db: &dyn AstDatabase,
-    _id: MacroCallId,
+    _id: LazyMacroId,
     tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     // We expand `format_args!("", a1, a2)` to
@@ -212,23 +245,44 @@ fn format_args_expand(
     Ok(expanded)
 }
 
+fn unquote_str(lit: &tt::Literal) -> Option<String> {
+    let lit = ast::make::tokens::literal(&lit.to_string());
+    let token = ast::String::cast(lit)?;
+    token.value()
+}
+
+fn concat_expand(tt: &tt::Subtree) -> Result<(tt::Subtree, FragmentKind), mbe::ExpandError> {
+    let mut text = String::new();
+    for (i, t) in tt.token_trees.iter().enumerate() {
+        match t {
+            tt::TokenTree::Leaf(tt::Leaf::Literal(it)) if i % 2 == 0 => {
+                text += &unquote_str(&it).ok_or_else(|| mbe::ExpandError::ConversionError)?;
+            }
+            tt::TokenTree::Leaf(tt::Leaf::Punct(punct)) if i % 2 == 1 && punct.char == ',' => (),
+            _ => return Err(mbe::ExpandError::UnexpectedToken),
+        }
+    }
+
+    Ok((quote!(#text), FragmentKind::Expr))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{name::AsName, test_db::TestDB, AstNode, MacroCallKind, MacroCallLoc};
+    use crate::{name::AsName, test_db::TestDB, AstNode, MacroCallId, MacroCallKind, MacroCallLoc};
     use ra_db::{fixture::WithFixture, SourceDatabase};
     use ra_syntax::ast::NameOwner;
 
-    fn expand_builtin_macro(s: &str) -> String {
-        let (db, file_id) = TestDB::with_single_file(&s);
+    fn expand_builtin_macro(ra_fixture: &str) -> String {
+        let (db, file_id) = TestDB::with_single_file(&ra_fixture);
         let parsed = db.parse(file_id);
         let macro_calls: Vec<_> =
             parsed.syntax_node().descendants().filter_map(ast::MacroCall::cast).collect();
 
         let ast_id_map = db.ast_id_map(file_id.into());
 
-        let expander =
-            BuiltinFnLikeExpander::by_name(&macro_calls[0].name().unwrap().as_name()).unwrap();
+        let expander = find_by_name(&macro_calls[0].name().unwrap().as_name()).unwrap();
+        let expander = expander.left().unwrap();
 
         // the first one should be a macro_rules
         let def = MacroDefId {

--- a/crates/ra_hir_expand/src/builtin_macro.rs
+++ b/crates/ra_hir_expand/src/builtin_macro.rs
@@ -80,6 +80,10 @@ fn stringify_expand(
     id: MacroCallId,
     _tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
+    let id = match id {
+        MacroCallId::LazyMacro(id) => id,
+    };
+
     let loc = db.lookup_intern_macro(id);
 
     let macro_content = {
@@ -241,7 +245,7 @@ mod tests {
             )),
         };
 
-        let id = db.intern_macro(loc);
+        let id: MacroCallId = db.intern_macro(loc).into();
         let parsed = db.parse_or_expand(id.as_file()).unwrap();
 
         parsed.text().to_string()

--- a/crates/ra_hir_expand/src/db.rs
+++ b/crates/ra_hir_expand/src/db.rs
@@ -172,9 +172,20 @@ pub(crate) fn parse_macro(
             // Note:
             // The final goal we would like to make all parse_macro success,
             // such that the following log will not call anyway.
-            let loc: MacroCallLoc = db.lookup_intern_macro(macro_call_id);
-            let node = loc.kind.node(db);
-            log::warn!("fail on macro_parse: (reason: {} macro_call: {:#})", err, node.value);
+            match macro_call_id {
+                MacroCallId::LazyMacro(id) => {
+                    let loc: MacroCallLoc = db.lookup_intern_macro(id);
+                    let node = loc.kind.node(db);
+                    log::warn!(
+                        "fail on macro_parse: (reason: {} macro_call: {:#})",
+                        err,
+                        node.value
+                    );
+                }
+                _ => {
+                    log::warn!("fail on macro_parse: (reason: {})", err);
+                }
+            }
         })
         .ok()?;
 

--- a/crates/ra_hir_expand/src/eager.rs
+++ b/crates/ra_hir_expand/src/eager.rs
@@ -1,0 +1,93 @@
+//! Eager expansion related utils
+
+use crate::{
+    ast::{self, AstNode},
+    db::AstDatabase,
+    EagerCallLoc, EagerMacroId, InFile, MacroCallId, MacroCallKind, MacroDefId, MacroDefKind,
+};
+
+use ra_parser::FragmentKind;
+use ra_syntax::{algo::replace_descendants, SyntaxElement, SyntaxNode};
+use std::{collections::HashMap, sync::Arc};
+
+fn to_subtree(node: &SyntaxNode) -> Option<tt::Subtree> {
+    let mut subtree = mbe::syntax_node_to_token_tree(node)?.0;
+    subtree.delimiter = None;
+    Some(subtree)
+}
+
+fn lazy_expand(
+    db: &impl AstDatabase,
+    def: &MacroDefId,
+    macro_call: InFile<ast::MacroCall>,
+) -> Option<InFile<SyntaxNode>> {
+    let ast_id = db.ast_id_map(macro_call.file_id).ast_id(&macro_call.value);
+
+    let id: MacroCallId =
+        def.as_lazy_macro(db, MacroCallKind::FnLike(macro_call.with_value(ast_id))).into();
+
+    db.parse_or_expand(id.as_file()).map(|node| InFile::new(id.as_file(), node))
+}
+
+fn eager_macro_recur(
+    db: &impl AstDatabase,
+    curr: InFile<SyntaxNode>,
+    macro_resolver: &dyn Fn(ast::Path) -> Option<MacroDefId>,
+) -> Option<SyntaxNode> {
+    let mut original = curr.value.clone();
+
+    let children = curr.value.descendants().filter_map(ast::MacroCall::cast);
+    let mut replaces: HashMap<SyntaxElement, SyntaxElement> = HashMap::default();
+
+    // Collect replacement
+    for child in children {
+        let def: MacroDefId = macro_resolver(child.path()?)?;
+        let insert = match def.kind {
+            MacroDefKind::BuiltInEager(_) => {
+                let id: MacroCallId =
+                    expand_eager_macro(db, curr.with_value(child.clone()), def, macro_resolver)?
+                        .into();
+                db.parse_or_expand(id.as_file())?
+            }
+            MacroDefKind::Declarative
+            | MacroDefKind::BuiltIn(_)
+            | MacroDefKind::BuiltInDerive(_) => {
+                let expanded = lazy_expand(db, &def, curr.with_value(child.clone()))?;
+                // replace macro inside
+                eager_macro_recur(db, expanded, macro_resolver)?
+            }
+        };
+
+        replaces.insert(child.syntax().clone().into(), insert.into());
+    }
+
+    if !replaces.is_empty() {
+        original = replace_descendants(&original, |n| replaces.get(n).cloned());
+    }
+
+    Some(original)
+}
+
+pub fn expand_eager_macro(
+    db: &impl AstDatabase,
+    macro_call: InFile<ast::MacroCall>,
+    def: MacroDefId,
+    resolver: &dyn Fn(ast::Path) -> Option<MacroDefId>,
+) -> Option<EagerMacroId> {
+    let args = macro_call.value.token_tree()?;
+    let parsed_args = mbe::ast_to_token_tree(&args)?.0;
+    let parsed_args = mbe::token_tree_to_syntax_node(&parsed_args, FragmentKind::Expr).ok()?.0;
+    let result = eager_macro_recur(db, macro_call.with_value(parsed_args.syntax_node()), resolver)?;
+
+    let subtree = to_subtree(&result)?;
+
+    if let MacroDefKind::BuiltInEager(eager) = def.kind {
+        let (subtree, fragment) = eager.expand(&subtree).ok()?;
+        let eager =
+            EagerCallLoc { def, fragment, subtree: Arc::new(subtree), file_id: macro_call.file_id };
+
+        Some(db.intern_eager_expansion(eager))
+    } else {
+        None
+    }
+}

--- a/crates/ra_hir_expand/src/eager.rs
+++ b/crates/ra_hir_expand/src/eager.rs
@@ -1,4 +1,23 @@
 //! Eager expansion related utils
+//!
+//! Here is a dump of a discussion from Vadim Petrochenkov about Eager Expansion and
+//! Its name resolution :
+//!
+//! > Eagerly expanded macros (and also macros eagerly expanded by eagerly expanded macros,
+//! > which actually happens in practice too!) are resolved at the location of the "root" macro
+//! > that performs the eager expansion on its arguments.
+//! > If some name cannot be resolved at the eager expansion time it's considered unresolved,
+//! > even if becomes available later (e.g. from a glob import or other macro).
+//!
+//! > Eagerly expanded macros don't add anything to the module structure of the crate and
+//! > don't build any speculative module structures, i.e. they are expanded in a "flat"
+//! > way even if tokens in them look like modules.
+//!
+//! > In other words, it kinda works for simple cases for which it was originally intended,
+//! > and we need to live with it because it's available on stable and widely relied upon.
+//!
+//!
+//! See the full discussion : https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/Eager.20expansion.20of.20built-in.20macros
 
 use crate::{
     ast::{self, AstNode},

--- a/crates/ra_hir_expand/src/hygiene.rs
+++ b/crates/ra_hir_expand/src/hygiene.rs
@@ -23,7 +23,10 @@ impl Hygiene {
         let def_crate = match file_id.0 {
             HirFileIdRepr::FileId(_) => None,
             HirFileIdRepr::MacroFile(macro_file) => {
-                let loc = db.lookup_intern_macro(macro_file.macro_call_id);
+                let lazy_id = match macro_file.macro_call_id {
+                    crate::MacroCallId::LazyMacro(id) => id,
+                };
+                let loc = db.lookup_intern_macro(lazy_id);
                 match loc.def.kind {
                     MacroDefKind::Declarative => loc.def.krate,
                     MacroDefKind::BuiltIn(_) => None,

--- a/crates/ra_hir_expand/src/name.rs
+++ b/crates/ra_hir_expand/src/name.rs
@@ -173,6 +173,7 @@ pub mod known {
         compile_error,
         line,
         stringify,
+        concat,
         format_args,
         format_args_nl,
         env,

--- a/crates/ra_hir_ty/src/tests/macros.rs
+++ b/crates/ra_hir_ty/src/tests/macros.rs
@@ -420,6 +420,25 @@ fn main() {
 }
 
 #[test]
+fn infer_builtin_macros_concat() {
+    assert_snapshot!(
+        infer(r#"
+#[rustc_builtin_macro]
+macro_rules! concat {() => {}}
+
+fn main() {
+    let x = concat!("hello", concat!("world", "!"));
+}
+"#),
+        @r###"
+    ![0; 13) '"helloworld!"': &str
+    [66; 122) '{     ...")); }': ()
+    [76; 77) 'x': &str
+    "###
+    );
+}
+
+#[test]
 fn infer_derive_clone_simple() {
     let (db, pos) = TestDB::with_position(
         r#"

--- a/crates/ra_parser/src/lib.rs
+++ b/crates/ra_parser/src/lib.rs
@@ -83,7 +83,7 @@ pub fn parse(token_source: &mut dyn TokenSource, tree_sink: &mut dyn TreeSink) {
     parse_from_tokens(token_source, tree_sink, grammar::root);
 }
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum FragmentKind {
     Path,
     Expr,

--- a/crates/ra_syntax/src/ast/make.rs
+++ b/crates/ra_syntax/src/ast/make.rs
@@ -219,7 +219,7 @@ fn unroot(n: SyntaxNode) -> SyntaxNode {
 }
 
 pub mod tokens {
-    use crate::{AstNode, Parse, SourceFile, SyntaxKind::*, SyntaxToken, T};
+    use crate::{ast, AstNode, Parse, SourceFile, SyntaxKind::*, SyntaxToken, T};
     use once_cell::sync::Lazy;
 
     pub(super) static SOURCE_FILE: Lazy<Parse<SourceFile>> =
@@ -249,6 +249,12 @@ pub mod tokens {
         assert!(text.trim().is_empty());
         let sf = SourceFile::parse(text).ok().unwrap();
         sf.syntax().first_child_or_token().unwrap().into_token().unwrap()
+    }
+
+    pub fn literal(text: &str) -> SyntaxToken {
+        assert_eq!(text.trim(), text);
+        let lit: ast::Literal = super::ast_from_text(&format!("fn f() {{ let _ = {}; }}", text));
+        lit.syntax().first_child_or_token().unwrap().into_token().unwrap()
     }
 
     pub fn single_newline() -> SyntaxToken {


### PR DESCRIPTION
This PR implements the following things:

1. Add basic eager macro infrastructure by introducing `EagerCallId` such that the new `MacroCallId` is defined as :

```
#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
pub enum MacroCallId {
    LazyMacro(LazyMacroId),
    EagerMacro(EagerMacroId),
}
```

2. Add `concat!` builtin macro.


