### PR TITLE
vscode: add support for light themes in "Show Syntax Tree" command

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -450,6 +450,15 @@
                     "light": "#747474",
                     "highContrast": "#BEBEBE"
                 }
+            },
+            {
+                "id": "rust_analyzer.syntaxTreeBorder",
+                "description": "Color of the border displayed in the Rust source code for the selected syntax node (see \"Show Syntax Tree\" command)",
+                "defaults": {
+                    "dark": "#ffffff",
+                    "light": "#b700ff",
+                    "highContrast": "#b700ff"
+                }
             }
         ],
         "semanticTokenTypes": [

--- a/editors/code/src/commands/syntax_tree.ts
+++ b/editors/code/src/commands/syntax_tree.ts
@@ -81,8 +81,10 @@ class TextDocumentContentProvider implements vscode.TextDocumentContentProvider 
 // https://code.visualstudio.com/api/extension-guides/tree-view
 class AstInspector implements vscode.HoverProvider, Disposable {
     private static readonly astDecorationType = vscode.window.createTextEditorDecorationType({
-        fontStyle: "normal",
-        border: "#ffffff 1px solid",
+        borderColor: new vscode.ThemeColor('rust_analyzer.syntaxTreeBorder'),
+        borderStyle: "solid",
+        borderWidth: "2px",
+
     });
     private rustEditor: undefined | RustEditor;
 


### PR DESCRIPTION
Fixes: #3810