### PR TITLE
lower bool literal value

### DIFF
--- a/crates/ra_hir_def/src/body/lower.rs
+++ b/crates/ra_hir_def/src/body/lower.rs
@@ -748,7 +748,7 @@ impl From<ast::LiteralKind> for Literal {
             LiteralKind::ByteString => Literal::ByteString(Default::default()),
             LiteralKind::String => Literal::String(Default::default()),
             LiteralKind::Byte => Literal::Int(Default::default(), Some(BuiltinInt::U8)),
-            LiteralKind::Bool => Literal::Bool(Default::default()),
+            LiteralKind::Bool(val) => Literal::Bool(val),
             LiteralKind::Char => Literal::Char(Default::default()),
         }
     }

--- a/crates/ra_syntax/src/ast/expr_extensions.rs
+++ b/crates/ra_syntax/src/ast/expr_extensions.rs
@@ -308,7 +308,7 @@ pub enum LiteralKind {
     Byte,
     IntNumber { suffix: Option<SmolStr> },
     FloatNumber { suffix: Option<SmolStr> },
-    Bool,
+    Bool(bool),
 }
 
 impl ast::Literal {
@@ -355,7 +355,8 @@ impl ast::Literal {
                 LiteralKind::FloatNumber { suffix: Self::find_suffix(&text, &FLOAT_SUFFIXES) }
             }
             STRING | RAW_STRING => LiteralKind::String,
-            T![true] | T![false] => LiteralKind::Bool,
+            T![true] => LiteralKind::Bool(true),
+            T![false] => LiteralKind::Bool(false),
             BYTE_STRING | RAW_BYTE_STRING => LiteralKind::ByteString,
             CHAR => LiteralKind::Char,
             BYTE => LiteralKind::Byte,


### PR DESCRIPTION
Following up on #3805, this PR adds the literal value to `ast::LiteralKind` so when we lower we can use the actual value from the source code rather than the default value for the type. Ultimately I plan to use this for exhaustiveness checking in #3706.

I didn't include this in the previous PR because I wasn't sure if it made sense to add this information to `ast::LiteralKind` or provide some other mechanism to get this from `ast::Literal`.

For now I've only implemented this for boolean literals, but I think it could be easily extended to other types. A possible exception to this are string literals, since we may not want to clone around an owned string to hold onto in `ast::LiteralKind`, and it'd be nice to avoid adding a generic lifetime as well. Perhaps we won't ever care about the actual value of a string literal? 