### PR TITLE
Unique package by name and version.

### DIFF
--- a/crates/ra_project_model/src/cargo_workspace.rs
+++ b/crates/ra_project_model/src/cargo_workspace.rs
@@ -75,7 +75,7 @@ pub type Target = Idx<TargetData>;
 
 #[derive(Debug, Clone)]
 pub struct PackageData {
-    pub id: String,
+    pub version: String,
     pub name: String,
     pub manifest: PathBuf,
     pub targets: Vec<Target>,
@@ -174,14 +174,15 @@ impl CargoWorkspace {
         let ws_members = &meta.workspace_members;
 
         for meta_pkg in meta.packages {
-            let cargo_metadata::Package { id, edition, name, manifest_path, .. } = meta_pkg;
+            let cargo_metadata::Package { id, edition, name, manifest_path, version, .. } =
+                meta_pkg;
             let is_member = ws_members.contains(&id);
             let edition = edition
                 .parse::<Edition>()
                 .with_context(|| format!("Failed to parse edition {}", edition))?;
             let pkg = packages.alloc(PackageData {
                 name,
-                id: id.to_string(),
+                version: version.to_string(),
                 manifest: manifest_path,
                 targets: Vec::new(),
                 is_member,
@@ -256,7 +257,7 @@ impl CargoWorkspace {
         if self.is_unique(&*package.name) {
             package.name.clone()
         } else {
-            package.id.clone()
+            format!("{}:{}", package.name, package.version)
         }
     }
 


### PR DESCRIPTION
This commit is a fixup of #3781 I introduced a bug by using a PackageId to refer to a crate when its name conflicts with a dependency.
It turns out the package id currently is `name version path` while cargo expects `name:version` as argument eg:
Cargo command with a `PackageId`:
```
> Executing task: cargo test --package 'config 0.1.0 (path+file:///Users/ignition/Projects/oss/config)' --test default -- test_with_name --exact --nocapture <
```
Cargo command with `name:version`:
```
> Executing task: cargo test --package 'config:0.1.0' --test default -- test_with_name --exact --nocapture <
```