### PR TITLE
Use markdown description in vscode

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -191,7 +191,7 @@
                     "properties": {
                         "lsp.diagnostics": {
                             "type": "boolean",
-                            "description": "Whether to show diagnostics from `cargo check`"
+                            "markdownDescription": "Whether to show diagnostics from `cargo check`"
                         },
                         "completion.insertion.add-call-parenthesis": {
                             "type": "boolean",
@@ -203,7 +203,7 @@
                         },
                         "completion.enable-postfix": {
                             "type": "boolean",
-                            "description": "Whether to show postfix snippets like `dbg`, `if`, `not`, etc."
+                            "markdownDescription": "Whether to show postfix snippets like `dbg`, `if`, `not`, etc."
                         },
                         "call-info.full": {
                             "type": "boolean",
@@ -211,11 +211,11 @@
                         },
                         "notifications.workspace-loaded": {
                             "type": "boolean",
-                            "description": "Whether to show `workspace loaded` message"
+                            "markdownDescription": "Whether to show `workspace loaded` message"
                         },
                         "notifications.cargo-toml-not-found": {
                             "type": "boolean",
-                            "description": "Whether to show `can't find Cargo.toml` error message"
+                            "markdownDescription": "Whether to show `can't find Cargo.toml` error message"
                         }
                     }
                 },
@@ -251,24 +251,24 @@
                 "rust-analyzer.cargo-watch.enable": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Run `cargo check` for diagnostics on save"
+                    "markdownDescription": "Run `cargo check` for diagnostics on save"
                 },
                 "rust-analyzer.cargo-watch.arguments": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     },
-                    "description": "`cargo-watch` arguments. (e.g: `--features=\"shumway,pdf\"` will run as `cargo watch -x \"check --features=\"shumway,pdf\"\"` )",
+                    "markdownDescription": "`cargo-watch` arguments. (e.g: `--features=\"shumway,pdf\"` will run as `cargo watch -x \"check --features=\"shumway,pdf\"\"` )",
                     "default": []
                 },
                 "rust-analyzer.cargo-watch.command": {
                     "type": "string",
-                    "description": "`cargo-watch` command. (e.g: `clippy` will run as `cargo watch -x clippy` )",
+                    "markdownDescription": "`cargo-watch` command. (e.g: `clippy` will run as `cargo watch -x clippy` )",
                     "default": "check"
                 },
                 "rust-analyzer.cargo-watch.allTargets": {
                     "type": "boolean",
-                    "description": "Check all targets and tests (will be passed as `--all-targets`)",
+                    "markdownDescription": "Check all targets and tests (will be passed as `--all-targets`)",
                     "default": true
                 },
                 "rust-analyzer.trace.server": {
@@ -320,7 +320,7 @@
                 "rust-analyzer.cargoFeatures.noDefaultFeatures": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Do not activate the `default` feature"
+                    "markdownDescription": "Do not activate the `default` feature"
                 },
                 "rust-analyzer.cargoFeatures.allFeatures": {
                     "type": "boolean",


### PR DESCRIPTION
By using `markdownDescription` the markdown in the description is parsed and displayed.

Before:

![image](https://user-images.githubusercontent.com/131878/76171725-cb2a0380-618e-11ea-956f-7668a746946f.png)

After:

![image](https://user-images.githubusercontent.com/131878/76171743-00365600-618f-11ea-8847-f4ab09639bb5.png)
