### PR TITLE
Fix cargo audit caching

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,9 +29,10 @@ jobs:
     - name: Cache cargo
       uses: actions/cache@v1
       with:
-        path: ~/.cargo
+        path: ~/.cargo/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
+    - run: sudo chown -R $(whoami):$(id -ng) ~/.cargo/
     - run: cargo install cargo-audit
     - run: cargo audit
 


### PR DESCRIPTION
In bash, && and || have the same priority.



bors r+
🤖