### PR TITLE
Append new match arms rather than replacing all of them

### DIFF
--- a/crates/ra_assists/src/handlers/fill_match_arms.rs
+++ b/crates/ra_assists/src/handlers/fill_match_arms.rs
@@ -665,7 +665,7 @@ mod tests {
             }
             fn foo(a: A) {
                 match a {
-                    // TODO: Fill this in<|>
+                    // foo bar baz<|>
                     A::One => {}
                     // This is where the rest should be
                 }
@@ -678,7 +678,7 @@ mod tests {
             }
             fn foo(a: A) {
                 match <|>a {
-                    // TODO: Fill this in
+                    // foo bar baz
                     A::One => {}
                     // This is where the rest should be
                     A::Two => {}
@@ -699,7 +699,7 @@ mod tests {
             }
             fn foo(a: A) {
                 match a {
-                    // TODO: Fill this in<|>
+                    // foo bar baz<|>
                 }
             }
             "#,
@@ -710,7 +710,7 @@ mod tests {
             }
             fn foo(a: A) {
                 match <|>a {
-                    // TODO: Fill this in
+                    // foo bar baz
                     A::One => {}
                     A::Two => {}
                 }

--- a/crates/ra_assists/src/handlers/fill_match_arms.rs
+++ b/crates/ra_assists/src/handlers/fill_match_arms.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use ra_ide_db::RootDatabase;
 
 use crate::{Assist, AssistCtx, AssistId};
-use ra_syntax::ast::{self, edit::IndentLevel, make, AstNode, NameOwner};
+use ra_syntax::ast::{self, make, AstNode, NameOwner};
 
 use ast::{MatchArm, Pat};
 
@@ -97,10 +97,8 @@ pub(crate) fn fill_match_arms(ctx: AssistCtx) -> Option<Assist> {
     }
 
     ctx.add_assist(AssistId("fill_match_arms"), "Fill match arms", |edit| {
-        arms.extend(missing_arms);
-
-        let indent_level = IndentLevel::from_node(match_arm_list.syntax());
-        let new_arm_list = indent_level.increase_indent(make::match_arm_list(arms));
+        let new_arm_list =
+            match_arm_list.remove_placeholder().append_arms(missing_arms.into_iter());
 
         edit.target(match_expr.syntax().text_range());
         edit.set_cursor(expr.syntax().text_range().start());
@@ -650,6 +648,71 @@ mod tests {
                 match <|>X {
                     X => {}
                     foo::E::Y => {}
+                }
+            }
+            "#,
+        );
+    }
+
+    #[test]
+    fn fill_match_arms_preserves_comments() {
+        check_assist(
+            fill_match_arms,
+            r#"
+            enum A {
+                One,
+                Two,
+            }
+            fn foo(a: A) {
+                match a {
+                    // TODO: Fill this in<|>
+                    A::One => {}
+                    // This is where the rest should be
+                }
+            }
+            "#,
+            r#"
+            enum A {
+                One,
+                Two,
+            }
+            fn foo(a: A) {
+                match <|>a {
+                    // TODO: Fill this in
+                    A::One => {}
+                    // This is where the rest should be
+                    A::Two => {}
+                }
+            }
+            "#,
+        );
+    }
+
+    #[test]
+    fn fill_match_arms_preserves_comments_empty() {
+        check_assist(
+            fill_match_arms,
+            r#"
+            enum A {
+                One,
+                Two,
+            }
+            fn foo(a: A) {
+                match a {
+                    // TODO: Fill this in<|>
+                }
+            }
+            "#,
+            r#"
+            enum A {
+                One,
+                Two,
+            }
+            fn foo(a: A) {
+                match <|>a {
+                    // TODO: Fill this in
+                    A::One => {}
+                    A::Two => {}
                 }
             }
             "#,

--- a/crates/ra_syntax/src/ast/edit.rs
+++ b/crates/ra_syntax/src/ast/edit.rs
@@ -364,8 +364,7 @@ impl ast::MatchArmList {
             Some(s) => s,
             None => start.clone(),
         };
-        let res = self.replace_children(start..=end, &mut iter::empty());
-        res
+        self.replace_children(start..=end, &mut iter::empty())
     }
 
     #[must_use]
@@ -411,8 +410,7 @@ impl ast::MatchArmList {
         let ws = tokens::WsBuilder::new(&format!("\n{}", indent));
         let to_insert: ArrayVec<[SyntaxElement; 2]> =
             [ws.ws().into(), item.syntax().clone().into()].into();
-        let res = self.insert_children(position, to_insert);
-        res
+        self.insert_children(position, to_insert)
     }
 }
 

--- a/crates/ra_syntax/src/ast/edit.rs
+++ b/crates/ra_syntax/src/ast/edit.rs
@@ -390,26 +390,12 @@ impl ast::MatchArmList {
             Some(t) => t,
             None => return self.clone(),
         };
-        let mut sib = r_curly.prev_sibling_or_token();
-        while let Some(s) = sib.clone() {
-            if let Some(tok) = s.as_token() {
-                if tok.kind() != WHITESPACE {
-                    break;
-                }
-                sib = s.prev_sibling_or_token();
-            } else {
-                break;
-            }
-        }
-        let indent = "    ".to_string() + &leading_indent(self.syntax()).unwrap_or_default();
-        let sib = match sib {
-            Some(s) => s,
-            None => return self.clone(),
-        };
-        let position = InsertPosition::After(sib.into());
-        let ws = tokens::WsBuilder::new(&format!("\n{}", indent));
-        let to_insert: ArrayVec<[SyntaxElement; 2]> =
-            [ws.ws().into(), item.syntax().clone().into()].into();
+        let position = InsertPosition::Before(r_curly.into());
+        let arm_ws = tokens::WsBuilder::new("    ");
+        let match_indent = &leading_indent(self.syntax()).unwrap_or_default();
+        let match_ws = tokens::WsBuilder::new(&format!("\n{}", match_indent));
+        let to_insert: ArrayVec<[SyntaxElement; 3]> =
+            [arm_ws.ws().into(), item.syntax().clone().into(), match_ws.ws().into()].into();
         self.insert_children(position, to_insert)
     }
 }


### PR DESCRIPTION
This means we now retain comments when filling in match arms. This fixes #3687. This is my first contribution so apologies if it needs a rethink! I think in particular the way I find the position to append to and remove_if_only_whitespace are a little hairy.