### PR TITLE
Implement builtin assert! macro

### DIFF
--- a/crates/ra_hir_expand/src/builtin_macro.rs
+++ b/crates/ra_hir_expand/src/builtin_macro.rs
@@ -158,9 +158,9 @@ fn assert_expand(
     tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     // A hacky implementation for goto def and hover
-    // We expand `assert!("", arg1, arg2)` to
+    // We expand `assert!(cond, arg1, arg2)` to
     // ```
-    // {(&(arg1), &(arg2));}
+    // {(cond, &(arg1), &(arg2));}
     // ```,
     // which is wrong but useful.
 
@@ -539,8 +539,8 @@ mod tests {
             r#"
             #[rustc_builtin_macro]
             macro_rules! assert {
-                ($fmt:expr) => ({ /* compiler built-in */ });
-                ($fmt:expr, $($args:tt)*) => ({ /* compiler built-in */ })
+                ($cond:expr) => ({ /* compiler built-in */ });
+                ($cond:expr, $($args:tt)*) => ({ /* compiler built-in */ })
             }
             assert!(true, "{} {:?}", arg1(a, b, c), arg2);
             "#,

--- a/crates/ra_hir_expand/src/builtin_macro.rs
+++ b/crates/ra_hir_expand/src/builtin_macro.rs
@@ -88,6 +88,7 @@ register_builtin! {
     (compile_error, CompileError) => compile_error_expand,
     (file, File) => file_expand,
     (line, Line) => line_expand,
+    (assert, Assert) => assert_expand,
     (stringify, Stringify) => stringify_expand,
     (format_args, FormatArgs) => format_args_expand,
     // format_args_nl only differs in that it adds a newline in the end,
@@ -148,6 +149,45 @@ fn column_expand(
         #col_num
     };
 
+    Ok(expanded)
+}
+
+fn assert_expand(
+    _db: &dyn AstDatabase,
+    _id: LazyMacroId,
+    tt: &tt::Subtree,
+) -> Result<tt::Subtree, mbe::ExpandError> {
+    // A hacky implementation for goto def and hover
+    // We expand `assert!("", arg1, arg2)` to
+    // ```
+    // {(&(arg1), &(arg2));}
+    // ```,
+    // which is wrong but useful.
+
+    let mut args = Vec::new();
+    let mut current = Vec::new();
+    for tt in tt.token_trees.iter().cloned() {
+        match tt {
+            tt::TokenTree::Leaf(tt::Leaf::Punct(p)) if p.char == ',' => {
+                args.push(current);
+                current = Vec::new();
+            }
+            _ => {
+                current.push(tt);
+            }
+        }
+    }
+    if !current.is_empty() {
+        args.push(current);
+    }
+
+    let arg_tts = args.into_iter().flat_map(|arg| {
+        quote! { &(##arg), }
+    }.token_trees).collect::<Vec<_>>();
+
+    let expanded = quote! {
+        { { (##arg_tts); } }
+    };
     Ok(expanded)
 }
 
@@ -491,6 +531,22 @@ mod tests {
         );
 
         assert_eq!(expanded, "\"\"");
+    }
+
+    #[test]
+    fn test_assert_expand() {
+        let expanded = expand_builtin_macro(
+            r#"
+            #[rustc_builtin_macro]
+            macro_rules! assert {
+                ($fmt:expr) => ({ /* compiler built-in */ });
+                ($fmt:expr, $($args:tt)*) => ({ /* compiler built-in */ })
+            }
+            assert!(true, "{} {:?}", arg1(a, b, c), arg2);
+            "#,
+        );
+
+        assert_eq!(expanded, "{{(&(true), &(\"{} {:?}\"), &(arg1(a,b,c)), &(arg2),);}}");
     }
 
     #[test]

--- a/crates/ra_hir_expand/src/name.rs
+++ b/crates/ra_hir_expand/src/name.rs
@@ -172,6 +172,7 @@ pub mod known {
         column,
         compile_error,
         line,
+        assert,
         stringify,
         concat,
         include,

--- a/crates/ra_hir_expand/src/quote.rs
+++ b/crates/ra_hir_expand/src/quote.rs
@@ -99,6 +99,7 @@ macro_rules! __quote {
     ( & ) => {$crate::__quote!(@PUNCT '&')};
     ( , ) => {$crate::__quote!(@PUNCT ',')};
     ( : ) => {$crate::__quote!(@PUNCT ':')};
+    ( ; ) => {$crate::__quote!(@PUNCT ';')};
     ( :: ) => {$crate::__quote!(@PUNCT ':', ':')};
     ( . ) => {$crate::__quote!(@PUNCT '.')};
     ( < ) => {$crate::__quote!(@PUNCT '<')};

--- a/crates/ra_ide/src/hover.rs
+++ b/crates/ra_ide/src/hover.rs
@@ -838,14 +838,10 @@ fn func(foo: i32) { if true { <|>foo; }; }
             r#"
             //- /lib.rs
             #[rustc_builtin_macro]
-            macro_rules! assert {
-                ($cond:expr) => {{ /* compiler built-in */ }};
-                ($cond:expr,) => {{ /* compiler built-in */ }};
-                ($cond:expr, $($arg:tt)+) => {{ /* compiler built-in */ }};
-            }
+            macro_rules! format {}
 
             fn foo() {
-                assert!("hel<|>lo");
+                format!("hel<|>lo {}", 0);
             }
             "#,
         );

--- a/crates/ra_ide/src/hover.rs
+++ b/crates/ra_ide/src/hover.rs
@@ -833,6 +833,25 @@ fn func(foo: i32) { if true { <|>foo; }; }
     }
 
     #[test]
+    fn test_hover_through_assert_macro() {
+        let hover_on = check_hover_result(
+            r#"
+            //- /lib.rs
+            #[rustc_builtin_macro]
+            macro_rules! assert {}
+
+            fn bar() -> bool { true }
+            fn foo() {
+                assert!(ba<|>r());
+            }
+            "#,
+            &["fn bar() -> bool"],
+        );
+
+        assert_eq!(hover_on, "bar");
+    }
+
+    #[test]
     fn test_hover_through_literal_string_in_builtin_macro() {
         check_hover_no_result(
             r#"


### PR DESCRIPTION
This PR add a dummy implementation for `assert!` macro, which mainly make `hover` and `goto-def` works on arguments inside it.