### PR TITLE
Fix completion with a partially unknown type

### DIFF
--- a/crates/ra_ide/src/completion/complete_dot.rs
+++ b/crates/ra_ide/src/completion/complete_dot.rs
@@ -718,4 +718,35 @@ mod tests {
         "###
         );
     }
+
+    #[test]
+    fn test_method_completion_3547() {
+        assert_debug_snapshot!(
+            do_ref_completion(
+                r"
+            struct HashSet<T> {}
+            impl<T> HashSet<T> {
+                pub fn the_method(&self) {}
+            }
+            fn foo() {
+                let s: HashSet<_>;
+                s.<|>
+            }
+            ",
+            ),
+            @r###"
+        [
+            CompletionItem {
+                label: "the_method()",
+                source_range: [201; 201),
+                delete: [201; 201),
+                insert: "the_method()$0",
+                kind: Method,
+                lookup: "the_method",
+                detail: "pub fn the_method(&self)",
+            },
+        ]
+        "###
+        );
+    }
 }


### PR DESCRIPTION
To test whether the receiver type matches for the impl, we unify the given self
type (in this case `HashSet<{unknown}>`) with the self type of the
impl (`HashSet<?0>`), but if the given self type contains Unknowns, they won't
be unified with the variables in those places. So we got a receiver type that
was different from the expected one, and concluded the impl doesn't match.

The fix is slightly hacky; if after the unification, our variables are still
there, we make them fall back to Unknown. This does make some sense though,
since we don't want to 'leak' the variables.

Fixes #3547.