### PR TITLE
Completition for type name? #3418

### DIFF
--- a/crates/ra_ide/src/completion/complete_pattern.rs
+++ b/crates/ra_ide/src/completion/complete_pattern.rs
@@ -98,6 +98,13 @@ mod tests {
                 kind: Const,
             },
             CompletionItem {
+                label: "Z",
+                source_range: [246; 246),
+                delete: [246; 246),
+                insert: "Z",
+                kind: Const,
+            },
+            CompletionItem {
                 label: "m",
                 source_range: [246; 246),
                 delete: [246; 246),
@@ -137,6 +144,21 @@ mod tests {
                 delete: [151; 151),
                 insert: "E",
                 kind: Enum,
+            },
+            CompletionItem {
+                label: "E",
+                source_range: [151; 151),
+                delete: [151; 151),
+                insert: "E",
+                kind: Enum,
+            },
+            CompletionItem {
+                label: "m!",
+                source_range: [151; 151),
+                delete: [151; 151),
+                insert: "m!($0)",
+                kind: Macro,
+                detail: "macro_rules! m",
             },
         ]
         "###);

--- a/crates/ra_ide/src/completion/complete_pattern.rs
+++ b/crates/ra_ide/src/completion/complete_pattern.rs
@@ -56,6 +56,20 @@ mod tests {
         assert_debug_snapshot!(completions, @r###"
         [
             CompletionItem {
+                label: "Bar",
+                source_range: [246; 246),
+                delete: [246; 246),
+                insert: "Bar",
+                kind: Struct,
+            },
+            CompletionItem {
+                label: "E",
+                source_range: [246; 246),
+                delete: [246; 246),
+                insert: "E",
+                kind: Enum,
+            },
+            CompletionItem {
                 label: "E",
                 source_range: [246; 246),
                 delete: [246; 246),
@@ -70,11 +84,25 @@ mod tests {
                 kind: EnumVariant,
             },
             CompletionItem {
+                label: "X",
+                source_range: [246; 246),
+                delete: [246; 246),
+                insert: "X",
+                kind: EnumVariant,
+            },
+            CompletionItem {
                 label: "Z",
                 source_range: [246; 246),
                 delete: [246; 246),
                 insert: "Z",
                 kind: Const,
+            },
+            CompletionItem {
+                label: "m",
+                source_range: [246; 246),
+                delete: [246; 246),
+                insert: "m",
+                kind: Module,
             },
             CompletionItem {
                 label: "m",

--- a/crates/ra_ide/src/completion/complete_scope.rs
+++ b/crates/ra_ide/src/completion/complete_scope.rs
@@ -1,7 +1,7 @@
 //! Completion of names from the current scope, e.g. locals and imported items.
 
 use crate::completion::{CompletionContext, Completions};
-use hir::ScopeDef;
+use hir::{ModuleDef, ScopeDef};
 
 pub(super) fn complete_scope(acc: &mut Completions, ctx: &CompletionContext) {
     if !ctx.is_trivial_path && !ctx.is_pat_binding_and_path {
@@ -9,7 +9,10 @@ pub(super) fn complete_scope(acc: &mut Completions, ctx: &CompletionContext) {
     }
 
     ctx.scope().process_all_names(&mut |name, res| match (ctx.is_pat_binding_and_path, &res) {
-        (true, ScopeDef::Local(..)) => {}
+        (true, ScopeDef::ModuleDef(ModuleDef::Function(..))) => (),
+        (true, ScopeDef::ModuleDef(ModuleDef::Static(..))) => (),
+        (true, ScopeDef::ModuleDef(ModuleDef::Const(..))) => (),
+        (true, ScopeDef::Local(..)) => (),
         _ => acc.add_resolution(ctx, name.to_string(), &res),
     });
 }
@@ -70,16 +73,6 @@ mod tests {
                     delete: [231; 233),
                     insert: "Enum",
                     kind: Enum,
-                },
-                CompletionItem {
-                    label: "quux(…)",
-                    source_range: [231; 233),
-                    delete: [231; 233),
-                    insert: "quux(${1:x})$0",
-                    kind: Function,
-                    lookup: "quux",
-                    detail: "fn quux(x: Option<Enum>)",
-                    trigger_call_info: true,
                 },
             ]
             "###

--- a/crates/ra_ide/src/completion/completion_context.rs
+++ b/crates/ra_ide/src/completion/completion_context.rs
@@ -190,19 +190,16 @@ impl<'a> CompletionContext<'a> {
         // suggest declaration names, see `CompletionKind::Magic`.
         if let Some(name) = find_node_at_offset::<ast::Name>(&file_with_fake_ident, offset) {
             if let Some(bind_pat) = name.syntax().ancestors().find_map(ast::BindPat::cast) {
-                let mut parent = bind_pat.syntax().parent();
+                let parent = bind_pat.syntax().parent();
                 if parent.clone().and_then(ast::MatchArm::cast).is_some()
                     || parent.clone().and_then(ast::Condition::cast).is_some()
                 {
                     self.is_pat_binding = true;
                 }
 
-                while let Some(_) = parent.clone().and_then(ast::TupleStructPat::cast) {
-                    parent = parent.and_then(|p| p.parent());
-                    if parent.clone().and_then(ast::MatchArm::cast).is_some() {
-                        self.is_pat_binding_and_path = true;
-                        break;
-                    }
+                let bind_pat_string = bind_pat.syntax().to_string();
+                if !bind_pat_string.contains("ref ") && !bind_pat_string.contains(" @ ") {
+                    self.is_pat_binding_and_path = true;
                 }
             }
             if is_node::<ast::Param>(name.syntax()) {

--- a/crates/ra_ide/src/completion/completion_context.rs
+++ b/crates/ra_ide/src/completion/completion_context.rs
@@ -36,6 +36,9 @@ pub(crate) struct CompletionContext<'a> {
     /// If a name-binding or reference to a const in a pattern.
     /// Irrefutable patterns (like let) are excluded.
     pub(super) is_pat_binding: bool,
+    // A bind battern which may also be part of a path.
+    // if let Some(En<|>) = Some(Enum::A)
+    pub(super) is_pat_binding_and_path: bool,
     /// A single-indent path, like `foo`. `::foo` should not be considered a trivial path.
     pub(super) is_trivial_path: bool,
     /// If not a trivial path, the prefix (qualifier).
@@ -95,6 +98,7 @@ impl<'a> CompletionContext<'a> {
             impl_def: None,
             is_param: false,
             is_pat_binding: false,
+            is_pat_binding_and_path: false,
             is_trivial_path: false,
             path_prefix: None,
             after_if: false,
@@ -186,11 +190,19 @@ impl<'a> CompletionContext<'a> {
         // suggest declaration names, see `CompletionKind::Magic`.
         if let Some(name) = find_node_at_offset::<ast::Name>(&file_with_fake_ident, offset) {
             if let Some(bind_pat) = name.syntax().ancestors().find_map(ast::BindPat::cast) {
-                let parent = bind_pat.syntax().parent();
+                let mut parent = bind_pat.syntax().parent();
                 if parent.clone().and_then(ast::MatchArm::cast).is_some()
-                    || parent.and_then(ast::Condition::cast).is_some()
+                    || parent.clone().and_then(ast::Condition::cast).is_some()
                 {
                     self.is_pat_binding = true;
+                }
+
+                while let Some(_) = parent.clone().and_then(ast::TupleStructPat::cast) {
+                    parent = parent.and_then(|p| p.parent());
+                    if parent.clone().and_then(ast::MatchArm::cast).is_some() {
+                        self.is_pat_binding_and_path = true;
+                        break;
+                    }
                 }
             }
             if is_node::<ast::Param>(name.syntax()) {

--- a/crates/ra_ide/src/completion/completion_context.rs
+++ b/crates/ra_ide/src/completion/completion_context.rs
@@ -197,9 +197,11 @@ impl<'a> CompletionContext<'a> {
                     self.is_pat_binding = true;
                 }
 
-                let bind_pat_string = bind_pat.syntax().to_string();
-                if !bind_pat_string.contains("ref ") && !bind_pat_string.contains(" @ ") {
-                    self.is_pat_binding_and_path = true;
+                if parent.and_then(ast::RecordFieldPatList::cast).is_none() {
+                    let bind_pat_string = bind_pat.syntax().to_string();
+                    if !bind_pat_string.contains("ref ") && !bind_pat_string.contains(" @ ") {
+                        self.is_pat_binding_and_path = true;
+                    }
                 }
             }
             if is_node::<ast::Param>(name.syntax()) {

--- a/crates/ra_ide/src/completion/completion_context.rs
+++ b/crates/ra_ide/src/completion/completion_context.rs
@@ -197,11 +197,11 @@ impl<'a> CompletionContext<'a> {
                     self.is_pat_binding = true;
                 }
 
-                if parent.and_then(ast::RecordFieldPatList::cast).is_none() {
-                    let bind_pat_string = bind_pat.syntax().to_string();
-                    if !bind_pat_string.contains("ref ") && !bind_pat_string.contains(" @ ") {
-                        self.is_pat_binding_and_path = true;
-                    }
+                if parent.and_then(ast::RecordFieldPatList::cast).is_none()
+                    && bind_pat.pat().is_none()
+                    && !bind_pat.is_ref()
+                {
+                    self.is_pat_binding_and_path = true;
                 }
             }
             if is_node::<ast::Param>(name.syntax()) {


### PR DESCRIPTION
Iterate through TupleStructPat's until a MatchArm if
one exists. Store in a new is_pat_bind_and_path bool
and allow the `complete_scope` to find matches.

Added some tests to ensure it works in simple and nested cases.