### PR TITLE
Introduce ra_proc_macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,6 +926,7 @@ name = "ra_db"
 version = "0.1.0"
 dependencies = [
  "ra_cfg",
+ "ra_proc_macro",
  "ra_prof",
  "ra_syntax",
  "relative-path",
@@ -1110,6 +1111,7 @@ dependencies = [
  "ra_cargo_watch",
  "ra_cfg",
  "ra_db",
+ "ra_proc_macro",
  "rustc-hash",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,6 +1082,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ra_proc_macro"
+version = "0.1.0"
+dependencies = [
+ "ra_mbe",
+ "ra_tt",
+]
+
+[[package]]
 name = "ra_prof"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,9 +926,9 @@ name = "ra_db"
 version = "0.1.0"
 dependencies = [
  "ra_cfg",
- "ra_proc_macro",
  "ra_prof",
  "ra_syntax",
+ "ra_tt",
  "relative-path",
  "rustc-hash",
  "salsa",
@@ -1086,7 +1086,6 @@ dependencies = [
 name = "ra_proc_macro"
 version = "0.1.0"
 dependencies = [
- "ra_mbe",
  "ra_tt",
 ]
 

--- a/crates/ra_db/Cargo.toml
+++ b/crates/ra_db/Cargo.toml
@@ -15,4 +15,5 @@ rustc-hash = "1.1.0"
 ra_syntax = { path = "../ra_syntax" }
 ra_cfg = { path = "../ra_cfg" }
 ra_prof = { path = "../ra_prof" }
+ra_proc_macro = { path = "../ra_proc_macro" }
 test_utils = { path = "../test_utils" }

--- a/crates/ra_db/Cargo.toml
+++ b/crates/ra_db/Cargo.toml
@@ -15,5 +15,5 @@ rustc-hash = "1.1.0"
 ra_syntax = { path = "../ra_syntax" }
 ra_cfg = { path = "../ra_cfg" }
 ra_prof = { path = "../ra_prof" }
-ra_proc_macro = { path = "../ra_proc_macro" }
+ra_tt = { path = "../ra_tt" }
 test_utils = { path = "../test_utils" }

--- a/crates/ra_db/src/fixture.rs
+++ b/crates/ra_db/src/fixture.rs
@@ -70,6 +70,7 @@ fn with_single_file(db: &mut dyn SourceDatabaseExt, ra_fixture: &str) -> FileId 
             meta.cfg,
             meta.env,
             Default::default(),
+            Default::default(),
         );
         crate_graph
     } else {
@@ -80,6 +81,7 @@ fn with_single_file(db: &mut dyn SourceDatabaseExt, ra_fixture: &str) -> FileId 
             None,
             CfgOptions::default(),
             Env::default(),
+            Default::default(),
             Default::default(),
         );
         crate_graph
@@ -130,6 +132,7 @@ fn with_files(db: &mut dyn SourceDatabaseExt, fixture: &str) -> Option<FilePosit
                 meta.cfg,
                 meta.env,
                 Default::default(),
+                Default::default(),
             );
             let prev = crates.insert(krate.clone(), crate_id);
             assert!(prev.is_none());
@@ -166,6 +169,7 @@ fn with_files(db: &mut dyn SourceDatabaseExt, fixture: &str) -> Option<FilePosit
             None,
             CfgOptions::default(),
             Env::default(),
+            Default::default(),
             Default::default(),
         );
     } else {

--- a/crates/ra_db/src/input.rs
+++ b/crates/ra_db/src/input.rs
@@ -19,6 +19,7 @@ use rustc_hash::FxHashSet;
 
 use crate::{RelativePath, RelativePathBuf};
 use fmt::Display;
+use ra_proc_macro::ProcMacro;
 
 /// `FileId` is an integer which uniquely identifies a file. File paths are
 /// messy and system-dependent, so most of the code should work directly with
@@ -115,6 +116,9 @@ impl Display for CrateName {
     }
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct ProcMacroId(pub usize);
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CrateData {
     pub root_file_id: FileId,
@@ -127,6 +131,7 @@ pub struct CrateData {
     pub env: Env,
     pub extern_source: ExternSource,
     pub dependencies: Vec<Dependency>,
+    pub proc_macro: Vec<ProcMacro>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -166,6 +171,7 @@ impl CrateGraph {
         cfg_options: CfgOptions,
         env: Env,
         extern_source: ExternSource,
+        proc_macro: Vec<ProcMacro>,
     ) -> CrateId {
         let data = CrateData {
             root_file_id: file_id,
@@ -174,6 +180,7 @@ impl CrateGraph {
             cfg_options,
             env,
             extern_source,
+            proc_macro,
             dependencies: Vec::new(),
         };
         let crate_id = CrateId(self.arena.len() as u32);
@@ -345,6 +352,7 @@ mod tests {
             CfgOptions::default(),
             Env::default(),
             Default::default(),
+            Default::default(),
         );
         let crate2 = graph.add_crate_root(
             FileId(2u32),
@@ -353,6 +361,7 @@ mod tests {
             CfgOptions::default(),
             Env::default(),
             Default::default(),
+            Default::default(),
         );
         let crate3 = graph.add_crate_root(
             FileId(3u32),
@@ -360,6 +369,7 @@ mod tests {
             None,
             CfgOptions::default(),
             Env::default(),
+            Default::default(),
             Default::default(),
         );
         assert!(graph.add_dep(crate1, CrateName::new("crate2").unwrap(), crate2).is_ok());
@@ -377,6 +387,7 @@ mod tests {
             CfgOptions::default(),
             Env::default(),
             Default::default(),
+            Default::default(),
         );
         let crate2 = graph.add_crate_root(
             FileId(2u32),
@@ -385,6 +396,7 @@ mod tests {
             CfgOptions::default(),
             Env::default(),
             Default::default(),
+            Default::default(),
         );
         let crate3 = graph.add_crate_root(
             FileId(3u32),
@@ -392,6 +404,7 @@ mod tests {
             None,
             CfgOptions::default(),
             Env::default(),
+            Default::default(),
             Default::default(),
         );
         assert!(graph.add_dep(crate1, CrateName::new("crate2").unwrap(), crate2).is_ok());
@@ -408,6 +421,7 @@ mod tests {
             CfgOptions::default(),
             Env::default(),
             Default::default(),
+            Default::default(),
         );
         let crate2 = graph.add_crate_root(
             FileId(2u32),
@@ -415,6 +429,7 @@ mod tests {
             None,
             CfgOptions::default(),
             Env::default(),
+            Default::default(),
             Default::default(),
         );
         assert!(graph

--- a/crates/ra_db/src/lib.rs
+++ b/crates/ra_db/src/lib.rs
@@ -12,9 +12,10 @@ pub use crate::{
     cancellation::Canceled,
     input::{
         CrateGraph, CrateId, CrateName, Dependency, Edition, Env, ExternSource, ExternSourceId,
-        FileId, SourceRoot, SourceRootId,
+        FileId, ProcMacroId, SourceRoot, SourceRootId,
     },
 };
+pub use ra_proc_macro::ProcMacro;
 pub use relative_path::{RelativePath, RelativePathBuf};
 pub use salsa;
 

--- a/crates/ra_db/src/lib.rs
+++ b/crates/ra_db/src/lib.rs
@@ -15,7 +15,6 @@ pub use crate::{
         FileId, ProcMacroId, SourceRoot, SourceRootId,
     },
 };
-pub use ra_proc_macro::ProcMacro;
 pub use relative_path::{RelativePath, RelativePathBuf};
 pub use salsa;
 

--- a/crates/ra_hir_def/src/nameres/collector.rs
+++ b/crates/ra_hir_def/src/nameres/collector.rs
@@ -12,7 +12,7 @@ use hir_expand::{
 };
 use ra_cfg::CfgOptions;
 use ra_db::{CrateId, FileId, ProcMacroId};
-use ra_syntax::{ast, SmolStr};
+use ra_syntax::ast;
 use rustc_hash::FxHashMap;
 use test_utils::tested_by;
 
@@ -59,8 +59,8 @@ pub(super) fn collect_defs(db: &dyn DefDatabase, mut def_map: CrateDefMap) -> Cr
         .enumerate()
         .map(|(idx, it)| {
             // FIXME: a hacky way to create a Name from string.
-            let name = tt::Ident { text: SmolStr::new(&it.name()), id: tt::TokenId::unspecified() };
-            (name.as_name(), ProcMacroExpander::new(def_map.krate, ProcMacroId(idx)))
+            let name = tt::Ident { text: it.name.clone(), id: tt::TokenId::unspecified() };
+            (name.as_name(), ProcMacroExpander::new(def_map.krate, ProcMacroId(idx as u32)))
         })
         .collect();
 

--- a/crates/ra_hir_expand/src/proc_macro.rs
+++ b/crates/ra_hir_expand/src/proc_macro.rs
@@ -23,9 +23,10 @@ impl ProcMacroExpander {
         let krate_graph = db.crate_graph();
         let proc_macro = krate_graph[self.krate]
             .proc_macro
-            .get(self.proc_macro_id.0)
+            .get(self.proc_macro_id.0 as usize)
             .clone()
             .ok_or_else(|| mbe::ExpandError::ConversionError)?;
-        proc_macro.custom_derive(tt)
+
+        proc_macro.expander.expand(&tt, None).map_err(mbe::ExpandError::from)
     }
 }

--- a/crates/ra_ide/src/lib.rs
+++ b/crates/ra_ide/src/lib.rs
@@ -213,6 +213,7 @@ impl Analysis {
             cfg_options,
             Env::default(),
             Default::default(),
+            Default::default(),
         );
         change.add_file(source_root, file_id, "main.rs".into(), Arc::new(text));
         change.set_crate_graph(crate_graph);

--- a/crates/ra_ide/src/mock_analysis.rs
+++ b/crates/ra_ide/src/mock_analysis.rs
@@ -103,6 +103,7 @@ impl MockAnalysis {
                     cfg_options,
                     Env::default(),
                     Default::default(),
+                    Default::default(),
                 ));
             } else if path.ends_with("/lib.rs") {
                 let crate_name = path.parent().unwrap().file_name().unwrap();
@@ -112,6 +113,7 @@ impl MockAnalysis {
                     Some(CrateName::new(crate_name).unwrap()),
                     cfg_options,
                     Env::default(),
+                    Default::default(),
                     Default::default(),
                 );
                 if let Some(root_crate) = root_crate {

--- a/crates/ra_ide/src/parent_module.rs
+++ b/crates/ra_ide/src/parent_module.rs
@@ -137,6 +137,7 @@ mod tests {
             CfgOptions::default(),
             Env::default(),
             Default::default(),
+            Default::default(),
         );
         let mut change = AnalysisChange::new();
         change.set_crate_graph(crate_graph);

--- a/crates/ra_mbe/src/lib.rs
+++ b/crates/ra_mbe/src/lib.rs
@@ -28,6 +28,13 @@ pub enum ExpandError {
     BindingError(String),
     ConversionError,
     InvalidRepeat,
+    ProcMacroError(tt::ExpansionError),
+}
+
+impl From<tt::ExpansionError> for ExpandError {
+    fn from(it: tt::ExpansionError) -> Self {
+        ExpandError::ProcMacroError(it)
+    }
 }
 
 pub use crate::syntax_bridge::{

--- a/crates/ra_proc_macro/Cargo.toml
+++ b/crates/ra_proc_macro/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+edition = "2018"
+name = "ra_proc_macro"
+version = "0.1.0"
+authors = ["rust-analyzer developers"]
+publish = false
+
+[lib]
+doctest = false
+
+[dependencies]
+ra_tt = { path = "../ra_tt" }
+ra_mbe = { path = "../ra_mbe" }

--- a/crates/ra_proc_macro/Cargo.toml
+++ b/crates/ra_proc_macro/Cargo.toml
@@ -10,4 +10,3 @@ doctest = false
 
 [dependencies]
 ra_tt = { path = "../ra_tt" }
-ra_mbe = { path = "../ra_mbe" }

--- a/crates/ra_proc_macro/src/lib.rs
+++ b/crates/ra_proc_macro/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/crates/ra_proc_macro/src/lib.rs
+++ b/crates/ra_proc_macro/src/lib.rs
@@ -1,7 +1,78 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
+//! Client-side Proc-Macro crate
+//!
+//! We separate proc-macro expanding logic to an extern program to allow
+//! different implementations (e.g. wasm or dylib loading). And this crate
+//! is used for provide basic infra-structure for commnicate between two
+//! process: Client (RA itself), Server (the external program)
+
+use ra_mbe::ExpandError;
+use ra_tt::Subtree;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+trait ProcMacroExpander: std::fmt::Debug + Send + Sync + std::panic::RefUnwindSafe {
+    fn custom_derive(&self, subtree: &Subtree, derive_name: &str) -> Result<Subtree, ExpandError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcMacroProcessExpander {
+    process_path: PathBuf,
+}
+
+impl ProcMacroExpander for ProcMacroProcessExpander {
+    fn custom_derive(
+        &self,
+        _subtree: &Subtree,
+        _derive_name: &str,
+    ) -> Result<Subtree, ExpandError> {
+        // FIXME: do nothing for now
+        Ok(Subtree::default())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ProcMacro {
+    expander: Arc<Box<dyn ProcMacroExpander>>,
+    name: String,
+}
+
+impl Eq for ProcMacro {}
+impl PartialEq for ProcMacro {
+    fn eq(&self, other: &ProcMacro) -> bool {
+        self.name == other.name && Arc::ptr_eq(&self.expander, &other.expander)
+    }
+}
+
+impl ProcMacro {
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    pub fn custom_derive(&self, subtree: &Subtree) -> Result<Subtree, ExpandError> {
+        self.expander.custom_derive(subtree, &self.name)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProcMacroClient {
+    Process { expander: Arc<ProcMacroProcessExpander> },
+    Dummy,
+}
+
+impl ProcMacroClient {
+    pub fn extern_process(process_path: &Path) -> ProcMacroClient {
+        let expander = ProcMacroProcessExpander { process_path: process_path.into() };
+        ProcMacroClient::Process { expander: Arc::new(expander) }
+    }
+
+    pub fn dummy() -> ProcMacroClient {
+        ProcMacroClient::Dummy
+    }
+
+    pub fn by_dylib_path(&self, _dylib_path: &Path) -> Vec<ProcMacro> {
+        // FIXME: return empty for now
+        vec![]
     }
 }

--- a/crates/ra_proc_macro/src/lib.rs
+++ b/crates/ra_proc_macro/src/lib.rs
@@ -5,53 +5,26 @@
 //! is used to provide basic infrastructure  for communication between two
 //! processes: Client (RA itself), Server (the external program)
 
-use ra_mbe::ExpandError;
-use ra_tt::Subtree;
+use ra_tt::{SmolStr, Subtree};
 use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
 
-trait ProcMacroExpander: std::fmt::Debug + Send + Sync + std::panic::RefUnwindSafe {
-    fn custom_derive(&self, subtree: &Subtree, derive_name: &str) -> Result<Subtree, ExpandError>;
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProcMacroProcessExpander {
     process: Arc<ProcMacroProcessSrv>,
+    name: SmolStr,
 }
 
-impl ProcMacroExpander for ProcMacroProcessExpander {
-    fn custom_derive(
+impl ra_tt::TokenExpander for ProcMacroProcessExpander {
+    fn expand(
         &self,
         _subtree: &Subtree,
-        _derive_name: &str,
-    ) -> Result<Subtree, ExpandError> {
+        _attr: Option<&Subtree>,
+    ) -> Result<Subtree, ra_tt::ExpansionError> {
         // FIXME: do nothing for now
         Ok(Subtree::default())
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct ProcMacro {
-    expander: Arc<dyn ProcMacroExpander>,
-    name: String,
-}
-
-impl Eq for ProcMacro {}
-impl PartialEq for ProcMacro {
-    fn eq(&self, other: &ProcMacro) -> bool {
-        self.name == other.name && Arc::ptr_eq(&self.expander, &other.expander)
-    }
-}
-
-impl ProcMacro {
-    pub fn name(&self) -> String {
-        self.name.clone()
-    }
-
-    pub fn custom_derive(&self, subtree: &Subtree) -> Result<Subtree, ExpandError> {
-        self.expander.custom_derive(subtree, &self.name)
     }
 }
 
@@ -76,7 +49,10 @@ impl ProcMacroClient {
         ProcMacroClient::Dummy
     }
 
-    pub fn by_dylib_path(&self, _dylib_path: &Path) -> Vec<ProcMacro> {
+    pub fn by_dylib_path(
+        &self,
+        _dylib_path: &Path,
+    ) -> Vec<(SmolStr, Arc<dyn ra_tt::TokenExpander>)> {
         // FIXME: return empty for now
         vec![]
     }

--- a/crates/ra_project_model/Cargo.toml
+++ b/crates/ra_project_model/Cargo.toml
@@ -17,6 +17,7 @@ ra_arena = { path = "../ra_arena" }
 ra_db = { path = "../ra_db" }
 ra_cfg = { path = "../ra_cfg" }
 ra_cargo_watch = { path = "../ra_cargo_watch" }
+ra_proc_macro =  { path = "../ra_proc_macro" }
 
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.48"

--- a/crates/ra_project_model/src/json_project.rs
+++ b/crates/ra_project_model/src/json_project.rs
@@ -23,6 +23,7 @@ pub struct Crate {
     pub(crate) atom_cfgs: FxHashSet<String>,
     pub(crate) key_value_cfgs: FxHashMap<String, String>,
     pub(crate) out_dir: Option<PathBuf>,
+    pub(crate) proc_macro_dylib_path: Option<PathBuf>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize)]

--- a/crates/ra_tt/src/lib.rs
+++ b/crates/ra_tt/src/lib.rs
@@ -14,9 +14,12 @@ macro_rules! impl_froms {
     }
 }
 
-use std::fmt;
+use std::{
+    fmt::{self, Debug},
+    panic::RefUnwindSafe,
+};
 
-use smol_str::SmolStr;
+pub use smol_str::SmolStr;
 
 /// Represents identity of the token.
 ///
@@ -184,3 +187,11 @@ impl Subtree {
 }
 
 pub mod buffer;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ExpansionError {}
+
+pub trait TokenExpander: Debug + Send + Sync + RefUnwindSafe {
+    fn expand(&self, subtree: &Subtree, attrs: Option<&Subtree>)
+        -> Result<Subtree, ExpansionError>;
+}

--- a/crates/rust-analyzer/src/world.rs
+++ b/crates/rust-analyzer/src/world.rs
@@ -16,7 +16,7 @@ use ra_ide::{
     Analysis, AnalysisChange, AnalysisHost, CrateGraph, FileId, InlayHintsOptions, LibraryData,
     SourceRootId,
 };
-use ra_project_model::{get_rustc_cfg_options, ProjectWorkspace};
+use ra_project_model::{get_rustc_cfg_options, ProcMacroClient, ProjectWorkspace};
 use ra_vfs::{LineEndings, RootEntry, Vfs, VfsChange, VfsFile, VfsRoot, VfsTask, Watch};
 use relative_path::RelativePathBuf;
 
@@ -150,9 +150,19 @@ impl WorldState {
             vfs_file.map(|f| FileId(f.0))
         };
 
+        let proc_macro_client =
+            ProcMacroClient::extern_process(std::path::Path::new("ra_proc_macro_srv"));
+
         workspaces
             .iter()
-            .map(|ws| ws.to_crate_graph(&default_cfg_options, &extern_source_roots, &mut load))
+            .map(|ws| {
+                ws.to_crate_graph(
+                    &default_cfg_options,
+                    &extern_source_roots,
+                    &proc_macro_client,
+                    &mut load,
+                )
+            })
             .for_each(|graph| {
                 crate_graph.extend(graph);
             });


### PR DESCRIPTION
This PR implemented:

1.  Reading dylib path of proc-macro crate from cargo check , similar to how `OUTDIR` is obtained.
2.  Added a new crate `ra_proc_macro` and implement the foot-work for reading result from external proc-macro expander. 
3. Added a struct `ProcMacroClient` , which will be responsible to the client side communication to the External process.

