### PR TITLE
Update OUT_DIR based on `cargo check` output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,6 +1092,7 @@ dependencies = [
  "cargo_metadata",
  "log",
  "ra_arena",
+ "ra_cargo_watch",
  "ra_cfg",
  "ra_db",
  "rustc-hash",

--- a/crates/ra_cargo_watch/src/lib.rs
+++ b/crates/ra_cargo_watch/src/lib.rs
@@ -249,7 +249,7 @@ enum CheckEvent {
 pub fn run_cargo(
     args: &[String],
     current_dir: Option<&Path>,
-    mut on_message: impl FnMut(cargo_metadata::Message) -> bool,
+    on_message: &mut dyn FnMut(cargo_metadata::Message) -> bool,
 ) -> Child {
     let mut command = Command::new("cargo");
     if let Some(current_dir) = current_dir {
@@ -325,7 +325,7 @@ impl WatchThread {
                 // which will break out of the loop, and continue the shutdown
                 let _ = message_send.send(CheckEvent::Begin);
 
-                let mut child = run_cargo(&args, Some(&workspace_root), |message| {
+                let mut child = run_cargo(&args, Some(&workspace_root), &mut |message| {
                     // Skip certain kinds of messages to only spend time on what's useful
                     match &message {
                         Message::CompilerArtifact(artifact) if artifact.fresh => return true,

--- a/crates/ra_cargo_watch/src/lib.rs
+++ b/crates/ra_cargo_watch/src/lib.rs
@@ -9,8 +9,8 @@ use lsp_types::{
 };
 use std::{
     io::{BufRead, BufReader},
-    path::PathBuf,
-    process::{Command, Stdio},
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
     thread::JoinHandle,
     time::Instant,
 };
@@ -246,18 +246,71 @@ enum CheckEvent {
     End,
 }
 
+pub fn run_cargo(
+    args: &[String],
+    current_dir: Option<&Path>,
+    mut on_message: impl FnMut(cargo_metadata::Message) -> bool,
+) -> Child {
+    let mut command = Command::new("cargo");
+    if let Some(current_dir) = current_dir {
+        command.current_dir(current_dir);
+    }
+
+    let mut child = command
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .stdin(Stdio::null())
+        .spawn()
+        .expect("couldn't launch cargo");
+
+    // We manually read a line at a time, instead of using serde's
+    // stream deserializers, because the deserializer cannot recover
+    // from an error, resulting in it getting stuck, because we try to
+    // be resillient against failures.
+    //
+    // Because cargo only outputs one JSON object per line, we can
+    // simply skip a line if it doesn't parse, which just ignores any
+    // erroneus output.
+    let stdout = BufReader::new(child.stdout.take().unwrap());
+    for line in stdout.lines() {
+        let line = match line {
+            Ok(line) => line,
+            Err(err) => {
+                log::error!("Couldn't read line from cargo: {}", err);
+                continue;
+            }
+        };
+
+        let message = serde_json::from_str::<cargo_metadata::Message>(&line);
+        let message = match message {
+            Ok(message) => message,
+            Err(err) => {
+                log::error!("Invalid json from cargo check, ignoring ({}): {:?} ", err, line);
+                continue;
+            }
+        };
+
+        if !on_message(message) {
+            break;
+        }
+    }
+
+    child
+}
+
 impl WatchThread {
     fn dummy() -> WatchThread {
         WatchThread { handle: None, message_recv: never() }
     }
 
-    fn new(options: &CheckOptions, workspace_root: &PathBuf) -> WatchThread {
+    fn new(options: &CheckOptions, workspace_root: &Path) -> WatchThread {
         let mut args: Vec<String> = vec![
             options.command.clone(),
             "--workspace".to_string(),
             "--message-format=json".to_string(),
             "--manifest-path".to_string(),
-            format!("{}/Cargo.toml", workspace_root.to_string_lossy()),
+            format!("{}/Cargo.toml", workspace_root.display()),
         ];
         if options.all_targets {
             args.push("--all-targets".to_string());
@@ -265,83 +318,47 @@ impl WatchThread {
         args.extend(options.args.iter().cloned());
 
         let (message_send, message_recv) = unbounded();
-        let enabled = options.enable;
-        let handle = std::thread::spawn(move || {
-            if !enabled {
-                return;
-            }
+        let workspace_root = workspace_root.to_owned();
+        let handle = if options.enable {
+            Some(std::thread::spawn(move || {
+                // If we trigger an error here, we will do so in the loop instead,
+                // which will break out of the loop, and continue the shutdown
+                let _ = message_send.send(CheckEvent::Begin);
 
-            let mut command = Command::new("cargo")
-                .args(&args)
-                .stdout(Stdio::piped())
-                .stderr(Stdio::null())
-                .stdin(Stdio::null())
-                .spawn()
-                .expect("couldn't launch cargo");
-
-            // If we trigger an error here, we will do so in the loop instead,
-            // which will break out of the loop, and continue the shutdown
-            let _ = message_send.send(CheckEvent::Begin);
-
-            // We manually read a line at a time, instead of using serde's
-            // stream deserializers, because the deserializer cannot recover
-            // from an error, resulting in it getting stuck, because we try to
-            // be resillient against failures.
-            //
-            // Because cargo only outputs one JSON object per line, we can
-            // simply skip a line if it doesn't parse, which just ignores any
-            // erroneus output.
-            let stdout = BufReader::new(command.stdout.take().unwrap());
-            for line in stdout.lines() {
-                let line = match line {
-                    Ok(line) => line,
-                    Err(err) => {
-                        log::error!("Couldn't read line from cargo: {}", err);
-                        continue;
+                let mut child = run_cargo(&args, Some(&workspace_root), |message| {
+                    // Skip certain kinds of messages to only spend time on what's useful
+                    match &message {
+                        Message::CompilerArtifact(artifact) if artifact.fresh => return true,
+                        Message::BuildScriptExecuted(_) => return true,
+                        Message::Unknown => return true,
+                        _ => {}
                     }
-                };
 
-                let message = serde_json::from_str::<cargo_metadata::Message>(&line);
-                let message = match message {
-                    Ok(message) => message,
-                    Err(err) => {
-                        log::error!(
-                            "Invalid json from cargo check, ignoring ({}): {:?} ",
-                            err,
-                            line
-                        );
-                        continue;
-                    }
-                };
+                    match message_send.send(CheckEvent::Msg(message)) {
+                        Ok(()) => {}
+                        Err(_err) => {
+                            // The send channel was closed, so we want to shutdown
+                            return false;
+                        }
+                    };
 
-                // Skip certain kinds of messages to only spend time on what's useful
-                match &message {
-                    Message::CompilerArtifact(artifact) if artifact.fresh => continue,
-                    Message::BuildScriptExecuted(_) => continue,
-                    Message::Unknown => continue,
-                    _ => {}
-                }
+                    true
+                });
 
-                match message_send.send(CheckEvent::Msg(message)) {
-                    Ok(()) => {}
-                    Err(_err) => {
-                        // The send channel was closed, so we want to shutdown
-                        break;
-                    }
-                }
-            }
+                // We can ignore any error here, as we are already in the progress
+                // of shutting down.
+                let _ = message_send.send(CheckEvent::End);
 
-            // We can ignore any error here, as we are already in the progress
-            // of shutting down.
-            let _ = message_send.send(CheckEvent::End);
+                // It is okay to ignore the result, as it only errors if the process is already dead
+                let _ = child.kill();
 
-            // It is okay to ignore the result, as it only errors if the process is already dead
-            let _ = command.kill();
-
-            // Again, we don't care about the exit status so just ignore the result
-            let _ = command.wait();
-        });
-        WatchThread { handle: Some(handle), message_recv }
+                // Again, we don't care about the exit status so just ignore the result
+                let _ = child.wait();
+            }))
+        } else {
+            None
+        };
+        WatchThread { handle, message_recv }
     }
 }
 

--- a/crates/ra_project_model/Cargo.toml
+++ b/crates/ra_project_model/Cargo.toml
@@ -16,6 +16,7 @@ cargo_metadata = "0.9.1"
 ra_arena = { path = "../ra_arena" }
 ra_db = { path = "../ra_db" }
 ra_cfg = { path = "../ra_cfg" }
+ra_cargo_watch = { path = "../ra_cargo_watch" }
 
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.48"

--- a/crates/ra_project_model/src/cargo_workspace.rs
+++ b/crates/ra_project_model/src/cargo_workspace.rs
@@ -142,7 +142,7 @@ impl Package {
         ws.packages[self].dependencies.iter()
     }
     pub fn out_dir(self, ws: &CargoWorkspace) -> Option<&Path> {
-        ws.packages[self].out_dir.as_ref().map(|od| od.as_path())
+        ws.packages[self].out_dir.as_ref().map(PathBuf::as_path)
     }
 }
 

--- a/crates/ra_project_model/src/cargo_workspace.rs
+++ b/crates/ra_project_model/src/cargo_workspace.rs
@@ -297,7 +297,7 @@ pub fn load_out_dirs(
     }
 
     let mut res = FxHashMap::default();
-    let mut child = run_cargo(&args, cargo_toml.parent(), |message| {
+    let mut child = run_cargo(&args, cargo_toml.parent(), &mut |message| {
         match message {
             Message::BuildScriptExecuted(message) => {
                 let package_id = message.package_id;

--- a/crates/ra_project_model/src/cargo_workspace.rs
+++ b/crates/ra_project_model/src/cargo_workspace.rs
@@ -39,9 +39,6 @@ pub struct CargoFeatures {
 
     /// Runs cargo check on launch to figure out the correct values of OUT_DIR
     pub load_out_dirs_from_check: bool,
-
-    /// Fine grained controls for additional `OUT_DIR` env variables
-    pub out_dir_overrides: FxHashMap<PackageId, PathBuf>,
 }
 
 impl Default for CargoFeatures {
@@ -51,7 +48,6 @@ impl Default for CargoFeatures {
             all_features: true,
             features: Vec::new(),
             load_out_dirs_from_check: false,
-            out_dir_overrides: FxHashMap::default(),
         }
     }
 }
@@ -195,10 +191,6 @@ impl CargoWorkspace {
         if cargo_features.load_out_dirs_from_check {
             out_dir_by_id = load_out_dirs(cargo_toml, cargo_features);
         }
-        // We explicitly extend afterwards to allow overriding the value returned by cargo
-        out_dir_by_id.extend(
-            cargo_features.out_dir_overrides.iter().map(|(id, path)| (id.clone(), path.clone())),
-        );
 
         let mut pkg_by_id = FxHashMap::default();
         let mut packages = Arena::default();

--- a/crates/ra_project_model/src/cargo_workspace.rs
+++ b/crates/ra_project_model/src/cargo_workspace.rs
@@ -39,6 +39,9 @@ pub struct CargoFeatures {
 
     /// Runs cargo check on launch to figure out the correct values of OUT_DIR
     pub load_out_dirs_from_check: bool,
+
+    /// Fine grained controls for additional `OUT_DIR` env variables
+    pub out_dir_overrides: FxHashMap<PackageId, PathBuf>,
 }
 
 impl Default for CargoFeatures {
@@ -48,6 +51,7 @@ impl Default for CargoFeatures {
             all_features: true,
             features: Vec::new(),
             load_out_dirs_from_check: false,
+            out_dir_overrides: FxHashMap::default(),
         }
     }
 }
@@ -191,6 +195,10 @@ impl CargoWorkspace {
         if cargo_features.load_out_dirs_from_check {
             out_dir_by_id = load_out_dirs(cargo_toml, cargo_features);
         }
+        // We explicitly extend afterwards to allow overriding the value returned by cargo
+        out_dir_by_id.extend(
+            cargo_features.out_dir_overrides.iter().map(|(id, path)| (id.clone(), path.clone())),
+        );
 
         let mut pkg_by_id = FxHashMap::default();
         let mut packages = Arena::default();

--- a/crates/ra_project_model/src/cargo_workspace.rs
+++ b/crates/ra_project_model/src/cargo_workspace.rs
@@ -3,8 +3,9 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use cargo_metadata::{CargoOpt, MetadataCommand};
+use cargo_metadata::{CargoOpt, Message, MetadataCommand, PackageId};
 use ra_arena::{impl_arena_id, Arena, RawId};
+use ra_cargo_watch::run_cargo;
 use ra_db::Edition;
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
@@ -35,11 +36,19 @@ pub struct CargoFeatures {
     /// List of features to activate.
     /// This will be ignored if `cargo_all_features` is true.
     pub features: Vec<String>,
+
+    /// Runs cargo check on launch to figure out the correct values of OUT_DIR
+    pub load_out_dirs_from_check: bool,
 }
 
 impl Default for CargoFeatures {
     fn default() -> Self {
-        CargoFeatures { no_default_features: false, all_features: true, features: Vec::new() }
+        CargoFeatures {
+            no_default_features: false,
+            all_features: true,
+            features: Vec::new(),
+            load_out_dirs_from_check: false,
+        }
     }
 }
 
@@ -60,6 +69,7 @@ struct PackageData {
     dependencies: Vec<PackageDependency>,
     edition: Edition,
     features: Vec<String>,
+    out_dir: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone)]
@@ -131,6 +141,9 @@ impl Package {
     ) -> impl Iterator<Item = &'a PackageDependency> + 'a {
         ws.packages[self].dependencies.iter()
     }
+    pub fn out_dir(self, ws: &CargoWorkspace) -> Option<&Path> {
+        ws.packages[self].out_dir.as_ref().map(|od| od.as_path())
+    }
 }
 
 impl Target {
@@ -173,6 +186,12 @@ impl CargoWorkspace {
         let meta = meta.exec().with_context(|| {
             format!("Failed to run `cargo metadata --manifest-path {}`", cargo_toml.display())
         })?;
+
+        let mut out_dir_by_id = FxHashMap::default();
+        if cargo_features.load_out_dirs_from_check {
+            out_dir_by_id = load_out_dirs(cargo_toml, cargo_features);
+        }
+
         let mut pkg_by_id = FxHashMap::default();
         let mut packages = Arena::default();
         let mut targets = Arena::default();
@@ -193,6 +212,7 @@ impl CargoWorkspace {
                 edition,
                 dependencies: Vec::new(),
                 features: Vec::new(),
+                out_dir: out_dir_by_id.get(&id).cloned(),
             });
             let pkg_data = &mut packages[pkg];
             pkg_by_id.insert(id, pkg);
@@ -251,4 +271,47 @@ impl CargoWorkspace {
     pub fn workspace_root(&self) -> &Path {
         &self.workspace_root
     }
+}
+
+pub fn load_out_dirs(
+    cargo_toml: &Path,
+    cargo_features: &CargoFeatures,
+) -> FxHashMap<PackageId, PathBuf> {
+    let mut args: Vec<String> = vec![
+        "check".to_string(),
+        "--message-format=json".to_string(),
+        "--manifest-path".to_string(),
+        format!("{}", cargo_toml.display()),
+    ];
+
+    if cargo_features.all_features {
+        args.push("--all-features".to_string());
+    } else if cargo_features.no_default_features {
+        // FIXME: `NoDefaultFeatures` is mutual exclusive with `SomeFeatures`
+        // https://github.com/oli-obk/cargo_metadata/issues/79
+        args.push("--no-default-features".to_string());
+    } else if !cargo_features.features.is_empty() {
+        for feature in &cargo_features.features {
+            args.push(feature.clone());
+        }
+    }
+
+    let mut res = FxHashMap::default();
+    let mut child = run_cargo(&args, cargo_toml.parent(), |message| {
+        match message {
+            Message::BuildScriptExecuted(message) => {
+                let package_id = message.package_id;
+                let out_dir = message.out_dir;
+                res.insert(package_id, out_dir);
+            }
+
+            Message::CompilerArtifact(_) => (),
+            Message::CompilerMessage(_) => (),
+            Message::Unknown => (),
+        }
+        true
+    });
+
+    let _ = child.wait();
+    res
 }

--- a/crates/ra_project_model/src/json_project.rs
+++ b/crates/ra_project_model/src/json_project.rs
@@ -22,6 +22,7 @@ pub struct Crate {
     pub(crate) deps: Vec<Dep>,
     pub(crate) atom_cfgs: FxHashSet<String>,
     pub(crate) key_value_cfgs: FxHashMap<String, String>,
+    pub(crate) out_dir: Option<PathBuf>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize)]

--- a/crates/rust-analyzer/src/bin/args.rs
+++ b/crates/rust-analyzer/src/bin/args.rs
@@ -28,10 +28,12 @@ pub(crate) enum Command {
         only: Option<String>,
         with_deps: bool,
         path: PathBuf,
+        load_output_dirs: bool,
     },
     Bench {
         path: PathBuf,
         what: BenchWhat,
+        load_output_dirs: bool,
     },
     RunServer,
     Version,
@@ -136,8 +138,9 @@ USAGE:
     rust-analyzer analysis-stats [FLAGS] [OPTIONS] [PATH]
 
 FLAGS:
-    -h, --help            Prints help information
+    -h, --help              Prints help information
         --memory-usage
+        --load-output-dirs  Load OUT_DIR values by running `cargo check` before analysis
     -v, --verbose
     -q, --quiet
 
@@ -154,6 +157,7 @@ ARGS:
                 let memory_usage = matches.contains("--memory-usage");
                 let only: Option<String> = matches.opt_value_from_str(["-o", "--only"])?;
                 let with_deps: bool = matches.contains("--with-deps");
+                let load_output_dirs = matches.contains("--load-output-dirs");
                 let path = {
                     let mut trailing = matches.free()?;
                     if trailing.len() != 1 {
@@ -162,7 +166,7 @@ ARGS:
                     trailing.pop().unwrap().into()
                 };
 
-                Command::Stats { randomize, memory_usage, only, with_deps, path }
+                Command::Stats { randomize, memory_usage, only, with_deps, path, load_output_dirs }
             }
             "analysis-bench" => {
                 if matches.contains(["-h", "--help"]) {
@@ -174,7 +178,8 @@ USAGE:
     rust-analyzer analysis-bench [FLAGS] [OPTIONS]
 
 FLAGS:
-    -h, --help        Prints help information
+    -h, --help          Prints help information
+    --load-output-dirs  Load OUT_DIR values by running `cargo check` before analysis
     -v, --verbose
 
 OPTIONS:
@@ -201,7 +206,8 @@ ARGS:
                         "exactly one of  `--highlight`, `--complete` or `--goto-def` must be set"
                     ),
                 };
-                Command::Bench { path, what }
+                let load_output_dirs = matches.contains("--load-output-dirs");
+                Command::Bench { path, what, load_output_dirs }
             }
             _ => {
                 eprintln!(

--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -19,19 +19,25 @@ fn main() -> Result<()> {
         args::Command::Parse { no_dump } => cli::parse(no_dump)?,
         args::Command::Symbols => cli::symbols()?,
         args::Command::Highlight { rainbow } => cli::highlight(rainbow)?,
-        args::Command::Stats { randomize, memory_usage, only, with_deps, path } => {
-            cli::analysis_stats(
-                args.verbosity,
-                memory_usage,
-                path.as_ref(),
-                only.as_ref().map(String::as_ref),
-                with_deps,
-                randomize,
-            )?
-        }
+        args::Command::Stats {
+            randomize,
+            memory_usage,
+            only,
+            with_deps,
+            path,
+            load_output_dirs,
+        } => cli::analysis_stats(
+            args.verbosity,
+            memory_usage,
+            path.as_ref(),
+            only.as_ref().map(String::as_ref),
+            with_deps,
+            randomize,
+            load_output_dirs,
+        )?,
 
-        args::Command::Bench { path, what } => {
-            cli::analysis_bench(args.verbosity, path.as_ref(), what)?
+        args::Command::Bench { path, what, load_output_dirs } => {
+            cli::analysis_bench(args.verbosity, path.as_ref(), what, load_output_dirs)?
         }
 
         args::Command::RunServer => run_server()?,

--- a/crates/rust-analyzer/src/cli/analysis_bench.rs
+++ b/crates/rust-analyzer/src/cli/analysis_bench.rs
@@ -42,12 +42,17 @@ fn rsplit_at_char(s: &str, c: char) -> Result<(&str, &str)> {
     Ok((&s[..idx], &s[idx + 1..]))
 }
 
-pub fn analysis_bench(verbosity: Verbosity, path: &Path, what: BenchWhat) -> Result<()> {
+pub fn analysis_bench(
+    verbosity: Verbosity,
+    path: &Path,
+    what: BenchWhat,
+    load_output_dirs: bool,
+) -> Result<()> {
     ra_prof::init();
 
     let start = Instant::now();
     eprint!("loading: ");
-    let (mut host, roots) = load_cargo(path)?;
+    let (mut host, roots) = load_cargo(path, load_output_dirs)?;
     let db = host.raw_database();
     eprintln!("{:?}\n", start.elapsed());
 

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -23,9 +23,10 @@ pub fn analysis_stats(
     only: Option<&str>,
     with_deps: bool,
     randomize: bool,
+    load_output_dirs: bool,
 ) -> Result<()> {
     let db_load_time = Instant::now();
-    let (mut host, roots) = load_cargo(path)?;
+    let (mut host, roots) = load_cargo(path, load_output_dirs)?;
     let db = host.raw_database();
     println!("Database loaded, {} roots, {:?}", roots.len(), db_load_time.elapsed());
     let analysis_time = Instant::now();

--- a/crates/rust-analyzer/src/cli/load_cargo.rs
+++ b/crates/rust-analyzer/src/cli/load_cargo.rs
@@ -53,19 +53,14 @@ pub(crate) fn load_cargo(
     };
 
     // FIXME: outdirs?
-    let outdirs = FxHashMap::default();
     let extern_source_roots = FxHashMap::default();
 
-    let crate_graph = ws.to_crate_graph(
-        &default_cfg_options,
-        &outdirs,
-        &extern_source_roots,
-        &mut |path: &Path| {
+    let crate_graph =
+        ws.to_crate_graph(&default_cfg_options, &extern_source_roots, &mut |path: &Path| {
             let vfs_file = vfs.load(path);
             log::debug!("vfs file {:?} -> {:?}", path, vfs_file);
             vfs_file.map(vfs_file_to_id)
-        },
-    );
+        });
     log::debug!("crate graph: {:?}", crate_graph);
 
     let source_roots = roots

--- a/crates/rust-analyzer/src/cli/load_cargo.rs
+++ b/crates/rust-analyzer/src/cli/load_cargo.rs
@@ -1,13 +1,13 @@
 //! Loads a Cargo project into a static instance of analysis, without support
 //! for incorporating changes.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use crossbeam_channel::{unbounded, Receiver};
-use ra_db::{CrateGraph, FileId, SourceRootId};
+use ra_db::{ExternSourceId, FileId, SourceRootId};
 use ra_ide::{AnalysisChange, AnalysisHost};
-use ra_project_model::{get_rustc_cfg_options, PackageRoot, ProjectWorkspace};
+use ra_project_model::{get_rustc_cfg_options, CargoFeatures, PackageRoot, ProjectWorkspace};
 use ra_vfs::{RootEntry, Vfs, VfsChange, VfsTask, Watch};
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -22,10 +22,21 @@ fn vfs_root_to_id(r: ra_vfs::VfsRoot) -> SourceRootId {
 
 pub(crate) fn load_cargo(
     root: &Path,
+    load_out_dirs_from_check: bool,
 ) -> Result<(AnalysisHost, FxHashMap<SourceRootId, PackageRoot>)> {
     let root = std::env::current_dir()?.join(root);
-    let ws = ProjectWorkspace::discover(root.as_ref(), &Default::default())?;
-    let project_roots = ws.to_roots();
+    let ws = ProjectWorkspace::discover(
+        root.as_ref(),
+        &CargoFeatures { load_out_dirs_from_check, ..Default::default() },
+    )?;
+
+    let mut extern_dirs = FxHashSet::default();
+    extern_dirs.extend(ws.out_dirs());
+
+    let mut project_roots = ws.to_roots();
+    project_roots
+        .extend(extern_dirs.iter().map(|path| PackageRoot::new(path.to_path_buf(), false)));
+
     let (sender, receiver) = unbounded();
     let sender = Box::new(move |t| sender.send(t).unwrap());
     let (mut vfs, roots) = Vfs::new(
@@ -44,25 +55,6 @@ pub(crate) fn load_cargo(
         Watch(false),
     );
 
-    // FIXME: cfg options?
-    let default_cfg_options = {
-        let mut opts = get_rustc_cfg_options();
-        opts.insert_atom("test".into());
-        opts.insert_atom("debug_assertion".into());
-        opts
-    };
-
-    // FIXME: outdirs?
-    let extern_source_roots = FxHashMap::default();
-
-    let crate_graph =
-        ws.to_crate_graph(&default_cfg_options, &extern_source_roots, &mut |path: &Path| {
-            let vfs_file = vfs.load(path);
-            log::debug!("vfs file {:?} -> {:?}", path, vfs_file);
-            vfs_file.map(vfs_file_to_id)
-        });
-    log::debug!("crate graph: {:?}", crate_graph);
-
     let source_roots = roots
         .iter()
         .map(|&vfs_root| {
@@ -75,23 +67,24 @@ pub(crate) fn load_cargo(
             (source_root_id, project_root)
         })
         .collect::<FxHashMap<_, _>>();
-    let host = load(&source_roots, crate_graph, &mut vfs, receiver);
+    let host = load(&source_roots, ws, &mut vfs, receiver, extern_dirs);
     Ok((host, source_roots))
 }
 
 pub(crate) fn load(
     source_roots: &FxHashMap<SourceRootId, PackageRoot>,
-    crate_graph: CrateGraph,
+    ws: ProjectWorkspace,
     vfs: &mut Vfs,
     receiver: Receiver<VfsTask>,
+    extern_dirs: FxHashSet<PathBuf>,
 ) -> AnalysisHost {
     let lru_cap = std::env::var("RA_LRU_CAP").ok().and_then(|it| it.parse::<usize>().ok());
     let mut host = AnalysisHost::new(lru_cap);
     let mut analysis_change = AnalysisChange::new();
-    analysis_change.set_crate_graph(crate_graph);
 
     // wait until Vfs has loaded all roots
     let mut roots_loaded = FxHashSet::default();
+    let mut extern_source_roots = FxHashMap::default();
     for task in receiver {
         vfs.handle_task(task);
         let mut done = false;
@@ -110,6 +103,11 @@ pub(crate) fn load(
                         source_root_id,
                         source_roots[&source_root_id].path().display().to_string(),
                     );
+
+                    let vfs_root_path = vfs.root2path(root);
+                    if extern_dirs.contains(&vfs_root_path) {
+                        extern_source_roots.insert(vfs_root_path, ExternSourceId(root.0));
+                    }
 
                     let mut file_map = FxHashMap::default();
                     for (vfs_file, path, text) in files {
@@ -137,6 +135,23 @@ pub(crate) fn load(
         }
     }
 
+    // FIXME: cfg options?
+    let default_cfg_options = {
+        let mut opts = get_rustc_cfg_options();
+        opts.insert_atom("test".into());
+        opts.insert_atom("debug_assertion".into());
+        opts
+    };
+
+    let crate_graph =
+        ws.to_crate_graph(&default_cfg_options, &extern_source_roots, &mut |path: &Path| {
+            let vfs_file = vfs.load(path);
+            log::debug!("vfs file {:?} -> {:?}", path, vfs_file);
+            vfs_file.map(vfs_file_to_id)
+        });
+    log::debug!("crate graph: {:?}", crate_graph);
+    analysis_change.set_crate_graph(crate_graph);
+
     host.apply_change(analysis_change);
     host
 }
@@ -150,7 +165,7 @@ mod tests {
     #[test]
     fn test_loading_rust_analyzer() {
         let path = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap().parent().unwrap();
-        let (host, _roots) = load_cargo(path).unwrap();
+        let (host, _roots) = load_cargo(path, false).unwrap();
         let n_crates = Crate::all(host.raw_database()).len();
         // RA has quite a few crates, but the exact count doesn't matter
         assert!(n_crates > 20);

--- a/crates/rust-analyzer/src/cli/load_cargo.rs
+++ b/crates/rust-analyzer/src/cli/load_cargo.rs
@@ -54,12 +54,18 @@ pub(crate) fn load_cargo(
 
     // FIXME: outdirs?
     let outdirs = FxHashMap::default();
+    let extern_source_roots = FxHashMap::default();
 
-    let crate_graph = ws.to_crate_graph(&default_cfg_options, &outdirs, &mut |path: &Path| {
-        let vfs_file = vfs.load(path);
-        log::debug!("vfs file {:?} -> {:?}", path, vfs_file);
-        vfs_file.map(vfs_file_to_id)
-    });
+    let crate_graph = ws.to_crate_graph(
+        &default_cfg_options,
+        &outdirs,
+        &extern_source_roots,
+        &mut |path: &Path| {
+            let vfs_file = vfs.load(path);
+            log::debug!("vfs file {:?} -> {:?}", path, vfs_file);
+            vfs_file.map(vfs_file_to_id)
+        },
+    );
     log::debug!("crate graph: {:?}", crate_graph);
 
     let source_roots = roots

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -48,9 +48,6 @@ pub struct ServerConfig {
     /// Fine grained feature flags to disable specific features.
     pub feature_flags: FxHashMap<String, bool>,
 
-    /// Fine grained controls for additional `OUT_DIR` env variables
-    pub additional_out_dirs: FxHashMap<String, String>,
-
     pub rustfmt_args: Vec<String>,
 
     /// Cargo feature configurations.
@@ -76,7 +73,6 @@ impl Default for ServerConfig {
             cargo_watch_all_targets: true,
             with_sysroot: true,
             feature_flags: FxHashMap::default(),
-            additional_out_dirs: FxHashMap::default(),
             cargo_features: Default::default(),
             rustfmt_args: Vec::new(),
             vscode_lldb: false,

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -204,7 +204,6 @@ pub fn main_loop(
             Watch(!config.use_client_watching),
             options,
             feature_flags,
-            config.additional_out_dirs,
         )
     };
 

--- a/crates/rust-analyzer/src/world.rs
+++ b/crates/rust-analyzer/src/world.rs
@@ -82,7 +82,6 @@ impl WorldState {
         watch: Watch,
         options: Options,
         feature_flags: FeatureFlags,
-        additional_out_dirs: FxHashMap<String, String>,
     ) -> WorldState {
         let mut change = AnalysisChange::new();
 
@@ -105,8 +104,7 @@ impl WorldState {
             }));
         }
 
-        let mut extern_dirs: FxHashSet<_> =
-            additional_out_dirs.iter().map(|(_, path)| (PathBuf::from(path))).collect();
+        let mut extern_dirs = FxHashSet::default();
         for ws in workspaces.iter() {
             extern_dirs.extend(ws.out_dirs());
         }
@@ -152,21 +150,9 @@ impl WorldState {
             vfs_file.map(|f| FileId(f.0))
         };
 
-        let additional_out_dirs: FxHashMap<String, PathBuf> = additional_out_dirs
-            .into_iter()
-            .map(|(name, path)| (name, PathBuf::from(&path)))
-            .collect();
-
         workspaces
             .iter()
-            .map(|ws| {
-                ws.to_crate_graph(
-                    &default_cfg_options,
-                    &additional_out_dirs,
-                    &extern_source_roots,
-                    &mut load,
-                )
-            })
+            .map(|ws| ws.to_crate_graph(&default_cfg_options, &extern_source_roots, &mut load))
             .for_each(|graph| {
                 crate_graph.extend(graph);
             });

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -362,6 +362,11 @@
                     },
                     "default": [],
                     "description": "List of features to activate"
+                },
+                "rust-analyzer.cargoFeatures.loadOutDirsFromCheck": {
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "Run `cargo check` on startup to get the correct value for package OUT_DIRs"
                 }
             }
         },

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -362,11 +362,6 @@
                     "type": "boolean",
                     "default": false,
                     "markdownDescription": "Run `cargo check` on startup to get the correct value for package OUT_DIRs"
-                },
-                "rust-analyzer.cargoFeatures.outDirOverrides": {
-                    "type": "object",
-                    "default": {},
-                    "markdownDescription": "Fine grained controls for OUT_DIR `env!(\"OUT_DIR\")` variable. e.g. `{\"foo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)\":\"/path/to/foo\"}`, "
                 }
             }
         },

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -237,11 +237,6 @@
                     "default": true,
                     "description": "Whether to ask for permission before downloading any files from the Internet"
                 },
-                "rust-analyzer.additionalOutDirs": {
-                    "type": "object",
-                    "default": {},
-                    "markdownDescription": "Fine grained controls for OUT_DIR `env!(\"OUT_DIR\")` variable. e.g. `{\"foo\":\"/path/to/foo\"}`, "
-                },
                 "rust-analyzer.serverPath": {
                     "type": [
                         "null",
@@ -367,6 +362,11 @@
                     "type": "boolean",
                     "default": false,
                     "markdownDescription": "Run `cargo check` on startup to get the correct value for package OUT_DIRs"
+                },
+                "rust-analyzer.cargoFeatures.outDirOverrides": {
+                    "type": "object",
+                    "default": {},
+                    "markdownDescription": "Fine grained controls for OUT_DIR `env!(\"OUT_DIR\")` variable. e.g. `{\"foo 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)\":\"/path/to/foo\"}`, "
                 }
             }
         },

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -42,7 +42,6 @@ export async function createClient(config: Config, serverPath: string): Promise<
             excludeGlobs: config.excludeGlobs,
             useClientWatching: config.useClientWatching,
             featureFlags: config.featureFlags,
-            additionalOutDirs: config.additionalOutDirs,
             withSysroot: config.withSysroot,
             cargoFeatures: config.cargoFeatures,
             rustfmtArgs: config.rustfmtArgs,

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -23,6 +23,7 @@ export interface CargoFeatures {
     allFeatures: boolean;
     features: string[];
     loadOutDirsFromCheck: boolean;
+    outDirOverrides: Record<string, string>;
 }
 
 export const enum UpdatesChannel {
@@ -203,7 +204,6 @@ export class Config {
     get excludeGlobs() { return this.cfg.get("excludeGlobs") as string[]; }
     get useClientWatching() { return this.cfg.get("useClientWatching") as boolean; }
     get featureFlags() { return this.cfg.get("featureFlags") as Record<string, boolean>; }
-    get additionalOutDirs() { return this.cfg.get("additionalOutDirs") as Record<string, string>; }
     get rustfmtArgs() { return this.cfg.get("rustfmtArgs") as string[]; }
     get loadOutDirsFromCheck() { return this.cfg.get("loadOutDirsFromCheck") as boolean; }
 
@@ -222,6 +222,7 @@ export class Config {
             allFeatures: this.cfg.get("cargoFeatures.allFeatures") as boolean,
             features: this.cfg.get("cargoFeatures.features") as string[],
             loadOutDirsFromCheck: this.cfg.get("cargoFeatures.loadOutDirsFromCheck") as boolean,
+            outDirOverrides: this.cfg.get("cargoFeatures.outDirOverrides") as Record<string, string>,
         };
     }
 

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -22,6 +22,7 @@ export interface CargoFeatures {
     noDefaultFeatures: boolean;
     allFeatures: boolean;
     features: string[];
+    loadOutDirsFromCheck: boolean;
 }
 
 export const enum UpdatesChannel {
@@ -204,6 +205,7 @@ export class Config {
     get featureFlags() { return this.cfg.get("featureFlags") as Record<string, boolean>; }
     get additionalOutDirs() { return this.cfg.get("additionalOutDirs") as Record<string, string>; }
     get rustfmtArgs() { return this.cfg.get("rustfmtArgs") as string[]; }
+    get loadOutDirsFromCheck() { return this.cfg.get("loadOutDirsFromCheck") as boolean; }
 
     get cargoWatchOptions(): CargoWatchOptions {
         return {
@@ -219,6 +221,7 @@ export class Config {
             noDefaultFeatures: this.cfg.get("cargoFeatures.noDefaultFeatures") as boolean,
             allFeatures: this.cfg.get("cargoFeatures.allFeatures") as boolean,
             features: this.cfg.get("cargoFeatures.features") as string[],
+            loadOutDirsFromCheck: this.cfg.get("cargoFeatures.loadOutDirsFromCheck") as boolean,
         };
     }
 

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -23,7 +23,6 @@ export interface CargoFeatures {
     allFeatures: boolean;
     features: string[];
     loadOutDirsFromCheck: boolean;
-    outDirOverrides: Record<string, string>;
 }
 
 export const enum UpdatesChannel {
@@ -222,7 +221,6 @@ export class Config {
             allFeatures: this.cfg.get("cargoFeatures.allFeatures") as boolean,
             features: this.cfg.get("cargoFeatures.features") as string[],
             loadOutDirsFromCheck: this.cfg.get("cargoFeatures.loadOutDirsFromCheck") as boolean,
-            outDirOverrides: this.cfg.get("cargoFeatures.outDirOverrides") as Record<string, string>,
         };
     }
 


### PR DESCRIPTION
This entire PR is basically annoying plumbing needed to pass through the correct OUT_DIR from a `cargo check` run to the right place in the crate graph.

It's in a semi working state: It correctly updates OUT_DIR in the crate graph, and get's to the point where macro's depending on `env!("OUT_DIR")` are re-evaluated, but I don't seem to get completion for the `gl` crate still. Not sure why, but decided to get the code public ASAP so we can discuss the right direction to take it.

Things that still need to be done/decided:
* [ ] When/if to schedule a single `cargo check` run on startup to get the correct OUT_DIR values.
* [ ] What's the story with features, targets and `OUT_DIR`?
* [ ] All the other things that I've overlooked

Depends on rust-analyzer/ra_vfs#20 but is currently patched to use my fork so things can work.