### PR TITLE
settings: rust-analyzer.cargo-watch.enable: clarify that the setting …

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -261,7 +261,7 @@
                 "rust-analyzer.cargo-watch.enable": {
                     "type": "boolean",
                     "default": true,
-                    "markdownDescription": "Run `cargo check` for diagnostics on save"
+                    "markdownDescription": "Run specified `cargo-watch` command for diagnostics on save"
                 },
                 "rust-analyzer.cargo-watch.arguments": {
                     "type": "array",


### PR DESCRIPTION
…enables the cargo-watch command and not "cargo check"