### PR TITLE
Add resolve diagnostics

### DIFF
--- a/crates/ra_assists/src/lib.rs
+++ b/crates/ra_assists/src/lib.rs
@@ -19,6 +19,7 @@ use ra_text_edit::TextEdit;
 
 pub(crate) use crate::assist_ctx::{Assist, AssistCtx, AssistHandler};
 use hir::Semantics;
+pub use utils::UnresolvedElement;
 
 /// Unique identifier of the assist, should not be shown to the user
 /// directly.

--- a/crates/ra_assists/src/utils.rs
+++ b/crates/ra_assists/src/utils.rs
@@ -1,13 +1,18 @@
 //! Assorted functions shared by several assists.
 pub(crate) mod insert_use;
 
-use hir::Semantics;
-use ra_ide_db::RootDatabase;
+use hir::{
+    AsAssocItem, AssocItemContainer, ModPath, Module, ModuleDef, PathResolution, Semantics, Trait,
+    Type,
+};
+use ra_ide_db::{imports_locator::ImportsLocator, RootDatabase};
+use ra_prof::profile;
 use ra_syntax::{
     ast::{self, make, NameOwner},
-    AstNode, T,
+    match_ast, AstNode, SyntaxNode, T,
 };
 use rustc_hash::FxHashSet;
+use std::collections::BTreeSet;
 
 pub use insert_use::insert_use_statement;
 
@@ -97,5 +102,218 @@ fn invert_special_case(expr: &ast::Expr) -> Option<ast::Expr> {
         // FIXME:
         // ast::Expr::Literal(true | false )
         _ => None,
+    }
+}
+
+pub struct UnresolvedElement {
+    pub import_candidate: ImportCandidate,
+    pub module_with_element: Module,
+    pub element_syntax: SyntaxNode,
+}
+
+impl UnresolvedElement {
+    pub fn for_method_call(
+        method_call: ast::MethodCallExpr,
+        sema: &Semantics<RootDatabase>,
+    ) -> Option<Self> {
+        let syntax_under_caret = method_call.syntax().to_owned();
+        let module_with_element = sema.scope(&syntax_under_caret).module()?;
+        Some(Self {
+            import_candidate: ImportCandidate::for_method_call(sema, &method_call)?,
+            module_with_element,
+            element_syntax: syntax_under_caret,
+        })
+    }
+
+    pub fn for_path(path_under_caret: ast::Path, sema: &Semantics<RootDatabase>) -> Option<Self> {
+        let syntax_under_caret = path_under_caret.syntax().to_owned();
+        for node in syntax_under_caret.ancestors() {
+            match_ast! {
+                match node {
+                    ast::UseItem(_it) => {
+                        return None;
+                    },
+                    ast::Attr(_it) => {
+                        return None;
+                    },
+                    _ => (),
+                }
+            }
+        }
+
+        let module_with_element = sema.scope(&syntax_under_caret).module()?;
+        Some(Self {
+            import_candidate: ImportCandidate::for_regular_path(sema, &path_under_caret)?,
+            module_with_element,
+            element_syntax: syntax_under_caret,
+        })
+    }
+
+    fn get_search_query(&self) -> &str {
+        match &self.import_candidate {
+            ImportCandidate::UnqualifiedName(name) => name,
+            ImportCandidate::QualifierStart(qualifier_start) => qualifier_start,
+            ImportCandidate::TraitAssocItem(_, trait_assoc_item_name) => trait_assoc_item_name,
+            ImportCandidate::TraitMethod(_, trait_method_name) => trait_method_name,
+        }
+    }
+
+    pub(crate) fn get_import_group_message(&self) -> String {
+        match &self.import_candidate {
+            ImportCandidate::UnqualifiedName(name) => format!("Import {}", name),
+            ImportCandidate::QualifierStart(qualifier_start) => {
+                format!("Import {}", qualifier_start)
+            }
+            ImportCandidate::TraitAssocItem(_, trait_assoc_item_name) => {
+                format!("Import a trait for item {}", trait_assoc_item_name)
+            }
+            ImportCandidate::TraitMethod(_, trait_method_name) => {
+                format!("Import a trait for method {}", trait_method_name)
+            }
+        }
+    }
+
+    pub(crate) fn search_for_imports(&self, db: &RootDatabase) -> BTreeSet<ModPath> {
+        let _p = profile("auto_import::search_for_imports");
+        let current_crate = self.module_with_element.krate();
+        ImportsLocator::new(db)
+            .find_imports(&self.get_search_query())
+            .into_iter()
+            .filter_map(|module_def| match &self.import_candidate {
+                ImportCandidate::TraitAssocItem(assoc_item_type, _) => {
+                    let located_assoc_item = match module_def {
+                        ModuleDef::Function(located_function) => located_function
+                            .as_assoc_item(db)
+                            .map(|assoc| assoc.container(db))
+                            .and_then(Self::assoc_to_trait),
+                        ModuleDef::Const(located_const) => located_const
+                            .as_assoc_item(db)
+                            .map(|assoc| assoc.container(db))
+                            .and_then(Self::assoc_to_trait),
+                        _ => None,
+                    }?;
+
+                    let mut trait_candidates = FxHashSet::default();
+                    trait_candidates.insert(located_assoc_item.into());
+
+                    assoc_item_type
+                        .iterate_path_candidates(
+                            db,
+                            current_crate,
+                            &trait_candidates,
+                            None,
+                            |_, assoc| Self::assoc_to_trait(assoc.container(db)),
+                        )
+                        .map(ModuleDef::from)
+                }
+                ImportCandidate::TraitMethod(function_callee, _) => {
+                    let located_assoc_item =
+                        if let ModuleDef::Function(located_function) = module_def {
+                            located_function
+                                .as_assoc_item(db)
+                                .map(|assoc| assoc.container(db))
+                                .and_then(Self::assoc_to_trait)
+                        } else {
+                            None
+                        }?;
+
+                    let mut trait_candidates = FxHashSet::default();
+                    trait_candidates.insert(located_assoc_item.into());
+
+                    function_callee
+                        .iterate_method_candidates(
+                            db,
+                            current_crate,
+                            &trait_candidates,
+                            None,
+                            |_, function| {
+                                Self::assoc_to_trait(function.as_assoc_item(db)?.container(db))
+                            },
+                        )
+                        .map(ModuleDef::from)
+                }
+                _ => Some(module_def),
+            })
+            .filter_map(|module_def| self.module_with_element.find_use_path(db, module_def))
+            .filter(|use_path| !use_path.segments.is_empty())
+            .take(20)
+            .collect::<BTreeSet<_>>()
+    }
+
+    fn assoc_to_trait(assoc: AssocItemContainer) -> Option<Trait> {
+        if let AssocItemContainer::Trait(extracted_trait) = assoc {
+            Some(extracted_trait)
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ImportCandidate {
+    /// Simple name like 'HashMap'
+    UnqualifiedName(String),
+    /// First part of the qualified name.
+    /// For 'std::collections::HashMap', that will be 'std'.
+    QualifierStart(String),
+    /// A trait associated function (with no self parameter) or associated constant.
+    /// For 'test_mod::TestEnum::test_function', `Type` is the `test_mod::TestEnum` expression type
+    /// and `String` is the `test_function`
+    TraitAssocItem(Type, String),
+    /// A trait method with self parameter.
+    /// For 'test_enum.test_method()', `Type` is the `test_enum` expression type
+    /// and `String` is the `test_method`
+    TraitMethod(Type, String),
+}
+
+impl ImportCandidate {
+    fn for_method_call(
+        sema: &Semantics<RootDatabase>,
+        method_call: &ast::MethodCallExpr,
+    ) -> Option<Self> {
+        if sema.resolve_method_call(method_call).is_some() {
+            return None;
+        }
+        Some(Self::TraitMethod(
+            sema.type_of_expr(&method_call.expr()?)?,
+            method_call.name_ref()?.syntax().to_string(),
+        ))
+    }
+
+    fn for_regular_path(
+        sema: &Semantics<RootDatabase>,
+        path_under_caret: &ast::Path,
+    ) -> Option<Self> {
+        if sema.resolve_path(path_under_caret).is_some() {
+            return None;
+        }
+
+        let segment = path_under_caret.segment()?;
+        if let Some(qualifier) = path_under_caret.qualifier() {
+            let qualifier_start = qualifier.syntax().descendants().find_map(ast::NameRef::cast)?;
+            let qualifier_start_path =
+                qualifier_start.syntax().ancestors().find_map(ast::Path::cast)?;
+            if let Some(qualifier_start_resolution) = sema.resolve_path(&qualifier_start_path) {
+                let qualifier_resolution = if qualifier_start_path == qualifier {
+                    qualifier_start_resolution
+                } else {
+                    sema.resolve_path(&qualifier)?
+                };
+                if let PathResolution::Def(ModuleDef::Adt(assoc_item_path)) = qualifier_resolution {
+                    Some(ImportCandidate::TraitAssocItem(
+                        assoc_item_path.ty(sema.db),
+                        segment.syntax().to_string(),
+                    ))
+                } else {
+                    None
+                }
+            } else {
+                Some(ImportCandidate::QualifierStart(qualifier_start.syntax().to_string()))
+            }
+        } else {
+            Some(ImportCandidate::UnqualifiedName(
+                segment.syntax().descendants().find_map(ast::NameRef::cast)?.syntax().to_string(),
+            ))
+        }
     }
 }

--- a/crates/ra_ide/src/lib.rs
+++ b/crates/ra_ide/src/lib.rs
@@ -78,6 +78,7 @@ pub use crate::{
     },
 };
 
+pub use diagnostics::DiagnosticsOptions;
 pub use hir::Documentation;
 pub use ra_db::{
     Canceled, CrateGraph, CrateId, Edition, FileId, FilePosition, FileRange, SourceRootId,
@@ -456,8 +457,12 @@ impl Analysis {
     }
 
     /// Computes the set of diagnostics for the given file.
-    pub fn diagnostics(&self, file_id: FileId) -> Cancelable<Vec<Diagnostic>> {
-        self.with_db(|db| diagnostics::diagnostics(db, file_id))
+    pub fn diagnostics(
+        &self,
+        file_id: FileId,
+        diagnostics_config: &DiagnosticsOptions,
+    ) -> Cancelable<Vec<Diagnostic>> {
+        self.with_db(|db| diagnostics::diagnostics(db, file_id, diagnostics_config))
     }
 
     /// Returns the edit required to rename reference at the position to the new

--- a/crates/rust-analyzer/src/cli/analysis_bench.rs
+++ b/crates/rust-analyzer/src/cli/analysis_bench.rs
@@ -12,7 +12,10 @@ use ra_db::{
     salsa::{Database, Durability},
     FileId, SourceDatabaseExt,
 };
-use ra_ide::{Analysis, AnalysisChange, AnalysisHost, CompletionOptions, FilePosition, LineCol};
+use ra_ide::{
+    Analysis, AnalysisChange, AnalysisHost, CompletionOptions, DiagnosticsOptions, FilePosition,
+    LineCol,
+};
 
 use crate::cli::{load_cargo::load_cargo, Verbosity};
 
@@ -77,7 +80,7 @@ pub fn analysis_bench(verbosity: Verbosity, path: &Path, what: BenchWhat) -> Res
     match &what {
         BenchWhat::Highlight { .. } => {
             let res = do_work(&mut host, file_id, |analysis| {
-                analysis.diagnostics(file_id).unwrap();
+                analysis.diagnostics(file_id, &DiagnosticsOptions::new()).unwrap();
                 analysis.highlight_as_html(file_id, false).unwrap()
             });
             if verbosity.is_verbose() {

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -55,6 +55,12 @@ pub struct ServerConfig {
 
     /// Cargo feature configurations.
     pub cargo_features: CargoFeatures,
+
+    /// Highlight unresolved paths
+    pub check_paths_resolution: bool,
+
+    /// Highlight unresolved method calls
+    pub check_methods_resolution: bool,
 }
 
 impl Default for ServerConfig {
@@ -76,6 +82,8 @@ impl Default for ServerConfig {
             additional_out_dirs: FxHashMap::default(),
             cargo_features: Default::default(),
             rustfmt_args: Vec::new(),
+            check_paths_resolution: true,
+            check_methods_resolution: false,
         }
     }
 }

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -18,7 +18,7 @@ use crossbeam_channel::{select, unbounded, RecvError, Sender};
 use lsp_server::{Connection, ErrorCode, Message, Notification, Request, RequestId, Response};
 use lsp_types::{ClientCapabilities, NumberOrString};
 use ra_cargo_watch::{url_from_path_with_drive_lowercasing, CheckOptions, CheckTask};
-use ra_ide::{Canceled, FileId, InlayHintsOptions, LibraryData, SourceRootId};
+use ra_ide::{Canceled, DiagnosticsOptions, FileId, InlayHintsOptions, LibraryData, SourceRootId};
 use ra_prof::profile;
 use ra_vfs::{VfsFile, VfsTask, Watch};
 use relative_path::RelativePathBuf;
@@ -189,6 +189,10 @@ pub fn main_loop(
                     all_targets: config.cargo_watch_all_targets,
                 },
                 rustfmt_args: config.rustfmt_args,
+                diagnostics_config: DiagnosticsOptions {
+                    check_methods_resolution: config.check_methods_resolution,
+                    check_paths_resolution: config.check_paths_resolution,
+                },
             }
         };
 

--- a/crates/rust-analyzer/src/main_loop/handlers.rs
+++ b/crates/rust-analyzer/src/main_loop/handlers.rs
@@ -696,7 +696,7 @@ pub fn handle_code_action(
     let line_index = world.analysis().file_line_index(file_id)?;
     let range = params.range.conv_with(&line_index);
 
-    let diagnostics = world.analysis().diagnostics(file_id)?;
+    let diagnostics = world.analysis().diagnostics(file_id, &world.options.diagnostics_config)?;
     let mut res = CodeActionResponse::default();
 
     let fixes_from_diagnostics = diagnostics
@@ -922,7 +922,7 @@ pub fn publish_diagnostics(world: &WorldSnapshot, file_id: FileId) -> Result<Dia
     let line_index = world.analysis().file_line_index(file_id)?;
     let diagnostics: Vec<Diagnostic> = world
         .analysis()
-        .diagnostics(file_id)?
+        .diagnostics(file_id, &world.options.diagnostics_config)?
         .into_iter()
         .map(|d| Diagnostic {
             range: d.range.conv_with(&line_index),

--- a/crates/rust-analyzer/src/world.rs
+++ b/crates/rust-analyzer/src/world.rs
@@ -13,8 +13,8 @@ use lsp_types::Url;
 use parking_lot::RwLock;
 use ra_cargo_watch::{url_from_path_with_drive_lowercasing, CheckOptions, CheckWatcher};
 use ra_ide::{
-    Analysis, AnalysisChange, AnalysisHost, CrateGraph, FileId, InlayHintsOptions, LibraryData,
-    SourceRootId,
+    Analysis, AnalysisChange, AnalysisHost, CrateGraph, DiagnosticsOptions, FileId,
+    InlayHintsOptions, LibraryData, SourceRootId,
 };
 use ra_project_model::{get_rustc_cfg_options, ProjectWorkspace};
 use ra_vfs::{LineEndings, RootEntry, Vfs, VfsChange, VfsFile, VfsRoot, VfsTask, Watch};
@@ -38,6 +38,7 @@ pub struct Options {
     pub inlay_hints: InlayHintsOptions,
     pub rustfmt_args: Vec<String>,
     pub cargo_watch: CheckOptions,
+    pub diagnostics_config: DiagnosticsOptions,
 }
 
 /// `WorldState` is the primary mutable state of the language server

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -349,6 +349,16 @@
                     },
                     "default": [],
                     "description": "List of features to activate"
+                },
+                "rust-analyzer.diagnosticsOptions.checkPathsResolution": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Highlight unresolved paths"
+                },
+                "rust-analyzer.diagnosticsOptions.checkMethodsResolution": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Highlight unresolved method calls"
                 }
             }
         },

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -22,8 +22,6 @@ export async function createClient(config: Config, serverPath: string): Promise<
     const traceOutputChannel = vscode.window.createOutputChannel(
         'Rust Analyzer Language Server Trace',
     );
-    const cargoWatchOpts = config.cargoWatchOptions;
-
     const clientOptions: lc.LanguageClientOptions = {
         documentSelector: [{ scheme: 'file', language: 'rust' }],
         initializationOptions: {
@@ -34,10 +32,10 @@ export async function createClient(config: Config, serverPath: string): Promise<
             inlayHintsParameter: config.inlayHints.parameterHints,
             inlayHintsMaxLength: config.inlayHints.maxLength,
 
-            cargoWatchEnable: cargoWatchOpts.enable,
-            cargoWatchArgs: cargoWatchOpts.arguments,
-            cargoWatchCommand: cargoWatchOpts.command,
-            cargoWatchAllTargets: cargoWatchOpts.allTargets,
+            cargoWatchEnable: config.cargoWatchOptions.enable,
+            cargoWatchArgs: config.cargoWatchOptions.arguments,
+            cargoWatchCommand: config.cargoWatchOptions.command,
+            cargoWatchAllTargets: config.cargoWatchOptions.allTargets,
 
             excludeGlobs: config.excludeGlobs,
             useClientWatching: config.useClientWatching,
@@ -46,6 +44,8 @@ export async function createClient(config: Config, serverPath: string): Promise<
             withSysroot: config.withSysroot,
             cargoFeatures: config.cargoFeatures,
             rustfmtArgs: config.rustfmtArgs,
+            checkPathsResolution: config.diagnosticsOptions.checkPathsResolution,
+            checkMethodsResolution: config.diagnosticsOptions.checkMethodsResolution,
         },
         traceOutputChannel,
         middleware: {

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -23,6 +23,12 @@ export interface CargoFeatures {
     allFeatures: boolean;
     features: string[];
 }
+
+export interface DiagnosticsOptions {
+    checkPathsResolution: boolean;
+    checkMethodsResolution: boolean;
+}
+
 export class Config {
     private static readonly rootSection = "rust-analyzer";
     private static readonly requiresReloadOpts = [
@@ -30,6 +36,7 @@ export class Config {
         "cargo-watch",
         "highlighting.semanticTokens",
         "inlayHints",
+        "diagnosticsOptions",
     ]
         .map(opt => `${Config.rootSection}.${opt}`);
 
@@ -168,6 +175,13 @@ export class Config {
     get featureFlags() { return this.cfg.get("featureFlags") as Record<string, boolean>; }
     get additionalOutDirs() { return this.cfg.get("additionalOutDirs") as Record<string, string>; }
     get rustfmtArgs() { return this.cfg.get("rustfmtArgs") as string[]; }
+
+    get diagnosticsOptions(): DiagnosticsOptions {
+        return {
+            checkPathsResolution: this.cfg.get("diagnosticsOptions.checkPathsResolution") as boolean,
+            checkMethodsResolution: this.cfg.get("diagnosticsOptions.checkMethodsResolution") as boolean,
+        };
+    }
 
     get cargoWatchOptions(): CargoWatchOptions {
         return {


### PR DESCRIPTION
Adds a set of diagnostics to highlight unresolved methods and paths.

The implementation idea is to use the part of the `auto_import` assist that goes before the actual import, since this part is responsible for resolution checks.
This reuse may also come in handy if we decide to generate import assists for this diagnostics.

I've turned off method resolution by default, since it gives a lot of false-positives.
The path resolution is way better (yet still has some glitches), so I've left it enabled.