### PR TITLE
Fix a bug for single dollar sign macro

### DIFF
--- a/crates/ra_mbe/src/parser.rs
+++ b/crates/ra_mbe/src/parser.rs
@@ -90,7 +90,11 @@ fn next_op<'a>(
 ) -> Result<Op<'a>, ExpandError> {
     let res = match first {
         tt::TokenTree::Leaf(tt::Leaf::Punct(tt::Punct { char: '$', .. })) => {
-            let second = src.next().ok_or_else(|| err!("bad var 1"))?;
+            // Note that the '$' itself is a valid token inside macro_rules.
+            let second = match src.next() {
+                None => return Ok(Op::TokenTree(first)),
+                Some(it) => it,
+            };
             match second {
                 tt::TokenTree::Subtree(subtree) => {
                     let (separator, kind) = parse_repeat(src)?;

--- a/crates/ra_mbe/src/tests.rs
+++ b/crates/ra_mbe/src/tests.rs
@@ -23,6 +23,7 @@ mod rule_parsing {
         check("($($i:ident)*) => ($_)");
         check("($($true:ident)*) => ($true)");
         check("($($false:ident)*) => ($false)");
+        check("($) => ($)");
     }
 
     #[test]


### PR DESCRIPTION
This PR fixed a bug to allow the following valid `macro_rules!` :

```rust
macro_rules! m {
    ($) => ($)
}
```