### PR TITLE
Inlay hints for method chaining pattern

### DIFF
--- a/crates/ra_ide/src/inlay_hints.rs
+++ b/crates/ra_ide/src/inlay_hints.rs
@@ -76,7 +76,6 @@ fn get_chaining_hints(
     }
 
     let ty = sema.type_of_expr(&expr)?;
-    let label = ty.display_truncated(sema.db, options.max_length).to_string();
     if ty.is_unknown() {
         return None;
     }
@@ -96,6 +95,7 @@ fn get_chaining_hints(
     let next = tokens.next()?.kind();
     let next_next = tokens.next()?.kind();
     if next == SyntaxKind::WHITESPACE && next_next == SyntaxKind::DOT {
+        let label = ty.display_truncated(sema.db, options.max_length).to_string();
         acc.push(InlayHint {
             range: expr.syntax().text_range(),
             kind: InlayKind::ChainingHint,
@@ -1105,7 +1105,7 @@ fn main() {
             r#"
             struct A(B);
             impl A { fn into_b(self) -> B { self.0 } }
-            struct B(C)
+            struct B(C);
             impl B { fn into_c(self) -> C { self.0 } }
             struct C;
 
@@ -1118,12 +1118,12 @@ fn main() {
         assert_debug_snapshot!(analysis.inlay_hints(file_id, &InlayHintsOptions{ parameter_hints: false, type_hints: false, chaining_hints: true, max_length: None}).unwrap(), @r###"
         [
             InlayHint {
-                range: [231; 268),
+                range: [232; 269),
                 kind: ChainingHint,
                 label: "B",
             },
             InlayHint {
-                range: [231; 238),
+                range: [232; 239),
                 kind: ChainingHint,
                 label: "A",
             },
@@ -1136,7 +1136,7 @@ fn main() {
             r#"
             struct A(B);
             impl A { fn into_b(self) -> B { self.0 } }
-            struct B(C)
+            struct B(C);
             impl B { fn into_c(self) -> C { self.0 } }
             struct C;
 

--- a/crates/ra_ide/src/inlay_hints.rs
+++ b/crates/ra_ide/src/inlay_hints.rs
@@ -5,7 +5,7 @@ use ra_ide_db::RootDatabase;
 use ra_prof::profile;
 use ra_syntax::{
     ast::{self, ArgListOwner, AstNode, TypeAscriptionOwner},
-    match_ast, SmolStr, TextRange, NodeOrToken, SyntaxKind, Direction
+    match_ast, Direction, NodeOrToken, SmolStr, SyntaxKind, TextRange,
 };
 
 use crate::{FileId, FunctionSignature};
@@ -20,12 +20,7 @@ pub struct InlayHintsOptions {
 
 impl Default for InlayHintsOptions {
     fn default() -> Self {
-        Self { 
-            type_hints: true, 
-            parameter_hints: true, 
-            chaining_hints: true,
-            max_length: None 
-        }
+        Self { type_hints: true, parameter_hints: true, chaining_hints: true, max_length: None }
     }
 }
 
@@ -86,7 +81,8 @@ fn get_chaining_hints(
         return None;
     }
 
-    let mut tokens = expr.syntax()
+    let mut tokens = expr
+        .syntax()
         .siblings_with_tokens(Direction::Next)
         .filter_map(NodeOrToken::into_token)
         .filter(|t| match t.kind() {
@@ -99,7 +95,7 @@ fn get_chaining_hints(
     // Ignoring extra whitespace and comments
     let next = tokens.next()?.kind();
     let next_next = tokens.next()?.kind();
-    if next == SyntaxKind::WHITESPACE && next_next == SyntaxKind::DOT { 
+    if next == SyntaxKind::WHITESPACE && next_next == SyntaxKind::DOT {
         acc.push(InlayHint {
             range: expr.syntax().text_range(),
             kind: InlayKind::ChainingHint,
@@ -1190,11 +1186,11 @@ fn main() {
     fn generic_chaining_hints() {
         let (analysis, file_id) = single_file(
             r#"
-            struct A<T>(T); 
+            struct A<T>(T);
             struct B<T>(T);
             struct C<T>(T);
             struct X<T,R>(T, R);
-            
+
             impl<T> A<T> {
                 fn new(t: T) -> Self { A(t) }
                 fn into_b(self) -> B<T> { B(self.0) }
@@ -1211,12 +1207,12 @@ fn main() {
         assert_debug_snapshot!(analysis.inlay_hints(file_id, &InlayHintsOptions{ parameter_hints: false, type_hints: false, chaining_hints: true, max_length: None}).unwrap(), @r###"
         [
             InlayHint {
-                range: [416; 465),
+                range: [403; 452),
                 kind: ChainingHint,
                 label: "B<X<i32, bool>>",
             },
             InlayHint {
-                range: [416; 435),
+                range: [403; 422),
                 kind: ChainingHint,
                 label: "A<X<i32, bool>>",
             },

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -34,6 +34,8 @@ pub struct ServerConfig {
     pub inlay_hints_type: bool,
     #[serde(deserialize_with = "nullable_bool_true")]
     pub inlay_hints_parameter: bool,
+    #[serde(deserialize_with = "nullable_bool_true")]
+    pub inlay_hints_chaining: bool,
     pub inlay_hints_max_length: Option<usize>,
 
     pub cargo_watch_enable: bool,
@@ -66,6 +68,7 @@ impl Default for ServerConfig {
             lru_capacity: None,
             inlay_hints_type: true,
             inlay_hints_parameter: true,
+            inlay_hints_chaining: true,
             inlay_hints_max_length: None,
             cargo_watch_enable: true,
             cargo_watch_args: Vec::new(),

--- a/crates/rust-analyzer/src/conv.rs
+++ b/crates/rust-analyzer/src/conv.rs
@@ -332,6 +332,7 @@ impl ConvWith<&LineIndex> for InlayHint {
             kind: match self.kind {
                 InlayKind::ParameterHint => req::InlayKind::ParameterHint,
                 InlayKind::TypeHint => req::InlayKind::TypeHint,
+                InlayKind::ChainingHint => req::InlayKind::ChainingHint,
             },
         }
     }

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -183,6 +183,7 @@ pub fn main_loop(
                 inlay_hints: InlayHintsOptions {
                     type_hints: config.inlay_hints_type,
                     parameter_hints: config.inlay_hints_parameter,
+                    chaining_hints: config.inlay_hints_chaining,
                     max_length: config.inlay_hints_max_length,
                 },
                 cargo_watch: CheckOptions {

--- a/crates/rust-analyzer/src/req.rs
+++ b/crates/rust-analyzer/src/req.rs
@@ -200,6 +200,7 @@ pub struct InlayHintsParams {
 pub enum InlayKind {
     TypeHint,
     ParameterHint,
+    ChainingHint,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/docs/user/features.md
+++ b/docs/user/features.md
@@ -185,6 +185,7 @@ These contain extended information on the hovered language item.
 Two types of inlay hints are displayed currently:
 
 * type hints, displaying the minimal information on the type of the expression (if the information is available)
+* method chaining hints, type information for multi-line method chains
 * parameter name hints, displaying the names of the parameters in the corresponding methods
 
 #### VS Code
@@ -192,6 +193,7 @@ Two types of inlay hints are displayed currently:
 In VS Code, the following settings can be used to configure the inlay hints:
 
 * `rust-analyzer.inlayHints.typeHints` - enable hints for inferred types.
+* `rust-analyzer.inlayHints.chainingHints` - enable hints for inferred types on method chains.
 * `rust-analyzer.inlayHints.parameterHints` - enable hints for function parameters.
 * `rust-analyzer.inlayHints.maxLength` — shortens the hints if their length exceeds the value specified. If no value is specified (`null`), no shortening is applied.
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -333,6 +333,11 @@
                     "default": true,
                     "description": "Whether to show inlay type hints"
                 },
+                "rust-analyzer.inlayHints.chainingHints": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether to show inlay type hints for method chains"
+                },
                 "rust-analyzer.inlayHints.parameterHints": {
                     "type": "boolean",
                     "default": true,

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -32,6 +32,7 @@ export async function createClient(config: Config, serverPath: string): Promise<
 
             inlayHintsType: config.inlayHints.typeHints,
             inlayHintsParameter: config.inlayHints.parameterHints,
+            inlayHintsChaining: config.inlayHints.chainingHints,
             inlayHintsMaxLength: config.inlayHints.maxLength,
 
             cargoWatchEnable: cargoWatchOpts.enable,

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -88,6 +88,7 @@ export class Config {
         return {
             typeHints: this.cfg.get<boolean>("inlayHints.typeHints")!,
             parameterHints: this.cfg.get<boolean>("inlayHints.parameterHints")!,
+            chainingHints: this.cfg.get<boolean>("inlayHints.chainingHints")!,
             maxLength: this.cfg.get<null | number>("inlayHints.maxLength")!,
         };
     }

--- a/editors/code/src/rust-analyzer-api.ts
+++ b/editors/code/src/rust-analyzer-api.ts
@@ -86,12 +86,13 @@ export interface Runnable {
 }
 export const runnables = request<RunnablesParams, Vec<Runnable>>("runnables");
 
-export type InlayHint = InlayHint.TypeHint | InlayHint.ParamHint;
+export type InlayHint = InlayHint.TypeHint | InlayHint.ParamHint | InlayHint.ChainingHint;
 
 export namespace InlayHint {
     export const enum Kind {
         TypeHint = "TypeHint",
         ParamHint = "ParameterHint",
+        ChainingHint = "ChainingHint",
     }
     interface Common {
         range: lc.Range;
@@ -99,6 +100,7 @@ export namespace InlayHint {
     }
     export type TypeHint = Common & { kind: Kind.TypeHint };
     export type ParamHint = Common & { kind: Kind.ParamHint };
+    export type ChainingHint = Common & { kind: Kind.ChainingHint };
 }
 export interface InlayHintsParams {
     textDocument: lc.TextDocumentIdentifier;


### PR DESCRIPTION
This PR adds inlay hints on method call chains:
![image](https://user-images.githubusercontent.com/13765376/77472008-8dc2a880-6e13-11ea-9c18-2c2e2b809799.png)

It is not only explicit `MethodCall`s where this can be helpful. The heuristic used here is that whenever any expression is followed by a new line and then a dot, it resembles a call chain and type information can be  #useful.

Changes:
- A new `InlayKind` for chaining.
- New option for disabling this type of hints.
- Tree traversal rules for identifying the chaining hints.
- VSCode decorators in the extension layer (and associated types).

Notes:
- IntelliJ has additional rules and configuration on this topic. Eg. minimum length of chain to start displaying hints and only displaying distinct types in the chain.
- I am checking for chaining on every `ast::Expr` in the tree; Are there performance concerns there?

This is my first contribution (to RA and to Rust in general) so would appreciate any feedback.
The only issue I can find the references this feature is #2741.