### PR TITLE
Add basic task support

### DIFF
--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -30,14 +30,14 @@ export function configToServerOptions(config: Config) {
     };
 }
 
-export async function createClient(config: Config, serverPath: string, workspaceFolder: vscode.WorkspaceFolder): Promise<lc.LanguageClient> {
+export async function createClient(config: Config, serverPath: string, cwd: string): Promise<lc.LanguageClient> {
     // '.' Is the fallback if no folder is open
     // TODO?: Workspace folders support Uri's (eg: file://test.txt).
     // It might be a good idea to test if the uri points to a file.
 
     const run: lc.Executable = {
         command: serverPath,
-        options: { cwd: workspaceFolder.uri.fsPath },
+        options: { cwd },
     };
     const serverOptions: lc.ServerOptions = {
         run,

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -30,15 +30,14 @@ export function configToServerOptions(config: Config) {
     };
 }
 
-export async function createClient(config: Config, serverPath: string): Promise<lc.LanguageClient> {
+export async function createClient(config: Config, serverPath: string, workspaceFolder: vscode.WorkspaceFolder | null): Promise<lc.LanguageClient> {
     // '.' Is the fallback if no folder is open
     // TODO?: Workspace folders support Uri's (eg: file://test.txt).
     // It might be a good idea to test if the uri points to a file.
-    const workspaceFolderPath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? '.';
 
     const run: lc.Executable = {
         command: serverPath,
-        options: { cwd: workspaceFolderPath },
+        options: { cwd: workspaceFolder?.uri.fsPath ?? '.' },
     };
     const serverOptions: lc.ServerOptions = {
         run,

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -30,14 +30,14 @@ export function configToServerOptions(config: Config) {
     };
 }
 
-export async function createClient(config: Config, serverPath: string, workspaceFolder: vscode.WorkspaceFolder | null): Promise<lc.LanguageClient> {
+export async function createClient(config: Config, serverPath: string, workspaceFolder: vscode.WorkspaceFolder): Promise<lc.LanguageClient> {
     // '.' Is the fallback if no folder is open
     // TODO?: Workspace folders support Uri's (eg: file://test.txt).
     // It might be a good idea to test if the uri points to a file.
 
     const run: lc.Executable = {
         command: serverPath,
-        options: { cwd: workspaceFolder?.uri.fsPath ?? '.' },
+        options: { cwd: workspaceFolder.uri.fsPath },
     };
     const serverOptions: lc.ServerOptions = {
         run,

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -15,8 +15,13 @@ export class Ctx {
 
     }
 
-    static async create(config: Config, extCtx: vscode.ExtensionContext, serverPath: string): Promise<Ctx> {
-        const client = await createClient(config, serverPath);
+    static async create(
+        config: Config,
+        extCtx: vscode.ExtensionContext,
+        serverPath: string,
+        workspaceFolder: vscode.WorkspaceFolder | null,
+    ): Promise<Ctx> {
+        const client = await createClient(config, serverPath, workspaceFolder);
         const res = new Ctx(config, extCtx, client, serverPath);
         res.pushCleanup(client.start());
         await client.onReady();

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -19,7 +19,7 @@ export class Ctx {
         config: Config,
         extCtx: vscode.ExtensionContext,
         serverPath: string,
-        workspaceFolder: vscode.WorkspaceFolder | null,
+        workspaceFolder: vscode.WorkspaceFolder,
     ): Promise<Ctx> {
         const client = await createClient(config, serverPath, workspaceFolder);
         const res = new Ctx(config, extCtx, client, serverPath);

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -19,9 +19,9 @@ export class Ctx {
         config: Config,
         extCtx: vscode.ExtensionContext,
         serverPath: string,
-        workspaceFolder: vscode.WorkspaceFolder,
+        cwd: string,
     ): Promise<Ctx> {
-        const client = await createClient(config, serverPath, workspaceFolder);
+        const client = await createClient(config, serverPath, cwd);
         const res = new Ctx(config, extCtx, client, serverPath);
         res.pushCleanup(client.start());
         await client.onReady();

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -42,7 +42,12 @@ export async function activate(context: vscode.ExtensionContext) {
     const state = new PersistentState(context.globalState);
     const serverPath = await bootstrap(config, state);
 
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0] ?? null;
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    if (workspaceFolder === undefined) {
+        const err = "Cannot activate rust-analyzer when no folder is opened";
+        void vscode.window.showErrorMessage(err);
+        throw new Error(err);
+    }
 
     // Note: we try to start the server before we activate type hints so that it
     // registers its `onDidChangeDocument` handler before us.

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -53,7 +53,7 @@ export async function activate(context: vscode.ExtensionContext) {
     // registers its `onDidChangeDocument` handler before us.
     //
     // This a horribly, horribly wrong way to deal with this problem.
-    ctx = await Ctx.create(config, context, serverPath, workspaceFolder);
+    ctx = await Ctx.create(config, context, serverPath, workspaceFolder.uri.fsPath);
 
     // Commands which invokes manually via command palette, shortcut, etc.
 

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -93,9 +93,7 @@ export async function activate(context: vscode.ExtensionContext) {
     ctx.registerCommand('applySourceChange', commands.applySourceChange);
     ctx.registerCommand('selectAndApplySourceChange', commands.selectAndApplySourceChange);
 
-    if (workspaceFolder !== null) {
-        ctx.pushCleanup(activateTaskProvider(workspaceFolder));
-    }
+    ctx.pushCleanup(activateTaskProvider(workspaceFolder));
 
     activateStatusDisplay(ctx);
 

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -13,6 +13,7 @@ import { log, assert } from './util';
 import { PersistentState } from './persistent_state';
 import { fetchRelease, download } from './net';
 import { spawnSync } from 'child_process';
+import { activateTaskProvider } from './tasks';
 
 let ctx: Ctx | undefined;
 
@@ -41,11 +42,13 @@ export async function activate(context: vscode.ExtensionContext) {
     const state = new PersistentState(context.globalState);
     const serverPath = await bootstrap(config, state);
 
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0] ?? null;
+
     // Note: we try to start the server before we activate type hints so that it
     // registers its `onDidChangeDocument` handler before us.
     //
     // This a horribly, horribly wrong way to deal with this problem.
-    ctx = await Ctx.create(config, context, serverPath);
+    ctx = await Ctx.create(config, context, serverPath, workspaceFolder);
 
     // Commands which invokes manually via command palette, shortcut, etc.
 
@@ -84,6 +87,10 @@ export async function activate(context: vscode.ExtensionContext) {
     ctx.registerCommand('showReferences', commands.showReferences);
     ctx.registerCommand('applySourceChange', commands.applySourceChange);
     ctx.registerCommand('selectAndApplySourceChange', commands.selectAndApplySourceChange);
+
+    if (workspaceFolder !== null) {
+        ctx.pushCleanup(activateTaskProvider(workspaceFolder));
+    }
 
     activateStatusDisplay(ctx);
 

--- a/editors/code/src/tasks.ts
+++ b/editors/code/src/tasks.ts
@@ -1,19 +1,11 @@
-import {
-    Disposable,
-    ShellExecution,
-    Task,
-    TaskGroup,
-    TaskProvider,
-    tasks,
-    WorkspaceFolder,
-} from 'vscode';
+import * as vscode from 'vscode';
 
 // This ends up as the `type` key in tasks.json. RLS also uses `cargo` and
 // our configuration should be compatible with it so use the same key.
 const TASK_TYPE = 'cargo';
 
-export function activateTaskProvider(target: WorkspaceFolder): Disposable {
-    const provider: TaskProvider = {
+export function activateTaskProvider(target: vscode.WorkspaceFolder): vscode.Disposable {
+    const provider: vscode.TaskProvider = {
         // Detect Rust tasks. Currently we do not do any actual detection
         // of tasks (e.g. aliases in .cargo/config) and just return a fixed
         // set of tasks that always exist. These tasks cannot be removed in
@@ -24,19 +16,19 @@ export function activateTaskProvider(target: WorkspaceFolder): Disposable {
         resolveTask: () => undefined,
     };
 
-    return tasks.registerTaskProvider(TASK_TYPE, provider);
+    return vscode.tasks.registerTaskProvider(TASK_TYPE, provider);
 }
 
-function getStandardCargoTasks(target: WorkspaceFolder): Task[] {
+function getStandardCargoTasks(target: vscode.WorkspaceFolder): vscode.Task[] {
     return [
-        { command: 'build', group: TaskGroup.Build },
-        { command: 'check', group: TaskGroup.Build },
-        { command: 'test', group: TaskGroup.Test },
-        { command: 'clean', group: TaskGroup.Clean },
+        { command: 'build', group: vscode.TaskGroup.Build },
+        { command: 'check', group: vscode.TaskGroup.Build },
+        { command: 'test', group: vscode.TaskGroup.Test },
+        { command: 'clean', group: vscode.TaskGroup.Clean },
         { command: 'run', group: undefined },
     ]
         .map(({ command, group }) => {
-            const vscodeTask = new Task(
+            const vscodeTask = new vscode.Task(
                 // The contents of this object end up in the tasks.json entries.
                 {
                     type: TASK_TYPE,
@@ -50,7 +42,7 @@ function getStandardCargoTasks(target: WorkspaceFolder): Task[] {
                 `cargo ${command}`,
                 'rust',
                 // What to do when this command is executed.
-                new ShellExecution('cargo', [command]),
+                new vscode.ShellExecution('cargo', [command]),
                 // Problem matchers.
                 ['$rustc'],
             );

--- a/editors/code/src/tasks.ts
+++ b/editors/code/src/tasks.ts
@@ -1,0 +1,60 @@
+import {
+    Disposable,
+    ShellExecution,
+    Task,
+    TaskGroup,
+    TaskProvider,
+    tasks,
+    WorkspaceFolder,
+} from 'vscode';
+
+// This ends up as the `type` key in tasks.json. RLS also uses `cargo` and
+// our configuration should be compatible with it so use the same key.
+const TASK_TYPE = 'cargo';
+
+export function activateTaskProvider(target: WorkspaceFolder): Disposable {
+    const provider: TaskProvider = {
+        // Detect Rust tasks. Currently we do not do any actual detection
+        // of tasks (e.g. aliases in .cargo/config) and just return a fixed
+        // set of tasks that always exist. These tasks cannot be removed in
+        // tasks.json - only tweaked.
+        provideTasks: () => getStandardCargoTasks(target),
+
+        // We don't need to implement this.
+        resolveTask: () => undefined,
+    };
+
+    return tasks.registerTaskProvider(TASK_TYPE, provider);
+}
+
+function getStandardCargoTasks(target: WorkspaceFolder): Task[] {
+    return [
+        { command: 'build', group: TaskGroup.Build },
+        { command: 'check', group: TaskGroup.Build },
+        { command: 'test', group: TaskGroup.Test },
+        { command: 'clean', group: TaskGroup.Clean },
+        { command: 'run', group: undefined },
+    ]
+        .map(({ command, group }) => {
+            const vscodeTask = new Task(
+                // The contents of this object end up in the tasks.json entries.
+                {
+                    type: TASK_TYPE,
+                    command,
+                },
+                // The scope of the task - workspace or specific folder (global
+                // is not supported).
+                target,
+                // The task name, and task source. These are shown in the UI as
+                // `${source}: ${name}`, e.g. `rust: cargo build`.
+                `cargo ${command}`,
+                'rust',
+                // What to do when this command is executed.
+                new ShellExecution('cargo', [command]),
+                // Problem matchers.
+                ['$rustc'],
+            );
+            vscodeTask.group = group;
+            return vscodeTask;
+        });
+}


### PR DESCRIPTION
This adds basic support for running `cargo build`, `cargo run`, etc.

Fixes #1935

I have tested this and it seems to work. There are two things I'm not sure about:

1. The workspace folder handling seems wrong - just get the first workspace folder? Is this just a TODO item? I don't know if it is right to lift `workspaceFolder` up to `activate()` but I couldn't see another way.
2. If you manually add an entry to `tasks.json` like this:

```
    {
      "type": "cargo",
      "command": "build",
      "problemMatcher": [
        "$rustc"
      ],
      "group": "build"
    }
```

then VSCode somehow magically knows to run `cargo build`. The documentation for `resolveTask` *sounds* like I should have to implement that for it to work:

```
 * Resolves a task that has no [`execution`](#Task.execution) set. Tasks are
 * often created from information found in the `tasks.json`-file. Such tasks miss
 * the information on how to execute them and a task provider must fill in
 * the missing information in the `resolveTask`-method.
```

But then it also says this:

```
* This method will not be
 * called for tasks returned from the above `provideTasks` method since those
 * tasks are always fully resolved. A valid default implementation for the
 * `resolveTask` method is to return `undefined`.
```

Either way, it works without implementing it so the only thing I can think is that it is doing some kind of crazy pattern matching of the tasks returned by `provideTasks()` and the ones found in `tasks.json`.