### PR TITLE
Macro patterns are not confused with expressions.

### DIFF
--- a/crates/ra_hir_def/src/body/lower.rs
+++ b/crates/ra_hir_def/src/body/lower.rs
@@ -672,8 +672,7 @@ impl ExprCollector<'_> {
             }
 
             // FIXME: implement
-            ast::Pat::BoxPat(_) => Pat::Missing,
-            ast::Pat::RangePat(_) => Pat::Missing,
+            ast::Pat::BoxPat(_) | ast::Pat::RangePat(_) | ast::Pat::MacroPat(_) => Pat::Missing,
         };
         let ptr = AstPtr::new(&pat);
         self.alloc_pat(pattern, Either::Left(ptr))

--- a/crates/ra_hir_ty/src/tests/macros.rs
+++ b/crates/ra_hir_ty/src/tests/macros.rs
@@ -1,7 +1,9 @@
-use super::{infer, type_at, type_at_pos};
-use crate::test_db::TestDB;
 use insta::assert_snapshot;
 use ra_db::fixture::WithFixture;
+
+use super::{infer, type_at, type_at_pos};
+
+use crate::test_db::TestDB;
 
 #[test]
 fn cfg_impl_def() {
@@ -657,4 +659,29 @@ fn test() {
 "#,
     );
     assert_eq!("S", type_at_pos(&db, pos));
+}
+
+#[test]
+fn macro_in_arm() {
+    assert_snapshot!(
+        infer(r#"
+macro_rules! unit {
+    () => { () };
+}
+
+fn main() {
+    let x = match () {
+        unit!() => 92u32,
+    };
+}
+"#),
+        @r###"
+    [52; 111) '{     ...  }; }': ()
+    [62; 63) 'x': u32
+    [66; 108) 'match ...     }': u32
+    [72; 74) '()': ()
+    [85; 92) 'unit!()': ()
+    [96; 101) '92u32': u32
+    "###
+    );
 }

--- a/crates/ra_parser/src/grammar/expressions.rs
+++ b/crates/ra_parser/src/grammar/expressions.rs
@@ -79,8 +79,6 @@ fn is_expr_stmt_attr_allowed(kind: SyntaxKind) -> bool {
 }
 
 pub(super) fn stmt(p: &mut Parser, with_semi: StmtWithSemi) {
-    // test block_items
-    // fn a() { fn b() {} }
     let m = p.start();
     // test attr_on_expr_stmt
     // fn foo() {
@@ -97,6 +95,8 @@ pub(super) fn stmt(p: &mut Parser, with_semi: StmtWithSemi) {
         return;
     }
 
+    // test block_items
+    // fn a() { fn b() {} }
     let m = match items::maybe_item(p, m, items::ItemFlavor::Mod) {
         Ok(()) => return,
         Err(m) => m,

--- a/crates/ra_parser/src/grammar/patterns.rs
+++ b/crates/ra_parser/src/grammar/patterns.rs
@@ -84,7 +84,7 @@ fn atom_pat(p: &mut Parser, recovery_set: TokenSet) -> Option<CompletedMarker> {
             // Checks the token after an IDENT to see if a pattern is a path (Struct { .. }) or macro
             // (T![x]).
             T!['('] | T!['{'] | T![!] => path_or_macro_pat(p),
-            T![:] if p.nth_at(1, T![::]) => path_pat(p),
+            T![:] if p.nth_at(1, T![::]) => path_or_macro_pat(p),
             _ => bind_pat(p, true),
         },
 
@@ -156,7 +156,7 @@ fn path_or_macro_pat(p: &mut Parser) -> CompletedMarker {
         // }
         T![!] => {
             items::macro_call_after_excl(p);
-            MACRO_CALL
+            return m.complete(p, MACRO_CALL).precede(p).complete(p, MACRO_PAT);
         }
         _ => PATH_PAT,
     };

--- a/crates/ra_parser/src/syntax_kind/generated.rs
+++ b/crates/ra_parser/src/syntax_kind/generated.rs
@@ -167,6 +167,7 @@ pub enum SyntaxKind {
     SLICE_PAT,
     RANGE_PAT,
     LITERAL_PAT,
+    MACRO_PAT,
     TUPLE_EXPR,
     ARRAY_EXPR,
     PAREN_EXPR,

--- a/crates/ra_syntax/test_data/parser/inline/ok/0129_marco_pat.txt
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0129_marco_pat.txt
@@ -15,16 +15,17 @@ SOURCE_FILE@[0; 33)
         LET_STMT@[16; 30)
           LET_KW@[16; 19) "let"
           WHITESPACE@[19; 20) " "
-          MACRO_CALL@[20; 25)
-            PATH@[20; 21)
-              PATH_SEGMENT@[20; 21)
-                NAME_REF@[20; 21)
-                  IDENT@[20; 21) "m"
-            EXCL@[21; 22) "!"
-            TOKEN_TREE@[22; 25)
-              L_PAREN@[22; 23) "("
-              IDENT@[23; 24) "x"
-              R_PAREN@[24; 25) ")"
+          MACRO_PAT@[20; 25)
+            MACRO_CALL@[20; 25)
+              PATH@[20; 21)
+                PATH_SEGMENT@[20; 21)
+                  NAME_REF@[20; 21)
+                    IDENT@[20; 21) "m"
+              EXCL@[21; 22) "!"
+              TOKEN_TREE@[22; 25)
+                L_PAREN@[22; 23) "("
+                IDENT@[23; 24) "x"
+                R_PAREN@[24; 25) ")"
           WHITESPACE@[25; 26) " "
           EQ@[26; 27) "="
           WHITESPACE@[27; 28) " "

--- a/xtask/src/ast_src.rs
+++ b/xtask/src/ast_src.rs
@@ -138,6 +138,7 @@ pub(crate) const KINDS_SRC: KindsSrc = KindsSrc {
         "SLICE_PAT",
         "RANGE_PAT",
         "LITERAL_PAT",
+        "MACRO_PAT",
         // atoms
         "TUPLE_EXPR",
         "ARRAY_EXPR",
@@ -440,6 +441,7 @@ pub(crate) const AST_SRC: AstSrc = AstSrc {
         struct SlicePat { args: [Pat] }
         struct RangePat {}
         struct LiteralPat { Literal }
+        struct MacroPat { MacroCall }
 
         struct RecordPat { RecordFieldPatList, Path }
         struct RecordFieldPatList {
@@ -622,6 +624,7 @@ pub(crate) const AST_SRC: AstSrc = AstSrc {
             SlicePat,
             RangePat,
             LiteralPat,
+            MacroPat,
         }
 
         enum AttrInput { Literal, TokenTree }


### PR DESCRIPTION
We treat macro calls as expressions (there's appropriate Into impl),
which causes problem if there's expresison and non-expression macro in
the same node (like in the match arm).

We fix this problem by nesting macor patterns into another node (the
same way we nest path into PathExpr or PathPat). Ideally, we probably
should add a similar nesting for macro expressions, but that needs
some careful thinking about macros in blocks: `{ am_i_expression!() }`.



bors r+
🤖