### PR TITLE
Fix panic on eager expansion

### DIFF
--- a/crates/ra_hir_expand/src/eager.rs
+++ b/crates/ra_hir_expand/src/eager.rs
@@ -40,7 +40,7 @@ pub fn expand_eager_macro(
 
     // Note:
     // When `lazy_expand` is called, its *parent* file must be already exists.
-    // Here we store an eager macro id for the argument expaned here
+    // Here we store an eager macro id for the argument expanded subtree here
     // for that purpose.
     let arg_id: MacroCallId = db
         .intern_eager_expansion({

--- a/crates/ra_hir_ty/src/tests/macros.rs
+++ b/crates/ra_hir_ty/src/tests/macros.rs
@@ -439,6 +439,27 @@ fn main() {
 }
 
 #[test]
+fn infer_builtin_macros_concat_with_lazy() {
+    assert_snapshot!(
+        infer(r#"
+macro_rules! hello {() => {"hello"}}
+
+#[rustc_builtin_macro]
+macro_rules! concat {() => {}}
+
+fn main() {
+    let x = concat!(hello!(), concat!("world", "!"));
+}
+"#),
+        @r###"
+    ![0; 13) '"helloworld!"': &str
+    [104; 161) '{     ...")); }': ()
+    [114; 115) 'x': &str
+    "###
+    );
+}
+
+#[test]
 fn infer_derive_clone_simple() {
     let (db, pos) = TestDB::with_position(
         r#"


### PR DESCRIPTION
When lazy expanding inside an eager macro, its *parent* file of that lazy macro call must be already exists such that a panic is occurred because that parent file is the eager macro we are processing.

This PR fix this bug by store the argument syntax node as another eager macro id for that purpose.

Personally I don't know if it is a good answer for this bug. 


