### PR TITLE
Use a not so dummy implementation of env macro

### DIFF
--- a/crates/ra_hir_expand/src/builtin_macro.rs
+++ b/crates/ra_hir_expand/src/builtin_macro.rs
@@ -142,6 +142,9 @@ fn env_expand(
     _tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     // dummy implementation for type-checking purposes
+    // we cannot use an empty string here, because for
+    // `include!(concat!(env!("OUT_DIR"), "/foo.rs"))` will become
+    // `include!("foo.rs"), which maybe infinite loop
     let expanded = quote! { "__RA_UNIMPLEMENTATED__" };
 
     Ok(expanded)
@@ -394,7 +397,7 @@ mod tests {
             "#,
         );
 
-        assert_eq!(expanded, "\"\"");
+        assert_eq!(expanded, "\"__RA_UNIMPLEMENTATED__\"");
     }
 
     #[test]

--- a/crates/ra_hir_expand/src/builtin_macro.rs
+++ b/crates/ra_hir_expand/src/builtin_macro.rs
@@ -142,7 +142,7 @@ fn env_expand(
     _tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     // dummy implementation for type-checking purposes
-    let expanded = quote! { "" };
+    let expanded = quote! { "__RA_UNIMPLEMENTATED__" };
 
     Ok(expanded)
 }

--- a/crates/ra_hir_ty/src/tests/macros.rs
+++ b/crates/ra_hir_ty/src/tests/macros.rs
@@ -484,6 +484,33 @@ fn bar() -> u32 {0}
 }
 
 #[test]
+fn infer_builtin_macros_include_concat_with_bad_env_should_failed() {
+    let (db, pos) = TestDB::with_position(
+        r#"
+//- /main.rs 
+#[rustc_builtin_macro]
+macro_rules! include {() => {}}
+
+#[rustc_builtin_macro]
+macro_rules! concat {() => {}}
+
+#[rustc_builtin_macro]
+macro_rules! env {() => {}}
+
+include!(concat!(env!("OUT_DIR"), "/foo.rs"));
+
+fn main() {
+    bar()<|>;
+}
+
+//- /foo.rs
+fn bar() -> u32 {0}
+"#,
+    );
+    assert_eq!("{unknown}", type_at_pos(&db, pos));
+}
+
+#[test]
 fn infer_builtin_macros_concat_with_lazy() {
     assert_snapshot!(
         infer(r#"


### PR DESCRIPTION
Currently we have a dummy `env` macro implementation which expand to an empty string, such that a `include!(concat!(env!("OUT_DIR"), "/foo.rs"))` will become `include!("/foo.rs")`, and here may be a infinite loop. :)

This PR use a not so dummy version of `env` macro to prevent this infinite loop. 