### PR TITLE
Install Node only for Linux

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,6 +42,7 @@ jobs:
         override: true
 
     - name: Install Nodejs
+      if: matrix.os == 'ubuntu-latest'
       uses: actions/setup-node@v1
       with:
         node-version: 12.x


### PR DESCRIPTION
Hopefully, this will lead to fewer errors like

https://github.com/rust-analyzer/rust-analyzer/runs/493983317?check_suite_focus=true#step:5:10



bors r+
🤖