### PR TITLE
Update docs to mention vscode installation path on macOS

### DIFF
--- a/docs/user/readme.adoc
+++ b/docs/user/readme.adoc
@@ -57,7 +57,7 @@ To disable this notification put the following to `settings.json`
 ----
 ====
 
-The server binary is stored in `~/.config/Code/User/globalStorage/matklad.rust-analyzer` (linux) or in `~/.Library/Application Support/Code/User/globalStorage/matklad.rust-analyzer (macOS)`.
+The server binary is stored in `~/.config/Code/User/globalStorage/matklad.rust-analyzer` (Linux) or in `~/.Library/Application Support/Code/User/globalStorage/matklad.rust-analyzer (macOS)`.
 
 Note that we only support the latest version of VS Code.
 

--- a/docs/user/readme.adoc
+++ b/docs/user/readme.adoc
@@ -57,7 +57,7 @@ To disable this notification put the following to `settings.json`
 ----
 ====
 
-The server binary is stored in `~/.config/Code/User/globalStorage/matklad.rust-analyzer`.
+The server binary is stored in `~/.config/Code/User/globalStorage/matklad.rust-analyzer` (linux) or in `~/.Library/Application Support/Code/User/globalStorage/matklad.rust-analyzer (macOS)`.
 
 Note that we only support the latest version of VS Code.
 


### PR DESCRIPTION
It took me a while to find it on macOS so I thought I'd spare the effort for others ;)