### PR TITLE
disable invert-if assist for if-let

### DIFF
--- a/crates/ra_assists/src/handlers/invert_if.rs
+++ b/crates/ra_assists/src/handlers/invert_if.rs
@@ -33,6 +33,11 @@ pub(crate) fn invert_if(ctx: AssistCtx) -> Option<Assist> {
         return None;
     }
 
+    // This assist should not apply for if-let.
+    if expr.condition()?.pat().is_some() {
+        return None;
+    }
+
     let cond = expr.condition()?.expr()?;
     let then_node = expr.then_branch()?.syntax().clone();
 
@@ -89,5 +94,13 @@ mod tests {
     #[test]
     fn invert_if_doesnt_apply_with_cursor_not_on_if() {
         check_assist_not_applicable(invert_if, "fn f() { if !<|>cond { 3 * 2 } else { 1 } }")
+    }
+
+    #[test]
+    fn invert_if_doesnt_apply_with_if_let() {
+        check_assist_not_applicable(
+            invert_if,
+            "fn f() { i<|>f let Some(_) = Some(1) { 1 } else { 0 } }",
+        )
     }
 }


### PR DESCRIPTION
Fixes #3281 

This disables the invert-if assist for if-let expressions, fixing the bug reported in #3281.

While in the exact case reported in #3281, `if let Some(_) = foo { ...`, it would be possible to invert the if-let pattern, in most cases it will not be possible, so disabling this assist for if-let expressions seems reasonable. 