### PR TITLE
Unfold groups with single assists into plain assists

### DIFF
--- a/crates/ra_assists/src/assist_ctx.rs
+++ b/crates/ra_assists/src/assist_ctx.rs
@@ -166,8 +166,11 @@ impl<'a> AssistGroup<'a> {
     }
 
     pub(crate) fn finish(self) -> Option<Assist> {
-        assert!(!self.assists.is_empty());
-        Some(Assist(self.assists))
+        if self.assists.is_empty() {
+            None
+        } else {
+            Some(Assist(self.assists))
+        }
     }
 }
 

--- a/crates/ra_assists/src/handlers/auto_import.rs
+++ b/crates/ra_assists/src/handlers/auto_import.rs
@@ -42,12 +42,7 @@ pub(crate) fn auto_import(ctx: AssistCtx) -> Option<Assist> {
         return None;
     }
 
-    let assist_group_name = if proposed_imports.len() == 1 {
-        format!("Import `{}`", proposed_imports.iter().next().unwrap())
-    } else {
-        auto_import_assets.get_import_group_message()
-    };
-    let mut group = ctx.add_assist_group(assist_group_name);
+    let mut group = ctx.add_assist_group(auto_import_assets.get_import_group_message());
     for import in proposed_imports {
         group.add_assist(AssistId("auto_import"), format!("Import `{}`", &import), |edit| {
             edit.target(auto_import_assets.syntax_under_caret.text_range());


### PR DESCRIPTION
A follow-up of https://github.com/rust-analyzer/rust-analyzer/pull/3120/files#r378788698 , made to show more detailed label when the assist group contains a single element