### PR TITLE
Better handling of a few kinds of cargo/clippy diagnostics

### DIFF
--- a/crates/ra_cargo_watch/src/conv/snapshots/ra_cargo_watch__conv__test__snap_clippy_pass_by_ref.snap
+++ b/crates/ra_cargo_watch/src/conv/snapshots/ra_cargo_watch__conv__test__snap_clippy_pass_by_ref.snap
@@ -2,98 +2,100 @@
 source: crates/ra_cargo_watch/src/conv/test.rs
 expression: diag
 ---
-MappedRustDiagnostic {
-    location: Location {
-        uri: "file:///test/compiler/mir/tagset.rs",
-        range: Range {
-            start: Position {
-                line: 41,
-                character: 23,
-            },
-            end: Position {
-                line: 41,
-                character: 28,
-            },
-        },
-    },
-    diagnostic: Diagnostic {
-        range: Range {
-            start: Position {
-                line: 41,
-                character: 23,
-            },
-            end: Position {
-                line: 41,
-                character: 28,
-            },
-        },
-        severity: Some(
-            Warning,
-        ),
-        code: Some(
-            String(
-                "trivially_copy_pass_by_ref",
-            ),
-        ),
-        source: Some(
-            "clippy",
-        ),
-        message: "this argument is passed by reference, but would be more efficient if passed by value\n#[warn(clippy::trivially_copy_pass_by_ref)] implied by #[warn(clippy::all)]\nfor further information visit https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref",
-        related_information: Some(
-            [
-                DiagnosticRelatedInformation {
-                    location: Location {
-                        uri: "file:///test/compiler/lib.rs",
-                        range: Range {
-                            start: Position {
-                                line: 0,
-                                character: 8,
-                            },
-                            end: Position {
-                                line: 0,
-                                character: 19,
-                            },
-                        },
-                    },
-                    message: "lint level defined here",
+[
+    MappedRustDiagnostic {
+        location: Location {
+            uri: "file:///test/compiler/mir/tagset.rs",
+            range: Range {
+                start: Position {
+                    line: 41,
+                    character: 23,
                 },
-            ],
-        ),
-        tags: None,
-    },
-    fixes: [
-        CodeAction {
-            title: "consider passing by value instead",
-            kind: Some(
-                "quickfix",
+                end: Position {
+                    line: 41,
+                    character: 28,
+                },
+            },
+        },
+        diagnostic: Diagnostic {
+            range: Range {
+                start: Position {
+                    line: 41,
+                    character: 23,
+                },
+                end: Position {
+                    line: 41,
+                    character: 28,
+                },
+            },
+            severity: Some(
+                Warning,
             ),
-            diagnostics: None,
-            edit: Some(
-                WorkspaceEdit {
-                    changes: Some(
-                        {
-                            "file:///test/compiler/mir/tagset.rs": [
-                                TextEdit {
-                                    range: Range {
-                                        start: Position {
-                                            line: 41,
-                                            character: 23,
-                                        },
-                                        end: Position {
-                                            line: 41,
-                                            character: 28,
-                                        },
-                                    },
-                                    new_text: "self",
+            code: Some(
+                String(
+                    "trivially_copy_pass_by_ref",
+                ),
+            ),
+            source: Some(
+                "clippy",
+            ),
+            message: "this argument is passed by reference, but would be more efficient if passed by value\n#[warn(clippy::trivially_copy_pass_by_ref)] implied by #[warn(clippy::all)]\nfor further information visit https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref",
+            related_information: Some(
+                [
+                    DiagnosticRelatedInformation {
+                        location: Location {
+                            uri: "file:///test/compiler/lib.rs",
+                            range: Range {
+                                start: Position {
+                                    line: 0,
+                                    character: 8,
                                 },
-                            ],
+                                end: Position {
+                                    line: 0,
+                                    character: 19,
+                                },
+                            },
                         },
-                    ),
-                    document_changes: None,
-                },
+                        message: "lint level defined here",
+                    },
+                ],
             ),
-            command: None,
-            is_preferred: None,
+            tags: None,
         },
-    ],
-}
+        fixes: [
+            CodeAction {
+                title: "consider passing by value instead",
+                kind: Some(
+                    "quickfix",
+                ),
+                diagnostics: None,
+                edit: Some(
+                    WorkspaceEdit {
+                        changes: Some(
+                            {
+                                "file:///test/compiler/mir/tagset.rs": [
+                                    TextEdit {
+                                        range: Range {
+                                            start: Position {
+                                                line: 41,
+                                                character: 23,
+                                            },
+                                            end: Position {
+                                                line: 41,
+                                                character: 28,
+                                            },
+                                        },
+                                        new_text: "self",
+                                    },
+                                ],
+                            },
+                        ),
+                        document_changes: None,
+                    },
+                ),
+                command: None,
+                is_preferred: None,
+            },
+        ],
+    },
+]

--- a/crates/ra_cargo_watch/src/conv/snapshots/ra_cargo_watch__conv__test__snap_handles_macro_location.snap
+++ b/crates/ra_cargo_watch/src/conv/snapshots/ra_cargo_watch__conv__test__snap_handles_macro_location.snap
@@ -2,45 +2,47 @@
 source: crates/ra_cargo_watch/src/conv/test.rs
 expression: diag
 ---
-MappedRustDiagnostic {
-    location: Location {
-        uri: "file:///test/src/main.rs",
-        range: Range {
-            start: Position {
-                line: 1,
-                character: 4,
-            },
-            end: Position {
-                line: 1,
-                character: 26,
-            },
-        },
-    },
-    diagnostic: Diagnostic {
-        range: Range {
-            start: Position {
-                line: 1,
-                character: 4,
-            },
-            end: Position {
-                line: 1,
-                character: 26,
+[
+    MappedRustDiagnostic {
+        location: Location {
+            uri: "file:///test/src/main.rs",
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 4,
+                },
+                end: Position {
+                    line: 1,
+                    character: 26,
+                },
             },
         },
-        severity: Some(
-            Error,
-        ),
-        code: Some(
-            String(
-                "E0277",
+        diagnostic: Diagnostic {
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 4,
+                },
+                end: Position {
+                    line: 1,
+                    character: 26,
+                },
+            },
+            severity: Some(
+                Error,
             ),
-        ),
-        source: Some(
-            "rustc",
-        ),
-        message: "can\'t compare `{integer}` with `&str`\nthe trait `std::cmp::PartialEq<&str>` is not implemented for `{integer}`",
-        related_information: None,
-        tags: None,
+            code: Some(
+                String(
+                    "E0277",
+                ),
+            ),
+            source: Some(
+                "rustc",
+            ),
+            message: "can\'t compare `{integer}` with `&str`\nthe trait `std::cmp::PartialEq<&str>` is not implemented for `{integer}`",
+            related_information: None,
+            tags: None,
+        },
+        fixes: [],
     },
-    fixes: [],
-}
+]

--- a/crates/ra_cargo_watch/src/conv/snapshots/ra_cargo_watch__conv__test__snap_macro_compiler_error.snap
+++ b/crates/ra_cargo_watch/src/conv/snapshots/ra_cargo_watch__conv__test__snap_macro_compiler_error.snap
@@ -2,60 +2,62 @@
 source: crates/ra_cargo_watch/src/conv/test.rs
 expression: diag
 ---
-MappedRustDiagnostic {
-    location: Location {
-        uri: "file:///test/crates/ra_hir_def/src/data.rs",
-        range: Range {
-            start: Position {
-                line: 79,
-                character: 15,
-            },
-            end: Position {
-                line: 79,
-                character: 41,
-            },
-        },
-    },
-    diagnostic: Diagnostic {
-        range: Range {
-            start: Position {
-                line: 79,
-                character: 15,
-            },
-            end: Position {
-                line: 79,
-                character: 41,
+[
+    MappedRustDiagnostic {
+        location: Location {
+            uri: "file:///test/crates/ra_hir_def/src/data.rs",
+            range: Range {
+                start: Position {
+                    line: 79,
+                    character: 15,
+                },
+                end: Position {
+                    line: 79,
+                    character: 41,
+                },
             },
         },
-        severity: Some(
-            Error,
-        ),
-        code: None,
-        source: Some(
-            "rustc",
-        ),
-        message: "Please register your known path in the path module",
-        related_information: Some(
-            [
-                DiagnosticRelatedInformation {
-                    location: Location {
-                        uri: "file:///test/crates/ra_hir_def/src/path.rs",
-                        range: Range {
-                            start: Position {
-                                line: 264,
-                                character: 8,
-                            },
-                            end: Position {
-                                line: 264,
-                                character: 76,
+        diagnostic: Diagnostic {
+            range: Range {
+                start: Position {
+                    line: 79,
+                    character: 15,
+                },
+                end: Position {
+                    line: 79,
+                    character: 41,
+                },
+            },
+            severity: Some(
+                Error,
+            ),
+            code: None,
+            source: Some(
+                "rustc",
+            ),
+            message: "Please register your known path in the path module",
+            related_information: Some(
+                [
+                    DiagnosticRelatedInformation {
+                        location: Location {
+                            uri: "file:///test/crates/ra_hir_def/src/path.rs",
+                            range: Range {
+                                start: Position {
+                                    line: 264,
+                                    character: 8,
+                                },
+                                end: Position {
+                                    line: 264,
+                                    character: 76,
+                                },
                             },
                         },
+                        message: "Error originated from macro here",
                     },
-                    message: "Error originated from macro here",
-                },
-            ],
-        ),
-        tags: None,
+                ],
+            ),
+            tags: None,
+        },
+        fixes: [],
     },
-    fixes: [],
-}
+]

--- a/crates/ra_cargo_watch/src/conv/snapshots/ra_cargo_watch__conv__test__snap_multi_line_fix.snap
+++ b/crates/ra_cargo_watch/src/conv/snapshots/ra_cargo_watch__conv__test__snap_multi_line_fix.snap
@@ -2,111 +2,113 @@
 source: crates/ra_cargo_watch/src/conv/test.rs
 expression: diag
 ---
-MappedRustDiagnostic {
-    location: Location {
-        uri: "file:///test/src/main.rs",
-        range: Range {
-            start: Position {
-                line: 3,
-                character: 4,
-            },
-            end: Position {
-                line: 3,
-                character: 5,
-            },
-        },
-    },
-    diagnostic: Diagnostic {
-        range: Range {
-            start: Position {
-                line: 3,
-                character: 4,
-            },
-            end: Position {
-                line: 3,
-                character: 5,
+[
+    MappedRustDiagnostic {
+        location: Location {
+            uri: "file:///test/src/main.rs",
+            range: Range {
+                start: Position {
+                    line: 3,
+                    character: 4,
+                },
+                end: Position {
+                    line: 3,
+                    character: 5,
+                },
             },
         },
-        severity: Some(
-            Warning,
-        ),
-        code: Some(
-            String(
-                "let_and_return",
+        diagnostic: Diagnostic {
+            range: Range {
+                start: Position {
+                    line: 3,
+                    character: 4,
+                },
+                end: Position {
+                    line: 3,
+                    character: 5,
+                },
+            },
+            severity: Some(
+                Warning,
             ),
-        ),
-        source: Some(
-            "clippy",
-        ),
-        message: "returning the result of a let binding from a block\n`#[warn(clippy::let_and_return)]` on by default\nfor further information visit https://rust-lang.github.io/rust-clippy/master/index.html#let_and_return",
-        related_information: Some(
-            [
-                DiagnosticRelatedInformation {
-                    location: Location {
-                        uri: "file:///test/src/main.rs",
-                        range: Range {
-                            start: Position {
-                                line: 2,
-                                character: 4,
-                            },
-                            end: Position {
-                                line: 2,
-                                character: 30,
+            code: Some(
+                String(
+                    "let_and_return",
+                ),
+            ),
+            source: Some(
+                "clippy",
+            ),
+            message: "returning the result of a let binding from a block\n`#[warn(clippy::let_and_return)]` on by default\nfor further information visit https://rust-lang.github.io/rust-clippy/master/index.html#let_and_return",
+            related_information: Some(
+                [
+                    DiagnosticRelatedInformation {
+                        location: Location {
+                            uri: "file:///test/src/main.rs",
+                            range: Range {
+                                start: Position {
+                                    line: 2,
+                                    character: 4,
+                                },
+                                end: Position {
+                                    line: 2,
+                                    character: 30,
+                                },
                             },
                         },
+                        message: "unnecessary let binding",
                     },
-                    message: "unnecessary let binding",
-                },
-            ],
-        ),
-        tags: None,
-    },
-    fixes: [
-        CodeAction {
-            title: "return the expression directly",
-            kind: Some(
-                "quickfix",
+                ],
             ),
-            diagnostics: None,
-            edit: Some(
-                WorkspaceEdit {
-                    changes: Some(
-                        {
-                            "file:///test/src/main.rs": [
-                                TextEdit {
-                                    range: Range {
-                                        start: Position {
-                                            line: 2,
-                                            character: 4,
-                                        },
-                                        end: Position {
-                                            line: 2,
-                                            character: 30,
-                                        },
-                                    },
-                                    new_text: "",
-                                },
-                                TextEdit {
-                                    range: Range {
-                                        start: Position {
-                                            line: 3,
-                                            character: 4,
-                                        },
-                                        end: Position {
-                                            line: 3,
-                                            character: 5,
-                                        },
-                                    },
-                                    new_text: "(0..10).collect()",
-                                },
-                            ],
-                        },
-                    ),
-                    document_changes: None,
-                },
-            ),
-            command: None,
-            is_preferred: None,
+            tags: None,
         },
-    ],
-}
+        fixes: [
+            CodeAction {
+                title: "return the expression directly",
+                kind: Some(
+                    "quickfix",
+                ),
+                diagnostics: None,
+                edit: Some(
+                    WorkspaceEdit {
+                        changes: Some(
+                            {
+                                "file:///test/src/main.rs": [
+                                    TextEdit {
+                                        range: Range {
+                                            start: Position {
+                                                line: 2,
+                                                character: 4,
+                                            },
+                                            end: Position {
+                                                line: 2,
+                                                character: 30,
+                                            },
+                                        },
+                                        new_text: "",
+                                    },
+                                    TextEdit {
+                                        range: Range {
+                                            start: Position {
+                                                line: 3,
+                                                character: 4,
+                                            },
+                                            end: Position {
+                                                line: 3,
+                                                character: 5,
+                                            },
+                                        },
+                                        new_text: "(0..10).collect()",
+                                    },
+                                ],
+                            },
+                        ),
+                        document_changes: None,
+                    },
+                ),
+                command: None,
+                is_preferred: None,
+            },
+        ],
+    },
+]

--- a/crates/ra_cargo_watch/src/conv/snapshots/ra_cargo_watch__conv__test__snap_multi_line_fix.snap
+++ b/crates/ra_cargo_watch/src/conv/snapshots/ra_cargo_watch__conv__test__snap_multi_line_fix.snap
@@ -4,27 +4,27 @@ expression: diag
 ---
 MappedRustDiagnostic {
     location: Location {
-        uri: "file:///test/compiler/mir/tagset.rs",
+        uri: "file:///test/src/main.rs",
         range: Range {
             start: Position {
-                line: 41,
-                character: 23,
+                line: 3,
+                character: 4,
             },
             end: Position {
-                line: 41,
-                character: 28,
+                line: 3,
+                character: 5,
             },
         },
     },
     diagnostic: Diagnostic {
         range: Range {
             start: Position {
-                line: 41,
-                character: 23,
+                line: 3,
+                character: 4,
             },
             end: Position {
-                line: 41,
-                character: 28,
+                line: 3,
+                character: 5,
             },
         },
         severity: Some(
@@ -32,30 +32,30 @@ MappedRustDiagnostic {
         ),
         code: Some(
             String(
-                "trivially_copy_pass_by_ref",
+                "let_and_return",
             ),
         ),
         source: Some(
             "clippy",
         ),
-        message: "this argument is passed by reference, but would be more efficient if passed by value\n#[warn(clippy::trivially_copy_pass_by_ref)] implied by #[warn(clippy::all)]\nfor further information visit https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref",
+        message: "returning the result of a let binding from a block\n`#[warn(clippy::let_and_return)]` on by default\nfor further information visit https://rust-lang.github.io/rust-clippy/master/index.html#let_and_return",
         related_information: Some(
             [
                 DiagnosticRelatedInformation {
                     location: Location {
-                        uri: "file:///test/compiler/lib.rs",
+                        uri: "file:///test/src/main.rs",
                         range: Range {
                             start: Position {
-                                line: 0,
-                                character: 8,
+                                line: 2,
+                                character: 4,
                             },
                             end: Position {
-                                line: 0,
-                                character: 19,
+                                line: 2,
+                                character: 30,
                             },
                         },
                     },
-                    message: "lint level defined here",
+                    message: "unnecessary let binding",
                 },
             ],
         ),
@@ -63,7 +63,7 @@ MappedRustDiagnostic {
     },
     fixes: [
         CodeAction {
-            title: "consider passing by value instead",
+            title: "return the expression directly",
             kind: Some(
                 "quickfix",
             ),
@@ -72,19 +72,32 @@ MappedRustDiagnostic {
                 WorkspaceEdit {
                     changes: Some(
                         {
-                            "file:///test/compiler/mir/tagset.rs": [
+                            "file:///test/src/main.rs": [
                                 TextEdit {
                                     range: Range {
                                         start: Position {
-                                            line: 41,
-                                            character: 23,
+                                            line: 2,
+                                            character: 4,
                                         },
                                         end: Position {
-                                            line: 41,
-                                            character: 28,
+                                            line: 2,
+                                            character: 30,
                                         },
                                     },
-                                    new_text: "self",
+                                    new_text: "",
+                                },
+                                TextEdit {
+                                    range: Range {
+                                        start: Position {
+                                            line: 3,
+                                            character: 4,
+                                        },
+                                        end: Position {
+                                            line: 3,
+                                            character: 5,
+                                        },
+                                    },
+                                    new_text: "(0..10).collect()",
                                 },
                             ],
                         },

--- a/crates/ra_cargo_watch/src/conv/snapshots/ra_cargo_watch__conv__test__snap_rustc_incompatible_type_for_trait.snap
+++ b/crates/ra_cargo_watch/src/conv/snapshots/ra_cargo_watch__conv__test__snap_rustc_incompatible_type_for_trait.snap
@@ -2,45 +2,47 @@
 source: crates/ra_cargo_watch/src/conv/test.rs
 expression: diag
 ---
-MappedRustDiagnostic {
-    location: Location {
-        uri: "file:///test/compiler/ty/list_iter.rs",
-        range: Range {
-            start: Position {
-                line: 51,
-                character: 4,
-            },
-            end: Position {
-                line: 51,
-                character: 47,
-            },
-        },
-    },
-    diagnostic: Diagnostic {
-        range: Range {
-            start: Position {
-                line: 51,
-                character: 4,
-            },
-            end: Position {
-                line: 51,
-                character: 47,
+[
+    MappedRustDiagnostic {
+        location: Location {
+            uri: "file:///test/compiler/ty/list_iter.rs",
+            range: Range {
+                start: Position {
+                    line: 51,
+                    character: 4,
+                },
+                end: Position {
+                    line: 51,
+                    character: 47,
+                },
             },
         },
-        severity: Some(
-            Error,
-        ),
-        code: Some(
-            String(
-                "E0053",
+        diagnostic: Diagnostic {
+            range: Range {
+                start: Position {
+                    line: 51,
+                    character: 4,
+                },
+                end: Position {
+                    line: 51,
+                    character: 47,
+                },
+            },
+            severity: Some(
+                Error,
             ),
-        ),
-        source: Some(
-            "rustc",
-        ),
-        message: "method `next` has an incompatible type for trait\nexpected type `fn(&mut ty::list_iter::ListIterator<\'list, M>) -> std::option::Option<&ty::Ref<M>>`\n   found type `fn(&ty::list_iter::ListIterator<\'list, M>) -> std::option::Option<&\'list ty::Ref<M>>`",
-        related_information: None,
-        tags: None,
+            code: Some(
+                String(
+                    "E0053",
+                ),
+            ),
+            source: Some(
+                "rustc",
+            ),
+            message: "method `next` has an incompatible type for trait\nexpected type `fn(&mut ty::list_iter::ListIterator<\'list, M>) -> std::option::Option<&ty::Ref<M>>`\n   found type `fn(&ty::list_iter::ListIterator<\'list, M>) -> std::option::Option<&\'list ty::Ref<M>>`",
+            related_information: None,
+            tags: None,
+        },
+        fixes: [],
     },
-    fixes: [],
-}
+]

--- a/crates/ra_cargo_watch/src/conv/snapshots/ra_cargo_watch__conv__test__snap_rustc_mismatched_type.snap
+++ b/crates/ra_cargo_watch/src/conv/snapshots/ra_cargo_watch__conv__test__snap_rustc_mismatched_type.snap
@@ -2,45 +2,47 @@
 source: crates/ra_cargo_watch/src/conv/test.rs
 expression: diag
 ---
-MappedRustDiagnostic {
-    location: Location {
-        uri: "file:///test/runtime/compiler_support.rs",
-        range: Range {
-            start: Position {
-                line: 47,
-                character: 64,
-            },
-            end: Position {
-                line: 47,
-                character: 69,
-            },
-        },
-    },
-    diagnostic: Diagnostic {
-        range: Range {
-            start: Position {
-                line: 47,
-                character: 64,
-            },
-            end: Position {
-                line: 47,
-                character: 69,
+[
+    MappedRustDiagnostic {
+        location: Location {
+            uri: "file:///test/runtime/compiler_support.rs",
+            range: Range {
+                start: Position {
+                    line: 47,
+                    character: 64,
+                },
+                end: Position {
+                    line: 47,
+                    character: 69,
+                },
             },
         },
-        severity: Some(
-            Error,
-        ),
-        code: Some(
-            String(
-                "E0308",
+        diagnostic: Diagnostic {
+            range: Range {
+                start: Position {
+                    line: 47,
+                    character: 64,
+                },
+                end: Position {
+                    line: 47,
+                    character: 69,
+                },
+            },
+            severity: Some(
+                Error,
             ),
-        ),
-        source: Some(
-            "rustc",
-        ),
-        message: "mismatched types\nexpected usize, found u32",
-        related_information: None,
-        tags: None,
+            code: Some(
+                String(
+                    "E0308",
+                ),
+            ),
+            source: Some(
+                "rustc",
+            ),
+            message: "mismatched types\nexpected usize, found u32",
+            related_information: None,
+            tags: None,
+        },
+        fixes: [],
     },
-    fixes: [],
-}
+]

--- a/crates/ra_cargo_watch/src/conv/snapshots/ra_cargo_watch__conv__test__snap_rustc_unused_variable.snap
+++ b/crates/ra_cargo_watch/src/conv/snapshots/ra_cargo_watch__conv__test__snap_rustc_unused_variable.snap
@@ -2,83 +2,85 @@
 source: crates/ra_cargo_watch/src/conv/test.rs
 expression: diag
 ---
-MappedRustDiagnostic {
-    location: Location {
-        uri: "file:///test/driver/subcommand/repl.rs",
-        range: Range {
-            start: Position {
-                line: 290,
-                character: 8,
-            },
-            end: Position {
-                line: 290,
-                character: 11,
-            },
-        },
-    },
-    diagnostic: Diagnostic {
-        range: Range {
-            start: Position {
-                line: 290,
-                character: 8,
-            },
-            end: Position {
-                line: 290,
-                character: 11,
-            },
-        },
-        severity: Some(
-            Warning,
-        ),
-        code: Some(
-            String(
-                "unused_variables",
-            ),
-        ),
-        source: Some(
-            "rustc",
-        ),
-        message: "unused variable: `foo`\n#[warn(unused_variables)] on by default",
-        related_information: None,
-        tags: Some(
-            [
-                Unnecessary,
-            ],
-        ),
-    },
-    fixes: [
-        CodeAction {
-            title: "consider prefixing with an underscore",
-            kind: Some(
-                "quickfix",
-            ),
-            diagnostics: None,
-            edit: Some(
-                WorkspaceEdit {
-                    changes: Some(
-                        {
-                            "file:///test/driver/subcommand/repl.rs": [
-                                TextEdit {
-                                    range: Range {
-                                        start: Position {
-                                            line: 290,
-                                            character: 8,
-                                        },
-                                        end: Position {
-                                            line: 290,
-                                            character: 11,
-                                        },
-                                    },
-                                    new_text: "_foo",
-                                },
-                            ],
-                        },
-                    ),
-                    document_changes: None,
+[
+    MappedRustDiagnostic {
+        location: Location {
+            uri: "file:///test/driver/subcommand/repl.rs",
+            range: Range {
+                start: Position {
+                    line: 290,
+                    character: 8,
                 },
-            ),
-            command: None,
-            is_preferred: None,
+                end: Position {
+                    line: 290,
+                    character: 11,
+                },
+            },
         },
-    ],
-}
+        diagnostic: Diagnostic {
+            range: Range {
+                start: Position {
+                    line: 290,
+                    character: 8,
+                },
+                end: Position {
+                    line: 290,
+                    character: 11,
+                },
+            },
+            severity: Some(
+                Warning,
+            ),
+            code: Some(
+                String(
+                    "unused_variables",
+                ),
+            ),
+            source: Some(
+                "rustc",
+            ),
+            message: "unused variable: `foo`\n#[warn(unused_variables)] on by default",
+            related_information: None,
+            tags: Some(
+                [
+                    Unnecessary,
+                ],
+            ),
+        },
+        fixes: [
+            CodeAction {
+                title: "consider prefixing with an underscore",
+                kind: Some(
+                    "quickfix",
+                ),
+                diagnostics: None,
+                edit: Some(
+                    WorkspaceEdit {
+                        changes: Some(
+                            {
+                                "file:///test/driver/subcommand/repl.rs": [
+                                    TextEdit {
+                                        range: Range {
+                                            start: Position {
+                                                line: 290,
+                                                character: 8,
+                                            },
+                                            end: Position {
+                                                line: 290,
+                                                character: 11,
+                                            },
+                                        },
+                                        new_text: "_foo",
+                                    },
+                                ],
+                            },
+                        ),
+                        document_changes: None,
+                    },
+                ),
+                command: None,
+                is_preferred: None,
+            },
+        ],
+    },
+]

--- a/crates/ra_cargo_watch/src/conv/snapshots/ra_cargo_watch__conv__test__snap_rustc_unused_variable.snap
+++ b/crates/ra_cargo_watch/src/conv/snapshots/ra_cargo_watch__conv__test__snap_rustc_unused_variable.snap
@@ -48,7 +48,7 @@ MappedRustDiagnostic {
     },
     fixes: [
         CodeAction {
-            title: "consider prefixing with an underscore: \'_foo\'",
+            title: "consider prefixing with an underscore",
             kind: Some(
                 "quickfix",
             ),

--- a/crates/ra_cargo_watch/src/conv/snapshots/ra_cargo_watch__conv__test__snap_rustc_wrong_number_of_parameters.snap
+++ b/crates/ra_cargo_watch/src/conv/snapshots/ra_cargo_watch__conv__test__snap_rustc_wrong_number_of_parameters.snap
@@ -2,64 +2,66 @@
 source: crates/ra_cargo_watch/src/conv/test.rs
 expression: diag
 ---
-MappedRustDiagnostic {
-    location: Location {
-        uri: "file:///test/compiler/ty/select.rs",
-        range: Range {
-            start: Position {
-                line: 103,
-                character: 17,
-            },
-            end: Position {
-                line: 103,
-                character: 29,
-            },
-        },
-    },
-    diagnostic: Diagnostic {
-        range: Range {
-            start: Position {
-                line: 103,
-                character: 17,
-            },
-            end: Position {
-                line: 103,
-                character: 29,
+[
+    MappedRustDiagnostic {
+        location: Location {
+            uri: "file:///test/compiler/ty/select.rs",
+            range: Range {
+                start: Position {
+                    line: 103,
+                    character: 17,
+                },
+                end: Position {
+                    line: 103,
+                    character: 29,
+                },
             },
         },
-        severity: Some(
-            Error,
-        ),
-        code: Some(
-            String(
-                "E0061",
+        diagnostic: Diagnostic {
+            range: Range {
+                start: Position {
+                    line: 103,
+                    character: 17,
+                },
+                end: Position {
+                    line: 103,
+                    character: 29,
+                },
+            },
+            severity: Some(
+                Error,
             ),
-        ),
-        source: Some(
-            "rustc",
-        ),
-        message: "this function takes 2 parameters but 3 parameters were supplied\nexpected 2 parameters",
-        related_information: Some(
-            [
-                DiagnosticRelatedInformation {
-                    location: Location {
-                        uri: "file:///test/compiler/ty/select.rs",
-                        range: Range {
-                            start: Position {
-                                line: 218,
-                                character: 4,
-                            },
-                            end: Position {
-                                line: 230,
-                                character: 5,
+            code: Some(
+                String(
+                    "E0061",
+                ),
+            ),
+            source: Some(
+                "rustc",
+            ),
+            message: "this function takes 2 parameters but 3 parameters were supplied\nexpected 2 parameters",
+            related_information: Some(
+                [
+                    DiagnosticRelatedInformation {
+                        location: Location {
+                            uri: "file:///test/compiler/ty/select.rs",
+                            range: Range {
+                                start: Position {
+                                    line: 218,
+                                    character: 4,
+                                },
+                                end: Position {
+                                    line: 230,
+                                    character: 5,
+                                },
                             },
                         },
+                        message: "defined here",
                     },
-                    message: "defined here",
-                },
-            ],
-        ),
-        tags: None,
+                ],
+            ),
+            tags: None,
+        },
+        fixes: [],
     },
-    fixes: [],
-}
+]

--- a/crates/ra_cargo_watch/src/conv/test.rs
+++ b/crates/ra_cargo_watch/src/conv/test.rs
@@ -58,7 +58,7 @@ fn snap_rustc_incompatible_type_for_trait() {
     );
 
     let workspace_root = PathBuf::from("/test/");
-    let diag = map_rust_diagnostic_to_lsp(&diag, &workspace_root).expect("couldn't map diagnostic");
+    let diag = map_rust_diagnostic_to_lsp(&diag, &workspace_root);
     insta::assert_debug_snapshot!(diag);
 }
 
@@ -141,7 +141,7 @@ fn snap_rustc_unused_variable() {
     );
 
     let workspace_root = PathBuf::from("/test/");
-    let diag = map_rust_diagnostic_to_lsp(&diag, &workspace_root).expect("couldn't map diagnostic");
+    let diag = map_rust_diagnostic_to_lsp(&diag, &workspace_root);
     insta::assert_debug_snapshot!(diag);
 }
 
@@ -266,7 +266,7 @@ fn snap_rustc_wrong_number_of_parameters() {
     );
 
     let workspace_root = PathBuf::from("/test/");
-    let diag = map_rust_diagnostic_to_lsp(&diag, &workspace_root).expect("couldn't map diagnostic");
+    let diag = map_rust_diagnostic_to_lsp(&diag, &workspace_root);
     insta::assert_debug_snapshot!(diag);
 }
 
@@ -387,7 +387,7 @@ fn snap_clippy_pass_by_ref() {
     );
 
     let workspace_root = PathBuf::from("/test/");
-    let diag = map_rust_diagnostic_to_lsp(&diag, &workspace_root).expect("couldn't map diagnostic");
+    let diag = map_rust_diagnostic_to_lsp(&diag, &workspace_root);
     insta::assert_debug_snapshot!(diag);
 }
 
@@ -431,7 +431,7 @@ fn snap_rustc_mismatched_type() {
     );
 
     let workspace_root = PathBuf::from("/test/");
-    let diag = map_rust_diagnostic_to_lsp(&diag, &workspace_root).expect("couldn't map diagnostic");
+    let diag = map_rust_diagnostic_to_lsp(&diag, &workspace_root);
     insta::assert_debug_snapshot!(diag);
 }
 
@@ -703,7 +703,7 @@ fn snap_handles_macro_location() {
     );
 
     let workspace_root = PathBuf::from("/test/");
-    let diag = map_rust_diagnostic_to_lsp(&diag, &workspace_root).expect("couldn't map diagnostic");
+    let diag = map_rust_diagnostic_to_lsp(&diag, &workspace_root);
     insta::assert_debug_snapshot!(diag);
 }
 
@@ -933,7 +933,7 @@ fn snap_macro_compiler_error() {
     );
 
     let workspace_root = PathBuf::from("/test/");
-    let diag = map_rust_diagnostic_to_lsp(&diag, &workspace_root).expect("couldn't map diagnostic");
+    let diag = map_rust_diagnostic_to_lsp(&diag, &workspace_root);
     insta::assert_debug_snapshot!(diag);
 }
 
@@ -1067,6 +1067,6 @@ fn snap_multi_line_fix() {
     );
 
     let workspace_root = PathBuf::from("/test/");
-    let diag = map_rust_diagnostic_to_lsp(&diag, &workspace_root).expect("couldn't map diagnostic");
+    let diag = map_rust_diagnostic_to_lsp(&diag, &workspace_root);
     insta::assert_debug_snapshot!(diag);
 }

--- a/crates/ra_cargo_watch/src/conv/test.rs
+++ b/crates/ra_cargo_watch/src/conv/test.rs
@@ -936,3 +936,137 @@ fn snap_macro_compiler_error() {
     let diag = map_rust_diagnostic_to_lsp(&diag, &workspace_root).expect("couldn't map diagnostic");
     insta::assert_debug_snapshot!(diag);
 }
+
+#[test]
+#[cfg(not(windows))]
+fn snap_multi_line_fix() {
+    let diag = parse_diagnostic(
+        r##"{
+            "rendered": "warning: returning the result of a let binding from a block\n --> src/main.rs:4:5\n  |\n3 |     let a = (0..10).collect();\n  |     -------------------------- unnecessary let binding\n4 |     a\n  |     ^\n  |\n  = note: `#[warn(clippy::let_and_return)]` on by default\n  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#let_and_return\nhelp: return the expression directly\n  |\n3 |     \n4 |     (0..10).collect()\n  |\n\n",
+            "children": [
+                {
+                "children": [],
+                "code": null,
+                "level": "note",
+                "message": "`#[warn(clippy::let_and_return)]` on by default",
+                "rendered": null,
+                "spans": []
+                },
+                {
+                "children": [],
+                "code": null,
+                "level": "help",
+                "message": "for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#let_and_return",
+                "rendered": null,
+                "spans": []
+                },
+                {
+                "children": [],
+                "code": null,
+                "level": "help",
+                "message": "return the expression directly",
+                "rendered": null,
+                "spans": [
+                    {
+                    "byte_end": 55,
+                    "byte_start": 29,
+                    "column_end": 31,
+                    "column_start": 5,
+                    "expansion": null,
+                    "file_name": "src/main.rs",
+                    "is_primary": true,
+                    "label": null,
+                    "line_end": 3,
+                    "line_start": 3,
+                    "suggested_replacement": "",
+                    "suggestion_applicability": "MachineApplicable",
+                    "text": [
+                        {
+                        "highlight_end": 31,
+                        "highlight_start": 5,
+                        "text": "    let a = (0..10).collect();"
+                        }
+                    ]
+                    },
+                    {
+                    "byte_end": 61,
+                    "byte_start": 60,
+                    "column_end": 6,
+                    "column_start": 5,
+                    "expansion": null,
+                    "file_name": "src/main.rs",
+                    "is_primary": true,
+                    "label": null,
+                    "line_end": 4,
+                    "line_start": 4,
+                    "suggested_replacement": "(0..10).collect()",
+                    "suggestion_applicability": "MachineApplicable",
+                    "text": [
+                        {
+                        "highlight_end": 6,
+                        "highlight_start": 5,
+                        "text": "    a"
+                        }
+                    ]
+                    }
+                ]
+                }
+            ],
+            "code": {
+                "code": "clippy::let_and_return",
+                "explanation": null
+            },
+            "level": "warning",
+            "message": "returning the result of a let binding from a block",
+            "spans": [
+                {
+                "byte_end": 55,
+                "byte_start": 29,
+                "column_end": 31,
+                "column_start": 5,
+                "expansion": null,
+                "file_name": "src/main.rs",
+                "is_primary": false,
+                "label": "unnecessary let binding",
+                "line_end": 3,
+                "line_start": 3,
+                "suggested_replacement": null,
+                "suggestion_applicability": null,
+                "text": [
+                    {
+                    "highlight_end": 31,
+                    "highlight_start": 5,
+                    "text": "    let a = (0..10).collect();"
+                    }
+                ]
+                },
+                {
+                "byte_end": 61,
+                "byte_start": 60,
+                "column_end": 6,
+                "column_start": 5,
+                "expansion": null,
+                "file_name": "src/main.rs",
+                "is_primary": true,
+                "label": null,
+                "line_end": 4,
+                "line_start": 4,
+                "suggested_replacement": null,
+                "suggestion_applicability": null,
+                "text": [
+                    {
+                    "highlight_end": 6,
+                    "highlight_start": 5,
+                    "text": "    a"
+                    }
+                ]
+                }
+            ]
+        }
+        "##,
+    );
+
+    let workspace_root = PathBuf::from("/test/");
+    let diag = map_rust_diagnostic_to_lsp(&diag, &workspace_root).expect("couldn't map diagnostic");
+    insta::assert_debug_snapshot!(diag);
+}


### PR DESCRIPTION
This was initially supposed to just be a fix for #3433, but I caught a few things that ended up being useful as well.

This PR primarily makes us handle multi-edit fix suggestions properly. Instead of just applying the first fix we apply all the parts of the fix in a single action.

Second up, this PR handles diagnostics with multiple primary spans, f.x. the unused import diagnostic from rustc:
![image](https://user-images.githubusercontent.com/209321/76531793-03269480-6476-11ea-9180-41c0ea705553.png)

The LSP doesn't handle this too well, as it only support a single complete range for each diagnostic, so we get duplicate messages in the problem panel of VSCode:
![image](https://user-images.githubusercontent.com/209321/76531901-29e4cb00-6476-11ea-9746-cd57f8974b85.png)

However, I feel like the improved visual aspect in-editor outweighs the duplication in the problem panel. I'm open to not including the second commit if anybody really doesn't like the idea of duplicate diagnostics in the problem pane.

Fixes #3433
Fixes #3257