### PR TITLE
Introduce TokenConverter Trait

### DIFF
--- a/crates/ra_mbe/src/tests.rs
+++ b/crates/ra_mbe/src/tests.rs
@@ -1449,8 +1449,8 @@ impl MacroFixture {
         let macro_invocation =
             source_file.syntax().descendants().find_map(ast::MacroCall::cast).unwrap();
 
-        let (invocation_tt, _) =
-            ast_to_token_tree(&macro_invocation.token_tree().unwrap()).unwrap();
+        let (invocation_tt, _) = ast_to_token_tree(&macro_invocation.token_tree().unwrap())
+            .ok_or_else(|| ExpandError::ConversionError)?;
 
         self.rules.expand(&invocation_tt).result()
     }
@@ -1694,5 +1694,5 @@ fn test_expand_bad_literal() {
         macro_rules! foo { ($i:literal) => {}; }
     "#,
     )
-    .assert_expand_err(r#"foo!(&k");"#, &ExpandError::BindingError("".to_string()));
+    .assert_expand_err(r#"foo!(&k");"#, &ExpandError::ConversionError);
 }

--- a/crates/ra_mbe/src/tests.rs
+++ b/crates/ra_mbe/src/tests.rs
@@ -1694,5 +1694,5 @@ fn test_expand_bad_literal() {
         macro_rules! foo { ($i:literal) => {}; }
     "#,
     )
-    .assert_expand_err(r#"foo!(&k");"#, &ExpandError::ConversionError);
+    .assert_expand_err(r#"foo!(&k");"#, &ExpandError::BindingError("".into()));
 }


### PR DESCRIPTION
This PR add a `TokenConverter` Trait to share the conversion logic between raw `lexer` token and Syntax Node Token.

Related #2158.