### PR TITLE
[POC][DO NOT MERGE] Custom Derive Proc-Macro 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,6 +916,7 @@ name = "ra_db"
 version = "0.1.0"
 dependencies = [
  "ra_cfg",
+ "ra_proc_macro",
  "ra_prof",
  "ra_syntax",
  "relative-path",
@@ -1099,6 +1100,7 @@ dependencies = [
  "ra_cargo_watch",
  "ra_cfg",
  "ra_db",
+ "ra_proc_macro",
  "rustc-hash",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,6 +1102,8 @@ dependencies = [
 name = "ra_proc_macro"
 version = "0.1.0"
 dependencies = [
+ "crossbeam-channel",
+ "log",
  "ra_mbe",
  "ra_tt",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ name = "chalk-macros"
 version = "0.1.1"
 source = "git+https://github.com/rust-lang/chalk.git?rev=177d71340acc7a7204a33115fc63075d86452179#177d71340acc7a7204a33115fc63075d86452179"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
 ]
 
 [[package]]
@@ -182,7 +182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90082ee5dcdd64dc4e9e0d37fbf3ee325419e39c0092191e0393df65518f741e"
 dependencies = [
  "atty",
- "lazy_static 1.4.0",
+ "lazy_static",
  "libc",
  "winapi 0.3.8",
 ]
@@ -204,7 +204,7 @@ checksum = "6728a28023f207181b193262711102bfbaf47cc9d13bc71d0736607ef8efe88c"
 dependencies = [
  "clicolors-control",
  "encode_unicode",
- "lazy_static 1.4.0",
+ "lazy_static",
  "libc",
  "termios",
  "winapi 0.3.8",
@@ -254,7 +254,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "lazy_static 1.4.0",
+ "lazy_static",
  "maybe-uninit",
  "memoffset",
  "scopeguard",
@@ -278,7 +278,7 @@ checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg",
  "cfg-if",
- "lazy_static 1.4.0",
+ "lazy_static",
 ]
 
 [[package]]
@@ -328,12 +328,6 @@ checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "log",
 ]
-
-[[package]]
-name = "error-chain"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e92ecf0a508c8e074c0e6fa8fe0fa38414848ad4dfc4db6f74c5e9753330b248"
 
 [[package]]
 name = "filetime"
@@ -513,7 +507,7 @@ checksum = "8de3f029212a3fe78a6090f1f2b993877ca245a9ded863f3fcbd6eae084fc1ed"
 dependencies = [
  "console",
  "difference",
- "lazy_static 1.4.0",
+ "lazy_static",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -596,12 +590,6 @@ dependencies = [
  "winapi 0.2.8",
  "winapi-build",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 
 [[package]]
 name = "lazy_static"
@@ -1136,7 +1124,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sharedlib",
 ]
 
 [[package]]
@@ -1285,7 +1272,7 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-queue",
  "crossbeam-utils",
- "lazy_static 1.4.0",
+ "lazy_static",
  "num_cpus",
 ]
 
@@ -1538,18 +1525,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharedlib"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1ab7ad123216d2b04448d3b31edd7e5314b500012b2b01812245725536df2c"
-dependencies = [
- "error-chain",
- "kernel32-sys",
- "lazy_static 0.2.11",
- "winapi 0.2.8",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1637,7 +1612,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ name = "chalk-macros"
 version = "0.1.1"
 source = "git+https://github.com/rust-lang/chalk.git?rev=177d71340acc7a7204a33115fc63075d86452179#177d71340acc7a7204a33115fc63075d86452179"
 dependencies = [
- "lazy_static",
+ "lazy_static 1.4.0",
 ]
 
 [[package]]
@@ -182,7 +182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90082ee5dcdd64dc4e9e0d37fbf3ee325419e39c0092191e0393df65518f741e"
 dependencies = [
  "atty",
- "lazy_static",
+ "lazy_static 1.4.0",
  "libc",
  "winapi 0.3.8",
 ]
@@ -204,7 +204,7 @@ checksum = "6728a28023f207181b193262711102bfbaf47cc9d13bc71d0736607ef8efe88c"
 dependencies = [
  "clicolors-control",
  "encode_unicode",
- "lazy_static",
+ "lazy_static 1.4.0",
  "libc",
  "termios",
  "winapi 0.3.8",
@@ -254,7 +254,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "lazy_static",
+ "lazy_static 1.4.0",
  "maybe-uninit",
  "memoffset",
  "scopeguard",
@@ -278,7 +278,7 @@ checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg",
  "cfg-if",
- "lazy_static",
+ "lazy_static 1.4.0",
 ]
 
 [[package]]
@@ -328,6 +328,12 @@ checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "error-chain"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e92ecf0a508c8e074c0e6fa8fe0fa38414848ad4dfc4db6f74c5e9753330b248"
 
 [[package]]
 name = "filetime"
@@ -431,6 +437,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "goblin"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd5e3132801a1ac34ac53b97acde50c4685414dd2f291b9ea52afa6f07468c8"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,7 +513,7 @@ checksum = "8de3f029212a3fe78a6090f1f2b993877ca245a9ded863f3fcbd6eae084fc1ed"
 dependencies = [
  "console",
  "difference",
- "lazy_static",
+ "lazy_static 1.4.0",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -582,6 +599,12 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
+
+[[package]]
+name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
@@ -597,6 +620,16 @@ name = "libc"
 version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
+
+[[package]]
+name = "libloading"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
+dependencies = [
+ "cc",
+ "winapi 0.3.8",
+]
 
 [[package]]
 name = "linked-hash-map"
@@ -838,6 +871,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ad1f1b834a05d42dae330066e9699a173b28185b3bdc3dbf14ca239585de8cc"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,6 +1116,27 @@ version = "0.1.0"
 dependencies = [
  "ra_mbe",
  "ra_tt",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "smol_str",
+]
+
+[[package]]
+name = "ra_proc_macro_srv"
+version = "0.1.0"
+dependencies = [
+ "cargo_metadata",
+ "difference",
+ "goblin",
+ "libloading",
+ "ra_mbe",
+ "ra_proc_macro",
+ "ra_tt",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sharedlib",
 ]
 
 [[package]]
@@ -1225,7 +1285,7 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-queue",
  "crossbeam-utils",
- "lazy_static",
+ "lazy_static 1.4.0",
  "num_cpus",
 ]
 
@@ -1388,6 +1448,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "scroll"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb2332cb595d33f7edd5700f4cbf94892e680c7f0ae56adab58a35190b66cb1"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8584eea9b9ff42825b46faf46a8c24d2cff13ec152fa2a50df788b87c07ee28"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1455,6 +1535,18 @@ dependencies = [
  "linked-hash-map",
  "serde",
  "yaml-rust",
+]
+
+[[package]]
+name = "sharedlib"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1ab7ad123216d2b04448d3b31edd7e5314b500012b2b01812245725536df2c"
+dependencies = [
+ "error-chain",
+ "kernel32-sys",
+ "lazy_static 0.2.11",
+ "winapi 0.2.8",
 ]
 
 [[package]]
@@ -1545,7 +1637,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
- "lazy_static",
+ "lazy_static 1.4.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,6 +1071,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ra_proc_macro"
+version = "0.1.0"
+dependencies = [
+ "ra_mbe",
+ "ra_tt",
+]
+
+[[package]]
 name = "ra_prof"
 version = "0.1.0"
 dependencies = [

--- a/crates/ra_db/Cargo.toml
+++ b/crates/ra_db/Cargo.toml
@@ -15,4 +15,5 @@ rustc-hash = "1.1.0"
 ra_syntax = { path = "../ra_syntax" }
 ra_cfg = { path = "../ra_cfg" }
 ra_prof = { path = "../ra_prof" }
+ra_proc_macro = { path = "../ra_proc_macro" }
 test_utils = { path = "../test_utils" }

--- a/crates/ra_db/src/fixture.rs
+++ b/crates/ra_db/src/fixture.rs
@@ -70,6 +70,7 @@ fn with_single_file(db: &mut dyn SourceDatabaseExt, ra_fixture: &str) -> FileId 
             meta.cfg,
             meta.env,
             Default::default(),
+            None,
         );
         crate_graph
     } else {
@@ -81,6 +82,7 @@ fn with_single_file(db: &mut dyn SourceDatabaseExt, ra_fixture: &str) -> FileId 
             CfgOptions::default(),
             Env::default(),
             Default::default(),
+            None,
         );
         crate_graph
     };
@@ -130,6 +132,7 @@ fn with_files(db: &mut dyn SourceDatabaseExt, fixture: &str) -> Option<FilePosit
                 meta.cfg,
                 meta.env,
                 Default::default(),
+                None,
             );
             let prev = crates.insert(krate.clone(), crate_id);
             assert!(prev.is_none());
@@ -167,6 +170,7 @@ fn with_files(db: &mut dyn SourceDatabaseExt, fixture: &str) -> Option<FilePosit
             CfgOptions::default(),
             Env::default(),
             Default::default(),
+            None,
         );
     } else {
         for (from, to) in crate_deps {

--- a/crates/ra_db/src/input.rs
+++ b/crates/ra_db/src/input.rs
@@ -19,6 +19,7 @@ use rustc_hash::FxHashSet;
 
 use crate::{RelativePath, RelativePathBuf};
 use fmt::Display;
+use ra_proc_macro::ProcMacro;
 
 /// `FileId` is an integer which uniquely identifies a file. File paths are
 /// messy and system-dependent, so most of the code should work directly with
@@ -127,6 +128,8 @@ pub struct CrateData {
     pub env: Env,
     pub extern_source: ExternSource,
     pub dependencies: Vec<Dependency>,
+    /// If it is a proc macro crate
+    pub proc_macro: Option<ProcMacro>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -166,6 +169,7 @@ impl CrateGraph {
         cfg_options: CfgOptions,
         env: Env,
         extern_source: ExternSource,
+        proc_macro: Option<ProcMacro>,
     ) -> CrateId {
         let data = CrateData {
             root_file_id: file_id,
@@ -174,6 +178,7 @@ impl CrateGraph {
             cfg_options,
             env,
             extern_source,
+            proc_macro,
             dependencies: Vec::new(),
         };
         let crate_id = CrateId(self.arena.len() as u32);
@@ -345,6 +350,7 @@ mod tests {
             CfgOptions::default(),
             Env::default(),
             Default::default(),
+            None,
         );
         let crate2 = graph.add_crate_root(
             FileId(2u32),
@@ -353,6 +359,7 @@ mod tests {
             CfgOptions::default(),
             Env::default(),
             Default::default(),
+            None,
         );
         let crate3 = graph.add_crate_root(
             FileId(3u32),
@@ -361,6 +368,7 @@ mod tests {
             CfgOptions::default(),
             Env::default(),
             Default::default(),
+            None,
         );
         assert!(graph.add_dep(crate1, CrateName::new("crate2").unwrap(), crate2).is_ok());
         assert!(graph.add_dep(crate2, CrateName::new("crate3").unwrap(), crate3).is_ok());
@@ -377,6 +385,7 @@ mod tests {
             CfgOptions::default(),
             Env::default(),
             Default::default(),
+            None,
         );
         let crate2 = graph.add_crate_root(
             FileId(2u32),
@@ -385,6 +394,7 @@ mod tests {
             CfgOptions::default(),
             Env::default(),
             Default::default(),
+            None,
         );
         let crate3 = graph.add_crate_root(
             FileId(3u32),
@@ -393,6 +403,7 @@ mod tests {
             CfgOptions::default(),
             Env::default(),
             Default::default(),
+            None,
         );
         assert!(graph.add_dep(crate1, CrateName::new("crate2").unwrap(), crate2).is_ok());
         assert!(graph.add_dep(crate2, CrateName::new("crate3").unwrap(), crate3).is_ok());
@@ -408,6 +419,7 @@ mod tests {
             CfgOptions::default(),
             Env::default(),
             Default::default(),
+            None,
         );
         let crate2 = graph.add_crate_root(
             FileId(2u32),
@@ -416,6 +428,7 @@ mod tests {
             CfgOptions::default(),
             Env::default(),
             Default::default(),
+            None,
         );
         assert!(graph
             .add_dep(crate1, CrateName::normalize_dashes("crate-name-with-dashes"), crate2)

--- a/crates/ra_db/src/input.rs
+++ b/crates/ra_db/src/input.rs
@@ -13,13 +13,13 @@ use std::{
 };
 
 use ra_cfg::CfgOptions;
+use ra_proc_macro::ProcMacro;
 use ra_syntax::SmolStr;
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
 use crate::{RelativePath, RelativePathBuf};
 use fmt::Display;
-use ra_proc_macro::ProcMacro;
 
 /// `FileId` is an integer which uniquely identifies a file. File paths are
 /// messy and system-dependent, so most of the code should work directly with

--- a/crates/ra_hir_def/src/lib.rs
+++ b/crates/ra_hir_def/src/lib.rs
@@ -475,6 +475,9 @@ impl AsMacroCall for AstIdWithPath<ast::ModuleItem> {
         resolver: impl Fn(path::ModPath) -> Option<MacroDefId>,
     ) -> Option<MacroCallId> {
         let def = resolver(self.path.clone())?;
-        Some(def.as_lazy_macro(db.upcast(), MacroCallKind::Attr(self.ast_id)).into())
+        Some(
+            def.as_lazy_macro(db.upcast(), MacroCallKind::Attr(self.ast_id, self.path.to_string()))
+                .into(),
+        )
     }
 }

--- a/crates/ra_hir_expand/src/eager.rs
+++ b/crates/ra_hir_expand/src/eager.rs
@@ -112,7 +112,8 @@ fn eager_macro_recur(
             }
             MacroDefKind::Declarative
             | MacroDefKind::BuiltIn(_)
-            | MacroDefKind::BuiltInDerive(_) => {
+            | MacroDefKind::BuiltInDerive(_)
+            | MacroDefKind::ProcMacro(_) => {
                 let expanded = lazy_expand(db, &def, curr.with_value(child.clone()))?;
                 // replace macro inside
                 eager_macro_recur(db, expanded, macro_resolver)?

--- a/crates/ra_hir_expand/src/hygiene.rs
+++ b/crates/ra_hir_expand/src/hygiene.rs
@@ -30,6 +30,7 @@ impl Hygiene {
                         MacroDefKind::BuiltIn(_) => None,
                         MacroDefKind::BuiltInDerive(_) => None,
                         MacroDefKind::BuiltInEager(_) => None,
+                        MacroDefKind::ProcMacro(_) => None,
                     }
                 }
                 MacroCallId::EagerMacro(_id) => None,

--- a/crates/ra_hir_expand/src/proc_macro.rs
+++ b/crates/ra_hir_expand/src/proc_macro.rs
@@ -1,11 +1,21 @@
 //! Proc Macro Expander stub
 
 use crate::{db::AstDatabase, LazyMacroId, MacroCallKind, MacroCallLoc};
+use mbe::{ExpandError, ProcMacroError};
 use ra_db::CrateId;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct ProcMacroExpander {
     krate: CrateId,
+}
+
+macro_rules! err {
+    ($fmt:literal, $($tt:tt),*) => {
+        ExpandError::ProcMacroError(ProcMacroError::Unknown(format!($fmt, $($tt),*)))
+    };
+    ($fmt:literal) => {
+        ExpandError::ProcMacroError(ProcMacroError::Unknown($fmt.to_string()))
+    }
 }
 
 impl ProcMacroExpander {
@@ -19,12 +29,23 @@ impl ProcMacroExpander {
         id: LazyMacroId,
         tt: &tt::Subtree,
     ) -> Result<tt::Subtree, mbe::ExpandError> {
-        let name = self.macro_name(db, id).ok_or_else(|| mbe::ExpandError::ConversionError)?;
+        let name = self.macro_name(db, id).ok_or_else(|| err!("Fail to find name in macro"))?;
+
+        let tt = remove_derive_atr(tt, &name)
+            .ok_or_else(|| err!("Fail to remove attr in macro {}", name))?;
         let proc_macro = db.crate_graph()[self.krate]
             .proc_macro
             .clone()
-            .ok_or_else(|| mbe::ExpandError::ConversionError)?;
-        proc_macro.custom_derive(tt, &name)
+            .ok_or_else(|| err!("Fail to find krate in proc macro"))?;
+        proc_macro.custom_derive(&tt, &name).map_err(|err| {
+            match err {
+                ProcMacroError::Dummy => (),
+                _ => {
+                    eprintln!("Proc macro expansion error : {:?}", err);
+                }
+            }
+            err.into()
+        })
     }
 
     fn macro_name(&self, db: &dyn AstDatabase, id: LazyMacroId) -> Option<String> {
@@ -34,4 +55,32 @@ impl ProcMacroExpander {
             MacroCallKind::Attr(_, name) => Some(name),
         }
     }
+}
+
+fn remove_derive_atr(tt: &tt::Subtree, _name: &str) -> Option<tt::Subtree> {
+    // FIXME: better handling
+    // We have a bug in mbe such that the following logic is wrong
+    // // We assume the first 2 tokens are #[derive(name)]
+    // if tt.token_trees.len() > 2 {
+    //     let mut tt = tt.clone();
+    //     tt.token_trees.remove(0);
+    //     tt.token_trees.remove(0);
+    //     return Some(tt);
+    // }
+    if tt.token_trees.len() > 2 {
+        let mut tt = tt.clone();
+        tt.token_trees.remove(0);
+        while tt.token_trees.len() > 0 {
+            let curr = tt.token_trees.remove(0);
+            if let tt::TokenTree::Leaf(tt::Leaf::Punct(punct)) = curr {
+                if punct.char == ']' {
+                    break;
+                }
+            }
+        }
+
+        return Some(tt);
+    }
+
+    None
 }

--- a/crates/ra_hir_expand/src/proc_macro.rs
+++ b/crates/ra_hir_expand/src/proc_macro.rs
@@ -1,0 +1,32 @@
+//! Proc Macro Expander stub
+
+use crate::{db::AstDatabase, LazyMacroId, MacroCallKind, MacroCallLoc};
+use ra_db::CrateId;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub struct ProcMacroExpander {
+    krate: CrateId,
+}
+
+impl ProcMacroExpander {
+    pub fn new(krate: CrateId) -> ProcMacroExpander {
+        ProcMacroExpander { krate }
+    }
+
+    pub fn expand(
+        &self,
+        db: &dyn AstDatabase,
+        id: LazyMacroId,
+        _tt: &tt::Subtree,
+    ) -> Result<tt::Subtree, mbe::ExpandError> {
+        let loc: MacroCallLoc = db.lookup_intern_macro(id);
+        let name = match loc.kind {
+            MacroCallKind::FnLike(_) => return Err(mbe::ExpandError::ConversionError),
+            MacroCallKind::Attr(_, name) => name,
+        };
+
+        dbg!(name);
+
+        unimplemented!()
+    }
+}

--- a/crates/ra_hir_ty/src/tests/macros.rs
+++ b/crates/ra_hir_ty/src/tests/macros.rs
@@ -639,3 +639,26 @@ mod clone {
     );
     assert_eq!("(Wrapper<S>, {unknown})", type_at_pos(&db, pos));
 }
+
+#[test]
+fn infer_custom_derive_simple() {
+    let (db, pos) = TestDB::with_position(
+        r#"
+//- /main.rs crate:main deps:foo
+use foo::Foo;
+
+#[derive(Foo)]
+struct S{}
+
+fn test() {
+    S{}<|>;
+}
+
+//- /lib.rs crate:foo
+#[proc_macro_derive(Foo)]
+pub fn derive_foo(_item: TokenStream) -> TokenStream {    
+}
+"#,
+    );
+    assert_eq!("S", type_at_pos(&db, pos));
+}

--- a/crates/ra_ide/src/lib.rs
+++ b/crates/ra_ide/src/lib.rs
@@ -213,6 +213,7 @@ impl Analysis {
             cfg_options,
             Env::default(),
             Default::default(),
+            None,
         );
         change.add_file(source_root, file_id, "main.rs".into(), Arc::new(text));
         change.set_crate_graph(crate_graph);

--- a/crates/ra_ide/src/mock_analysis.rs
+++ b/crates/ra_ide/src/mock_analysis.rs
@@ -103,6 +103,7 @@ impl MockAnalysis {
                     cfg_options,
                     Env::default(),
                     Default::default(),
+                    None,
                 ));
             } else if path.ends_with("/lib.rs") {
                 let crate_name = path.parent().unwrap().file_name().unwrap();
@@ -113,6 +114,7 @@ impl MockAnalysis {
                     cfg_options,
                     Env::default(),
                     Default::default(),
+                    None,
                 );
                 if let Some(root_crate) = root_crate {
                     crate_graph

--- a/crates/ra_ide/src/parent_module.rs
+++ b/crates/ra_ide/src/parent_module.rs
@@ -137,6 +137,7 @@ mod tests {
             CfgOptions::default(),
             Env::default(),
             Default::default(),
+            None,
         );
         let mut change = AnalysisChange::new();
         change.set_crate_graph(crate_graph);

--- a/crates/ra_mbe/src/lib.rs
+++ b/crates/ra_mbe/src/lib.rs
@@ -21,6 +21,29 @@ pub enum ParseError {
     Expected(String),
 }
 
+#[derive(Debug)]
+pub enum ProcMacroError {
+    Dummy,
+    IOError(std::io::Error),
+    JsonError(String),
+    Unknown(String),
+    ExpansionError(String),
+}
+
+impl Eq for ProcMacroError {}
+impl PartialEq for ProcMacroError {
+    fn eq(&self, other: &ProcMacroError) -> bool {
+        match (self, other) {
+            (ProcMacroError::Dummy, ProcMacroError::Dummy) => true,
+            (ProcMacroError::IOError(a), ProcMacroError::IOError(b)) => a.kind() == b.kind(),
+            (ProcMacroError::Unknown(a), ProcMacroError::Unknown(b)) => a == b,
+            (ProcMacroError::JsonError(a), ProcMacroError::JsonError(b)) => a == b,
+            (ProcMacroError::ExpansionError(a), ProcMacroError::ExpansionError(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum ExpandError {
     NoMatchingRule,
@@ -28,6 +51,13 @@ pub enum ExpandError {
     BindingError(String),
     ConversionError,
     InvalidRepeat,
+    ProcMacroError(ProcMacroError),
+}
+
+impl From<ProcMacroError> for ExpandError {
+    fn from(err: ProcMacroError) -> Self {
+        ExpandError::ProcMacroError(err)
+    }
 }
 
 pub use crate::syntax_bridge::{

--- a/crates/ra_mbe/src/syntax_bridge.rs
+++ b/crates/ra_mbe/src/syntax_bridge.rs
@@ -34,7 +34,7 @@ impl TokenTextRange {
 }
 
 /// Maps `tt::TokenId` to the relative range of the original token.
-#[derive(Debug, PartialEq, Eq, Default)]
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct TokenMap {
     /// Maps `tt::TokenId` to the *relative* source range.
     entries: Vec<(tt::TokenId, TokenTextRange)>,

--- a/crates/ra_proc_macro/Cargo.toml
+++ b/crates/ra_proc_macro/Cargo.toml
@@ -14,5 +14,7 @@ ra_mbe = { path = "../ra_mbe" }
 serde_derive = "1.0.104"
 serde = "1.0.104"
 serde_json = "1.0.48"
+log = "0.4.8"
+crossbeam-channel = "0.4.0"
 
 smol_str = { version = "0.1.15", features = ["serde"] }

--- a/crates/ra_proc_macro/Cargo.toml
+++ b/crates/ra_proc_macro/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+edition = "2018"
+name = "ra_proc_macro"
+version = "0.1.0"
+authors = ["rust-analyzer developers"]
+publish = false
+
+[lib]
+doctest = false
+
+[dependencies]
+ra_tt = { path = "../ra_tt" }
+ra_mbe = { path = "../ra_mbe" }

--- a/crates/ra_proc_macro/src/lib.rs
+++ b/crates/ra_proc_macro/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/crates/ra_proc_macro/src/lib.rs
+++ b/crates/ra_proc_macro/src/lib.rs
@@ -1,7 +1,57 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
+//! Client-side Proc-Macro crate
+//!
+//! We separate proc-macro expanding logic to an extern program to allow
+//! different implementations (e.g. wasm or dylib loading). And this crate
+//! is used for provide basic infra-structure for commnicate between two
+//! process: Client (RA itself), Server (the external program)
+
+#![allow(unused_variables)]
+
+use ra_mbe::ExpandError;
+use ra_tt::Subtree;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcMacroProcessExpander {
+    process_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcMacro {
+    expander: Arc<ProcMacroProcessExpander>,
+    dylib_path: PathBuf,
+}
+
+impl ProcMacro {
+    pub fn custom_derive(
+        &self,
+        subtree: &Subtree,
+        derive_name: &str,
+    ) -> Result<Subtree, ExpandError> {
+        unimplemented!()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcMacroClient {
+    expander: Arc<ProcMacroProcessExpander>,
+}
+
+impl ProcMacroClient {
+    pub fn extern_process(process_path: &Path) -> ProcMacroClient {
+        let expander = ProcMacroProcessExpander { process_path: process_path.into() };
+        ProcMacroClient { expander: Arc::new(expander) }
+    }
+
+    pub fn dummy() -> ProcMacroClient {
+        let expander = ProcMacroProcessExpander { process_path: "".into() };
+        ProcMacroClient { expander: Arc::new(expander) }
+    }
+
+    pub fn by_dylib_path(&self, dylib_path: &Path) -> ProcMacro {
+        ProcMacro { expander: self.expander.clone(), dylib_path: dylib_path.into() }
     }
 }

--- a/crates/ra_proc_macro/src/lib.rs
+++ b/crates/ra_proc_macro/src/lib.rs
@@ -7,16 +7,66 @@
 
 #![allow(unused_variables)]
 
-use ra_mbe::ExpandError;
+mod rpc;
+
+use ra_mbe::ProcMacroError;
 use ra_tt::Subtree;
+pub use rpc::{ExpansionResult, ExpansionTask};
 use std::{
+    io::{Read, Write},
     path::{Path, PathBuf},
+    process::{Command, Stdio},
     sync::Arc,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProcMacroProcessExpander {
     process_path: PathBuf,
+}
+
+impl ProcMacroProcessExpander {
+    pub fn custom_derive(
+        &self,
+        dylib_path: &Path,
+        subtree: &Subtree,
+        derive_name: &str,
+    ) -> Result<Subtree, ProcMacroError> {
+        if self.process_path == PathBuf::default() {
+            return Err(ProcMacroError::Dummy);
+        }
+        let process = match Command::new(self.process_path.clone())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+        {
+            Ok(process) => process,
+            Err(err) => Err(ProcMacroError::IOError(err))?,
+        };
+
+        let task = ExpansionTask {
+            macro_body: subtree.clone(),
+            macro_name: derive_name.to_string(),
+            attributes: None,
+            lib: dylib_path.to_path_buf(),
+        };
+        let data = serde_json::to_string(&task)
+            .map_err(|err| ProcMacroError::JsonError(err.to_string()))?;
+        if let Err(err) = process.stdin.unwrap().write_all(data.as_bytes()) {
+            return Err(ProcMacroError::IOError(err));
+        };
+
+        let mut s = String::new();
+        match process.stdout.unwrap().read_to_string(&mut s) {
+            Err(err) => return Err(ProcMacroError::IOError(err)),
+            Ok(_) => (),
+        }
+        let result: ExpansionResult =
+            serde_json::from_str(&s).map_err(|err| ProcMacroError::JsonError(err.to_string()))?;
+        match result {
+            ExpansionResult::Success { expansion } => Ok(expansion),
+            ExpansionResult::Error { reason } => Err(ProcMacroError::ExpansionError(reason)),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -30,8 +80,8 @@ impl ProcMacro {
         &self,
         subtree: &Subtree,
         derive_name: &str,
-    ) -> Result<Subtree, ExpandError> {
-        unimplemented!()
+    ) -> Result<Subtree, ProcMacroError> {
+        self.expander.custom_derive(&self.dylib_path, subtree, derive_name)
     }
 }
 
@@ -47,7 +97,7 @@ impl ProcMacroClient {
     }
 
     pub fn dummy() -> ProcMacroClient {
-        let expander = ProcMacroProcessExpander { process_path: "".into() };
+        let expander = ProcMacroProcessExpander { process_path: PathBuf::default() };
         ProcMacroClient { expander: Arc::new(expander) }
     }
 

--- a/crates/ra_proc_macro/src/lib.rs
+++ b/crates/ra_proc_macro/src/lib.rs
@@ -4,75 +4,31 @@
 //! different implementations (e.g. wasm or dylib loading). And this crate
 //! is used for provide basic infra-structure for commnicate between two
 //! process: Client (RA itself), Server (the external program)
-
-#![allow(unused_variables)]
-
 mod rpc;
+mod process;
+pub mod msg;
 
+use process::ProcMacroProcessExpander;
 use ra_mbe::ProcMacroError;
 use ra_tt::Subtree;
 pub use rpc::{ExpansionResult, ExpansionTask};
+
 use std::{
-    io::{Read, Write},
     path::{Path, PathBuf},
-    process::{Command, Stdio},
     sync::Arc,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ProcMacroProcessExpander {
-    process_path: PathBuf,
-}
-
-impl ProcMacroProcessExpander {
-    pub fn custom_derive(
-        &self,
-        dylib_path: &Path,
-        subtree: &Subtree,
-        derive_name: &str,
-    ) -> Result<Subtree, ProcMacroError> {
-        if self.process_path == PathBuf::default() {
-            return Err(ProcMacroError::Dummy);
-        }
-        let process = match Command::new(self.process_path.clone())
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .spawn()
-        {
-            Ok(process) => process,
-            Err(err) => Err(ProcMacroError::IOError(err))?,
-        };
-
-        let task = ExpansionTask {
-            macro_body: subtree.clone(),
-            macro_name: derive_name.to_string(),
-            attributes: None,
-            lib: dylib_path.to_path_buf(),
-        };
-        let data = serde_json::to_string(&task)
-            .map_err(|err| ProcMacroError::JsonError(err.to_string()))?;
-        if let Err(err) = process.stdin.unwrap().write_all(data.as_bytes()) {
-            return Err(ProcMacroError::IOError(err));
-        };
-
-        let mut s = String::new();
-        match process.stdout.unwrap().read_to_string(&mut s) {
-            Err(err) => return Err(ProcMacroError::IOError(err)),
-            Ok(_) => (),
-        }
-        let result: ExpansionResult =
-            serde_json::from_str(&s).map_err(|err| ProcMacroError::JsonError(err.to_string()))?;
-        match result {
-            ExpansionResult::Success { expansion } => Ok(expansion),
-            ExpansionResult::Error { reason } => Err(ProcMacroError::ExpansionError(reason)),
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct ProcMacro {
     expander: Arc<ProcMacroProcessExpander>,
     dylib_path: PathBuf,
+}
+
+impl Eq for ProcMacro {}
+impl PartialEq for ProcMacro {
+    fn eq(&self, other: &ProcMacro) -> bool {
+        Arc::ptr_eq(&self.expander, &other.expander) && self.dylib_path == other.dylib_path
+    }
 }
 
 impl ProcMacro {
@@ -85,19 +41,19 @@ impl ProcMacro {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct ProcMacroClient {
     expander: Arc<ProcMacroProcessExpander>,
 }
 
 impl ProcMacroClient {
-    pub fn extern_process(process_path: &Path) -> ProcMacroClient {
-        let expander = ProcMacroProcessExpander { process_path: process_path.into() };
-        ProcMacroClient { expander: Arc::new(expander) }
+    pub fn extern_process(process_path: &Path) -> Result<ProcMacroClient, std::io::Error> {
+        let expander = ProcMacroProcessExpander::run(process_path)?;
+        Ok(ProcMacroClient { expander: Arc::new(expander) })
     }
 
     pub fn dummy() -> ProcMacroClient {
-        let expander = ProcMacroProcessExpander { process_path: PathBuf::default() };
+        let expander = ProcMacroProcessExpander::default();
         ProcMacroClient { expander: Arc::new(expander) }
     }
 

--- a/crates/ra_proc_macro/src/msg.rs
+++ b/crates/ra_proc_macro/src/msg.rs
@@ -1,0 +1,218 @@
+//! A simplified version of lsp base protocol for rpc
+
+use std::{
+    fmt,
+    io::{self, BufRead, Write},
+};
+
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum Message {
+    Request(Request),
+    Response(Response),
+}
+
+impl From<Request> for Message {
+    fn from(request: Request) -> Message {
+        Message::Request(request)
+    }
+}
+
+impl From<Response> for Message {
+    fn from(response: Response) -> Message {
+        Message::Response(response)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[serde(transparent)]
+pub struct RequestId(IdRepr);
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[serde(untagged)]
+enum IdRepr {
+    U64(u64),
+    String(String),
+}
+
+impl From<u64> for RequestId {
+    fn from(id: u64) -> RequestId {
+        RequestId(IdRepr::U64(id))
+    }
+}
+
+impl From<String> for RequestId {
+    fn from(id: String) -> RequestId {
+        RequestId(IdRepr::String(id))
+    }
+}
+
+impl fmt::Display for RequestId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.0 {
+            IdRepr::U64(it) => fmt::Display::fmt(it, f),
+            IdRepr::String(it) => fmt::Display::fmt(it, f),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Request {
+    pub id: RequestId,
+    pub method: String,
+    pub params: serde_json::Value,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Response {
+    // JSON RPC allows this to be null if it was impossible
+    // to decode the request's id. Ignore this special case
+    // and just die horribly.
+    pub id: RequestId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ResponseError>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ResponseError {
+    pub code: i32,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[allow(unused)]
+pub enum ErrorCode {
+    // Defined by JSON RPC
+    ParseError = -32700,
+    InvalidRequest = -32600,
+    MethodNotFound = -32601,
+    InvalidParams = -32602,
+    InternalError = -32603,
+    ServerErrorStart = -32099,
+    ServerErrorEnd = -32000,
+    ServerNotInitialized = -32002,
+    UnknownErrorCode = -32001,
+
+    // Defined by protocol
+    ExpansionError = -32900,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Notification {
+    pub method: String,
+    pub params: serde_json::Value,
+}
+
+impl Message {
+    pub fn read(r: &mut impl BufRead) -> io::Result<Option<Message>> {
+        let text = match read_msg_text(r)? {
+            None => return Ok(None),
+            Some(text) => text,
+        };
+        let msg = serde_json::from_str(&text)?;
+        Ok(Some(msg))
+    }
+    pub fn write(self, w: &mut impl Write) -> io::Result<()> {
+        #[derive(Serialize)]
+        struct JsonRpc {
+            jsonrpc: &'static str,
+            #[serde(flatten)]
+            msg: Message,
+        }
+        let text = serde_json::to_string(&JsonRpc { jsonrpc: "2.0", msg: self })?;
+        write_msg_text(w, &text)
+    }
+}
+
+impl Response {
+    pub fn new_ok<R: Serialize>(id: RequestId, result: R) -> Response {
+        Response { id, result: Some(serde_json::to_value(result).unwrap()), error: None }
+    }
+    pub fn new_err(id: RequestId, code: i32, message: String) -> Response {
+        let error = ResponseError { code, message, data: None };
+        Response { id, result: None, error: Some(error) }
+    }
+}
+
+impl Request {
+    pub fn new<P: Serialize>(id: RequestId, method: String, params: P) -> Request {
+        Request { id, method, params: serde_json::to_value(params).unwrap() }
+    }
+    pub fn extract<P: DeserializeOwned>(self, method: &str) -> Result<(RequestId, P), Request> {
+        if self.method == method {
+            let params = serde_json::from_value(self.params).unwrap_or_else(|err| {
+                panic!("Invalid request\nMethod: {}\n error: {}", method, err)
+            });
+            Ok((self.id, params))
+        } else {
+            Err(self)
+        }
+    }
+}
+
+impl Notification {
+    pub fn new(method: String, params: impl Serialize) -> Notification {
+        Notification { method, params: serde_json::to_value(params).unwrap() }
+    }
+    pub fn extract<P: DeserializeOwned>(self, method: &str) -> Result<P, Notification> {
+        if self.method == method {
+            let params = serde_json::from_value(self.params).unwrap();
+            Ok(params)
+        } else {
+            Err(self)
+        }
+    }
+}
+
+fn read_msg_text(inp: &mut impl BufRead) -> io::Result<Option<String>> {
+    fn invalid_data(error: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> io::Error {
+        io::Error::new(io::ErrorKind::InvalidData, error)
+    }
+    macro_rules! invalid_data {
+        ($($tt:tt)*) => (invalid_data(format!($($tt)*)))
+    }
+
+    let mut size = None;
+    let mut buf = String::new();
+    loop {
+        buf.clear();
+        if inp.read_line(&mut buf)? == 0 {
+            return Ok(None);
+        }
+        if !buf.ends_with("\r\n") {
+            return Err(invalid_data!("malformed header: {:?}", buf));
+        }
+        let buf = &buf[..buf.len() - 2];
+        if buf.is_empty() {
+            break;
+        }
+        let mut parts = buf.splitn(2, ": ");
+        let header_name = parts.next().unwrap();
+        let header_value =
+            parts.next().ok_or_else(|| invalid_data!("malformed header: {:?}", buf))?;
+        if header_name == "Content-Length" {
+            size = Some(header_value.parse::<usize>().map_err(invalid_data)?);
+        }
+    }
+    let size: usize = size.ok_or_else(|| invalid_data!("no Content-Length"))?;
+    let mut buf = buf.into_bytes();
+    buf.resize(size, 0);
+    inp.read_exact(&mut buf)?;
+    let buf = String::from_utf8(buf).map_err(invalid_data)?;
+    log::debug!("< {}", buf);
+    Ok(Some(buf))
+}
+
+fn write_msg_text(out: &mut impl Write, msg: &str) -> io::Result<()> {
+    log::debug!("> {}", msg);
+    write!(out, "Content-Length: {}\r\n\r\n", msg.len())?;
+    out.write_all(msg.as_bytes())?;
+    out.flush()?;
+    Ok(())
+}

--- a/crates/ra_proc_macro/src/process.rs
+++ b/crates/ra_proc_macro/src/process.rs
@@ -1,0 +1,179 @@
+use crossbeam_channel::{bounded, Receiver, Sender};
+use ra_mbe::ProcMacroError;
+use ra_tt::Subtree;
+
+use crate::msg::{ErrorCode, Message, Request, Response, ResponseError};
+use crate::rpc::{ExpansionResult, ExpansionTask};
+
+use io::{BufRead, BufReader};
+use std::{
+    io::{self, Write},
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+    thread::spawn,
+};
+
+#[derive(Debug, Default)]
+pub(crate) struct ProcMacroProcessExpander {
+    inner: Option<Handle>,
+}
+
+#[derive(Debug)]
+struct Handle {
+    sender: Sender<Message>,
+    receiver: Receiver<Message>,
+}
+
+struct Process {
+    path: PathBuf,
+    child: Child,
+}
+
+impl Process {
+    fn run(process_path: &Path) -> Result<Process, io::Error> {
+        let child = Command::new(process_path.clone())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()?;
+
+        Ok(Process { path: process_path.into(), child })
+    }
+
+    fn restart(&mut self) -> Result<(), io::Error> {
+        let _ = self.child.kill();
+        self.child =
+            Command::new(self.path.clone()).stdin(Stdio::piped()).stdout(Stdio::piped()).spawn()?;
+        Ok(())
+    }
+
+    fn stdio(&mut self) -> Option<(impl Write, impl BufRead)> {
+        let stdin = self.child.stdin.take()?;
+        let stdout = self.child.stdout.take()?;
+        let read = BufReader::new(stdout);
+
+        Some((stdin, read))
+    }
+}
+
+impl ProcMacroProcessExpander {
+    pub fn run(process_path: &Path) -> Result<ProcMacroProcessExpander, io::Error> {
+        let process = Process::run(process_path)?;
+
+        let (task_tx, task_rx) = bounded(0);
+        let (res_tx, res_rx) = bounded(0);
+
+        let _ = spawn(move || {
+            client_loop(task_rx, res_tx, process);
+        });
+        Ok(ProcMacroProcessExpander { inner: Some(Handle { sender: task_tx, receiver: res_rx }) })
+    }
+
+    pub fn custom_derive(
+        &self,
+        dylib_path: &Path,
+        subtree: &Subtree,
+        derive_name: &str,
+    ) -> Result<Subtree, ProcMacroError> {
+        let handle = match &self.inner {
+            None => return Err(ProcMacroError::Dummy),
+            Some(it) => it,
+        };
+
+        let task = ExpansionTask {
+            macro_body: subtree.clone(),
+            macro_name: derive_name.to_string(),
+            attributes: None,
+            lib: dylib_path.to_path_buf(),
+        };
+
+        // FIXME: use a proper request id
+        let id = 0;
+        let req = Request {
+            id: id.into(),
+            method: "".into(),
+            params: serde_json::to_value(task).unwrap(),
+        };
+
+        handle.sender.send(req.into()).unwrap();
+        let response = handle.receiver.recv().unwrap();
+
+        match response {
+            Message::Request(_) => {
+                return Err(ProcMacroError::Unknown("Return request from ra_proc_srv".into()))
+            }
+            Message::Response(res) => {
+                if let Some(err) = res.error {
+                    return Err(ProcMacroError::ExpansionError(err.message));
+                }
+                match res.result {
+                    None => Ok(Subtree::default()),
+                    Some(res) => {
+                        let result: ExpansionResult = serde_json::from_value(res)
+                            .map_err(|err| ProcMacroError::JsonError(err.to_string()))?;
+                        Ok(result.expansion)
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn client_loop(task_rx: Receiver<Message>, res_tx: Sender<Message>, mut process: Process) {
+    let (mut stdin, mut stdout) = match process.stdio() {
+        None => return,
+        Some(it) => it,
+    };
+
+    loop {
+        let msg = match task_rx.recv() {
+            Ok(msg) => msg,
+            Err(_) => break,
+        };
+
+        let res = match send_message(&mut stdin, &mut stdout, msg) {
+            Ok(res) => res,
+            Err(_err) => {
+                let res = Response {
+                    id: 0.into(),
+                    result: None,
+                    error: Some(ResponseError {
+                        code: ErrorCode::ServerErrorEnd as i32,
+                        message: "Server closed".into(),
+                        data: None,
+                    }),
+                };
+                if res_tx.send(res.into()).is_err() {
+                    break;
+                }
+                // Restart the process
+                if process.restart().is_err() {
+                    break;
+                }
+                let stdio = match process.stdio() {
+                    None => break,
+                    Some(it) => it,
+                };
+                stdin = stdio.0;
+                stdout = stdio.1;
+                continue;
+            }
+        };
+
+        if let Some(res) = res {
+            if res_tx.send(res).is_err() {
+                break;
+            }
+        }
+    }
+
+    let _ = process.child.kill();
+}
+
+fn send_message(
+    mut writer: &mut impl Write,
+    mut reader: &mut impl BufRead,
+    msg: Message,
+) -> Result<Option<Message>, io::Error> {
+    msg.write(&mut writer)?;
+    Ok(Message::read(&mut reader)?)
+}

--- a/crates/ra_proc_macro/src/rpc.rs
+++ b/crates/ra_proc_macro/src/rpc.rs
@@ -1,0 +1,228 @@
+//! Data struture serialization related stuffs for RPC
+
+use ra_tt::{
+    Delimiter, DelimiterKind, Ident, Leaf, Literal, Punct, Spacing, Subtree, TokenId, TokenTree,
+};
+use serde::{Deserialize, Serialize};
+use smol_str::SmolStr;
+use std::path::PathBuf;
+
+#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+pub struct ExpansionTask {
+    /// Argument of macro call.
+    ///
+    /// In custom derive that would be a struct or enum; in attribute-like macro - underlying
+    /// item; in function-like macro - the macro body.
+    #[serde(with = "SubtreeDef")]
+    pub macro_body: Subtree,
+
+    /// Names of macros to expand.
+    ///
+    /// In custom derive those are names of derived traits (`Serialize`, `Getters`, etc.). In
+    /// attribute-like and functiona-like macros - single name of macro itself (`show_streams`).
+    pub macro_name: String,
+
+    /// Possible attributes for the attribute-like macros.
+    #[serde(with = "opt_subtree_def")]
+    pub attributes: Option<Subtree>,
+
+    pub lib: PathBuf,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ExpansionResult {
+    #[serde(rename = "success", with = "SubtreeDef")]
+    Success { expansion: Subtree },
+    #[serde(rename = "error")]
+    Error { reason: String },
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "DelimiterKind")]
+enum DelimiterKindDef {
+    Parenthesis,
+    Brace,
+    Bracket,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "TokenId")]
+struct TokenIdDef(u32);
+
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "Delimiter")]
+struct DelimiterDef {
+    #[serde(with = "TokenIdDef")]
+    pub id: TokenId,
+    #[serde(with = "DelimiterKindDef")]
+    pub kind: DelimiterKind,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "Subtree")]
+struct SubtreeDef {
+    #[serde(default, with = "opt_delimiter_def")]
+    pub delimiter: Option<Delimiter>,
+    #[serde(with = "vec_token_tree")]
+    pub token_trees: Vec<TokenTree>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "TokenTree")]
+enum TokenTreeDef {
+    #[serde(with = "LeafDef")]
+    Leaf(Leaf),
+    #[serde(with = "SubtreeDef")]
+    Subtree(Subtree),
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "Leaf")]
+enum LeafDef {
+    #[serde(with = "LiteralDef")]
+    Literal(Literal),
+    #[serde(with = "PunctDef")]
+    Punct(Punct),
+    #[serde(with = "IdentDef")]
+    Ident(Ident),
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "Literal")]
+struct LiteralDef {
+    pub text: SmolStr,
+    #[serde(with = "TokenIdDef")]
+    pub id: TokenId,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "Punct")]
+struct PunctDef {
+    pub char: char,
+    #[serde(with = "SpacingDef")]
+    pub spacing: Spacing,
+    #[serde(with = "TokenIdDef")]
+    pub id: TokenId,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "Spacing")]
+enum SpacingDef {
+    Alone,
+    Joint,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "Ident")]
+struct IdentDef {
+    pub text: SmolStr,
+    #[serde(with = "TokenIdDef")]
+    pub id: TokenId,
+}
+
+mod opt_delimiter_def {
+    use super::{Delimiter, DelimiterDef};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S>(value: &Option<Delimiter>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        #[derive(Serialize)]
+        struct Helper<'a>(#[serde(with = "DelimiterDef")] &'a Delimiter);
+        value.as_ref().map(Helper).serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Delimiter>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Helper(#[serde(with = "DelimiterDef")] Delimiter);
+        let helper = Option::deserialize(deserializer)?;
+        Ok(helper.map(|Helper(external)| external))
+    }
+}
+
+mod opt_subtree_def {
+    use super::{Subtree, SubtreeDef};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S>(value: &Option<Subtree>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        #[derive(Serialize)]
+        struct Helper<'a>(#[serde(with = "SubtreeDef")] &'a Subtree);
+        value.as_ref().map(Helper).serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Subtree>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Helper(#[serde(with = "SubtreeDef")] Subtree);
+        let helper = Option::deserialize(deserializer)?;
+        Ok(helper.map(|Helper(external)| external))
+    }
+}
+
+mod vec_token_tree {
+    use super::{TokenTree, TokenTreeDef};
+    use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S>(value: &Vec<TokenTree>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        #[derive(Serialize)]
+        struct Helper<'a>(#[serde(with = "TokenTreeDef")] &'a TokenTree);
+
+        let items: Vec<_> = value.iter().map(Helper).collect();
+        let mut seq = serializer.serialize_seq(Some(items.len()))?;
+        for element in items {
+            seq.serialize_element(&element)?;
+        }
+        seq.end()
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<TokenTree>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Helper(#[serde(with = "TokenTreeDef")] TokenTree);
+
+        let helper = Vec::deserialize(deserializer)?;
+        Ok(helper.into_iter().map(|Helper(external)| external).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_proc_macro_rpc_works() {
+        let tt = ra_mbe::parse_to_token_tree("struct Foo {}").unwrap().0;
+        let task = ExpansionTask {
+            macro_body: tt.clone(),
+            macro_name: Default::default(),
+            attributes: None,
+            lib: Default::default(),
+        };
+
+        let json = serde_json::to_string(&task).unwrap();
+        let back: ExpansionTask = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(task.macro_body, back.macro_body);
+
+        let result = ExpansionResult::Success { expansion: tt.clone() };
+        let json = serde_json::to_string(&task).unwrap();
+        let back: ExpansionResult = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(result, back);
+    }
+}

--- a/crates/ra_proc_macro/src/rpc.rs
+++ b/crates/ra_proc_macro/src/rpc.rs
@@ -30,12 +30,9 @@ pub struct ExpansionTask {
 }
 
 #[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
-#[serde(tag = "type")]
-pub enum ExpansionResult {
-    #[serde(rename = "success", with = "SubtreeDef")]
-    Success { expansion: Subtree },
-    #[serde(rename = "error")]
-    Error { reason: String },
+pub struct ExpansionResult {
+    #[serde(with = "SubtreeDef")]
+    pub expansion: Subtree,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -219,7 +216,7 @@ mod tests {
 
         assert_eq!(task.macro_body, back.macro_body);
 
-        let result = ExpansionResult::Success { expansion: tt.clone() };
+        let result = ExpansionResult { expansion: tt.clone() };
         let json = serde_json::to_string(&task).unwrap();
         let back: ExpansionResult = serde_json::from_str(&json).unwrap();
 

--- a/crates/ra_proc_macro_srv/Cargo.toml
+++ b/crates/ra_proc_macro_srv/Cargo.toml
@@ -17,9 +17,8 @@ serde_derive = "1.0.104"
 serde = "1.0.104"
 serde_json = "1.0.48"
 libloading = "0.5.2"
-sharedlib = "7.0.0"
 goblin = "0.2.0"
-difference = "2.0.0"
 
 [dev-dependencies]
 cargo_metadata = "0.9.1"
+difference = "2.0.0"

--- a/crates/ra_proc_macro_srv/Cargo.toml
+++ b/crates/ra_proc_macro_srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 edition = "2018"
-name = "ra_proc_macro"
+name = "ra_proc_macro_srv"
 version = "0.1.0"
 authors = ["rust-analyzer developers"]
 publish = false
@@ -11,8 +11,15 @@ doctest = false
 [dependencies]
 ra_tt = { path = "../ra_tt" }
 ra_mbe = { path = "../ra_mbe" }
+ra_proc_macro = { path = "../ra_proc_macro" }
+
 serde_derive = "1.0.104"
 serde = "1.0.104"
 serde_json = "1.0.48"
+libloading = "0.5.2"
+sharedlib = "7.0.0"
+goblin = "0.2.0"
+difference = "2.0.0"
 
-smol_str = { version = "0.1.15", features = ["serde"] }
+[dev-dependencies]
+cargo_metadata = "0.9.1"

--- a/crates/ra_proc_macro_srv/src/dylib.rs
+++ b/crates/ra_proc_macro_srv/src/dylib.rs
@@ -1,0 +1,193 @@
+//use dylib::DynamicLibrary;
+use crate::proc_macro::bridge;
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+use goblin::{mach::Mach, Object};
+use libloading::Library;
+
+static NEW_REGISTRAR_SYMBOL: &str = "__rustc_proc_macro_decls_";
+static _OLD_REGISTRAR_SYMBOL: &str = "__rustc_derive_registrar_";
+
+fn read_bytes(file: &Path) -> Option<Vec<u8>> {
+    let mut fd = File::open(file).ok()?;
+    let mut buffer = Vec::new();
+    fd.read_to_end(&mut buffer).ok()?;
+
+    Some(buffer)
+}
+
+fn get_symbols_from_lib(file: &Path) -> Option<Vec<String>> {
+    let buffer = read_bytes(file)?;
+    let object = Object::parse(&buffer).ok()?;
+
+    return match object {
+        Object::Elf(elf) => {
+            let symbols = elf.dynstrtab.to_vec().ok()?;
+            let names = symbols.iter().map(|s| s.to_string()).collect();
+
+            Some(names)
+        }
+
+        Object::PE(pe) => {
+            let symbol_names =
+                pe.exports.iter().flat_map(|s| s.name).map(|n| n.to_string()).collect();
+            Some(symbol_names)
+        }
+
+        Object::Mach(mach) => match mach {
+            Mach::Binary(binary) => {
+                let exports = binary.exports().ok()?;
+                let names = exports.iter().map(|s| s.name.clone()).collect();
+
+                Some(names)
+            }
+
+            Mach::Fat(_) => None,
+        },
+
+        Object::Archive(_) | Object::Unknown(_) => None,
+    };
+}
+
+fn is_derive_registrar_symbol(symbol: &str) -> bool {
+    symbol.contains(NEW_REGISTRAR_SYMBOL)
+}
+
+fn find_registrar_symbol(file: &Path) -> Option<String> {
+    let symbols = get_symbols_from_lib(file)?;
+
+    symbols.iter().find(|s| is_derive_registrar_symbol(s)).map(|s| s.to_string())
+}
+
+/// Loads dynamic library in platform dependent manner.
+///
+/// For unix, you have to use RTLD_DEEPBIND flag to escape problems described
+/// [here](https://github.com/fedochet/rust-proc-macro-panic-inside-panic-expample)
+/// and [here](https://github.com/rust-lang/rust/issues/60593).
+///
+/// Usage of RTLD_DEEPBIND
+/// [here](https://github.com/fedochet/rust-proc-macro-panic-inside-panic-expample/issues/1)
+///
+/// It seems that on Windows that behaviour is default, so we do nothing in that case.
+#[cfg(windows)]
+fn load_library(file: &Path) -> Result<Library, std::io::Error> {
+    Library::new(file)
+}
+
+#[cfg(unix)]
+fn load_library(file: &Path) -> Result<Library, std::io::Error> {
+    use libloading::os::unix::Library as UnixLibrary;
+    use std::os::raw::c_int;
+
+    const RTLD_NOW: c_int = 0x00002;
+    const RTLD_DEEPBIND: c_int = 0x00008;
+
+    UnixLibrary::open(Some(file), RTLD_NOW | RTLD_DEEPBIND).map(|lib| lib.into())
+}
+
+struct ProcMacroLibraryLibloading {
+    _lib: Library,
+    exported_macros: Vec<bridge::client::ProcMacro>,
+}
+
+impl ProcMacroLibraryLibloading {
+    fn open(file: &Path) -> Result<Self, String> {
+        let symbol_name = find_registrar_symbol(file)
+            .ok_or(format!("Cannot find registrar symbol in file {:?}", file))?;
+
+        let lib = load_library(file).map_err(|e| e.to_string())?;
+
+        let exported_macros = {
+            let macros: libloading::Symbol<&&[bridge::client::ProcMacro]> =
+                unsafe { lib.get(symbol_name.as_bytes()) }.map_err(|e| e.to_string())?;
+
+            macros.to_vec()
+        };
+
+        Ok(ProcMacroLibraryLibloading { _lib: lib, exported_macros })
+    }
+}
+
+type ProcMacroLibraryImpl = ProcMacroLibraryLibloading;
+
+pub struct Expander {
+    libs: Vec<ProcMacroLibraryImpl>,
+}
+
+impl Expander {
+    pub fn new<P: AsRef<Path>>(lib: &P) -> Result<Expander, String> {
+        let mut libs = vec![];
+
+        /* Some libraries for dynamic loading require canonicalized path (even when it is
+        already absolute
+        */
+        let lib =
+            lib.as_ref().canonicalize().expect(&format!("Cannot canonicalize {:?}", lib.as_ref()));
+
+        let library = ProcMacroLibraryImpl::open(&lib)?;
+        libs.push(library);
+
+        Ok(Expander { libs })
+    }
+
+    pub fn expand(
+        &self,
+        macro_name: &str,
+        macro_body: &ra_tt::Subtree,
+        attributes: Option<&ra_tt::Subtree>,
+    ) -> Result<ra_tt::Subtree, bridge::PanicMessage> {
+        let parsed_body = crate::rustc_server::TokenStream::with_subtree(macro_body.clone());
+
+        let parsed_attributes = attributes
+            .map_or(crate::rustc_server::TokenStream::new(), |attr| {
+                crate::rustc_server::TokenStream::with_subtree(attr.clone())
+            });
+
+        for lib in &self.libs {
+            for proc_macro in &lib.exported_macros {
+                match proc_macro {
+                    bridge::client::ProcMacro::CustomDerive { trait_name, client, .. }
+                        if *trait_name == macro_name =>
+                    {
+                        let res = client.run(
+                            &crate::proc_macro::bridge::server::SameThread,
+                            crate::rustc_server::Rustc::default(),
+                            parsed_body,
+                        );
+
+                        return res.map(|it| it.subtree);
+                    }
+
+                    bridge::client::ProcMacro::Bang { name, client } if *name == macro_name => {
+                        let res = client.run(
+                            &crate::proc_macro::bridge::server::SameThread,
+                            crate::rustc_server::Rustc::default(),
+                            parsed_body,
+                        );
+
+                        return res.map(|it| it.subtree);
+                    }
+
+                    bridge::client::ProcMacro::Attr { name, client } if *name == macro_name => {
+                        let res = client.run(
+                            &crate::proc_macro::bridge::server::SameThread,
+                            crate::rustc_server::Rustc::default(),
+                            parsed_attributes,
+                            parsed_body,
+                        );
+
+                        return res.map(|it| it.subtree);
+                    }
+
+                    _ => {
+                        continue;
+                    }
+                }
+            }
+        }
+
+        Err(bridge::PanicMessage::String("Nothing to expand".to_string()))
+    }
+}

--- a/crates/ra_proc_macro_srv/src/lib.rs
+++ b/crates/ra_proc_macro_srv/src/lib.rs
@@ -1,0 +1,44 @@
+//! RA Proc Macro Server
+//!
+//! This library is able to call compiled Rust custom derive dynamic libraries on arbitrary code.
+//! The general idea here is based on https://github.com/fedochet/rust-proc-macro-expander.
+//!
+//! But we change some several design for fitting RA needs:
+//!
+//! * We use `ra_tt` for proc-macro `TokenStream` server, it is easy to manipute and interact with
+//!   RA then proc-macro2 token stream.
+//! * By **copying** the whole rustc `lib_proc_macro` code, we are able to build this with `stable`
+//!   rustc rather than `unstable`. (Although in gerenal ABI compatibility is still an issue)
+
+mod dylib;
+#[doc(hidden)]
+#[allow(dead_code)]
+mod proc_macro;
+mod rustc_server;
+
+use proc_macro::bridge::client::TokenStream;
+use ra_proc_macro::{ExpansionResult, ExpansionTask};
+
+pub fn expand_task(task: &ExpansionTask) -> ExpansionResult {
+    let expander = dylib::Expander::new(&task.lib)
+        .expect(&format!("Cannot expand with provided libraries: ${:?}", &task.lib));
+
+    let result = match expander.expand(&task.macro_name, &task.macro_body, task.attributes.as_ref())
+    {
+        Ok(expansion) => ExpansionResult::Success { expansion },
+        Err(msg) => {
+            let reason = format!(
+                "Cannot perform expansion for {}: error {:?}!",
+                &task.macro_name,
+                msg.as_str()
+            );
+
+            ExpansionResult::Error { reason }
+        }
+    };
+
+    result
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/ra_proc_macro_srv/src/lib.rs
+++ b/crates/ra_proc_macro_srv/src/lib.rs
@@ -19,13 +19,13 @@ mod rustc_server;
 use proc_macro::bridge::client::TokenStream;
 use ra_proc_macro::{ExpansionResult, ExpansionTask};
 
-pub fn expand_task(task: &ExpansionTask) -> ExpansionResult {
+pub fn expand_task(task: &ExpansionTask) -> Result<ExpansionResult, String> {
     let expander = dylib::Expander::new(&task.lib)
         .expect(&format!("Cannot expand with provided libraries: ${:?}", &task.lib));
 
     let result = match expander.expand(&task.macro_name, &task.macro_body, task.attributes.as_ref())
     {
-        Ok(expansion) => ExpansionResult::Success { expansion },
+        Ok(expansion) => Ok(ExpansionResult { expansion }),
         Err(msg) => {
             let reason = format!(
                 "Cannot perform expansion for {}: error {:?}!",
@@ -33,7 +33,7 @@ pub fn expand_task(task: &ExpansionTask) -> ExpansionResult {
                 msg.as_str()
             );
 
-            ExpansionResult::Error { reason }
+            Err(reason)
         }
     };
 

--- a/crates/ra_proc_macro_srv/src/main.rs
+++ b/crates/ra_proc_macro_srv/src/main.rs
@@ -1,0 +1,16 @@
+use std::io::Read;
+
+fn read_stdin() -> String {
+    let mut buff = String::new();
+    std::io::stdin().read_to_string(&mut buff).expect("Cannot read from stdin!");
+
+    buff
+}
+
+fn main() {
+    let input = read_stdin();
+    let task = serde_json::from_str(&input).expect(&format!("Cannot parse '{}'", &input));
+    let results = ra_proc_macro_srv::expand_task(&task);
+
+    println!("{}", &serde_json::to_string(&results).expect("Cannot serialize results!"));
+}

--- a/crates/ra_proc_macro_srv/src/main.rs
+++ b/crates/ra_proc_macro_srv/src/main.rs
@@ -1,16 +1,64 @@
-use std::io::Read;
+use ra_proc_macro::{msg, ExpansionResult, ExpansionTask};
+use std::io;
 
-fn read_stdin() -> String {
-    let mut buff = String::new();
-    std::io::stdin().read_to_string(&mut buff).expect("Cannot read from stdin!");
+fn read_task() -> Result<Option<ExpansionTask>, io::Error> {
+    let stdin = io::stdin();
+    let mut stdin = stdin.lock();
+    let msg = msg::Message::read(&mut stdin)?;
 
-    buff
+    let msg = match msg {
+        None => return Ok(None),
+        Some(msg) => msg,
+    };
+
+    let req = match msg {
+        msg::Message::Request(req) => req,
+        msg::Message::Response(_) => {
+            // Ignore response here.
+            return Ok(None);
+        }
+    };
+
+    Ok(serde_json::from_value(req.params)?)
 }
 
-fn main() {
-    let input = read_stdin();
-    let task = serde_json::from_str(&input).expect(&format!("Cannot parse '{}'", &input));
-    let results = ra_proc_macro_srv::expand_task(&task);
+fn write_result(id: u64, res: Result<ExpansionResult, String>) -> Result<(), io::Error> {
+    let msg: msg::Message = match res {
+        Ok(result) => msg::Response {
+            id: id.into(),
+            result: Some(serde_json::to_value(result)?),
+            error: None,
+        },
+        Err(err) => {
+            let err = msg::ResponseError {
+                code: msg::ErrorCode::ExpansionError as i32,
+                message: err,
+                data: None,
+            };
+            msg::Response { id: id.into(), result: None, error: Some(err) }
+        }
+    }
+    .into();
 
-    println!("{}", &serde_json::to_string(&results).expect("Cannot serialize results!"));
+    let stdout = io::stdout();
+    let mut stdout = stdout.lock();
+    msg.write(&mut stdout)
+}
+fn main() {
+    let mut response_id = 0;
+    loop {
+        let task = read_task();
+        match task {
+            Err(err) => {
+                eprintln!("Read message error on ra_proc_macro_srv: {}", err.to_string());
+            }
+            Ok(None) => (),
+            Ok(Some(task)) => {
+                if let Err(err) = write_result(response_id, ra_proc_macro_srv::expand_task(&task)) {
+                    eprintln!("Write message error on ra_proc_macro_srv: {}", err);
+                }
+                response_id += 1;
+            }
+        }
+    }
 }

--- a/crates/ra_proc_macro_srv/src/proc_macro/bridge/buffer.rs
+++ b/crates/ra_proc_macro_srv/src/proc_macro/bridge/buffer.rs
@@ -1,0 +1,146 @@
+//! Buffer management for same-process client<->server communication.
+
+use std::io::{self, Write};
+use std::mem;
+use std::ops::{Deref, DerefMut};
+use std::slice;
+
+#[repr(C)]
+struct Slice<'a, T> {
+    data: &'a [T; 0],
+    len: usize,
+}
+
+unsafe impl<'a, T: Sync> Sync for Slice<'a, T> {}
+unsafe impl<'a, T: Sync> Send for Slice<'a, T> {}
+
+impl<'a, T> Copy for Slice<'a, T> {}
+impl<'a, T> Clone for Slice<'a, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, T> From<&'a [T]> for Slice<'a, T> {
+    fn from(xs: &'a [T]) -> Self {
+        Slice { data: unsafe { &*(xs.as_ptr() as *const [T; 0]) }, len: xs.len() }
+    }
+}
+
+impl<'a, T> Deref for Slice<'a, T> {
+    type Target = [T];
+    fn deref(&self) -> &[T] {
+        unsafe { slice::from_raw_parts(self.data.as_ptr(), self.len) }
+    }
+}
+
+#[repr(C)]
+pub struct Buffer<T: Copy> {
+    data: *mut T,
+    len: usize,
+    capacity: usize,
+    extend_from_slice: extern "C" fn(Buffer<T>, Slice<'_, T>) -> Buffer<T>,
+    drop: extern "C" fn(Buffer<T>),
+}
+
+unsafe impl<T: Copy + Sync> Sync for Buffer<T> {}
+unsafe impl<T: Copy + Send> Send for Buffer<T> {}
+
+impl<T: Copy> Default for Buffer<T> {
+    fn default() -> Self {
+        Self::from(vec![])
+    }
+}
+
+impl<T: Copy> Deref for Buffer<T> {
+    type Target = [T];
+    fn deref(&self) -> &[T] {
+        unsafe { slice::from_raw_parts(self.data as *const T, self.len) }
+    }
+}
+
+impl<T: Copy> DerefMut for Buffer<T> {
+    fn deref_mut(&mut self) -> &mut [T] {
+        unsafe { slice::from_raw_parts_mut(self.data, self.len) }
+    }
+}
+
+impl<T: Copy> Buffer<T> {
+    pub(super) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(super) fn clear(&mut self) {
+        self.len = 0;
+    }
+
+    pub(super) fn take(&mut self) -> Self {
+        mem::take(self)
+    }
+
+    pub(super) fn extend_from_slice(&mut self, xs: &[T]) {
+        // Fast path to avoid going through an FFI call.
+        if let Some(final_len) = self.len.checked_add(xs.len()) {
+            if final_len <= self.capacity {
+                let dst = unsafe { slice::from_raw_parts_mut(self.data, self.capacity) };
+                dst[self.len..][..xs.len()].copy_from_slice(xs);
+                self.len = final_len;
+                return;
+            }
+        }
+        let b = self.take();
+        *self = (b.extend_from_slice)(b, Slice::from(xs));
+    }
+}
+
+impl Write for Buffer<u8> {
+    fn write(&mut self, xs: &[u8]) -> io::Result<usize> {
+        self.extend_from_slice(xs);
+        Ok(xs.len())
+    }
+
+    fn write_all(&mut self, xs: &[u8]) -> io::Result<()> {
+        self.extend_from_slice(xs);
+        Ok(())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<T: Copy> Drop for Buffer<T> {
+    fn drop(&mut self) {
+        let b = self.take();
+        (b.drop)(b);
+    }
+}
+
+impl<T: Copy> From<Vec<T>> for Buffer<T> {
+    fn from(mut v: Vec<T>) -> Self {
+        let (data, len, capacity) = (v.as_mut_ptr(), v.len(), v.capacity());
+        mem::forget(v);
+
+        // This utility function is nested in here because it can *only*
+        // be safely called on `Buffer`s created by *this* `proc_macro`.
+        fn to_vec<T: Copy>(b: Buffer<T>) -> Vec<T> {
+            unsafe {
+                let Buffer { data, len, capacity, .. } = b;
+                mem::forget(b);
+                Vec::from_raw_parts(data, len, capacity)
+            }
+        }
+
+        extern "C" fn extend_from_slice<T: Copy>(b: Buffer<T>, xs: Slice<'_, T>) -> Buffer<T> {
+            let mut v = to_vec(b);
+            v.extend_from_slice(&xs);
+            Buffer::from(v)
+        }
+
+        extern "C" fn drop<T: Copy>(b: Buffer<T>) {
+            mem::drop(to_vec(b));
+        }
+
+        Buffer { data, len, capacity, extend_from_slice, drop }
+    }
+}

--- a/crates/ra_proc_macro_srv/src/proc_macro/bridge/client.rs
+++ b/crates/ra_proc_macro_srv/src/proc_macro/bridge/client.rs
@@ -1,0 +1,469 @@
+//! Client-side types.
+
+use super::*;
+
+macro_rules! define_handles {
+    (
+        'owned: $($oty:ident,)*
+        'interned: $($ity:ident,)*
+    ) => {
+        #[repr(C)]
+        #[allow(non_snake_case)]
+        pub struct HandleCounters {
+            $($oty: AtomicUsize,)*
+            $($ity: AtomicUsize,)*
+        }
+
+        impl HandleCounters {
+            // FIXME(eddyb) use a reference to the `static COUNTERS`, intead of
+            // a wrapper `fn` pointer, once `const fn` can reference `static`s.
+            extern "C" fn get() -> &'static Self {
+                static COUNTERS: HandleCounters = HandleCounters {
+                    $($oty: AtomicUsize::new(1),)*
+                    $($ity: AtomicUsize::new(1),)*
+                };
+                &COUNTERS
+            }
+        }
+
+        // FIXME(eddyb) generate the definition of `HandleStore` in `server.rs`.
+        #[repr(C)]
+        #[allow(non_snake_case)]
+        pub(super) struct HandleStore<S: server::Types> {
+            $($oty: handle::OwnedStore<S::$oty>,)*
+            $($ity: handle::InternedStore<S::$ity>,)*
+        }
+
+        impl<S: server::Types> HandleStore<S> {
+            pub(super) fn new(handle_counters: &'static HandleCounters) -> Self {
+                HandleStore {
+                    $($oty: handle::OwnedStore::new(&handle_counters.$oty),)*
+                    $($ity: handle::InternedStore::new(&handle_counters.$ity),)*
+                }
+            }
+        }
+
+        $(
+            #[repr(C)]
+            pub struct $oty(pub(crate) handle::Handle);
+            // impl !Send for $oty {}
+            // impl !Sync for $oty {}
+
+            // Forward `Drop::drop` to the inherent `drop` method.
+            impl Drop for $oty {
+                fn drop(&mut self) {
+                    $oty(self.0).drop();
+                }
+            }
+
+            impl<S> Encode<S> for $oty {
+                fn encode(self, w: &mut Writer, s: &mut S) {
+                    let handle = self.0;
+                    mem::forget(self);
+                    handle.encode(w, s);
+                }
+            }
+
+            impl<S: server::Types> DecodeMut<'_, '_, HandleStore<server::MarkedTypes<S>>>
+                for Marked<S::$oty, $oty>
+            {
+                fn decode(r: &mut Reader<'_>, s: &mut HandleStore<server::MarkedTypes<S>>) -> Self {
+                    s.$oty.take(handle::Handle::decode(r, &mut ()))
+                }
+            }
+
+            impl<S> Encode<S> for &$oty {
+                fn encode(self, w: &mut Writer, s: &mut S) {
+                    self.0.encode(w, s);
+                }
+            }
+
+            impl<'s, S: server::Types,> Decode<'_, 's, HandleStore<server::MarkedTypes<S>>>
+                for &'s Marked<S::$oty, $oty>
+            {
+                fn decode(r: &mut Reader<'_>, s: &'s HandleStore<server::MarkedTypes<S>>) -> Self {
+                    &s.$oty[handle::Handle::decode(r, &mut ())]
+                }
+            }
+
+            impl<S> Encode<S> for &mut $oty {
+                fn encode(self, w: &mut Writer, s: &mut S) {
+                    self.0.encode(w, s);
+                }
+            }
+
+            impl<'s, S: server::Types> DecodeMut<'_, 's, HandleStore<server::MarkedTypes<S>>>
+                for &'s mut Marked<S::$oty, $oty>
+            {
+                fn decode(
+                    r: &mut Reader<'_>,
+                    s: &'s mut HandleStore<server::MarkedTypes<S>>
+                ) -> Self {
+                    &mut s.$oty[handle::Handle::decode(r, &mut ())]
+                }
+            }
+
+            impl<S: server::Types> Encode<HandleStore<server::MarkedTypes<S>>>
+                for Marked<S::$oty, $oty>
+            {
+                fn encode(self, w: &mut Writer, s: &mut HandleStore<server::MarkedTypes<S>>) {
+                    s.$oty.alloc(self).encode(w, s);
+                }
+            }
+
+            impl<S> DecodeMut<'_, '_, S> for $oty {
+                fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
+                    $oty(handle::Handle::decode(r, s))
+                }
+            }
+        )*
+
+        $(
+            #[repr(C)]
+            #[derive(Copy, Clone, PartialEq, Eq, Hash)]
+            pub(crate) struct $ity(handle::Handle);
+            // impl !Send for $ity {}
+            // impl !Sync for $ity {}
+
+            impl<S> Encode<S> for $ity {
+                fn encode(self, w: &mut Writer, s: &mut S) {
+                    self.0.encode(w, s);
+                }
+            }
+
+            impl<S: server::Types> DecodeMut<'_, '_, HandleStore<server::MarkedTypes<S>>>
+                for Marked<S::$ity, $ity>
+            {
+                fn decode(r: &mut Reader<'_>, s: &mut HandleStore<server::MarkedTypes<S>>) -> Self {
+                    s.$ity.copy(handle::Handle::decode(r, &mut ()))
+                }
+            }
+
+            impl<S: server::Types> Encode<HandleStore<server::MarkedTypes<S>>>
+                for Marked<S::$ity, $ity>
+            {
+                fn encode(self, w: &mut Writer, s: &mut HandleStore<server::MarkedTypes<S>>) {
+                    s.$ity.alloc(self).encode(w, s);
+                }
+            }
+
+            impl<S> DecodeMut<'_, '_, S> for $ity {
+                fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
+                    $ity(handle::Handle::decode(r, s))
+                }
+            }
+        )*
+    }
+}
+define_handles! {
+    'owned:
+    TokenStream,
+    TokenStreamBuilder,
+    TokenStreamIter,
+    Group,
+    Literal,
+    SourceFile,
+    MultiSpan,
+    Diagnostic,
+
+    'interned:
+    Punct,
+    Ident,
+    Span,
+}
+
+// FIXME(eddyb) generate these impls by pattern-matching on the
+// names of methods - also could use the presence of `fn drop`
+// to distinguish between 'owned and 'interned, above.
+// Alternatively, special 'modes" could be listed of types in with_api
+// instead of pattern matching on methods, here and in server decl.
+
+impl Clone for TokenStream {
+    fn clone(&self) -> Self {
+        self.clone()
+    }
+}
+
+impl Clone for TokenStreamIter {
+    fn clone(&self) -> Self {
+        self.clone()
+    }
+}
+
+impl Clone for Group {
+    fn clone(&self) -> Self {
+        self.clone()
+    }
+}
+
+impl Clone for Literal {
+    fn clone(&self) -> Self {
+        self.clone()
+    }
+}
+
+// FIXME(eddyb) `Literal` should not expose internal `Debug` impls.
+impl fmt::Debug for Literal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.debug())
+    }
+}
+
+impl Clone for SourceFile {
+    fn clone(&self) -> Self {
+        self.clone()
+    }
+}
+
+impl fmt::Debug for Span {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.debug())
+    }
+}
+
+macro_rules! define_client_side {
+    ($($name:ident {
+        $(fn $method:ident($($arg:ident: $arg_ty:ty),* $(,)?) $(-> $ret_ty:ty)*;)*
+    }),* $(,)?) => {
+        $(impl $name {
+            #[allow(unused)]
+            $(pub(crate) fn $method($($arg: $arg_ty),*) $(-> $ret_ty)* {
+                panic!("hello");
+                // Bridge::with(|bridge| {
+                //     let mut b = bridge.cached_buffer.take();
+
+                //     b.clear();
+                //     api_tags::Method::$name(api_tags::$name::$method).encode(&mut b, &mut ());
+                //     reverse_encode!(b; $($arg),*);
+
+                //     b = bridge.dispatch.call(b);
+
+                //     let r = Result::<_, PanicMessage>::decode(&mut &b[..], &mut ());
+
+                //     bridge.cached_buffer = b;
+
+                //     r.unwrap_or_else(|e| panic::resume_unwind(e.into()))
+                // })
+            })*
+        })*
+    }
+}
+with_api!(self, self, define_client_side);
+
+enum BridgeState<'a> {
+    /// No server is currently connected to this client.
+    NotConnected,
+
+    /// A server is connected and available for requests.
+    Connected(Bridge<'a>),
+
+    /// Access to the bridge is being exclusively acquired
+    /// (e.g., during `BridgeState::with`).
+    InUse,
+}
+
+enum BridgeStateL {}
+
+impl<'a> scoped_cell::ApplyL<'a> for BridgeStateL {
+    type Out = BridgeState<'a>;
+}
+
+thread_local! {
+    static BRIDGE_STATE: scoped_cell::ScopedCell<BridgeStateL> =
+        scoped_cell::ScopedCell::new(BridgeState::NotConnected);
+}
+
+impl BridgeState<'_> {
+    /// Take exclusive control of the thread-local
+    /// `BridgeState`, and pass it to `f`, mutably.
+    /// The state will be restored after `f` exits, even
+    /// by panic, including modifications made to it by `f`.
+    ///
+    /// N.B., while `f` is running, the thread-local state
+    /// is `BridgeState::InUse`.
+    fn with<R>(f: impl FnOnce(&mut BridgeState<'_>) -> R) -> R {
+        BRIDGE_STATE.with(|state| {
+            state.replace(BridgeState::InUse, |mut state| {
+                // FIXME(#52812) pass `f` directly to `replace` when `RefMutL` is gone
+                f(&mut *state)
+            })
+        })
+    }
+}
+
+impl Bridge<'_> {
+    fn enter<R>(self, f: impl FnOnce() -> R) -> R {
+        // Hide the default panic output within `proc_macro` expansions.
+        // NB. the server can't do this because it may use a different libstd.
+        static HIDE_PANICS_DURING_EXPANSION: Once = Once::new();
+        HIDE_PANICS_DURING_EXPANSION.call_once(|| {
+            let prev = panic::take_hook();
+            panic::set_hook(Box::new(move |info| {
+                let hide = BridgeState::with(|state| match state {
+                    BridgeState::NotConnected => false,
+                    BridgeState::Connected(_) | BridgeState::InUse => true,
+                });
+                if !hide {
+                    prev(info)
+                }
+            }));
+        });
+
+        BRIDGE_STATE.with(|state| state.set(BridgeState::Connected(self), f))
+    }
+
+    fn with<R>(f: impl FnOnce(&mut Bridge<'_>) -> R) -> R {
+        BridgeState::with(|state| match state {
+            BridgeState::NotConnected => {
+                panic!("procedural macro API is used outside of a procedural macro");
+            }
+            BridgeState::InUse => {
+                panic!("procedural macro API is used while it's already in use");
+            }
+            BridgeState::Connected(bridge) => f(bridge),
+        })
+    }
+}
+
+/// A client-side "global object" (usually a function pointer),
+/// which may be using a different `proc_macro` from the one
+/// used by the server, but can be interacted with compatibly.
+///
+/// N.B., `F` must have FFI-friendly memory layout (e.g., a pointer).
+/// The call ABI of function pointers used for `F` doesn't
+/// need to match between server and client, since it's only
+/// passed between them and (eventually) called by the client.
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct Client<F> {
+    // FIXME(eddyb) use a reference to the `static COUNTERS`, intead of
+    // a wrapper `fn` pointer, once `const fn` can reference `static`s.
+    pub(super) get_handle_counters: extern "C" fn() -> &'static HandleCounters,
+    pub(super) run: extern "C" fn(Bridge<'_>, F) -> Buffer<u8>,
+    pub(super) f: F,
+}
+
+/// Client-side helper for handling client panics, entering the bridge,
+/// deserializing input and serializing output.
+// FIXME(eddyb) maybe replace `Bridge::enter` with this?
+fn run_client<A: for<'a, 's> DecodeMut<'a, 's, ()>, R: Encode<()>>(
+    mut bridge: Bridge<'_>,
+    f: impl FnOnce(A) -> R,
+) -> Buffer<u8> {
+    // The initial `cached_buffer` contains the input.
+    let mut b = bridge.cached_buffer.take();
+
+    panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        bridge.enter(|| {
+            let reader = &mut &b[..];
+            let input = A::decode(reader, &mut ());
+
+            // Put the `cached_buffer` back in the `Bridge`, for requests.
+            Bridge::with(|bridge| bridge.cached_buffer = b.take());
+
+            let output = f(input);
+
+            // Take the `cached_buffer` back out, for the output value.
+            b = Bridge::with(|bridge| bridge.cached_buffer.take());
+
+            // HACK(eddyb) Separate encoding a success value (`Ok(output)`)
+            // from encoding a panic (`Err(e: PanicMessage)`) to avoid
+            // having handles outside the `bridge.enter(|| ...)` scope, and
+            // to catch panics that could happen while encoding the success.
+            //
+            // Note that panics should be impossible beyond this point, but
+            // this is defensively trying to avoid any accidental panicking
+            // reaching the `extern "C"` (which should `abort` but may not
+            // at the moment, so this is also potentially preventing UB).
+            b.clear();
+            Ok::<_, ()>(output).encode(&mut b, &mut ());
+        })
+    }))
+    .map_err(PanicMessage::from)
+    .unwrap_or_else(|e| {
+        b.clear();
+        Err::<(), _>(e).encode(&mut b, &mut ());
+    });
+    b
+}
+
+impl Client<fn(crate::TokenStream) -> crate::TokenStream> {
+    pub fn expand1(f: fn(crate::TokenStream) -> crate::TokenStream) -> Self {
+        extern "C" fn run(
+            bridge: Bridge<'_>,
+            f: impl FnOnce(crate::TokenStream) -> crate::TokenStream,
+        ) -> Buffer<u8> {
+            run_client(bridge, |input| f(crate::TokenStream(input)).0)
+        }
+        Client { get_handle_counters: HandleCounters::get, run, f }
+    }
+}
+
+impl Client<fn(crate::TokenStream, crate::TokenStream) -> crate::TokenStream> {
+    pub fn expand2(f: fn(crate::TokenStream, crate::TokenStream) -> crate::TokenStream) -> Self {
+        extern "C" fn run(
+            bridge: Bridge<'_>,
+            f: impl FnOnce(crate::TokenStream, crate::TokenStream) -> crate::TokenStream,
+        ) -> Buffer<u8> {
+            run_client(bridge, |(input, input2)| {
+                f(crate::TokenStream(input), crate::TokenStream(input2)).0
+            })
+        }
+        Client { get_handle_counters: HandleCounters::get, run, f }
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub enum ProcMacro {
+    CustomDerive {
+        trait_name: &'static str,
+        attributes: &'static [&'static str],
+        client: Client<fn(crate::TokenStream) -> crate::TokenStream>,
+    },
+
+    Attr {
+        name: &'static str,
+        client: Client<fn(crate::TokenStream, crate::TokenStream) -> crate::TokenStream>,
+    },
+
+    Bang {
+        name: &'static str,
+        client: Client<fn(crate::TokenStream) -> crate::TokenStream>,
+    },
+}
+
+impl std::fmt::Debug for ProcMacro {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ProcMacro {{ name: {} }}", self.name())
+    }
+}
+
+impl ProcMacro {
+    pub fn name(&self) -> &'static str {
+        match self {
+            ProcMacro::CustomDerive { trait_name, .. } => trait_name,
+            ProcMacro::Attr { name, .. } => name,
+            ProcMacro::Bang { name, .. } => name,
+        }
+    }
+
+    pub fn custom_derive(
+        trait_name: &'static str,
+        attributes: &'static [&'static str],
+        expand: fn(crate::TokenStream) -> crate::TokenStream,
+    ) -> Self {
+        ProcMacro::CustomDerive { trait_name, attributes, client: Client::expand1(expand) }
+    }
+
+    pub fn attr(
+        name: &'static str,
+        expand: fn(crate::TokenStream, crate::TokenStream) -> crate::TokenStream,
+    ) -> Self {
+        ProcMacro::Attr { name, client: Client::expand2(expand) }
+    }
+
+    pub fn bang(name: &'static str, expand: fn(crate::TokenStream) -> crate::TokenStream) -> Self {
+        ProcMacro::Bang { name, client: Client::expand1(expand) }
+    }
+}

--- a/crates/ra_proc_macro_srv/src/proc_macro/bridge/closure.rs
+++ b/crates/ra_proc_macro_srv/src/proc_macro/bridge/closure.rs
@@ -1,0 +1,24 @@
+//! Closure type (equivalent to `&mut dyn FnMut(A) -> R`) that's `repr(C)`.
+
+#[repr(C)]
+pub struct Closure<'a, A, R> {
+    call: unsafe extern "C" fn(&mut Env, A) -> R,
+    env: &'a mut Env,
+}
+
+struct Env;
+
+impl<'a, A, R, F: FnMut(A) -> R> From<&'a mut F> for Closure<'a, A, R> {
+    fn from(f: &'a mut F) -> Self {
+        unsafe extern "C" fn call<A, R, F: FnMut(A) -> R>(env: &mut Env, arg: A) -> R {
+            (*(env as *mut _ as *mut F))(arg)
+        }
+        Closure { call: call::<A, R, F>, env: unsafe { &mut *(f as *mut _ as *mut Env) } }
+    }
+}
+
+impl<'a, A, R> Closure<'a, A, R> {
+    pub fn call(&mut self, arg: A) -> R {
+        unsafe { (self.call)(self.env, arg) }
+    }
+}

--- a/crates/ra_proc_macro_srv/src/proc_macro/bridge/handle.rs
+++ b/crates/ra_proc_macro_srv/src/proc_macro/bridge/handle.rs
@@ -1,0 +1,70 @@
+//! Server-side handles and storage for per-handle data.
+
+use std::collections::{BTreeMap, HashMap};
+use std::hash::Hash;
+use std::num::NonZeroU32;
+use std::ops::{Index, IndexMut};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+pub(super) type Handle = NonZeroU32;
+
+pub(super) struct OwnedStore<T: 'static> {
+    counter: &'static AtomicUsize,
+    data: BTreeMap<Handle, T>,
+}
+
+impl<T> OwnedStore<T> {
+    pub(super) fn new(counter: &'static AtomicUsize) -> Self {
+        // Ensure the handle counter isn't 0, which would panic later,
+        // when `NonZeroU32::new` (aka `Handle::new`) is called in `alloc`.
+        assert_ne!(counter.load(Ordering::SeqCst), 0);
+
+        OwnedStore { counter, data: BTreeMap::new() }
+    }
+}
+
+impl<T> OwnedStore<T> {
+    pub(super) fn alloc(&mut self, x: T) -> Handle {
+        let counter = self.counter.fetch_add(1, Ordering::SeqCst);
+        let handle = Handle::new(counter as u32).expect("`proc_macro` handle counter overflowed");
+        assert!(self.data.insert(handle, x).is_none());
+        handle
+    }
+
+    pub(super) fn take(&mut self, h: Handle) -> T {
+        self.data.remove(&h).expect("use-after-free in `proc_macro` handle")
+    }
+}
+
+impl<T> Index<Handle> for OwnedStore<T> {
+    type Output = T;
+    fn index(&self, h: Handle) -> &T {
+        self.data.get(&h).expect("use-after-free in `proc_macro` handle")
+    }
+}
+
+impl<T> IndexMut<Handle> for OwnedStore<T> {
+    fn index_mut(&mut self, h: Handle) -> &mut T {
+        self.data.get_mut(&h).expect("use-after-free in `proc_macro` handle")
+    }
+}
+
+pub(super) struct InternedStore<T: 'static> {
+    owned: OwnedStore<T>,
+    interner: HashMap<T, Handle>,
+}
+
+impl<T: Copy + Eq + Hash> InternedStore<T> {
+    pub(super) fn new(counter: &'static AtomicUsize) -> Self {
+        InternedStore { owned: OwnedStore::new(counter), interner: HashMap::new() }
+    }
+
+    pub(super) fn alloc(&mut self, x: T) -> Handle {
+        let owned = &mut self.owned;
+        *self.interner.entry(x).or_insert_with(|| owned.alloc(x))
+    }
+
+    pub(super) fn copy(&mut self, h: Handle) -> T {
+        self.owned[h]
+    }
+}

--- a/crates/ra_proc_macro_srv/src/proc_macro/bridge/mod.rs
+++ b/crates/ra_proc_macro_srv/src/proc_macro/bridge/mod.rs
@@ -1,0 +1,399 @@
+//! Internal interface for communicating between a `proc_macro` client
+//! (a proc macro crate) and a `proc_macro` server (a compiler front-end).
+//!
+//! Serialization (with C ABI buffers) and unique integer handles are employed
+//! to allow safely interfacing between two copies of `proc_macro` built
+//! (from the same source) by different compilers with potentially mismatching
+//! Rust ABIs (e.g., stage0/bin/rustc vs stage1/bin/rustc during bootstrap).
+
+#![deny(unsafe_code)]
+
+pub use crate::proc_macro::{Delimiter, Level, LineColumn, Spacing};
+use std::fmt;
+use std::hash::Hash;
+use std::marker;
+use std::mem;
+use std::ops::Bound;
+use std::panic;
+use std::sync::atomic::AtomicUsize;
+use std::sync::Once;
+use std::thread;
+
+/// Higher-order macro describing the server RPC API, allowing automatic
+/// generation of type-safe Rust APIs, both client-side and server-side.
+///
+/// `with_api!(MySelf, my_self, my_macro)` expands to:
+/// ```rust,ignore (pseudo-code)
+/// my_macro! {
+///     // ...
+///     Literal {
+///         // ...
+///         fn character(ch: char) -> MySelf::Literal;
+///         // ...
+///         fn span(my_self: &MySelf::Literal) -> MySelf::Span;
+///         fn set_span(my_self: &mut MySelf::Literal, span: MySelf::Span);
+///     },
+///     // ...
+/// }
+/// ```
+///
+/// The first two arguments serve to customize the arguments names
+/// and argument/return types, to enable several different usecases:
+///
+/// If `my_self` is just `self`, then each `fn` signature can be used
+/// as-is for a method. If it's anything else (`self_` in practice),
+/// then the signatures don't have a special `self` argument, and
+/// can, therefore, have a different one introduced.
+///
+/// If `MySelf` is just `Self`, then the types are only valid inside
+/// a trait or a trait impl, where the trait has associated types
+/// for each of the API types. If non-associated types are desired,
+/// a module name (`self` in practice) can be used instead of `Self`.
+macro_rules! with_api {
+    ($S:ident, $self:ident, $m:ident) => {
+        $m! {
+            TokenStream {
+                fn drop($self: $S::TokenStream);
+                fn clone($self: &$S::TokenStream) -> $S::TokenStream;
+                fn new() -> $S::TokenStream;
+                fn is_empty($self: &$S::TokenStream) -> bool;
+                fn from_str(src: &str) -> $S::TokenStream;
+                fn to_string($self: &$S::TokenStream) -> String;
+                fn from_token_tree(
+                    tree: TokenTree<$S::Group, $S::Punct, $S::Ident, $S::Literal>,
+                ) -> $S::TokenStream;
+                fn into_iter($self: $S::TokenStream) -> $S::TokenStreamIter;
+            },
+            TokenStreamBuilder {
+                fn drop($self: $S::TokenStreamBuilder);
+                fn new() -> $S::TokenStreamBuilder;
+                fn push($self: &mut $S::TokenStreamBuilder, stream: $S::TokenStream);
+                fn build($self: $S::TokenStreamBuilder) -> $S::TokenStream;
+            },
+            TokenStreamIter {
+                fn drop($self: $S::TokenStreamIter);
+                fn clone($self: &$S::TokenStreamIter) -> $S::TokenStreamIter;
+                fn next(
+                    $self: &mut $S::TokenStreamIter,
+                ) -> Option<TokenTree<$S::Group, $S::Punct, $S::Ident, $S::Literal>>;
+            },
+            Group {
+                fn drop($self: $S::Group);
+                fn clone($self: &$S::Group) -> $S::Group;
+                fn new(delimiter: Delimiter, stream: $S::TokenStream) -> $S::Group;
+                fn delimiter($self: &$S::Group) -> Delimiter;
+                fn stream($self: &$S::Group) -> $S::TokenStream;
+                fn span($self: &$S::Group) -> $S::Span;
+                fn span_open($self: &$S::Group) -> $S::Span;
+                fn span_close($self: &$S::Group) -> $S::Span;
+                fn set_span($self: &mut $S::Group, span: $S::Span);
+            },
+            Punct {
+                fn new(ch: char, spacing: Spacing) -> $S::Punct;
+                fn as_char($self: $S::Punct) -> char;
+                fn spacing($self: $S::Punct) -> Spacing;
+                fn span($self: $S::Punct) -> $S::Span;
+                fn with_span($self: $S::Punct, span: $S::Span) -> $S::Punct;
+            },
+            Ident {
+                fn new(string: &str, span: $S::Span, is_raw: bool) -> $S::Ident;
+                fn span($self: $S::Ident) -> $S::Span;
+                fn with_span($self: $S::Ident, span: $S::Span) -> $S::Ident;
+            },
+            Literal {
+                fn drop($self: $S::Literal);
+                fn clone($self: &$S::Literal) -> $S::Literal;
+                // FIXME(eddyb) `Literal` should not expose internal `Debug` impls.
+                fn debug($self: &$S::Literal) -> String;
+                fn integer(n: &str) -> $S::Literal;
+                fn typed_integer(n: &str, kind: &str) -> $S::Literal;
+                fn float(n: &str) -> $S::Literal;
+                fn f32(n: &str) -> $S::Literal;
+                fn f64(n: &str) -> $S::Literal;
+                fn string(string: &str) -> $S::Literal;
+                fn character(ch: char) -> $S::Literal;
+                fn byte_string(bytes: &[u8]) -> $S::Literal;
+                fn span($self: &$S::Literal) -> $S::Span;
+                fn set_span($self: &mut $S::Literal, span: $S::Span);
+                fn subspan(
+                    $self: &$S::Literal,
+                    start: Bound<usize>,
+                    end: Bound<usize>,
+                ) -> Option<$S::Span>;
+            },
+            SourceFile {
+                fn drop($self: $S::SourceFile);
+                fn clone($self: &$S::SourceFile) -> $S::SourceFile;
+                fn eq($self: &$S::SourceFile, other: &$S::SourceFile) -> bool;
+                fn path($self: &$S::SourceFile) -> String;
+                fn is_real($self: &$S::SourceFile) -> bool;
+            },
+            MultiSpan {
+                fn drop($self: $S::MultiSpan);
+                fn new() -> $S::MultiSpan;
+                fn push($self: &mut $S::MultiSpan, span: $S::Span);
+            },
+            Diagnostic {
+                fn drop($self: $S::Diagnostic);
+                fn new(level: Level, msg: &str, span: $S::MultiSpan) -> $S::Diagnostic;
+                fn sub(
+                    $self: &mut $S::Diagnostic,
+                    level: Level,
+                    msg: &str,
+                    span: $S::MultiSpan,
+                );
+                fn emit($self: $S::Diagnostic);
+            },
+            Span {
+                fn debug($self: $S::Span) -> String;
+                fn def_site() -> $S::Span;
+                fn call_site() -> $S::Span;
+                fn mixed_site() -> $S::Span;
+                fn source_file($self: $S::Span) -> $S::SourceFile;
+                fn parent($self: $S::Span) -> Option<$S::Span>;
+                fn source($self: $S::Span) -> $S::Span;
+                fn start($self: $S::Span) -> LineColumn;
+                fn end($self: $S::Span) -> LineColumn;
+                fn join($self: $S::Span, other: $S::Span) -> Option<$S::Span>;
+                fn resolved_at($self: $S::Span, at: $S::Span) -> $S::Span;
+                fn source_text($self: $S::Span) -> Option<String>;
+            },
+        }
+    };
+}
+
+// FIXME(eddyb) this calls `encode` for each argument, but in reverse,
+// to avoid borrow conflicts from borrows started by `&mut` arguments.
+macro_rules! reverse_encode {
+    ($writer:ident;) => {};
+    ($writer:ident; $first:ident $(, $rest:ident)*) => {
+        reverse_encode!($writer; $($rest),*);
+        $first.encode(&mut $writer, &mut ());
+    }
+}
+
+// FIXME(eddyb) this calls `decode` for each argument, but in reverse,
+// to avoid borrow conflicts from borrows started by `&mut` arguments.
+macro_rules! reverse_decode {
+    ($reader:ident, $s:ident;) => {};
+    ($reader:ident, $s:ident; $first:ident: $first_ty:ty $(, $rest:ident: $rest_ty:ty)*) => {
+        reverse_decode!($reader, $s; $($rest: $rest_ty),*);
+        let $first = <$first_ty>::decode(&mut $reader, $s);
+    }
+}
+
+#[allow(unsafe_code)]
+mod buffer;
+#[forbid(unsafe_code)]
+pub mod client;
+#[allow(unsafe_code)]
+mod closure;
+#[forbid(unsafe_code)]
+mod handle;
+#[macro_use]
+#[forbid(unsafe_code)]
+mod rpc;
+#[allow(unsafe_code)]
+mod scoped_cell;
+#[forbid(unsafe_code)]
+pub mod server;
+
+use buffer::Buffer;
+pub use rpc::PanicMessage;
+use rpc::{Decode, DecodeMut, Encode, Reader, Writer};
+
+/// An active connection between a server and a client.
+/// The server creates the bridge (`Bridge::run_server` in `server.rs`),
+/// then passes it to the client through the function pointer in the `run`
+/// field of `client::Client`. The client holds its copy of the `Bridge`
+/// in TLS during its execution (`Bridge::{enter, with}` in `client.rs`).
+#[repr(C)]
+pub struct Bridge<'a> {
+    /// Reusable buffer (only `clear`-ed, never shrunk), primarily
+    /// used for making requests, but also for passing input to client.
+    cached_buffer: Buffer<u8>,
+
+    /// Server-side function that the client uses to make requests.
+    dispatch: closure::Closure<'a, Buffer<u8>, Buffer<u8>>,
+}
+
+#[forbid(unsafe_code)]
+#[allow(non_camel_case_types)]
+mod api_tags {
+    use super::rpc::{DecodeMut, Encode, Reader, Writer};
+
+    macro_rules! declare_tags {
+        ($($name:ident {
+            $(fn $method:ident($($arg:ident: $arg_ty:ty),* $(,)?) $(-> $ret_ty:ty)*;)*
+        }),* $(,)?) => {
+            $(
+                pub(super) enum $name {
+                    $($method),*
+                }
+                rpc_encode_decode!(enum $name { $($method),* });
+            )*
+
+
+            pub(super) enum Method {
+                $($name($name)),*
+            }
+            rpc_encode_decode!(enum Method { $($name(m)),* });
+        }
+    }
+    with_api!(self, self, declare_tags);
+}
+
+/// Helper to wrap associated types to allow trait impl dispatch.
+/// That is, normally a pair of impls for `T::Foo` and `T::Bar`
+/// can overlap, but if the impls are, instead, on types like
+/// `Marked<T::Foo, Foo>` and `Marked<T::Bar, Bar>`, they can't.
+trait Mark {
+    type Unmarked;
+    fn mark(unmarked: Self::Unmarked) -> Self;
+}
+
+/// Unwrap types wrapped by `Mark::mark` (see `Mark` for details).
+trait Unmark {
+    type Unmarked;
+    fn unmark(self) -> Self::Unmarked;
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+struct Marked<T, M> {
+    value: T,
+    _marker: marker::PhantomData<M>,
+}
+
+impl<T, M> Mark for Marked<T, M> {
+    type Unmarked = T;
+    fn mark(unmarked: Self::Unmarked) -> Self {
+        Marked { value: unmarked, _marker: marker::PhantomData }
+    }
+}
+impl<T, M> Unmark for Marked<T, M> {
+    type Unmarked = T;
+    fn unmark(self) -> Self::Unmarked {
+        self.value
+    }
+}
+impl<'a, T, M> Unmark for &'a Marked<T, M> {
+    type Unmarked = &'a T;
+    fn unmark(self) -> Self::Unmarked {
+        &self.value
+    }
+}
+impl<'a, T, M> Unmark for &'a mut Marked<T, M> {
+    type Unmarked = &'a mut T;
+    fn unmark(self) -> Self::Unmarked {
+        &mut self.value
+    }
+}
+
+impl<T: Mark> Mark for Option<T> {
+    type Unmarked = Option<T::Unmarked>;
+    fn mark(unmarked: Self::Unmarked) -> Self {
+        unmarked.map(T::mark)
+    }
+}
+impl<T: Unmark> Unmark for Option<T> {
+    type Unmarked = Option<T::Unmarked>;
+    fn unmark(self) -> Self::Unmarked {
+        self.map(T::unmark)
+    }
+}
+
+macro_rules! mark_noop {
+    ($($ty:ty),* $(,)?) => {
+        $(
+            impl Mark for $ty {
+                type Unmarked = Self;
+                fn mark(unmarked: Self::Unmarked) -> Self {
+                    unmarked
+                }
+            }
+            impl Unmark for $ty {
+                type Unmarked = Self;
+                fn unmark(self) -> Self::Unmarked {
+                    self
+                }
+            }
+        )*
+    }
+}
+mark_noop! {
+    (),
+    bool,
+    char,
+    &'_ [u8],
+    &'_ str,
+    String,
+    Delimiter,
+    Level,
+    LineColumn,
+    Spacing,
+    Bound<usize>,
+}
+
+rpc_encode_decode!(
+    enum Delimiter {
+        Parenthesis,
+        Brace,
+        Bracket,
+        None,
+    }
+);
+rpc_encode_decode!(
+    enum Level {
+        Error,
+        Warning,
+        Note,
+        Help,
+    }
+);
+rpc_encode_decode!(struct LineColumn { line, column });
+rpc_encode_decode!(
+    enum Spacing {
+        Alone,
+        Joint,
+    }
+);
+
+#[derive(Clone)]
+pub enum TokenTree<G, P, I, L> {
+    Group(G),
+    Punct(P),
+    Ident(I),
+    Literal(L),
+}
+
+impl<G: Mark, P: Mark, I: Mark, L: Mark> Mark for TokenTree<G, P, I, L> {
+    type Unmarked = TokenTree<G::Unmarked, P::Unmarked, I::Unmarked, L::Unmarked>;
+    fn mark(unmarked: Self::Unmarked) -> Self {
+        match unmarked {
+            TokenTree::Group(tt) => TokenTree::Group(G::mark(tt)),
+            TokenTree::Punct(tt) => TokenTree::Punct(P::mark(tt)),
+            TokenTree::Ident(tt) => TokenTree::Ident(I::mark(tt)),
+            TokenTree::Literal(tt) => TokenTree::Literal(L::mark(tt)),
+        }
+    }
+}
+impl<G: Unmark, P: Unmark, I: Unmark, L: Unmark> Unmark for TokenTree<G, P, I, L> {
+    type Unmarked = TokenTree<G::Unmarked, P::Unmarked, I::Unmarked, L::Unmarked>;
+    fn unmark(self) -> Self::Unmarked {
+        match self {
+            TokenTree::Group(tt) => TokenTree::Group(tt.unmark()),
+            TokenTree::Punct(tt) => TokenTree::Punct(tt.unmark()),
+            TokenTree::Ident(tt) => TokenTree::Ident(tt.unmark()),
+            TokenTree::Literal(tt) => TokenTree::Literal(tt.unmark()),
+        }
+    }
+}
+
+rpc_encode_decode!(
+    enum TokenTree<G, P, I, L> {
+        Group(tt),
+        Punct(tt),
+        Ident(tt),
+        Literal(tt),
+    }
+);

--- a/crates/ra_proc_macro_srv/src/proc_macro/bridge/rpc.rs
+++ b/crates/ra_proc_macro_srv/src/proc_macro/bridge/rpc.rs
@@ -1,0 +1,306 @@
+//! Serialization for client-server communication.
+
+use std::any::Any;
+use std::char;
+use std::io::Write;
+use std::num::NonZeroU32;
+use std::ops::Bound;
+use std::str;
+
+pub(super) type Writer = super::buffer::Buffer<u8>;
+
+pub(super) trait Encode<S>: Sized {
+    fn encode(self, w: &mut Writer, s: &mut S);
+}
+
+pub(super) type Reader<'a> = &'a [u8];
+
+pub(super) trait Decode<'a, 's, S>: Sized {
+    fn decode(r: &mut Reader<'a>, s: &'s S) -> Self;
+}
+
+pub(super) trait DecodeMut<'a, 's, S>: Sized {
+    fn decode(r: &mut Reader<'a>, s: &'s mut S) -> Self;
+}
+
+macro_rules! rpc_encode_decode {
+    (le $ty:ty) => {
+        impl<S> Encode<S> for $ty {
+            fn encode(self, w: &mut Writer, _: &mut S) {
+                w.write_all(&self.to_le_bytes()).unwrap();
+            }
+        }
+
+        impl<S> DecodeMut<'_, '_, S> for $ty {
+            fn decode(r: &mut Reader<'_>, _: &mut S) -> Self {
+                const N: usize = ::std::mem::size_of::<$ty>();
+
+                let mut bytes = [0; N];
+                bytes.copy_from_slice(&r[..N]);
+                *r = &r[N..];
+
+                Self::from_le_bytes(bytes)
+            }
+        }
+    };
+    (struct $name:ident { $($field:ident),* $(,)? }) => {
+        impl<S> Encode<S> for $name {
+            fn encode(self, w: &mut Writer, s: &mut S) {
+                $(self.$field.encode(w, s);)*
+            }
+        }
+
+        impl<S> DecodeMut<'_, '_, S> for $name {
+            fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
+                $name {
+                    $($field: DecodeMut::decode(r, s)),*
+                }
+            }
+        }
+    };
+    (enum $name:ident $(<$($T:ident),+>)? { $($variant:ident $(($field:ident))*),* $(,)? }) => {
+        impl<S, $($($T: Encode<S>),+)?> Encode<S> for $name $(<$($T),+>)? {
+            fn encode(self, w: &mut Writer, s: &mut S) {
+                // HACK(eddyb): `Tag` enum duplicated between the
+                // two impls as there's no other place to stash it.
+                #[allow(non_upper_case_globals)]
+                mod tag {
+                    #[repr(u8)] enum Tag { $($variant),* }
+
+                    $(pub const $variant: u8 = Tag::$variant as u8;)*
+                }
+
+                match self {
+                    $($name::$variant $(($field))* => {
+                        tag::$variant.encode(w, s);
+                        $($field.encode(w, s);)*
+                    })*
+                }
+            }
+        }
+
+        impl<'a, S, $($($T: for<'s> DecodeMut<'a, 's, S>),+)?> DecodeMut<'a, '_, S>
+            for $name $(<$($T),+>)?
+        {
+            fn decode(r: &mut Reader<'a>, s: &mut S) -> Self {
+                // HACK(eddyb): `Tag` enum duplicated between the
+                // two impls as there's no other place to stash it.
+                #[allow(non_upper_case_globals)]
+                mod tag {
+                    #[repr(u8)] enum Tag { $($variant),* }
+
+                    $(pub const $variant: u8 = Tag::$variant as u8;)*
+                }
+
+                match u8::decode(r, s) {
+                    $(tag::$variant => {
+                        $(let $field = DecodeMut::decode(r, s);)*
+                        $name::$variant $(($field))*
+                    })*
+                    _ => unreachable!(),
+                }
+            }
+        }
+    }
+}
+
+impl<S> Encode<S> for () {
+    fn encode(self, _: &mut Writer, _: &mut S) {}
+}
+
+impl<S> DecodeMut<'_, '_, S> for () {
+    fn decode(_: &mut Reader<'_>, _: &mut S) -> Self {}
+}
+
+impl<S> Encode<S> for u8 {
+    fn encode(self, w: &mut Writer, _: &mut S) {
+        w.write_all(&[self]).unwrap();
+    }
+}
+
+impl<S> DecodeMut<'_, '_, S> for u8 {
+    fn decode(r: &mut Reader<'_>, _: &mut S) -> Self {
+        let x = r[0];
+        *r = &r[1..];
+        x
+    }
+}
+
+rpc_encode_decode!(le u32);
+rpc_encode_decode!(le usize);
+
+impl<S> Encode<S> for bool {
+    fn encode(self, w: &mut Writer, s: &mut S) {
+        (self as u8).encode(w, s);
+    }
+}
+
+impl<S> DecodeMut<'_, '_, S> for bool {
+    fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
+        match u8::decode(r, s) {
+            0 => false,
+            1 => true,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<S> Encode<S> for char {
+    fn encode(self, w: &mut Writer, s: &mut S) {
+        (self as u32).encode(w, s);
+    }
+}
+
+impl<S> DecodeMut<'_, '_, S> for char {
+    fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
+        char::from_u32(u32::decode(r, s)).unwrap()
+    }
+}
+
+impl<S> Encode<S> for NonZeroU32 {
+    fn encode(self, w: &mut Writer, s: &mut S) {
+        self.get().encode(w, s);
+    }
+}
+
+impl<S> DecodeMut<'_, '_, S> for NonZeroU32 {
+    fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
+        Self::new(u32::decode(r, s)).unwrap()
+    }
+}
+
+impl<S, A: Encode<S>, B: Encode<S>> Encode<S> for (A, B) {
+    fn encode(self, w: &mut Writer, s: &mut S) {
+        self.0.encode(w, s);
+        self.1.encode(w, s);
+    }
+}
+
+impl<'a, S, A: for<'s> DecodeMut<'a, 's, S>, B: for<'s> DecodeMut<'a, 's, S>> DecodeMut<'a, '_, S>
+    for (A, B)
+{
+    fn decode(r: &mut Reader<'a>, s: &mut S) -> Self {
+        (DecodeMut::decode(r, s), DecodeMut::decode(r, s))
+    }
+}
+
+rpc_encode_decode!(
+    enum Bound<T> {
+        Included(x),
+        Excluded(x),
+        Unbounded,
+    }
+);
+
+rpc_encode_decode!(
+    enum Option<T> {
+        None,
+        Some(x),
+    }
+);
+
+rpc_encode_decode!(
+    enum Result<T, E> {
+        Ok(x),
+        Err(e),
+    }
+);
+
+impl<S> Encode<S> for &[u8] {
+    fn encode(self, w: &mut Writer, s: &mut S) {
+        self.len().encode(w, s);
+        w.write_all(self).unwrap();
+    }
+}
+
+impl<'a, S> DecodeMut<'a, '_, S> for &'a [u8] {
+    fn decode(r: &mut Reader<'a>, s: &mut S) -> Self {
+        let len = usize::decode(r, s);
+        let xs = &r[..len];
+        *r = &r[len..];
+        xs
+    }
+}
+
+impl<S> Encode<S> for &str {
+    fn encode(self, w: &mut Writer, s: &mut S) {
+        self.as_bytes().encode(w, s);
+    }
+}
+
+impl<'a, S> DecodeMut<'a, '_, S> for &'a str {
+    fn decode(r: &mut Reader<'a>, s: &mut S) -> Self {
+        str::from_utf8(<&[u8]>::decode(r, s)).unwrap()
+    }
+}
+
+impl<S> Encode<S> for String {
+    fn encode(self, w: &mut Writer, s: &mut S) {
+        self[..].encode(w, s);
+    }
+}
+
+impl<S> DecodeMut<'_, '_, S> for String {
+    fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
+        <&str>::decode(r, s).to_string()
+    }
+}
+
+/// Simplied version of panic payloads, ignoring
+/// types other than `&'static str` and `String`.
+#[derive(Debug)]
+pub enum PanicMessage {
+    StaticStr(&'static str),
+    String(String),
+    Unknown,
+}
+
+impl From<Box<dyn Any + Send>> for PanicMessage {
+    fn from(payload: Box<dyn Any + Send + 'static>) -> Self {
+        if let Some(s) = payload.downcast_ref::<&'static str>() {
+            return PanicMessage::StaticStr(s);
+        }
+        if let Ok(s) = payload.downcast::<String>() {
+            return PanicMessage::String(*s);
+        }
+        PanicMessage::Unknown
+    }
+}
+
+impl Into<Box<dyn Any + Send>> for PanicMessage {
+    fn into(self) -> Box<dyn Any + Send> {
+        match self {
+            PanicMessage::StaticStr(s) => Box::new(s),
+            PanicMessage::String(s) => Box::new(s),
+            PanicMessage::Unknown => {
+                struct UnknownPanicMessage;
+                Box::new(UnknownPanicMessage)
+            }
+        }
+    }
+}
+
+impl PanicMessage {
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            PanicMessage::StaticStr(s) => Some(s),
+            PanicMessage::String(s) => Some(s),
+            PanicMessage::Unknown => None,
+        }
+    }
+}
+
+impl<S> Encode<S> for PanicMessage {
+    fn encode(self, w: &mut Writer, s: &mut S) {
+        self.as_str().encode(w, s);
+    }
+}
+
+impl<S> DecodeMut<'_, '_, S> for PanicMessage {
+    fn decode(r: &mut Reader<'_>, s: &mut S) -> Self {
+        match Option::<String>::decode(r, s) {
+            Some(s) => PanicMessage::String(s),
+            None => PanicMessage::Unknown,
+        }
+    }
+}

--- a/crates/ra_proc_macro_srv/src/proc_macro/bridge/scoped_cell.rs
+++ b/crates/ra_proc_macro_srv/src/proc_macro/bridge/scoped_cell.rs
@@ -1,0 +1,81 @@
+//! `Cell` variant for (scoped) existential lifetimes.
+
+use std::cell::Cell;
+use std::mem;
+use std::ops::{Deref, DerefMut};
+
+/// Type lambda application, with a lifetime.
+#[allow(unused_lifetimes)]
+pub trait ApplyL<'a> {
+    type Out;
+}
+
+/// Type lambda taking a lifetime, i.e., `Lifetime -> Type`.
+pub trait LambdaL: for<'a> ApplyL<'a> {}
+
+impl<T: for<'a> ApplyL<'a>> LambdaL for T {}
+
+// HACK(eddyb) work around projection limitations with a newtype
+// FIXME(#52812) replace with `&'a mut <T as ApplyL<'b>>::Out`
+pub struct RefMutL<'a, 'b, T: LambdaL>(&'a mut <T as ApplyL<'b>>::Out);
+
+impl<'a, 'b, T: LambdaL> Deref for RefMutL<'a, 'b, T> {
+    type Target = <T as ApplyL<'b>>::Out;
+    fn deref(&self) -> &Self::Target {
+        self.0
+    }
+}
+
+impl<'a, 'b, T: LambdaL> DerefMut for RefMutL<'a, 'b, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0
+    }
+}
+
+pub struct ScopedCell<T: LambdaL>(Cell<<T as ApplyL<'static>>::Out>);
+
+impl<T: LambdaL> ScopedCell<T> {
+    pub fn new(value: <T as ApplyL<'static>>::Out) -> Self {
+        ScopedCell(Cell::new(value))
+    }
+
+    /// Sets the value in `self` to `replacement` while
+    /// running `f`, which gets the old value, mutably.
+    /// The old value will be restored after `f` exits, even
+    /// by panic, including modifications made to it by `f`.
+    pub fn replace<'a, R>(
+        &self,
+        replacement: <T as ApplyL<'a>>::Out,
+        f: impl for<'b, 'c> FnOnce(RefMutL<'b, 'c, T>) -> R,
+    ) -> R {
+        /// Wrapper that ensures that the cell always gets filled
+        /// (with the original state, optionally changed by `f`),
+        /// even if `f` had panicked.
+        struct PutBackOnDrop<'a, T: LambdaL> {
+            cell: &'a ScopedCell<T>,
+            value: Option<<T as ApplyL<'static>>::Out>,
+        }
+
+        impl<'a, T: LambdaL> Drop for PutBackOnDrop<'a, T> {
+            fn drop(&mut self) {
+                self.cell.0.set(self.value.take().unwrap());
+            }
+        }
+
+        let mut put_back_on_drop = PutBackOnDrop {
+            cell: self,
+            value: Some(self.0.replace(unsafe {
+                let erased = mem::transmute_copy(&replacement);
+                mem::forget(replacement);
+                erased
+            })),
+        };
+
+        f(RefMutL(put_back_on_drop.value.as_mut().unwrap()))
+    }
+
+    /// Sets the value in `self` to `value` while running `f`.
+    pub fn set<R>(&self, value: <T as ApplyL<'_>>::Out, f: impl FnOnce() -> R) -> R {
+        self.replace(value, |_| f())
+    }
+}

--- a/crates/ra_proc_macro_srv/src/proc_macro/bridge/server.rs
+++ b/crates/ra_proc_macro_srv/src/proc_macro/bridge/server.rs
@@ -1,0 +1,320 @@
+//! Server-side traits.
+
+use super::*;
+
+// FIXME(eddyb) generate the definition of `HandleStore` in `server.rs`.
+use super::client::HandleStore;
+
+/// Declare an associated item of one of the traits below, optionally
+/// adjusting it (i.e., adding bounds to types and default bodies to methods).
+macro_rules! associated_item {
+    (type TokenStream) =>
+        (type TokenStream: 'static + Clone;);
+    (type TokenStreamBuilder) =>
+        (type TokenStreamBuilder: 'static;);
+    (type TokenStreamIter) =>
+        (type TokenStreamIter: 'static + Clone;);
+    (type Group) =>
+        (type Group: 'static + Clone;);
+    (type Punct) =>
+        (type Punct: 'static + Copy + Eq + Hash;);
+    (type Ident) =>
+        (type Ident: 'static + Copy + Eq + Hash;);
+    (type Literal) =>
+        (type Literal: 'static + Clone;);
+    (type SourceFile) =>
+        (type SourceFile: 'static + Clone;);
+    (type MultiSpan) =>
+        (type MultiSpan: 'static;);
+    (type Diagnostic) =>
+        (type Diagnostic: 'static;);
+    (type Span) =>
+        (type Span: 'static + Copy + Eq + Hash;);
+    (fn drop(&mut self, $arg:ident: $arg_ty:ty)) =>
+        (fn drop(&mut self, $arg: $arg_ty) { mem::drop($arg) });
+    (fn clone(&mut self, $arg:ident: $arg_ty:ty) -> $ret_ty:ty) =>
+        (fn clone(&mut self, $arg: $arg_ty) -> $ret_ty { $arg.clone() });
+    ($($item:tt)*) => ($($item)*;)
+}
+
+macro_rules! declare_server_traits {
+    ($($name:ident {
+        $(fn $method:ident($($arg:ident: $arg_ty:ty),* $(,)?) $(-> $ret_ty:ty)?;)*
+    }),* $(,)?) => {
+        pub trait Types {
+            $(associated_item!(type $name);)*
+        }
+
+        $(pub trait $name: Types {
+            $(associated_item!(fn $method(&mut self, $($arg: $arg_ty),*) $(-> $ret_ty)?);)*
+        })*
+
+        pub trait Server: Types $(+ $name)* {}
+        impl<S: Types $(+ $name)*> Server for S {}
+    }
+}
+with_api!(Self, self_, declare_server_traits);
+
+pub(super) struct MarkedTypes<S: Types>(S);
+
+macro_rules! define_mark_types_impls {
+    ($($name:ident {
+        $(fn $method:ident($($arg:ident: $arg_ty:ty),* $(,)?) $(-> $ret_ty:ty)?;)*
+    }),* $(,)?) => {
+        impl<S: Types> Types for MarkedTypes<S> {
+            $(type $name = Marked<S::$name, client::$name>;)*
+        }
+
+        $(impl<S: $name> $name for MarkedTypes<S> {
+            $(fn $method(&mut self, $($arg: $arg_ty),*) $(-> $ret_ty)? {
+                <_>::mark($name::$method(&mut self.0, $($arg.unmark()),*))
+            })*
+        })*
+    }
+}
+with_api!(Self, self_, define_mark_types_impls);
+
+struct Dispatcher<S: Types> {
+    handle_store: HandleStore<S>,
+    server: S,
+}
+
+macro_rules! define_dispatcher_impl {
+    ($($name:ident {
+        $(fn $method:ident($($arg:ident: $arg_ty:ty),* $(,)?) $(-> $ret_ty:ty)?;)*
+    }),* $(,)?) => {
+        // FIXME(eddyb) `pub` only for `ExecutionStrategy` below.
+        pub trait DispatcherTrait {
+            // HACK(eddyb) these are here to allow `Self::$name` to work below.
+            $(type $name;)*
+            fn dispatch(&mut self, b: Buffer<u8>) -> Buffer<u8>;
+        }
+
+        impl<S: Server> DispatcherTrait for Dispatcher<MarkedTypes<S>> {
+            $(type $name = <MarkedTypes<S> as Types>::$name;)*
+            fn dispatch(&mut self, mut b: Buffer<u8>) -> Buffer<u8> {
+                let Dispatcher { handle_store, server } = self;
+
+                let mut reader = &b[..];
+                match api_tags::Method::decode(&mut reader, &mut ()) {
+                    $(api_tags::Method::$name(m) => match m {
+                        $(api_tags::$name::$method => {
+                            let mut call_method = || {
+                                reverse_decode!(reader, handle_store; $($arg: $arg_ty),*);
+                                $name::$method(server, $($arg),*)
+                            };
+                            // HACK(eddyb) don't use `panic::catch_unwind` in a panic.
+                            // If client and server happen to use the same `libstd`,
+                            // `catch_unwind` asserts that the panic counter was 0,
+                            // even when the closure passed to it didn't panic.
+                            let r = if thread::panicking() {
+                                Ok(call_method())
+                            } else {
+                                panic::catch_unwind(panic::AssertUnwindSafe(call_method))
+                                    .map_err(PanicMessage::from)
+                            };
+
+                            b.clear();
+                            r.encode(&mut b, handle_store);
+                        })*
+                    }),*
+                }
+                b
+            }
+        }
+    }
+}
+with_api!(Self, self_, define_dispatcher_impl);
+
+pub trait ExecutionStrategy {
+    fn run_bridge_and_client<D: Copy + Send + 'static>(
+        &self,
+        dispatcher: &mut impl DispatcherTrait,
+        input: Buffer<u8>,
+        run_client: extern "C" fn(Bridge<'_>, D) -> Buffer<u8>,
+        client_data: D,
+    ) -> Buffer<u8>;
+}
+
+pub struct SameThread;
+
+impl ExecutionStrategy for SameThread {
+    fn run_bridge_and_client<D: Copy + Send + 'static>(
+        &self,
+        dispatcher: &mut impl DispatcherTrait,
+        input: Buffer<u8>,
+        run_client: extern "C" fn(Bridge<'_>, D) -> Buffer<u8>,
+        client_data: D,
+    ) -> Buffer<u8> {
+        let mut dispatch = |b| dispatcher.dispatch(b);
+
+        run_client(Bridge { cached_buffer: input, dispatch: (&mut dispatch).into() }, client_data)
+    }
+}
+
+// NOTE(eddyb) Two implementations are provided, the second one is a bit
+// faster but neither is anywhere near as fast as same-thread execution.
+
+pub struct CrossThread1;
+
+impl ExecutionStrategy for CrossThread1 {
+    fn run_bridge_and_client<D: Copy + Send + 'static>(
+        &self,
+        dispatcher: &mut impl DispatcherTrait,
+        input: Buffer<u8>,
+        run_client: extern "C" fn(Bridge<'_>, D) -> Buffer<u8>,
+        client_data: D,
+    ) -> Buffer<u8> {
+        use std::sync::mpsc::channel;
+
+        let (req_tx, req_rx) = channel();
+        let (res_tx, res_rx) = channel();
+
+        let join_handle = thread::spawn(move || {
+            let mut dispatch = |b| {
+                req_tx.send(b).unwrap();
+                res_rx.recv().unwrap()
+            };
+
+            run_client(
+                Bridge { cached_buffer: input, dispatch: (&mut dispatch).into() },
+                client_data,
+            )
+        });
+
+        for b in req_rx {
+            res_tx.send(dispatcher.dispatch(b)).unwrap();
+        }
+
+        join_handle.join().unwrap()
+    }
+}
+
+pub struct CrossThread2;
+
+impl ExecutionStrategy for CrossThread2 {
+    fn run_bridge_and_client<D: Copy + Send + 'static>(
+        &self,
+        dispatcher: &mut impl DispatcherTrait,
+        input: Buffer<u8>,
+        run_client: extern "C" fn(Bridge<'_>, D) -> Buffer<u8>,
+        client_data: D,
+    ) -> Buffer<u8> {
+        use std::sync::{Arc, Mutex};
+
+        enum State<T> {
+            Req(T),
+            Res(T),
+        }
+
+        let mut state = Arc::new(Mutex::new(State::Res(Buffer::new())));
+
+        let server_thread = thread::current();
+        let state2 = state.clone();
+        let join_handle = thread::spawn(move || {
+            let mut dispatch = |b| {
+                *state2.lock().unwrap() = State::Req(b);
+                server_thread.unpark();
+                loop {
+                    thread::park();
+                    if let State::Res(b) = &mut *state2.lock().unwrap() {
+                        break b.take();
+                    }
+                }
+            };
+
+            let r = run_client(
+                Bridge { cached_buffer: input, dispatch: (&mut dispatch).into() },
+                client_data,
+            );
+
+            // Wake up the server so it can exit the dispatch loop.
+            drop(state2);
+            server_thread.unpark();
+
+            r
+        });
+
+        // Check whether `state2` was dropped, to know when to stop.
+        while Arc::get_mut(&mut state).is_none() {
+            thread::park();
+            let mut b = match &mut *state.lock().unwrap() {
+                State::Req(b) => b.take(),
+                _ => continue,
+            };
+            b = dispatcher.dispatch(b.take());
+            *state.lock().unwrap() = State::Res(b);
+            join_handle.thread().unpark();
+        }
+
+        join_handle.join().unwrap()
+    }
+}
+
+fn run_server<
+    S: Server,
+    I: Encode<HandleStore<MarkedTypes<S>>>,
+    O: for<'a, 's> DecodeMut<'a, 's, HandleStore<MarkedTypes<S>>>,
+    D: Copy + Send + 'static,
+>(
+    strategy: &impl ExecutionStrategy,
+    handle_counters: &'static client::HandleCounters,
+    server: S,
+    input: I,
+    run_client: extern "C" fn(Bridge<'_>, D) -> Buffer<u8>,
+    client_data: D,
+) -> Result<O, PanicMessage> {
+    let mut dispatcher =
+        Dispatcher { handle_store: HandleStore::new(handle_counters), server: MarkedTypes(server) };
+
+    let mut b = Buffer::new();
+    input.encode(&mut b, &mut dispatcher.handle_store);
+
+    b = strategy.run_bridge_and_client(&mut dispatcher, b, run_client, client_data);
+
+    Result::decode(&mut &b[..], &mut dispatcher.handle_store)
+}
+
+impl client::Client<fn(crate::TokenStream) -> crate::TokenStream> {
+    pub fn run<S: Server>(
+        &self,
+        strategy: &impl ExecutionStrategy,
+        server: S,
+        input: S::TokenStream,
+    ) -> Result<S::TokenStream, PanicMessage> {
+        let client::Client { get_handle_counters, run, f } = *self;
+        run_server(
+            strategy,
+            get_handle_counters(),
+            server,
+            <MarkedTypes<S> as Types>::TokenStream::mark(input),
+            run,
+            f,
+        )
+        .map(<MarkedTypes<S> as Types>::TokenStream::unmark)
+    }
+}
+
+impl client::Client<fn(crate::TokenStream, crate::TokenStream) -> crate::TokenStream> {
+    pub fn run<S: Server>(
+        &self,
+        strategy: &impl ExecutionStrategy,
+        server: S,
+        input: S::TokenStream,
+        input2: S::TokenStream,
+    ) -> Result<S::TokenStream, PanicMessage> {
+        let client::Client { get_handle_counters, run, f } = *self;
+        run_server(
+            strategy,
+            get_handle_counters(),
+            server,
+            (
+                <MarkedTypes<S> as Types>::TokenStream::mark(input),
+                <MarkedTypes<S> as Types>::TokenStream::mark(input2),
+            ),
+            run,
+            f,
+        )
+        .map(<MarkedTypes<S> as Types>::TokenStream::unmark)
+    }
+}

--- a/crates/ra_proc_macro_srv/src/proc_macro/diagnostic.rs
+++ b/crates/ra_proc_macro_srv/src/proc_macro/diagnostic.rs
@@ -1,0 +1,165 @@
+use crate::proc_macro::Span;
+
+/// An enum representing a diagnostic level.
+#[derive(Copy, Clone, Debug)]
+#[non_exhaustive]
+pub enum Level {
+    /// An error.
+    Error,
+    /// A warning.
+    Warning,
+    /// A note.
+    Note,
+    /// A help message.
+    Help,
+}
+
+/// Trait implemented by types that can be converted into a set of `Span`s.
+pub trait MultiSpan {
+    /// Converts `self` into a `Vec<Span>`.
+    fn into_spans(self) -> Vec<Span>;
+}
+
+impl MultiSpan for Span {
+    fn into_spans(self) -> Vec<Span> {
+        vec![self]
+    }
+}
+
+impl MultiSpan for Vec<Span> {
+    fn into_spans(self) -> Vec<Span> {
+        self
+    }
+}
+
+impl<'a> MultiSpan for &'a [Span] {
+    fn into_spans(self) -> Vec<Span> {
+        self.to_vec()
+    }
+}
+
+/// A structure representing a diagnostic message and associated children
+/// messages.
+#[derive(Clone, Debug)]
+pub struct Diagnostic {
+    level: Level,
+    message: String,
+    spans: Vec<Span>,
+    children: Vec<Diagnostic>,
+}
+
+macro_rules! diagnostic_child_methods {
+    ($spanned:ident, $regular:ident, $level:expr) => (
+        /// Adds a new child diagnostic message to `self` with the level
+        /// identified by this method's name with the given `spans` and
+        /// `message`.
+        pub fn $spanned<S, T>(mut self, spans: S, message: T) -> Diagnostic
+            where S: MultiSpan, T: Into<String>
+        {
+            self.children.push(Diagnostic::spanned(spans, $level, message));
+            self
+        }
+
+        /// Adds a new child diagnostic message to `self` with the level
+        /// identified by this method's name with the given `message`.
+        pub fn $regular<T: Into<String>>(mut self, message: T) -> Diagnostic {
+            self.children.push(Diagnostic::new($level, message));
+            self
+        }
+    )
+}
+
+/// Iterator over the children diagnostics of a `Diagnostic`.
+#[derive(Debug, Clone)]
+pub struct Children<'a>(std::slice::Iter<'a, Diagnostic>);
+
+impl<'a> Iterator for Children<'a> {
+    type Item = &'a Diagnostic;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl Diagnostic {
+    /// Creates a new diagnostic with the given `level` and `message`.
+    pub fn new<T: Into<String>>(level: Level, message: T) -> Diagnostic {
+        Diagnostic { level: level, message: message.into(), spans: vec![], children: vec![] }
+    }
+
+    /// Creates a new diagnostic with the given `level` and `message` pointing to
+    /// the given set of `spans`.
+    pub fn spanned<S, T>(spans: S, level: Level, message: T) -> Diagnostic
+    where
+        S: MultiSpan,
+        T: Into<String>,
+    {
+        Diagnostic {
+            level: level,
+            message: message.into(),
+            spans: spans.into_spans(),
+            children: vec![],
+        }
+    }
+
+    diagnostic_child_methods!(span_error, error, Level::Error);
+    diagnostic_child_methods!(span_warning, warning, Level::Warning);
+    diagnostic_child_methods!(span_note, note, Level::Note);
+    diagnostic_child_methods!(span_help, help, Level::Help);
+
+    /// Returns the diagnostic `level` for `self`.
+    pub fn level(&self) -> Level {
+        self.level
+    }
+
+    /// Sets the level in `self` to `level`.
+    pub fn set_level(&mut self, level: Level) {
+        self.level = level;
+    }
+
+    /// Returns the message in `self`.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    /// Sets the message in `self` to `message`.
+    pub fn set_message<T: Into<String>>(&mut self, message: T) {
+        self.message = message.into();
+    }
+
+    /// Returns the `Span`s in `self`.
+    pub fn spans(&self) -> &[Span] {
+        &self.spans
+    }
+
+    /// Sets the `Span`s in `self` to `spans`.
+    pub fn set_spans<S: MultiSpan>(&mut self, spans: S) {
+        self.spans = spans.into_spans();
+    }
+
+    /// Returns an iterator over the children diagnostics of `self`.
+    pub fn children(&self) -> Children<'_> {
+        Children(self.children.iter())
+    }
+
+    /// Emit the diagnostic.
+    pub fn emit(self) {
+        fn to_internal(spans: Vec<Span>) -> crate::proc_macro::bridge::client::MultiSpan {
+            let mut multi_span = crate::proc_macro::bridge::client::MultiSpan::new();
+            for span in spans {
+                multi_span.push(span.0);
+            }
+            multi_span
+        }
+
+        let mut diag = crate::proc_macro::bridge::client::Diagnostic::new(
+            self.level,
+            &self.message[..],
+            to_internal(self.spans),
+        );
+        for c in self.children {
+            diag.sub(c.level, &c.message[..], to_internal(c.spans));
+        }
+        diag.emit();
+    }
+}

--- a/crates/ra_proc_macro_srv/src/proc_macro/mod.rs
+++ b/crates/ra_proc_macro_srv/src/proc_macro/mod.rs
@@ -1,0 +1,921 @@
+// NOTE(@edwin0cheng):
+// Because we just copy the bridge module from rustc for ABI compatible
+// There is some unused stuffs inside it.
+// We suppress these warning here.
+#[doc(hidden)]
+#[allow(unused_macros)]
+#[allow(unused_variables)]
+pub mod bridge;
+
+mod diagnostic;
+
+pub use diagnostic::{Diagnostic, Level, MultiSpan};
+
+use std::ops::{Bound, RangeBounds};
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::{fmt, iter, mem};
+
+/// The main type provided by this crate, representing an abstract stream of
+/// tokens, or, more specifically, a sequence of token trees.
+/// The type provide interfaces for iterating over those token trees and, conversely,
+/// collecting a number of token trees into one stream.
+///
+/// This is both the input and output of `#[proc_macro]`, `#[proc_macro_attribute]`
+/// and `#[proc_macro_derive]` definitions.
+#[derive(Clone)]
+pub struct TokenStream(bridge::client::TokenStream);
+
+/// Error returned from `TokenStream::from_str`
+#[derive(Debug)]
+pub struct LexError {
+    _inner: (),
+}
+
+impl TokenStream {
+    /// Returns an empty `TokenStream` containing no token trees.
+    pub fn new() -> TokenStream {
+        TokenStream(bridge::client::TokenStream::new())
+    }
+
+    /// Checks if this `TokenStream` is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// Attempts to break the string into tokens and parse those tokens into a token stream.
+/// May fail for a number of reasons, for example, if the string contains unbalanced delimiters
+/// or characters not existing in the language.
+/// All tokens in the parsed stream get `Span::call_site()` spans.
+///
+/// NOTE: some errors may cause panics instead of returning `LexError`. We reserve the right to
+/// change these errors into `LexError`s later.
+impl FromStr for TokenStream {
+    type Err = LexError;
+
+    fn from_str(src: &str) -> Result<TokenStream, LexError> {
+        Ok(TokenStream(bridge::client::TokenStream::from_str(src)))
+    }
+}
+
+// N.B., the bridge only provides `to_string`, implement `fmt::Display`
+// based on it (the reverse of the usual relationship between the two).
+// impl ToString for TokenStream {
+//     fn to_string(&self) -> String {
+//         self.0.to_string()
+//     }
+// }
+
+/// Prints the token stream as a string that is supposed to be losslessly convertible back
+/// into the same token stream (modulo spans), except for possibly `TokenTree::Group`s
+/// with `Delimiter::None` delimiters and negative numeric literals.
+impl fmt::Display for TokenStream {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_string())
+    }
+}
+
+/// Prints token in a form convenient for debugging.
+impl fmt::Debug for TokenStream {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("TokenStream ")?;
+        f.debug_list().entries(self.clone()).finish()
+    }
+}
+
+/// Creates a token stream containing a single token tree.
+impl From<TokenTree> for TokenStream {
+    fn from(tree: TokenTree) -> TokenStream {
+        TokenStream(bridge::client::TokenStream::from_token_tree(match tree {
+            TokenTree::Group(tt) => bridge::TokenTree::Group(tt.0),
+            TokenTree::Punct(tt) => bridge::TokenTree::Punct(tt.0),
+            TokenTree::Ident(tt) => bridge::TokenTree::Ident(tt.0),
+            TokenTree::Literal(tt) => bridge::TokenTree::Literal(tt.0),
+        }))
+    }
+}
+
+/// Collects a number of token trees into a single stream.
+impl iter::FromIterator<TokenTree> for TokenStream {
+    fn from_iter<I: IntoIterator<Item = TokenTree>>(trees: I) -> Self {
+        trees.into_iter().map(TokenStream::from).collect()
+    }
+}
+
+/// A "flattening" operation on token streams, collects token trees
+/// from multiple token streams into a single stream.
+impl iter::FromIterator<TokenStream> for TokenStream {
+    fn from_iter<I: IntoIterator<Item = TokenStream>>(streams: I) -> Self {
+        let mut builder = bridge::client::TokenStreamBuilder::new();
+        streams.into_iter().for_each(|stream| builder.push(stream.0));
+        TokenStream(builder.build())
+    }
+}
+
+impl Extend<TokenTree> for TokenStream {
+    fn extend<I: IntoIterator<Item = TokenTree>>(&mut self, trees: I) {
+        self.extend(trees.into_iter().map(TokenStream::from));
+    }
+}
+
+impl Extend<TokenStream> for TokenStream {
+    fn extend<I: IntoIterator<Item = TokenStream>>(&mut self, streams: I) {
+        // FIXME(eddyb) Use an optimized implementation if/when possible.
+        *self = iter::once(mem::replace(self, Self::new())).chain(streams).collect();
+    }
+}
+
+/// Public implementation details for the `TokenStream` type, such as iterators.
+pub mod token_stream {
+    use crate::proc_macro::{bridge, Group, Ident, Literal, Punct, TokenStream, TokenTree};
+
+    /// An iterator over `TokenStream`'s `TokenTree`s.
+    /// The iteration is "shallow", e.g., the iterator doesn't recurse into delimited groups,
+    /// and returns whole groups as token trees.
+    #[derive(Clone)]
+    pub struct IntoIter(bridge::client::TokenStreamIter);
+
+    impl Iterator for IntoIter {
+        type Item = TokenTree;
+
+        fn next(&mut self) -> Option<TokenTree> {
+            self.0.next().map(|tree| match tree {
+                bridge::TokenTree::Group(tt) => TokenTree::Group(Group(tt)),
+                bridge::TokenTree::Punct(tt) => TokenTree::Punct(Punct(tt)),
+                bridge::TokenTree::Ident(tt) => TokenTree::Ident(Ident(tt)),
+                bridge::TokenTree::Literal(tt) => TokenTree::Literal(Literal(tt)),
+            })
+        }
+    }
+
+    impl IntoIterator for TokenStream {
+        type Item = TokenTree;
+        type IntoIter = IntoIter;
+
+        fn into_iter(self) -> IntoIter {
+            IntoIter(self.0.into_iter())
+        }
+    }
+}
+
+/// A region of source code, along with macro expansion information.
+#[derive(Copy, Clone)]
+pub struct Span(bridge::client::Span);
+
+macro_rules! diagnostic_method {
+    ($name:ident, $level:expr) => (
+        /// Creates a new `Diagnostic` with the given `message` at the span
+        /// `self`.
+        pub fn $name<T: Into<String>>(self, message: T) -> Diagnostic {
+            Diagnostic::spanned(self, $level, message)
+        }
+    )
+}
+
+impl Span {
+    /// A span that resolves at the macro definition site.
+    pub fn def_site() -> Span {
+        Span(bridge::client::Span::def_site())
+    }
+
+    /// The span of the invocation of the current procedural macro.
+    /// Identifiers created with this span will be resolved as if they were written
+    /// directly at the macro call location (call-site hygiene) and other code
+    /// at the macro call site will be able to refer to them as well.
+    pub fn call_site() -> Span {
+        Span(bridge::client::Span::call_site())
+    }
+
+    /// A span that represents `macro_rules` hygiene, and sometimes resolves at the macro
+    /// definition site (local variables, labels, `$crate`) and sometimes at the macro
+    /// call site (everything else).
+    /// The span location is taken from the call-site.
+    pub fn mixed_site() -> Span {
+        Span(bridge::client::Span::mixed_site())
+    }
+
+    /// The original source file into which this span points.
+    pub fn source_file(&self) -> SourceFile {
+        SourceFile(self.0.source_file())
+    }
+
+    /// The `Span` for the tokens in the previous macro expansion from which
+    /// `self` was generated from, if any.
+    pub fn parent(&self) -> Option<Span> {
+        self.0.parent().map(Span)
+    }
+
+    /// The span for the origin source code that `self` was generated from. If
+    /// this `Span` wasn't generated from other macro expansions then the return
+    /// value is the same as `*self`.
+    pub fn source(&self) -> Span {
+        Span(self.0.source())
+    }
+
+    /// Gets the starting line/column in the source file for this span.
+    pub fn start(&self) -> LineColumn {
+        self.0.start()
+    }
+
+    /// Gets the ending line/column in the source file for this span.
+    pub fn end(&self) -> LineColumn {
+        self.0.end()
+    }
+
+    /// Creates a new span encompassing `self` and `other`.
+    ///
+    /// Returns `None` if `self` and `other` are from different files.
+    pub fn join(&self, other: Span) -> Option<Span> {
+        self.0.join(other.0).map(Span)
+    }
+
+    /// Creates a new span with the same line/column information as `self` but
+    /// that resolves symbols as though it were at `other`.
+    pub fn resolved_at(&self, other: Span) -> Span {
+        Span(self.0.resolved_at(other.0))
+    }
+
+    /// Creates a new span with the same name resolution behavior as `self` but
+    /// with the line/column information of `other`.
+    pub fn located_at(&self, other: Span) -> Span {
+        other.resolved_at(*self)
+    }
+
+    /// Compares to spans to see if they're equal.
+    pub fn eq(&self, other: &Span) -> bool {
+        self.0 == other.0
+    }
+
+    /// Returns the source text behind a span. This preserves the original source
+    /// code, including spaces and comments. It only returns a result if the span
+    /// corresponds to real source code.
+    ///
+    /// Note: The observable result of a macro should only rely on the tokens and
+    /// not on this source text. The result of this function is a best effort to
+    /// be used for diagnostics only.
+    pub fn source_text(&self) -> Option<String> {
+        self.0.source_text()
+    }
+
+    diagnostic_method!(error, Level::Error);
+    diagnostic_method!(warning, Level::Warning);
+    diagnostic_method!(note, Level::Note);
+    diagnostic_method!(help, Level::Help);
+}
+
+/// Prints a span in a form convenient for debugging.
+impl fmt::Debug for Span {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// A line-column pair representing the start or end of a `Span`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct LineColumn {
+    /// The 1-indexed line in the source file on which the span starts or ends (inclusive).
+    pub line: usize,
+    /// The 0-indexed column (in UTF-8 characters) in the source file on which
+    /// the span starts or ends (inclusive).
+    pub column: usize,
+}
+
+/// The source file of a given `Span`.
+#[derive(Clone)]
+pub struct SourceFile(bridge::client::SourceFile);
+
+impl SourceFile {
+    /// Gets the path to this source file.
+    ///
+    /// ### Note
+    /// If the code span associated with this `SourceFile` was generated by an external macro, this
+    /// macro, this may not be an actual path on the filesystem. Use [`is_real`] to check.
+    ///
+    /// Also note that even if `is_real` returns `true`, if `--remap-path-prefix` was passed on
+    /// the command line, the path as given may not actually be valid.
+    ///
+    /// [`is_real`]: #method.is_real
+    pub fn path(&self) -> PathBuf {
+        PathBuf::from(self.0.path())
+    }
+
+    /// Returns `true` if this source file is a real source file, and not generated by an external
+    /// macro's expansion.
+    pub fn is_real(&self) -> bool {
+        // This is a hack until intercrate spans are implemented and we can have real source files
+        // for spans generated in external macros.
+        // https://github.com/rust-lang/rust/pull/43604#issuecomment-333334368
+        self.0.is_real()
+    }
+}
+
+impl fmt::Debug for SourceFile {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SourceFile")
+            .field("path", &self.path())
+            .field("is_real", &self.is_real())
+            .finish()
+    }
+}
+
+impl PartialEq for SourceFile {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.eq(&other.0)
+    }
+}
+
+impl Eq for SourceFile {}
+
+/// A single token or a delimited sequence of token trees (e.g., `[1, (), ..]`).
+#[derive(Clone)]
+pub enum TokenTree {
+    /// A token stream surrounded by bracket delimiters.
+    Group(Group),
+    /// An identifier.
+    Ident(Ident),
+    /// A single punctuation character (`+`, `,`, `$`, etc.).
+    Punct(Punct),
+    /// A literal character (`'a'`), string (`"hello"`), number (`2.3`), etc.
+    Literal(Literal),
+}
+
+impl TokenTree {
+    /// Returns the span of this tree, delegating to the `span` method of
+    /// the contained token or a delimited stream.
+    pub fn span(&self) -> Span {
+        match *self {
+            TokenTree::Group(ref t) => t.span(),
+            TokenTree::Ident(ref t) => t.span(),
+            TokenTree::Punct(ref t) => t.span(),
+            TokenTree::Literal(ref t) => t.span(),
+        }
+    }
+
+    /// Configures the span for *only this token*.
+    ///
+    /// Note that if this token is a `Group` then this method will not configure
+    /// the span of each of the internal tokens, this will simply delegate to
+    /// the `set_span` method of each variant.
+    pub fn set_span(&mut self, span: Span) {
+        match *self {
+            TokenTree::Group(ref mut t) => t.set_span(span),
+            TokenTree::Ident(ref mut t) => t.set_span(span),
+            TokenTree::Punct(ref mut t) => t.set_span(span),
+            TokenTree::Literal(ref mut t) => t.set_span(span),
+        }
+    }
+}
+
+/// Prints token tree in a form convenient for debugging.
+impl fmt::Debug for TokenTree {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Each of these has the name in the struct type in the derived debug,
+        // so don't bother with an extra layer of indirection
+        match *self {
+            TokenTree::Group(ref tt) => tt.fmt(f),
+            TokenTree::Ident(ref tt) => tt.fmt(f),
+            TokenTree::Punct(ref tt) => tt.fmt(f),
+            TokenTree::Literal(ref tt) => tt.fmt(f),
+        }
+    }
+}
+
+impl From<Group> for TokenTree {
+    fn from(g: Group) -> TokenTree {
+        TokenTree::Group(g)
+    }
+}
+
+impl From<Ident> for TokenTree {
+    fn from(g: Ident) -> TokenTree {
+        TokenTree::Ident(g)
+    }
+}
+
+impl From<Punct> for TokenTree {
+    fn from(g: Punct) -> TokenTree {
+        TokenTree::Punct(g)
+    }
+}
+
+impl From<Literal> for TokenTree {
+    fn from(g: Literal) -> TokenTree {
+        TokenTree::Literal(g)
+    }
+}
+
+// N.B., the bridge only provides `to_string`, implement `fmt::Display`
+// based on it (the reverse of the usual relationship between the two).
+// impl ToString for TokenTree {
+//     fn to_string(&self) -> String {
+//         match *self {
+//             TokenTree::Group(ref t) => t.to_string(),
+//             TokenTree::Ident(ref t) => t.to_string(),
+//             TokenTree::Punct(ref t) => t.to_string(),
+//             TokenTree::Literal(ref t) => t.to_string(),
+//         }
+//     }
+// }
+
+/// Prints the token tree as a string that is supposed to be losslessly convertible back
+/// into the same token tree (modulo spans), except for possibly `TokenTree::Group`s
+/// with `Delimiter::None` delimiters and negative numeric literals.
+impl fmt::Display for TokenTree {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_string())
+    }
+}
+
+/// A delimited token stream.
+///
+/// A `Group` internally contains a `TokenStream` which is surrounded by `Delimiter`s.
+#[derive(Clone)]
+pub struct Group(bridge::client::Group);
+
+/// Describes how a sequence of token trees is delimited.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Delimiter {
+    /// `( ... )`
+    Parenthesis,
+    /// `{ ... }`
+    Brace,
+    /// `[ ... ]`
+    Bracket,
+    /// `Ø ... Ø`
+    /// An implicit delimiter, that may, for example, appear around tokens coming from a
+    /// "macro variable" `$var`. It is important to preserve operator priorities in cases like
+    /// `$var * 3` where `$var` is `1 + 2`.
+    /// Implicit delimiters may not survive roundtrip of a token stream through a string.
+    None,
+}
+
+impl Group {
+    /// Creates a new `Group` with the given delimiter and token stream.
+    ///
+    /// This constructor will set the span for this group to
+    /// `Span::call_site()`. To change the span you can use the `set_span`
+    /// method below.
+    pub fn new(delimiter: Delimiter, stream: TokenStream) -> Group {
+        Group(bridge::client::Group::new(delimiter, stream.0))
+    }
+
+    /// Returns the delimiter of this `Group`
+    pub fn delimiter(&self) -> Delimiter {
+        self.0.delimiter()
+    }
+
+    /// Returns the `TokenStream` of tokens that are delimited in this `Group`.
+    ///
+    /// Note that the returned token stream does not include the delimiter
+    /// returned above.
+    pub fn stream(&self) -> TokenStream {
+        TokenStream(self.0.stream())
+    }
+
+    /// Returns the span for the delimiters of this token stream, spanning the
+    /// entire `Group`.
+    ///
+    /// ```text
+    /// pub fn span(&self) -> Span {
+    ///            ^^^^^^^
+    /// ```
+    pub fn span(&self) -> Span {
+        Span(self.0.span())
+    }
+
+    /// Returns the span pointing to the opening delimiter of this group.
+    ///
+    /// ```text
+    /// pub fn span_open(&self) -> Span {
+    ///                 ^
+    /// ```
+    pub fn span_open(&self) -> Span {
+        Span(self.0.span_open())
+    }
+
+    /// Returns the span pointing to the closing delimiter of this group.
+    ///
+    /// ```text
+    /// pub fn span_close(&self) -> Span {
+    ///                        ^
+    /// ```
+    pub fn span_close(&self) -> Span {
+        Span(self.0.span_close())
+    }
+
+    /// Configures the span for this `Group`'s delimiters, but not its internal
+    /// tokens.
+    ///
+    /// This method will **not** set the span of all the internal tokens spanned
+    /// by this group, but rather it will only set the span of the delimiter
+    /// tokens at the level of the `Group`.
+    pub fn set_span(&mut self, span: Span) {
+        self.0.set_span(span.0);
+    }
+}
+
+// N.B., the bridge only provides `to_string`, implement `fmt::Display`
+// based on it (the reverse of the usual relationship between the two).
+// impl ToString for Group {
+//     fn to_string(&self) -> String {
+//         TokenStream::from(TokenTree::from(self.clone())).to_string()
+//     }
+// }
+
+/// Prints the group as a string that should be losslessly convertible back
+/// into the same group (modulo spans), except for possibly `TokenTree::Group`s
+/// with `Delimiter::None` delimiters.
+impl fmt::Display for Group {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_string())
+    }
+}
+
+impl fmt::Debug for Group {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Group")
+            .field("delimiter", &self.delimiter())
+            .field("stream", &self.stream())
+            .field("span", &self.span())
+            .finish()
+    }
+}
+
+/// An `Punct` is an single punctuation character like `+`, `-` or `#`.
+///
+/// Multi-character operators like `+=` are represented as two instances of `Punct` with different
+/// forms of `Spacing` returned.
+#[derive(Clone)]
+pub struct Punct(bridge::client::Punct);
+
+/// Whether an `Punct` is followed immediately by another `Punct` or
+/// followed by another token or whitespace.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Spacing {
+    /// e.g., `+` is `Alone` in `+ =`, `+ident` or `+()`.
+    Alone,
+    /// e.g., `+` is `Joint` in `+=` or `'#`.
+    /// Additionally, single quote `'` can join with identifiers to form lifetimes `'ident`.
+    Joint,
+}
+
+impl Punct {
+    /// Creates a new `Punct` from the given character and spacing.
+    /// The `ch` argument must be a valid punctuation character permitted by the language,
+    /// otherwise the function will panic.
+    ///
+    /// The returned `Punct` will have the default span of `Span::call_site()`
+    /// which can be further configured with the `set_span` method below.    
+    pub fn new(ch: char, spacing: Spacing) -> Punct {
+        Punct(bridge::client::Punct::new(ch, spacing))
+    }
+
+    /// Returns the value of this punctuation character as `char`.
+    pub fn as_char(&self) -> char {
+        self.0.as_char()
+    }
+
+    /// Returns the spacing of this punctuation character, indicating whether it's immediately
+    /// followed by another `Punct` in the token stream, so they can potentially be combined into
+    /// a multi-character operator (`Joint`), or it's followed by some other token or whitespace
+    /// (`Alone`) so the operator has certainly ended.
+    pub fn spacing(&self) -> Spacing {
+        self.0.spacing()
+    }
+
+    /// Returns the span for this punctuation character.
+    pub fn span(&self) -> Span {
+        Span(self.0.span())
+    }
+
+    /// Configure the span for this punctuation character.
+    pub fn set_span(&mut self, span: Span) {
+        self.0 = self.0.with_span(span.0);
+    }
+}
+
+// N.B., the bridge only provides `to_string`, implement `fmt::Display`
+// based on it (the reverse of the usual relationship between the two).
+// impl ToString for Punct {
+//     fn to_string(&self) -> String {
+//         TokenStream::from(TokenTree::from(self.clone())).to_string()
+//     }
+// }
+
+/// Prints the punctuation character as a string that should be losslessly convertible
+/// back into the same character.
+impl fmt::Display for Punct {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_string())
+    }
+}
+
+impl fmt::Debug for Punct {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Punct")
+            .field("ch", &self.as_char())
+            .field("spacing", &self.spacing())
+            .field("span", &self.span())
+            .finish()
+    }
+}
+
+/// An identifier (`ident`).
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct Ident(bridge::client::Ident);
+
+impl Ident {
+    /// Creates a new `Ident` with the given `string` as well as the specified
+    /// `span`.
+    /// The `string` argument must be a valid identifier permitted by the
+    /// language, otherwise the function will panic.
+    ///
+    /// Note that `span`, currently in rustc, configures the hygiene information
+    /// for this identifier.
+    ///
+    /// As of this time `Span::call_site()` explicitly opts-in to "call-site" hygiene
+    /// meaning that identifiers created with this span will be resolved as if they were written
+    /// directly at the location of the macro call, and other code at the macro call site will be
+    /// able to refer to them as well.
+    ///
+    /// Later spans like `Span::def_site()` will allow to opt-in to "definition-site" hygiene
+    /// meaning that identifiers created with this span will be resolved at the location of the
+    /// macro definition and other code at the macro call site will not be able to refer to them.
+    ///
+    /// Due to the current importance of hygiene this constructor, unlike other
+    /// tokens, requires a `Span` to be specified at construction.
+    pub fn new(string: &str, span: Span) -> Ident {
+        Ident(bridge::client::Ident::new(string, span.0, false))
+    }
+
+    /// Same as `Ident::new`, but creates a raw identifier (`r#ident`).
+    pub fn new_raw(string: &str, span: Span) -> Ident {
+        Ident(bridge::client::Ident::new(string, span.0, true))
+    }
+
+    /// Returns the span of this `Ident`, encompassing the entire string returned
+    /// by `as_str`.
+    pub fn span(&self) -> Span {
+        Span(self.0.span())
+    }
+
+    /// Configures the span of this `Ident`, possibly changing its hygiene context.
+    pub fn set_span(&mut self, span: Span) {
+        self.0 = self.0.with_span(span.0);
+    }
+}
+
+// N.B., the bridge only provides `to_string`, implement `fmt::Display`
+// based on it (the reverse of the usual relationship between the two).
+// impl ToString for Ident {
+//     fn to_string(&self) -> String {
+//         TokenStream::from(TokenTree::from(self.clone())).to_string()
+//     }
+// }
+
+/// Prints the identifier as a string that should be losslessly convertible
+/// back into the same identifier.
+impl fmt::Display for Ident {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_string())
+    }
+}
+
+impl fmt::Debug for Ident {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Ident")
+            .field("ident", &self.to_string())
+            .field("span", &self.span())
+            .finish()
+    }
+}
+
+/// A literal string (`"hello"`), byte string (`b"hello"`),
+/// character (`'a'`), byte character (`b'a'`), an integer or floating point number
+/// with or without a suffix (`1`, `1u8`, `2.3`, `2.3f32`).
+/// Boolean literals like `true` and `false` do not belong here, they are `Ident`s.
+#[derive(Clone)]
+pub struct Literal(bridge::client::Literal);
+
+macro_rules! suffixed_int_literals {
+    ($($name:ident => $kind:ident,)*) => ($(
+        /// Creates a new suffixed integer literal with the specified value.
+        ///
+        /// This function will create an integer like `1u32` where the integer
+        /// value specified is the first part of the token and the integral is
+        /// also suffixed at the end.
+        /// Literals created from negative numbers may not survive round-trips through
+        /// `TokenStream` or strings and may be broken into two tokens (`-` and positive literal).
+        ///
+        /// Literals created through this method have the `Span::call_site()`
+        /// span by default, which can be configured with the `set_span` method
+        /// below.
+        pub fn $name(n: $kind) -> Literal {
+            Literal(bridge::client::Literal::typed_integer(&n.to_string(), stringify!($kind)))
+        }
+    )*)
+}
+
+macro_rules! unsuffixed_int_literals {
+    ($($name:ident => $kind:ident,)*) => ($(
+        /// Creates a new unsuffixed integer literal with the specified value.
+        ///
+        /// This function will create an integer like `1` where the integer
+        /// value specified is the first part of the token. No suffix is
+        /// specified on this token, meaning that invocations like
+        /// `Literal::i8_unsuffixed(1)` are equivalent to
+        /// `Literal::u32_unsuffixed(1)`.
+        /// Literals created from negative numbers may not survive rountrips through
+        /// `TokenStream` or strings and may be broken into two tokens (`-` and positive literal).
+        ///
+        /// Literals created through this method have the `Span::call_site()`
+        /// span by default, which can be configured with the `set_span` method
+        /// below.
+        pub fn $name(n: $kind) -> Literal {
+            Literal(bridge::client::Literal::integer(&n.to_string()))
+        }
+    )*)
+}
+
+impl Literal {
+    suffixed_int_literals! {
+        u8_suffixed => u8,
+        u16_suffixed => u16,
+        u32_suffixed => u32,
+        u64_suffixed => u64,
+        u128_suffixed => u128,
+        usize_suffixed => usize,
+        i8_suffixed => i8,
+        i16_suffixed => i16,
+        i32_suffixed => i32,
+        i64_suffixed => i64,
+        i128_suffixed => i128,
+        isize_suffixed => isize,
+    }
+
+    unsuffixed_int_literals! {
+        u8_unsuffixed => u8,
+        u16_unsuffixed => u16,
+        u32_unsuffixed => u32,
+        u64_unsuffixed => u64,
+        u128_unsuffixed => u128,
+        usize_unsuffixed => usize,
+        i8_unsuffixed => i8,
+        i16_unsuffixed => i16,
+        i32_unsuffixed => i32,
+        i64_unsuffixed => i64,
+        i128_unsuffixed => i128,
+        isize_unsuffixed => isize,
+    }
+
+    /// Creates a new unsuffixed floating-point literal.
+    ///
+    /// This constructor is similar to those like `Literal::i8_unsuffixed` where
+    /// the float's value is emitted directly into the token but no suffix is
+    /// used, so it may be inferred to be a `f64` later in the compiler.
+    /// Literals created from negative numbers may not survive rountrips through
+    /// `TokenStream` or strings and may be broken into two tokens (`-` and positive literal).
+    ///
+    /// # Panics
+    ///
+    /// This function requires that the specified float is finite, for
+    /// example if it is infinity or NaN this function will panic.
+    pub fn f32_unsuffixed(n: f32) -> Literal {
+        if !n.is_finite() {
+            panic!("Invalid float literal {}", n);
+        }
+        Literal(bridge::client::Literal::float(&n.to_string()))
+    }
+
+    /// Creates a new suffixed floating-point literal.
+    ///
+    /// This constructor will create a literal like `1.0f32` where the value
+    /// specified is the preceding part of the token and `f32` is the suffix of
+    /// the token. This token will always be inferred to be an `f32` in the
+    /// compiler.
+    /// Literals created from negative numbers may not survive rountrips through
+    /// `TokenStream` or strings and may be broken into two tokens (`-` and positive literal).
+    ///
+    /// # Panics
+    ///
+    /// This function requires that the specified float is finite, for
+    /// example if it is infinity or NaN this function will panic.
+    pub fn f32_suffixed(n: f32) -> Literal {
+        if !n.is_finite() {
+            panic!("Invalid float literal {}", n);
+        }
+        Literal(bridge::client::Literal::f32(&n.to_string()))
+    }
+
+    /// Creates a new unsuffixed floating-point literal.
+    ///
+    /// This constructor is similar to those like `Literal::i8_unsuffixed` where
+    /// the float's value is emitted directly into the token but no suffix is
+    /// used, so it may be inferred to be a `f64` later in the compiler.
+    /// Literals created from negative numbers may not survive rountrips through
+    /// `TokenStream` or strings and may be broken into two tokens (`-` and positive literal).
+    ///
+    /// # Panics
+    ///
+    /// This function requires that the specified float is finite, for
+    /// example if it is infinity or NaN this function will panic.
+    pub fn f64_unsuffixed(n: f64) -> Literal {
+        if !n.is_finite() {
+            panic!("Invalid float literal {}", n);
+        }
+        Literal(bridge::client::Literal::float(&n.to_string()))
+    }
+
+    /// Creates a new suffixed floating-point literal.
+    ///
+    /// This constructor will create a literal like `1.0f64` where the value
+    /// specified is the preceding part of the token and `f64` is the suffix of
+    /// the token. This token will always be inferred to be an `f64` in the
+    /// compiler.
+    /// Literals created from negative numbers may not survive rountrips through
+    /// `TokenStream` or strings and may be broken into two tokens (`-` and positive literal).
+    ///
+    /// # Panics
+    ///
+    /// This function requires that the specified float is finite, for
+    /// example if it is infinity or NaN this function will panic.
+    pub fn f64_suffixed(n: f64) -> Literal {
+        if !n.is_finite() {
+            panic!("Invalid float literal {}", n);
+        }
+        Literal(bridge::client::Literal::f64(&n.to_string()))
+    }
+
+    /// String literal.
+    pub fn string(string: &str) -> Literal {
+        Literal(bridge::client::Literal::string(string))
+    }
+
+    /// Character literal.
+    pub fn character(ch: char) -> Literal {
+        Literal(bridge::client::Literal::character(ch))
+    }
+
+    /// Byte string literal.
+    pub fn byte_string(bytes: &[u8]) -> Literal {
+        Literal(bridge::client::Literal::byte_string(bytes))
+    }
+
+    /// Returns the span encompassing this literal.
+    pub fn span(&self) -> Span {
+        Span(self.0.span())
+    }
+
+    /// Configures the span associated for this literal.
+    pub fn set_span(&mut self, span: Span) {
+        self.0.set_span(span.0);
+    }
+
+    /// Returns a `Span` that is a subset of `self.span()` containing only the
+    /// source bytes in range `range`. Returns `None` if the would-be trimmed
+    /// span is outside the bounds of `self`.
+    // FIXME(SergioBenitez): check that the byte range starts and ends at a
+    // UTF-8 boundary of the source. otherwise, it's likely that a panic will
+    // occur elsewhere when the source text is printed.
+    // FIXME(SergioBenitez): there is no way for the user to know what
+    // `self.span()` actually maps to, so this method can currently only be
+    // called blindly. For example, `to_string()` for the character 'c' returns
+    // "'\u{63}'"; there is no way for the user to know whether the source text
+    // was 'c' or whether it was '\u{63}'.
+    pub fn subspan<R: RangeBounds<usize>>(&self, range: R) -> Option<Span> {
+        // HACK(eddyb) something akin to `Option::cloned`, but for `Bound<&T>`.
+        fn cloned_bound<T: Clone>(bound: Bound<&T>) -> Bound<T> {
+            match bound {
+                Bound::Included(x) => Bound::Included(x.clone()),
+                Bound::Excluded(x) => Bound::Excluded(x.clone()),
+                Bound::Unbounded => Bound::Unbounded,
+            }
+        }
+
+        self.0.subspan(cloned_bound(range.start_bound()), cloned_bound(range.end_bound())).map(Span)
+    }
+}
+
+// N.B., the bridge only provides `to_string`, implement `fmt::Display`
+// based on it (the reverse of the usual relationship between the two).
+// impl ToString for Literal {
+//     fn to_string(&self) -> String {
+//         TokenStream::from(TokenTree::from(self.clone())).to_string()
+//     }
+// }
+
+/// Prints the literal as a string that should be losslessly convertible
+/// back into the same literal (except for possible rounding for floating point literals).
+impl fmt::Display for Literal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_string())
+    }
+}
+
+impl fmt::Debug for Literal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // FIXME(eddyb) `Literal` should not expose internal `Debug` impls.
+        self.0.fmt(f)
+    }
+}

--- a/crates/ra_proc_macro_srv/src/rustc_server.rs
+++ b/crates/ra_proc_macro_srv/src/rustc_server.rs
@@ -1,0 +1,710 @@
+//! Rustc proc-macro server implementation with ra_tt
+//!
+//! Based on idea from https://github.com/fedochet/rust-proc-macro-expander
+//! The lib-proc-macro server backend is `TokenStream`-agnostic, such that
+//! we could provide any TokenStream implementation.
+//! The original idea from fedochet is using proc-macro2 as backend,
+//! we use ra_tt instead for better intergation with RA.
+//!
+//! FIXME: No span and source file informatin is implemented yet
+
+use crate::proc_macro::bridge::{self, server};
+use ra_tt as tt;
+
+use std::collections::{Bound, HashMap};
+use std::hash::Hash;
+use std::iter::FromIterator;
+use std::str::FromStr;
+use std::{ascii, vec::IntoIter};
+
+// type Delimiter = crate::proc_macro::Delimiter;
+// type Group = crate::proc_macro::Group;
+// type TokenTree = crate::proc_macro::TokenTree;
+// type Ident = crate::proc_macro::Ident;
+// type Punct = crate::proc_macro::Punct;
+// type Spacing = crate::proc_macro::Spacing;
+// type Literal = crate::proc_macro::Literal;
+// type TokenStream = crate::proc_macro::TokenStream;
+// type TokenStream = crate::proc_macro::TokenStream;
+
+type Group = tt::Subtree;
+type TokenTree = tt::TokenTree;
+type Punct = tt::Punct;
+type Spacing = tt::Spacing;
+type Literal = tt::Literal;
+type Span = tt::TokenId;
+
+#[derive(Clone)]
+pub struct TokenStream {
+    pub subtree: tt::Subtree,
+}
+
+impl TokenStream {
+    pub fn new() -> Self {
+        TokenStream { subtree: Default::default() }
+    }
+    pub fn with_subtree(subtree: tt::Subtree) -> Self {
+        TokenStream { subtree }
+    }
+    pub fn is_empty(&self) -> bool {
+        self.subtree.token_trees.is_empty()
+    }
+}
+
+/// Creates a token stream containing a single token tree.
+impl From<TokenTree> for TokenStream {
+    fn from(tree: TokenTree) -> TokenStream {
+        TokenStream { subtree: tt::Subtree { delimiter: None, token_trees: vec![tree] } }
+    }
+}
+
+/// Collects a number of token trees into a single stream.
+impl FromIterator<TokenTree> for TokenStream {
+    fn from_iter<I: IntoIterator<Item = TokenTree>>(trees: I) -> Self {
+        trees.into_iter().map(TokenStream::from).collect()
+    }
+}
+
+/// A "flattening" operation on token streams, collects token trees
+/// from multiple token streams into a single stream.
+impl FromIterator<TokenStream> for TokenStream {
+    fn from_iter<I: IntoIterator<Item = TokenStream>>(streams: I) -> Self {
+        let mut builder = TokenStreamBuilder::new();
+        streams.into_iter().for_each(|stream| builder.push(stream));
+        builder.build()
+    }
+}
+
+impl Extend<TokenTree> for TokenStream {
+    fn extend<I: IntoIterator<Item = TokenTree>>(&mut self, trees: I) {
+        self.extend(trees.into_iter().map(TokenStream::from));
+    }
+}
+
+impl Extend<TokenStream> for TokenStream {
+    fn extend<I: IntoIterator<Item = TokenStream>>(&mut self, streams: I) {
+        for item in streams {
+            self.subtree.token_trees.extend(&mut item.into_iter())
+        }
+    }
+}
+
+type Level = crate::proc_macro::Level;
+type LineColumn = crate::proc_macro::LineColumn;
+type SourceFile = crate::proc_macro::SourceFile;
+
+/// A structure representing a diagnostic message and associated children
+/// messages.
+#[derive(Clone, Debug)]
+pub struct Diagnostic {
+    level: Level,
+    message: String,
+    spans: Vec<Span>,
+    children: Vec<Diagnostic>,
+}
+
+impl Diagnostic {
+    /// Creates a new diagnostic with the given `level` and `message`.
+    pub fn new<T: Into<String>>(level: Level, message: T) -> Diagnostic {
+        Diagnostic { level, message: message.into(), spans: vec![], children: vec![] }
+    }
+
+    // /// Creates a new diagnostic with the given `level` and `message` pointing to
+    // /// the given set of `spans`.
+    // pub fn spanned<S, T>(spans: S, level: Level, message: T) -> Diagnostic
+    //     where S: MultiSpan, T: Into<String>
+    // {
+    //     Diagnostic {
+    //         level: level,
+    //         message: message.into(),
+    //         spans: spans.into_spans(),
+    //         children: vec![]
+    //     }
+    // }
+}
+
+// Rustc Server Ident has to be `Copyable`
+// We use a stub here for bypassing
+#[derive(Hash, Eq, PartialEq, Copy, Clone)]
+pub struct IdentId(u32);
+
+#[derive(Clone, Hash, Eq, PartialEq)]
+struct IdentData(tt::Ident);
+
+#[derive(Default)]
+struct IdentInterner {
+    idents: HashMap<IdentData, u32>,
+    ident_data: Vec<IdentData>,
+}
+
+impl IdentInterner {
+    fn intern(&mut self, data: &IdentData) -> u32 {
+        if let Some(index) = self.idents.get(data) {
+            return *index;
+        }
+
+        let index = self.idents.len() as u32;
+        self.ident_data.push(data.clone());
+        self.idents.insert(data.clone(), index);
+        index
+    }
+
+    fn get(&self, index: u32) -> &IdentData {
+        &self.ident_data[index as usize]
+    }
+
+    #[allow(unused)]
+    fn get_mut(&mut self, index: u32) -> &mut IdentData {
+        self.ident_data.get_mut(index as usize).expect("Should be consistent")
+    }
+}
+
+pub struct TokenStreamBuilder {
+    acc: TokenStream,
+}
+
+/// Public implementation details for the `TokenStream` type, such as iterators.
+pub mod token_stream {
+    use super::{tt, TokenStream, TokenTree};
+    use std::str::FromStr;
+
+    /// An iterator over `TokenStream`'s `TokenTree`s.
+    /// The iteration is "shallow", e.g., the iterator doesn't recurse into delimited groups,
+    /// and returns whole groups as token trees.
+    impl IntoIterator for TokenStream {
+        type Item = TokenTree;
+        type IntoIter = super::IntoIter<TokenTree>;
+
+        fn into_iter(self) -> Self::IntoIter {
+            self.subtree.token_trees.into_iter()
+        }
+    }
+
+    type LexError = String;
+
+    /// Attempts to break the string into tokens and parse those tokens into a token stream.
+    /// May fail for a number of reasons, for example, if the string contains unbalanced delimiters
+    /// or characters not existing in the language.
+    /// All tokens in the parsed stream get `Span::call_site()` spans.
+    ///
+    /// NOTE: some errors may cause panics instead of returning `LexError`. We reserve the right to
+    /// change these errors into `LexError`s later.
+    impl FromStr for TokenStream {
+        type Err = LexError;
+
+        fn from_str(src: &str) -> Result<TokenStream, LexError> {
+            let (subtree, _token_map) =
+                ra_mbe::parse_to_token_tree(src).ok_or("Failed to parse from mbe")?;
+
+            let tt: tt::TokenTree = subtree.into();
+            Ok(tt.into())
+        }
+    }
+
+    impl ToString for TokenStream {
+        fn to_string(&self) -> String {
+            let tt = self.subtree.clone().into();
+            to_text(&tt)
+        }
+    }
+
+    fn to_text(tkn: &tt::TokenTree) -> String {
+        match tkn {
+            tt::TokenTree::Leaf(tt::Leaf::Ident(ident)) => ident.text.clone().into(),
+            tt::TokenTree::Leaf(tt::Leaf::Literal(literal)) => literal.text.clone().into(),
+            tt::TokenTree::Leaf(tt::Leaf::Punct(punct)) => format!("{}", punct.char),
+            tt::TokenTree::Subtree(subtree) => {
+                let content = subtree
+                    .token_trees
+                    .iter()
+                    .map(|tkn| {
+                        let s = to_text(tkn);
+                        if let tt::TokenTree::Leaf(tt::Leaf::Punct(punct)) = tkn {
+                            if punct.spacing == tt::Spacing::Joint {
+                                return s;
+                            }
+                        }
+                        s + " "
+                    })
+                    .collect::<Vec<_>>()
+                    .concat();
+                let (open, close) = match subtree.delimiter.map(|it| it.kind) {
+                    None => ("", ""),
+                    Some(tt::DelimiterKind::Brace) => ("{", "}"),
+                    Some(tt::DelimiterKind::Parenthesis) => ("(", ")"),
+                    Some(tt::DelimiterKind::Bracket) => ("[", "]"),
+                };
+                format!("{}{}{}", open, content, close)
+            }
+        }
+    }
+}
+
+impl TokenStreamBuilder {
+    fn new() -> TokenStreamBuilder {
+        TokenStreamBuilder { acc: TokenStream::new() }
+    }
+
+    fn push(&mut self, stream: TokenStream) {
+        self.acc.extend(stream.into_iter())
+    }
+
+    fn build(self) -> TokenStream {
+        self.acc
+    }
+}
+
+#[derive(Clone)]
+pub struct TokenStreamIter {
+    trees: IntoIter<TokenTree>,
+}
+
+#[derive(Default)]
+pub struct Rustc {
+    ident_interner: IdentInterner,
+    //    def_side: MySpan,
+    //    call_site: MySpan,
+}
+
+impl server::Types for Rustc {
+    type TokenStream = TokenStream;
+    type TokenStreamBuilder = TokenStreamBuilder;
+    type TokenStreamIter = TokenStreamIter;
+    type Group = Group;
+    type Punct = Punct;
+    type Ident = IdentId;
+    type Literal = Literal;
+    type SourceFile = SourceFile;
+    type Diagnostic = Diagnostic;
+    type Span = Span;
+    type MultiSpan = Vec<Span>;
+}
+
+impl server::TokenStream for Rustc {
+    fn new(&mut self) -> Self::TokenStream {
+        Self::TokenStream::new()
+    }
+
+    fn is_empty(&mut self, stream: &Self::TokenStream) -> bool {
+        stream.is_empty()
+    }
+    fn from_str(&mut self, src: &str) -> Self::TokenStream {
+        Self::TokenStream::from_str(src).expect("cannot parse string")
+    }
+    fn to_string(&mut self, stream: &Self::TokenStream) -> String {
+        stream.to_string()
+    }
+    fn from_token_tree(
+        &mut self,
+        tree: bridge::TokenTree<Self::Group, Self::Punct, Self::Ident, Self::Literal>,
+    ) -> Self::TokenStream {
+        match tree {
+            bridge::TokenTree::Group(group) => {
+                let tree = TokenTree::from(group);
+                Self::TokenStream::from_iter(vec![tree])
+            }
+
+            bridge::TokenTree::Ident(IdentId(index)) => {
+                let IdentData(ident) = self.ident_interner.get(index).clone();
+                let ident: tt::Ident = ident;
+                let leaf = tt::Leaf::from(ident);
+                let tree = TokenTree::from(leaf);
+                Self::TokenStream::from_iter(vec![tree])
+            }
+
+            bridge::TokenTree::Literal(literal) => {
+                let leaf = tt::Leaf::from(literal);
+                let tree = TokenTree::from(leaf);
+                Self::TokenStream::from_iter(vec![tree])
+            }
+
+            bridge::TokenTree::Punct(p) => {
+                let leaf = tt::Leaf::from(p);
+                let tree = TokenTree::from(leaf);
+                Self::TokenStream::from_iter(vec![tree])
+            }
+        }
+    }
+
+    fn into_iter(&mut self, stream: Self::TokenStream) -> Self::TokenStreamIter {
+        let trees: Vec<TokenTree> = stream.into_iter().collect();
+        TokenStreamIter { trees: trees.into_iter() }
+    }
+}
+
+impl server::TokenStreamBuilder for Rustc {
+    fn new(&mut self) -> Self::TokenStreamBuilder {
+        Self::TokenStreamBuilder::new()
+    }
+    fn push(&mut self, builder: &mut Self::TokenStreamBuilder, stream: Self::TokenStream) {
+        builder.push(stream)
+    }
+    fn build(&mut self, builder: Self::TokenStreamBuilder) -> Self::TokenStream {
+        builder.build()
+    }
+}
+
+impl server::TokenStreamIter for Rustc {
+    fn next(
+        &mut self,
+        iter: &mut Self::TokenStreamIter,
+    ) -> Option<bridge::TokenTree<Self::Group, Self::Punct, Self::Ident, Self::Literal>> {
+        iter.trees.next().map(|tree| match tree {
+            TokenTree::Subtree(group) => bridge::TokenTree::Group(group),
+            TokenTree::Leaf(tt::Leaf::Ident(ident)) => {
+                bridge::TokenTree::Ident(IdentId(self.ident_interner.intern(&IdentData(ident))))
+            }
+            TokenTree::Leaf(tt::Leaf::Literal(literal)) => bridge::TokenTree::Literal(literal),
+            TokenTree::Leaf(tt::Leaf::Punct(punct)) => bridge::TokenTree::Punct(punct),
+        })
+    }
+}
+
+fn delim_to_internal(d: bridge::Delimiter) -> Option<tt::Delimiter> {
+    let kind = match d {
+        bridge::Delimiter::Parenthesis => tt::DelimiterKind::Parenthesis,
+        bridge::Delimiter::Brace => tt::DelimiterKind::Brace,
+        bridge::Delimiter::Bracket => tt::DelimiterKind::Bracket,
+        bridge::Delimiter::None => return None,
+    };
+    Some(tt::Delimiter { id: tt::TokenId::unspecified(), kind })
+}
+
+fn delim_to_external(d: Option<tt::Delimiter>) -> bridge::Delimiter {
+    match d.map(|it| it.kind) {
+        Some(tt::DelimiterKind::Parenthesis) => bridge::Delimiter::Parenthesis,
+        Some(tt::DelimiterKind::Brace) => bridge::Delimiter::Brace,
+        Some(tt::DelimiterKind::Bracket) => bridge::Delimiter::Bracket,
+        None => bridge::Delimiter::None,
+    }
+}
+
+fn spacing_to_internal(spacing: bridge::Spacing) -> Spacing {
+    match spacing {
+        bridge::Spacing::Alone => Spacing::Alone,
+        bridge::Spacing::Joint => Spacing::Joint,
+    }
+}
+
+fn spacing_to_external(spacing: Spacing) -> bridge::Spacing {
+    match spacing {
+        Spacing::Alone => bridge::Spacing::Alone,
+        Spacing::Joint => bridge::Spacing::Joint,
+    }
+}
+
+impl server::Group for Rustc {
+    fn new(&mut self, delimiter: bridge::Delimiter, stream: Self::TokenStream) -> Self::Group {
+        Self::Group {
+            delimiter: delim_to_internal(delimiter),
+            token_trees: stream.subtree.token_trees,
+        }
+    }
+    fn delimiter(&mut self, group: &Self::Group) -> bridge::Delimiter {
+        delim_to_external(group.delimiter)
+    }
+
+    // NOTE: Return value of do not include delimiter
+    fn stream(&mut self, group: &Self::Group) -> Self::TokenStream {
+        TokenStream {
+            subtree: tt::Subtree { delimiter: None, token_trees: group.token_trees.clone() },
+        }
+    }
+
+    fn span(&mut self, group: &Self::Group) -> Self::Span {
+        group.delimiter.map(|it| it.id).unwrap_or_else(|| tt::TokenId::unspecified())
+    }
+
+    fn set_span(&mut self, _group: &mut Self::Group, _span: Self::Span) {
+        // FIXME handle span
+    }
+
+    fn span_open(&mut self, _group: &Self::Group) -> Self::Span {
+        // FIXME handle span
+        // MySpan(self.span_interner.intern(&MySpanData(group.span_open())))
+        tt::TokenId::unspecified()
+    }
+
+    fn span_close(&mut self, _group: &Self::Group) -> Self::Span {
+        // FIXME handle span
+        tt::TokenId::unspecified()
+    }
+}
+
+impl server::Punct for Rustc {
+    fn new(&mut self, ch: char, spacing: bridge::Spacing) -> Self::Punct {
+        tt::Punct {
+            char: ch,
+            spacing: spacing_to_internal(spacing),
+            id: tt::TokenId::unspecified(),
+        }
+    }
+    fn as_char(&mut self, punct: Self::Punct) -> char {
+        punct.char
+    }
+    fn spacing(&mut self, punct: Self::Punct) -> bridge::Spacing {
+        spacing_to_external(punct.spacing)
+    }
+    fn span(&mut self, _punct: Self::Punct) -> Self::Span {
+        // FIXME handle span
+        tt::TokenId::unspecified()
+    }
+    fn with_span(&mut self, punct: Self::Punct, _span: Self::Span) -> Self::Punct {
+        // FIXME handle span
+        punct
+    }
+}
+
+impl server::Ident for Rustc {
+    fn new(&mut self, string: &str, _span: Self::Span, _is_raw: bool) -> Self::Ident {
+        IdentId(
+            self.ident_interner.intern(&IdentData(tt::Ident {
+                text: string.into(),
+                id: tt::TokenId::unspecified(),
+            })),
+        )
+    }
+
+    fn span(&mut self, _ident: Self::Ident) -> Self::Span {
+        // FIXME handle span
+        tt::TokenId::unspecified()
+    }
+    fn with_span(&mut self, ident: Self::Ident, _span: Self::Span) -> Self::Ident {
+        // FIXME handle span
+        ident
+    }
+}
+
+impl server::Literal for Rustc {
+    // FIXME(eddyb) `Literal` should not expose internal `Debug` impls.
+    fn debug(&mut self, literal: &Self::Literal) -> String {
+        format!("{:?}", literal)
+    }
+
+    fn integer(&mut self, n: &str) -> Self::Literal {
+        let n: i128 = n.parse().unwrap();
+        Literal { text: n.to_string().into(), id: tt::TokenId::unspecified() }
+    }
+
+    fn typed_integer(&mut self, n: &str, kind: &str) -> Self::Literal {
+        macro_rules! def_suffixed_integer {
+            ($kind:ident, $($ty:ty),*) => {
+                match $kind {
+                    $(
+                        stringify!($ty) => {
+                            let n: $ty = n.parse().unwrap();
+                            format!(concat!("{}", stringify!($ty)), n)
+                        }
+                    )*
+                    _ => unimplemented!("unknown args for typed_integer: n {}, kind {}", n, $kind),
+                }
+            }
+        }
+
+        let text =
+            def_suffixed_integer! {kind, u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128};
+
+        Literal { text: text.into(), id: tt::TokenId::unspecified() }
+    }
+
+    fn float(&mut self, n: &str) -> Self::Literal {
+        let n: f64 = n.parse().unwrap();
+        let mut text = f64::to_string(&n);
+        if !text.contains('.') {
+            text += ".0"
+        }
+        Literal { text: text.into(), id: tt::TokenId::unspecified() }
+    }
+
+    fn f32(&mut self, n: &str) -> Self::Literal {
+        let n: f32 = n.parse().unwrap();
+        let text = format!("{}f32", n);
+        Literal { text: text.into(), id: tt::TokenId::unspecified() }
+    }
+
+    fn f64(&mut self, n: &str) -> Self::Literal {
+        let n: f64 = n.parse().unwrap();
+        let text = format!("{}f64", n);
+        Literal { text: text.into(), id: tt::TokenId::unspecified() }
+    }
+
+    fn string(&mut self, string: &str) -> Self::Literal {
+        let mut escaped = String::new();
+        for ch in string.chars() {
+            escaped.extend(ch.escape_debug());
+        }
+        Literal { text: format!("\"{}\"", escaped).into(), id: tt::TokenId::unspecified() }
+    }
+
+    fn character(&mut self, ch: char) -> Self::Literal {
+        Literal { text: format!("'{}'", ch).into(), id: tt::TokenId::unspecified() }
+    }
+
+    fn byte_string(&mut self, bytes: &[u8]) -> Self::Literal {
+        let string = bytes
+            .iter()
+            .cloned()
+            .flat_map(ascii::escape_default)
+            .map(Into::<char>::into)
+            .collect::<String>();
+
+        Literal { text: format!("b\"{}\"", string).into(), id: tt::TokenId::unspecified() }
+    }
+
+    fn span(&mut self, literal: &Self::Literal) -> Self::Span {
+        literal.id
+    }
+
+    fn set_span(&mut self, _literal: &mut Self::Literal, _span: Self::Span) {
+        // FIXME handle span
+    }
+
+    fn subspan(
+        &mut self,
+        _literal: &Self::Literal,
+        _start: Bound<usize>,
+        _end: Bound<usize>,
+    ) -> Option<Self::Span> {
+        // FIXME handle span
+        None
+    }
+}
+
+impl server::SourceFile for Rustc {
+    fn eq(&mut self, file1: &Self::SourceFile, file2: &Self::SourceFile) -> bool {
+        file1.eq(file2)
+    }
+    fn path(&mut self, file: &Self::SourceFile) -> String {
+        String::from(
+            file.path().to_str().expect("non-UTF8 file path in `proc_macro::SourceFile::path`"),
+        )
+    }
+    fn is_real(&mut self, file: &Self::SourceFile) -> bool {
+        file.is_real()
+    }
+}
+
+impl server::Diagnostic for Rustc {
+    fn new(&mut self, level: Level, msg: &str, spans: Self::MultiSpan) -> Self::Diagnostic {
+        let mut diag = Diagnostic::new(level, msg);
+        diag.spans = spans;
+        diag
+    }
+
+    fn sub(
+        &mut self,
+        _diag: &mut Self::Diagnostic,
+        _level: Level,
+        _msg: &str,
+        _spans: Self::MultiSpan,
+    ) {
+        // FIXME handle diagnostic
+        //
+    }
+
+    fn emit(&mut self, _diag: Self::Diagnostic) {
+        // FIXME handle diagnostic
+        // diag.emit()
+    }
+}
+
+impl server::Span for Rustc {
+    fn debug(&mut self, span: Self::Span) -> String {
+        format!("{:?}", span.0)
+    }
+    fn def_site(&mut self) -> Self::Span {
+        // MySpan(self.span_interner.intern(&MySpanData(Span::def_site())))
+        // FIXME handle span
+        tt::TokenId::unspecified()
+    }
+    fn call_site(&mut self) -> Self::Span {
+        // MySpan(self.span_interner.intern(&MySpanData(Span::call_site())))
+        // FIXME handle span
+        tt::TokenId::unspecified()
+    }
+    fn source_file(&mut self, _span: Self::Span) -> Self::SourceFile {
+        // let MySpanData(span) = self.span_interner.get(span.0);
+        unimplemented!()
+    }
+
+    /// Recent feature, not yet in the proc_macro
+    ///
+    /// See PR:
+    /// https://github.com/rust-lang/rust/pull/55780
+    fn source_text(&mut self, _span: Self::Span) -> Option<String> {
+        None
+    }
+
+    fn parent(&mut self, _span: Self::Span) -> Option<Self::Span> {
+        // FIXME handle span
+        None
+    }
+    fn source(&mut self, span: Self::Span) -> Self::Span {
+        // FIXME handle span
+        span
+    }
+    fn start(&mut self, _span: Self::Span) -> LineColumn {
+        // FIXME handle span
+        LineColumn { line: 0, column: 0 }
+    }
+    fn end(&mut self, _span: Self::Span) -> LineColumn {
+        // FIXME handle span
+        LineColumn { line: 0, column: 0 }
+    }
+    fn join(&mut self, _first: Self::Span, _second: Self::Span) -> Option<Self::Span> {
+        None
+    }
+    fn resolved_at(&mut self, _span: Self::Span, _at: Self::Span) -> Self::Span {
+        // FIXME handle span
+        tt::TokenId::unspecified()
+    }
+
+    fn mixed_site(&mut self) -> Self::Span {
+        // FIXME handle span
+        tt::TokenId::unspecified()
+    }
+}
+
+impl server::MultiSpan for Rustc {
+    fn new(&mut self) -> Self::MultiSpan {
+        // FIXME handle span
+        vec![]
+    }
+
+    fn push(&mut self, other: &mut Self::MultiSpan, span: Self::Span) {
+        //TODP
+        other.push(span)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proc_macro::bridge::server::Literal;
+
+    #[test]
+    fn test_rustc_server_literals() {
+        let mut srv = Rustc { ident_interner: IdentInterner::default() };
+        assert_eq!(srv.integer("1234").text, "1234");
+
+        assert_eq!(srv.typed_integer("12", "u8").text, "12u8");
+        assert_eq!(srv.typed_integer("255", "u16").text, "255u16");
+        assert_eq!(srv.typed_integer("1234", "u32").text, "1234u32");
+        assert_eq!(srv.typed_integer("15846685", "u64").text, "15846685u64");
+        assert_eq!(srv.typed_integer("15846685258", "u128").text, "15846685258u128");
+        assert_eq!(srv.typed_integer("156788984", "usize").text, "156788984usize");
+        assert_eq!(srv.typed_integer("127", "i8").text, "127i8");
+        assert_eq!(srv.typed_integer("255", "i16").text, "255i16");
+        assert_eq!(srv.typed_integer("1234", "i32").text, "1234i32");
+        assert_eq!(srv.typed_integer("15846685", "i64").text, "15846685i64");
+        assert_eq!(srv.typed_integer("15846685258", "i128").text, "15846685258i128");
+        assert_eq!(srv.float("0").text, "0.0");
+        assert_eq!(srv.float("15684.5867").text, "15684.5867");
+        assert_eq!(srv.f32("15684.58").text, "15684.58f32");
+        assert_eq!(srv.f64("15684.58").text, "15684.58f64");
+
+        assert_eq!(srv.string("hello_world").text, "\"hello_world\"");
+        assert_eq!(srv.character('c').text, "'c'");
+        assert_eq!(srv.byte_string(b"1234586\x88").text, "b\"1234586\\x88\"");
+    }
+}

--- a/crates/ra_proc_macro_srv/src/tests/fixtures/test_serialize_proc_macro.txt
+++ b/crates/ra_proc_macro_srv/src/tests/fixtures/test_serialize_proc_macro.txt
@@ -1,0 +1,188 @@
+SUBTREE NODELIM
+  PUNCH   # [alone]
+  SUBTREE []
+    IDENT   allow
+    SUBTREE ()
+      IDENT   non_upper_case_globals
+      PUNCH   , [alone]
+      IDENT   unused_attributes
+      PUNCH   , [alone]
+      IDENT   unused_qualifications
+  IDENT   const
+  IDENT   _IMPL_SERIALIZE_FOR_Foo
+  PUNCH   : [alone]
+  SUBTREE ()
+  PUNCH   = [alone]
+  SUBTREE {}
+    PUNCH   # [alone]
+    SUBTREE []
+      IDENT   allow
+      SUBTREE ()
+        IDENT   unknown_lints
+    PUNCH   # [alone]
+    SUBTREE []
+      IDENT   cfg_attr
+      SUBTREE ()
+        IDENT   feature
+        PUNCH   = [alone]
+        SUBTREE NODELIM
+          LITERAL "cargo-clippy"
+        PUNCH   , [alone]
+        IDENT   allow
+        SUBTREE ()
+          IDENT   useless_attribute
+    PUNCH   # [alone]
+    SUBTREE []
+      IDENT   allow
+      SUBTREE ()
+        IDENT   rust_2018_idioms
+    IDENT   extern
+    IDENT   crate
+    IDENT   serde
+    IDENT   as
+    IDENT   _serde
+    PUNCH   ; [alone]
+    PUNCH   # [alone]
+    SUBTREE []
+      IDENT   allow
+      SUBTREE ()
+        IDENT   unused_macros
+    IDENT   macro_rules
+    PUNCH   ! [alone]
+    IDENT   try
+    SUBTREE {}
+      SUBTREE ()
+        PUNCH   $ [alone]
+        IDENT   __expr
+        PUNCH   : [alone]
+        IDENT   expr
+      PUNCH   = [joint]
+      PUNCH   > [alone]
+      SUBTREE {}
+        IDENT   match
+        PUNCH   $ [alone]
+        IDENT   __expr
+        SUBTREE {}
+          IDENT   _serde
+          PUNCH   : [joint]
+          PUNCH   : [alone]
+          IDENT   export
+          PUNCH   : [joint]
+          PUNCH   : [alone]
+          IDENT   Ok
+          SUBTREE ()
+            IDENT   __val
+          PUNCH   = [joint]
+          PUNCH   > [alone]
+          IDENT   __val
+          PUNCH   , [alone]
+          IDENT   _serde
+          PUNCH   : [joint]
+          PUNCH   : [alone]
+          IDENT   export
+          PUNCH   : [joint]
+          PUNCH   : [alone]
+          IDENT   Err
+          SUBTREE ()
+            IDENT   __err
+          PUNCH   = [joint]
+          PUNCH   > [alone]
+          SUBTREE {}
+            IDENT   return
+            IDENT   _serde
+            PUNCH   : [joint]
+            PUNCH   : [alone]
+            IDENT   export
+            PUNCH   : [joint]
+            PUNCH   : [alone]
+            IDENT   Err
+            SUBTREE ()
+              IDENT   __err
+            PUNCH   ; [alone]
+    PUNCH   # [alone]
+    SUBTREE []
+      IDENT   automatically_derived
+    IDENT   impl
+    IDENT   _serde
+    PUNCH   : [joint]
+    PUNCH   : [alone]
+    IDENT   Serialize
+    IDENT   for
+    IDENT   Foo
+    SUBTREE {}
+      IDENT   fn
+      IDENT   serialize
+      PUNCH   < [alone]
+      IDENT   __S
+      PUNCH   > [alone]
+      SUBTREE ()
+        PUNCH   & [alone]
+        IDENT   self
+        PUNCH   , [alone]
+        IDENT   __serializer
+        PUNCH   : [alone]
+        IDENT   __S
+      PUNCH   - [joint]
+      PUNCH   > [alone]
+      IDENT   _serde
+      PUNCH   : [joint]
+      PUNCH   : [alone]
+      IDENT   export
+      PUNCH   : [joint]
+      PUNCH   : [alone]
+      IDENT   Result
+      PUNCH   < [alone]
+      IDENT   __S
+      PUNCH   : [joint]
+      PUNCH   : [alone]
+      IDENT   Ok
+      PUNCH   , [alone]
+      IDENT   __S
+      PUNCH   : [joint]
+      PUNCH   : [alone]
+      IDENT   Error
+      PUNCH   > [alone]
+      IDENT   where
+      IDENT   __S
+      PUNCH   : [alone]
+      IDENT   _serde
+      PUNCH   : [joint]
+      PUNCH   : [alone]
+      IDENT   Serializer
+      PUNCH   , [alone]
+      SUBTREE {}
+        IDENT   let
+        IDENT   __serde_state
+        PUNCH   = [alone]
+        IDENT   try
+        PUNCH   ! [alone]
+        SUBTREE ()
+          IDENT   _serde
+          PUNCH   : [joint]
+          PUNCH   : [alone]
+          IDENT   Serializer
+          PUNCH   : [joint]
+          PUNCH   : [alone]
+          IDENT   serialize_struct
+          SUBTREE ()
+            IDENT   __serializer
+            PUNCH   , [alone]
+            LITERAL "Foo"
+            PUNCH   , [alone]
+            IDENT   false
+            IDENT   as
+            IDENT   usize
+        PUNCH   ; [alone]
+        IDENT   _serde
+        PUNCH   : [joint]
+        PUNCH   : [alone]
+        IDENT   ser
+        PUNCH   : [joint]
+        PUNCH   : [alone]
+        IDENT   SerializeStruct
+        PUNCH   : [joint]
+        PUNCH   : [alone]
+        IDENT   end
+        SUBTREE ()
+          IDENT   __serde_state
+  PUNCH   ; [alone]

--- a/crates/ra_proc_macro_srv/src/tests/mod.rs
+++ b/crates/ra_proc_macro_srv/src/tests/mod.rs
@@ -1,0 +1,37 @@
+#[macro_use]
+mod utils;
+use utils::*;
+
+#[test]
+fn test_serialize_proc_macro() {
+    let res = expand(
+        "serde_derive",
+        "Serialize",
+        r##"
+    struct Foo {}
+    "##,
+    );
+    assert_eq_file!(&res, "fixtures/test_serialize_proc_macro.txt");
+}
+
+#[test]
+fn test_serialize_proc_macro_failed() {
+    let res = expand(
+        "serde_derive",
+        "Serialize",
+        r##"
+    struct {}
+    "##,
+    );
+
+    assert_eq_text!(
+        &res,
+        r##"
+SUBTREE NODELIM
+  IDENT   compile_error
+  PUNCH   ! [alone]
+  SUBTREE {}
+    LITERAL "expected identifier"
+"##
+    );
+}

--- a/crates/ra_proc_macro_srv/src/tests/utils.rs
+++ b/crates/ra_proc_macro_srv/src/tests/utils.rs
@@ -1,0 +1,122 @@
+use crate::dylib;
+pub use difference::Changeset as __Changeset;
+use ra_tt::*;
+use std::{fmt, str::FromStr};
+
+fn nice_format_recur(tkn: &TokenTree, f: &mut fmt::Formatter, level: usize) -> fmt::Result {
+    let align = std::iter::repeat("  ").take(level).collect::<String>();
+
+    match tkn {
+        TokenTree::Leaf(leaf) => match leaf {
+            Leaf::Literal(lit) => write!(f, "{}LITERAL {}", align, lit.text)?,
+            Leaf::Punct(punct) => write!(
+                f,
+                "{}PUNCH   {} [{}]",
+                align,
+                punct.char,
+                if punct.spacing == Spacing::Alone { "alone" } else { "joint" }
+            )?,
+            Leaf::Ident(ident) => write!(f, "{}IDENT   {}", align, ident.text)?,
+        },
+        TokenTree::Subtree(subtree) => {
+            let delim = match subtree.delimiter.map(|it| it.kind) {
+                None => ("NODELIM"),
+                Some(DelimiterKind::Parenthesis) => "()",
+                Some(DelimiterKind::Brace) => "{}",
+                Some(DelimiterKind::Bracket) => "[]",
+            };
+            if subtree.token_trees.is_empty() {
+                write!(f, "{}SUBTREE {}", align, delim)?;
+            } else {
+                writeln!(f, "{}SUBTREE {}", align, delim)?;
+                for (idx, child) in subtree.token_trees.iter().enumerate() {
+                    nice_format_recur(child, f, level + 1)?;
+                    if idx != subtree.token_trees.len() - 1 {
+                        writeln!(f, "")?;
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+struct NiceFormat<'a>(&'a TokenTree);
+impl std::fmt::Display for NiceFormat<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        nice_format_recur(self.0, f, 0)
+    }
+}
+
+fn nice_format(tkn: &TokenTree) -> String {
+    format!("{}", NiceFormat(tkn))
+}
+
+macro_rules! assert_eq_text {
+    ($left:expr, $right:expr) => {
+        assert_eq_text!($left, $right,)
+    };
+    ($left:expr, $right:expr, $($tt:tt)*) => {{
+        let left = $left.trim();
+        let right = $right.trim();
+        if left != right {
+            let changeset = __Changeset::new(right, left, "\n");
+            eprintln!("Diff:\n{}\n", changeset);
+            eprintln!($($tt)*);
+            panic!("text differs");
+        }
+    }};
+}
+
+macro_rules! assert_eq_file {
+    ($left:expr, $right:literal) => {
+        assert_eq_file!($left, $right,)
+    };
+    ($left:expr, $right:literal, $($tt:tt)*) => {{
+        let right_raw = include_str!($right).replace("\r\n", "\n");
+        assert_eq_text!($left,right_raw.trim(),$($tt)*);
+    }};
+}
+
+mod fixtures {
+    use cargo_metadata::{parse_messages, Message};
+    use std::process::Command;
+
+    // Use current project metadata to get the proc-macro dylib path
+    pub fn dylib_path(crate_name: &str) -> std::path::PathBuf {
+        let command = Command::new("cargo")
+            .args(&["check", "--message-format", "json"])
+            .output()
+            .unwrap()
+            .stdout;
+
+        for message in parse_messages(command.as_slice()) {
+            match message.unwrap() {
+                Message::CompilerArtifact(artifact) => {
+                    if artifact.target.kind.contains(&"proc-macro".to_string()) {
+                        if artifact.package_id.repr.starts_with(crate_name) {
+                            return artifact.filenames[0].clone();
+                        }
+                    }
+                }
+                _ => (), // Unknown message
+            }
+        }
+
+        panic!("No proc-macro dylib for {} found!", crate_name);
+    }
+}
+
+fn parse_string(code: &str) -> Option<crate::rustc_server::TokenStream> {
+    Some(crate::rustc_server::TokenStream::from_str(code).unwrap())
+}
+
+pub fn expand(crate_name: &str, macro_name: &str, fixture: &str) -> String {
+    let path = fixtures::dylib_path(crate_name);
+    let expander = dylib::Expander::new(&path).unwrap();
+    let fixture = parse_string(fixture).unwrap();
+
+    let res = expander.expand(macro_name, &fixture.subtree, None).unwrap();
+    nice_format(&res.into())
+}

--- a/crates/ra_project_model/Cargo.toml
+++ b/crates/ra_project_model/Cargo.toml
@@ -17,6 +17,7 @@ ra_arena = { path = "../ra_arena" }
 ra_db = { path = "../ra_db" }
 ra_cfg = { path = "../ra_cfg" }
 ra_cargo_watch = { path = "../ra_cargo_watch" }
+ra_proc_macro =  { path = "../ra_proc_macro" }
 
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.48"

--- a/crates/ra_project_model/src/cargo_workspace.rs
+++ b/crates/ra_project_model/src/cargo_workspace.rs
@@ -1,8 +1,8 @@
 //! FIXME: write short doc here
 
 use std::{
-    ops,
     ffi::OsStr,
+    ops,
     path::{Path, PathBuf},
 };
 

--- a/crates/ra_project_model/src/json_project.rs
+++ b/crates/ra_project_model/src/json_project.rs
@@ -23,6 +23,7 @@ pub struct Crate {
     pub(crate) atom_cfgs: FxHashSet<String>,
     pub(crate) key_value_cfgs: FxHashMap<String, String>,
     pub(crate) out_dir: Option<PathBuf>,
+    pub(crate) proc_macro_dylib_path: Option<PathBuf>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize)]

--- a/crates/ra_project_model/src/lib.rs
+++ b/crates/ra_project_model/src/lib.rs
@@ -23,6 +23,7 @@ pub use crate::{
     json_project::JsonProject,
     sysroot::Sysroot,
 };
+pub use ra_proc_macro::ProcMacroClient;
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct CargoTomlNotFoundError {
@@ -173,6 +174,29 @@ impl ProjectWorkspace {
         }
     }
 
+    pub fn proc_macro_dylib_paths(&self) -> Vec<PathBuf> {
+        match self {
+            ProjectWorkspace::Json { project } => {
+                let mut proc_macro_dylib_paths = Vec::with_capacity(project.crates.len());
+                for krate in &project.crates {
+                    if let Some(out_dir) = &krate.proc_macro_dylib_path {
+                        proc_macro_dylib_paths.push(out_dir.to_path_buf());
+                    }
+                }
+                proc_macro_dylib_paths
+            }
+            ProjectWorkspace::Cargo { cargo, sysroot: _sysroot } => {
+                let mut proc_macro_dylib_paths = Vec::with_capacity(cargo.packages().len());
+                for pkg in cargo.packages() {
+                    if let Some(dylib_path) = &cargo[pkg].proc_macro_dylib_path {
+                        proc_macro_dylib_paths.push(dylib_path.to_path_buf());
+                    }
+                }
+                proc_macro_dylib_paths
+            }
+        }
+    }
+
     pub fn n_packages(&self) -> usize {
         match self {
             ProjectWorkspace::Json { project } => project.crates.len(),
@@ -186,6 +210,7 @@ impl ProjectWorkspace {
         &self,
         default_cfg_options: &CfgOptions,
         extern_source_roots: &FxHashMap<PathBuf, ExternSourceId>,
+        proc_macro_client: &ProcMacroClient,
         load: &mut dyn FnMut(&Path) -> Option<FileId>,
     ) -> CrateGraph {
         let mut crate_graph = CrateGraph::default();
@@ -219,7 +244,10 @@ impl ProjectWorkspace {
                                 extern_source.set_extern_path(&out_dir, extern_source_id);
                             }
                         }
-
+                        let proc_macro = krate
+                            .proc_macro_dylib_path
+                            .clone()
+                            .map(|it| proc_macro_client.by_dylib_path(&it));
                         // FIXME: No crate name in json definition such that we cannot add OUT_DIR to env
                         crates.insert(
                             crate_id,
@@ -231,6 +259,7 @@ impl ProjectWorkspace {
                                 cfg_options,
                                 env,
                                 extern_source,
+                                proc_macro,
                             ),
                         );
                     }
@@ -270,6 +299,8 @@ impl ProjectWorkspace {
 
                         let env = Env::default();
                         let extern_source = ExternSource::default();
+                        let proc_macro = None;
+
                         let crate_id = crate_graph.add_crate_root(
                             file_id,
                             Edition::Edition2018,
@@ -280,6 +311,7 @@ impl ProjectWorkspace {
                             cfg_options,
                             env,
                             extern_source,
+                            proc_macro,
                         );
                         sysroot_crates.insert(krate, crate_id);
                     }
@@ -327,6 +359,9 @@ impl ProjectWorkspace {
                                     extern_source.set_extern_path(&out_dir, extern_source_id);
                                 }
                             }
+                            let proc_macro =  cargo[pkg].proc_macro_dylib_path.as_ref()
+                                .map(|it| proc_macro_client.by_dylib_path(&it));
+
                             let crate_id = crate_graph.add_crate_root(
                                 file_id,
                                 edition,
@@ -334,6 +369,7 @@ impl ProjectWorkspace {
                                 cfg_options,
                                 env,
                                 extern_source,
+                                proc_macro.clone(),
                             );
                             if cargo[tgt].kind == TargetKind::Lib {
                                 lib_tgt = Some((crate_id, cargo[tgt].name.clone()));

--- a/crates/ra_project_model/src/lib.rs
+++ b/crates/ra_project_model/src/lib.rs
@@ -359,7 +359,10 @@ impl ProjectWorkspace {
                                     extern_source.set_extern_path(&out_dir, extern_source_id);
                                 }
                             }
-                            let proc_macro =  cargo[pkg].proc_macro_dylib_path.as_ref()
+
+                            let proc_macro = &cargo[pkg]
+                                .proc_macro_dylib_path
+                                .as_ref()
                                 .map(|it| proc_macro_client.by_dylib_path(&it));
 
                             let crate_id = crate_graph.add_crate_root(

--- a/crates/rust-analyzer/src/world.rs
+++ b/crates/rust-analyzer/src/world.rs
@@ -150,8 +150,19 @@ impl WorldState {
             vfs_file.map(|f| FileId(f.0))
         };
 
-        let proc_macro_client =
-            ProcMacroClient::extern_process(std::path::Path::new("ra_proc_macro_srv"));
+        // FIXME: set the path of proc macro srv in config
+        let proc_macro_srv = Path::new("ra_proc_macro_srv");
+        let proc_macro_client = match ProcMacroClient::extern_process(proc_macro_srv) {
+            Ok(it) => it,
+            Err(err) => {
+                log::error!(
+                    "Fail to run ra_proc_macro_srv from path {}, error : {}",
+                    proc_macro_srv.to_string_lossy(),
+                    err
+                );
+                ProcMacroClient::dummy()
+            }
+        };
 
         workspaces
             .iter()

--- a/crates/rust-analyzer/src/world.rs
+++ b/crates/rust-analyzer/src/world.rs
@@ -16,7 +16,7 @@ use ra_ide::{
     Analysis, AnalysisChange, AnalysisHost, CrateGraph, FileId, InlayHintsOptions, LibraryData,
     SourceRootId,
 };
-use ra_project_model::{get_rustc_cfg_options, ProjectWorkspace};
+use ra_project_model::{get_rustc_cfg_options, ProcMacroClient, ProjectWorkspace};
 use ra_vfs::{LineEndings, RootEntry, Vfs, VfsChange, VfsFile, VfsRoot, VfsTask, Watch};
 use relative_path::RelativePathBuf;
 
@@ -150,9 +150,19 @@ impl WorldState {
             vfs_file.map(|f| FileId(f.0))
         };
 
+        let proc_macro_client =
+            ProcMacroClient::extern_process(std::path::Path::new("ra_proc_macro_srv"));
+
         workspaces
             .iter()
-            .map(|ws| ws.to_crate_graph(&default_cfg_options, &extern_source_roots, &mut load))
+            .map(|ws| {
+                ws.to_crate_graph(
+                    &default_cfg_options,
+                    &extern_source_roots,
+                    &proc_macro_client,
+                    &mut load,
+                )
+            })
             .for_each(|graph| {
                 crate_graph.extend(graph);
             });

--- a/xtask/src/install.rs
+++ b/xtask/src/install.rs
@@ -12,6 +12,7 @@ const REQUIRED_RUST_VERSION: u32 = 41;
 pub struct InstallCmd {
     pub client: Option<ClientOpt>,
     pub server: Option<ServerOpt>,
+    pub proc_macro: Option<ProcMacroOpt>,
 }
 
 pub enum ClientOpt {
@@ -22,6 +23,10 @@ pub struct ServerOpt {
     pub jemalloc: bool,
 }
 
+pub struct ProcMacroOpt {
+    pub jemalloc: bool,
+}
+
 impl InstallCmd {
     pub fn run(self) -> Result<()> {
         if cfg!(target_os = "macos") {
@@ -29,6 +34,9 @@ impl InstallCmd {
         }
         if let Some(server) = self.server {
             install_server(server).context("install server")?;
+        }
+        if let Some(proc_macro) = self.proc_macro {
+            install_proc_macro_srv(proc_macro).context("install proc-macro server")?;
         }
         if let Some(client) = self.client {
             install_client(client).context("install client")?;
@@ -140,6 +148,12 @@ fn install_server(opts: ServerOpt) -> Result<()> {
         );
     }
 
+    res.map(drop)
+}
+
+fn install_proc_macro_srv(opts: ProcMacroOpt) -> Result<()> {
+    let jemalloc = if opts.jemalloc { "--features jemalloc" } else { "" };
+    let res = run!("cargo install --path crates/ra_proc_macro_srv --locked --force {}", jemalloc);
     res.map(drop)
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -14,7 +14,7 @@ use pico_args::Arguments;
 use xtask::{
     codegen::{self, Mode},
     dist::{run_dist, ClientOpts},
-    install::{ClientOpt, InstallCmd, ServerOpt},
+    install::{ClientOpt, InstallCmd, ProcMacroOpt, ServerOpt},
     not_bash::pushd,
     pre_commit, project_root, run_clippy, run_fuzzer, run_pre_cache, run_release, run_rustfmt,
     Result,
@@ -44,6 +44,7 @@ USAGE:
 FLAGS:
         --client-code    Install only VS Code plugin
         --server         Install only the language server
+        --proc-macro     Install with proc macro server
         --jemalloc       Use jemalloc for server
     -h, --help           Prints help information
         "
@@ -59,14 +60,15 @@ FLAGS:
                 );
                 return Ok(());
             }
-
             let jemalloc = args.contains("--jemalloc");
+            let proc_macro = args.contains("--proc-macro");
 
             args.finish()?;
 
             InstallCmd {
                 client: if server { None } else { Some(ClientOpt::VsCode) },
                 server: if client_code { None } else { Some(ServerOpt { jemalloc }) },
+                proc_macro: if proc_macro { Some(ProcMacroOpt { jemalloc }) } else { None },
             }
             .run()
         }


### PR DESCRIPTION
### This PR is a proof of concept how proc-macro works under RA infrastructure. I will seperate it to several small PRs after it is polish enough to merge.

### How to run 
It needs another executable to work, you need to install it (and the RA server itself) by running:
```
cargo xtask install --proc-macro
```
And you have to enable the outdir flag: 
```
"rust-analyzer.cargoFeatures.loadOutDirsFromCheck": true
```

### Key Idea

The general idea are based on @matklad and [`rust-proc-macro-expander` project](https://github.com/fedochet/rust-proc-macro-expander) by @fedochet. 

* Originally, `rustc` (*Server*) loads a proc-macro (*Client*) as a dylib while compiling, and use byte buffer as a [RPC](https://github.com/rust-lang/rust/blob/3c6f982cc908aacc39c3ac97f31c989f81cc213c/src/libproc_macro/bridge/rpc.rs#L26) to send and receive `TokenStream`. We can use [unstable bridge api](https://github.com/rust-lang/rust/blob/3c6f982cc908aacc39c3ac97f31c989f81cc213c/src/libproc_macro/lib.rs#L33) to send the `TokenStream` to `proc-macro` ourself if we implement all the *server* side code as `rustc` do.
* And because it is based on ABI compatibility and unstable api, we do want to separate it to different process. 

### Idea To Prove In This PR

* Personally I don't want to work with nightly rustc. By copying the whole `libproc_macro` from `rustc`, we could use stable instead of unstable-api. (It is because the whole idea is based on ABI compatibility, if ABI is changed, we have to fix it anyway). And this is an improvement over `rust-proc-macro-expander` project.
* And because the bridge api itself is "TokenStream-agnostic", and to simplify the whole communication process, we use `ra_tt` as the `TokenStream` for the server instead of `proc-macro2`  as the original project did.

### How it works:

We add a new `MacroDefKind::ProcMacro` and process it similar to  `MacroDefKind::BuiltinDerive`. And then we look for `ProcMacro` from `CrateData` for expanding. This `ProcMacro` is registered similar to how we get the `OutDir` from `cargo-check`. OTOH, these `ProcMacro` are created from `ProcMacroClient`, which mainly use for spawning / communicating with a separated process `ra_proc_macro_srv`.  

### Questions:

Currently this implementation is using a pull model, such that every time we ask for a expansion of a macro, we spawn the process and get the result. However, it is not ideal if the expansion time is long and we might want to use a push model. i.e: When the server finish the process, it pushes the result back to salsa database and we update the result. But I don't know how it actually works.

### Todo:

- [ ] There is a bug in mbe #2158 which make me do some hacking to removing `attr` in a TokenTree.
- [ ] Find a way to test it without external projects

### Screen Shot
![proc-macro](https://user-images.githubusercontent.com/11014119/77074975-96d70280-6a2c-11ea-9a80-14b42fcd2492.png)






