### PR TITLE
gen_assists_docs skip hidden files

### DIFF
--- a/xtask/src/codegen/gen_assists_docs.rs
+++ b/xtask/src/codegen/gen_assists_docs.rs
@@ -4,7 +4,7 @@ use std::{fs, path::Path};
 
 use crate::{
     codegen::{self, extract_comment_blocks_with_empty_lines, Mode},
-    project_root, Result,
+    project_root, rust_files, Result,
 };
 
 pub fn generate_assists_docs(mode: Mode) -> Result<()> {
@@ -46,12 +46,8 @@ fn reveal_hash_comments(text: &str) -> String {
 
 fn collect_assists() -> Result<Vec<Assist>> {
     let mut res = Vec::new();
-    for entry in fs::read_dir(project_root().join(codegen::ASSISTS_DIR))? {
-        let entry = entry?;
-        let path = entry.path();
-        if path.is_file() {
-            collect_file(&mut res, path.as_path())?;
-        }
+    for path in rust_files(&project_root().join(codegen::ASSISTS_DIR)) {
+        collect_file(&mut res, path.as_path())?;
     }
     res.sort_by(|lhs, rhs| lhs.id.cmp(&rhs.id));
     return Ok(res);

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -17,6 +17,7 @@ use std::{
     path::{Path, PathBuf},
     process::{Command, Stdio},
 };
+use walkdir::{DirEntry, WalkDir};
 
 use crate::{
     codegen::Mode,
@@ -35,6 +36,21 @@ pub fn project_root() -> PathBuf {
     .nth(1)
     .unwrap()
     .to_path_buf()
+}
+
+pub fn rust_files(path: &Path) -> impl Iterator<Item = PathBuf> {
+    let iter = WalkDir::new(path);
+    return iter
+        .into_iter()
+        .filter_entry(|e| !is_hidden(e))
+        .map(|e| e.unwrap())
+        .filter(|e| !e.file_type().is_dir())
+        .map(|e| e.into_path())
+        .filter(|path| path.extension().map(|it| it == "rs").unwrap_or(false));
+
+    fn is_hidden(entry: &DirEntry) -> bool {
+        entry.file_name().to_str().map(|s| s.starts_with('.')).unwrap_or(false)
+    }
 }
 
 pub fn run_rustfmt(mode: Mode) -> Result<()> {

--- a/xtask/tests/tidy-tests/main.rs
+++ b/xtask/tests/tidy-tests/main.rs
@@ -5,13 +5,12 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use walkdir::{DirEntry, WalkDir};
-use xtask::{not_bash::fs2, project_root};
+use xtask::{not_bash::fs2, project_root, rust_files};
 
 #[test]
 fn rust_files_are_tidy() {
     let mut tidy_docs = TidyDocs::default();
-    for path in rust_files() {
+    for path in rust_files(&project_root().join("crates")) {
         let text = fs2::read_to_string(&path).unwrap();
         check_todo(&path, &text);
         check_trailing_ws(&path, &text);
@@ -141,20 +140,4 @@ fn is_exclude_dir(p: &Path, dirs_to_exclude: &[&str]) -> bool {
     }
 
     false
-}
-
-fn rust_files() -> impl Iterator<Item = PathBuf> {
-    let crates = project_root().join("crates");
-    let iter = WalkDir::new(crates);
-    return iter
-        .into_iter()
-        .filter_entry(|e| !is_hidden(e))
-        .map(|e| e.unwrap())
-        .filter(|e| !e.file_type().is_dir())
-        .map(|e| e.into_path())
-        .filter(|path| path.extension().map(|it| it == "rs").unwrap_or(false));
-
-    fn is_hidden(entry: &DirEntry) -> bool {
-        entry.file_name().to_str().map(|s| s.starts_with('.')).unwrap_or(false)
-    }
 }


### PR DESCRIPTION
Fixes #3670 

Skips hidden files when generating assist docs, which fixes an issue where the tests would fail while an editor has created a temp file in the assists directory.

There is similar logic [here](https://github.com/rust-analyzer/rust-analyzer/blob/2720e2374be951bb762ff2815dd67c7ffe3419b7/xtask/tests/tidy-tests/main.rs#L157), although in that case the `DirEntry` is a `walkdir::DirEntry` rather than a `fs::DirEntry`. Also, it's not immediately clear that it is worth moving this functionality to somewhere accessible from both of these places and creating dependencies in this way. Let me know if this is off the mark.