### PR TITLE
ra_hir: dont expose ra_hir_ty api

### DIFF
--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -60,4 +60,4 @@ pub use hir_def::{
 pub use hir_expand::{
     name::Name, HirFileId, InFile, MacroCallId, MacroCallLoc, MacroDefId, MacroFile, Origin,
 };
-pub use hir_ty::{display::HirDisplay, CallableDef};
+pub use hir_ty::{display::HirDisplay};

--- a/crates/ra_hir_ty/src/lib.rs
+++ b/crates/ra_hir_ty/src/lib.rs
@@ -664,10 +664,10 @@ impl Ty {
         }
     }
 
-    pub fn as_callable(&self) -> Option<(CallableDef, &Substs)> {
+    pub fn as_callable(&self) -> Option<CallableDef> {
         match self {
-            Ty::Apply(ApplicationTy { ctor: TypeCtor::FnDef(callable_def), parameters }) => {
-                Some((*callable_def, parameters))
+            Ty::Apply(ApplicationTy { ctor: TypeCtor::FnDef(callable_def), .. }) => {
+                Some(*callable_def)
             }
             _ => None,
         }


### PR DESCRIPTION
I have doubts about the api. Used some `expect()`s since otherwise, we may silence a bug with invariants.
@matklad what would you do in this case?