### PR TITLE
Add support for macro in symbol_index

### DIFF
--- a/crates/ra_hir_def/src/body/lower.rs
+++ b/crates/ra_hir_def/src/body/lower.rs
@@ -453,7 +453,7 @@ impl ExprCollector<'_> {
                 }
             }
             ast::Expr::MacroCall(e) => {
-                if let Some(name) = is_macro_rules(&e) {
+                if let Some(name) = e.is_macro_rules().map(|it| it.as_name()) {
                     let mac = MacroDefId {
                         krate: Some(self.expander.module.krate),
                         ast_id: Some(self.expander.ast_id(&e)),
@@ -694,16 +694,6 @@ impl ExprCollector<'_> {
         } else {
             self.missing_pat()
         }
-    }
-}
-
-fn is_macro_rules(m: &ast::MacroCall) -> Option<Name> {
-    let name = m.path()?.segment()?.name_ref()?.as_name();
-
-    if name == name![macro_rules] {
-        Some(m.name()?.as_name())
-    } else {
-        None
     }
 }
 

--- a/crates/ra_ide_db/src/symbol_index.rs
+++ b/crates/ra_ide_db/src/symbol_index.rs
@@ -362,6 +362,13 @@ fn to_symbol(node: &SyntaxNode) -> Option<(SmolStr, SyntaxNodePtr, TextRange)> {
             ast::TypeAliasDef(it) => { decl(it) },
             ast::ConstDef(it) => { decl(it) },
             ast::StaticDef(it) => { decl(it) },
+            ast::MacroCall(it) => {
+                if it.is_macro_rules().is_some() {
+                    decl(it)
+                } else {
+                    None
+                }
+            },
             _ => None,
         }
     }

--- a/crates/ra_syntax/src/ast/extensions.rs
+++ b/crates/ra_syntax/src/ast/extensions.rs
@@ -4,7 +4,7 @@
 use itertools::Itertools;
 
 use crate::{
-    ast::{self, child_opt, children, AstNode, AttrInput, SyntaxNode},
+    ast::{self, child_opt, children, AstNode, AttrInput, NameOwner, SyntaxNode},
     SmolStr, SyntaxElement,
     SyntaxKind::*,
     SyntaxToken, T,
@@ -512,5 +512,16 @@ impl ast::Visibility {
 
     fn is_pub_super(&self) -> bool {
         self.syntax().children_with_tokens().any(|it| it.kind() == T![super])
+    }
+}
+
+impl ast::MacroCall {
+    pub fn is_macro_rules(&self) -> Option<ast::Name> {
+        let name_ref = self.path()?.segment()?.name_ref()?;
+        if name_ref.text() == "macro_rules" {
+            self.name()
+        } else {
+            None
+        }
     }
 }


### PR DESCRIPTION
This PR allows macro showing up in `Open symbol` search:

![show_macro](https://user-images.githubusercontent.com/11014119/77244297-548d0b80-6c4e-11ea-8613-15926cc297b3.png)
