### PR TITLE
vscode: add cancellation handling for downloads and update channel switching

### DIFF
--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -3,7 +3,7 @@ import * as lc from 'vscode-languageclient';
 
 import { Config } from './config';
 import { createClient } from './client';
-import { isRustEditor, RustEditor } from './util';
+import { isRustEditor, RustEditor, Disposable } from './util';
 import { PersistentState } from './persistent_state';
 
 export class Ctx {
@@ -55,7 +55,5 @@ export class Ctx {
     }
 }
 
-export interface Disposable {
-    dispose(): void;
-}
+
 export type Cmd = (...args: any[]) => unknown;

--- a/editors/code/src/inlay_hints.ts
+++ b/editors/code/src/inlay_hints.ts
@@ -2,8 +2,8 @@ import * as lc from "vscode-languageclient";
 import * as vscode from 'vscode';
 import * as ra from './rust-analyzer-api';
 
-import { Ctx, Disposable } from './ctx';
-import { sendRequestWithRetry, isRustDocument, RustDocument, RustEditor } from './util';
+import { Ctx } from './ctx';
+import { sendRequestWithRetry, isRustDocument, RustDocument, RustEditor, Disposable } from './util';
 
 
 export function activateInlayHints(ctx: Ctx) {

--- a/editors/code/src/installation/downloads.ts
+++ b/editors/code/src/installation/downloads.ts
@@ -57,8 +57,6 @@ async function downloadFile(
     } catch (err) {
         if (!isAbortError(err)) throw err;
 
-        assert(ct.isCancellationRequested, "cancellation must've caused the AbortError");
-
         log.debug(`Download was canceled, removing probably corrupted "${destFilePath}"...`);
 
         await fs.promises.unlink(destFilePath);

--- a/editors/code/src/installation/downloads.ts
+++ b/editors/code/src/installation/downloads.ts
@@ -123,16 +123,13 @@ export async function downloadArtifactWithProgressUi(
 }
 
 function anyCt(a: vscode.CancellationToken, b: vscode.CancellationToken): vscode.CancellationToken {
-    const cancellation = new vscode.EventEmitter();
-    const cancel = once(() => cancellation.fire());
+    const cts = new vscode.CancellationTokenSource();
+    const cancel = once(() => cts.cancel());
 
     a.onCancellationRequested(cancel);
     b.onCancellationRequested(cancel);
 
-    return {
-        get isCancellationRequested() { return a.isCancellationRequested || b.isCancellationRequested; },
-        onCancellationRequested: cancellation.event
-    };
+    return cts.token;
 }
 
 

--- a/editors/code/src/installation/downloads.ts
+++ b/editors/code/src/installation/downloads.ts
@@ -149,7 +149,7 @@ type Listener = (this: AbortSignal, event: any) => unknown;
 class AbortSignal implements IAbortSignal {
     subscriptions = new WeakMap<Listener, vscode.Disposable>();
 
-    constructor(private readonly ct: vscode.CancellationToken) {}
+    constructor(private readonly ct: vscode.CancellationToken) { }
 
     get aborted() {
         return this.ct.isCancellationRequested;
@@ -164,6 +164,6 @@ class AbortSignal implements IAbortSignal {
     }
 
     // Some excess APIs that are not used by `node_fetch` impl
-    onabort = null
+    onabort = null;
     dispatchEvent() { return false; }
 }

--- a/editors/code/src/installation/extension.ts
+++ b/editors/code/src/installation/extension.ts
@@ -38,14 +38,16 @@ export async function ensureProperExtensionVersion(
         // VSCode should handle updates for stable channel
         if (currentUpdChannel === UpdatesChannel.Stable) return;
 
-        if (!await askToDownloadProperExtensionVersion(config, "", ct)) return;
+        if (!await askToDownloadProperExtensionVersion(config, ct)) return;
 
         await vscodeReinstallExtension(config.extensionId);
         await vscodeReloadWindow(); // never returns
     }
 
     if (currentUpdChannel === UpdatesChannel.Stable) {
-        if (!await askToDownloadProperExtensionVersion(config, "", ct)) return;
+        if (!await askToDownloadProperExtensionVersion(config, ct)) {
+            return;
+        }
 
         return await tryDownloadNightlyExtension(config, state, ct, () => true);
     }
@@ -70,7 +72,7 @@ export async function ensureProperExtensionVersion(
     if (hoursSinceLastUpdate < HEURISTIC_NIGHTLY_RELEASE_PERIOD_IN_HOURS) {
         return;
     }
-    if (!await askToDownloadProperExtensionVersion(config, "The installed nightly version is most likely outdated. ", ct)) {
+    if (!await askToDownloadProperExtensionVersion(config, ct, "The installed nightly version is most likely outdated. ")) {
         return;
     }
 
@@ -94,8 +96,8 @@ export async function ensureProperExtensionVersion(
 
 async function askToDownloadProperExtensionVersion(
     config: Config,
-    reason: string,
-    ct: vscode.CancellationToken
+    ct: vscode.CancellationToken,
+    reason = "",
 ) {
     if (!config.askBeforeDownload) return true;
 

--- a/editors/code/src/installation/server.ts
+++ b/editors/code/src/installation/server.ts
@@ -93,7 +93,10 @@ const downloadServer = notReentrant(async (
     try {
         const releaseInfo = await fetchArtifactReleaseInfo(source.repo, source.file, source.tag);
 
-        await downloadArtifactWithProgressUi(releaseInfo, source.file, source.dir, "language server");
+        if (!await downloadArtifactWithProgressUi(releaseInfo, source.file, source.dir, "language server")) {
+            return null;
+        }
+
         await Promise.all([
             state.serverReleaseTag.set(releaseInfo.releaseName),
             state.serverReleaseDate.set(releaseInfo.releaseDate)

--- a/editors/code/src/util.ts
+++ b/editors/code/src/util.ts
@@ -100,7 +100,7 @@ export function once<TParams extends any[]>(fn: (...params: TParams) => void): t
         if (wasCalled) return;
         wasCalled = true;
         fn(...params);
-    }
+    };
 }
 
 export function cancelWhenReentered(fn: (cts: vscode.CancellationToken) => Promise<void>) {
@@ -113,7 +113,7 @@ export function cancelWhenReentered(fn: (cts: vscode.CancellationToken) => Promi
         activeCts = cts;
 
         return fn(cts.token).finally(() => { if (activeCts === cts) activeCts = null; });
-    }
+    };
 }
 
 export function notReentrant<TThis, TParams extends any[], TRet>(


### PR DESCRIPTION
This adds support for canceling the downloads of any artifacts. And we also now properly handle the configuration changes to update channel (when the user changed config while `ensureProperExtension()` was awaiting the user response or downloading the `.vsix`). Though this is quite a rare error, but a tricky one and not handling would be bad...