### PR TITLE
implement fill match arm assist for tuple of enums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,6 +876,7 @@ name = "ra_assists"
 version = "0.1.0"
 dependencies = [
  "format-buf",
+ "itertools",
  "join_to_string",
  "ra_db",
  "ra_fmt",

--- a/crates/ra_assists/Cargo.toml
+++ b/crates/ra_assists/Cargo.toml
@@ -11,6 +11,7 @@ doctest = false
 format-buf = "1.0.0"
 join_to_string = "0.1.3"
 rustc-hash = "1.1.0"
+itertools = "0.8.2"
 
 ra_syntax = { path = "../ra_syntax" }
 ra_text_edit = { path = "../ra_text_edit" }

--- a/crates/ra_syntax/src/ast/make.rs
+++ b/crates/ra_syntax/src/ast/make.rs
@@ -136,6 +136,15 @@ pub fn placeholder_pat() -> ast::PlaceholderPat {
     }
 }
 
+pub fn tuple_pat(pats: impl IntoIterator<Item = ast::Pat>) -> ast::TuplePat {
+    let pats_str = pats.into_iter().map(|p| p.syntax().to_string()).join(", ");
+    return from_text(&format!("({})", pats_str));
+
+    fn from_text(text: &str) -> ast::TuplePat {
+        ast_from_text(&format!("fn f({}: ())", text))
+    }
+}
+
 pub fn tuple_struct_pat(
     path: ast::Path,
     pats: impl IntoIterator<Item = ast::Pat>,

--- a/crates/ra_syntax/src/ast/make.rs
+++ b/crates/ra_syntax/src/ast/make.rs
@@ -136,8 +136,13 @@ pub fn placeholder_pat() -> ast::PlaceholderPat {
     }
 }
 
+/// Creates a tuple of patterns from an interator of patterns.
+///
+/// Invariant: `pats` must be length > 1
+///
+/// FIXME handle `pats` length == 1
 pub fn tuple_pat(pats: impl IntoIterator<Item = ast::Pat>) -> ast::TuplePat {
-    let pats_str = pats.into_iter().map(|p| p.syntax().to_string()).join(", ");
+    let pats_str = pats.into_iter().map(|p| p.to_string()).join(", ");
     return from_text(&format!("({})", pats_str));
 
     fn from_text(text: &str) -> ast::TuplePat {


### PR DESCRIPTION
This updates the fill match arm assist to work in cases where the user is matching on a tuple of enums. 

Note, for now this does not apply when some match arms exist (other than the trivial `_`), but I think this could be added in the future.

I think this also lays the groundwork for filling match arms when matching on tuples of non-enum values, for example a tuple of an enum and a boolean.