### PR TITLE
Attach doc-comment to declaration if there are newlines in between

### DIFF
--- a/crates/ra_syntax/src/parsing/text_tree_sink.rs
+++ b/crates/ra_syntax/src/parsing/text_tree_sink.rs
@@ -149,10 +149,21 @@ fn n_attached_trivias<'a>(
         MACRO_CALL | CONST_DEF | TYPE_ALIAS_DEF | STRUCT_DEF | ENUM_DEF | ENUM_VARIANT | FN_DEF
         | TRAIT_DEF | MODULE | RECORD_FIELD_DEF | STATIC_DEF => {
             let mut res = 0;
-            for (i, (kind, text)) in trivias.enumerate() {
+            let mut trivias = trivias.enumerate().peekable();
+
+            while let Some((i, (kind, text))) = trivias.next() {
                 match kind {
                     WHITESPACE => {
                         if text.contains("\n\n") {
+                            // we check whether the next token is a doc-comment
+                            // and skip the whitespace in this case
+                            if let Some((peek_kind, peek_text)) =
+                                trivias.peek().map(|(_, pair)| pair)
+                            {
+                                if *peek_kind == COMMENT && peek_text.starts_with("///") {
+                                    continue;
+                                }
+                            }
                             break;
                         }
                     }

--- a/crates/ra_syntax/test_data/parser/ok/0065_comment_newline.rs
+++ b/crates/ra_syntax/test_data/parser/ok/0065_comment_newline.rs
@@ -1,0 +1,3 @@
+/// Example
+
+fn test() {}

--- a/crates/ra_syntax/test_data/parser/ok/0065_comment_newline.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0065_comment_newline.txt
@@ -1,0 +1,17 @@
+SOURCE_FILE@[0; 26)
+  FN_DEF@[0; 25)
+    COMMENT@[0; 11) "/// Example"
+    WHITESPACE@[11; 13) "\n\n"
+    FN_KW@[13; 15) "fn"
+    WHITESPACE@[15; 16) " "
+    NAME@[16; 20)
+      IDENT@[16; 20) "test"
+    PARAM_LIST@[20; 22)
+      L_PAREN@[20; 21) "("
+      R_PAREN@[21; 22) ")"
+    WHITESPACE@[22; 23) " "
+    BLOCK_EXPR@[23; 25)
+      BLOCK@[23; 25)
+        L_CURLY@[23; 24) "{"
+        R_CURLY@[24; 25) "}"
+  WHITESPACE@[25; 26) "\n"


### PR DESCRIPTION
This commit changes the parser to attach doc-comments to the corresponding declaration in case there are newlines in between the doc-comment and the declaration.

Implements the changes proposed in #3757 