### PR TITLE
Support local macro_rules

### DIFF
--- a/crates/ra_hir_def/src/data.rs
+++ b/crates/ra_hir_def/src/data.rs
@@ -280,7 +280,7 @@ fn collect_impl_items_in_macro(
         return Vec::new();
     }
 
-    if let Some((mark, items)) = expander.enter_expand(db, m) {
+    if let Some((mark, items)) = expander.enter_expand(db, None, m) {
         let items: InFile<ast::MacroItems> = expander.to_source(items);
         let mut res = collect_impl_items(
             db,

--- a/crates/ra_hir_ty/src/tests/macros.rs
+++ b/crates/ra_hir_ty/src/tests/macros.rs
@@ -363,6 +363,26 @@ fn main() {
 }
 
 #[test]
+fn infer_local_macro() {
+    assert_snapshot!(
+        infer(r#"
+fn main() {
+    macro_rules! foo {
+        () => { 1usize }
+    }
+    let _a  = foo!();
+}
+"#),
+        @r###"
+        ![0; 6) '1usize': usize
+        [11; 90) '{     ...!(); }': ()
+        [17; 66) 'macro_...     }': {unknown}
+        [75; 77) '_a': usize
+    "###
+    );
+}
+
+#[test]
 fn infer_builtin_macros_line() {
     assert_snapshot!(
         infer(r#"

--- a/crates/ra_ide/src/goto_definition.rs
+++ b/crates/ra_ide/src/goto_definition.rs
@@ -788,6 +788,21 @@ mod tests {
     }
 
     #[test]
+    fn goto_def_in_local_macro() {
+        check_goto(
+            "
+            //- /lib.rs            
+            fn bar() {
+                macro_rules! foo { () => { () } }
+                <|>foo!();
+            }
+            ",
+            "foo MACRO_CALL FileId(1) [15; 48) [28; 31)",
+            "macro_rules! foo { () => { () } }|foo",
+        );
+    }
+
+    #[test]
     fn goto_def_for_field_init_shorthand() {
         covers!(ra_ide_db::goto_def_for_field_init_shorthand);
         check_goto(


### PR DESCRIPTION
This PR implement local `macro_rules` in function body, by adding following things:

1. While lowering, add a `MacroDefId` in body's `ItemScope` as a textual legacy macro. 
2. Make `Expander::enter_expand` search with given `ItemScope`.
3. Make `Resolver::resolve_path_as_macro` search with `LocalItemScope`.

Fix #2181