### PR TITLE
Fix rename argument in macro call 

### DIFF
--- a/crates/ra_hir/src/semantics.rs
+++ b/crates/ra_hir/src/semantics.rs
@@ -12,7 +12,8 @@ use hir_expand::ExpansionInfo;
 use ra_db::{FileId, FileRange};
 use ra_prof::profile;
 use ra_syntax::{
-    algo::skip_trivia_token, ast, AstNode, Direction, SyntaxNode, SyntaxToken, TextRange, TextUnit,
+    algo::{find_node_at_offset, skip_trivia_token},
+    ast, AstNode, Direction, SyntaxNode, SyntaxToken, TextRange, TextUnit,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -108,6 +109,17 @@ impl<'db, DB: HirDatabase> Semantics<'db, DB> {
         token.value
     }
 
+    pub fn descend_node_at_offset<N: ast::AstNode>(
+        &self,
+        node: &SyntaxNode,
+        offset: TextUnit,
+    ) -> Option<N> {
+        // Handle macro token cases
+        node.token_at_offset(offset)
+            .map(|token| self.descend_into_macros(token))
+            .find_map(|it| self.ancestors_with_macros(it.parent()).find_map(N::cast))
+    }
+
     pub fn original_range(&self, node: &SyntaxNode) -> FileRange {
         let node = self.find_file(node.clone());
         original_range(self.db, node.as_ref())
@@ -129,12 +141,27 @@ impl<'db, DB: HirDatabase> Semantics<'db, DB> {
             .kmerge_by(|node1, node2| node1.text_range().len() < node2.text_range().len())
     }
 
+    /// Find a AstNode by offset inside SyntaxNode, if it is inside *Macrofile*,
+    /// search up until it is target AstNode type
     pub fn find_node_at_offset_with_macros<N: AstNode>(
         &self,
         node: &SyntaxNode,
         offset: TextUnit,
     ) -> Option<N> {
         self.ancestors_at_offset_with_macros(node, offset).find_map(N::cast)
+    }
+
+    /// Find a AstNode by offset inside SyntaxNode, if it is inside *MacroCall*,
+    /// descend it and find again
+    pub fn find_node_at_offset_with_descend<N: AstNode>(
+        &self,
+        node: &SyntaxNode,
+        offset: TextUnit,
+    ) -> Option<N> {
+        if let Some(it) = find_node_at_offset(&node, offset) {
+            return Some(it);
+        }
+        self.descend_node_at_offset(&node, offset)
     }
 
     pub fn type_of_expr(&self, expr: &ast::Expr) -> Option<Type> {

--- a/crates/ra_hir/src/semantics.rs
+++ b/crates/ra_hir/src/semantics.rs
@@ -142,7 +142,7 @@ impl<'db, DB: HirDatabase> Semantics<'db, DB> {
     }
 
     /// Find a AstNode by offset inside SyntaxNode, if it is inside *Macrofile*,
-    /// search up until it is target AstNode type
+    /// search up until it is of the target AstNode type
     pub fn find_node_at_offset_with_macros<N: AstNode>(
         &self,
         node: &SyntaxNode,

--- a/crates/ra_ide/src/references/rename.rs
+++ b/crates/ra_ide/src/references/rename.rs
@@ -250,6 +250,63 @@ mod tests {
     }
 
     #[test]
+    fn test_rename_for_macro_args_rev() {
+        test_rename(
+            r#"
+    macro_rules! foo {($i:ident) => {$i} }
+    fn main() {
+        let a = "test";
+        foo!(a<|>);
+    }"#,
+            "b",
+            r#"
+    macro_rules! foo {($i:ident) => {$i} }
+    fn main() {
+        let b = "test";
+        foo!(b);
+    }"#,
+        );
+    }
+
+    #[test]
+    fn test_rename_for_macro_define_fn() {
+        test_rename(
+            r#"
+    macro_rules! define_fn {($id:ident) => { fn $id{} }}
+    define_fn!(foo);
+    fn main() {
+        fo<|>o();
+    }"#,
+            "bar",
+            r#"
+    macro_rules! define_fn {($id:ident) => { fn $id{} }}
+    define_fn!(bar);
+    fn main() {
+        bar();
+    }"#,
+        );
+    }
+
+    #[test]
+    fn test_rename_for_macro_define_fn_rev() {
+        test_rename(
+            r#"
+    macro_rules! define_fn {($id:ident) => { fn $id{} }}
+    define_fn!(fo<|>o);
+    fn main() {
+        foo();
+    }"#,
+            "bar",
+            r#"
+    macro_rules! define_fn {($id:ident) => { fn $id{} }}
+    define_fn!(bar);
+    fn main() {
+        bar();
+    }"#,
+        );
+    }
+
+    #[test]
     fn test_rename_for_param_inside() {
         test_rename(
             r#"


### PR DESCRIPTION
This PR fixes rename argument in macro call bug stated in #3622 and adds more helper functions related to `descend_into_macro` in `Semantic`.

Fixes #3622