### PR TITLE
Macro expansion error recovery

### DIFF
--- a/crates/ra_ide/src/completion/complete_dot.rs
+++ b/crates/ra_ide/src/completion/complete_dot.rs
@@ -688,7 +688,18 @@ mod tests {
                 }
                 ",
             ),
-            @r###"[]"###
+            @r###"
+            [
+                CompletionItem {
+                    label: "the_field",
+                    source_range: [156; 156),
+                    delete: [156; 156),
+                    insert: "the_field",
+                    kind: Field,
+                    detail: "u32",
+                },
+            ]
+            "###
         );
     }
 

--- a/crates/ra_ide/src/completion/complete_pattern.rs
+++ b/crates/ra_ide/src/completion/complete_pattern.rs
@@ -89,7 +89,6 @@ mod tests {
 
     #[test]
     fn completes_in_simple_macro_call() {
-        // FIXME: doesn't work yet because of missing error recovery in macro expansion
         let completions = complete(
             r"
             macro_rules! m { ($e:expr) => { $e } }
@@ -102,6 +101,16 @@ mod tests {
             }
             ",
         );
-        assert_debug_snapshot!(completions, @r###"[]"###);
+        assert_debug_snapshot!(completions, @r###"
+        [
+            CompletionItem {
+                label: "E",
+                source_range: [151; 151),
+                delete: [151; 151),
+                insert: "E",
+                kind: Enum,
+            },
+        ]
+        "###);
     }
 }

--- a/crates/ra_ide/src/completion/complete_scope.rs
+++ b/crates/ra_ide/src/completion/complete_scope.rs
@@ -853,6 +853,59 @@ mod tests {
     }
 
     #[test]
+    fn completes_in_simple_macro_without_closing_parens() {
+        assert_debug_snapshot!(
+            do_reference_completion(
+                r"
+                macro_rules! m { ($e:expr) => { $e } }
+                fn quux(x: i32) {
+                    let y = 92;
+                    m!(x<|>
+                }
+                "
+            ),
+            @r###"
+        [
+            CompletionItem {
+                label: "m!",
+                source_range: [145; 146),
+                delete: [145; 146),
+                insert: "m!($0)",
+                kind: Macro,
+                detail: "macro_rules! m",
+            },
+            CompletionItem {
+                label: "quux(…)",
+                source_range: [145; 146),
+                delete: [145; 146),
+                insert: "quux(${1:x})$0",
+                kind: Function,
+                lookup: "quux",
+                detail: "fn quux(x: i32)",
+                trigger_call_info: true,
+            },
+            CompletionItem {
+                label: "x",
+                source_range: [145; 146),
+                delete: [145; 146),
+                insert: "x",
+                kind: Binding,
+                detail: "i32",
+            },
+            CompletionItem {
+                label: "y",
+                source_range: [145; 146),
+                delete: [145; 146),
+                insert: "y",
+                kind: Binding,
+                detail: "i32",
+            },
+        ]
+        "###
+        );
+    }
+
+    #[test]
     fn completes_in_simple_macro_2() {
         assert_debug_snapshot!(
             do_reference_completion(

--- a/crates/ra_ide/src/completion/complete_scope.rs
+++ b/crates/ra_ide/src/completion/complete_scope.rs
@@ -811,7 +811,44 @@ mod tests {
                 }
                 "
             ),
-            @"[]"
+            @r###"
+            [
+                CompletionItem {
+                    label: "m!",
+                    source_range: [145; 145),
+                    delete: [145; 145),
+                    insert: "m!($0)",
+                    kind: Macro,
+                    detail: "macro_rules! m",
+                },
+                CompletionItem {
+                    label: "quux(…)",
+                    source_range: [145; 145),
+                    delete: [145; 145),
+                    insert: "quux(${1:x})$0",
+                    kind: Function,
+                    lookup: "quux",
+                    detail: "fn quux(x: i32)",
+                    trigger_call_info: true,
+                },
+                CompletionItem {
+                    label: "x",
+                    source_range: [145; 145),
+                    delete: [145; 145),
+                    insert: "x",
+                    kind: Binding,
+                    detail: "i32",
+                },
+                CompletionItem {
+                    label: "y",
+                    source_range: [145; 145),
+                    delete: [145; 145),
+                    insert: "y",
+                    kind: Binding,
+                    detail: "i32",
+                },
+            ]
+            "###
         );
     }
 

--- a/crates/ra_ide/src/completion/completion_context.rs
+++ b/crates/ra_ide/src/completion/completion_context.rs
@@ -135,7 +135,7 @@ impl<'a> CompletionContext<'a> {
                 ),
             ) {
                 let new_offset = hypothetical_expansion.1.text_range().start();
-                if new_offset >= actual_expansion.text_range().end() {
+                if new_offset > actual_expansion.text_range().end() {
                     break;
                 }
                 original_file = actual_expansion;

--- a/crates/ra_ide/src/expand_macro.rs
+++ b/crates/ra_ide/src/expand_macro.rs
@@ -259,7 +259,7 @@ fn some_thing() -> u32 {
         );
 
         assert_eq!(res.name, "foo");
-        assert_snapshot!(res.expansion, @r###"bar!()"###);
+        assert_snapshot!(res.expansion, @r###""###);
     }
 
     #[test]

--- a/crates/ra_ide/src/hover.rs
+++ b/crates/ra_ide/src/hover.rs
@@ -287,11 +287,6 @@ mod tests {
         content[hover.range].to_string()
     }
 
-    fn check_hover_no_result(fixture: &str) {
-        let (analysis, position) = analysis_and_position(fixture);
-        assert!(analysis.hover(position).unwrap().is_none());
-    }
-
     #[test]
     fn hover_shows_type_of_an_expression() {
         let (analysis, position) = single_file_with_position(
@@ -853,7 +848,7 @@ fn func(foo: i32) { if true { <|>foo; }; }
 
     #[test]
     fn test_hover_through_literal_string_in_builtin_macro() {
-        check_hover_no_result(
+        let hover_on = check_hover_result(
             r#"
             //- /lib.rs
             #[rustc_builtin_macro]
@@ -863,7 +858,10 @@ fn func(foo: i32) { if true { <|>foo; }; }
                 format!("hel<|>lo {}", 0);
             }
             "#,
+            &["&str"],
         );
+
+        assert_eq!(hover_on, "\"hello {}\"");
     }
 
     #[test]

--- a/crates/ra_mbe/src/tests.rs
+++ b/crates/ra_mbe/src/tests.rs
@@ -1433,10 +1433,6 @@ impl MacroFixture {
         self.rules.expand(&invocation_tt)
     }
 
-    fn assert_expand_err(&self, invocation: &str, err: &ExpandError) {
-        assert_eq!(self.try_expand_tt(invocation).as_ref(), Err(err));
-    }
-
     fn expand_items(&self, invocation: &str) -> SyntaxNode {
         let expanded = self.expand_tt(invocation);
         token_tree_to_syntax_node(&expanded, FragmentKind::Items).unwrap().0.syntax_node()
@@ -1653,14 +1649,4 @@ fn test_no_space_after_semi_colon() {
       IDENT@[50; 51) "f"
     SEMI@[51; 52) ";""###,
     );
-}
-
-#[test]
-fn test_expand_bad_literal() {
-    parse_macro(
-        r#"
-        macro_rules! foo { ($i:literal) => {}; }
-    "#,
-    )
-    .assert_expand_err(r#"foo!(&k");"#, &ExpandError::NoMatchingRule);
 }


### PR DESCRIPTION
This PR introduces a very basic macro expansion error recovery strategy. If none of the macro rules matches it just returns the tokens which were passed in. Long term I doubt this is the ideal solution, but in the short term it seems to significantly improve completions within macros. 

It also allows completion in macros without a closing paren, which is especially handy.

Notes to reviewers:

* I don't fully understand why it was necessary to set the delimiter to None on the returned token tree in `expand`
* I don't fully understand the implications of changing the `>=` to `>` in `completion_context`
* The test change in `expand_macro.rs` seems like perhaps this is a regression? But I did some manual testing in an actual editor and I can't see any issues with the new behavior.
* The `test_expand_bad_literal` test was deleted because it checks for errors during the expansion process, but the expansion process no longer returns errors. Again here I'm not sure what practical implication this could have.
* The `expand` method still returns a Result, although it cannot fail (at least for now). I left it this way because it seemed like leaving the Result as part of the public API would allow more flexibility in perhaps solving this problem differently in the future. But I'd be happy to remove it if you'd prefer. 
* The completion in macros without a closing paren works with a locally defined macro, but for some reason it does not work for std lib macros