### PR TITLE
vscode: remove unnecessary code

### DIFF
--- a/editors/code/src/inlay_hints.ts
+++ b/editors/code/src/inlay_hints.ts
@@ -134,8 +134,6 @@ class HintsUpdater implements Disposable {
 
             // No text documents changed, so we may try to use the cache
             if (!file.cachedDecorations) {
-                file.inlaysRequest?.cancel();
-
                 const hints = await this.fetchHints(file);
                 if (!hints) return;
 


### PR DESCRIPTION
This cancel is unnecessary since we cancel the previous inlay hints requests in `fetchHints()` method itself. This is not a hard error, we just called cancel() 2 times.