### PR TITLE
vscode: highlight syntax tree ro editor

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -411,6 +411,21 @@
                 ]
             }
         ],
+        "languages": [
+            {
+                "id": "ra_syntax_tree",
+                "extensions": [
+                    ".rast"
+                ]
+            }
+        ],
+        "grammars": [
+            {
+                "language": "ra_syntax_tree",
+                "scopeName": "source.ra_syntax_tree",
+                "path": "ra_syntax_tree.tmGrammar.json"
+            }
+        ],
         "problemMatchers": [
             {
                 "name": "rustc",

--- a/editors/code/ra_syntax_tree.tmGrammar.json
+++ b/editors/code/ra_syntax_tree.tmGrammar.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+
+    "scopeName": "source.ra_syntax_tree",
+    "patterns": [
+        { "include": "#node_type" },
+        { "include": "#node_range_index" },
+        { "include": "#token_text" }
+    ],
+    "repository": {
+        "node_type": {
+            "match": "^\\s*([A-Z_]+?)@",
+            "captures": {
+                "1": {
+                    "name": "entity.name.class"
+                }
+            }
+        },
+        "node_range_index": {
+            "match": "\\d+",
+            "name": "constant.numeric"
+        },
+        "token_text": {
+            "match": "\".+\"",
+            "name": "string"
+        }
+    },
+    "fileTypes": [
+        "rast"
+    ]
+}

--- a/editors/code/src/commands/syntax_tree.ts
+++ b/editors/code/src/commands/syntax_tree.ts
@@ -15,6 +15,9 @@ export function syntaxTree(ctx: Ctx): Cmd {
     void new AstInspector(ctx);
 
     ctx.pushCleanup(vscode.workspace.registerTextDocumentContentProvider(AST_FILE_SCHEME, tdcp));
+    ctx.pushCleanup(vscode.languages.setLanguageConfiguration("ra_syntax_tree", {
+        brackets: [["[", ")"]],
+    }));
 
     return async () => {
         const editor = vscode.window.activeTextEditor;
@@ -36,7 +39,7 @@ export function syntaxTree(ctx: Ctx): Cmd {
 }
 
 class TextDocumentContentProvider implements vscode.TextDocumentContentProvider {
-    readonly uri = vscode.Uri.parse('rust-analyzer://syntaxtree');
+    readonly uri = vscode.Uri.parse('rust-analyzer://syntaxtree/tree.rast');
     readonly eventEmitter = new vscode.EventEmitter<vscode.Uri>();
 
 


### PR DESCRIPTION
Small textmate grammar declaration to make rust-analyzer syntax tree more easily inspectable:
Btw, if we change the file extension of our `ra_syntax/test_data/**` files to `.rast` they should be highlighted in vscode too.

The colors of the tokens are actually going to be color-theme dependent, or you can customize them via:
```jsonc
{
    "editor.tokenColorCustomizations": {
        "textMateRules": [ { "scope": "name", "settings": { /* */ } } ] 
    }
}
```
![image](https://user-images.githubusercontent.com/36276403/78204947-99f9d600-74a3-11ea-8315-cb1c87810c7c.png)

Related: #3682