### PR TITLE
Check that no file contains trailing ws

### DIFF
--- a/crates/ra_hir_def/src/nameres/tests.rs
+++ b/crates/ra_hir_def/src/nameres/tests.rs
@@ -12,8 +12,8 @@ use test_utils::covers;
 
 use crate::{db::DefDatabase, nameres::*, test_db::TestDB};
 
-fn def_map(fixture: &str) -> String {
-    compute_crate_def_map(fixture).dump()
+fn def_map(ra_fixture: &str) -> String {
+    compute_crate_def_map(ra_fixture).dump()
 }
 
 fn compute_crate_def_map(fixture: &str) -> Arc<CrateDefMap> {

--- a/crates/ra_hir_def/src/nameres/tests/globs.rs
+++ b/crates/ra_hir_def/src/nameres/tests/globs.rs
@@ -3,7 +3,7 @@ use super::*;
 #[test]
 fn glob_1() {
     let map = def_map(
-        "
+        r"
         //- /lib.rs
         mod foo;
         use foo::*;
@@ -76,7 +76,7 @@ fn glob_2() {
 #[test]
 fn glob_privacy_1() {
     let map = def_map(
-        "
+        r"
         //- /lib.rs
         mod foo;
         use foo::*;
@@ -93,21 +93,21 @@ fn glob_privacy_1() {
         ",
     );
     assert_snapshot!(map, @r###"
-    crate
-    Baz: t v
-    bar: t
-    foo: t
-    
-    crate::foo
-    Baz: t v
-    PrivateStructFoo: t v
-    bar: t
-    
-    crate::foo::bar
-    Baz: t v
-    PrivateStructBar: t v
-    PrivateStructFoo: t v
-    bar: t
+        ⋮crate
+        ⋮Baz: t v
+        ⋮bar: t
+        ⋮foo: t
+        ⋮
+        ⋮crate::foo
+        ⋮Baz: t v
+        ⋮PrivateStructFoo: t v
+        ⋮bar: t
+        ⋮
+        ⋮crate::foo::bar
+        ⋮Baz: t v
+        ⋮PrivateStructBar: t v
+        ⋮PrivateStructFoo: t v
+        ⋮bar: t
     "###
     );
 }
@@ -115,7 +115,7 @@ fn glob_privacy_1() {
 #[test]
 fn glob_privacy_2() {
     let map = def_map(
-        "
+        r"
         //- /lib.rs
         mod foo;
         use foo::*;
@@ -133,19 +133,19 @@ fn glob_privacy_2() {
         ",
     );
     assert_snapshot!(map, @r###"
-    crate
-    Foo: t
-    PubCrateStruct: t v
-    foo: t
-    
-    crate::foo
-    Foo: t v
-    bar: t
-    
-    crate::foo::bar
-    PrivateBar: t v
-    PrivateBaz: t v
-    PubCrateStruct: t v
+        ⋮crate
+        ⋮Foo: t
+        ⋮PubCrateStruct: t v
+        ⋮foo: t
+        ⋮
+        ⋮crate::foo
+        ⋮Foo: t v
+        ⋮bar: t
+        ⋮
+        ⋮crate::foo::bar
+        ⋮PrivateBar: t v
+        ⋮PrivateBaz: t v
+        ⋮PubCrateStruct: t v
     "###
     );
 }
@@ -154,7 +154,7 @@ fn glob_privacy_2() {
 fn glob_across_crates() {
     covers!(glob_across_crates);
     let map = def_map(
-        "
+        r"
         //- /main.rs crate:main deps:test_crate
         use test_crate::*;
 
@@ -163,8 +163,8 @@ fn glob_across_crates() {
         ",
     );
     assert_snapshot!(map, @r###"
-   ⋮crate
-   ⋮Baz: t v
+        ⋮crate
+        ⋮Baz: t v
     "###
     );
 }
@@ -173,7 +173,7 @@ fn glob_across_crates() {
 fn glob_privacy_across_crates() {
     covers!(glob_across_crates);
     let map = def_map(
-        "
+        r"
         //- /main.rs crate:main deps:test_crate
         use test_crate::*;
 
@@ -183,8 +183,8 @@ fn glob_privacy_across_crates() {
         ",
     );
     assert_snapshot!(map, @r###"
-   ⋮crate
-   ⋮Baz: t v
+        ⋮crate
+        ⋮Baz: t v
     "###
     );
 }
@@ -202,10 +202,10 @@ fn glob_enum() {
         ",
     );
     assert_snapshot!(map, @r###"
-   ⋮crate
-   ⋮Bar: t v
-   ⋮Baz: t v
-   ⋮Foo: t
+        ⋮crate
+        ⋮Bar: t v
+        ⋮Baz: t v
+        ⋮Foo: t
     "###
     );
 }
@@ -214,7 +214,7 @@ fn glob_enum() {
 fn glob_enum_group() {
     covers!(glob_enum_group);
     let map = def_map(
-        "
+        r"
         //- /lib.rs
         enum Foo {
             Bar, Baz
@@ -223,10 +223,10 @@ fn glob_enum_group() {
         ",
     );
     assert_snapshot!(map, @r###"
-   ⋮crate
-   ⋮Bar: t v
-   ⋮Baz: t v
-   ⋮Foo: t
+        ⋮crate
+        ⋮Bar: t v
+        ⋮Baz: t v
+        ⋮Foo: t
     "###
     );
 }

--- a/crates/ra_hir_def/src/nameres/tests/macros.rs
+++ b/crates/ra_hir_def/src/nameres/tests/macros.rs
@@ -3,7 +3,7 @@ use super::*;
 #[test]
 fn macro_rules_are_globally_visible() {
     let map = def_map(
-        "
+        r"
         //- /lib.rs
         macro_rules! structs {
             ($($i:ident),*) => {
@@ -31,7 +31,7 @@ fn macro_rules_are_globally_visible() {
 #[test]
 fn macro_rules_can_define_modules() {
     let map = def_map(
-        "
+        r"
         //- /lib.rs
         macro_rules! m {
             ($name:ident) => { mod $name;  }
@@ -51,21 +51,21 @@ fn macro_rules_can_define_modules() {
         ",
     );
     assert_snapshot!(map, @r###"
-    crate
-    m: t
-    n1: t
-    
-    crate::m
-    n3: t
-    
-    crate::m::n3
-    Y: t v
-    
-    crate::n1
-    n2: t
-    
-    crate::n1::n2
-    X: t v
+        ⋮crate
+        ⋮m: t
+        ⋮n1: t
+        ⋮
+        ⋮crate::m
+        ⋮n3: t
+        ⋮
+        ⋮crate::m::n3
+        ⋮Y: t v
+        ⋮
+        ⋮crate::n1
+        ⋮n2: t
+        ⋮
+        ⋮crate::n1::n2
+        ⋮X: t v
     "###);
 }
 

--- a/crates/ra_hir_def/src/nameres/tests/mod_resolution.rs
+++ b/crates/ra_hir_def/src/nameres/tests/mod_resolution.rs
@@ -4,7 +4,7 @@ use super::*;
 fn name_res_works_for_broken_modules() {
     covers!(name_res_works_for_broken_modules);
     let map = def_map(
-        "
+        r"
         //- /lib.rs
         mod foo // no `;`, no body
 
@@ -28,7 +28,7 @@ fn name_res_works_for_broken_modules() {
 #[test]
 fn nested_module_resolution() {
     let map = def_map(
-        "
+        r"
         //- /lib.rs
         mod n1;
 
@@ -55,7 +55,7 @@ fn nested_module_resolution() {
 #[test]
 fn nested_module_resolution_2() {
     let map = def_map(
-        "
+        r"
         //- /lib.rs
         mod prelude;
         mod iter;
@@ -77,23 +77,23 @@ fn nested_module_resolution_2() {
     );
 
     assert_snapshot!(map, @r###"
-    crate
-    iter: t
-    prelude: t
-    
-    crate::iter
-    Iterator: t
-    traits: t
-    
-    crate::iter::traits
-    Iterator: t
-    iterator: t
-    
-    crate::iter::traits::iterator
-    Iterator: t
-    
-    crate::prelude
-    Iterator: t
+        ⋮crate
+        ⋮iter: t
+        ⋮prelude: t
+        ⋮
+        ⋮crate::iter
+        ⋮Iterator: t
+        ⋮traits: t
+        ⋮
+        ⋮crate::iter::traits
+        ⋮Iterator: t
+        ⋮iterator: t
+        ⋮
+        ⋮crate::iter::traits::iterator
+        ⋮Iterator: t
+        ⋮
+        ⋮crate::prelude
+        ⋮Iterator: t
     "###);
 }
 
@@ -780,17 +780,17 @@ fn nested_out_of_line_module() {
     );
 
     assert_snapshot!(map, @r###"
-    crate
-    a: t
-    
-    crate::a
-    b: t
-    
-    crate::a::b
-    c: t
-    
-    crate::a::b::c
-    X: t v
+        ⋮crate
+        ⋮a: t
+        ⋮
+        ⋮crate::a
+        ⋮b: t
+        ⋮
+        ⋮crate::a::b
+        ⋮c: t
+        ⋮
+        ⋮crate::a::b::c
+        ⋮X: t v
     "###);
 }
 
@@ -812,16 +812,16 @@ fn nested_out_of_line_module_with_path() {
     );
 
     assert_snapshot!(map, @r###"
-    crate
-    a: t
-    
-    crate::a
-    b: t
-    
-    crate::a::b
-    c: t
-    
-    crate::a::b::c
-    X: t v
+        ⋮crate
+        ⋮a: t
+        ⋮
+        ⋮crate::a
+        ⋮b: t
+        ⋮
+        ⋮crate::a::b
+        ⋮c: t
+        ⋮
+        ⋮crate::a::b::c
+        ⋮X: t v
     "###);
 }

--- a/crates/ra_ide/src/goto_definition.rs
+++ b/crates/ra_ide/src/goto_definition.rs
@@ -100,8 +100,8 @@ mod tests {
 
     use crate::mock_analysis::analysis_and_position;
 
-    fn check_goto(fixture: &str, expected: &str, expected_range: &str) {
-        let (analysis, pos) = analysis_and_position(fixture);
+    fn check_goto(ra_fixture: &str, expected: &str, expected_range: &str) {
+        let (analysis, pos) = analysis_and_position(ra_fixture);
 
         let mut navs = analysis.goto_definition(pos).unwrap().unwrap().info;
         assert_eq!(navs.len(), 1);
@@ -790,8 +790,8 @@ mod tests {
     #[test]
     fn goto_def_in_local_macro() {
         check_goto(
-            "
-            //- /lib.rs            
+            r"
+            //- /lib.rs
             fn bar() {
                 macro_rules! foo { () => { () } }
                 <|>foo!();


### PR DESCRIPTION
rustfmt allows trailing spaces in string literals unfortunately.



bors r+
🤖