### PR TITLE
Add ItemScope::visibility_of

### DIFF
--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -234,6 +234,10 @@ impl Module {
             .collect()
     }
 
+    pub fn visibility_of(self, db: &dyn HirDatabase, def: &ModuleDef) -> Option<Visibility> {
+        db.crate_def_map(self.id.krate)[self.id.local_id].scope.visbility_of(def.clone().into())
+    }
+
     pub fn diagnostics(self, db: &dyn HirDatabase, sink: &mut DiagnosticSink) {
         let _p = profile("Module::diagnostics");
         let crate_def_map = db.crate_def_map(self.id.krate);

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -54,7 +54,7 @@ pub use crate::{
         Adt, AsAssocItem, AssocItem, AssocItemContainer, AttrDef, Const, Crate, CrateDependency,
         DefWithBody, Docs, Enum, EnumVariant, FieldSource, Function, GenericDef, HasAttrs,
         HasVisibility, ImplDef, Local, MacroDef, Module, ModuleDef, ScopeDef, Static, Struct,
-        StructField, Trait, Type, TypeAlias, TypeParam, Union, VariantDef,
+        StructField, Trait, Type, TypeAlias, TypeParam, Union, VariantDef, Visibility,
     },
     has_source::HasSource,
     semantics::{original_range, PathResolution, Semantics, SemanticsScope},

--- a/crates/ra_hir_def/src/item_scope.rs
+++ b/crates/ra_hir_def/src/item_scope.rs
@@ -68,6 +68,12 @@ impl ItemScope {
         self.impls.iter().copied()
     }
 
+    pub fn visbility_of(&self, def: ModuleDefId) -> Option<Visibility> {
+        self.name_of(ItemInNs::Types(def))
+            .or_else(|| self.name_of(ItemInNs::Values(def)))
+            .map(|(_, v)| v)
+    }
+
     /// Iterate over all module scoped macros
     pub(crate) fn macros<'a>(&'a self) -> impl Iterator<Item = (&'a Name, MacroDefId)> + 'a {
         self.visible.iter().filter_map(|(name, def)| def.take_macros().map(|macro_| (name, macro_)))


### PR DESCRIPTION
~This PR implements `HasVisibility` for various constructs and change `Definition::search_scope` to use `Visibility` directly instead of depends on ad-hoc string parsing.~

This PR added `visibility_of`  in `ItemScope` and `Module` and use it directly directly instead of depends on ad-hoc string parsing.

And also add a FIXME to indicate that there is a bug which do not search child-submodules in other files recursively in `Definition::search_scope`.

I will submit another PR to fix that bug after this is merged.

cc @flodiebold 