### PR TITLE
Completion in macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,6 +960,7 @@ name = "ra_hir"
 version = "0.1.0"
 dependencies = [
  "either",
+ "itertools",
  "log",
  "ra_db",
  "ra_hir_def",

--- a/crates/ra_hir/Cargo.toml
+++ b/crates/ra_hir/Cargo.toml
@@ -12,6 +12,8 @@ log = "0.4.8"
 rustc-hash = "1.1.0"
 either = "1.5.3"
 
+itertools = "0.8.2"
+
 ra_syntax = { path = "../ra_syntax" }
 ra_db = { path = "../ra_db" }
 ra_prof = { path = "../ra_prof" }

--- a/crates/ra_hir_expand/src/db.rs
+++ b/crates/ra_hir_expand/src/db.rs
@@ -133,7 +133,6 @@ pub(crate) fn macro_expand(
     macro_expand_with_arg(db, id, None)
 }
 
-// TODO hack
 pub fn expander(
     db: &dyn AstDatabase,
     id: MacroCallId,
@@ -141,8 +140,7 @@ pub fn expander(
     let lazy_id = match id {
         MacroCallId::LazyMacro(id) => id,
         MacroCallId::EagerMacro(_id) => {
-            // TODO
-            unimplemented!()
+            return None;
         }
     };
 
@@ -159,8 +157,11 @@ pub(crate) fn macro_expand_with_arg(
     let lazy_id = match id {
         MacroCallId::LazyMacro(id) => id,
         MacroCallId::EagerMacro(id) => {
-            // TODO
-            return Ok(db.lookup_intern_eager_expansion(id).subtree);
+            if arg.is_some() {
+                return Err("hypothetical macro expansion not implemented for eager macro".to_owned());
+            } else {
+                return Ok(db.lookup_intern_eager_expansion(id).subtree);
+            }
         }
     };
 

--- a/crates/ra_hir_expand/src/lib.rs
+++ b/crates/ra_hir_expand/src/lib.rs
@@ -157,6 +157,13 @@ impl HirFileId {
             }
         }
     }
+
+    pub fn macro_file(self) -> Option<MacroFile> {
+        match self.0 {
+            HirFileIdRepr::FileId(_) => None,
+            HirFileIdRepr::MacroFile(m) => Some(m),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -296,7 +303,7 @@ pub struct ExpansionInfo {
     exp_map: Arc<mbe::TokenMap>,
 }
 
-pub use mbe::Origin;
+pub use mbe::{syntax_node_to_token_tree, Origin};
 use ra_parser::FragmentKind;
 
 impl ExpansionInfo {

--- a/crates/ra_hir_expand/src/lib.rs
+++ b/crates/ra_hir_expand/src/lib.rs
@@ -157,13 +157,6 @@ impl HirFileId {
             }
         }
     }
-
-    pub fn macro_file(self) -> Option<MacroFile> {
-        match self.0 {
-            HirFileIdRepr::FileId(_) => None,
-            HirFileIdRepr::MacroFile(m) => Some(m),
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -303,7 +296,7 @@ pub struct ExpansionInfo {
     exp_map: Arc<mbe::TokenMap>,
 }
 
-pub use mbe::{syntax_node_to_token_tree, Origin};
+pub use mbe::Origin;
 use ra_parser::FragmentKind;
 
 impl ExpansionInfo {

--- a/crates/ra_ide/src/completion/complete_dot.rs
+++ b/crates/ra_ide/src/completion/complete_dot.rs
@@ -584,4 +584,102 @@ mod tests {
         "###
         );
     }
+
+    #[test]
+    fn works_in_simple_macro_1() {
+        assert_debug_snapshot!(
+            do_ref_completion(
+                r"
+                macro_rules! m { ($e:expr) => { $e } }
+                struct A { the_field: u32 }
+                fn foo(a: A) {
+                    m!(a.x<|>)
+                }
+                ",
+            ),
+            @r###"
+        [
+            CompletionItem {
+                label: "the_field",
+                source_range: [156; 157),
+                delete: [156; 157),
+                insert: "the_field",
+                kind: Field,
+                detail: "u32",
+            },
+        ]
+        "###
+        );
+    }
+
+    #[test]
+    fn works_in_simple_macro_recursive() {
+        assert_debug_snapshot!(
+            do_ref_completion(
+                r"
+                macro_rules! m { ($e:expr) => { $e } }
+                struct A { the_field: u32 }
+                fn foo(a: A) {
+                    m!(a.x<|>)
+                }
+                ",
+            ),
+            @r###"
+        [
+            CompletionItem {
+                label: "the_field",
+                source_range: [156; 157),
+                delete: [156; 157),
+                insert: "the_field",
+                kind: Field,
+                detail: "u32",
+            },
+        ]
+        "###
+        );
+    }
+
+    #[test]
+    fn works_in_simple_macro_2() {
+        // this doesn't work yet because the macro doesn't expand without the token -- maybe it can be fixed with better recovery
+        assert_debug_snapshot!(
+            do_ref_completion(
+                r"
+                macro_rules! m { ($e:expr) => { $e } }
+                struct A { the_field: u32 }
+                fn foo(a: A) {
+                    m!(a.<|>)
+                }
+                ",
+            ),
+            @r###"[]"###
+        );
+    }
+
+    #[test]
+    fn works_in_simple_macro_recursive_1() {
+        assert_debug_snapshot!(
+            do_ref_completion(
+                r"
+                macro_rules! m { ($e:expr) => { $e } }
+                struct A { the_field: u32 }
+                fn foo(a: A) {
+                    m!(m!(m!(a.x<|>)))
+                }
+                ",
+            ),
+            @r###"
+        [
+            CompletionItem {
+                label: "the_field",
+                source_range: [162; 163),
+                delete: [162; 163),
+                insert: "the_field",
+                kind: Field,
+                detail: "u32",
+            },
+        ]
+        "###
+        );
+    }
 }

--- a/crates/ra_ide/src/completion/complete_dot.rs
+++ b/crates/ra_ide/src/completion/complete_dot.rs
@@ -38,7 +38,7 @@ pub(super) fn complete_dot(acc: &mut Completions, ctx: &CompletionContext) {
 fn complete_fields(acc: &mut Completions, ctx: &CompletionContext, receiver: &Type) {
     for receiver in receiver.autoderef(ctx.db) {
         for (field, ty) in receiver.fields(ctx.db) {
-            if ctx.module.map_or(false, |m| !field.is_visible_from(ctx.db, m)) {
+            if ctx.scope().module().map_or(false, |m| !field.is_visible_from(ctx.db, m)) {
                 // Skip private field. FIXME: If the definition location of the
                 // field is editable, we should show the completion
                 continue;
@@ -53,7 +53,7 @@ fn complete_fields(acc: &mut Completions, ctx: &CompletionContext, receiver: &Ty
 }
 
 fn complete_methods(acc: &mut Completions, ctx: &CompletionContext, receiver: &Type) {
-    if let Some(krate) = ctx.module.map(|it| it.krate()) {
+    if let Some(krate) = ctx.krate {
         let mut seen_methods = FxHashSet::default();
         let traits_in_scope = ctx.scope().traits_in_scope();
         receiver.iterate_method_candidates(ctx.db, krate, &traits_in_scope, None, |_ty, func| {

--- a/crates/ra_ide/src/completion/complete_keyword.rs
+++ b/crates/ra_ide/src/completion/complete_keyword.rs
@@ -79,6 +79,7 @@ pub(super) fn complete_expr_keyword(acc: &mut Completions, ctx: &CompletionConte
 }
 
 fn is_in_loop_body(leaf: &SyntaxToken) -> bool {
+    // FIXME move this to CompletionContext and make it handle macros
     for node in leaf.parent().ancestors() {
         if node.kind() == FN_DEF || node.kind() == LAMBDA_EXPR {
             break;

--- a/crates/ra_ide/src/completion/complete_path.rs
+++ b/crates/ra_ide/src/completion/complete_path.rs
@@ -1,4 +1,4 @@
-//! Completion of paths, including when writing a single name.
+//! Completion of paths, i.e. `some::prefix::<|>`.
 
 use hir::{Adt, PathResolution, ScopeDef};
 use ra_syntax::AstNode;

--- a/crates/ra_ide/src/completion/complete_path.rs
+++ b/crates/ra_ide/src/completion/complete_path.rs
@@ -47,7 +47,7 @@ pub(super) fn complete_path(acc: &mut Completions, ctx: &CompletionContext) {
             };
             // Iterate assoc types separately
             // FIXME: complete T::AssocType
-            let krate = ctx.module.map(|m| m.krate());
+            let krate = ctx.krate;
             if let Some(krate) = krate {
                 let traits_in_scope = ctx.scope().traits_in_scope();
                 ty.iterate_path_candidates(ctx.db, krate, &traits_in_scope, None, |_ty, item| {

--- a/crates/ra_ide/src/completion/complete_path.rs
+++ b/crates/ra_ide/src/completion/complete_path.rs
@@ -835,4 +835,37 @@ mod tests {
         "###
         );
     }
+
+    #[test]
+    fn completes_in_simple_macro_call() {
+        let completions = do_reference_completion(
+            r#"
+                macro_rules! m { ($e:expr) => { $e } }
+                fn main() { m!(self::f<|>); }
+                fn foo() {}
+            "#,
+        );
+        assert_debug_snapshot!(completions, @r###"
+        [
+            CompletionItem {
+                label: "foo()",
+                source_range: [93; 94),
+                delete: [93; 94),
+                insert: "foo()$0",
+                kind: Function,
+                lookup: "foo",
+                detail: "fn foo()",
+            },
+            CompletionItem {
+                label: "main()",
+                source_range: [93; 94),
+                delete: [93; 94),
+                insert: "main()$0",
+                kind: Function,
+                lookup: "main",
+                detail: "fn main()",
+            },
+        ]
+        "###);
+    }
 }

--- a/crates/ra_ide/src/completion/complete_pattern.rs
+++ b/crates/ra_ide/src/completion/complete_pattern.rs
@@ -86,4 +86,22 @@ mod tests {
         ]
         "###);
     }
+
+    #[test]
+    fn completes_in_simple_macro_call() {
+        // FIXME: doesn't work yet because of missing error recovery in macro expansion
+        let completions = complete(
+            r"
+            macro_rules! m { ($e:expr) => { $e } }
+            enum E { X }
+
+            fn foo() {
+               m!(match E::X {
+                   <|>
+               })
+            }
+            ",
+        );
+        assert_debug_snapshot!(completions, @r###"[]"###);
+    }
 }

--- a/crates/ra_ide/src/completion/complete_record_literal.rs
+++ b/crates/ra_ide/src/completion/complete_record_literal.rs
@@ -153,4 +153,29 @@ mod tests {
         ]
         "###);
     }
+
+    #[test]
+    fn test_record_literal_field_in_simple_macro() {
+        let completions = complete(
+            r"
+            macro_rules! m { ($e:expr) => { $e } }
+            struct A { the_field: u32 }
+            fn foo() {
+               m!(A { the<|> })
+            }
+            ",
+        );
+        assert_debug_snapshot!(completions, @r###"
+        [
+            CompletionItem {
+                label: "the_field",
+                source_range: [137; 140),
+                delete: [137; 140),
+                insert: "the_field",
+                kind: Field,
+                detail: "u32",
+            },
+        ]
+        "###);
+    }
 }

--- a/crates/ra_ide/src/completion/complete_record_pattern.rs
+++ b/crates/ra_ide/src/completion/complete_record_pattern.rs
@@ -87,4 +87,32 @@ mod tests {
         ]
         "###);
     }
+
+    #[test]
+    fn test_record_pattern_field_in_simple_macro() {
+        let completions = complete(
+            r"
+            macro_rules! m { ($e:expr) => { $e } }
+            struct S { foo: u32 }
+
+            fn process(f: S) {
+                m!(match f {
+                    S { f<|>: 92 } => (),
+                })
+            }
+            ",
+        );
+        assert_debug_snapshot!(completions, @r###"
+        [
+            CompletionItem {
+                label: "foo",
+                source_range: [171; 172),
+                delete: [171; 172),
+                insert: "foo",
+                kind: Field,
+                detail: "u32",
+            },
+        ]
+        "###);
+    }
 }

--- a/crates/ra_ide/src/completion/complete_scope.rs
+++ b/crates/ra_ide/src/completion/complete_scope.rs
@@ -1,4 +1,4 @@
-//! FIXME: write short doc here
+//! Completion of names from the current scope, e.g. locals and imported items.
 
 use crate::completion::{CompletionContext, Completions};
 
@@ -796,5 +796,73 @@ mod tests {
         ]
         "###
         )
+    }
+
+    #[test]
+    fn completes_in_simple_macro_1() {
+        assert_debug_snapshot!(
+            do_reference_completion(
+                r"
+                macro_rules! m { ($e:expr) => { $e } }
+                fn quux(x: i32) {
+                    let y = 92;
+                    m!(<|>);
+                }
+                "
+            ),
+            @"[]"
+        );
+    }
+
+    #[test]
+    fn completes_in_simple_macro_2() {
+        assert_debug_snapshot!(
+            do_reference_completion(
+                r"
+                macro_rules! m { ($e:expr) => { $e } }
+                fn quux(x: i32) {
+                    let y = 92;
+                    m!(x<|>);
+                }
+                "
+            ),
+            @r###"
+        [
+            CompletionItem {
+                label: "m!",
+                source_range: [145; 146),
+                delete: [145; 146),
+                insert: "m!($0)",
+                kind: Macro,
+                detail: "macro_rules! m",
+            },
+            CompletionItem {
+                label: "quux(…)",
+                source_range: [145; 146),
+                delete: [145; 146),
+                insert: "quux(${1:x})$0",
+                kind: Function,
+                lookup: "quux",
+                detail: "fn quux(x: i32)",
+            },
+            CompletionItem {
+                label: "x",
+                source_range: [145; 146),
+                delete: [145; 146),
+                insert: "x",
+                kind: Binding,
+                detail: "i32",
+            },
+            CompletionItem {
+                label: "y",
+                source_range: [145; 146),
+                delete: [145; 146),
+                insert: "y",
+                kind: Binding,
+                detail: "i32",
+            },
+        ]
+        "###
+        );
     }
 }

--- a/crates/ra_ide/src/completion/completion_context.rs
+++ b/crates/ra_ide/src/completion/completion_context.rs
@@ -119,11 +119,15 @@ impl<'a> CompletionContext<'a> {
             {
                 break;
             }
+            let hypothetical_args = match macro_call_with_fake_ident.token_tree() {
+                Some(tt) => tt,
+                None => break,
+            };
             if let (Some(actual_expansion), Some(hypothetical_expansion)) = (
                 ctx.sema.expand(&actual_macro_call),
                 ctx.sema.expand_hypothetical(
                     &actual_macro_call,
-                    &macro_call_with_fake_ident,
+                    &hypothetical_args,
                     fake_ident_token,
                 ),
             ) {

--- a/crates/ra_ide/src/completion/completion_context.rs
+++ b/crates/ra_ide/src/completion/completion_context.rs
@@ -185,7 +185,7 @@ impl<'a> CompletionContext<'a> {
             }
             if name.syntax().ancestors().find_map(ast::RecordFieldPatList::cast).is_some() {
                 self.record_lit_pat =
-                    self.sema.find_node_at_offset_with_macros(&original_file, self.offset);
+                    self.sema.find_node_at_offset_with_macros(&original_file, offset);
             }
         }
     }

--- a/crates/ra_ide/src/completion/completion_context.rs
+++ b/crates/ra_ide/src/completion/completion_context.rs
@@ -165,7 +165,7 @@ impl<'a> CompletionContext<'a> {
                 self.is_param = true;
                 return;
             }
-            self.classify_name_ref(original_file, name_ref);
+            self.classify_name_ref(original_file, name_ref, offset);
         }
 
         // Otherwise, see if this is a declaration. We can use heuristics to
@@ -190,13 +190,18 @@ impl<'a> CompletionContext<'a> {
         }
     }
 
-    fn classify_name_ref(&mut self, original_file: &SyntaxNode, name_ref: ast::NameRef) {
+    fn classify_name_ref(
+        &mut self,
+        original_file: &SyntaxNode,
+        name_ref: ast::NameRef,
+        offset: TextUnit,
+    ) {
         self.name_ref_syntax =
             find_node_at_offset(&original_file, name_ref.syntax().text_range().start());
         let name_range = name_ref.syntax().text_range();
         if name_ref.syntax().parent().and_then(ast::RecordField::cast).is_some() {
             self.record_lit_syntax =
-                self.sema.find_node_at_offset_with_macros(&original_file, self.offset);
+                self.sema.find_node_at_offset_with_macros(&original_file, offset);
         }
 
         self.impl_def = self

--- a/crates/ra_mbe/src/mbe_expander/matcher.rs
+++ b/crates/ra_mbe/src/mbe_expander/matcher.rs
@@ -247,6 +247,7 @@ impl<'a> TtIter<'a> {
         ra_parser::parse_fragment(&mut src, &mut sink, fragment_kind);
 
         if !sink.cursor.is_root() || sink.error {
+            // FIXME better recovery in this case would help completion inside macros immensely
             return Err(());
         }
 
@@ -375,7 +376,8 @@ fn match_meta_var(kind: &str, input: &mut TtIter) -> Result<Option<Fragment>, Ex
             return Ok(Some(Fragment::Tokens(tt)));
         }
     };
-    let tt = input.expect_fragment(fragment).map_err(|()| err!())?;
+    let tt =
+        input.expect_fragment(fragment).map_err(|()| err!("fragment did not parse as {}", kind))?;
     let fragment = if kind == "expr" { Fragment::Ast(tt) } else { Fragment::Tokens(tt) };
     Ok(Some(fragment))
 }


### PR DESCRIPTION
I experimented a bit with completion in macros. It's kind of working, but there are a lot of rough edges.

 - I'm trying to expand the macro call with the inserted fake token. This requires some hacky additions on the HIR level to be able to do "hypothetical" expansions. There should probably be a nicer API for this, if we want to do it this way. I'm not sure whether it's worth it, because we still can't do a lot if the original macro call didn't expand in nearly the same way. E.g. if we have something like `println!("", x<|>)` the expansions will look the same and everything is fine; but in that case we could maybe have achieved the same result in a simpler way. If we have something like `m!(<|>)` where `m!()` doesn't even expand or expands to something very different, we don't really know what to do anyway.
 - Relatedly, there are a lot of cases where this doesn't work because either the original call or the hypothetical call doesn't expand. E.g. if we have `m!(x.<|>)` the original token tree doesn't parse as an expression; if we have `m!(match x { <|> })` the hypothetical token tree doesn't parse. It would be nice if we could have better error recovery in these cases.