### PR TITLE
vscode: askBeforeDownload option

### DIFF
--- a/docs/user/readme.adoc
+++ b/docs/user/readme.adoc
@@ -2,6 +2,13 @@
 :toc: preamble
 :sectanchors:
 :page-layout: post
+// https://gist.github.com/dcode/0cfbf2699a1fe9b46ff04c41721dda74#admonitions
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+
 
 
 // Master copy of this document lives in the https://github.com/rust-analyzer/rust-analyzer repository
@@ -40,12 +47,15 @@ By default, the plugin will prompt you to download the matching version of the s
 
 image::https://user-images.githubusercontent.com/9021944/75067008-17502500-54ba-11ea-835a-f92aac50e866.png[]
 
-> Note: to disable this notification put the following to `settings.json`
-> ```json
-{
-    "rust-analyzer.askBeforeDownload": false
-}
-```
+[NOTE]
+====
+To disable this notification put the following to `settings.json`
+
+[source,json]
+----
+{ "rust-analyzer.askBeforeDownload": false }
+----
+====
 
 The server binary is stored in `~/.config/Code/User/globalStorage/matklad.rust-analyzer`.
 

--- a/docs/user/readme.adoc
+++ b/docs/user/readme.adoc
@@ -43,7 +43,7 @@ image::https://user-images.githubusercontent.com/9021944/75067008-17502500-54ba-
 > Note: to disable this notification put the following to `settings.json`
 > ```json
 {
-    "rust-analyzer.alwaysDownloadServer": true
+    "rust-analyzer.askBeforeDownload": false
 }
 ```
 

--- a/docs/user/readme.adoc
+++ b/docs/user/readme.adoc
@@ -30,7 +30,7 @@ $ rustup component add rust-src
 
 === VS Code
 
-This the best supported editor at the moment.
+This is the best supported editor at the moment.
 rust-analyzer plugin for VS Code is maintained
 https://github.com/rust-analyzer/rust-analyzer/tree/master/editors/code[in tree].
 
@@ -39,6 +39,13 @@ https://marketplace.visualstudio.com/items?itemName=matklad.rust-analyzer[the ma
 By default, the plugin will prompt you to download the matching version of the server as well:
 
 image::https://user-images.githubusercontent.com/9021944/75067008-17502500-54ba-11ea-835a-f92aac50e866.png[]
+
+> Note: to disable this notification put the following to `settings.json`
+> ```json
+{
+    "rust-analyzer.alwaysDownloadServer": true
+}
+```
 
 The server binary is stored in `~/.config/Code/User/globalStorage/matklad.rust-analyzer`.
 

--- a/docs/user/readme.adoc
+++ b/docs/user/readme.adoc
@@ -53,7 +53,7 @@ To disable this notification put the following to `settings.json`
 
 [source,json]
 ----
-{ "rust-analyzer.askBeforeDownload": false }
+{ "rust-analyzer.updates.askBeforeDownload": false }
 ----
 ====
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -219,7 +219,7 @@
                         }
                     }
                 },
-                "rust-analyzer.askBeforeDownload": {
+                "rust-analyzer.updates.askBeforeDownload": {
                     "type": "boolean",
                     "default": true,
                     "description": "Whether to ask for permission before downloading any files from the Internet"

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -219,6 +219,11 @@
                         }
                     }
                 },
+                "rust-analyzer.alwaysDownloadServer": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether to ask before downloading the language server binary"
+                },
                 "rust-analyzer.serverPath": {
                     "type": [
                         "null",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -219,10 +219,10 @@
                         }
                     }
                 },
-                "rust-analyzer.alwaysDownloadServer": {
+                "rust-analyzer.askBeforeDownload": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Whether to ask before downloading the language server binary"
+                    "default": true,
+                    "description": "Whether to ask for permission before downloading any files from the Internet"
                 },
                 "rust-analyzer.serverPath": {
                     "type": [

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -134,7 +134,7 @@ export class Config {
             file: prebuiltBinaryName,
             storage: this.ctx.globalState,
             tag: Config.extensionVersion,
-            askBeforeDownload: this.cfg.get("askBeforeDownload") as boolean,
+            askBeforeDownload: this.cfg.get("updates.askBeforeDownload") as boolean,
             repo: {
                 name: "rust-analyzer",
                 owner: "rust-analyzer",

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -1,6 +1,6 @@
 import * as os from "os";
 import * as vscode from 'vscode';
-import { BinarySource } from "./installation/interfaces";
+import { ArtifactSource } from "./installation/interfaces";
 import { log } from "./util";
 
 const RA_LSP_DEBUG = process.env.__RA_LSP_SERVER_DEBUG;
@@ -114,12 +114,12 @@ export class Config {
         }
     }
 
-    get serverSource(): null | BinarySource {
+    get serverSource(): null | ArtifactSource {
         const serverPath = RA_LSP_DEBUG ?? this.cfg.get<null | string>("serverPath");
 
         if (serverPath) {
             return {
-                type: BinarySource.Type.ExplicitPath,
+                type: ArtifactSource.Type.ExplicitPath,
                 path: Config.replaceTildeWithHomeDir(serverPath)
             };
         }
@@ -129,11 +129,12 @@ export class Config {
         if (!prebuiltBinaryName) return null;
 
         return {
-            type: BinarySource.Type.GithubRelease,
+            type: ArtifactSource.Type.GithubRelease,
             dir: this.ctx.globalStoragePath,
             file: prebuiltBinaryName,
             storage: this.ctx.globalState,
-            version: Config.extensionVersion,
+            tag: Config.extensionVersion,
+            askBeforeDownload: !(this.cfg.get("alwaysDownloadServer") as boolean),
             repo: {
                 name: "rust-analyzer",
                 owner: "rust-analyzer",

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -134,7 +134,7 @@ export class Config {
             file: prebuiltBinaryName,
             storage: this.ctx.globalState,
             tag: Config.extensionVersion,
-            askBeforeDownload: !(this.cfg.get("alwaysDownloadServer") as boolean),
+            askBeforeDownload: !(this.cfg.get("askBeforeDownload") as boolean),
             repo: {
                 name: "rust-analyzer",
                 owner: "rust-analyzer",

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -134,7 +134,7 @@ export class Config {
             file: prebuiltBinaryName,
             storage: this.ctx.globalState,
             tag: Config.extensionVersion,
-            askBeforeDownload: !(this.cfg.get("askBeforeDownload") as boolean),
+            askBeforeDownload: this.cfg.get("askBeforeDownload") as boolean,
             repo: {
                 name: "rust-analyzer",
                 owner: "rust-analyzer",

--- a/editors/code/src/installation/interfaces.ts
+++ b/editors/code/src/installation/interfaces.ts
@@ -14,14 +14,14 @@ export interface ArtifactReleaseInfo {
 }
 
 /**
- * Represents the source of a binary artifact which is either specified by the user
+ * Represents the source of a an artifact which is either specified by the user
  * explicitly, or bundled by this extension from GitHub releases.
  */
-export type BinarySource = BinarySource.ExplicitPath | BinarySource.GithubRelease;
+export type ArtifactSource = ArtifactSource.ExplicitPath | ArtifactSource.GithubRelease;
 
-export namespace BinarySource {
+export namespace ArtifactSource {
     /**
-     * Type tag for `BinarySource` discriminated union.
+     * Type tag for `ArtifactSource` discriminated union.
      */
     export const enum Type { ExplicitPath, GithubRelease }
 
@@ -56,13 +56,18 @@ export namespace BinarySource {
         /**
          * Tag of github release that denotes a version required by this extension.
          */
-        version: string;
+        tag: string;
 
         /**
          * Object that provides `get()/update()` operations to store metadata
          * about the actual binary, e.g. its actual version.
          */
         storage: vscode.Memento;
+
+        /**
+         * Ask for the user permission before downloading the artifact.
+         */
+        askBeforeDownload: boolean;
     }
 
 }


### PR DESCRIPTION
This is a small step towards #3402, also implements my proposal stated in #3403

Also renamed `BinarySource` to `ArtifactSource` in anticipation of nightlies installation that requires downloading not a binary itself but `.vsix` package, thus generalized to `artifact` term.

@matklad @lnicola 