### PR TITLE
Fix merge-imports assist for wildcard imports

### DIFF
--- a/crates/ra_assists/src/handlers/merge_imports.rs
+++ b/crates/ra_assists/src/handlers/merge_imports.rs
@@ -171,6 +171,34 @@ use std::{fmt::<|>{Display, Debug}};
     }
 
     #[test]
+    fn test_merge_single_wildcard_diff_prefixes() {
+        check_assist(
+            merge_imports,
+            r"
+use std<|>::cell::*;
+use std::str;
+",
+            r"
+use std<|>::{cell::*, str};
+",
+        )
+    }
+
+    #[test]
+    fn test_merge_both_wildcard_diff_prefixes() {
+        check_assist(
+            merge_imports,
+            r"
+use std<|>::cell::*;
+use std::str::*;
+",
+            r"
+use std<|>::{cell::*, str::*};
+",
+        )
+    }
+
+    #[test]
     fn removes_just_enough_whitespace() {
         check_assist(
             merge_imports,

--- a/crates/ra_syntax/src/ast/edit.rs
+++ b/crates/ra_syntax/src/ast/edit.rs
@@ -302,9 +302,10 @@ impl ast::UseTree {
             Some(it) => it,
             None => return self.clone(),
         };
-        let use_tree = make::use_tree(suffix.clone(), self.use_tree_list(), self.alias());
+        let use_tree =
+            make::use_tree(suffix.clone(), self.use_tree_list(), self.alias(), self.has_star());
         let nested = make::use_tree_list(iter::once(use_tree));
-        return make::use_tree(prefix.clone(), Some(nested), None);
+        return make::use_tree(prefix.clone(), Some(nested), None, false);
 
         fn split_path_prefix(prefix: &ast::Path) -> Option<ast::Path> {
             let parent = prefix.parent_path()?;

--- a/crates/ra_syntax/src/ast/make.rs
+++ b/crates/ra_syntax/src/ast/make.rs
@@ -29,12 +29,17 @@ pub fn use_tree(
     path: ast::Path,
     use_tree_list: Option<ast::UseTreeList>,
     alias: Option<ast::Alias>,
+    add_star: bool,
 ) -> ast::UseTree {
     let mut buf = "use ".to_string();
     buf += &path.syntax().to_string();
     if let Some(use_tree_list) = use_tree_list {
         buf += &format!("::{}", use_tree_list);
     }
+    if add_star {
+        buf += "::*";
+    }
+
     if let Some(alias) = alias {
         buf += &format!(" {}", alias);
     }


### PR DESCRIPTION
Refs #3728 

Besides the case mentioned in issue merging two diff-prefix wildcard uses will now work as well e.g. 

```rust
use std::cell::*;
use std::str::*;
```

will translate into:

```rust
use std::{cell::*, str::*}
```

I'd also like to explore usage of the `merge-imports` for same-prefix uses to simplify redundancy, but it seems like an idea for another issue and I'm not sure if it's something that this assist should do e.g.:

```rust
use std::cell::Cell;
use std::cell::*;
```

into:

```rust
use std::cell::*;
```