### PR TITLE
Renames work on struct field shorthands

### DIFF
--- a/crates/ra_ide/src/references/rename.rs
+++ b/crates/ra_ide/src/references/rename.rs
@@ -382,6 +382,76 @@ mod tests {
     }
 
     #[test]
+    fn test_field_shorthand_correct_struct() {
+        test_rename(
+            r#"
+    struct Foo {
+        i<|>: i32,
+    }
+
+    struct Bar {
+        i: i32,
+    }
+
+    impl Bar {
+        fn new(i: i32) -> Self {
+            Self { i }
+        }
+    }
+    "#,
+            "j",
+            r#"
+    struct Foo {
+        j: i32,
+    }
+
+    struct Bar {
+        i: i32,
+    }
+
+    impl Bar {
+        fn new(i: i32) -> Self {
+            Self { i }
+        }
+    }
+    "#,
+        );
+    }
+
+    #[test]
+    fn test_shadow_local_for_struct_shorthand() {
+        test_rename(
+            r#"
+    struct Foo {
+        i: i32,
+    }
+
+    fn baz(i<|>: i32) -> Self {
+         let x = Foo { i };
+         {
+             let i = 0;
+             Foo { i }
+         }
+     }
+    "#,
+            "j",
+            r#"
+    struct Foo {
+        i: i32,
+    }
+
+    fn baz(j: i32) -> Self {
+         let x = Foo { i: j };
+         {
+             let i = 0;
+             Foo { i }
+         }
+     }
+    "#,
+        );
+    }
+
+    #[test]
     fn test_rename_mod() {
         let (analysis, position) = analysis_and_position(
             "

--- a/crates/ra_ide_db/src/search.rs
+++ b/crates/ra_ide_db/src/search.rs
@@ -256,21 +256,21 @@ impl Definition {
                             access: reference_access(&def, &name_ref),
                         });
                     }
-                    Some(NameRefClass::FieldShorthand { local, field: _ }) => {
-                        let kind = match self {
-                            Definition::StructField(_) => {
-                                ReferenceKind::StructFieldShorthandForField
-                            }
-                            Definition::Local(_) => ReferenceKind::StructFieldShorthandForLocal,
-                            _ => continue,
-                        };
+                    Some(NameRefClass::FieldShorthand { local, field }) => {
+                        match self {
+                            Definition::StructField(_) if &field == self => refs.push(Reference {
+                                file_range: sema.original_range(name_ref.syntax()),
+                                kind: ReferenceKind::StructFieldShorthandForField,
+                                access: reference_access(&field, &name_ref),
+                            }),
+                            Definition::Local(l) if &local == l => refs.push(Reference {
+                                file_range: sema.original_range(name_ref.syntax()),
+                                kind: ReferenceKind::StructFieldShorthandForLocal,
+                                access: reference_access(&Definition::Local(local), &name_ref),
+                            }),
 
-                        let file_range = sema.original_range(name_ref.syntax());
-                        refs.push(Reference {
-                            file_range,
-                            kind,
-                            access: reference_access(&Definition::Local(local), &name_ref),
-                        });
+                            _ => {} // not a usage
+                        };
                     }
                     _ => {} // not a usage
                 }


### PR DESCRIPTION
When renaming either a local or a struct field, struct field shorthands are now renamed correctly.

Happy to refactor this if it doesn't fit the design of the code. Thanks for adding the suggestion of where to start on the issue.

I wasn't sure if I should also look at the behavior of renaming when placing the cursor at the field shorthand; the following describes the behavior with this patch:

```rust
#[test]
fn test_rename_field_shorthand_for_unspecified() {
    // when renaming a shorthand, should we have a way to specify
    // between renaming the field and the local?
    //
    // If not is this the correct default?
    test_rename(
        r#"
struct Foo {
    i: i32,
}
 impl Foo {
    fn new(i: i32) -> Self {
        Self { i<|> }
    }
}
"#,
        "j",
        r#"
struct Foo {
    i: i32,
}
 impl Foo {
    fn new(j: i32) -> Self {
        Self { i: j }
    }
}
"#,
    );
}
```
Resolves #3431