### PR TITLE
Don't reuse the Chalk solver

### DIFF
--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -18,8 +18,7 @@ pub use hir_ty::db::{
     FieldTypesQuery, GenericDefaultsQuery, GenericPredicatesForParamQuery, GenericPredicatesQuery,
     HirDatabase, HirDatabaseStorage, ImplDatumQuery, ImplSelfTyQuery, ImplTraitQuery,
     ImplsForTraitQuery, ImplsInCrateQuery, InternAssocTyValueQuery, InternChalkImplQuery,
-    InternTypeCtorQuery, StructDatumQuery, TraitDatumQuery, TraitSolveQuery, TraitSolverQuery,
-    TyQuery, ValueTyQuery,
+    InternTypeCtorQuery, StructDatumQuery, TraitDatumQuery, TraitSolveQuery, TyQuery, ValueTyQuery,
 };
 
 #[test]

--- a/crates/ra_hir_ty/src/db.rs
+++ b/crates/ra_hir_ty/src/db.rs
@@ -66,14 +66,6 @@ pub trait HirDatabase: DefDatabase {
     #[salsa::invoke(crate::traits::impls_for_trait_query)]
     fn impls_for_trait(&self, krate: CrateId, trait_: TraitId) -> Arc<[ImplId]>;
 
-    /// This provides the Chalk trait solver instance. Because Chalk always
-    /// works from a specific crate, this query is keyed on the crate; and
-    /// because Chalk does its own internal caching, the solver is wrapped in a
-    /// Mutex and the query does an untracked read internally, to make sure the
-    /// cached state is thrown away when input facts change.
-    #[salsa::invoke(crate::traits::trait_solver_query)]
-    fn trait_solver(&self, krate: CrateId) -> crate::traits::TraitSolver;
-
     // Interned IDs for Chalk integration
     #[salsa::interned]
     fn intern_type_ctor(&self, type_ctor: TypeCtor) -> crate::TypeCtorId;

--- a/crates/ra_ide_db/src/change.rs
+++ b/crates/ra_ide_db/src/change.rs
@@ -362,7 +362,6 @@ impl RootDatabase {
             hir::db::GenericDefaultsQuery
             hir::db::ImplsInCrateQuery
             hir::db::ImplsForTraitQuery
-            hir::db::TraitSolverQuery
             hir::db::InternTypeCtorQuery
             hir::db::InternChalkImplQuery
             hir::db::InternAssocTyValueQuery


### PR DESCRIPTION
This slows down analysis-stats a bit (~5% in my measurement), but improves
incremental checking a lot because we can reuse trait solve results.