### PR TITLE
Completions do not show for function with same name as mod

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,6 +940,7 @@ dependencies = [
 name = "ra_hir"
 version = "0.1.0"
 dependencies = [
+ "arrayvec",
  "either",
  "itertools",
  "log",

--- a/crates/ra_hir/Cargo.toml
+++ b/crates/ra_hir/Cargo.toml
@@ -11,6 +11,7 @@ doctest = false
 log = "0.4.8"
 rustc-hash = "1.1.0"
 either = "1.5.3"
+arrayvec = "0.5.1"
 
 itertools = "0.8.2"
 

--- a/crates/ra_hir/src/semantics.rs
+++ b/crates/ra_hir/src/semantics.rs
@@ -344,7 +344,13 @@ impl<'a, DB: HirDatabase> SemanticsScope<'a, DB> {
 
         resolver.process_all_names(self.db, &mut |name, def| {
             let def = match def {
-                resolver::ScopeDef::PerNs(it) => it.into(),
+                resolver::ScopeDef::PerNs(it) => {
+                    let items = ScopeDef::all_items(it);
+                    for item in items {
+                        f(name.clone(), item);
+                    }
+                    return
+                },
                 resolver::ScopeDef::ImplSelfType(it) => ScopeDef::ImplSelfType(it.into()),
                 resolver::ScopeDef::AdtSelfType(it) => ScopeDef::AdtSelfType(it.into()),
                 resolver::ScopeDef::GenericParam(id) => ScopeDef::GenericParam(TypeParam { id }),

--- a/crates/ra_hir_def/src/nameres/tests.rs
+++ b/crates/ra_hir_def/src/nameres/tests.rs
@@ -102,6 +102,28 @@ fn crate_def_map_super_super() {
 }
 
 #[test]
+fn crate_def_map_fn_mod_same_name() {
+    let map = def_map(
+        "
+        //- /lib.rs
+        mod m {
+            pub mod z {}
+            pub fn z() {}
+        }
+        ",
+    );
+    assert_snapshot!(map, @r###"
+        ⋮crate
+        ⋮m: t
+        ⋮
+        ⋮crate::m
+        ⋮z: t v
+        ⋮
+        ⋮crate::m::z
+    "###)
+}
+
+#[test]
 fn bogus_paths() {
     covers!(bogus_paths);
     let map = def_map(

--- a/crates/ra_ide/src/completion/complete_path.rs
+++ b/crates/ra_ide/src/completion/complete_path.rs
@@ -967,4 +967,43 @@ mod tests {
         ]
         "###);
     }
+
+    #[test]
+    fn function_mod_share_name() {
+        assert_debug_snapshot!(
+        do_reference_completion(
+                r"
+                fn foo() {
+                    self::m::<|>
+                }
+
+                mod m {
+                    pub mod z {}
+                    pub fn z() {}
+                }
+                ",
+        ),
+            @r###"
+        [
+            CompletionItem {
+                label: "z",
+                source_range: [57; 57),
+                delete: [57; 57),
+                insert: "z",
+                kind: Module,
+            },
+            CompletionItem {
+                label: "z()",
+                source_range: [57; 57),
+                delete: [57; 57),
+                insert: "z()$0",
+                kind: Function,
+                lookup: "z",
+                detail: "pub fn z()",
+            },
+        ]
+        "###
+        );
+    }
+
 }


### PR DESCRIPTION
fixes #3444 

I've added a test case in `crates/ra_ide/src/completion/complete_path.rs` which verifies the described behavior in #3444. Digging in, I found that [the module scope iterator](https://github.com/JoshMcguigan/rust-analyzer/blob/ba62d8bd1ce8a68b8d21aaf89ae1ea6787f18366/crates/ra_ide/src/completion/complete_path.rs#L22) only provides the module `z`, and does not provide the function `z` (although if I name the function something else then it does show up here). 

I thought perhaps the name wasn't being properly resolved, but I added a test in `crates/ra_hir_def/src/nameres/tests.rs` which seems to suggest that it is? I've tried to figure out how to bridge the gap between these two tests (one passing, one failing) to see where the function `z` is being dropped, but to this point I haven't been able to track it down.

Any pointers on where I might look for this? 