### PR TITLE
Auto import macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,6 +884,7 @@ version = "0.1.0"
 name = "ra_assists"
 version = "0.1.0"
 dependencies = [
+ "either",
  "format-buf",
  "itertools 0.9.0",
  "join_to_string",
@@ -1045,6 +1046,7 @@ dependencies = [
 name = "ra_ide_db"
 version = "0.1.0"
 dependencies = [
+ "either",
  "fst",
  "log",
  "once_cell",

--- a/crates/ra_assists/Cargo.toml
+++ b/crates/ra_assists/Cargo.toml
@@ -12,6 +12,7 @@ format-buf = "1.0.0"
 join_to_string = "0.1.3"
 rustc-hash = "1.1.0"
 itertools = "0.9.0"
+either = "1.5.3"
 
 ra_syntax = { path = "../ra_syntax" }
 ra_text_edit = { path = "../ra_text_edit" }

--- a/crates/ra_assists/src/ast_transform.rs
+++ b/crates/ra_assists/src/ast_transform.rs
@@ -129,7 +129,7 @@ impl<'a> QualifyPaths<'a> {
         let resolution = self.source_scope.resolve_hir_path(&hir_path?)?;
         match resolution {
             PathResolution::Def(def) => {
-                let found_path = from.find_use_path(self.source_scope.db, def)?;
+                let found_path = from.find_use_path(self.source_scope.db, def.into())?;
                 let mut path = path_to_ast(found_path);
 
                 let type_args = p

--- a/crates/ra_assists/src/ast_transform.rs
+++ b/crates/ra_assists/src/ast_transform.rs
@@ -129,7 +129,7 @@ impl<'a> QualifyPaths<'a> {
         let resolution = self.source_scope.resolve_hir_path(&hir_path?)?;
         match resolution {
             PathResolution::Def(def) => {
-                let found_path = from.find_use_path(self.source_scope.db, def.into())?;
+                let found_path = from.find_use_path(self.source_scope.db, def)?;
                 let mut path = path_to_ast(found_path);
 
                 let type_args = p

--- a/crates/ra_assists/src/handlers/auto_import.rs
+++ b/crates/ra_assists/src/handlers/auto_import.rs
@@ -59,6 +59,7 @@ pub(crate) fn auto_import(ctx: AssistCtx) -> Option<Assist> {
     group.finish()
 }
 
+#[derive(Debug)]
 struct AutoImportAssets {
     import_candidate: ImportCandidate,
     module_with_name_to_import: Module,
@@ -446,6 +447,30 @@ mod tests {
                 pub fn test_function() {};
             }
             ",
+        );
+    }
+
+    #[test]
+    fn macro_import() {
+        check_assist(
+            auto_import,
+            r"
+                    //- /lib.rs crate:crate_with_macro
+                    #[macro_export]
+                    macro_rules! foo {
+                        () => ()
+                    }
+
+                    //- /main.rs crate:main deps:crate_with_macro
+                    fn main() {
+                        foo<|>
+                    }",
+            r"use crate_with_macro::foo;
+
+fn main() {
+    foo<|>
+}
+",
         );
     }
 

--- a/crates/ra_assists/src/handlers/auto_import.rs
+++ b/crates/ra_assists/src/handlers/auto_import.rs
@@ -4,7 +4,7 @@ use hir::{
     AsAssocItem, AssocItemContainer, ModPath, Module, ModuleDef, PathResolution, Semantics, Trait,
     Type,
 };
-use ra_ide_db::{defs::Definition, imports_locator::ImportsLocator, RootDatabase};
+use ra_ide_db::{imports_locator::ImportsLocator, RootDatabase};
 use ra_prof::profile;
 use ra_syntax::{
     ast::{self, AstNode},
@@ -17,6 +17,7 @@ use crate::{
     utils::insert_use_statement,
     AssistId,
 };
+use either::Either;
 
 // Assist: auto_import
 //
@@ -127,16 +128,14 @@ impl AutoImportAssets {
         ImportsLocator::new(db)
             .find_imports(&self.get_search_query())
             .into_iter()
-            .filter_map(|definition| match &self.import_candidate {
+            .filter_map(|candidate| match &self.import_candidate {
                 ImportCandidate::TraitAssocItem(assoc_item_type, _) => {
-                    let located_assoc_item = match definition {
-                        Definition::ModuleDef(ModuleDef::Function(located_function)) => {
-                            located_function
-                                .as_assoc_item(db)
-                                .map(|assoc| assoc.container(db))
-                                .and_then(Self::assoc_to_trait)
-                        }
-                        Definition::ModuleDef(ModuleDef::Const(located_const)) => located_const
+                    let located_assoc_item = match candidate {
+                        Either::Left(ModuleDef::Function(located_function)) => located_function
+                            .as_assoc_item(db)
+                            .map(|assoc| assoc.container(db))
+                            .and_then(Self::assoc_to_trait),
+                        Either::Left(ModuleDef::Const(located_const)) => located_const
                             .as_assoc_item(db)
                             .map(|assoc| assoc.container(db))
                             .and_then(Self::assoc_to_trait),
@@ -154,13 +153,12 @@ impl AutoImportAssets {
                             None,
                             |_, assoc| Self::assoc_to_trait(assoc.container(db)),
                         )
-                        .map(|located_trait| ModuleDef::from(located_trait).into())
+                        .map(ModuleDef::from)
+                        .map(Either::Left)
                 }
                 ImportCandidate::TraitMethod(function_callee, _) => {
                     let located_assoc_item =
-                        if let Definition::ModuleDef(ModuleDef::Function(located_function)) =
-                            definition
-                        {
+                        if let Either::Left(ModuleDef::Function(located_function)) = candidate {
                             located_function
                                 .as_assoc_item(db)
                                 .map(|assoc| assoc.container(db))
@@ -182,15 +180,19 @@ impl AutoImportAssets {
                                 Self::assoc_to_trait(function.as_assoc_item(db)?.container(db))
                             },
                         )
-                        .map(|located_trait| ModuleDef::from(located_trait).into())
+                        .map(ModuleDef::from)
+                        .map(Either::Left)
                 }
-                _ => match definition {
-                    Definition::ModuleDef(module_def) => Some(module_def.into()),
-                    Definition::Macro(macro_def) => Some(macro_def.into()),
-                    _ => None,
-                },
+                _ => Some(candidate),
             })
-            .filter_map(|item| self.module_with_name_to_import.find_use_path(db, item))
+            .filter_map(|candidate| match candidate {
+                Either::Left(module_def) => {
+                    self.module_with_name_to_import.find_use_path(db, module_def)
+                }
+                Either::Right(macro_def) => {
+                    self.module_with_name_to_import.find_use_path(db, macro_def)
+                }
+            })
             .filter(|use_path| !use_path.segments.is_empty())
             .take(20)
             .collect::<BTreeSet<_>>()

--- a/crates/ra_assists/src/handlers/fill_match_arms.rs
+++ b/crates/ra_assists/src/handlers/fill_match_arms.rs
@@ -154,8 +154,7 @@ fn resolve_tuple_of_enum_def(
 }
 
 fn build_pat(db: &RootDatabase, module: hir::Module, var: hir::EnumVariant) -> Option<ast::Pat> {
-    let path =
-        crate::ast_transform::path_to_ast(module.find_use_path(db, ModuleDef::from(var).into())?);
+    let path = crate::ast_transform::path_to_ast(module.find_use_path(db, ModuleDef::from(var))?);
 
     // FIXME: use HIR for this; it doesn't currently expose struct vs. tuple vs. unit variants though
     let pat: ast::Pat = match var.source(db).value.kind() {

--- a/crates/ra_assists/src/handlers/fill_match_arms.rs
+++ b/crates/ra_assists/src/handlers/fill_match_arms.rs
@@ -2,7 +2,7 @@
 
 use std::iter;
 
-use hir::{Adt, HasSource, Semantics};
+use hir::{Adt, HasSource, ModuleDef, Semantics};
 use itertools::Itertools;
 use ra_ide_db::RootDatabase;
 
@@ -154,7 +154,8 @@ fn resolve_tuple_of_enum_def(
 }
 
 fn build_pat(db: &RootDatabase, module: hir::Module, var: hir::EnumVariant) -> Option<ast::Pat> {
-    let path = crate::ast_transform::path_to_ast(module.find_use_path(db, var.into())?);
+    let path =
+        crate::ast_transform::path_to_ast(module.find_use_path(db, ModuleDef::from(var).into())?);
 
     // FIXME: use HIR for this; it doesn't currently expose struct vs. tuple vs. unit variants though
     let pat: ast::Pat = match var.source(db).value.kind() {

--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -143,17 +143,6 @@ impl ModuleDef {
     }
 }
 
-impl From<ModuleDef> for ItemInNs {
-    fn from(module_def: ModuleDef) -> Self {
-        match module_def {
-            ModuleDef::Static(_) | ModuleDef::Const(_) | ModuleDef::Function(_) => {
-                ItemInNs::Values(module_def.into())
-            }
-            _ => ItemInNs::Types(module_def.into()),
-        }
-    }
-}
-
 pub use hir_def::{
     attr::Attrs, item_scope::ItemInNs, visibility::Visibility, AssocItemId, AssocItemLoc,
 };
@@ -290,9 +279,9 @@ impl Module {
     pub fn find_use_path(
         self,
         db: &dyn DefDatabase,
-        item: ItemInNs,
+        item: impl Into<ItemInNs>,
     ) -> Option<hir_def::path::ModPath> {
-        hir_def::find_path::find_path(db, item, self.into())
+        hir_def::find_path::find_path(db, item.into(), self.into())
     }
 }
 
@@ -761,12 +750,6 @@ impl MacroDef {
     /// XXX: this parses the file
     pub fn name(self, db: &dyn HirDatabase) -> Option<Name> {
         self.source(db).value.name().map(|it| it.as_name())
-    }
-}
-
-impl From<MacroDef> for ItemInNs {
-    fn from(macro_def: MacroDef) -> Self {
-        ItemInNs::Macros(macro_def.into())
     }
 }
 

--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -33,7 +33,11 @@ use ra_syntax::{
 };
 use rustc_hash::FxHashSet;
 
-use crate::{db::HirDatabase, has_source::HasSource, CallableDef, HirDisplay, InFile, Name};
+use crate::{
+    db::{DefDatabase, HirDatabase},
+    has_source::HasSource,
+    CallableDef, HirDisplay, InFile, Name,
+};
 
 /// hir::Crate describes a single crate. It's the main interface with which
 /// a crate's dependencies interact. Mostly, it should be just a proxy for the
@@ -285,10 +289,10 @@ impl Module {
     /// this module, if possible.
     pub fn find_use_path(
         self,
-        db: &dyn HirDatabase,
+        db: &dyn DefDatabase,
         item: ItemInNs,
     ) -> Option<hir_def::path::ModPath> {
-        hir_def::find_path::find_path(db.upcast(), item, self.into())
+        hir_def::find_path::find_path(db, item, self.into())
     }
 }
 

--- a/crates/ra_hir/src/from_id.rs
+++ b/crates/ra_hir/src/from_id.rs
@@ -9,8 +9,8 @@ use hir_def::{
 };
 
 use crate::{
-    Adt, AssocItem, AttrDef, DefWithBody, EnumVariant, GenericDef, Local, ModuleDef, StructField,
-    VariantDef,
+    code_model::ItemInNs, Adt, AssocItem, AttrDef, DefWithBody, EnumVariant, GenericDef, Local,
+    MacroDef, ModuleDef, StructField, VariantDef,
 };
 
 macro_rules! from_id {
@@ -226,5 +226,22 @@ impl From<AssocItem> for GenericDefId {
 impl From<(DefWithBodyId, PatId)> for Local {
     fn from((parent, pat_id): (DefWithBodyId, PatId)) -> Self {
         Local { parent, pat_id }
+    }
+}
+
+impl From<MacroDef> for ItemInNs {
+    fn from(macro_def: MacroDef) -> Self {
+        ItemInNs::Macros(macro_def.into())
+    }
+}
+
+impl From<ModuleDef> for ItemInNs {
+    fn from(module_def: ModuleDef) -> Self {
+        match module_def {
+            ModuleDef::Static(_) | ModuleDef::Const(_) | ModuleDef::Function(_) => {
+                ItemInNs::Values(module_def.into())
+            }
+            _ => ItemInNs::Types(module_def.into()),
+        }
     }
 }

--- a/crates/ra_ide_db/Cargo.toml
+++ b/crates/ra_ide_db/Cargo.toml
@@ -17,6 +17,7 @@ fst = { version = "0.4", default-features = false }
 rustc-hash = "1.1.0"
 superslice = "1.0.0"
 once_cell = "1.3.1"
+either = "1.5.3"
 
 ra_syntax = { path = "../ra_syntax" }
 ra_text_edit = { path = "../ra_text_edit" }

--- a/crates/ra_ide_db/src/imports_locator.rs
+++ b/crates/ra_ide_db/src/imports_locator.rs
@@ -1,7 +1,7 @@
 //! This module contains an import search funcionality that is provided to the ra_assists module.
 //! Later, this should be moved away to a separate crate that is accessible from the ra_assists module.
 
-use hir::Semantics;
+use hir::{MacroDef, ModuleDef, Semantics};
 use ra_prof::profile;
 use ra_syntax::{ast, AstNode, SyntaxKind::NAME};
 
@@ -10,6 +10,7 @@ use crate::{
     symbol_index::{self, FileSymbol, Query},
     RootDatabase,
 };
+use either::Either;
 
 pub struct ImportsLocator<'a> {
     sema: Semantics<'a, RootDatabase>,
@@ -20,7 +21,7 @@ impl<'a> ImportsLocator<'a> {
         Self { sema: Semantics::new(db) }
     }
 
-    pub fn find_imports(&mut self, name_to_import: &str) -> Vec<Definition> {
+    pub fn find_imports(&mut self, name_to_import: &str) -> Vec<Either<ModuleDef, MacroDef>> {
         let _p = profile("search_for_imports");
         let db = self.sema.db;
 
@@ -42,6 +43,11 @@ impl<'a> ImportsLocator<'a> {
             .into_iter()
             .chain(lib_results.into_iter())
             .filter_map(|import_candidate| self.get_name_definition(&import_candidate))
+            .filter_map(|name_definition_to_import| match name_definition_to_import {
+                Definition::ModuleDef(module_def) => Some(Either::Left(module_def)),
+                Definition::Macro(macro_def) => Some(Either::Right(macro_def)),
+                _ => None,
+            })
             .collect()
     }
 

--- a/crates/ra_ide_db/src/imports_locator.rs
+++ b/crates/ra_ide_db/src/imports_locator.rs
@@ -1,7 +1,7 @@
 //! This module contains an import search funcionality that is provided to the ra_assists module.
 //! Later, this should be moved away to a separate crate that is accessible from the ra_assists module.
 
-use hir::{ModuleDef, Semantics};
+use hir::Semantics;
 use ra_prof::profile;
 use ra_syntax::{ast, AstNode, SyntaxKind::NAME};
 
@@ -20,7 +20,7 @@ impl<'a> ImportsLocator<'a> {
         Self { sema: Semantics::new(db) }
     }
 
-    pub fn find_imports(&mut self, name_to_import: &str) -> Vec<ModuleDef> {
+    pub fn find_imports(&mut self, name_to_import: &str) -> Vec<Definition> {
         let _p = profile("search_for_imports");
         let db = self.sema.db;
 
@@ -42,10 +42,6 @@ impl<'a> ImportsLocator<'a> {
             .into_iter()
             .chain(lib_results.into_iter())
             .filter_map(|import_candidate| self.get_name_definition(&import_candidate))
-            .filter_map(|name_definition_to_import| match name_definition_to_import {
-                Definition::ModuleDef(module_def) => Some(module_def),
-                _ => None,
-            })
             .collect()
     }
 


### PR DESCRIPTION
If I got it right, assists test infra does not support multiple crates snippets (https://github.com/rust-analyzer/rust-analyzer/blob/2720e2374be951bb762ff2815dd67c7ffe3419b7/crates/ra_hir_def/src/nameres/tests.rs#L491) hence no tests added for the macro import.