### PR TITLE
Implement include macro

### DIFF
--- a/crates/ra_hir_expand/src/name.rs
+++ b/crates/ra_hir_expand/src/name.rs
@@ -174,6 +174,7 @@ pub mod known {
         line,
         stringify,
         concat,
+        include,
         format_args,
         format_args_nl,
         env,

--- a/crates/ra_hir_ty/src/tests/macros.rs
+++ b/crates/ra_hir_ty/src/tests/macros.rs
@@ -439,6 +439,51 @@ fn main() {
 }
 
 #[test]
+fn infer_builtin_macros_include() {
+    let (db, pos) = TestDB::with_position(
+        r#"
+//- /main.rs 
+#[rustc_builtin_macro]
+macro_rules! include {() => {}}
+
+include!("foo.rs");
+
+fn main() {
+    bar()<|>;
+}
+
+//- /foo.rs
+fn bar() -> u32 {0}
+"#,
+    );
+    assert_eq!("u32", type_at_pos(&db, pos));
+}
+
+#[test]
+fn infer_builtin_macros_include_concat() {
+    let (db, pos) = TestDB::with_position(
+        r#"
+//- /main.rs 
+#[rustc_builtin_macro]
+macro_rules! include {() => {}}
+
+#[rustc_builtin_macro]
+macro_rules! concat {() => {}}
+
+include!(concat!("f", "oo.rs"));
+
+fn main() {
+    bar()<|>;
+}
+
+//- /foo.rs
+fn bar() -> u32 {0}
+"#,
+    );
+    assert_eq!("u32", type_at_pos(&db, pos));
+}
+
+#[test]
 fn infer_builtin_macros_concat_with_lazy() {
     assert_snapshot!(
         infer(r#"


### PR DESCRIPTION
This PR implement builtin `include` macro.

* It does not support include as expression yet.
* It doesn't consider `env!("OUT_DIR")` yet.
