### PR TITLE
ra_cargo_watch: log errors

### DIFF
--- a/crates/ra_cargo_watch/src/lib.rs
+++ b/crates/ra_cargo_watch/src/lib.rs
@@ -318,7 +318,7 @@ pub fn run_cargo(
         Ok(exit_code) if !exit_code.success() && !read_at_least_one_message => {
             // FIXME: Read the stderr to display the reason, see `read2()` reference in PR comment:
             // https://github.com/rust-analyzer/rust-analyzer/pull/3632#discussion_r395605298
-            format!("the command produced no valid metadata:\n cargo {}", args.join(" "))
+            format!("the command produced no valid metadata: cargo {}", args.join(" "))
         }
         Err(err) => format!("io error: {:?}", err),
         Ok(_) => return Ok(()),

--- a/crates/ra_cargo_watch/src/lib.rs
+++ b/crates/ra_cargo_watch/src/lib.rs
@@ -362,7 +362,7 @@ impl WatchThread {
                         _ => {}
                     }
 
-                    // if the send channel was closed, so we want to shutdown
+                    // if the send channel was closed, we want to shutdown
                     message_send.send(CheckEvent::Msg(message)).is_ok()
                 });
 

--- a/crates/ra_cargo_watch/src/lib.rs
+++ b/crates/ra_cargo_watch/src/lib.rs
@@ -318,7 +318,11 @@ pub fn run_cargo(
         Ok(exit_code) if !exit_code.success() && !read_at_least_one_message => {
             // FIXME: Read the stderr to display the reason, see `read2()` reference in PR comment:
             // https://github.com/rust-analyzer/rust-analyzer/pull/3632#discussion_r395605298
-            format!("the command produced no valid metadata: cargo {}", args.join(" "))
+            format!(
+                "the command produced no valid metadata (exit code: {:?}): cargo {}",
+                exit_code,
+                args.join(" ")
+            )
         }
         Err(err) => format!("io error: {:?}", err),
         Ok(_) => return Ok(()),


### PR DESCRIPTION
Until this moment we totally ignored all the errors from cargo process. Though this is still true, but we
now try to log ones that are critical (i.e. misconfiguration errors and ignore compile errors).

This fixes #3631, and gives us a better error message to more gracefully handle the #3265
![image](https://user-images.githubusercontent.com/36276403/76958683-d7e1f080-6920-11ea-83d8-04561c11ccc4.png)

Though I think that outputting this only to `Output` channel is not enough. We should somehow warn the user that he passed wrong arguments to `cargo-watch.args`. I didn't bother looking for how to do this now, but this PR at least gives us something.

*cc* @kiljacken @matklad 