### PR TITLE
Check all crates of the workspace

### DIFF
--- a/crates/ra_cargo_watch/src/lib.rs
+++ b/crates/ra_cargo_watch/src/lib.rs
@@ -254,6 +254,7 @@ impl WatchThread {
     fn new(options: &CheckOptions, workspace_root: &PathBuf) -> WatchThread {
         let mut args: Vec<String> = vec![
             options.command.clone(),
+            "--workspace".to_string(),
             "--message-format=json".to_string(),
             "--manifest-path".to_string(),
             format!("{}/Cargo.toml", workspace_root.to_string_lossy()),


### PR DESCRIPTION
Previously, if the root of the was was a real crate, only this crate
was checked.

Ideally, we might want some kind of config here (which might be just
overriding the whole command), but `--workspace` is def a nicer
default.

r? @kiljacken 