### PR TITLE
Prevent include! macro include itself

### DIFF
--- a/crates/ra_hir_expand/src/builtin_macro.rs
+++ b/crates/ra_hir_expand/src/builtin_macro.rs
@@ -279,7 +279,12 @@ fn relative_file(db: &dyn AstDatabase, call_id: MacroCallId, path: &str) -> Opti
     let call_site = call_id.as_file().original_file(db);
     let path = RelativePath::new(&path);
 
-    db.resolve_relative_path(call_site, &path)
+    let res = db.resolve_relative_path(call_site, &path)?;
+    // Prevent include itself
+    if res == call_site {
+        return None;
+    }
+    Some(res)
 }
 
 fn include_expand(

--- a/crates/ra_hir_ty/src/tests/macros.rs
+++ b/crates/ra_hir_ty/src/tests/macros.rs
@@ -511,6 +511,24 @@ fn bar() -> u32 {0}
 }
 
 #[test]
+fn infer_builtin_macros_include_itself_should_failed() {
+    let (db, pos) = TestDB::with_position(
+        r#"
+//- /main.rs 
+#[rustc_builtin_macro]
+macro_rules! include {() => {}}
+
+include!("main.rs");
+
+fn main() {
+    0<|>
+}
+"#,
+    );
+    assert_eq!("i32", type_at_pos(&db, pos));
+}
+
+#[test]
 fn infer_builtin_macros_concat_with_lazy() {
     assert_snapshot!(
         infer(r#"


### PR DESCRIPTION
This PR prevent `include` macro including itself. 

Note: It **does not** prevent a cyclic include: 
```rust
// foo.rs
include!("bar.rs")

// bar.rs
include!("foo.rs")
```