### PR TITLE
Experiment: compte crate def amp in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,6 +1050,7 @@ dependencies = [
  "ra_syntax",
  "ra_text_edit",
  "rand",
+ "rayon",
  "rustc-hash",
  "test_utils",
 ]

--- a/crates/ra_ide/Cargo.toml
+++ b/crates/ra_ide/Cargo.toml
@@ -19,6 +19,7 @@ join_to_string = "0.1.3"
 log = "0.4.8"
 rustc-hash = "1.1.0"
 rand = { version = "0.7.3", features = ["small_rng"] }
+rayon = "1.3.0"
 
 ra_syntax = { path = "../ra_syntax" }
 ra_text_edit = { path = "../ra_text_edit" }

--- a/crates/ra_ide/src/prime_caches.rs
+++ b/crates/ra_ide/src/prime_caches.rs
@@ -3,13 +3,53 @@
 //! request takes longer to compute. This modules implemented prepopulating of
 //! various caches, it's not really advanced at the moment.
 
-use hir::Semantics;
+use hir::db::DefDatabase;
+use ra_db::{salsa::ParallelDatabase, FileLoader, SourceDatabase};
+use rustc_hash::FxHashSet;
 
-use crate::{FileId, RootDatabase};
+use crate::{CrateGraph, CrateId, FileId, RootDatabase};
 
 pub(crate) fn prime_caches(db: &RootDatabase, files: Vec<FileId>) {
-    let sema = Semantics::new(db);
-    for file in files {
-        let _ = sema.to_module_def(file);
+    let crates = files
+        .into_iter()
+        .flat_map(|file_id| db.relevant_crates(file_id).first().copied())
+        .collect::<Vec<_>>();
+    let crate_graph = db.crate_graph();
+    let crates = top_sort(&crate_graph, crates);
+
+    let _t = ra_prof::print_time("cache-priming");
+    let db = db.snapshot();
+    rayon::scope(move |s| {
+        for krate in crates {
+            let db = db.snapshot();
+            s.spawn(move |_| {
+                db.crate_def_map(krate);
+            })
+        }
+    })
+}
+
+fn top_sort(graph: &CrateGraph, sources: Vec<CrateId>) -> Vec<CrateId> {
+    let mut res = Vec::new();
+    let mut visited = FxHashSet::default();
+    for krate in sources {
+        go(graph, &mut visited, &mut res, krate);
+    }
+
+    return res;
+
+    fn go(
+        graph: &CrateGraph,
+        visited: &mut FxHashSet<CrateId>,
+        res: &mut Vec<CrateId>,
+        source: CrateId,
+    ) {
+        if !visited.insert(source) {
+            return;
+        }
+        for dep in graph[source].dependencies.iter() {
+            go(graph, visited, res, dep.crate_id)
+        }
+        res.push(source)
     }
 }

--- a/crates/rust-analyzer/src/cli/analysis_bench.rs
+++ b/crates/rust-analyzer/src/cli/analysis_bench.rs
@@ -94,17 +94,19 @@ pub fn analysis_bench(verbosity: Verbosity, path: &Path, what: BenchWhat) -> Res
                 .analysis()
                 .file_line_index(file_id)?
                 .offset(LineCol { line: pos.line - 1, col_utf16: pos.column });
-            let file_postion = FilePosition { file_id, offset };
+            let file_position = FilePosition { file_id, offset };
 
             if is_completion {
                 let res =
-                    do_work(&mut host, file_id, |analysis| analysis.completions(file_postion));
+                    do_work(&mut host, file_id, |analysis| analysis.completions(file_position));
                 if verbosity.is_verbose() {
                     println!("\n{:#?}", res);
                 }
             } else {
-                let res =
-                    do_work(&mut host, file_id, |analysis| analysis.goto_definition(file_postion));
+                let res = do_work(&mut host, file_id, |analysis| {
+                    analysis.prime_caches(vec![file_position.file_id]).unwrap();
+                    analysis.goto_definition(file_position)
+                });
                 if verbosity.is_verbose() {
                     println!("\n{:#?}", res);
                 }


### PR DESCRIPTION
```
λ hyperfine './target/rust-analyzer-baseline  analysis-bench --goto-def ~/projects/rustraytracer/src/rendering/mod.rs:87:47 --project ~/projects/rustraytracer/' './target/rust-analyzer-prime-par  analysis-bench --goto-def ~/projects/rustraytracer/src/rendering/mod.rs:87:47 --project ~/projects/rustraytracer/'
Benchmark #1: ./target/rust-analyzer-baseline  analysis-bench --goto-def ~/projects/rustraytracer/src/rendering/mod.rs:87:47 --project ~/projects/rustraytracer/
  Time (mean ± σ):      7.661 s ±  0.172 s    [User: 7.584 s, System: 0.098 s]
  Range (min … max):    7.519 s …  7.922 s    10 runs
 
Benchmark #2: ./target/rust-analyzer-prime-par  analysis-bench --goto-def ~/projects/rustraytracer/src/rendering/mod.rs:87:47 --project ~/projects/rustraytracer/
  Time (mean ± σ):      6.833 s ±  0.188 s    [User: 8.003 s, System: 0.163 s]
  Range (min … max):    6.468 s …  7.107 s    10 runs
 
Summary
  './target/rust-analyzer-prime-par  analysis-bench --goto-def ~/projects/rustraytracer/src/rendering/mod.rs:87:47 --project ~/projects/rustraytracer/' ran
    1.12 ± 0.04 times faster than './target/rust-analyzer-baseline  analysis-bench --goto-def ~/projects/rustraytracer/src/rendering/mod.rs:87:47 --project ~/projects/rustraytracer/'
```

So, not impressive, given that, with parallelism, we kind of expect at least 2x improvement :-(

Analysis: the actual crate graph is not **that** parallel, everyone depends on core/std which have a ton of macros. And, after that, we still hit the "parsing twice becuase of LRU" problem, which we now do sequentially. 