### PR TITLE
Reload part of the server configuration without restarts

### DIFF
--- a/crates/ra_ide/src/lib.rs
+++ b/crates/ra_ide/src/lib.rs
@@ -138,6 +138,11 @@ impl AnalysisHost {
     pub fn new(lru_capacity: Option<usize>) -> AnalysisHost {
         AnalysisHost { db: RootDatabase::new(lru_capacity) }
     }
+
+    pub fn update_lru_capacity(&mut self, lru_capacity: Option<usize>) {
+        self.db.update_lru_capacity(lru_capacity);
+    }
+
     /// Returns a snapshot of the current state, which you can query for
     /// semantic information.
     pub fn analysis(&self) -> Analysis {

--- a/crates/ra_ide_db/src/lib.rs
+++ b/crates/ra_ide_db/src/lib.rs
@@ -115,11 +115,15 @@ impl RootDatabase {
         db.set_crate_graph_with_durability(Default::default(), Durability::HIGH);
         db.set_local_roots_with_durability(Default::default(), Durability::HIGH);
         db.set_library_roots_with_durability(Default::default(), Durability::HIGH);
-        let lru_capacity = lru_capacity.unwrap_or(ra_db::DEFAULT_LRU_CAP);
-        db.query_mut(ra_db::ParseQuery).set_lru_capacity(lru_capacity);
-        db.query_mut(hir::db::ParseMacroQuery).set_lru_capacity(lru_capacity);
-        db.query_mut(hir::db::MacroExpandQuery).set_lru_capacity(lru_capacity);
+        db.update_lru_capacity(lru_capacity);
         db
+    }
+
+    pub fn update_lru_capacity(&mut self, lru_capacity: Option<usize>) {
+        let lru_capacity = lru_capacity.unwrap_or(ra_db::DEFAULT_LRU_CAP);
+        self.query_mut(ra_db::ParseQuery).set_lru_capacity(lru_capacity);
+        self.query_mut(hir::db::ParseMacroQuery).set_lru_capacity(lru_capacity);
+        self.query_mut(hir::db::MacroExpandQuery).set_lru_capacity(lru_capacity);
     }
 }
 

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -417,22 +417,19 @@ fn loop_turn(
                 if Some(resp.id) == loop_state.configuration_request_id {
                     loop_state.configuration_request_id = None;
                     if let Some(err) = resp.error {
-                        log::error!("failed fetch the server settings: {:?}", err)
-                    } else if resp.result.is_none() {
-                        log::error!("received empty server settings response from the client")
-                    } else {
-                        let new_config =
-                            serde_json::from_value::<Vec<ServerConfig>>(resp.result.unwrap())?
-                                .first()
-                                .expect(
-                                    "The client is expected to always send a non-empty config data",
-                                )
-                                .to_owned();
+                        log::error!("failed to fetch the server settings: {:?}", err)
+                    } else if let Some(result) = resp.result {
+                        let new_config = serde_json::from_value::<Vec<ServerConfig>>(result)?
+                            .first()
+                            .expect("The client is expected to always send a non-empty config data")
+                            .to_owned();
                         world_state.update_configuration(
                             new_config.lru_capacity,
                             get_options(&new_config, text_document_caps),
                             get_feature_flags(&new_config, connection),
                         );
+                    } else {
+                        log::error!("received empty server settings response from the client")
                     }
                 }
             }
@@ -673,7 +670,7 @@ fn on_notification(
                 ConfigurationParams::default(),
             );
             msg_sender.send(request.into())?;
-            loop_state.configuration_request_id.replace(request_id);
+            loop_state.configuration_request_id = Some(request_id);
 
             return Ok(());
         }

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -641,9 +641,15 @@ fn on_notification(
     };
     let not = match notification_cast::<req::DidChangeConfiguration>(not) {
         Ok(_params) => {
+            dbg!(_params);
+            // let request = request_new::<req::WorkspaceConfiguration>(
+            //     loop_state.next_request_id(),
+            //     ConfigurationParams::default(),
+            // );
+            // let zz = connection.sender.send(request.into()).unwrap();
             return Ok(());
         }
-        Err(not) => not,
+        Err(not) => dbg!(not),
     };
     let not = match notification_cast::<req::DidChangeWatchedFiles>(not) {
         Ok(params) => {

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -415,7 +415,7 @@ fn loop_turn(
                 }
 
                 if Some(resp.id) == loop_state.configuration_request_id {
-                    loop_state.configuration_request_id.take();
+                    loop_state.configuration_request_id = None;
                     if let Some(err) = resp.error {
                         log::error!("failed fetch the server settings: {:?}", err)
                     } else if resp.result.is_none() {

--- a/crates/rust-analyzer/src/req.rs
+++ b/crates/rust-analyzer/src/req.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 pub use lsp_types::{
     notification::*, request::*, ApplyWorkspaceEditParams, CodeActionParams, CodeLens,
-    CodeLensParams, CompletionParams, CompletionResponse, DiagnosticTag,
+    CodeLensParams, CompletionParams, CompletionResponse, ConfigurationParams, DiagnosticTag,
     DidChangeConfigurationParams, DidChangeWatchedFilesParams,
     DidChangeWatchedFilesRegistrationOptions, DocumentOnTypeFormattingParams, DocumentSymbolParams,
     DocumentSymbolResponse, FileSystemWatcher, Hover, InitializeResult, MessageType,

--- a/crates/rust-analyzer/src/world.rs
+++ b/crates/rust-analyzer/src/world.rs
@@ -184,7 +184,6 @@ impl WorldState {
             });
         change.set_crate_graph(crate_graph);
 
-        // FIXME: Figure out the multi-workspace situation
         let check_watcher = create_watcher(&workspaces, &options);
 
         let mut analysis_host = AnalysisHost::new(lru_capacity);

--- a/crates/rust-analyzer/src/world.rs
+++ b/crates/rust-analyzer/src/world.rs
@@ -31,7 +31,7 @@ use crate::{
 use ra_db::ExternSourceId;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-fn create_watcher(workspaces: &[ProjectWorkspace], options: &Options) -> CheckWatcher {
+fn create_watcher(workspaces: &[ProjectWorkspace], options: &Options) -> Option<CheckWatcher> {
     // FIXME: Figure out the multi-workspace situation
     workspaces
         .iter()

--- a/crates/rust-analyzer/src/world.rs
+++ b/crates/rust-analyzer/src/world.rs
@@ -32,6 +32,7 @@ use ra_db::ExternSourceId;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 fn create_watcher(workspaces: &[ProjectWorkspace], options: &Options) -> CheckWatcher {
+    // FIXME: Figure out the multi-workspace situation
     workspaces
         .iter()
         .find_map(|w| match w {

--- a/crates/rust-analyzer/src/world.rs
+++ b/crates/rust-analyzer/src/world.rs
@@ -31,6 +31,23 @@ use crate::{
 use ra_db::ExternSourceId;
 use rustc_hash::{FxHashMap, FxHashSet};
 
+fn create_watcher(workspaces: &[ProjectWorkspace], options: &Options) -> CheckWatcher {
+    workspaces
+        .iter()
+        .find_map(|w| match w {
+            ProjectWorkspace::Cargo { cargo, .. } => Some(cargo),
+            ProjectWorkspace::Json { .. } => None,
+        })
+        .map(|cargo| {
+            let cargo_project_root = cargo.workspace_root().to_path_buf();
+            Some(CheckWatcher::new(&options.cargo_watch, cargo_project_root))
+        })
+        .unwrap_or_else(|| {
+            log::warn!("Cargo check watching only supported for cargo workspaces, disabling");
+            None
+        })
+}
+
 #[derive(Debug, Clone)]
 pub struct Options {
     pub publish_decorations: bool,
@@ -168,20 +185,7 @@ impl WorldState {
         change.set_crate_graph(crate_graph);
 
         // FIXME: Figure out the multi-workspace situation
-        let check_watcher = workspaces
-            .iter()
-            .find_map(|w| match w {
-                ProjectWorkspace::Cargo { cargo, .. } => Some(cargo),
-                ProjectWorkspace::Json { .. } => None,
-            })
-            .map(|cargo| {
-                let cargo_project_root = cargo.workspace_root().to_path_buf();
-                Some(CheckWatcher::new(&options.cargo_watch, cargo_project_root))
-            })
-            .unwrap_or_else(|| {
-                log::warn!("Cargo check watching only supported for cargo workspaces, disabling");
-                None
-            });
+        let check_watcher = create_watcher(&workspaces, &options);
 
         let mut analysis_host = AnalysisHost::new(lru_capacity);
         analysis_host.apply_change(change);
@@ -207,6 +211,7 @@ impl WorldState {
     ) {
         self.feature_flags = Arc::new(feature_flags);
         self.analysis_host.update_lru_capacity(lru_capacity);
+        self.check_watcher = create_watcher(&self.workspaces, &options);
         self.options = options;
     }
 

--- a/crates/rust-analyzer/src/world.rs
+++ b/crates/rust-analyzer/src/world.rs
@@ -199,6 +199,17 @@ impl WorldState {
         }
     }
 
+    pub fn update_configuration(
+        &mut self,
+        lru_capacity: Option<usize>,
+        options: Options,
+        feature_flags: FeatureFlags,
+    ) {
+        self.feature_flags = Arc::new(feature_flags);
+        self.analysis_host.update_lru_capacity(lru_capacity);
+        self.options = options;
+    }
+
     /// Returns a vec of libraries
     /// FIXME: better API here
     pub fn process_changes(

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -5,7 +5,7 @@ import { Config } from './config';
 import { CallHierarchyFeature } from 'vscode-languageclient/lib/callHierarchy.proposed';
 import { SemanticTokensFeature, DocumentSemanticsTokensSignature } from 'vscode-languageclient/lib/semanticTokens.proposed';
 
-export function configToServerOptions(config: Config): object {
+export function configToServerOptions(config: Config) {
     return {
         publishDecorations: !config.highlightingSemanticTokens,
         lruCapacity: config.lruCapacity,

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -5,6 +5,31 @@ import { Config } from './config';
 import { CallHierarchyFeature } from 'vscode-languageclient/lib/callHierarchy.proposed';
 import { SemanticTokensFeature, DocumentSemanticsTokensSignature } from 'vscode-languageclient/lib/semanticTokens.proposed';
 
+export function configToOptions(config: Config): object {
+    return {
+        publishDecorations: !config.highlightingSemanticTokens,
+        lruCapacity: config.lruCapacity,
+
+        inlayHintsType: config.inlayHints.typeHints,
+        inlayHintsParameter: config.inlayHints.parameterHints,
+        inlayHintsChaining: config.inlayHints.chainingHints,
+        inlayHintsMaxLength: config.inlayHints.maxLength,
+
+        cargoWatchEnable: config.cargoWatchOptions.enable,
+        cargoWatchArgs: config.cargoWatchOptions.arguments,
+        cargoWatchCommand: config.cargoWatchOptions.command,
+        cargoWatchAllTargets: config.cargoWatchOptions.allTargets,
+
+        excludeGlobs: config.excludeGlobs,
+        useClientWatching: config.useClientWatching,
+        featureFlags: config.featureFlags,
+        withSysroot: config.withSysroot,
+        cargoFeatures: config.cargoFeatures,
+        rustfmtArgs: config.rustfmtArgs,
+        vscodeLldb: vscode.extensions.getExtension("vadimcn.vscode-lldb") != null,
+    };
+}
+
 export async function createClient(config: Config, serverPath: string): Promise<lc.LanguageClient> {
     // '.' Is the fallback if no folder is open
     // TODO?: Workspace folders support Uri's (eg: file://test.txt).
@@ -22,32 +47,10 @@ export async function createClient(config: Config, serverPath: string): Promise<
     const traceOutputChannel = vscode.window.createOutputChannel(
         'Rust Analyzer Language Server Trace',
     );
-    const cargoWatchOpts = config.cargoWatchOptions;
 
     const clientOptions: lc.LanguageClientOptions = {
         documentSelector: [{ scheme: 'file', language: 'rust' }],
-        initializationOptions: {
-            publishDecorations: !config.highlightingSemanticTokens,
-            lruCapacity: config.lruCapacity,
-
-            inlayHintsType: config.inlayHints.typeHints,
-            inlayHintsParameter: config.inlayHints.parameterHints,
-            inlayHintsChaining: config.inlayHints.chainingHints,
-            inlayHintsMaxLength: config.inlayHints.maxLength,
-
-            cargoWatchEnable: cargoWatchOpts.enable,
-            cargoWatchArgs: cargoWatchOpts.arguments,
-            cargoWatchCommand: cargoWatchOpts.command,
-            cargoWatchAllTargets: cargoWatchOpts.allTargets,
-
-            excludeGlobs: config.excludeGlobs,
-            useClientWatching: config.useClientWatching,
-            featureFlags: config.featureFlags,
-            withSysroot: config.withSysroot,
-            cargoFeatures: config.cargoFeatures,
-            rustfmtArgs: config.rustfmtArgs,
-            vscodeLldb: vscode.extensions.getExtension("vadimcn.vscode-lldb") != null,
-        },
+        initializationOptions: configToOptions(config),
         traceOutputChannel,
         middleware: {
             // Workaround for https://github.com/microsoft/vscode-languageserver-node/issues/576

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -5,7 +5,7 @@ import { Config } from './config';
 import { CallHierarchyFeature } from 'vscode-languageclient/lib/callHierarchy.proposed';
 import { SemanticTokensFeature, DocumentSemanticsTokensSignature } from 'vscode-languageclient/lib/semanticTokens.proposed';
 
-export function configToOptions(config: Config): object {
+export function configToServerOptions(config: Config): object {
     return {
         publishDecorations: !config.highlightingSemanticTokens,
         lruCapacity: config.lruCapacity,
@@ -50,7 +50,7 @@ export async function createClient(config: Config, serverPath: string): Promise<
 
     const clientOptions: lc.LanguageClientOptions = {
         documentSelector: [{ scheme: 'file', language: 'rust' }],
-        initializationOptions: configToOptions(config),
+        initializationOptions: configToServerOptions(config),
         traceOutputChannel,
         middleware: {
             // Workaround for https://github.com/microsoft/vscode-languageserver-node/issues/576

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -12,9 +12,9 @@ export class Config {
     private readonly requiresReloadOpts = [
         "serverPath",
         "cargoFeatures",
-        "cargo-watch",
-        "highlighting.semanticTokens",
-        "inlayHints",
+        "excludeGlobs",
+        "useClientWatching",
+        "highlighting",
         "updates.channel",
     ]
         .map(opt => `${this.rootSection}.${opt}`);

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as lc from 'vscode-languageclient';
 
 import { Config } from './config';
-import { createClient, configToOptions } from './client';
+import { createClient, configToServerOptions } from './client';
 import { isRustEditor, RustEditor } from './util';
 
 export class Ctx {
@@ -20,7 +20,7 @@ export class Ctx {
         const res = new Ctx(config, extCtx, client, serverPath);
         res.pushCleanup(client.start());
         await client.onReady();
-        client.onRequest('workspace/configuration', _ => [configToOptions(config)]);
+        client.onRequest('workspace/configuration', _ => [configToServerOptions(config)]);
         return res;
     }
 

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as lc from 'vscode-languageclient';
 
 import { Config } from './config';
-import { createClient } from './client';
+import { createClient, configToOptions } from './client';
 import { isRustEditor, RustEditor } from './util';
 
 export class Ctx {
@@ -20,6 +20,7 @@ export class Ctx {
         const res = new Ctx(config, extCtx, client, serverPath);
         res.pushCleanup(client.start());
         await client.onReady();
+        client.onRequest('workspace/configuration', _ => [configToOptions(config)]);
         return res;
     }
 

--- a/editors/code/src/inlay_hints.ts
+++ b/editors/code/src/inlay_hints.ts
@@ -17,9 +17,11 @@ export function activateInlayHints(ctx: Ctx) {
             ) {
                 return this.dispose();
             }
-            if (!this.updater) this.updater = new HintsUpdater(ctx);
-
-            this.updater.syncCacheAndRenderHints();
+            if (this.updater) {
+                this.updater.syncCacheAndRenderHints();
+            } else {
+                this.updater = new HintsUpdater(ctx);
+            }
         },
         dispose() {
             this.updater?.dispose();
@@ -126,7 +128,7 @@ class HintsUpdater implements Disposable {
         this.syncCacheAndRenderHints();
     }
 
-    public syncCacheAndRenderHints() {
+    syncCacheAndRenderHints() {
         // FIXME: make inlayHints request pass an array of files?
         this.sourceFiles.forEach((file, uri) => this.fetchHints(file).then(hints => {
             if (!hints) return;

--- a/editors/code/src/inlay_hints.ts
+++ b/editors/code/src/inlay_hints.ts
@@ -18,6 +18,8 @@ export function activateInlayHints(ctx: Ctx) {
                 return this.dispose();
             }
             if (!this.updater) this.updater = new HintsUpdater(ctx);
+
+            this.updater.syncCacheAndRenderHints();
         },
         dispose() {
             this.updater?.dispose();
@@ -124,7 +126,7 @@ class HintsUpdater implements Disposable {
         this.syncCacheAndRenderHints();
     }
 
-    private syncCacheAndRenderHints() {
+    public syncCacheAndRenderHints() {
         // FIXME: make inlayHints request pass an array of files?
         this.sourceFiles.forEach((file, uri) => this.fetchHints(file).then(hints => {
             if (!hints) return;

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -91,6 +91,12 @@ export async function activate(context: vscode.ExtensionContext) {
         activateHighlighting(ctx);
     }
     activateInlayHints(ctx);
+
+    vscode.workspace.onDidChangeConfiguration(
+        _ => ctx?.client?.sendNotification('workspace/didChangeConfiguration', { settings: "" }),
+        null,
+        ctx?.subscriptions,
+    );
 }
 
 export async function deactivate() {

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -95,7 +95,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.workspace.onDidChangeConfiguration(
         _ => ctx?.client?.sendNotification('workspace/didChangeConfiguration', { settings: "" }),
         null,
-        ctx?.subscriptions,
+        ctx.subscriptions,
     );
 }
 


### PR DESCRIPTION
Partially addresses https://github.com/rust-analyzer/rust-analyzer/issues/2857

Closes #3751

Reloads all server configuration that's not related to VFS without restarts.

The VFS-related parameters are not considered, since VFS is planned to be rewritten/replaced in the future and I have a suspicion that with the current code, swapping the VFS and the file watchers on the fly will cause big troubles.

I have to store and process the config request id separately, since the `workspace/configuration` response returns `any[]` (https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_configuration), if there's a better way to handle those responses, let me know.

