### PR TITLE
vscode: add goto ast node definition from rust source code

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -155,6 +155,16 @@ There's also two VS Code commands which might be of interest:
 
 * `Rust Analyzer: Syntax Tree` shows syntax tree of the current file/selection.
 
+  You can hover over syntax nodes in the opened text file to see the appropriate
+  rust code that it refers to and the rust editor will also highlight the proper
+  text range.
+
+  If you press <kbd>Ctrl</kbd> (i.e. trigger goto definition) in the inspected
+  Rust source file the syntax tree read-only editor should scroll to and select the
+  appropriate syntax node token.
+
+  ![demo](https://user-images.githubusercontent.com/36276403/78225773-6636a480-74d3-11ea-9d9f-1c9d42da03b0.png)
+
 # Profiling
 
 We have a built-in hierarchical profiler, you can enable it by using `RA_PROFILE` env-var:

--- a/docs/user/features.md
+++ b/docs/user/features.md
@@ -81,16 +81,6 @@ Join selected lines into one, smartly fixing up whitespace and trailing commas.
 Shows the parse tree of the current file. It exists mostly for debugging
 rust-analyzer itself.
 
-You can hover over syntax nodes in the opened text file to see the appropriate
-rust code that it refers to and the rust editor will also highlight the proper
-text range.
-
-If you press <kbd>Ctrl</kbd> (i.e. trigger goto definition) in the inspected
-Rust source file the syntax tree readonly editor should scroll to and select the
-appropriate syntax node token.
-
-<img src="https://user-images.githubusercontent.com/36276403/78043783-7425e180-737c-11ea-8653-b02b773c5aa1.png" alt="demo" height="200px" >
-
 #### Expand Macro Recursively
 
 Shows the full macro expansion of the macro at current cursor.

--- a/docs/user/features.md
+++ b/docs/user/features.md
@@ -85,6 +85,10 @@ You can hover over syntax nodes in the opened text file to see the appropriate
 rust code that it refers to and the rust editor will also highlight the proper
 text range.
 
+If you press <kbd>Ctrl</kbd> (i.e. trigger goto definition) in the inspected
+Rust source file the syntax tree readonly editor should scroll to and select the
+appropriate syntax node token.
+
 <img src="https://user-images.githubusercontent.com/36276403/78043783-7425e180-737c-11ea-8653-b02b773c5aa1.png" alt="demo" height="200px" >
 
 #### Expand Macro Recursively

--- a/editors/code/src/commands/syntax_tree.ts
+++ b/editors/code/src/commands/syntax_tree.ts
@@ -189,18 +189,18 @@ class AstInspector implements vscode.HoverProvider, Disposable {
     provideHover(doc: vscode.TextDocument, hoverPosition: vscode.Position): vscode.ProviderResult<vscode.Hover> {
         if (!this.rustEditor) return;
 
-        const astTextLine = doc.lineAt(hoverPosition.line);
+        const astFileLine = doc.lineAt(hoverPosition.line);
 
-        const rustTextRange = this.parseRustTextRange(this.rustEditor.document, astTextLine.text);
-        if (!rustTextRange) return;
+        const rustFileRange = this.parseRustTextRange(this.rustEditor.document, astFileLine.text);
+        if (!rustFileRange) return;
 
-        this.rustEditor.setDecorations(this.astDecorationType, [rustTextRange]);
-        this.rustEditor.revealRange(rustTextRange);
+        this.rustEditor.setDecorations(this.astDecorationType, [rustFileRange]);
+        this.rustEditor.revealRange(rustFileRange);
 
-        const rustSourceCode = this.rustEditor.document.getText(rustTextRange);
-        const astTextRange = this.findAstRange(astTextLine);
+        const rustSourceCode = this.rustEditor.document.getText(rustFileRange);
+        const astFileRange = this.findAstRange(astFileLine);
 
-        return new vscode.Hover(["```rust\n" + rustSourceCode + "\n```"], astTextRange);
+        return new vscode.Hover(["```rust\n" + rustSourceCode + "\n```"], astFileRange);
     }
 
     private findAstRange(astLine: vscode.TextLine) {


### PR DESCRIPTION
By holding the `Ctrl` key you can now goto-definition of the appropriate syntax token in the syntax tree read-only editor. But actually going to the definition is not very convenient, since it opens the new editor, you'd rather just hold the `Ctrl` and look at the syntax tree because it is automatically scrolled to the proper node and the node itself is enclosed with text selection.

Unfortunately, the algorithm is very simple (because we don't do any elaborate parsing of the syntax tree text received from the server), but it is enough to debug not very large source files.
I tested the performance and in a bad case (rust source file with 5K lines of code) it takes `1.3` seconds to build the `rust -> ast` mapping index (lazily once on the first goto definition request) and each lookup in this worst-case is approx `20-120` ms. I think this is good enough. In the simple case where the file is < 100 lines of code, it is instant.

One peculiarity that I've noticed is that vscode doesn't trigger the goto-definition provider when the user triggers it on some punctuation characters (i.e. it doesn't underline them and invoke te goto-definition provider), but if you explicitly click `Ctrl+LMB` it will only then invoke the provider and navigate to the definition in a new editor. I think this is fine ;D

![rust2ast](https://user-images.githubusercontent.com/36276403/78198718-24d1d500-7492-11ea-91f6-2687cedf26ee.gif)


Related: #3682 