### PR TITLE
Implement env! macro

### DIFF
--- a/crates/ra_db/src/fixture.rs
+++ b/crates/ra_db/src/fixture.rs
@@ -61,7 +61,14 @@ fn with_single_file(db: &mut dyn SourceDatabaseExt, ra_fixture: &str) -> FileId 
         };
 
         let mut crate_graph = CrateGraph::default();
-        crate_graph.add_crate_root(file_id, meta.edition, meta.krate, meta.cfg, meta.env);
+        crate_graph.add_crate_root(
+            file_id,
+            meta.edition,
+            meta.krate,
+            meta.cfg,
+            meta.env,
+            Default::default(),
+        );
         crate_graph
     } else {
         let mut crate_graph = CrateGraph::default();
@@ -71,6 +78,7 @@ fn with_single_file(db: &mut dyn SourceDatabaseExt, ra_fixture: &str) -> FileId 
             None,
             CfgOptions::default(),
             Env::default(),
+            Default::default(),
         );
         crate_graph
     };
@@ -119,6 +127,7 @@ fn with_files(db: &mut dyn SourceDatabaseExt, fixture: &str) -> Option<FilePosit
                 Some(krate.clone()),
                 meta.cfg,
                 meta.env,
+                Default::default(),
             );
             let prev = crates.insert(krate.clone(), crate_id);
             assert!(prev.is_none());
@@ -155,6 +164,7 @@ fn with_files(db: &mut dyn SourceDatabaseExt, fixture: &str) -> Option<FilePosit
             None,
             CfgOptions::default(),
             Env::default(),
+            Default::default(),
         );
     } else {
         for (from, to) in crate_deps {

--- a/crates/ra_db/src/lib.rs
+++ b/crates/ra_db/src/lib.rs
@@ -11,8 +11,8 @@ use ra_syntax::{ast, Parse, SourceFile, TextRange, TextUnit};
 pub use crate::{
     cancellation::Canceled,
     input::{
-        CrateGraph, CrateId, CrateName, Dependency, Edition, Env, ExternSourceId, FileId,
-        SourceRoot, SourceRootId,
+        CrateGraph, CrateId, CrateName, Dependency, Edition, Env, ExternSource, ExternSourceId,
+        FileId, SourceRoot, SourceRootId,
     },
 };
 pub use relative_path::{RelativePath, RelativePathBuf};

--- a/crates/ra_hir_def/src/test_db.rs
+++ b/crates/ra_hir_def/src/test_db.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use crate::db::DefDatabase;
-use ra_db::{salsa, CrateId, FileId, FileLoader, FileLoaderDelegate, RelativePath};
+use ra_db::{salsa, CrateId, ExternSourceId, FileId, FileLoader, FileLoaderDelegate, RelativePath};
 
 #[salsa::database(
     ra_db::SourceDatabaseExtStorage,
@@ -51,6 +51,14 @@ impl FileLoader for TestDB {
     }
     fn relevant_crates(&self, file_id: FileId) -> Arc<Vec<CrateId>> {
         FileLoaderDelegate(self).relevant_crates(file_id)
+    }
+
+    fn resolve_extern_path(
+        &self,
+        extern_id: ExternSourceId,
+        relative_path: &RelativePath,
+    ) -> Option<FileId> {
+        FileLoaderDelegate(self).resolve_extern_path(extern_id, relative_path)
     }
 }
 

--- a/crates/ra_hir_expand/src/builtin_macro.rs
+++ b/crates/ra_hir_expand/src/builtin_macro.rs
@@ -90,15 +90,15 @@ register_builtin! {
     (line, Line) => line_expand,
     (stringify, Stringify) => stringify_expand,
     (format_args, FormatArgs) => format_args_expand,
-    (env, Env) => env_expand,
-    (option_env, OptionEnv) => option_env_expand,
     // format_args_nl only differs in that it adds a newline in the end,
     // so we use the same stub expansion for now
     (format_args_nl, FormatArgsNl) => format_args_expand,
 
     EAGER:
     (concat, Concat) => concat_expand,
-    (include, Include) => include_expand
+    (include, Include) => include_expand,
+    (env, Env) => env_expand,
+    (option_env, OptionEnv) => option_env_expand
 }
 
 fn line_expand(
@@ -133,31 +133,6 @@ fn stringify_expand(
     let expanded = quote! {
         #macro_content
     };
-
-    Ok(expanded)
-}
-
-fn env_expand(
-    _db: &dyn AstDatabase,
-    _id: LazyMacroId,
-    _tt: &tt::Subtree,
-) -> Result<tt::Subtree, mbe::ExpandError> {
-    // dummy implementation for type-checking purposes
-    // we cannot use an empty string here, because for
-    // `include!(concat!(env!("OUT_DIR"), "/foo.rs"))` will become
-    // `include!("foo.rs"), which maybe infinite loop
-    let expanded = quote! { "__RA_UNIMPLEMENTATED__" };
-
-    Ok(expanded)
-}
-
-fn option_env_expand(
-    _db: &dyn AstDatabase,
-    _id: LazyMacroId,
-    _tt: &tt::Subtree,
-) -> Result<tt::Subtree, mbe::ExpandError> {
-    // dummy implementation for type-checking purposes
-    let expanded = quote! { std::option::Option::None::<&str> };
 
     Ok(expanded)
 }
@@ -278,14 +253,28 @@ fn concat_expand(
 
 fn relative_file(db: &dyn AstDatabase, call_id: MacroCallId, path: &str) -> Option<FileId> {
     let call_site = call_id.as_file().original_file(db);
-    let path = RelativePath::new(&path);
 
-    let res = db.resolve_relative_path(call_site, &path)?;
-    // Prevent include itself
-    if res == call_site {
-        return None;
+    // Handle trivial case
+    if let Some(res) = db.resolve_relative_path(call_site, &RelativePath::new(&path)) {
+        // Prevent include itself
+        return if res == call_site { None } else { Some(res) };
     }
-    Some(res)
+
+    // Extern paths ?
+    let krate = db.relevant_crates(call_site).get(0)?.clone();
+    let (extern_source_id, relative_file) = db.crate_graph()[krate].env.extern_path(path)?;
+
+    db.resolve_extern_path(extern_source_id, &relative_file)
+}
+
+fn parse_string(tt: &tt::Subtree) -> Result<String, mbe::ExpandError> {
+    tt.token_trees
+        .get(0)
+        .and_then(|tt| match tt {
+            tt::TokenTree::Leaf(tt::Leaf::Literal(it)) => unquote_str(&it),
+            _ => None,
+        })
+        .ok_or_else(|| mbe::ExpandError::ConversionError)
 }
 
 fn include_expand(
@@ -293,15 +282,7 @@ fn include_expand(
     arg_id: EagerMacroId,
     tt: &tt::Subtree,
 ) -> Result<(tt::Subtree, FragmentKind), mbe::ExpandError> {
-    let path = tt
-        .token_trees
-        .get(0)
-        .and_then(|tt| match tt {
-            tt::TokenTree::Leaf(tt::Leaf::Literal(it)) => unquote_str(&it),
-            _ => None,
-        })
-        .ok_or_else(|| mbe::ExpandError::ConversionError)?;
-
+    let path = parse_string(tt)?;
     let file_id =
         relative_file(db, arg_id.into(), &path).ok_or_else(|| mbe::ExpandError::ConversionError)?;
 
@@ -314,12 +295,58 @@ fn include_expand(
     Ok((res, FragmentKind::Items))
 }
 
+fn get_env_inner(db: &dyn AstDatabase, arg_id: EagerMacroId, key: &str) -> Option<String> {
+    let call_id: MacroCallId = arg_id.into();
+    let original_file = call_id.as_file().original_file(db);
+
+    let krate = db.relevant_crates(original_file).get(0)?.clone();
+    db.crate_graph()[krate].env.get(key)
+}
+
+fn env_expand(
+    db: &dyn AstDatabase,
+    arg_id: EagerMacroId,
+    tt: &tt::Subtree,
+) -> Result<(tt::Subtree, FragmentKind), mbe::ExpandError> {
+    let key = parse_string(tt)?;
+
+    // FIXME:
+    // If the environment variable is not defined int rustc, then a compilation error will be emitted.
+    // We might do the same if we fully support all other stuffs.
+    // But for now on, we should return some dummy string for better type infer purpose.
+    // However, we cannot use an empty string here, because for
+    // `include!(concat!(env!("OUT_DIR"), "/foo.rs"))` will become
+    // `include!("foo.rs"), which might go to infinite loop
+    let s = get_env_inner(db, arg_id, &key).unwrap_or("__RA_UNIMPLEMENTATED__".to_string());
+    let expanded = quote! { #s };
+
+    Ok((expanded, FragmentKind::Expr))
+}
+
+fn option_env_expand(
+    db: &dyn AstDatabase,
+    arg_id: EagerMacroId,
+    tt: &tt::Subtree,
+) -> Result<(tt::Subtree, FragmentKind), mbe::ExpandError> {
+    let key = parse_string(tt)?;
+    let expanded = match get_env_inner(db, arg_id, &key) {
+        None => quote! { std::option::Option::None::<&str> },
+        Some(s) => quote! { std::option::Some(#s) },
+    };
+
+    Ok((expanded, FragmentKind::Expr))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{name::AsName, test_db::TestDB, AstNode, MacroCallId, MacroCallKind, MacroCallLoc};
+    use crate::{
+        name::AsName, test_db::TestDB, AstNode, EagerCallLoc, MacroCallId, MacroCallKind,
+        MacroCallLoc,
+    };
     use ra_db::{fixture::WithFixture, SourceDatabase};
     use ra_syntax::ast::NameOwner;
+    use std::sync::Arc;
 
     fn expand_builtin_macro(ra_fixture: &str) -> String {
         let (db, file_id) = TestDB::with_single_file(&ra_fixture);
@@ -330,27 +357,61 @@ mod tests {
         let ast_id_map = db.ast_id_map(file_id.into());
 
         let expander = find_by_name(&macro_calls[0].name().unwrap().as_name()).unwrap();
-        let expander = expander.left().unwrap();
 
-        // the first one should be a macro_rules
-        let def = MacroDefId {
-            krate: Some(CrateId(0)),
-            ast_id: Some(AstId::new(file_id.into(), ast_id_map.ast_id(&macro_calls[0]))),
-            kind: MacroDefKind::BuiltIn(expander),
+        let file_id = match expander {
+            Either::Left(expander) => {
+                // the first one should be a macro_rules
+                let def = MacroDefId {
+                    krate: Some(CrateId(0)),
+                    ast_id: Some(AstId::new(file_id.into(), ast_id_map.ast_id(&macro_calls[0]))),
+                    kind: MacroDefKind::BuiltIn(expander),
+                };
+
+                let loc = MacroCallLoc {
+                    def,
+                    kind: MacroCallKind::FnLike(AstId::new(
+                        file_id.into(),
+                        ast_id_map.ast_id(&macro_calls[1]),
+                    )),
+                };
+
+                let id: MacroCallId = db.intern_macro(loc).into();
+                id.as_file()
+            }
+            Either::Right(expander) => {
+                // the first one should be a macro_rules
+                let def = MacroDefId {
+                    krate: Some(CrateId(0)),
+                    ast_id: Some(AstId::new(file_id.into(), ast_id_map.ast_id(&macro_calls[0]))),
+                    kind: MacroDefKind::BuiltInEager(expander),
+                };
+
+                let args = macro_calls[1].token_tree().unwrap();
+                let parsed_args = mbe::ast_to_token_tree(&args).unwrap().0;
+
+                let arg_id = db.intern_eager_expansion({
+                    EagerCallLoc {
+                        def,
+                        fragment: FragmentKind::Expr,
+                        subtree: Arc::new(parsed_args.clone()),
+                        file_id: file_id.into(),
+                    }
+                });
+
+                let (subtree, fragment) = expander.expand(&db, arg_id, &parsed_args).unwrap();
+                let eager = EagerCallLoc {
+                    def,
+                    fragment,
+                    subtree: Arc::new(subtree),
+                    file_id: file_id.into(),
+                };
+
+                let id: MacroCallId = db.intern_eager_expansion(eager.into()).into();
+                id.as_file()
+            }
         };
 
-        let loc = MacroCallLoc {
-            def,
-            kind: MacroCallKind::FnLike(AstId::new(
-                file_id.into(),
-                ast_id_map.ast_id(&macro_calls[1]),
-            )),
-        };
-
-        let id: MacroCallId = db.intern_macro(loc).into();
-        let parsed = db.parse_or_expand(id.as_file()).unwrap();
-
-        parsed.text().to_string()
+        db.parse_or_expand(file_id).unwrap().to_string()
     }
 
     #[test]

--- a/crates/ra_hir_expand/src/builtin_macro.rs
+++ b/crates/ra_hir_expand/src/builtin_macro.rs
@@ -262,7 +262,8 @@ fn relative_file(db: &dyn AstDatabase, call_id: MacroCallId, path: &str) -> Opti
 
     // Extern paths ?
     let krate = db.relevant_crates(call_site).get(0)?.clone();
-    let (extern_source_id, relative_file) = db.crate_graph()[krate].env.extern_path(path)?;
+    let (extern_source_id, relative_file) =
+        db.crate_graph()[krate].extern_source.extern_path(path)?;
 
     db.resolve_extern_path(extern_source_id, &relative_file)
 }

--- a/crates/ra_hir_expand/src/test_db.rs
+++ b/crates/ra_hir_expand/src/test_db.rs
@@ -5,7 +5,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use ra_db::{salsa, CrateId, FileId, FileLoader, FileLoaderDelegate, RelativePath};
+use ra_db::{salsa, CrateId, ExternSourceId, FileId, FileLoader, FileLoaderDelegate, RelativePath};
 
 #[salsa::database(
     ra_db::SourceDatabaseExtStorage,
@@ -50,5 +50,12 @@ impl FileLoader for TestDB {
     }
     fn relevant_crates(&self, file_id: FileId) -> Arc<Vec<CrateId>> {
         FileLoaderDelegate(self).relevant_crates(file_id)
+    }
+    fn resolve_extern_path(
+        &self,
+        anchor: ExternSourceId,
+        relative_path: &RelativePath,
+    ) -> Option<FileId> {
+        FileLoaderDelegate(self).resolve_extern_path(anchor, relative_path)
     }
 }

--- a/crates/ra_hir_ty/src/test_db.rs
+++ b/crates/ra_hir_ty/src/test_db.rs
@@ -67,6 +67,13 @@ impl FileLoader for TestDB {
     fn relevant_crates(&self, file_id: FileId) -> Arc<Vec<CrateId>> {
         FileLoaderDelegate(self).relevant_crates(file_id)
     }
+    fn resolve_extern_path(
+        &self,
+        extern_id: ra_db::ExternSourceId,
+        relative_path: &RelativePath,
+    ) -> Option<FileId> {
+        FileLoaderDelegate(self).resolve_extern_path(extern_id, relative_path)
+    }
 }
 
 impl TestDB {

--- a/crates/ra_hir_ty/src/tests/macros.rs
+++ b/crates/ra_hir_ty/src/tests/macros.rs
@@ -550,6 +550,26 @@ fn main() {
 }
 
 #[test]
+fn infer_builtin_macros_env() {
+    assert_snapshot!(
+        infer(r#"
+//- /main.rs env:foo=bar
+#[rustc_builtin_macro]
+macro_rules! env {() => {}}
+
+fn main() {
+    let x = env!("foo");
+}
+"#),
+        @r###"
+    ![0; 5) '"bar"': &str
+    [88; 116) '{     ...o"); }': ()
+    [98; 99) 'x': &str
+    "###
+    );
+}
+
+#[test]
 fn infer_derive_clone_simple() {
     let (db, pos) = TestDB::with_position(
         r#"

--- a/crates/ra_ide/src/lib.rs
+++ b/crates/ra_ide/src/lib.rs
@@ -217,6 +217,7 @@ impl Analysis {
             None,
             cfg_options,
             Env::default(),
+            Default::default(),
         );
         change.add_file(source_root, file_id, "main.rs".into(), Arc::new(text));
         change.set_crate_graph(crate_graph);

--- a/crates/ra_ide/src/mock_analysis.rs
+++ b/crates/ra_ide/src/mock_analysis.rs
@@ -102,6 +102,7 @@ impl MockAnalysis {
                     None,
                     cfg_options,
                     Env::default(),
+                    Default::default(),
                 ));
             } else if path.ends_with("/lib.rs") {
                 let crate_name = path.parent().unwrap().file_name().unwrap();
@@ -111,6 +112,7 @@ impl MockAnalysis {
                     Some(crate_name.to_owned()),
                     cfg_options,
                     Env::default(),
+                    Default::default(),
                 );
                 if let Some(root_crate) = root_crate {
                     crate_graph

--- a/crates/ra_ide/src/parent_module.rs
+++ b/crates/ra_ide/src/parent_module.rs
@@ -136,6 +136,7 @@ mod tests {
             None,
             CfgOptions::default(),
             Env::default(),
+            Default::default(),
         );
         let mut change = AnalysisChange::new();
         change.set_crate_graph(crate_graph);

--- a/crates/ra_ide_db/src/lib.rs
+++ b/crates/ra_ide_db/src/lib.rs
@@ -57,6 +57,13 @@ impl FileLoader for RootDatabase {
     fn relevant_crates(&self, file_id: FileId) -> Arc<Vec<CrateId>> {
         FileLoaderDelegate(self).relevant_crates(file_id)
     }
+    fn resolve_extern_path(
+        &self,
+        extern_id: ra_db::ExternSourceId,
+        relative_path: &RelativePath,
+    ) -> Option<FileId> {
+        FileLoaderDelegate(self).resolve_extern_path(extern_id, relative_path)
+    }
 }
 
 impl salsa::Database for RootDatabase {

--- a/crates/rust-analyzer/src/cli/load_cargo.rs
+++ b/crates/rust-analyzer/src/cli/load_cargo.rs
@@ -52,7 +52,10 @@ pub(crate) fn load_cargo(
         opts
     };
 
-    let crate_graph = ws.to_crate_graph(&default_cfg_options, &mut |path: &Path| {
+    // FIXME: outdirs?
+    let outdirs = FxHashMap::default();
+
+    let crate_graph = ws.to_crate_graph(&default_cfg_options, &outdirs, &mut |path: &Path| {
         let vfs_file = vfs.load(path);
         log::debug!("vfs file {:?} -> {:?}", path, vfs_file);
         vfs_file.map(vfs_file_to_id)

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -44,6 +44,9 @@ pub struct ServerConfig {
     /// Fine grained feature flags to disable specific features.
     pub feature_flags: FxHashMap<String, bool>,
 
+    /// Fine grained controls for additional `OUT_DIR` env variables
+    pub additional_out_dirs: FxHashMap<String, String>,
+
     pub rustfmt_args: Vec<String>,
 
     /// Cargo feature configurations.
@@ -64,6 +67,7 @@ impl Default for ServerConfig {
             cargo_watch_all_targets: true,
             with_sysroot: true,
             feature_flags: FxHashMap::default(),
+            additional_out_dirs: FxHashMap::default(),
             cargo_features: Default::default(),
             rustfmt_args: Vec::new(),
         }

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -195,6 +195,7 @@ pub fn main_loop(
             Watch(!config.use_client_watching),
             options,
             feature_flags,
+            config.additional_out_dirs,
         )
     };
 

--- a/crates/rust-analyzer/src/world.rs
+++ b/crates/rust-analyzer/src/world.rs
@@ -76,6 +76,7 @@ impl WorldState {
         watch: Watch,
         options: Options,
         feature_flags: FeatureFlags,
+        additional_out_dirs: FxHashMap<String, String>,
     ) -> WorldState {
         let mut change = AnalysisChange::new();
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -224,6 +224,11 @@
                     "default": true,
                     "description": "Whether to ask for permission before downloading any files from the Internet"
                 },
+                "rust-analyzer.additionalOutDirs": {
+                    "type": "object",
+                    "default": {},
+                    "markdownDescription": "Fine grained controls for OUT_DIR `env!(\"OUT_DIR\")` variable. e.g. `{\"foo\":\"/path/to/foo\"}`, "
+                },
                 "rust-analyzer.serverPath": {
                     "type": [
                         "null",

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -37,6 +37,7 @@ export async function createClient(config: Config, serverPath: string): Promise<
             excludeGlobs: config.excludeGlobs,
             useClientWatching: config.useClientWatching,
             featureFlags: config.featureFlags,
+            additionalOutDirs: config.additionalOutDirs,
             withSysroot: config.withSysroot,
             cargoFeatures: config.cargoFeatures,
             rustfmtArgs: config.rustfmtArgs,

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -154,6 +154,7 @@ export class Config {
     get excludeGlobs() { return this.cfg.get("excludeGlobs") as string[]; }
     get useClientWatching() { return this.cfg.get("useClientWatching") as boolean; }
     get featureFlags() { return this.cfg.get("featureFlags") as Record<string, boolean>; }
+    get additionalOutDirs() { return this.cfg.get("additionalOutDirs") as Record<string, string>; }
     get rustfmtArgs() { return this.cfg.get("rustfmtArgs") as string[]; }
 
     get cargoWatchOptions(): CargoWatchOptions {


### PR DESCRIPTION
This PR implements `env!` macro by adding following things:

1. Added `additional_outdirs` settings in vscode. (naming to be bikeshed)
2. Added `ExternSourceId` which is a wrapping for SourceRootId but only used in extern sources. It is because `OUT_DIR` is not belonged to any crate and we have to access it behind an `AstDatabase`.
3. This PR does not implement the `OUT_DIR` parsing from `cargo check`. I don't have general design about this,  @kiljacken could we reuse some cargo watch code for that ?

~~Block on [#3536]~~

PS: After this PR , we (kind of) completed the `include!(concat!(env!('OUT_DIR'),  "foo.rs")` macro call combo. [Exodia Obliterate!](https://www.youtube.com/watch?v=RfqNH3FoGi0)