### PR TITLE
AST improvements to support conversion to rustc AST

### DIFF
--- a/crates/ra_assists/src/handlers/add_impl.rs
+++ b/crates/ra_assists/src/handlers/add_impl.rs
@@ -1,5 +1,5 @@
 use ra_syntax::{
-    ast::{self, AstNode, NameOwner, TypeParamsOwner},
+    ast::{self, AstNode, AstToken, NameOwner, TypeParamsOwner},
     TextUnit,
 };
 use stdx::{format_to, SepBy};
@@ -42,7 +42,7 @@ pub(crate) fn add_impl(ctx: AssistCtx) -> Option<Assist> {
         if let Some(type_params) = type_params {
             let lifetime_params = type_params
                 .lifetime_params()
-                .filter_map(|it| it.lifetime_token())
+                .filter_map(|it| it.lifetime())
                 .map(|it| it.text().clone());
             let type_params =
                 type_params.type_params().filter_map(|it| it.name()).map(|it| it.text().clone());

--- a/crates/ra_assists/src/handlers/add_new.rs
+++ b/crates/ra_assists/src/handlers/add_new.rs
@@ -1,7 +1,8 @@
 use hir::Adt;
 use ra_syntax::{
     ast::{
-        self, AstNode, NameOwner, StructKind, TypeAscriptionOwner, TypeParamsOwner, VisibilityOwner,
+        self, AstNode, AstToken, NameOwner, StructKind, TypeAscriptionOwner, TypeParamsOwner,
+        VisibilityOwner,
     },
     TextUnit, T,
 };
@@ -105,7 +106,7 @@ fn generate_impl_text(strukt: &ast::StructDef, code: &str) -> String {
     if let Some(type_params) = type_params {
         let lifetime_params = type_params
             .lifetime_params()
-            .filter_map(|it| it.lifetime_token())
+            .filter_map(|it| it.lifetime())
             .map(|it| it.text().clone());
         let type_params =
             type_params.type_params().filter_map(|it| it.name()).map(|it| it.text().clone());

--- a/crates/ra_assists/src/handlers/introduce_variable.rs
+++ b/crates/ra_assists/src/handlers/introduce_variable.rs
@@ -1,5 +1,5 @@
 use ra_syntax::{
-    ast::{self, AstNode},
+    ast::{self, AstElement, AstNode},
     SyntaxKind::{
         BLOCK_EXPR, BREAK_EXPR, COMMENT, LAMBDA_EXPR, LOOP_EXPR, MATCH_ARM, PATH_EXPR, RETURN_EXPR,
         WHITESPACE,
@@ -124,7 +124,7 @@ fn anchor_stmt(expr: ast::Expr) -> Option<(SyntaxNode, bool)> {
             }
         }
 
-        if ast::Stmt::cast(node.clone()).is_some() {
+        if ast::Stmt::cast_element(node.clone().into()).is_some() {
             return Some((node, false));
         }
 

--- a/crates/ra_assists/src/handlers/merge_imports.rs
+++ b/crates/ra_assists/src/handlers/merge_imports.rs
@@ -3,7 +3,7 @@ use std::iter::successors;
 use ra_syntax::{
     algo::{neighbor, SyntaxRewriter},
     ast::{self, edit::AstNodeEdit, make},
-    AstNode, Direction, InsertPosition, SyntaxElement, T,
+    AstNode, AstToken, Direction, InsertPosition, SyntaxElement, T,
 };
 
 use crate::{Assist, AssistCtx, AssistId};
@@ -82,7 +82,7 @@ fn try_merge_trees(old: &ast::UseTree, new: &ast::UseTree) -> Option<ast::UseTre
             .filter(|it| it.kind() != T!['{'] && it.kind() != T!['}']),
     );
     let use_tree_list = lhs.use_tree_list()?;
-    let pos = InsertPosition::Before(use_tree_list.r_curly()?.into());
+    let pos = InsertPosition::Before(use_tree_list.r_curly()?.syntax().clone().into());
     let use_tree_list = use_tree_list.insert_children(pos, to_insert);
     Some(lhs.with_use_tree_list(use_tree_list))
 }

--- a/crates/ra_fmt/src/lib.rs
+++ b/crates/ra_fmt/src/lib.rs
@@ -60,10 +60,10 @@ pub fn extract_trivial_expression(block: &ast::BlockExpr) -> Option<ast::Expr> {
     } else {
         // Unwrap `{ continue; }`
         let (stmt,) = block.statements().next_tuple()?;
-        if has_anything_else(stmt.syntax()) {
-            return None;
-        }
         if let ast::Stmt::ExprStmt(expr_stmt) = stmt {
+            if has_anything_else(expr_stmt.syntax()) {
+                return None;
+            }
             let expr = expr_stmt.expr()?;
             match expr.syntax().kind() {
                 CONTINUE_EXPR | BREAK_EXPR | RETURN_EXPR => return Some(expr),

--- a/crates/ra_hir_def/src/body/lower.rs
+++ b/crates/ra_hir_def/src/body/lower.rs
@@ -688,6 +688,7 @@ impl ExprCollector<'_> {
             ast::Pat::BoxPat(_) => Pat::Missing,
             ast::Pat::LiteralPat(_) => Pat::Missing,
             ast::Pat::RangePat(_) => Pat::Missing,
+            ast::Pat::MacroCall(_) => Pat::Missing,
         };
         let ptr = AstPtr::new(&pat);
         self.alloc_pat(pattern, Either::Left(ptr))

--- a/crates/ra_hir_def/src/body/lower.rs
+++ b/crates/ra_hir_def/src/body/lower.rs
@@ -501,14 +501,17 @@ impl ExprCollector<'_> {
         self.collect_block_items(&block);
         let statements = block
             .statements()
-            .map(|s| match s {
+            .filter_map(|s| match s {
                 ast::Stmt::LetStmt(stmt) => {
                     let pat = self.collect_pat_opt(stmt.pat());
                     let type_ref = stmt.ascribed_type().map(TypeRef::from_ast);
                     let initializer = stmt.initializer().map(|e| self.collect_expr(e));
-                    Statement::Let { pat, type_ref, initializer }
+                    Some(Statement::Let { pat, type_ref, initializer })
                 }
-                ast::Stmt::ExprStmt(stmt) => Statement::Expr(self.collect_expr_opt(stmt.expr())),
+                ast::Stmt::ExprStmt(stmt) => {
+                    Some(Statement::Expr(self.collect_expr_opt(stmt.expr())))
+                }
+                ast::Stmt::ModuleItem(_) => None,
             })
             .collect();
         let tail = block.expr().map(|e| self.collect_expr(e));
@@ -560,6 +563,7 @@ impl ExprCollector<'_> {
                     let ast_id = self.expander.ast_id(&def);
                     (TraitLoc { container, ast_id }.intern(self.db).into(), def.name())
                 }
+                ast::ModuleItem::ExternBlock(_) => continue, // FIXME: collect from extern blocks
                 ast::ModuleItem::ImplDef(_)
                 | ast::ModuleItem::UseItem(_)
                 | ast::ModuleItem::ExternCrateItem(_)

--- a/crates/ra_hir_def/src/nameres/raw.rs
+++ b/crates/ra_hir_def/src/nameres/raw.rs
@@ -266,6 +266,10 @@ impl RawItemsCollector {
                 self.add_macro(current_module, it);
                 return;
             }
+            ast::ModuleItem::ExternBlock(_) => {
+                // FIXME: add extern block
+                return;
+            }
         };
         if let Some(name) = name {
             let name = name.as_name();

--- a/crates/ra_hir_def/src/path/lower.rs
+++ b/crates/ra_hir_def/src/path/lower.rs
@@ -28,7 +28,7 @@ pub(super) fn lower_path(mut path: ast::Path, hygiene: &Hygiene) -> Option<Path>
     loop {
         let segment = path.segment()?;
 
-        if segment.has_colon_colon() {
+        if segment.coloncolon().is_some() {
             kind = PathKind::Abs;
         }
 

--- a/crates/ra_hir_def/src/path/lower/lower_use.rs
+++ b/crates/ra_hir_def/src/path/lower/lower_use.rs
@@ -34,7 +34,7 @@ pub(crate) fn lower_use_tree(
         let alias = tree.alias().map(|a| {
             a.name().map(|it| it.as_name()).map_or(ImportAlias::Underscore, ImportAlias::Alias)
         });
-        let is_glob = tree.has_star();
+        let is_glob = tree.star().is_some();
         if let Some(ast_path) = tree.path() {
             // Handle self in a path.
             // E.g. `use something::{self, <...>}`

--- a/crates/ra_hir_def/src/visibility.rs
+++ b/crates/ra_hir_def/src/visibility.rs
@@ -84,6 +84,10 @@ impl RawVisibility {
                 let path = ModPath { kind: PathKind::Super(1), segments: Vec::new() };
                 RawVisibility::Module(path)
             }
+            ast::VisibilityKind::PubSelf => {
+                let path = ModPath { kind: PathKind::Plain, segments: Vec::new() };
+                RawVisibility::Module(path)
+            }
             ast::VisibilityKind::Pub => RawVisibility::Public,
         }
     }

--- a/crates/ra_hir_ty/src/tests.rs
+++ b/crates/ra_hir_ty/src/tests.rs
@@ -23,7 +23,7 @@ use insta::assert_snapshot;
 use ra_db::{fixture::WithFixture, salsa::Database, FilePosition, SourceDatabase};
 use ra_syntax::{
     algo,
-    ast::{self, AstNode},
+    ast::{self, AstNode, AstToken},
 };
 use stdx::format_to;
 
@@ -101,7 +101,7 @@ fn infer_with_mismatches(content: &str, include_mismatches: bool) -> String {
             let node = src_ptr.value.to_node(&src_ptr.file_syntax(&db));
 
             let (range, text) = if let Some(self_param) = ast::SelfParam::cast(node.clone()) {
-                (self_param.self_kw_token().text_range(), "self".to_string())
+                (self_param.self_kw().unwrap().syntax().text_range(), "self".to_string())
             } else {
                 (src_ptr.value.range(), node.text().to_string().replace("\n", " "))
             };

--- a/crates/ra_parser/src/grammar.rs
+++ b/crates/ra_parser/src/grammar.rs
@@ -245,7 +245,7 @@ fn opt_fn_ret_type(p: &mut Parser) -> bool {
     if p.at(T![->]) {
         let m = p.start();
         p.bump(T![->]);
-        types::type_(p);
+        types::type_no_bounds(p);
         m.complete(p, RET_TYPE);
         true
     } else {

--- a/crates/ra_parser/src/lib.rs
+++ b/crates/ra_parser/src/lib.rs
@@ -12,6 +12,8 @@
 //!
 //! Tests for this crate live in `ra_syntax` crate.
 
+#![allow(elided_lifetimes_in_paths)]
+
 #[macro_use]
 mod token_set;
 #[macro_use]

--- a/crates/ra_parser/src/syntax_kind/generated.rs
+++ b/crates/ra_parser/src/syntax_kind/generated.rs
@@ -105,6 +105,7 @@ pub enum SyntaxKind {
     DEFAULT_KW,
     EXISTENTIAL_KW,
     UNION_KW,
+    RAW_KW,
     INT_NUMBER,
     FLOAT_NUMBER,
     CHAR,
@@ -257,7 +258,7 @@ impl SyntaxKind {
             | IMPL_KW | IN_KW | LET_KW | LOOP_KW | MACRO_KW | MATCH_KW | MOD_KW | MOVE_KW
             | MUT_KW | PUB_KW | REF_KW | RETURN_KW | SELF_KW | STATIC_KW | STRUCT_KW | SUPER_KW
             | TRAIT_KW | TRUE_KW | TRY_KW | TYPE_KW | UNSAFE_KW | USE_KW | WHERE_KW | WHILE_KW
-            | AUTO_KW | DEFAULT_KW | EXISTENTIAL_KW | UNION_KW => true,
+            | AUTO_KW | DEFAULT_KW | EXISTENTIAL_KW | UNION_KW | RAW_KW => true,
             _ => false,
         }
     }
@@ -649,5 +650,8 @@ macro_rules! T {
     };
     ( union ) => {
         $crate::SyntaxKind::UNION_KW
+    };
+    ( raw ) => {
+        $crate::SyntaxKind::RAW_KW
     };
 }

--- a/crates/ra_syntax/src/algo.rs
+++ b/crates/ra_syntax/src/algo.rs
@@ -316,7 +316,7 @@ impl<'a> SyntaxRewriter<'a> {
     }
 }
 
-impl<'a> ops::AddAssign for SyntaxRewriter<'_> {
+impl ops::AddAssign for SyntaxRewriter<'_> {
     fn add_assign(&mut self, rhs: SyntaxRewriter) {
         assert!(rhs.f.is_none());
         self.replacements.extend(rhs.replacements)

--- a/crates/ra_syntax/src/ast.rs
+++ b/crates/ra_syntax/src/ast.rs
@@ -369,7 +369,7 @@ where
     let pred = predicates.next().unwrap();
     let mut bounds = pred.type_bound_list().unwrap().bounds();
 
-    assert_eq!("'a", pred.lifetime_token().unwrap().text());
+    assert_eq!("'a", pred.lifetime().unwrap().text());
 
     assert_bound("'b", bounds.next());
     assert_bound("'c", bounds.next());

--- a/crates/ra_syntax/src/ast/expr_extensions.rs
+++ b/crates/ra_syntax/src/ast/expr_extensions.rs
@@ -52,6 +52,10 @@ impl ast::RefExpr {
     pub fn is_mut(&self) -> bool {
         self.syntax().children_with_tokens().any(|n| n.kind() == T![mut])
     }
+
+    pub fn raw_token(&self) -> Option<SyntaxToken> {
+        None // FIXME: implement &raw
+    }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]

--- a/crates/ra_syntax/src/ast/extensions.rs
+++ b/crates/ra_syntax/src/ast/extensions.rs
@@ -529,3 +529,27 @@ impl ast::TokenTree {
         self.syntax().last_child_or_token().and_then(ast::RightDelimiter::cast_element)
     }
 }
+
+impl ast::Condition {
+    pub fn pat(&self) -> Option<ast::Pat> {
+        if self.eq().is_some() {
+            self.syntax()
+                .children_with_tokens()
+                .take_while(|x| x.kind() != T![=])
+                .find_map(ast::Pat::cast_element)
+        } else {
+            None
+        }
+    }
+
+    pub fn expr(&self) -> Option<ast::Expr> {
+        if self.eq().is_some() {
+            self.syntax()
+                .children_with_tokens()
+                .skip_while(|x| x.kind() != T![=])
+                .find_map(ast::Expr::cast_element)
+        } else {
+            child_opt(self)
+        }
+    }
+}

--- a/crates/ra_syntax/src/ast/extensions.rs
+++ b/crates/ra_syntax/src/ast/extensions.rs
@@ -4,7 +4,10 @@
 use itertools::Itertools;
 
 use crate::{
-    ast::{self, child_opt, children, AstNode, AttrInput, NameOwner, SyntaxNode},
+    ast::{
+        self, child_opt, child_token_opt, children, AstElement, AstNode, AstToken, AttrInput,
+        NameOwner, SyntaxNode,
+    },
     SmolStr, SyntaxElement,
     SyntaxKind::*,
     SyntaxToken, T,
@@ -130,13 +133,6 @@ impl ast::PathSegment {
         };
         Some(res)
     }
-
-    pub fn has_colon_colon(&self) -> bool {
-        match self.syntax.first_child_or_token().map(|s| s.kind()) {
-            Some(T![::]) => true,
-            _ => false,
-        }
-    }
 }
 
 impl ast::Path {
@@ -154,32 +150,12 @@ impl ast::Module {
     }
 }
 
-impl ast::UseTree {
-    pub fn has_star(&self) -> bool {
-        self.syntax().children_with_tokens().any(|it| it.kind() == T![*])
-    }
-}
-
 impl ast::UseTreeList {
     pub fn parent_use_tree(&self) -> ast::UseTree {
         self.syntax()
             .parent()
             .and_then(ast::UseTree::cast)
             .expect("UseTreeLists are always nested in UseTrees")
-    }
-    pub fn l_curly(&self) -> Option<SyntaxToken> {
-        self.token(T!['{'])
-    }
-
-    pub fn r_curly(&self) -> Option<SyntaxToken> {
-        self.token(T!['}'])
-    }
-
-    fn token(&self, kind: SyntaxKind) -> Option<SyntaxToken> {
-        self.syntax()
-            .children_with_tokens()
-            .filter_map(|it| it.into_token())
-            .find(|it| it.kind() == kind)
     }
 }
 
@@ -384,24 +360,9 @@ pub enum SelfParamKind {
 }
 
 impl ast::SelfParam {
-    pub fn self_kw_token(&self) -> SyntaxToken {
-        self.syntax()
-            .children_with_tokens()
-            .filter_map(|it| it.into_token())
-            .find(|it| it.kind() == T![self])
-            .expect("invalid tree: self param must have self")
-    }
-
     pub fn kind(&self) -> SelfParamKind {
-        let borrowed = self.syntax().children_with_tokens().any(|n| n.kind() == T![&]);
-        if borrowed {
-            // check for a `mut` coming after the & -- `mut &self` != `&mut self`
-            if self
-                .syntax()
-                .children_with_tokens()
-                .skip_while(|n| n.kind() != T![&])
-                .any(|n| n.kind() == T![mut])
-            {
+        if self.amp().is_some() {
+            if self.amp_mut_kw().is_some() {
                 SelfParamKind::MutRef
             } else {
                 SelfParamKind::Ref
@@ -410,32 +371,23 @@ impl ast::SelfParam {
             SelfParamKind::Owned
         }
     }
-}
 
-impl ast::LifetimeParam {
-    pub fn lifetime_token(&self) -> Option<SyntaxToken> {
+    /// the "mut" in "mut self", not the one in "&mut self"
+    pub fn mut_kw(&self) -> Option<ast::MutKw> {
         self.syntax()
             .children_with_tokens()
             .filter_map(|it| it.into_token())
-            .find(|it| it.kind() == LIFETIME)
+            .take_while(|it| it.kind() != T![&])
+            .find_map(ast::MutKw::cast)
     }
-}
 
-impl ast::TypeParam {
-    pub fn colon_token(&self) -> Option<SyntaxToken> {
+    /// the "mut" in "&mut self", not the one in "mut self"
+    pub fn amp_mut_kw(&self) -> Option<ast::MutKw> {
         self.syntax()
             .children_with_tokens()
             .filter_map(|it| it.into_token())
-            .find(|it| it.kind() == T![:])
-    }
-}
-
-impl ast::WherePred {
-    pub fn lifetime_token(&self) -> Option<SyntaxToken> {
-        self.syntax()
-            .children_with_tokens()
-            .filter_map(|it| it.into_token())
-            .find(|it| it.kind() == LIFETIME)
+            .skip_while(|it| it.kind() != T![&])
+            .find_map(ast::MutKw::cast)
     }
 }
 
@@ -446,7 +398,7 @@ pub enum TypeBoundKind {
     /// for<'a> ...
     ForType(ast::ForType),
     /// 'a
-    Lifetime(ast::SyntaxToken),
+    Lifetime(ast::Lifetime),
 }
 
 impl ast::TypeBound {
@@ -462,21 +414,28 @@ impl ast::TypeBound {
         }
     }
 
-    fn lifetime(&self) -> Option<SyntaxToken> {
-        self.syntax()
-            .children_with_tokens()
-            .filter_map(|it| it.into_token())
-            .find(|it| it.kind() == LIFETIME)
+    pub fn has_question_mark(&self) -> bool {
+        self.question().is_some()
     }
 
-    pub fn question_mark_token(&self) -> Option<SyntaxToken> {
+    pub fn const_question(&self) -> Option<ast::Question> {
         self.syntax()
             .children_with_tokens()
             .filter_map(|it| it.into_token())
-            .find(|it| it.kind() == T![?])
+            .take_while(|it| it.kind() != T![const])
+            .find_map(ast::Question::cast)
     }
-    pub fn has_question_mark(&self) -> bool {
-        self.question_mark_token().is_some()
+
+    pub fn question(&self) -> Option<ast::Question> {
+        if self.const_kw().is_some() {
+            self.syntax()
+                .children_with_tokens()
+                .filter_map(|it| it.into_token())
+                .skip_while(|it| it.kind() != T![const])
+                .find_map(ast::Question::cast)
+        } else {
+            child_token_opt(self)
+        }
     }
 }
 
@@ -490,6 +449,7 @@ pub enum VisibilityKind {
     In(ast::Path),
     PubCrate,
     PubSuper,
+    PubSelf,
     Pub,
 }
 
@@ -500,6 +460,8 @@ impl ast::Visibility {
         } else if self.is_pub_crate() {
             VisibilityKind::PubCrate
         } else if self.is_pub_super() {
+            VisibilityKind::PubSuper
+        } else if self.is_pub_self() {
             VisibilityKind::PubSuper
         } else {
             VisibilityKind::Pub
@@ -513,6 +475,10 @@ impl ast::Visibility {
     fn is_pub_super(&self) -> bool {
         self.syntax().children_with_tokens().any(|it| it.kind() == T![super])
     }
+
+    fn is_pub_self(&self) -> bool {
+        self.syntax().children_with_tokens().any(|it| it.kind() == T![self])
+    }
 }
 
 impl ast::MacroCall {
@@ -523,5 +489,43 @@ impl ast::MacroCall {
         } else {
             None
         }
+    }
+}
+
+impl ast::LifetimeParam {
+    pub fn lifetime_bounds(&self) -> impl Iterator<Item = ast::Lifetime> {
+        self.syntax()
+            .children_with_tokens()
+            .filter_map(|it| it.into_token())
+            .skip_while(|x| x.kind() != T![:])
+            .filter_map(ast::Lifetime::cast)
+    }
+}
+
+impl ast::RangePat {
+    pub fn start(&self) -> Option<ast::Pat> {
+        self.syntax()
+            .children_with_tokens()
+            .take_while(|it| !ast::RangeSeparator::can_cast_element(it.kind()))
+            .filter_map(|it| it.into_node())
+            .find_map(ast::Pat::cast)
+    }
+
+    pub fn end(&self) -> Option<ast::Pat> {
+        self.syntax()
+            .children_with_tokens()
+            .skip_while(|it| !ast::RangeSeparator::can_cast_element(it.kind()))
+            .filter_map(|it| it.into_node())
+            .find_map(ast::Pat::cast)
+    }
+}
+
+impl ast::TokenTree {
+    pub fn left_delimiter(&self) -> Option<ast::LeftDelimiter> {
+        self.syntax().first_child_or_token().and_then(ast::LeftDelimiter::cast_element)
+    }
+
+    pub fn right_delimiter(&self) -> Option<ast::RightDelimiter> {
+        self.syntax().last_child_or_token().and_then(ast::RightDelimiter::cast_element)
     }
 }

--- a/crates/ra_syntax/src/ast/generated.rs
+++ b/crates/ra_syntax/src/ast/generated.rs
@@ -6303,13 +6303,22 @@ impl ast::DocCommentsOwner for EnumVariant {}
 impl ast::AttrsOwner for EnumVariant {}
 impl EnumVariant {
     pub fn field_def_list(&self) -> Option<FieldDefList> {
-        self.syntax.children().filter_map(FieldDefList::cast).next()
+        self.syntax
+            .children_with_tokens()
+            .take_while(|x| !Eq::can_cast_element(x.kind()))
+            .filter_map(FieldDefList::cast_element)
+            .next()
     }
     pub fn eq(&self) -> Option<Eq> {
         self.syntax.children_with_tokens().filter_map(Eq::cast_element).next()
     }
     pub fn expr(&self) -> Option<Expr> {
-        self.syntax.children().filter_map(Expr::cast).next()
+        self.syntax
+            .children_with_tokens()
+            .skip_while(|x| !Eq::can_cast_element(x.kind()))
+            .skip(1)
+            .filter_map(Expr::cast_element)
+            .next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -6572,19 +6581,37 @@ impl ast::DocCommentsOwner for ConstDef {}
 impl ast::TypeAscriptionOwner for ConstDef {}
 impl ConstDef {
     pub fn default_kw(&self) -> Option<DefaultKw> {
-        self.syntax.children_with_tokens().filter_map(DefaultKw::cast_element).next()
+        self.syntax
+            .children_with_tokens()
+            .take_while(|x| !Eq::can_cast_element(x.kind()))
+            .filter_map(DefaultKw::cast_element)
+            .next()
     }
     pub fn const_kw(&self) -> Option<ConstKw> {
-        self.syntax.children_with_tokens().filter_map(ConstKw::cast_element).next()
+        self.syntax
+            .children_with_tokens()
+            .take_while(|x| !Eq::can_cast_element(x.kind()))
+            .filter_map(ConstKw::cast_element)
+            .next()
     }
     pub fn eq(&self) -> Option<Eq> {
         self.syntax.children_with_tokens().filter_map(Eq::cast_element).next()
     }
     pub fn body(&self) -> Option<Expr> {
-        self.syntax.children().filter_map(Expr::cast).next()
+        self.syntax
+            .children_with_tokens()
+            .skip_while(|x| !Eq::can_cast_element(x.kind()))
+            .skip(1)
+            .filter_map(Expr::cast_element)
+            .next()
     }
     pub fn semi(&self) -> Option<Semi> {
-        self.syntax.children_with_tokens().filter_map(Semi::cast_element).next()
+        self.syntax
+            .children_with_tokens()
+            .skip_while(|x| !Eq::can_cast_element(x.kind()))
+            .skip(1)
+            .filter_map(Semi::cast_element)
+            .next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -6646,19 +6673,37 @@ impl ast::DocCommentsOwner for StaticDef {}
 impl ast::TypeAscriptionOwner for StaticDef {}
 impl StaticDef {
     pub fn static_kw(&self) -> Option<StaticKw> {
-        self.syntax.children_with_tokens().filter_map(StaticKw::cast_element).next()
+        self.syntax
+            .children_with_tokens()
+            .take_while(|x| !Eq::can_cast_element(x.kind()))
+            .filter_map(StaticKw::cast_element)
+            .next()
     }
     pub fn mut_kw(&self) -> Option<MutKw> {
-        self.syntax.children_with_tokens().filter_map(MutKw::cast_element).next()
+        self.syntax
+            .children_with_tokens()
+            .take_while(|x| !Eq::can_cast_element(x.kind()))
+            .filter_map(MutKw::cast_element)
+            .next()
     }
     pub fn eq(&self) -> Option<Eq> {
         self.syntax.children_with_tokens().filter_map(Eq::cast_element).next()
     }
     pub fn body(&self) -> Option<Expr> {
-        self.syntax.children().filter_map(Expr::cast).next()
+        self.syntax
+            .children_with_tokens()
+            .skip_while(|x| !Eq::can_cast_element(x.kind()))
+            .skip(1)
+            .filter_map(Expr::cast_element)
+            .next()
     }
     pub fn semi(&self) -> Option<Semi> {
-        self.syntax.children_with_tokens().filter_map(Semi::cast_element).next()
+        self.syntax
+            .children_with_tokens()
+            .skip_while(|x| !Eq::can_cast_element(x.kind()))
+            .skip(1)
+            .filter_map(Semi::cast_element)
+            .next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -6720,19 +6765,37 @@ impl ast::DocCommentsOwner for TypeAliasDef {}
 impl ast::TypeBoundsOwner for TypeAliasDef {}
 impl TypeAliasDef {
     pub fn default_kw(&self) -> Option<DefaultKw> {
-        self.syntax.children_with_tokens().filter_map(DefaultKw::cast_element).next()
+        self.syntax
+            .children_with_tokens()
+            .take_while(|x| !Eq::can_cast_element(x.kind()))
+            .filter_map(DefaultKw::cast_element)
+            .next()
     }
     pub fn type_kw(&self) -> Option<TypeKw> {
-        self.syntax.children_with_tokens().filter_map(TypeKw::cast_element).next()
+        self.syntax
+            .children_with_tokens()
+            .take_while(|x| !Eq::can_cast_element(x.kind()))
+            .filter_map(TypeKw::cast_element)
+            .next()
     }
     pub fn eq(&self) -> Option<Eq> {
         self.syntax.children_with_tokens().filter_map(Eq::cast_element).next()
     }
     pub fn type_ref(&self) -> Option<TypeRef> {
-        self.syntax.children().filter_map(TypeRef::cast).next()
+        self.syntax
+            .children_with_tokens()
+            .skip_while(|x| !Eq::can_cast_element(x.kind()))
+            .skip(1)
+            .filter_map(TypeRef::cast_element)
+            .next()
     }
     pub fn semi(&self) -> Option<Semi> {
-        self.syntax.children_with_tokens().filter_map(Semi::cast_element).next()
+        self.syntax
+            .children_with_tokens()
+            .skip_while(|x| !Eq::can_cast_element(x.kind()))
+            .skip(1)
+            .filter_map(Semi::cast_element)
+            .next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -8157,16 +8220,29 @@ impl ast::AttrsOwner for ForExpr {}
 impl ast::LoopBodyOwner for ForExpr {}
 impl ForExpr {
     pub fn for_kw(&self) -> Option<ForKw> {
-        self.syntax.children_with_tokens().filter_map(ForKw::cast_element).next()
+        self.syntax
+            .children_with_tokens()
+            .take_while(|x| !InKw::can_cast_element(x.kind()))
+            .filter_map(ForKw::cast_element)
+            .next()
     }
     pub fn pat(&self) -> Option<Pat> {
-        self.syntax.children().filter_map(Pat::cast).next()
+        self.syntax
+            .children_with_tokens()
+            .take_while(|x| !InKw::can_cast_element(x.kind()))
+            .filter_map(Pat::cast_element)
+            .next()
     }
     pub fn in_kw(&self) -> Option<InKw> {
         self.syntax.children_with_tokens().filter_map(InKw::cast_element).next()
     }
     pub fn iterable(&self) -> Option<Expr> {
-        self.syntax.children().filter_map(Expr::cast).next()
+        self.syntax
+            .children_with_tokens()
+            .skip_while(|x| !InKw::can_cast_element(x.kind()))
+            .skip(1)
+            .filter_map(Expr::cast_element)
+            .next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -9498,16 +9574,29 @@ impl AstElement for MatchArm {
 impl ast::AttrsOwner for MatchArm {}
 impl MatchArm {
     pub fn pat(&self) -> Option<Pat> {
-        self.syntax.children().filter_map(Pat::cast).next()
+        self.syntax
+            .children_with_tokens()
+            .take_while(|x| !FatArrow::can_cast_element(x.kind()))
+            .filter_map(Pat::cast_element)
+            .next()
     }
     pub fn guard(&self) -> Option<MatchGuard> {
-        self.syntax.children().filter_map(MatchGuard::cast).next()
+        self.syntax
+            .children_with_tokens()
+            .take_while(|x| !FatArrow::can_cast_element(x.kind()))
+            .filter_map(MatchGuard::cast_element)
+            .next()
     }
     pub fn fat_arrow(&self) -> Option<FatArrow> {
         self.syntax.children_with_tokens().filter_map(FatArrow::cast_element).next()
     }
     pub fn expr(&self) -> Option<Expr> {
-        self.syntax.children().filter_map(Expr::cast).next()
+        self.syntax
+            .children_with_tokens()
+            .skip_while(|x| !FatArrow::can_cast_element(x.kind()))
+            .skip(1)
+            .filter_map(Expr::cast_element)
+            .next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -11753,16 +11842,29 @@ impl ast::AttrsOwner for LetStmt {}
 impl ast::TypeAscriptionOwner for LetStmt {}
 impl LetStmt {
     pub fn let_kw(&self) -> Option<LetKw> {
-        self.syntax.children_with_tokens().filter_map(LetKw::cast_element).next()
+        self.syntax
+            .children_with_tokens()
+            .take_while(|x| !Eq::can_cast_element(x.kind()))
+            .filter_map(LetKw::cast_element)
+            .next()
     }
     pub fn pat(&self) -> Option<Pat> {
-        self.syntax.children().filter_map(Pat::cast).next()
+        self.syntax
+            .children_with_tokens()
+            .take_while(|x| !Eq::can_cast_element(x.kind()))
+            .filter_map(Pat::cast_element)
+            .next()
     }
     pub fn eq(&self) -> Option<Eq> {
         self.syntax.children_with_tokens().filter_map(Eq::cast_element).next()
     }
     pub fn initializer(&self) -> Option<Expr> {
-        self.syntax.children().filter_map(Expr::cast).next()
+        self.syntax
+            .children_with_tokens()
+            .skip_while(|x| !Eq::can_cast_element(x.kind()))
+            .skip(1)
+            .filter_map(Expr::cast_element)
+            .next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -11820,14 +11922,8 @@ impl Condition {
     pub fn let_kw(&self) -> Option<LetKw> {
         self.syntax.children_with_tokens().filter_map(LetKw::cast_element).next()
     }
-    pub fn pat(&self) -> Option<Pat> {
-        self.syntax.children().filter_map(Pat::cast).next()
-    }
     pub fn eq(&self) -> Option<Eq> {
         self.syntax.children_with_tokens().filter_map(Eq::cast_element).next()
-    }
-    pub fn expr(&self) -> Option<Expr> {
-        self.syntax.children().filter_map(Expr::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/ra_syntax/src/ast/generated.rs
+++ b/crates/ra_syntax/src/ast/generated.rs
@@ -5599,8 +5599,8 @@ impl ast::ModuleItemOwner for SourceFile {}
 impl ast::FnDefOwner for SourceFile {}
 impl ast::AttrsOwner for SourceFile {}
 impl SourceFile {
-    pub fn modules(&self) -> AstChildren<Module> {
-        AstChildren::new(&self.syntax)
+    pub fn modules(&self) -> impl Iterator<Item = Module> + Clone {
+        self.syntax.children().filter_map(Module::cast)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -5661,34 +5661,34 @@ impl ast::DocCommentsOwner for FnDef {}
 impl ast::AttrsOwner for FnDef {}
 impl FnDef {
     pub fn abi(&self) -> Option<Abi> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Abi::cast).next()
     }
     pub fn const_kw(&self) -> Option<ConstKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(ConstKw::cast_element).next()
     }
     pub fn default_kw(&self) -> Option<DefaultKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(DefaultKw::cast_element).next()
     }
     pub fn async_kw(&self) -> Option<AsyncKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(AsyncKw::cast_element).next()
     }
     pub fn unsafe_kw(&self) -> Option<UnsafeKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(UnsafeKw::cast_element).next()
     }
     pub fn fn_kw(&self) -> Option<FnKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(FnKw::cast_element).next()
     }
     pub fn param_list(&self) -> Option<ParamList> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(ParamList::cast).next()
     }
     pub fn ret_type(&self) -> Option<RetType> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(RetType::cast).next()
     }
     pub fn body(&self) -> Option<BlockExpr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(BlockExpr::cast).next()
     }
     pub fn semi(&self) -> Option<Semi> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Semi::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -5744,10 +5744,10 @@ impl AstElement for RetType {
 }
 impl RetType {
     pub fn thin_arrow(&self) -> Option<ThinArrow> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(ThinArrow::cast_element).next()
     }
     pub fn type_ref(&self) -> Option<TypeRef> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(TypeRef::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -5808,13 +5808,13 @@ impl ast::AttrsOwner for StructDef {}
 impl ast::DocCommentsOwner for StructDef {}
 impl StructDef {
     pub fn struct_kw(&self) -> Option<StructKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(StructKw::cast_element).next()
     }
     pub fn field_def_list(&self) -> Option<FieldDefList> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(FieldDefList::cast).next()
     }
     pub fn semi(&self) -> Option<Semi> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Semi::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -5875,10 +5875,10 @@ impl ast::AttrsOwner for UnionDef {}
 impl ast::DocCommentsOwner for UnionDef {}
 impl UnionDef {
     pub fn union_kw(&self) -> Option<UnionKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(UnionKw::cast_element).next()
     }
     pub fn record_field_def_list(&self) -> Option<RecordFieldDefList> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(RecordFieldDefList::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -5934,13 +5934,13 @@ impl AstElement for RecordFieldDefList {
 }
 impl RecordFieldDefList {
     pub fn l_curly(&self) -> Option<LCurly> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LCurly::cast_element).next()
     }
-    pub fn fields(&self) -> AstChildren<RecordFieldDef> {
-        AstChildren::new(&self.syntax)
+    pub fn fields(&self) -> impl Iterator<Item = RecordFieldDef> + Clone {
+        self.syntax.children().filter_map(RecordFieldDef::cast)
     }
     pub fn r_curly(&self) -> Option<RCurly> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RCurly::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -6053,13 +6053,13 @@ impl AstElement for TupleFieldDefList {
 }
 impl TupleFieldDefList {
     pub fn l_paren(&self) -> Option<LParen> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LParen::cast_element).next()
     }
-    pub fn fields(&self) -> AstChildren<TupleFieldDef> {
-        AstChildren::new(&self.syntax)
+    pub fn fields(&self) -> impl Iterator<Item = TupleFieldDef> + Clone {
+        self.syntax.children().filter_map(TupleFieldDef::cast)
     }
     pub fn r_paren(&self) -> Option<RParen> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RParen::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -6117,7 +6117,7 @@ impl ast::VisibilityOwner for TupleFieldDef {}
 impl ast::AttrsOwner for TupleFieldDef {}
 impl TupleFieldDef {
     pub fn type_ref(&self) -> Option<TypeRef> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(TypeRef::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -6178,10 +6178,10 @@ impl ast::AttrsOwner for EnumDef {}
 impl ast::DocCommentsOwner for EnumDef {}
 impl EnumDef {
     pub fn enum_kw(&self) -> Option<EnumKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(EnumKw::cast_element).next()
     }
     pub fn variant_list(&self) -> Option<EnumVariantList> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(EnumVariantList::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -6237,13 +6237,13 @@ impl AstElement for EnumVariantList {
 }
 impl EnumVariantList {
     pub fn l_curly(&self) -> Option<LCurly> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LCurly::cast_element).next()
     }
-    pub fn variants(&self) -> AstChildren<EnumVariant> {
-        AstChildren::new(&self.syntax)
+    pub fn variants(&self) -> impl Iterator<Item = EnumVariant> + Clone {
+        self.syntax.children().filter_map(EnumVariant::cast)
     }
     pub fn r_curly(&self) -> Option<RCurly> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RCurly::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -6303,13 +6303,13 @@ impl ast::DocCommentsOwner for EnumVariant {}
 impl ast::AttrsOwner for EnumVariant {}
 impl EnumVariant {
     pub fn field_def_list(&self) -> Option<FieldDefList> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(FieldDefList::cast).next()
     }
     pub fn eq(&self) -> Option<Eq> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Eq::cast_element).next()
     }
     pub fn expr(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -6371,16 +6371,16 @@ impl ast::TypeParamsOwner for TraitDef {}
 impl ast::TypeBoundsOwner for TraitDef {}
 impl TraitDef {
     pub fn unsafe_kw(&self) -> Option<UnsafeKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(UnsafeKw::cast_element).next()
     }
     pub fn auto_kw(&self) -> Option<AutoKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(AutoKw::cast_element).next()
     }
     pub fn trait_kw(&self) -> Option<TraitKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(TraitKw::cast_element).next()
     }
     pub fn item_list(&self) -> Option<ItemList> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(ItemList::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -6440,13 +6440,13 @@ impl ast::AttrsOwner for Module {}
 impl ast::DocCommentsOwner for Module {}
 impl Module {
     pub fn mod_kw(&self) -> Option<ModKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(ModKw::cast_element).next()
     }
     pub fn item_list(&self) -> Option<ItemList> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(ItemList::cast).next()
     }
     pub fn semi(&self) -> Option<Semi> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Semi::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -6504,13 +6504,13 @@ impl ast::FnDefOwner for ItemList {}
 impl ast::ModuleItemOwner for ItemList {}
 impl ItemList {
     pub fn l_curly(&self) -> Option<LCurly> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LCurly::cast_element).next()
     }
-    pub fn impl_items(&self) -> AstChildren<ImplItem> {
-        AstChildren::new(&self.syntax)
+    pub fn impl_items(&self) -> impl Iterator<Item = ImplItem> + Clone {
+        self.syntax.children().filter_map(ImplItem::cast)
     }
     pub fn r_curly(&self) -> Option<RCurly> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RCurly::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -6572,19 +6572,19 @@ impl ast::DocCommentsOwner for ConstDef {}
 impl ast::TypeAscriptionOwner for ConstDef {}
 impl ConstDef {
     pub fn default_kw(&self) -> Option<DefaultKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(DefaultKw::cast_element).next()
     }
     pub fn const_kw(&self) -> Option<ConstKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(ConstKw::cast_element).next()
     }
     pub fn eq(&self) -> Option<Eq> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Eq::cast_element).next()
     }
     pub fn body(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
     pub fn semi(&self) -> Option<Semi> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Semi::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -6646,19 +6646,19 @@ impl ast::DocCommentsOwner for StaticDef {}
 impl ast::TypeAscriptionOwner for StaticDef {}
 impl StaticDef {
     pub fn static_kw(&self) -> Option<StaticKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(StaticKw::cast_element).next()
     }
     pub fn mut_kw(&self) -> Option<MutKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(MutKw::cast_element).next()
     }
     pub fn eq(&self) -> Option<Eq> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Eq::cast_element).next()
     }
     pub fn body(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
     pub fn semi(&self) -> Option<Semi> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Semi::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -6720,19 +6720,19 @@ impl ast::DocCommentsOwner for TypeAliasDef {}
 impl ast::TypeBoundsOwner for TypeAliasDef {}
 impl TypeAliasDef {
     pub fn default_kw(&self) -> Option<DefaultKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(DefaultKw::cast_element).next()
     }
     pub fn type_kw(&self) -> Option<TypeKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(TypeKw::cast_element).next()
     }
     pub fn eq(&self) -> Option<Eq> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Eq::cast_element).next()
     }
     pub fn type_ref(&self) -> Option<TypeRef> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(TypeRef::cast).next()
     }
     pub fn semi(&self) -> Option<Semi> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Semi::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -6790,25 +6790,25 @@ impl ast::TypeParamsOwner for ImplDef {}
 impl ast::AttrsOwner for ImplDef {}
 impl ImplDef {
     pub fn default_kw(&self) -> Option<DefaultKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(DefaultKw::cast_element).next()
     }
     pub fn const_kw(&self) -> Option<ConstKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(ConstKw::cast_element).next()
     }
     pub fn unsafe_kw(&self) -> Option<UnsafeKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(UnsafeKw::cast_element).next()
     }
     pub fn impl_kw(&self) -> Option<ImplKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(ImplKw::cast_element).next()
     }
     pub fn excl(&self) -> Option<Excl> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Excl::cast_element).next()
     }
     pub fn for_kw(&self) -> Option<ForKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(ForKw::cast_element).next()
     }
     pub fn item_list(&self) -> Option<ItemList> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(ItemList::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -6864,13 +6864,13 @@ impl AstElement for ParenType {
 }
 impl ParenType {
     pub fn l_paren(&self) -> Option<LParen> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LParen::cast_element).next()
     }
     pub fn type_ref(&self) -> Option<TypeRef> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(TypeRef::cast).next()
     }
     pub fn r_paren(&self) -> Option<RParen> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RParen::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -6926,13 +6926,13 @@ impl AstElement for TupleType {
 }
 impl TupleType {
     pub fn l_paren(&self) -> Option<LParen> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LParen::cast_element).next()
     }
-    pub fn fields(&self) -> AstChildren<TypeRef> {
-        AstChildren::new(&self.syntax)
+    pub fn fields(&self) -> impl Iterator<Item = TypeRef> + Clone {
+        self.syntax.children().filter_map(TypeRef::cast)
     }
     pub fn r_paren(&self) -> Option<RParen> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RParen::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -6988,7 +6988,7 @@ impl AstElement for NeverType {
 }
 impl NeverType {
     pub fn excl(&self) -> Option<Excl> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Excl::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -7044,7 +7044,7 @@ impl AstElement for PathType {
 }
 impl PathType {
     pub fn path(&self) -> Option<Path> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Path::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -7100,13 +7100,13 @@ impl AstElement for PointerType {
 }
 impl PointerType {
     pub fn star(&self) -> Option<Star> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Star::cast_element).next()
     }
     pub fn const_kw(&self) -> Option<ConstKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(ConstKw::cast_element).next()
     }
     pub fn type_ref(&self) -> Option<TypeRef> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(TypeRef::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -7162,19 +7162,19 @@ impl AstElement for ArrayType {
 }
 impl ArrayType {
     pub fn l_brack(&self) -> Option<LBrack> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LBrack::cast_element).next()
     }
     pub fn type_ref(&self) -> Option<TypeRef> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(TypeRef::cast).next()
     }
     pub fn semi(&self) -> Option<Semi> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Semi::cast_element).next()
     }
     pub fn expr(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
     pub fn r_brack(&self) -> Option<RBrack> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RBrack::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -7230,13 +7230,13 @@ impl AstElement for SliceType {
 }
 impl SliceType {
     pub fn l_brack(&self) -> Option<LBrack> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LBrack::cast_element).next()
     }
     pub fn type_ref(&self) -> Option<TypeRef> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(TypeRef::cast).next()
     }
     pub fn r_brack(&self) -> Option<RBrack> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RBrack::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -7292,16 +7292,16 @@ impl AstElement for ReferenceType {
 }
 impl ReferenceType {
     pub fn amp(&self) -> Option<Amp> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Amp::cast_element).next()
     }
     pub fn lifetime(&self) -> Option<Lifetime> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Lifetime::cast_element).next()
     }
     pub fn mut_kw(&self) -> Option<MutKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(MutKw::cast_element).next()
     }
     pub fn type_ref(&self) -> Option<TypeRef> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(TypeRef::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -7357,7 +7357,7 @@ impl AstElement for PlaceholderType {
 }
 impl PlaceholderType {
     pub fn underscore(&self) -> Option<Underscore> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Underscore::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -7413,19 +7413,19 @@ impl AstElement for FnPointerType {
 }
 impl FnPointerType {
     pub fn abi(&self) -> Option<Abi> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Abi::cast).next()
     }
     pub fn unsafe_kw(&self) -> Option<UnsafeKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(UnsafeKw::cast_element).next()
     }
     pub fn fn_kw(&self) -> Option<FnKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(FnKw::cast_element).next()
     }
     pub fn param_list(&self) -> Option<ParamList> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(ParamList::cast).next()
     }
     pub fn ret_type(&self) -> Option<RetType> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(RetType::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -7481,13 +7481,13 @@ impl AstElement for ForType {
 }
 impl ForType {
     pub fn for_kw(&self) -> Option<ForKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(ForKw::cast_element).next()
     }
     pub fn type_param_list(&self) -> Option<TypeParamList> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(TypeParamList::cast).next()
     }
     pub fn type_ref(&self) -> Option<TypeRef> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(TypeRef::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -7544,7 +7544,7 @@ impl AstElement for ImplTraitType {
 impl ast::TypeBoundsOwner for ImplTraitType {}
 impl ImplTraitType {
     pub fn impl_kw(&self) -> Option<ImplKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(ImplKw::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -7601,7 +7601,7 @@ impl AstElement for DynTraitType {
 impl ast::TypeBoundsOwner for DynTraitType {}
 impl DynTraitType {
     pub fn dyn_kw(&self) -> Option<DynKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(DynKw::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -7658,13 +7658,13 @@ impl AstElement for TupleExpr {
 impl ast::AttrsOwner for TupleExpr {}
 impl TupleExpr {
     pub fn l_paren(&self) -> Option<LParen> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LParen::cast_element).next()
     }
-    pub fn exprs(&self) -> AstChildren<Expr> {
-        AstChildren::new(&self.syntax)
+    pub fn exprs(&self) -> impl Iterator<Item = Expr> + Clone {
+        self.syntax.children().filter_map(Expr::cast)
     }
     pub fn r_paren(&self) -> Option<RParen> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RParen::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -7721,16 +7721,16 @@ impl AstElement for ArrayExpr {
 impl ast::AttrsOwner for ArrayExpr {}
 impl ArrayExpr {
     pub fn l_brack(&self) -> Option<LBrack> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LBrack::cast_element).next()
     }
-    pub fn exprs(&self) -> AstChildren<Expr> {
-        AstChildren::new(&self.syntax)
+    pub fn exprs(&self) -> impl Iterator<Item = Expr> + Clone {
+        self.syntax.children().filter_map(Expr::cast)
     }
     pub fn semi(&self) -> Option<Semi> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Semi::cast_element).next()
     }
     pub fn r_brack(&self) -> Option<RBrack> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RBrack::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -7787,13 +7787,13 @@ impl AstElement for ParenExpr {
 impl ast::AttrsOwner for ParenExpr {}
 impl ParenExpr {
     pub fn l_paren(&self) -> Option<LParen> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LParen::cast_element).next()
     }
     pub fn expr(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
     pub fn r_paren(&self) -> Option<RParen> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RParen::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -7849,7 +7849,7 @@ impl AstElement for PathExpr {
 }
 impl PathExpr {
     pub fn path(&self) -> Option<Path> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Path::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -7906,22 +7906,22 @@ impl AstElement for LambdaExpr {
 impl ast::AttrsOwner for LambdaExpr {}
 impl LambdaExpr {
     pub fn static_kw(&self) -> Option<StaticKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(StaticKw::cast_element).next()
     }
     pub fn async_kw(&self) -> Option<AsyncKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(AsyncKw::cast_element).next()
     }
     pub fn move_kw(&self) -> Option<MoveKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(MoveKw::cast_element).next()
     }
     pub fn param_list(&self) -> Option<ParamList> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(ParamList::cast).next()
     }
     pub fn ret_type(&self) -> Option<RetType> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(RetType::cast).next()
     }
     pub fn body(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -7978,10 +7978,10 @@ impl AstElement for IfExpr {
 impl ast::AttrsOwner for IfExpr {}
 impl IfExpr {
     pub fn if_kw(&self) -> Option<IfKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(IfKw::cast_element).next()
     }
     pub fn condition(&self) -> Option<Condition> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Condition::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -8039,7 +8039,7 @@ impl ast::AttrsOwner for LoopExpr {}
 impl ast::LoopBodyOwner for LoopExpr {}
 impl LoopExpr {
     pub fn loop_kw(&self) -> Option<LoopKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LoopKw::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -8096,10 +8096,10 @@ impl AstElement for TryBlockExpr {
 impl ast::AttrsOwner for TryBlockExpr {}
 impl TryBlockExpr {
     pub fn try_kw(&self) -> Option<TryKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(TryKw::cast_element).next()
     }
     pub fn body(&self) -> Option<BlockExpr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(BlockExpr::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -8157,16 +8157,16 @@ impl ast::AttrsOwner for ForExpr {}
 impl ast::LoopBodyOwner for ForExpr {}
 impl ForExpr {
     pub fn for_kw(&self) -> Option<ForKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(ForKw::cast_element).next()
     }
     pub fn pat(&self) -> Option<Pat> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Pat::cast).next()
     }
     pub fn in_kw(&self) -> Option<InKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(InKw::cast_element).next()
     }
     pub fn iterable(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -8224,10 +8224,10 @@ impl ast::AttrsOwner for WhileExpr {}
 impl ast::LoopBodyOwner for WhileExpr {}
 impl WhileExpr {
     pub fn while_kw(&self) -> Option<WhileKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(WhileKw::cast_element).next()
     }
     pub fn condition(&self) -> Option<Condition> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Condition::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -8284,10 +8284,10 @@ impl AstElement for ContinueExpr {
 impl ast::AttrsOwner for ContinueExpr {}
 impl ContinueExpr {
     pub fn continue_kw(&self) -> Option<ContinueKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(ContinueKw::cast_element).next()
     }
     pub fn lifetime(&self) -> Option<Lifetime> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Lifetime::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -8344,13 +8344,13 @@ impl AstElement for BreakExpr {
 impl ast::AttrsOwner for BreakExpr {}
 impl BreakExpr {
     pub fn break_kw(&self) -> Option<BreakKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(BreakKw::cast_element).next()
     }
     pub fn lifetime(&self) -> Option<Lifetime> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Lifetime::cast_element).next()
     }
     pub fn expr(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -8406,7 +8406,7 @@ impl AstElement for Label {
 }
 impl Label {
     pub fn lifetime(&self) -> Option<Lifetime> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Lifetime::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -8463,13 +8463,13 @@ impl AstElement for BlockExpr {
 impl ast::AttrsOwner for BlockExpr {}
 impl BlockExpr {
     pub fn label(&self) -> Option<Label> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Label::cast).next()
     }
     pub fn unsafe_kw(&self) -> Option<UnsafeKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(UnsafeKw::cast_element).next()
     }
     pub fn block(&self) -> Option<Block> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Block::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -8526,7 +8526,7 @@ impl AstElement for ReturnExpr {
 impl ast::AttrsOwner for ReturnExpr {}
 impl ReturnExpr {
     pub fn expr(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -8583,7 +8583,7 @@ impl AstElement for CallExpr {
 impl ast::ArgListOwner for CallExpr {}
 impl CallExpr {
     pub fn expr(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -8641,16 +8641,16 @@ impl ast::AttrsOwner for MethodCallExpr {}
 impl ast::ArgListOwner for MethodCallExpr {}
 impl MethodCallExpr {
     pub fn expr(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
     pub fn dot(&self) -> Option<Dot> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Dot::cast_element).next()
     }
     pub fn name_ref(&self) -> Option<NameRef> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(NameRef::cast).next()
     }
     pub fn type_arg_list(&self) -> Option<TypeArgList> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(TypeArgList::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -8707,10 +8707,10 @@ impl AstElement for IndexExpr {
 impl ast::AttrsOwner for IndexExpr {}
 impl IndexExpr {
     pub fn l_brack(&self) -> Option<LBrack> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LBrack::cast_element).next()
     }
     pub fn r_brack(&self) -> Option<RBrack> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RBrack::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -8767,13 +8767,13 @@ impl AstElement for FieldExpr {
 impl ast::AttrsOwner for FieldExpr {}
 impl FieldExpr {
     pub fn expr(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
     pub fn dot(&self) -> Option<Dot> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Dot::cast_element).next()
     }
     pub fn name_ref(&self) -> Option<NameRef> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(NameRef::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -8830,13 +8830,13 @@ impl AstElement for AwaitExpr {
 impl ast::AttrsOwner for AwaitExpr {}
 impl AwaitExpr {
     pub fn expr(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
     pub fn dot(&self) -> Option<Dot> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Dot::cast_element).next()
     }
     pub fn await_kw(&self) -> Option<AwaitKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(AwaitKw::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -8893,10 +8893,10 @@ impl AstElement for TryExpr {
 impl ast::AttrsOwner for TryExpr {}
 impl TryExpr {
     pub fn try_kw(&self) -> Option<TryKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(TryKw::cast_element).next()
     }
     pub fn expr(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -8953,13 +8953,13 @@ impl AstElement for CastExpr {
 impl ast::AttrsOwner for CastExpr {}
 impl CastExpr {
     pub fn expr(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
     pub fn as_kw(&self) -> Option<AsKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(AsKw::cast_element).next()
     }
     pub fn type_ref(&self) -> Option<TypeRef> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(TypeRef::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -9016,16 +9016,16 @@ impl AstElement for RefExpr {
 impl ast::AttrsOwner for RefExpr {}
 impl RefExpr {
     pub fn amp(&self) -> Option<Amp> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Amp::cast_element).next()
     }
     pub fn raw_kw(&self) -> Option<RawKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RawKw::cast_element).next()
     }
     pub fn mut_kw(&self) -> Option<MutKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(MutKw::cast_element).next()
     }
     pub fn expr(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -9082,10 +9082,10 @@ impl AstElement for PrefixExpr {
 impl ast::AttrsOwner for PrefixExpr {}
 impl PrefixExpr {
     pub fn prefix_op(&self) -> Option<PrefixOp> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(PrefixOp::cast_element).next()
     }
     pub fn expr(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -9142,10 +9142,10 @@ impl AstElement for BoxExpr {
 impl ast::AttrsOwner for BoxExpr {}
 impl BoxExpr {
     pub fn box_kw(&self) -> Option<BoxKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(BoxKw::cast_element).next()
     }
     pub fn expr(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -9202,7 +9202,7 @@ impl AstElement for RangeExpr {
 impl ast::AttrsOwner for RangeExpr {}
 impl RangeExpr {
     pub fn range_op(&self) -> Option<RangeOp> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RangeOp::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -9259,7 +9259,7 @@ impl AstElement for BinExpr {
 impl ast::AttrsOwner for BinExpr {}
 impl BinExpr {
     pub fn bin_op(&self) -> Option<BinOp> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(BinOp::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -9315,7 +9315,7 @@ impl AstElement for Literal {
 }
 impl Literal {
     pub fn literal_token(&self) -> Option<LiteralToken> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LiteralToken::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -9372,13 +9372,13 @@ impl AstElement for MatchExpr {
 impl ast::AttrsOwner for MatchExpr {}
 impl MatchExpr {
     pub fn match_kw(&self) -> Option<MatchKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(MatchKw::cast_element).next()
     }
     pub fn expr(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
     pub fn match_arm_list(&self) -> Option<MatchArmList> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(MatchArmList::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -9435,13 +9435,13 @@ impl AstElement for MatchArmList {
 impl ast::AttrsOwner for MatchArmList {}
 impl MatchArmList {
     pub fn l_curly(&self) -> Option<LCurly> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LCurly::cast_element).next()
     }
-    pub fn arms(&self) -> AstChildren<MatchArm> {
-        AstChildren::new(&self.syntax)
+    pub fn arms(&self) -> impl Iterator<Item = MatchArm> + Clone {
+        self.syntax.children().filter_map(MatchArm::cast)
     }
     pub fn r_curly(&self) -> Option<RCurly> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RCurly::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -9498,16 +9498,16 @@ impl AstElement for MatchArm {
 impl ast::AttrsOwner for MatchArm {}
 impl MatchArm {
     pub fn pat(&self) -> Option<Pat> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Pat::cast).next()
     }
     pub fn guard(&self) -> Option<MatchGuard> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(MatchGuard::cast).next()
     }
     pub fn fat_arrow(&self) -> Option<FatArrow> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(FatArrow::cast_element).next()
     }
     pub fn expr(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -9563,10 +9563,10 @@ impl AstElement for MatchGuard {
 }
 impl MatchGuard {
     pub fn if_kw(&self) -> Option<IfKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(IfKw::cast_element).next()
     }
     pub fn expr(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -9622,10 +9622,10 @@ impl AstElement for RecordLit {
 }
 impl RecordLit {
     pub fn path(&self) -> Option<Path> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Path::cast).next()
     }
     pub fn record_field_list(&self) -> Option<RecordFieldList> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(RecordFieldList::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -9681,19 +9681,19 @@ impl AstElement for RecordFieldList {
 }
 impl RecordFieldList {
     pub fn l_curly(&self) -> Option<LCurly> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LCurly::cast_element).next()
     }
-    pub fn fields(&self) -> AstChildren<RecordField> {
-        AstChildren::new(&self.syntax)
+    pub fn fields(&self) -> impl Iterator<Item = RecordField> + Clone {
+        self.syntax.children().filter_map(RecordField::cast)
     }
     pub fn dotdot(&self) -> Option<Dotdot> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Dotdot::cast_element).next()
     }
     pub fn spread(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
     pub fn r_curly(&self) -> Option<RCurly> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RCurly::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -9750,13 +9750,13 @@ impl AstElement for RecordField {
 impl ast::AttrsOwner for RecordField {}
 impl RecordField {
     pub fn name_ref(&self) -> Option<NameRef> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(NameRef::cast).next()
     }
     pub fn colon(&self) -> Option<Colon> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Colon::cast_element).next()
     }
     pub fn expr(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -9811,8 +9811,8 @@ impl AstElement for OrPat {
     }
 }
 impl OrPat {
-    pub fn pats(&self) -> AstChildren<Pat> {
-        AstChildren::new(&self.syntax)
+    pub fn pats(&self) -> impl Iterator<Item = Pat> + Clone {
+        self.syntax.children().filter_map(Pat::cast)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -9868,13 +9868,13 @@ impl AstElement for ParenPat {
 }
 impl ParenPat {
     pub fn l_paren(&self) -> Option<LParen> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LParen::cast_element).next()
     }
     pub fn pat(&self) -> Option<Pat> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Pat::cast).next()
     }
     pub fn r_paren(&self) -> Option<RParen> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RParen::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -9930,13 +9930,13 @@ impl AstElement for RefPat {
 }
 impl RefPat {
     pub fn amp(&self) -> Option<Amp> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Amp::cast_element).next()
     }
     pub fn mut_kw(&self) -> Option<MutKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(MutKw::cast_element).next()
     }
     pub fn pat(&self) -> Option<Pat> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Pat::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -9992,10 +9992,10 @@ impl AstElement for BoxPat {
 }
 impl BoxPat {
     pub fn box_kw(&self) -> Option<BoxKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(BoxKw::cast_element).next()
     }
     pub fn pat(&self) -> Option<Pat> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Pat::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -10053,13 +10053,13 @@ impl ast::AttrsOwner for BindPat {}
 impl ast::NameOwner for BindPat {}
 impl BindPat {
     pub fn ref_kw(&self) -> Option<RefKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RefKw::cast_element).next()
     }
     pub fn mut_kw(&self) -> Option<MutKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(MutKw::cast_element).next()
     }
     pub fn pat(&self) -> Option<Pat> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Pat::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -10115,7 +10115,7 @@ impl AstElement for PlaceholderPat {
 }
 impl PlaceholderPat {
     pub fn underscore(&self) -> Option<Underscore> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Underscore::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -10171,7 +10171,7 @@ impl AstElement for DotDotPat {
 }
 impl DotDotPat {
     pub fn dotdot(&self) -> Option<Dotdot> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Dotdot::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -10227,7 +10227,7 @@ impl AstElement for PathPat {
 }
 impl PathPat {
     pub fn path(&self) -> Option<Path> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Path::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -10283,13 +10283,13 @@ impl AstElement for SlicePat {
 }
 impl SlicePat {
     pub fn l_brack(&self) -> Option<LBrack> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LBrack::cast_element).next()
     }
-    pub fn args(&self) -> AstChildren<Pat> {
-        AstChildren::new(&self.syntax)
+    pub fn args(&self) -> impl Iterator<Item = Pat> + Clone {
+        self.syntax.children().filter_map(Pat::cast)
     }
     pub fn r_brack(&self) -> Option<RBrack> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RBrack::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -10345,7 +10345,7 @@ impl AstElement for RangePat {
 }
 impl RangePat {
     pub fn range_separator(&self) -> Option<RangeSeparator> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RangeSeparator::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -10401,7 +10401,7 @@ impl AstElement for LiteralPat {
 }
 impl LiteralPat {
     pub fn literal(&self) -> Option<Literal> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Literal::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -10457,10 +10457,10 @@ impl AstElement for RecordPat {
 }
 impl RecordPat {
     pub fn record_field_pat_list(&self) -> Option<RecordFieldPatList> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(RecordFieldPatList::cast).next()
     }
     pub fn path(&self) -> Option<Path> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Path::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -10516,22 +10516,22 @@ impl AstElement for RecordFieldPatList {
 }
 impl RecordFieldPatList {
     pub fn l_curly(&self) -> Option<LCurly> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LCurly::cast_element).next()
     }
-    pub fn pats(&self) -> AstChildren<RecordInnerPat> {
-        AstChildren::new(&self.syntax)
+    pub fn pats(&self) -> impl Iterator<Item = RecordInnerPat> + Clone {
+        self.syntax.children().filter_map(RecordInnerPat::cast)
     }
-    pub fn record_field_pats(&self) -> AstChildren<RecordFieldPat> {
-        AstChildren::new(&self.syntax)
+    pub fn record_field_pats(&self) -> impl Iterator<Item = RecordFieldPat> + Clone {
+        self.syntax.children().filter_map(RecordFieldPat::cast)
     }
-    pub fn bind_pats(&self) -> AstChildren<BindPat> {
-        AstChildren::new(&self.syntax)
+    pub fn bind_pats(&self) -> impl Iterator<Item = BindPat> + Clone {
+        self.syntax.children().filter_map(BindPat::cast)
     }
     pub fn dotdot(&self) -> Option<Dotdot> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Dotdot::cast_element).next()
     }
     pub fn r_curly(&self) -> Option<RCurly> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RCurly::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -10589,10 +10589,10 @@ impl ast::AttrsOwner for RecordFieldPat {}
 impl ast::NameOwner for RecordFieldPat {}
 impl RecordFieldPat {
     pub fn colon(&self) -> Option<Colon> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Colon::cast_element).next()
     }
     pub fn pat(&self) -> Option<Pat> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Pat::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -10648,16 +10648,16 @@ impl AstElement for TupleStructPat {
 }
 impl TupleStructPat {
     pub fn path(&self) -> Option<Path> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Path::cast).next()
     }
     pub fn l_paren(&self) -> Option<LParen> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LParen::cast_element).next()
     }
-    pub fn args(&self) -> AstChildren<Pat> {
-        AstChildren::new(&self.syntax)
+    pub fn args(&self) -> impl Iterator<Item = Pat> + Clone {
+        self.syntax.children().filter_map(Pat::cast)
     }
     pub fn r_paren(&self) -> Option<RParen> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RParen::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -10713,13 +10713,13 @@ impl AstElement for TuplePat {
 }
 impl TuplePat {
     pub fn l_paren(&self) -> Option<LParen> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LParen::cast_element).next()
     }
-    pub fn args(&self) -> AstChildren<Pat> {
-        AstChildren::new(&self.syntax)
+    pub fn args(&self) -> impl Iterator<Item = Pat> + Clone {
+        self.syntax.children().filter_map(Pat::cast)
     }
     pub fn r_paren(&self) -> Option<RParen> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RParen::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -10775,16 +10775,16 @@ impl AstElement for Visibility {
 }
 impl Visibility {
     pub fn pub_kw(&self) -> Option<PubKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(PubKw::cast_element).next()
     }
     pub fn super_kw(&self) -> Option<SuperKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(SuperKw::cast_element).next()
     }
     pub fn self_kw(&self) -> Option<SelfKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(SelfKw::cast_element).next()
     }
     pub fn crate_kw(&self) -> Option<CrateKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(CrateKw::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -10840,7 +10840,7 @@ impl AstElement for Name {
 }
 impl Name {
     pub fn ident(&self) -> Option<Ident> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Ident::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -10896,7 +10896,7 @@ impl AstElement for NameRef {
 }
 impl NameRef {
     pub fn name_ref_token(&self) -> Option<NameRefToken> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(NameRefToken::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -10955,16 +10955,16 @@ impl ast::AttrsOwner for MacroCall {}
 impl ast::DocCommentsOwner for MacroCall {}
 impl MacroCall {
     pub fn path(&self) -> Option<Path> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Path::cast).next()
     }
     pub fn excl(&self) -> Option<Excl> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Excl::cast_element).next()
     }
     pub fn token_tree(&self) -> Option<TokenTree> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(TokenTree::cast).next()
     }
     pub fn semi(&self) -> Option<Semi> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Semi::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -11020,25 +11020,25 @@ impl AstElement for Attr {
 }
 impl Attr {
     pub fn pound(&self) -> Option<Pound> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Pound::cast_element).next()
     }
     pub fn excl(&self) -> Option<Excl> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Excl::cast_element).next()
     }
     pub fn l_brack(&self) -> Option<LBrack> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LBrack::cast_element).next()
     }
     pub fn path(&self) -> Option<Path> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Path::cast).next()
     }
     pub fn eq(&self) -> Option<Eq> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Eq::cast_element).next()
     }
     pub fn input(&self) -> Option<AttrInput> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(AttrInput::cast).next()
     }
     pub fn r_brack(&self) -> Option<RBrack> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RBrack::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -11146,22 +11146,22 @@ impl AstElement for TypeParamList {
 }
 impl TypeParamList {
     pub fn l_angle(&self) -> Option<LAngle> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LAngle::cast_element).next()
     }
-    pub fn generic_params(&self) -> AstChildren<GenericParam> {
-        AstChildren::new(&self.syntax)
+    pub fn generic_params(&self) -> impl Iterator<Item = GenericParam> + Clone {
+        self.syntax.children().filter_map(GenericParam::cast)
     }
-    pub fn type_params(&self) -> AstChildren<TypeParam> {
-        AstChildren::new(&self.syntax)
+    pub fn type_params(&self) -> impl Iterator<Item = TypeParam> + Clone {
+        self.syntax.children().filter_map(TypeParam::cast)
     }
-    pub fn lifetime_params(&self) -> AstChildren<LifetimeParam> {
-        AstChildren::new(&self.syntax)
+    pub fn lifetime_params(&self) -> impl Iterator<Item = LifetimeParam> + Clone {
+        self.syntax.children().filter_map(LifetimeParam::cast)
     }
-    pub fn const_params(&self) -> AstChildren<ConstParam> {
-        AstChildren::new(&self.syntax)
+    pub fn const_params(&self) -> impl Iterator<Item = ConstParam> + Clone {
+        self.syntax.children().filter_map(ConstParam::cast)
     }
     pub fn r_angle(&self) -> Option<RAngle> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RAngle::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -11220,10 +11220,10 @@ impl ast::AttrsOwner for TypeParam {}
 impl ast::TypeBoundsOwner for TypeParam {}
 impl TypeParam {
     pub fn eq(&self) -> Option<Eq> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Eq::cast_element).next()
     }
     pub fn default_type(&self) -> Option<TypeRef> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(TypeRef::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -11282,10 +11282,10 @@ impl ast::AttrsOwner for ConstParam {}
 impl ast::TypeAscriptionOwner for ConstParam {}
 impl ConstParam {
     pub fn eq(&self) -> Option<Eq> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Eq::cast_element).next()
     }
     pub fn default_val(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -11342,7 +11342,7 @@ impl AstElement for LifetimeParam {
 impl ast::AttrsOwner for LifetimeParam {}
 impl LifetimeParam {
     pub fn lifetime(&self) -> Option<Lifetime> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Lifetime::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -11398,13 +11398,13 @@ impl AstElement for TypeBound {
 }
 impl TypeBound {
     pub fn lifetime(&self) -> Option<Lifetime> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Lifetime::cast_element).next()
     }
     pub fn const_kw(&self) -> Option<ConstKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(ConstKw::cast_element).next()
     }
     pub fn type_ref(&self) -> Option<TypeRef> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(TypeRef::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -11459,8 +11459,8 @@ impl AstElement for TypeBoundList {
     }
 }
 impl TypeBoundList {
-    pub fn bounds(&self) -> AstChildren<TypeBound> {
-        AstChildren::new(&self.syntax)
+    pub fn bounds(&self) -> impl Iterator<Item = TypeBound> + Clone {
+        self.syntax.children().filter_map(TypeBound::cast)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -11517,10 +11517,10 @@ impl AstElement for WherePred {
 impl ast::TypeBoundsOwner for WherePred {}
 impl WherePred {
     pub fn lifetime(&self) -> Option<Lifetime> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Lifetime::cast_element).next()
     }
     pub fn type_ref(&self) -> Option<TypeRef> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(TypeRef::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -11576,10 +11576,10 @@ impl AstElement for WhereClause {
 }
 impl WhereClause {
     pub fn where_kw(&self) -> Option<WhereKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(WhereKw::cast_element).next()
     }
-    pub fn predicates(&self) -> AstChildren<WherePred> {
-        AstChildren::new(&self.syntax)
+    pub fn predicates(&self) -> impl Iterator<Item = WherePred> + Clone {
+        self.syntax.children().filter_map(WherePred::cast)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -11635,7 +11635,7 @@ impl AstElement for Abi {
 }
 impl Abi {
     pub fn string(&self) -> Option<String> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(String::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -11692,10 +11692,10 @@ impl AstElement for ExprStmt {
 impl ast::AttrsOwner for ExprStmt {}
 impl ExprStmt {
     pub fn expr(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
     pub fn semi(&self) -> Option<Semi> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Semi::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -11753,16 +11753,16 @@ impl ast::AttrsOwner for LetStmt {}
 impl ast::TypeAscriptionOwner for LetStmt {}
 impl LetStmt {
     pub fn let_kw(&self) -> Option<LetKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LetKw::cast_element).next()
     }
     pub fn pat(&self) -> Option<Pat> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Pat::cast).next()
     }
     pub fn eq(&self) -> Option<Eq> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Eq::cast_element).next()
     }
     pub fn initializer(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -11818,16 +11818,16 @@ impl AstElement for Condition {
 }
 impl Condition {
     pub fn let_kw(&self) -> Option<LetKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LetKw::cast_element).next()
     }
     pub fn pat(&self) -> Option<Pat> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Pat::cast).next()
     }
     pub fn eq(&self) -> Option<Eq> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Eq::cast_element).next()
     }
     pub fn expr(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -11885,19 +11885,19 @@ impl ast::AttrsOwner for Block {}
 impl ast::ModuleItemOwner for Block {}
 impl Block {
     pub fn l_curly(&self) -> Option<LCurly> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LCurly::cast_element).next()
     }
-    pub fn statements(&self) -> AstChildren<Stmt> {
-        AstChildren::new(&self.syntax)
+    pub fn statements(&self) -> impl Iterator<Item = Stmt> + Clone {
+        self.syntax.children().filter_map(Stmt::cast)
     }
-    pub fn statements_or_semi(&self) -> AstChildElements<StmtOrSemi> {
-        AstChildElements::new(&self.syntax)
+    pub fn statements_or_semi(&self) -> impl Iterator<Item = StmtOrSemi> + Clone {
+        self.syntax.children_with_tokens().filter_map(StmtOrSemi::cast_element)
     }
     pub fn expr(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
     pub fn r_curly(&self) -> Option<RCurly> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RCurly::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -11953,16 +11953,16 @@ impl AstElement for ParamList {
 }
 impl ParamList {
     pub fn l_paren(&self) -> Option<LParen> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LParen::cast_element).next()
     }
     pub fn self_param(&self) -> Option<SelfParam> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(SelfParam::cast).next()
     }
-    pub fn params(&self) -> AstChildren<Param> {
-        AstChildren::new(&self.syntax)
+    pub fn params(&self) -> impl Iterator<Item = Param> + Clone {
+        self.syntax.children().filter_map(Param::cast)
     }
     pub fn r_paren(&self) -> Option<RParen> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RParen::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -12020,13 +12020,13 @@ impl ast::TypeAscriptionOwner for SelfParam {}
 impl ast::AttrsOwner for SelfParam {}
 impl SelfParam {
     pub fn amp(&self) -> Option<Amp> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Amp::cast_element).next()
     }
     pub fn lifetime(&self) -> Option<Lifetime> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Lifetime::cast_element).next()
     }
     pub fn self_kw(&self) -> Option<SelfKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(SelfKw::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -12084,10 +12084,10 @@ impl ast::TypeAscriptionOwner for Param {}
 impl ast::AttrsOwner for Param {}
 impl Param {
     pub fn pat(&self) -> Option<Pat> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Pat::cast).next()
     }
     pub fn dotdotdot(&self) -> Option<Dotdotdot> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Dotdotdot::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -12145,10 +12145,10 @@ impl ast::AttrsOwner for UseItem {}
 impl ast::VisibilityOwner for UseItem {}
 impl UseItem {
     pub fn use_kw(&self) -> Option<UseKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(UseKw::cast_element).next()
     }
     pub fn use_tree(&self) -> Option<UseTree> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(UseTree::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -12204,16 +12204,16 @@ impl AstElement for UseTree {
 }
 impl UseTree {
     pub fn path(&self) -> Option<Path> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Path::cast).next()
     }
     pub fn star(&self) -> Option<Star> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Star::cast_element).next()
     }
     pub fn use_tree_list(&self) -> Option<UseTreeList> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(UseTreeList::cast).next()
     }
     pub fn alias(&self) -> Option<Alias> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Alias::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -12270,7 +12270,7 @@ impl AstElement for Alias {
 impl ast::NameOwner for Alias {}
 impl Alias {
     pub fn as_kw(&self) -> Option<AsKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(AsKw::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -12326,13 +12326,13 @@ impl AstElement for UseTreeList {
 }
 impl UseTreeList {
     pub fn l_curly(&self) -> Option<LCurly> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LCurly::cast_element).next()
     }
-    pub fn use_trees(&self) -> AstChildren<UseTree> {
-        AstChildren::new(&self.syntax)
+    pub fn use_trees(&self) -> impl Iterator<Item = UseTree> + Clone {
+        self.syntax.children().filter_map(UseTree::cast)
     }
     pub fn r_curly(&self) -> Option<RCurly> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RCurly::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -12390,16 +12390,16 @@ impl ast::AttrsOwner for ExternCrateItem {}
 impl ast::VisibilityOwner for ExternCrateItem {}
 impl ExternCrateItem {
     pub fn extern_kw(&self) -> Option<ExternKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(ExternKw::cast_element).next()
     }
     pub fn crate_kw(&self) -> Option<CrateKw> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(CrateKw::cast_element).next()
     }
     pub fn name_ref(&self) -> Option<NameRef> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(NameRef::cast).next()
     }
     pub fn alias(&self) -> Option<Alias> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Alias::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -12455,13 +12455,13 @@ impl AstElement for ArgList {
 }
 impl ArgList {
     pub fn l_paren(&self) -> Option<LParen> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LParen::cast_element).next()
     }
-    pub fn args(&self) -> AstChildren<Expr> {
-        AstChildren::new(&self.syntax)
+    pub fn args(&self) -> impl Iterator<Item = Expr> + Clone {
+        self.syntax.children().filter_map(Expr::cast)
     }
     pub fn r_paren(&self) -> Option<RParen> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RParen::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -12517,10 +12517,10 @@ impl AstElement for Path {
 }
 impl Path {
     pub fn segment(&self) -> Option<PathSegment> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(PathSegment::cast).next()
     }
     pub fn qualifier(&self) -> Option<Path> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Path::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -12576,28 +12576,28 @@ impl AstElement for PathSegment {
 }
 impl PathSegment {
     pub fn coloncolon(&self) -> Option<Coloncolon> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Coloncolon::cast_element).next()
     }
     pub fn l_angle(&self) -> Option<LAngle> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LAngle::cast_element).next()
     }
     pub fn name_ref(&self) -> Option<NameRef> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(NameRef::cast).next()
     }
     pub fn type_arg_list(&self) -> Option<TypeArgList> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(TypeArgList::cast).next()
     }
     pub fn param_list(&self) -> Option<ParamList> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(ParamList::cast).next()
     }
     pub fn ret_type(&self) -> Option<RetType> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(RetType::cast).next()
     }
     pub fn path_type(&self) -> Option<PathType> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(PathType::cast).next()
     }
     pub fn r_angle(&self) -> Option<RAngle> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RAngle::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -12653,28 +12653,28 @@ impl AstElement for TypeArgList {
 }
 impl TypeArgList {
     pub fn coloncolon(&self) -> Option<Coloncolon> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Coloncolon::cast_element).next()
     }
     pub fn l_angle(&self) -> Option<LAngle> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LAngle::cast_element).next()
     }
-    pub fn generic_args(&self) -> AstChildren<GenericArg> {
-        AstChildren::new(&self.syntax)
+    pub fn generic_args(&self) -> impl Iterator<Item = GenericArg> + Clone {
+        self.syntax.children().filter_map(GenericArg::cast)
     }
-    pub fn type_args(&self) -> AstChildren<TypeArg> {
-        AstChildren::new(&self.syntax)
+    pub fn type_args(&self) -> impl Iterator<Item = TypeArg> + Clone {
+        self.syntax.children().filter_map(TypeArg::cast)
     }
-    pub fn lifetime_args(&self) -> AstChildren<LifetimeArg> {
-        AstChildren::new(&self.syntax)
+    pub fn lifetime_args(&self) -> impl Iterator<Item = LifetimeArg> + Clone {
+        self.syntax.children().filter_map(LifetimeArg::cast)
     }
-    pub fn assoc_type_args(&self) -> AstChildren<AssocTypeArg> {
-        AstChildren::new(&self.syntax)
+    pub fn assoc_type_args(&self) -> impl Iterator<Item = AssocTypeArg> + Clone {
+        self.syntax.children().filter_map(AssocTypeArg::cast)
     }
-    pub fn const_args(&self) -> AstChildren<ConstArg> {
-        AstChildren::new(&self.syntax)
+    pub fn const_args(&self) -> impl Iterator<Item = ConstArg> + Clone {
+        self.syntax.children().filter_map(ConstArg::cast)
     }
     pub fn r_angle(&self) -> Option<RAngle> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RAngle::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -12730,7 +12730,7 @@ impl AstElement for TypeArg {
 }
 impl TypeArg {
     pub fn type_ref(&self) -> Option<TypeRef> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(TypeRef::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -12787,13 +12787,13 @@ impl AstElement for AssocTypeArg {
 impl ast::TypeBoundsOwner for AssocTypeArg {}
 impl AssocTypeArg {
     pub fn name_ref(&self) -> Option<NameRef> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(NameRef::cast).next()
     }
     pub fn eq(&self) -> Option<Eq> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Eq::cast_element).next()
     }
     pub fn type_ref(&self) -> Option<TypeRef> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(TypeRef::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -12849,7 +12849,7 @@ impl AstElement for LifetimeArg {
 }
 impl LifetimeArg {
     pub fn lifetime(&self) -> Option<Lifetime> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Lifetime::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -12905,13 +12905,13 @@ impl AstElement for ConstArg {
 }
 impl ConstArg {
     pub fn literal(&self) -> Option<Literal> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Literal::cast).next()
     }
     pub fn eq(&self) -> Option<Eq> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Eq::cast_element).next()
     }
     pub fn block_expr(&self) -> Option<BlockExpr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(BlockExpr::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -13020,11 +13020,11 @@ impl AstElement for MacroStmts {
     }
 }
 impl MacroStmts {
-    pub fn statements(&self) -> AstChildren<Stmt> {
-        AstChildren::new(&self.syntax)
+    pub fn statements(&self) -> impl Iterator<Item = Stmt> + Clone {
+        self.syntax.children().filter_map(Stmt::cast)
     }
     pub fn expr(&self) -> Option<Expr> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Expr::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -13082,13 +13082,13 @@ impl ast::FnDefOwner for ExternItemList {}
 impl ast::ModuleItemOwner for ExternItemList {}
 impl ExternItemList {
     pub fn l_curly(&self) -> Option<LCurly> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(LCurly::cast_element).next()
     }
-    pub fn extern_items(&self) -> AstChildren<ExternItem> {
-        AstChildren::new(&self.syntax)
+    pub fn extern_items(&self) -> impl Iterator<Item = ExternItem> + Clone {
+        self.syntax.children().filter_map(ExternItem::cast)
     }
     pub fn r_curly(&self) -> Option<RCurly> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(RCurly::cast_element).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -13144,10 +13144,10 @@ impl AstElement for ExternBlock {
 }
 impl ExternBlock {
     pub fn abi(&self) -> Option<Abi> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Abi::cast).next()
     }
     pub fn extern_item_list(&self) -> Option<ExternItemList> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(ExternItemList::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -13203,16 +13203,16 @@ impl AstElement for MetaItem {
 }
 impl MetaItem {
     pub fn path(&self) -> Option<Path> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Path::cast).next()
     }
     pub fn eq(&self) -> Option<Eq> {
-        AstChildTokens::new(&self.syntax).next()
+        self.syntax.children_with_tokens().filter_map(Eq::cast_element).next()
     }
     pub fn attr_input(&self) -> Option<AttrInput> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(AttrInput::cast).next()
     }
-    pub fn nested_meta_items(&self) -> AstChildren<MetaItem> {
-        AstChildren::new(&self.syntax)
+    pub fn nested_meta_items(&self) -> impl Iterator<Item = MetaItem> + Clone {
+        self.syntax.children().filter_map(MetaItem::cast)
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -13268,10 +13268,10 @@ impl AstElement for MacroDef {
 }
 impl MacroDef {
     pub fn name(&self) -> Option<Name> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(Name::cast).next()
     }
     pub fn token_tree(&self) -> Option<TokenTree> {
-        AstChildren::new(&self.syntax).next()
+        self.syntax.children().filter_map(TokenTree::cast).next()
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/ra_syntax/src/ast/generated.rs
+++ b/crates/ra_syntax/src/ast/generated.rs
@@ -1,10 +1,5500 @@
 //! Generated file, do not edit by hand, see `xtask/src/codegen`
 
+#[allow(unused_imports)]
 use crate::{
-    ast::{self, AstChildren, AstNode},
+    ast::{self, AstChildElements, AstChildTokens, AstChildren, AstElement, AstNode, AstToken},
+    NodeOrToken, SyntaxElement,
     SyntaxKind::{self, *},
-    SyntaxNode,
+    SyntaxNode, SyntaxToken,
 };
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Semi(SyntaxToken);
+impl std::fmt::Display for Semi {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Semi {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            SEMI => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Semi {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            SEMI => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Comma(SyntaxToken);
+impl std::fmt::Display for Comma {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Comma {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            COMMA => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Comma {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            COMMA => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LParen(SyntaxToken);
+impl std::fmt::Display for LParen {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for LParen {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            L_PAREN => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for LParen {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            L_PAREN => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RParen(SyntaxToken);
+impl std::fmt::Display for RParen {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for RParen {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            R_PAREN => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for RParen {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            R_PAREN => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LCurly(SyntaxToken);
+impl std::fmt::Display for LCurly {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for LCurly {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            L_CURLY => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for LCurly {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            L_CURLY => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RCurly(SyntaxToken);
+impl std::fmt::Display for RCurly {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for RCurly {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            R_CURLY => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for RCurly {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            R_CURLY => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LBrack(SyntaxToken);
+impl std::fmt::Display for LBrack {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for LBrack {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            L_BRACK => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for LBrack {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            L_BRACK => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RBrack(SyntaxToken);
+impl std::fmt::Display for RBrack {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for RBrack {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            R_BRACK => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for RBrack {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            R_BRACK => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LAngle(SyntaxToken);
+impl std::fmt::Display for LAngle {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for LAngle {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            L_ANGLE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for LAngle {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            L_ANGLE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RAngle(SyntaxToken);
+impl std::fmt::Display for RAngle {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for RAngle {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            R_ANGLE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for RAngle {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            R_ANGLE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct At(SyntaxToken);
+impl std::fmt::Display for At {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for At {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            AT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for At {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            AT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Pound(SyntaxToken);
+impl std::fmt::Display for Pound {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Pound {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            POUND => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Pound {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            POUND => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Tilde(SyntaxToken);
+impl std::fmt::Display for Tilde {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Tilde {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            TILDE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Tilde {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            TILDE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Question(SyntaxToken);
+impl std::fmt::Display for Question {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Question {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            QUESTION => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Question {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            QUESTION => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Dollar(SyntaxToken);
+impl std::fmt::Display for Dollar {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Dollar {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            DOLLAR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Dollar {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            DOLLAR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Amp(SyntaxToken);
+impl std::fmt::Display for Amp {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Amp {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            AMP => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Amp {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            AMP => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Pipe(SyntaxToken);
+impl std::fmt::Display for Pipe {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Pipe {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            PIPE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Pipe {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            PIPE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Plus(SyntaxToken);
+impl std::fmt::Display for Plus {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Plus {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            PLUS => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Plus {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            PLUS => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Star(SyntaxToken);
+impl std::fmt::Display for Star {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Star {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            STAR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Star {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            STAR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Slash(SyntaxToken);
+impl std::fmt::Display for Slash {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Slash {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            SLASH => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Slash {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            SLASH => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Caret(SyntaxToken);
+impl std::fmt::Display for Caret {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Caret {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            CARET => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Caret {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            CARET => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Percent(SyntaxToken);
+impl std::fmt::Display for Percent {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Percent {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            PERCENT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Percent {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            PERCENT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Underscore(SyntaxToken);
+impl std::fmt::Display for Underscore {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Underscore {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            UNDERSCORE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Underscore {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            UNDERSCORE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Dot(SyntaxToken);
+impl std::fmt::Display for Dot {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Dot {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            DOT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Dot {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            DOT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Dotdot(SyntaxToken);
+impl std::fmt::Display for Dotdot {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Dotdot {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            DOTDOT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Dotdot {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            DOTDOT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Dotdotdot(SyntaxToken);
+impl std::fmt::Display for Dotdotdot {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Dotdotdot {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            DOTDOTDOT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Dotdotdot {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            DOTDOTDOT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Dotdoteq(SyntaxToken);
+impl std::fmt::Display for Dotdoteq {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Dotdoteq {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            DOTDOTEQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Dotdoteq {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            DOTDOTEQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Colon(SyntaxToken);
+impl std::fmt::Display for Colon {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Colon {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            COLON => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Colon {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            COLON => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Coloncolon(SyntaxToken);
+impl std::fmt::Display for Coloncolon {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Coloncolon {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            COLONCOLON => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Coloncolon {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            COLONCOLON => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Eq(SyntaxToken);
+impl std::fmt::Display for Eq {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Eq {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            EQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Eq {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            EQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Eqeq(SyntaxToken);
+impl std::fmt::Display for Eqeq {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Eqeq {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            EQEQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Eqeq {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            EQEQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FatArrow(SyntaxToken);
+impl std::fmt::Display for FatArrow {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for FatArrow {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            FAT_ARROW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for FatArrow {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            FAT_ARROW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Excl(SyntaxToken);
+impl std::fmt::Display for Excl {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Excl {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            EXCL => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Excl {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            EXCL => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Neq(SyntaxToken);
+impl std::fmt::Display for Neq {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Neq {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            NEQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Neq {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            NEQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Minus(SyntaxToken);
+impl std::fmt::Display for Minus {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Minus {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            MINUS => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Minus {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            MINUS => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ThinArrow(SyntaxToken);
+impl std::fmt::Display for ThinArrow {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for ThinArrow {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            THIN_ARROW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for ThinArrow {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            THIN_ARROW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Lteq(SyntaxToken);
+impl std::fmt::Display for Lteq {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Lteq {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            LTEQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Lteq {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            LTEQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Gteq(SyntaxToken);
+impl std::fmt::Display for Gteq {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Gteq {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            GTEQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Gteq {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            GTEQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Pluseq(SyntaxToken);
+impl std::fmt::Display for Pluseq {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Pluseq {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            PLUSEQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Pluseq {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            PLUSEQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Minuseq(SyntaxToken);
+impl std::fmt::Display for Minuseq {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Minuseq {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            MINUSEQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Minuseq {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            MINUSEQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Pipeeq(SyntaxToken);
+impl std::fmt::Display for Pipeeq {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Pipeeq {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            PIPEEQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Pipeeq {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            PIPEEQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Ampeq(SyntaxToken);
+impl std::fmt::Display for Ampeq {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Ampeq {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            AMPEQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Ampeq {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            AMPEQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Careteq(SyntaxToken);
+impl std::fmt::Display for Careteq {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Careteq {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            CARETEQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Careteq {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            CARETEQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Slasheq(SyntaxToken);
+impl std::fmt::Display for Slasheq {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Slasheq {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            SLASHEQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Slasheq {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            SLASHEQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Stareq(SyntaxToken);
+impl std::fmt::Display for Stareq {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Stareq {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            STAREQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Stareq {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            STAREQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Percenteq(SyntaxToken);
+impl std::fmt::Display for Percenteq {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Percenteq {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            PERCENTEQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Percenteq {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            PERCENTEQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Ampamp(SyntaxToken);
+impl std::fmt::Display for Ampamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Ampamp {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            AMPAMP => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Ampamp {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            AMPAMP => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Pipepipe(SyntaxToken);
+impl std::fmt::Display for Pipepipe {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Pipepipe {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            PIPEPIPE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Pipepipe {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            PIPEPIPE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Shl(SyntaxToken);
+impl std::fmt::Display for Shl {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Shl {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            SHL => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Shl {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            SHL => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Shr(SyntaxToken);
+impl std::fmt::Display for Shr {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Shr {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            SHR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Shr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            SHR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Shleq(SyntaxToken);
+impl std::fmt::Display for Shleq {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Shleq {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            SHLEQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Shleq {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            SHLEQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Shreq(SyntaxToken);
+impl std::fmt::Display for Shreq {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Shreq {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            SHREQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Shreq {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            SHREQ => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AsKw(SyntaxToken);
+impl std::fmt::Display for AsKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for AsKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            AS_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for AsKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            AS_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AsyncKw(SyntaxToken);
+impl std::fmt::Display for AsyncKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for AsyncKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            ASYNC_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for AsyncKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            ASYNC_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AwaitKw(SyntaxToken);
+impl std::fmt::Display for AwaitKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for AwaitKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            AWAIT_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for AwaitKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            AWAIT_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BoxKw(SyntaxToken);
+impl std::fmt::Display for BoxKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for BoxKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            BOX_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for BoxKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            BOX_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BreakKw(SyntaxToken);
+impl std::fmt::Display for BreakKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for BreakKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            BREAK_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for BreakKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            BREAK_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ConstKw(SyntaxToken);
+impl std::fmt::Display for ConstKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for ConstKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            CONST_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for ConstKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            CONST_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ContinueKw(SyntaxToken);
+impl std::fmt::Display for ContinueKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for ContinueKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            CONTINUE_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for ContinueKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            CONTINUE_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CrateKw(SyntaxToken);
+impl std::fmt::Display for CrateKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for CrateKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            CRATE_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for CrateKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            CRATE_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DynKw(SyntaxToken);
+impl std::fmt::Display for DynKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for DynKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            DYN_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for DynKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            DYN_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ElseKw(SyntaxToken);
+impl std::fmt::Display for ElseKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for ElseKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            ELSE_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for ElseKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            ELSE_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct EnumKw(SyntaxToken);
+impl std::fmt::Display for EnumKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for EnumKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            ENUM_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for EnumKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            ENUM_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ExternKw(SyntaxToken);
+impl std::fmt::Display for ExternKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for ExternKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            EXTERN_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for ExternKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            EXTERN_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FalseKw(SyntaxToken);
+impl std::fmt::Display for FalseKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for FalseKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            FALSE_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for FalseKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            FALSE_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FnKw(SyntaxToken);
+impl std::fmt::Display for FnKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for FnKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            FN_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for FnKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            FN_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ForKw(SyntaxToken);
+impl std::fmt::Display for ForKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for ForKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            FOR_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for ForKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            FOR_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct IfKw(SyntaxToken);
+impl std::fmt::Display for IfKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for IfKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            IF_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for IfKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            IF_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ImplKw(SyntaxToken);
+impl std::fmt::Display for ImplKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for ImplKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            IMPL_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for ImplKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            IMPL_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct InKw(SyntaxToken);
+impl std::fmt::Display for InKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for InKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            IN_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for InKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            IN_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LetKw(SyntaxToken);
+impl std::fmt::Display for LetKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for LetKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            LET_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for LetKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            LET_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LoopKw(SyntaxToken);
+impl std::fmt::Display for LoopKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for LoopKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            LOOP_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for LoopKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            LOOP_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct MacroKw(SyntaxToken);
+impl std::fmt::Display for MacroKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for MacroKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            MACRO_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for MacroKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            MACRO_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct MatchKw(SyntaxToken);
+impl std::fmt::Display for MatchKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for MatchKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            MATCH_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for MatchKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            MATCH_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ModKw(SyntaxToken);
+impl std::fmt::Display for ModKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for ModKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            MOD_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for ModKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            MOD_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct MoveKw(SyntaxToken);
+impl std::fmt::Display for MoveKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for MoveKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            MOVE_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for MoveKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            MOVE_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct MutKw(SyntaxToken);
+impl std::fmt::Display for MutKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for MutKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            MUT_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for MutKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            MUT_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PubKw(SyntaxToken);
+impl std::fmt::Display for PubKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for PubKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            PUB_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for PubKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            PUB_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RefKw(SyntaxToken);
+impl std::fmt::Display for RefKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for RefKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            REF_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for RefKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            REF_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ReturnKw(SyntaxToken);
+impl std::fmt::Display for ReturnKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for ReturnKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            RETURN_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for ReturnKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            RETURN_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SelfKw(SyntaxToken);
+impl std::fmt::Display for SelfKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for SelfKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            SELF_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for SelfKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            SELF_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StaticKw(SyntaxToken);
+impl std::fmt::Display for StaticKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for StaticKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            STATIC_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for StaticKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            STATIC_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StructKw(SyntaxToken);
+impl std::fmt::Display for StructKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for StructKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            STRUCT_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for StructKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            STRUCT_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SuperKw(SyntaxToken);
+impl std::fmt::Display for SuperKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for SuperKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            SUPER_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for SuperKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            SUPER_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TraitKw(SyntaxToken);
+impl std::fmt::Display for TraitKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for TraitKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            TRAIT_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for TraitKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            TRAIT_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TrueKw(SyntaxToken);
+impl std::fmt::Display for TrueKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for TrueKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            TRUE_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for TrueKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            TRUE_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TryKw(SyntaxToken);
+impl std::fmt::Display for TryKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for TryKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            TRY_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for TryKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            TRY_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TypeKw(SyntaxToken);
+impl std::fmt::Display for TypeKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for TypeKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            TYPE_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for TypeKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            TYPE_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct UnsafeKw(SyntaxToken);
+impl std::fmt::Display for UnsafeKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for UnsafeKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            UNSAFE_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for UnsafeKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            UNSAFE_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct UseKw(SyntaxToken);
+impl std::fmt::Display for UseKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for UseKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            USE_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for UseKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            USE_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct WhereKw(SyntaxToken);
+impl std::fmt::Display for WhereKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for WhereKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            WHERE_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for WhereKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            WHERE_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct WhileKw(SyntaxToken);
+impl std::fmt::Display for WhileKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for WhileKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            WHILE_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for WhileKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            WHILE_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AutoKw(SyntaxToken);
+impl std::fmt::Display for AutoKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for AutoKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            AUTO_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for AutoKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            AUTO_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DefaultKw(SyntaxToken);
+impl std::fmt::Display for DefaultKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for DefaultKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            DEFAULT_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for DefaultKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            DEFAULT_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ExistentialKw(SyntaxToken);
+impl std::fmt::Display for ExistentialKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for ExistentialKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            EXISTENTIAL_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for ExistentialKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            EXISTENTIAL_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct UnionKw(SyntaxToken);
+impl std::fmt::Display for UnionKw {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for UnionKw {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            UNION_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for UnionKw {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            UNION_KW => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct IntNumber(SyntaxToken);
+impl std::fmt::Display for IntNumber {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for IntNumber {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            INT_NUMBER => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for IntNumber {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            INT_NUMBER => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FloatNumber(SyntaxToken);
+impl std::fmt::Display for FloatNumber {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for FloatNumber {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            FLOAT_NUMBER => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for FloatNumber {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            FLOAT_NUMBER => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Char(SyntaxToken);
+impl std::fmt::Display for Char {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Char {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            CHAR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Char {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            CHAR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Byte(SyntaxToken);
+impl std::fmt::Display for Byte {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Byte {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            BYTE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Byte {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            BYTE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct String(SyntaxToken);
+impl std::fmt::Display for String {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for String {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            STRING => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for String {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            STRING => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RawString(SyntaxToken);
+impl std::fmt::Display for RawString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for RawString {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            RAW_STRING => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for RawString {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            RAW_STRING => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ByteString(SyntaxToken);
+impl std::fmt::Display for ByteString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for ByteString {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            BYTE_STRING => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for ByteString {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            BYTE_STRING => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RawByteString(SyntaxToken);
+impl std::fmt::Display for RawByteString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for RawByteString {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            RAW_BYTE_STRING => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for RawByteString {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            RAW_BYTE_STRING => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Error(SyntaxToken);
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Error {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            ERROR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Error {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            ERROR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Ident(SyntaxToken);
+impl std::fmt::Display for Ident {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Ident {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            IDENT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Ident {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            IDENT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Whitespace(SyntaxToken);
+impl std::fmt::Display for Whitespace {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Whitespace {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            WHITESPACE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Whitespace {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            WHITESPACE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Lifetime(SyntaxToken);
+impl std::fmt::Display for Lifetime {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Lifetime {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            LIFETIME => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Lifetime {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            LIFETIME => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Comment(SyntaxToken);
+impl std::fmt::Display for Comment {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Comment {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            COMMENT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Comment {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            COMMENT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Shebang(SyntaxToken);
+impl std::fmt::Display for Shebang {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for Shebang {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            SHEBANG => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for Shebang {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            SHEBANG => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LDollar(SyntaxToken);
+impl std::fmt::Display for LDollar {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for LDollar {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            L_DOLLAR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for LDollar {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            L_DOLLAR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RDollar(SyntaxToken);
+impl std::fmt::Display for RDollar {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl AstToken for RDollar {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            R_DOLLAR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+        if Self::can_cast(syntax.kind()) {
+            Ok(Self(syntax))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax(&self) -> &SyntaxToken {
+        &self.0
+    }
+    fn into_syntax(self) -> SyntaxToken {
+        self.0
+    }
+}
+impl AstElement for RDollar {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            R_DOLLAR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self(syntax.into_token().unwrap()))
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Token(&self.0)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Token(self.0)
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SourceFile {
     pub(crate) syntax: SyntaxNode,
@@ -21,15 +5511,39 @@ impl AstNode for SourceFile {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for SourceFile {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            SOURCE_FILE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::ModuleItemOwner for SourceFile {}
@@ -55,15 +5569,39 @@ impl AstNode for FnDef {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for FnDef {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            FN_DEF => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::VisibilityOwner for FnDef {}
@@ -98,15 +5636,39 @@ impl AstNode for RetType {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for RetType {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            RET_TYPE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl RetType {
@@ -130,15 +5692,39 @@ impl AstNode for StructDef {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for StructDef {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            STRUCT_DEF => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::VisibilityOwner for StructDef {}
@@ -163,15 +5749,39 @@ impl AstNode for UnionDef {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for UnionDef {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            UNION_DEF => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::VisibilityOwner for UnionDef {}
@@ -200,15 +5810,39 @@ impl AstNode for RecordFieldDefList {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for RecordFieldDefList {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            RECORD_FIELD_DEF_LIST => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl RecordFieldDefList {
@@ -232,15 +5866,39 @@ impl AstNode for RecordFieldDef {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for RecordFieldDef {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            RECORD_FIELD_DEF => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::VisibilityOwner for RecordFieldDef {}
@@ -265,15 +5923,39 @@ impl AstNode for TupleFieldDefList {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for TupleFieldDefList {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            TUPLE_FIELD_DEF_LIST => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl TupleFieldDefList {
@@ -297,15 +5979,39 @@ impl AstNode for TupleFieldDef {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for TupleFieldDef {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            TUPLE_FIELD_DEF => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::VisibilityOwner for TupleFieldDef {}
@@ -331,15 +6037,39 @@ impl AstNode for EnumDef {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for EnumDef {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            ENUM_DEF => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::VisibilityOwner for EnumDef {}
@@ -368,15 +6098,39 @@ impl AstNode for EnumVariantList {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for EnumVariantList {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            ENUM_VARIANT_LIST => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl EnumVariantList {
@@ -400,15 +6154,39 @@ impl AstNode for EnumVariant {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for EnumVariant {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            ENUM_VARIANT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::NameOwner for EnumVariant {}
@@ -435,15 +6213,39 @@ impl AstNode for TraitDef {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for TraitDef {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            TRAIT_DEF => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::VisibilityOwner for TraitDef {}
@@ -473,15 +6275,39 @@ impl AstNode for Module {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for Module {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            MODULE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::VisibilityOwner for Module {}
@@ -509,15 +6335,39 @@ impl AstNode for ItemList {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for ItemList {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            ITEM_LIST => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::FnDefOwner for ItemList {}
@@ -543,15 +6393,39 @@ impl AstNode for ConstDef {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for ConstDef {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            CONST_DEF => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::VisibilityOwner for ConstDef {}
@@ -581,15 +6455,39 @@ impl AstNode for StaticDef {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for StaticDef {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            STATIC_DEF => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::VisibilityOwner for StaticDef {}
@@ -619,15 +6517,39 @@ impl AstNode for TypeAliasDef {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for TypeAliasDef {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            TYPE_ALIAS_DEF => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::VisibilityOwner for TypeAliasDef {}
@@ -657,15 +6579,39 @@ impl AstNode for ImplDef {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for ImplDef {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            IMPL_DEF => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::TypeParamsOwner for ImplDef {}
@@ -691,15 +6637,39 @@ impl AstNode for ParenType {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for ParenType {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            PAREN_TYPE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ParenType {
@@ -723,15 +6693,39 @@ impl AstNode for TupleType {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for TupleType {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            TUPLE_TYPE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl TupleType {
@@ -755,15 +6749,39 @@ impl AstNode for NeverType {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for NeverType {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            NEVER_TYPE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl NeverType {}
@@ -783,15 +6801,39 @@ impl AstNode for PathType {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for PathType {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            PATH_TYPE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl PathType {
@@ -815,15 +6857,39 @@ impl AstNode for PointerType {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for PointerType {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            POINTER_TYPE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl PointerType {
@@ -847,15 +6913,39 @@ impl AstNode for ArrayType {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for ArrayType {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            ARRAY_TYPE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ArrayType {
@@ -882,15 +6972,39 @@ impl AstNode for SliceType {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for SliceType {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            SLICE_TYPE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl SliceType {
@@ -914,15 +7028,39 @@ impl AstNode for ReferenceType {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for ReferenceType {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            REFERENCE_TYPE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ReferenceType {
@@ -946,15 +7084,39 @@ impl AstNode for PlaceholderType {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for PlaceholderType {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            PLACEHOLDER_TYPE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl PlaceholderType {}
@@ -974,15 +7136,39 @@ impl AstNode for FnPointerType {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for FnPointerType {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            FN_POINTER_TYPE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl FnPointerType {
@@ -1009,15 +7195,39 @@ impl AstNode for ForType {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for ForType {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            FOR_TYPE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ForType {
@@ -1041,15 +7251,39 @@ impl AstNode for ImplTraitType {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for ImplTraitType {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            IMPL_TRAIT_TYPE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::TypeBoundsOwner for ImplTraitType {}
@@ -1070,15 +7304,39 @@ impl AstNode for DynTraitType {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for DynTraitType {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            DYN_TRAIT_TYPE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::TypeBoundsOwner for DynTraitType {}
@@ -1099,15 +7357,39 @@ impl AstNode for TupleExpr {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for TupleExpr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            TUPLE_EXPR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl TupleExpr {
@@ -1131,15 +7413,39 @@ impl AstNode for ArrayExpr {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for ArrayExpr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            ARRAY_EXPR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ArrayExpr {
@@ -1163,15 +7469,39 @@ impl AstNode for ParenExpr {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for ParenExpr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            PAREN_EXPR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ParenExpr {
@@ -1195,15 +7525,39 @@ impl AstNode for PathExpr {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for PathExpr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            PATH_EXPR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl PathExpr {
@@ -1227,15 +7581,39 @@ impl AstNode for LambdaExpr {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for LambdaExpr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            LAMBDA_EXPR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl LambdaExpr {
@@ -1265,15 +7643,39 @@ impl AstNode for IfExpr {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for IfExpr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            IF_EXPR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl IfExpr {
@@ -1297,15 +7699,39 @@ impl AstNode for LoopExpr {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for LoopExpr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            LOOP_EXPR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::LoopBodyOwner for LoopExpr {}
@@ -1326,15 +7752,39 @@ impl AstNode for TryBlockExpr {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for TryBlockExpr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            TRY_BLOCK_EXPR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl TryBlockExpr {
@@ -1358,15 +7808,39 @@ impl AstNode for ForExpr {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for ForExpr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            FOR_EXPR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::LoopBodyOwner for ForExpr {}
@@ -1394,15 +7868,39 @@ impl AstNode for WhileExpr {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for WhileExpr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            WHILE_EXPR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::LoopBodyOwner for WhileExpr {}
@@ -1427,15 +7925,39 @@ impl AstNode for ContinueExpr {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for ContinueExpr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            CONTINUE_EXPR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ContinueExpr {}
@@ -1455,15 +7977,39 @@ impl AstNode for BreakExpr {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for BreakExpr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            BREAK_EXPR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl BreakExpr {
@@ -1487,15 +8033,39 @@ impl AstNode for Label {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for Label {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            LABEL => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl Label {}
@@ -1515,15 +8085,39 @@ impl AstNode for BlockExpr {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for BlockExpr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            BLOCK_EXPR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl BlockExpr {
@@ -1547,15 +8141,39 @@ impl AstNode for ReturnExpr {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for ReturnExpr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            RETURN_EXPR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ReturnExpr {
@@ -1579,15 +8197,39 @@ impl AstNode for CallExpr {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for CallExpr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            CALL_EXPR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::ArgListOwner for CallExpr {}
@@ -1612,15 +8254,39 @@ impl AstNode for MethodCallExpr {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for MethodCallExpr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            METHOD_CALL_EXPR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::ArgListOwner for MethodCallExpr {}
@@ -1651,15 +8317,39 @@ impl AstNode for IndexExpr {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for IndexExpr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            INDEX_EXPR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl IndexExpr {}
@@ -1679,15 +8369,39 @@ impl AstNode for FieldExpr {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for FieldExpr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            FIELD_EXPR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl FieldExpr {
@@ -1714,15 +8428,39 @@ impl AstNode for AwaitExpr {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for AwaitExpr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            AWAIT_EXPR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl AwaitExpr {
@@ -1746,15 +8484,39 @@ impl AstNode for TryExpr {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for TryExpr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            TRY_EXPR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl TryExpr {
@@ -1778,15 +8540,39 @@ impl AstNode for CastExpr {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for CastExpr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            CAST_EXPR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl CastExpr {
@@ -1813,15 +8599,39 @@ impl AstNode for RefExpr {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for RefExpr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            REF_EXPR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl RefExpr {
@@ -1845,15 +8655,39 @@ impl AstNode for PrefixExpr {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for PrefixExpr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            PREFIX_EXPR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl PrefixExpr {
@@ -1877,15 +8711,39 @@ impl AstNode for BoxExpr {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for BoxExpr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            BOX_EXPR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl BoxExpr {
@@ -1909,15 +8767,39 @@ impl AstNode for RangeExpr {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for RangeExpr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            RANGE_EXPR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl RangeExpr {}
@@ -1937,15 +8819,39 @@ impl AstNode for BinExpr {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for BinExpr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            BIN_EXPR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl BinExpr {}
@@ -1965,15 +8871,39 @@ impl AstNode for Literal {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for Literal {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            LITERAL => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl Literal {}
@@ -1993,15 +8923,39 @@ impl AstNode for MatchExpr {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for MatchExpr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            MATCH_EXPR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl MatchExpr {
@@ -2028,15 +8982,39 @@ impl AstNode for MatchArmList {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for MatchArmList {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            MATCH_ARM_LIST => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::AttrsOwner for MatchArmList {}
@@ -2061,15 +9039,39 @@ impl AstNode for MatchArm {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for MatchArm {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            MATCH_ARM => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::AttrsOwner for MatchArm {}
@@ -2100,15 +9102,39 @@ impl AstNode for MatchGuard {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for MatchGuard {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            MATCH_GUARD => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl MatchGuard {
@@ -2132,15 +9158,39 @@ impl AstNode for RecordLit {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for RecordLit {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            RECORD_LIT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl RecordLit {
@@ -2167,15 +9217,39 @@ impl AstNode for RecordFieldList {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for RecordFieldList {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            RECORD_FIELD_LIST => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl RecordFieldList {
@@ -2202,15 +9276,39 @@ impl AstNode for RecordField {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for RecordField {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            RECORD_FIELD => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl RecordField {
@@ -2237,15 +9335,39 @@ impl AstNode for OrPat {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for OrPat {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            OR_PAT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl OrPat {
@@ -2269,15 +9391,39 @@ impl AstNode for ParenPat {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for ParenPat {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            PAREN_PAT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ParenPat {
@@ -2301,15 +9447,39 @@ impl AstNode for RefPat {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for RefPat {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            REF_PAT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl RefPat {
@@ -2333,15 +9503,39 @@ impl AstNode for BoxPat {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for BoxPat {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            BOX_PAT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl BoxPat {
@@ -2365,15 +9559,39 @@ impl AstNode for BindPat {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for BindPat {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            BIND_PAT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::NameOwner for BindPat {}
@@ -2398,15 +9616,39 @@ impl AstNode for PlaceholderPat {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for PlaceholderPat {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            PLACEHOLDER_PAT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl PlaceholderPat {}
@@ -2426,15 +9668,39 @@ impl AstNode for DotDotPat {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for DotDotPat {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            DOT_DOT_PAT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl DotDotPat {}
@@ -2454,15 +9720,39 @@ impl AstNode for PathPat {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for PathPat {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            PATH_PAT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl PathPat {
@@ -2486,15 +9776,39 @@ impl AstNode for SlicePat {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for SlicePat {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            SLICE_PAT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl SlicePat {
@@ -2518,15 +9832,39 @@ impl AstNode for RangePat {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for RangePat {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            RANGE_PAT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl RangePat {}
@@ -2546,15 +9884,39 @@ impl AstNode for LiteralPat {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for LiteralPat {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            LITERAL_PAT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl LiteralPat {
@@ -2578,15 +9940,39 @@ impl AstNode for RecordPat {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for RecordPat {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            RECORD_PAT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl RecordPat {
@@ -2613,15 +9999,39 @@ impl AstNode for RecordFieldPatList {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for RecordFieldPatList {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            RECORD_FIELD_PAT_LIST => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl RecordFieldPatList {
@@ -2648,15 +10058,39 @@ impl AstNode for RecordFieldPat {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for RecordFieldPat {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            RECORD_FIELD_PAT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::NameOwner for RecordFieldPat {}
@@ -2681,15 +10115,39 @@ impl AstNode for TupleStructPat {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for TupleStructPat {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            TUPLE_STRUCT_PAT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl TupleStructPat {
@@ -2716,15 +10174,39 @@ impl AstNode for TuplePat {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for TuplePat {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            TUPLE_PAT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl TuplePat {
@@ -2748,15 +10230,39 @@ impl AstNode for Visibility {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for Visibility {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            VISIBILITY => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl Visibility {}
@@ -2776,15 +10282,39 @@ impl AstNode for Name {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for Name {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            NAME => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl Name {}
@@ -2804,15 +10334,39 @@ impl AstNode for NameRef {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for NameRef {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            NAME_REF => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl NameRef {}
@@ -2832,15 +10386,39 @@ impl AstNode for MacroCall {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for MacroCall {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            MACRO_CALL => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::NameOwner for MacroCall {}
@@ -2870,15 +10448,39 @@ impl AstNode for Attr {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for Attr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            ATTR => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl Attr {
@@ -2905,15 +10507,39 @@ impl AstNode for TokenTree {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for TokenTree {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            TOKEN_TREE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl TokenTree {}
@@ -2933,15 +10559,39 @@ impl AstNode for TypeParamList {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for TypeParamList {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            TYPE_PARAM_LIST => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl TypeParamList {
@@ -2968,15 +10618,39 @@ impl AstNode for TypeParam {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for TypeParam {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            TYPE_PARAM => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::NameOwner for TypeParam {}
@@ -3003,15 +10677,39 @@ impl AstNode for ConstParam {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for ConstParam {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            CONST_PARAM => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::NameOwner for ConstParam {}
@@ -3038,15 +10736,39 @@ impl AstNode for LifetimeParam {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for LifetimeParam {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            LIFETIME_PARAM => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::AttrsOwner for LifetimeParam {}
@@ -3067,15 +10789,39 @@ impl AstNode for TypeBound {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for TypeBound {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            TYPE_BOUND => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl TypeBound {
@@ -3099,15 +10845,39 @@ impl AstNode for TypeBoundList {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for TypeBoundList {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            TYPE_BOUND_LIST => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl TypeBoundList {
@@ -3131,15 +10901,39 @@ impl AstNode for WherePred {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for WherePred {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            WHERE_PRED => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::TypeBoundsOwner for WherePred {}
@@ -3164,15 +10958,39 @@ impl AstNode for WhereClause {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for WhereClause {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            WHERE_CLAUSE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl WhereClause {
@@ -3196,15 +11014,39 @@ impl AstNode for ExprStmt {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for ExprStmt {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            EXPR_STMT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ExprStmt {
@@ -3228,15 +11070,39 @@ impl AstNode for LetStmt {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for LetStmt {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            LET_STMT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::TypeAscriptionOwner for LetStmt {}
@@ -3264,15 +11130,39 @@ impl AstNode for Condition {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for Condition {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            CONDITION => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl Condition {
@@ -3299,15 +11189,39 @@ impl AstNode for Block {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for Block {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            BLOCK => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::AttrsOwner for Block {}
@@ -3336,15 +11250,39 @@ impl AstNode for ParamList {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for ParamList {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            PARAM_LIST => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ParamList {
@@ -3371,15 +11309,39 @@ impl AstNode for SelfParam {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for SelfParam {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            SELF_PARAM => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::TypeAscriptionOwner for SelfParam {}
@@ -3401,15 +11363,39 @@ impl AstNode for Param {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for Param {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            PARAM => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::TypeAscriptionOwner for Param {}
@@ -3435,15 +11421,39 @@ impl AstNode for UseItem {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for UseItem {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            USE_ITEM => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::AttrsOwner for UseItem {}
@@ -3469,15 +11479,39 @@ impl AstNode for UseTree {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for UseTree {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            USE_TREE => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl UseTree {
@@ -3507,15 +11541,39 @@ impl AstNode for Alias {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for Alias {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            ALIAS => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::NameOwner for Alias {}
@@ -3536,15 +11594,39 @@ impl AstNode for UseTreeList {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for UseTreeList {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            USE_TREE_LIST => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl UseTreeList {
@@ -3568,15 +11650,39 @@ impl AstNode for ExternCrateItem {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for ExternCrateItem {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            EXTERN_CRATE_ITEM => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::AttrsOwner for ExternCrateItem {}
@@ -3605,15 +11711,39 @@ impl AstNode for ArgList {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for ArgList {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            ARG_LIST => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ArgList {
@@ -3637,15 +11767,39 @@ impl AstNode for Path {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for Path {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            PATH => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl Path {
@@ -3672,15 +11826,39 @@ impl AstNode for PathSegment {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for PathSegment {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            PATH_SEGMENT => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl PathSegment {
@@ -3716,15 +11894,39 @@ impl AstNode for TypeArgList {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for TypeArgList {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            TYPE_ARG_LIST => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl TypeArgList {
@@ -3757,15 +11959,39 @@ impl AstNode for TypeArg {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for TypeArg {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            TYPE_ARG => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl TypeArg {
@@ -3789,15 +12015,39 @@ impl AstNode for AssocTypeArg {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for AssocTypeArg {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            ASSOC_TYPE_ARG => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl AssocTypeArg {
@@ -3824,15 +12074,39 @@ impl AstNode for LifetimeArg {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for LifetimeArg {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            LIFETIME_ARG => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl LifetimeArg {}
@@ -3852,15 +12126,39 @@ impl AstNode for ConstArg {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for ConstArg {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            CONST_ARG => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ConstArg {
@@ -3887,15 +12185,39 @@ impl AstNode for MacroItems {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for MacroItems {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            MACRO_ITEMS => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl ast::ModuleItemOwner for MacroItems {}
@@ -3917,15 +12239,39 @@ impl AstNode for MacroStmts {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
         if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
+            Ok(Self { syntax })
         } else {
-            None
+            Err(syntax)
         }
     }
     fn syntax(&self) -> &SyntaxNode {
         &self.syntax
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        self.syntax
+    }
+}
+impl AstElement for MacroStmts {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            MACRO_STMTS => true,
+            _ => false,
+        }
+    }
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        if Self::can_cast_element(syntax.kind()) {
+            Ok(Self { syntax: syntax.into_node().unwrap() })
+        } else {
+            Err(syntax)
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        NodeOrToken::Node(&self.syntax)
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        NodeOrToken::Node(self.syntax)
     }
 }
 impl MacroStmts {
@@ -3959,30 +12305,74 @@ impl From<UnionDef> for NominalDef {
 }
 impl std::fmt::Display for NominalDef {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        std::fmt::Display::fmt(self.syntax(), f)
+        match self {
+            NominalDef::StructDef(it) => std::fmt::Display::fmt(it, f),
+            NominalDef::EnumDef(it) => std::fmt::Display::fmt(it, f),
+            NominalDef::UnionDef(it) => std::fmt::Display::fmt(it, f),
+        }
     }
 }
 impl AstNode for NominalDef {
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
-            STRUCT_DEF | ENUM_DEF | UNION_DEF => true,
+            ENUM_DEF | STRUCT_DEF | UNION_DEF => true,
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
-        let res = match syntax.kind() {
-            STRUCT_DEF => NominalDef::StructDef(StructDef { syntax }),
-            ENUM_DEF => NominalDef::EnumDef(EnumDef { syntax }),
-            UNION_DEF => NominalDef::UnionDef(UnionDef { syntax }),
-            _ => return None,
-        };
-        Some(res)
+    #[allow(unreachable_patterns)]
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
+        match syntax.kind() {
+            STRUCT_DEF => StructDef::cast_or_return(syntax).map(|x| NominalDef::StructDef(x)),
+            ENUM_DEF => EnumDef::cast_or_return(syntax).map(|x| NominalDef::EnumDef(x)),
+            UNION_DEF => UnionDef::cast_or_return(syntax).map(|x| NominalDef::UnionDef(x)),
+            _ => Err(syntax),
+        }
     }
     fn syntax(&self) -> &SyntaxNode {
         match self {
-            NominalDef::StructDef(it) => &it.syntax,
-            NominalDef::EnumDef(it) => &it.syntax,
-            NominalDef::UnionDef(it) => &it.syntax,
+            NominalDef::StructDef(it) => it.syntax(),
+            NominalDef::EnumDef(it) => it.syntax(),
+            NominalDef::UnionDef(it) => it.syntax(),
+        }
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        match self {
+            NominalDef::StructDef(it) => it.into_syntax(),
+            NominalDef::EnumDef(it) => it.into_syntax(),
+            NominalDef::UnionDef(it) => it.into_syntax(),
+        }
+    }
+}
+impl AstElement for NominalDef {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            ENUM_DEF | STRUCT_DEF | UNION_DEF => true,
+            _ => false,
+        }
+    }
+    #[allow(unreachable_patterns)]
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        match syntax.kind() {
+            STRUCT_DEF => {
+                StructDef::cast_or_return_element(syntax).map(|x| NominalDef::StructDef(x))
+            }
+            ENUM_DEF => EnumDef::cast_or_return_element(syntax).map(|x| NominalDef::EnumDef(x)),
+            UNION_DEF => UnionDef::cast_or_return_element(syntax).map(|x| NominalDef::UnionDef(x)),
+            _ => Err(syntax),
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        match self {
+            NominalDef::StructDef(it) => it.syntax_element(),
+            NominalDef::EnumDef(it) => it.syntax_element(),
+            NominalDef::UnionDef(it) => it.syntax_element(),
+        }
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        match self {
+            NominalDef::StructDef(it) => it.into_syntax_element(),
+            NominalDef::EnumDef(it) => it.into_syntax_element(),
+            NominalDef::UnionDef(it) => it.into_syntax_element(),
         }
     }
 }
@@ -4072,52 +12462,168 @@ impl From<DynTraitType> for TypeRef {
 }
 impl std::fmt::Display for TypeRef {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        std::fmt::Display::fmt(self.syntax(), f)
+        match self {
+            TypeRef::ParenType(it) => std::fmt::Display::fmt(it, f),
+            TypeRef::TupleType(it) => std::fmt::Display::fmt(it, f),
+            TypeRef::NeverType(it) => std::fmt::Display::fmt(it, f),
+            TypeRef::PathType(it) => std::fmt::Display::fmt(it, f),
+            TypeRef::PointerType(it) => std::fmt::Display::fmt(it, f),
+            TypeRef::ArrayType(it) => std::fmt::Display::fmt(it, f),
+            TypeRef::SliceType(it) => std::fmt::Display::fmt(it, f),
+            TypeRef::ReferenceType(it) => std::fmt::Display::fmt(it, f),
+            TypeRef::PlaceholderType(it) => std::fmt::Display::fmt(it, f),
+            TypeRef::FnPointerType(it) => std::fmt::Display::fmt(it, f),
+            TypeRef::ForType(it) => std::fmt::Display::fmt(it, f),
+            TypeRef::ImplTraitType(it) => std::fmt::Display::fmt(it, f),
+            TypeRef::DynTraitType(it) => std::fmt::Display::fmt(it, f),
+        }
     }
 }
 impl AstNode for TypeRef {
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
-            PAREN_TYPE | TUPLE_TYPE | NEVER_TYPE | PATH_TYPE | POINTER_TYPE | ARRAY_TYPE
-            | SLICE_TYPE | REFERENCE_TYPE | PLACEHOLDER_TYPE | FN_POINTER_TYPE | FOR_TYPE
-            | IMPL_TRAIT_TYPE | DYN_TRAIT_TYPE => true,
+            ARRAY_TYPE | DYN_TRAIT_TYPE | FN_POINTER_TYPE | FOR_TYPE | IMPL_TRAIT_TYPE
+            | NEVER_TYPE | PAREN_TYPE | PATH_TYPE | PLACEHOLDER_TYPE | POINTER_TYPE
+            | REFERENCE_TYPE | SLICE_TYPE | TUPLE_TYPE => true,
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
-        let res = match syntax.kind() {
-            PAREN_TYPE => TypeRef::ParenType(ParenType { syntax }),
-            TUPLE_TYPE => TypeRef::TupleType(TupleType { syntax }),
-            NEVER_TYPE => TypeRef::NeverType(NeverType { syntax }),
-            PATH_TYPE => TypeRef::PathType(PathType { syntax }),
-            POINTER_TYPE => TypeRef::PointerType(PointerType { syntax }),
-            ARRAY_TYPE => TypeRef::ArrayType(ArrayType { syntax }),
-            SLICE_TYPE => TypeRef::SliceType(SliceType { syntax }),
-            REFERENCE_TYPE => TypeRef::ReferenceType(ReferenceType { syntax }),
-            PLACEHOLDER_TYPE => TypeRef::PlaceholderType(PlaceholderType { syntax }),
-            FN_POINTER_TYPE => TypeRef::FnPointerType(FnPointerType { syntax }),
-            FOR_TYPE => TypeRef::ForType(ForType { syntax }),
-            IMPL_TRAIT_TYPE => TypeRef::ImplTraitType(ImplTraitType { syntax }),
-            DYN_TRAIT_TYPE => TypeRef::DynTraitType(DynTraitType { syntax }),
-            _ => return None,
-        };
-        Some(res)
+    #[allow(unreachable_patterns)]
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
+        match syntax.kind() {
+            PAREN_TYPE => ParenType::cast_or_return(syntax).map(|x| TypeRef::ParenType(x)),
+            TUPLE_TYPE => TupleType::cast_or_return(syntax).map(|x| TypeRef::TupleType(x)),
+            NEVER_TYPE => NeverType::cast_or_return(syntax).map(|x| TypeRef::NeverType(x)),
+            PATH_TYPE => PathType::cast_or_return(syntax).map(|x| TypeRef::PathType(x)),
+            POINTER_TYPE => PointerType::cast_or_return(syntax).map(|x| TypeRef::PointerType(x)),
+            ARRAY_TYPE => ArrayType::cast_or_return(syntax).map(|x| TypeRef::ArrayType(x)),
+            SLICE_TYPE => SliceType::cast_or_return(syntax).map(|x| TypeRef::SliceType(x)),
+            REFERENCE_TYPE => {
+                ReferenceType::cast_or_return(syntax).map(|x| TypeRef::ReferenceType(x))
+            }
+            PLACEHOLDER_TYPE => {
+                PlaceholderType::cast_or_return(syntax).map(|x| TypeRef::PlaceholderType(x))
+            }
+            FN_POINTER_TYPE => {
+                FnPointerType::cast_or_return(syntax).map(|x| TypeRef::FnPointerType(x))
+            }
+            FOR_TYPE => ForType::cast_or_return(syntax).map(|x| TypeRef::ForType(x)),
+            IMPL_TRAIT_TYPE => {
+                ImplTraitType::cast_or_return(syntax).map(|x| TypeRef::ImplTraitType(x))
+            }
+            DYN_TRAIT_TYPE => {
+                DynTraitType::cast_or_return(syntax).map(|x| TypeRef::DynTraitType(x))
+            }
+            _ => Err(syntax),
+        }
     }
     fn syntax(&self) -> &SyntaxNode {
         match self {
-            TypeRef::ParenType(it) => &it.syntax,
-            TypeRef::TupleType(it) => &it.syntax,
-            TypeRef::NeverType(it) => &it.syntax,
-            TypeRef::PathType(it) => &it.syntax,
-            TypeRef::PointerType(it) => &it.syntax,
-            TypeRef::ArrayType(it) => &it.syntax,
-            TypeRef::SliceType(it) => &it.syntax,
-            TypeRef::ReferenceType(it) => &it.syntax,
-            TypeRef::PlaceholderType(it) => &it.syntax,
-            TypeRef::FnPointerType(it) => &it.syntax,
-            TypeRef::ForType(it) => &it.syntax,
-            TypeRef::ImplTraitType(it) => &it.syntax,
-            TypeRef::DynTraitType(it) => &it.syntax,
+            TypeRef::ParenType(it) => it.syntax(),
+            TypeRef::TupleType(it) => it.syntax(),
+            TypeRef::NeverType(it) => it.syntax(),
+            TypeRef::PathType(it) => it.syntax(),
+            TypeRef::PointerType(it) => it.syntax(),
+            TypeRef::ArrayType(it) => it.syntax(),
+            TypeRef::SliceType(it) => it.syntax(),
+            TypeRef::ReferenceType(it) => it.syntax(),
+            TypeRef::PlaceholderType(it) => it.syntax(),
+            TypeRef::FnPointerType(it) => it.syntax(),
+            TypeRef::ForType(it) => it.syntax(),
+            TypeRef::ImplTraitType(it) => it.syntax(),
+            TypeRef::DynTraitType(it) => it.syntax(),
+        }
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        match self {
+            TypeRef::ParenType(it) => it.into_syntax(),
+            TypeRef::TupleType(it) => it.into_syntax(),
+            TypeRef::NeverType(it) => it.into_syntax(),
+            TypeRef::PathType(it) => it.into_syntax(),
+            TypeRef::PointerType(it) => it.into_syntax(),
+            TypeRef::ArrayType(it) => it.into_syntax(),
+            TypeRef::SliceType(it) => it.into_syntax(),
+            TypeRef::ReferenceType(it) => it.into_syntax(),
+            TypeRef::PlaceholderType(it) => it.into_syntax(),
+            TypeRef::FnPointerType(it) => it.into_syntax(),
+            TypeRef::ForType(it) => it.into_syntax(),
+            TypeRef::ImplTraitType(it) => it.into_syntax(),
+            TypeRef::DynTraitType(it) => it.into_syntax(),
+        }
+    }
+}
+impl AstElement for TypeRef {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            ARRAY_TYPE | DYN_TRAIT_TYPE | FN_POINTER_TYPE | FOR_TYPE | IMPL_TRAIT_TYPE
+            | NEVER_TYPE | PAREN_TYPE | PATH_TYPE | PLACEHOLDER_TYPE | POINTER_TYPE
+            | REFERENCE_TYPE | SLICE_TYPE | TUPLE_TYPE => true,
+            _ => false,
+        }
+    }
+    #[allow(unreachable_patterns)]
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        match syntax.kind() {
+            PAREN_TYPE => ParenType::cast_or_return_element(syntax).map(|x| TypeRef::ParenType(x)),
+            TUPLE_TYPE => TupleType::cast_or_return_element(syntax).map(|x| TypeRef::TupleType(x)),
+            NEVER_TYPE => NeverType::cast_or_return_element(syntax).map(|x| TypeRef::NeverType(x)),
+            PATH_TYPE => PathType::cast_or_return_element(syntax).map(|x| TypeRef::PathType(x)),
+            POINTER_TYPE => {
+                PointerType::cast_or_return_element(syntax).map(|x| TypeRef::PointerType(x))
+            }
+            ARRAY_TYPE => ArrayType::cast_or_return_element(syntax).map(|x| TypeRef::ArrayType(x)),
+            SLICE_TYPE => SliceType::cast_or_return_element(syntax).map(|x| TypeRef::SliceType(x)),
+            REFERENCE_TYPE => {
+                ReferenceType::cast_or_return_element(syntax).map(|x| TypeRef::ReferenceType(x))
+            }
+            PLACEHOLDER_TYPE => {
+                PlaceholderType::cast_or_return_element(syntax).map(|x| TypeRef::PlaceholderType(x))
+            }
+            FN_POINTER_TYPE => {
+                FnPointerType::cast_or_return_element(syntax).map(|x| TypeRef::FnPointerType(x))
+            }
+            FOR_TYPE => ForType::cast_or_return_element(syntax).map(|x| TypeRef::ForType(x)),
+            IMPL_TRAIT_TYPE => {
+                ImplTraitType::cast_or_return_element(syntax).map(|x| TypeRef::ImplTraitType(x))
+            }
+            DYN_TRAIT_TYPE => {
+                DynTraitType::cast_or_return_element(syntax).map(|x| TypeRef::DynTraitType(x))
+            }
+            _ => Err(syntax),
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        match self {
+            TypeRef::ParenType(it) => it.syntax_element(),
+            TypeRef::TupleType(it) => it.syntax_element(),
+            TypeRef::NeverType(it) => it.syntax_element(),
+            TypeRef::PathType(it) => it.syntax_element(),
+            TypeRef::PointerType(it) => it.syntax_element(),
+            TypeRef::ArrayType(it) => it.syntax_element(),
+            TypeRef::SliceType(it) => it.syntax_element(),
+            TypeRef::ReferenceType(it) => it.syntax_element(),
+            TypeRef::PlaceholderType(it) => it.syntax_element(),
+            TypeRef::FnPointerType(it) => it.syntax_element(),
+            TypeRef::ForType(it) => it.syntax_element(),
+            TypeRef::ImplTraitType(it) => it.syntax_element(),
+            TypeRef::DynTraitType(it) => it.syntax_element(),
+        }
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        match self {
+            TypeRef::ParenType(it) => it.into_syntax_element(),
+            TypeRef::TupleType(it) => it.into_syntax_element(),
+            TypeRef::NeverType(it) => it.into_syntax_element(),
+            TypeRef::PathType(it) => it.into_syntax_element(),
+            TypeRef::PointerType(it) => it.into_syntax_element(),
+            TypeRef::ArrayType(it) => it.into_syntax_element(),
+            TypeRef::SliceType(it) => it.into_syntax_element(),
+            TypeRef::ReferenceType(it) => it.into_syntax_element(),
+            TypeRef::PlaceholderType(it) => it.into_syntax_element(),
+            TypeRef::FnPointerType(it) => it.into_syntax_element(),
+            TypeRef::ForType(it) => it.into_syntax_element(),
+            TypeRef::ImplTraitType(it) => it.into_syntax_element(),
+            TypeRef::DynTraitType(it) => it.into_syntax_element(),
         }
     }
 }
@@ -4204,51 +12710,157 @@ impl From<MacroCall> for ModuleItem {
 }
 impl std::fmt::Display for ModuleItem {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        std::fmt::Display::fmt(self.syntax(), f)
+        match self {
+            ModuleItem::StructDef(it) => std::fmt::Display::fmt(it, f),
+            ModuleItem::UnionDef(it) => std::fmt::Display::fmt(it, f),
+            ModuleItem::EnumDef(it) => std::fmt::Display::fmt(it, f),
+            ModuleItem::FnDef(it) => std::fmt::Display::fmt(it, f),
+            ModuleItem::TraitDef(it) => std::fmt::Display::fmt(it, f),
+            ModuleItem::TypeAliasDef(it) => std::fmt::Display::fmt(it, f),
+            ModuleItem::ImplDef(it) => std::fmt::Display::fmt(it, f),
+            ModuleItem::UseItem(it) => std::fmt::Display::fmt(it, f),
+            ModuleItem::ExternCrateItem(it) => std::fmt::Display::fmt(it, f),
+            ModuleItem::ConstDef(it) => std::fmt::Display::fmt(it, f),
+            ModuleItem::StaticDef(it) => std::fmt::Display::fmt(it, f),
+            ModuleItem::Module(it) => std::fmt::Display::fmt(it, f),
+            ModuleItem::MacroCall(it) => std::fmt::Display::fmt(it, f),
+        }
     }
 }
 impl AstNode for ModuleItem {
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
-            STRUCT_DEF | UNION_DEF | ENUM_DEF | FN_DEF | TRAIT_DEF | TYPE_ALIAS_DEF | IMPL_DEF
-            | USE_ITEM | EXTERN_CRATE_ITEM | CONST_DEF | STATIC_DEF | MODULE | MACRO_CALL => true,
+            CONST_DEF | ENUM_DEF | EXTERN_CRATE_ITEM | FN_DEF | IMPL_DEF | MACRO_CALL | MODULE
+            | STATIC_DEF | STRUCT_DEF | TRAIT_DEF | TYPE_ALIAS_DEF | UNION_DEF | USE_ITEM => true,
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
-        let res = match syntax.kind() {
-            STRUCT_DEF => ModuleItem::StructDef(StructDef { syntax }),
-            UNION_DEF => ModuleItem::UnionDef(UnionDef { syntax }),
-            ENUM_DEF => ModuleItem::EnumDef(EnumDef { syntax }),
-            FN_DEF => ModuleItem::FnDef(FnDef { syntax }),
-            TRAIT_DEF => ModuleItem::TraitDef(TraitDef { syntax }),
-            TYPE_ALIAS_DEF => ModuleItem::TypeAliasDef(TypeAliasDef { syntax }),
-            IMPL_DEF => ModuleItem::ImplDef(ImplDef { syntax }),
-            USE_ITEM => ModuleItem::UseItem(UseItem { syntax }),
-            EXTERN_CRATE_ITEM => ModuleItem::ExternCrateItem(ExternCrateItem { syntax }),
-            CONST_DEF => ModuleItem::ConstDef(ConstDef { syntax }),
-            STATIC_DEF => ModuleItem::StaticDef(StaticDef { syntax }),
-            MODULE => ModuleItem::Module(Module { syntax }),
-            MACRO_CALL => ModuleItem::MacroCall(MacroCall { syntax }),
-            _ => return None,
-        };
-        Some(res)
+    #[allow(unreachable_patterns)]
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
+        match syntax.kind() {
+            STRUCT_DEF => StructDef::cast_or_return(syntax).map(|x| ModuleItem::StructDef(x)),
+            UNION_DEF => UnionDef::cast_or_return(syntax).map(|x| ModuleItem::UnionDef(x)),
+            ENUM_DEF => EnumDef::cast_or_return(syntax).map(|x| ModuleItem::EnumDef(x)),
+            FN_DEF => FnDef::cast_or_return(syntax).map(|x| ModuleItem::FnDef(x)),
+            TRAIT_DEF => TraitDef::cast_or_return(syntax).map(|x| ModuleItem::TraitDef(x)),
+            TYPE_ALIAS_DEF => {
+                TypeAliasDef::cast_or_return(syntax).map(|x| ModuleItem::TypeAliasDef(x))
+            }
+            IMPL_DEF => ImplDef::cast_or_return(syntax).map(|x| ModuleItem::ImplDef(x)),
+            USE_ITEM => UseItem::cast_or_return(syntax).map(|x| ModuleItem::UseItem(x)),
+            EXTERN_CRATE_ITEM => {
+                ExternCrateItem::cast_or_return(syntax).map(|x| ModuleItem::ExternCrateItem(x))
+            }
+            CONST_DEF => ConstDef::cast_or_return(syntax).map(|x| ModuleItem::ConstDef(x)),
+            STATIC_DEF => StaticDef::cast_or_return(syntax).map(|x| ModuleItem::StaticDef(x)),
+            MODULE => Module::cast_or_return(syntax).map(|x| ModuleItem::Module(x)),
+            MACRO_CALL => MacroCall::cast_or_return(syntax).map(|x| ModuleItem::MacroCall(x)),
+            _ => Err(syntax),
+        }
     }
     fn syntax(&self) -> &SyntaxNode {
         match self {
-            ModuleItem::StructDef(it) => &it.syntax,
-            ModuleItem::UnionDef(it) => &it.syntax,
-            ModuleItem::EnumDef(it) => &it.syntax,
-            ModuleItem::FnDef(it) => &it.syntax,
-            ModuleItem::TraitDef(it) => &it.syntax,
-            ModuleItem::TypeAliasDef(it) => &it.syntax,
-            ModuleItem::ImplDef(it) => &it.syntax,
-            ModuleItem::UseItem(it) => &it.syntax,
-            ModuleItem::ExternCrateItem(it) => &it.syntax,
-            ModuleItem::ConstDef(it) => &it.syntax,
-            ModuleItem::StaticDef(it) => &it.syntax,
-            ModuleItem::Module(it) => &it.syntax,
-            ModuleItem::MacroCall(it) => &it.syntax,
+            ModuleItem::StructDef(it) => it.syntax(),
+            ModuleItem::UnionDef(it) => it.syntax(),
+            ModuleItem::EnumDef(it) => it.syntax(),
+            ModuleItem::FnDef(it) => it.syntax(),
+            ModuleItem::TraitDef(it) => it.syntax(),
+            ModuleItem::TypeAliasDef(it) => it.syntax(),
+            ModuleItem::ImplDef(it) => it.syntax(),
+            ModuleItem::UseItem(it) => it.syntax(),
+            ModuleItem::ExternCrateItem(it) => it.syntax(),
+            ModuleItem::ConstDef(it) => it.syntax(),
+            ModuleItem::StaticDef(it) => it.syntax(),
+            ModuleItem::Module(it) => it.syntax(),
+            ModuleItem::MacroCall(it) => it.syntax(),
+        }
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        match self {
+            ModuleItem::StructDef(it) => it.into_syntax(),
+            ModuleItem::UnionDef(it) => it.into_syntax(),
+            ModuleItem::EnumDef(it) => it.into_syntax(),
+            ModuleItem::FnDef(it) => it.into_syntax(),
+            ModuleItem::TraitDef(it) => it.into_syntax(),
+            ModuleItem::TypeAliasDef(it) => it.into_syntax(),
+            ModuleItem::ImplDef(it) => it.into_syntax(),
+            ModuleItem::UseItem(it) => it.into_syntax(),
+            ModuleItem::ExternCrateItem(it) => it.into_syntax(),
+            ModuleItem::ConstDef(it) => it.into_syntax(),
+            ModuleItem::StaticDef(it) => it.into_syntax(),
+            ModuleItem::Module(it) => it.into_syntax(),
+            ModuleItem::MacroCall(it) => it.into_syntax(),
+        }
+    }
+}
+impl AstElement for ModuleItem {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            CONST_DEF | ENUM_DEF | EXTERN_CRATE_ITEM | FN_DEF | IMPL_DEF | MACRO_CALL | MODULE
+            | STATIC_DEF | STRUCT_DEF | TRAIT_DEF | TYPE_ALIAS_DEF | UNION_DEF | USE_ITEM => true,
+            _ => false,
+        }
+    }
+    #[allow(unreachable_patterns)]
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        match syntax.kind() {
+            STRUCT_DEF => {
+                StructDef::cast_or_return_element(syntax).map(|x| ModuleItem::StructDef(x))
+            }
+            UNION_DEF => UnionDef::cast_or_return_element(syntax).map(|x| ModuleItem::UnionDef(x)),
+            ENUM_DEF => EnumDef::cast_or_return_element(syntax).map(|x| ModuleItem::EnumDef(x)),
+            FN_DEF => FnDef::cast_or_return_element(syntax).map(|x| ModuleItem::FnDef(x)),
+            TRAIT_DEF => TraitDef::cast_or_return_element(syntax).map(|x| ModuleItem::TraitDef(x)),
+            TYPE_ALIAS_DEF => {
+                TypeAliasDef::cast_or_return_element(syntax).map(|x| ModuleItem::TypeAliasDef(x))
+            }
+            IMPL_DEF => ImplDef::cast_or_return_element(syntax).map(|x| ModuleItem::ImplDef(x)),
+            USE_ITEM => UseItem::cast_or_return_element(syntax).map(|x| ModuleItem::UseItem(x)),
+            EXTERN_CRATE_ITEM => ExternCrateItem::cast_or_return_element(syntax)
+                .map(|x| ModuleItem::ExternCrateItem(x)),
+            CONST_DEF => ConstDef::cast_or_return_element(syntax).map(|x| ModuleItem::ConstDef(x)),
+            STATIC_DEF => {
+                StaticDef::cast_or_return_element(syntax).map(|x| ModuleItem::StaticDef(x))
+            }
+            MODULE => Module::cast_or_return_element(syntax).map(|x| ModuleItem::Module(x)),
+            MACRO_CALL => {
+                MacroCall::cast_or_return_element(syntax).map(|x| ModuleItem::MacroCall(x))
+            }
+            _ => Err(syntax),
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        match self {
+            ModuleItem::StructDef(it) => it.syntax_element(),
+            ModuleItem::UnionDef(it) => it.syntax_element(),
+            ModuleItem::EnumDef(it) => it.syntax_element(),
+            ModuleItem::FnDef(it) => it.syntax_element(),
+            ModuleItem::TraitDef(it) => it.syntax_element(),
+            ModuleItem::TypeAliasDef(it) => it.syntax_element(),
+            ModuleItem::ImplDef(it) => it.syntax_element(),
+            ModuleItem::UseItem(it) => it.syntax_element(),
+            ModuleItem::ExternCrateItem(it) => it.syntax_element(),
+            ModuleItem::ConstDef(it) => it.syntax_element(),
+            ModuleItem::StaticDef(it) => it.syntax_element(),
+            ModuleItem::Module(it) => it.syntax_element(),
+            ModuleItem::MacroCall(it) => it.syntax_element(),
+        }
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        match self {
+            ModuleItem::StructDef(it) => it.into_syntax_element(),
+            ModuleItem::UnionDef(it) => it.into_syntax_element(),
+            ModuleItem::EnumDef(it) => it.into_syntax_element(),
+            ModuleItem::FnDef(it) => it.into_syntax_element(),
+            ModuleItem::TraitDef(it) => it.into_syntax_element(),
+            ModuleItem::TypeAliasDef(it) => it.into_syntax_element(),
+            ModuleItem::ImplDef(it) => it.into_syntax_element(),
+            ModuleItem::UseItem(it) => it.into_syntax_element(),
+            ModuleItem::ExternCrateItem(it) => it.into_syntax_element(),
+            ModuleItem::ConstDef(it) => it.into_syntax_element(),
+            ModuleItem::StaticDef(it) => it.into_syntax_element(),
+            ModuleItem::Module(it) => it.into_syntax_element(),
+            ModuleItem::MacroCall(it) => it.into_syntax_element(),
         }
     }
 }
@@ -4277,30 +12889,76 @@ impl From<ConstDef> for ImplItem {
 }
 impl std::fmt::Display for ImplItem {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        std::fmt::Display::fmt(self.syntax(), f)
+        match self {
+            ImplItem::FnDef(it) => std::fmt::Display::fmt(it, f),
+            ImplItem::TypeAliasDef(it) => std::fmt::Display::fmt(it, f),
+            ImplItem::ConstDef(it) => std::fmt::Display::fmt(it, f),
+        }
     }
 }
 impl AstNode for ImplItem {
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
-            FN_DEF | TYPE_ALIAS_DEF | CONST_DEF => true,
+            CONST_DEF | FN_DEF | TYPE_ALIAS_DEF => true,
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
-        let res = match syntax.kind() {
-            FN_DEF => ImplItem::FnDef(FnDef { syntax }),
-            TYPE_ALIAS_DEF => ImplItem::TypeAliasDef(TypeAliasDef { syntax }),
-            CONST_DEF => ImplItem::ConstDef(ConstDef { syntax }),
-            _ => return None,
-        };
-        Some(res)
+    #[allow(unreachable_patterns)]
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
+        match syntax.kind() {
+            FN_DEF => FnDef::cast_or_return(syntax).map(|x| ImplItem::FnDef(x)),
+            TYPE_ALIAS_DEF => {
+                TypeAliasDef::cast_or_return(syntax).map(|x| ImplItem::TypeAliasDef(x))
+            }
+            CONST_DEF => ConstDef::cast_or_return(syntax).map(|x| ImplItem::ConstDef(x)),
+            _ => Err(syntax),
+        }
     }
     fn syntax(&self) -> &SyntaxNode {
         match self {
-            ImplItem::FnDef(it) => &it.syntax,
-            ImplItem::TypeAliasDef(it) => &it.syntax,
-            ImplItem::ConstDef(it) => &it.syntax,
+            ImplItem::FnDef(it) => it.syntax(),
+            ImplItem::TypeAliasDef(it) => it.syntax(),
+            ImplItem::ConstDef(it) => it.syntax(),
+        }
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        match self {
+            ImplItem::FnDef(it) => it.into_syntax(),
+            ImplItem::TypeAliasDef(it) => it.into_syntax(),
+            ImplItem::ConstDef(it) => it.into_syntax(),
+        }
+    }
+}
+impl AstElement for ImplItem {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            CONST_DEF | FN_DEF | TYPE_ALIAS_DEF => true,
+            _ => false,
+        }
+    }
+    #[allow(unreachable_patterns)]
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        match syntax.kind() {
+            FN_DEF => FnDef::cast_or_return_element(syntax).map(|x| ImplItem::FnDef(x)),
+            TYPE_ALIAS_DEF => {
+                TypeAliasDef::cast_or_return_element(syntax).map(|x| ImplItem::TypeAliasDef(x))
+            }
+            CONST_DEF => ConstDef::cast_or_return_element(syntax).map(|x| ImplItem::ConstDef(x)),
+            _ => Err(syntax),
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        match self {
+            ImplItem::FnDef(it) => it.syntax_element(),
+            ImplItem::TypeAliasDef(it) => it.syntax_element(),
+            ImplItem::ConstDef(it) => it.syntax_element(),
+        }
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        match self {
+            ImplItem::FnDef(it) => it.into_syntax_element(),
+            ImplItem::TypeAliasDef(it) => it.into_syntax_element(),
+            ImplItem::ConstDef(it) => it.into_syntax_element(),
         }
     }
 }
@@ -4496,91 +13154,284 @@ impl From<BoxExpr> for Expr {
 }
 impl std::fmt::Display for Expr {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        std::fmt::Display::fmt(self.syntax(), f)
+        match self {
+            Expr::TupleExpr(it) => std::fmt::Display::fmt(it, f),
+            Expr::ArrayExpr(it) => std::fmt::Display::fmt(it, f),
+            Expr::ParenExpr(it) => std::fmt::Display::fmt(it, f),
+            Expr::PathExpr(it) => std::fmt::Display::fmt(it, f),
+            Expr::LambdaExpr(it) => std::fmt::Display::fmt(it, f),
+            Expr::IfExpr(it) => std::fmt::Display::fmt(it, f),
+            Expr::LoopExpr(it) => std::fmt::Display::fmt(it, f),
+            Expr::ForExpr(it) => std::fmt::Display::fmt(it, f),
+            Expr::WhileExpr(it) => std::fmt::Display::fmt(it, f),
+            Expr::ContinueExpr(it) => std::fmt::Display::fmt(it, f),
+            Expr::BreakExpr(it) => std::fmt::Display::fmt(it, f),
+            Expr::Label(it) => std::fmt::Display::fmt(it, f),
+            Expr::BlockExpr(it) => std::fmt::Display::fmt(it, f),
+            Expr::ReturnExpr(it) => std::fmt::Display::fmt(it, f),
+            Expr::MatchExpr(it) => std::fmt::Display::fmt(it, f),
+            Expr::RecordLit(it) => std::fmt::Display::fmt(it, f),
+            Expr::CallExpr(it) => std::fmt::Display::fmt(it, f),
+            Expr::IndexExpr(it) => std::fmt::Display::fmt(it, f),
+            Expr::MethodCallExpr(it) => std::fmt::Display::fmt(it, f),
+            Expr::FieldExpr(it) => std::fmt::Display::fmt(it, f),
+            Expr::AwaitExpr(it) => std::fmt::Display::fmt(it, f),
+            Expr::TryExpr(it) => std::fmt::Display::fmt(it, f),
+            Expr::TryBlockExpr(it) => std::fmt::Display::fmt(it, f),
+            Expr::CastExpr(it) => std::fmt::Display::fmt(it, f),
+            Expr::RefExpr(it) => std::fmt::Display::fmt(it, f),
+            Expr::PrefixExpr(it) => std::fmt::Display::fmt(it, f),
+            Expr::RangeExpr(it) => std::fmt::Display::fmt(it, f),
+            Expr::BinExpr(it) => std::fmt::Display::fmt(it, f),
+            Expr::Literal(it) => std::fmt::Display::fmt(it, f),
+            Expr::MacroCall(it) => std::fmt::Display::fmt(it, f),
+            Expr::BoxExpr(it) => std::fmt::Display::fmt(it, f),
+        }
     }
 }
 impl AstNode for Expr {
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
-            TUPLE_EXPR | ARRAY_EXPR | PAREN_EXPR | PATH_EXPR | LAMBDA_EXPR | IF_EXPR
-            | LOOP_EXPR | FOR_EXPR | WHILE_EXPR | CONTINUE_EXPR | BREAK_EXPR | LABEL
-            | BLOCK_EXPR | RETURN_EXPR | MATCH_EXPR | RECORD_LIT | CALL_EXPR | INDEX_EXPR
-            | METHOD_CALL_EXPR | FIELD_EXPR | AWAIT_EXPR | TRY_EXPR | TRY_BLOCK_EXPR
-            | CAST_EXPR | REF_EXPR | PREFIX_EXPR | RANGE_EXPR | BIN_EXPR | LITERAL | MACRO_CALL
-            | BOX_EXPR => true,
+            ARRAY_EXPR | AWAIT_EXPR | BIN_EXPR | BLOCK_EXPR | BOX_EXPR | BREAK_EXPR | CALL_EXPR
+            | CAST_EXPR | CONTINUE_EXPR | FIELD_EXPR | FOR_EXPR | IF_EXPR | INDEX_EXPR | LABEL
+            | LAMBDA_EXPR | LITERAL | LOOP_EXPR | MACRO_CALL | MATCH_EXPR | METHOD_CALL_EXPR
+            | PAREN_EXPR | PATH_EXPR | PREFIX_EXPR | RANGE_EXPR | RECORD_LIT | REF_EXPR
+            | RETURN_EXPR | TRY_BLOCK_EXPR | TRY_EXPR | TUPLE_EXPR | WHILE_EXPR => true,
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
-        let res = match syntax.kind() {
-            TUPLE_EXPR => Expr::TupleExpr(TupleExpr { syntax }),
-            ARRAY_EXPR => Expr::ArrayExpr(ArrayExpr { syntax }),
-            PAREN_EXPR => Expr::ParenExpr(ParenExpr { syntax }),
-            PATH_EXPR => Expr::PathExpr(PathExpr { syntax }),
-            LAMBDA_EXPR => Expr::LambdaExpr(LambdaExpr { syntax }),
-            IF_EXPR => Expr::IfExpr(IfExpr { syntax }),
-            LOOP_EXPR => Expr::LoopExpr(LoopExpr { syntax }),
-            FOR_EXPR => Expr::ForExpr(ForExpr { syntax }),
-            WHILE_EXPR => Expr::WhileExpr(WhileExpr { syntax }),
-            CONTINUE_EXPR => Expr::ContinueExpr(ContinueExpr { syntax }),
-            BREAK_EXPR => Expr::BreakExpr(BreakExpr { syntax }),
-            LABEL => Expr::Label(Label { syntax }),
-            BLOCK_EXPR => Expr::BlockExpr(BlockExpr { syntax }),
-            RETURN_EXPR => Expr::ReturnExpr(ReturnExpr { syntax }),
-            MATCH_EXPR => Expr::MatchExpr(MatchExpr { syntax }),
-            RECORD_LIT => Expr::RecordLit(RecordLit { syntax }),
-            CALL_EXPR => Expr::CallExpr(CallExpr { syntax }),
-            INDEX_EXPR => Expr::IndexExpr(IndexExpr { syntax }),
-            METHOD_CALL_EXPR => Expr::MethodCallExpr(MethodCallExpr { syntax }),
-            FIELD_EXPR => Expr::FieldExpr(FieldExpr { syntax }),
-            AWAIT_EXPR => Expr::AwaitExpr(AwaitExpr { syntax }),
-            TRY_EXPR => Expr::TryExpr(TryExpr { syntax }),
-            TRY_BLOCK_EXPR => Expr::TryBlockExpr(TryBlockExpr { syntax }),
-            CAST_EXPR => Expr::CastExpr(CastExpr { syntax }),
-            REF_EXPR => Expr::RefExpr(RefExpr { syntax }),
-            PREFIX_EXPR => Expr::PrefixExpr(PrefixExpr { syntax }),
-            RANGE_EXPR => Expr::RangeExpr(RangeExpr { syntax }),
-            BIN_EXPR => Expr::BinExpr(BinExpr { syntax }),
-            LITERAL => Expr::Literal(Literal { syntax }),
-            MACRO_CALL => Expr::MacroCall(MacroCall { syntax }),
-            BOX_EXPR => Expr::BoxExpr(BoxExpr { syntax }),
-            _ => return None,
-        };
-        Some(res)
+    #[allow(unreachable_patterns)]
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
+        match syntax.kind() {
+            TUPLE_EXPR => TupleExpr::cast_or_return(syntax).map(|x| Expr::TupleExpr(x)),
+            ARRAY_EXPR => ArrayExpr::cast_or_return(syntax).map(|x| Expr::ArrayExpr(x)),
+            PAREN_EXPR => ParenExpr::cast_or_return(syntax).map(|x| Expr::ParenExpr(x)),
+            PATH_EXPR => PathExpr::cast_or_return(syntax).map(|x| Expr::PathExpr(x)),
+            LAMBDA_EXPR => LambdaExpr::cast_or_return(syntax).map(|x| Expr::LambdaExpr(x)),
+            IF_EXPR => IfExpr::cast_or_return(syntax).map(|x| Expr::IfExpr(x)),
+            LOOP_EXPR => LoopExpr::cast_or_return(syntax).map(|x| Expr::LoopExpr(x)),
+            FOR_EXPR => ForExpr::cast_or_return(syntax).map(|x| Expr::ForExpr(x)),
+            WHILE_EXPR => WhileExpr::cast_or_return(syntax).map(|x| Expr::WhileExpr(x)),
+            CONTINUE_EXPR => ContinueExpr::cast_or_return(syntax).map(|x| Expr::ContinueExpr(x)),
+            BREAK_EXPR => BreakExpr::cast_or_return(syntax).map(|x| Expr::BreakExpr(x)),
+            LABEL => Label::cast_or_return(syntax).map(|x| Expr::Label(x)),
+            BLOCK_EXPR => BlockExpr::cast_or_return(syntax).map(|x| Expr::BlockExpr(x)),
+            RETURN_EXPR => ReturnExpr::cast_or_return(syntax).map(|x| Expr::ReturnExpr(x)),
+            MATCH_EXPR => MatchExpr::cast_or_return(syntax).map(|x| Expr::MatchExpr(x)),
+            RECORD_LIT => RecordLit::cast_or_return(syntax).map(|x| Expr::RecordLit(x)),
+            CALL_EXPR => CallExpr::cast_or_return(syntax).map(|x| Expr::CallExpr(x)),
+            INDEX_EXPR => IndexExpr::cast_or_return(syntax).map(|x| Expr::IndexExpr(x)),
+            METHOD_CALL_EXPR => {
+                MethodCallExpr::cast_or_return(syntax).map(|x| Expr::MethodCallExpr(x))
+            }
+            FIELD_EXPR => FieldExpr::cast_or_return(syntax).map(|x| Expr::FieldExpr(x)),
+            AWAIT_EXPR => AwaitExpr::cast_or_return(syntax).map(|x| Expr::AwaitExpr(x)),
+            TRY_EXPR => TryExpr::cast_or_return(syntax).map(|x| Expr::TryExpr(x)),
+            TRY_BLOCK_EXPR => TryBlockExpr::cast_or_return(syntax).map(|x| Expr::TryBlockExpr(x)),
+            CAST_EXPR => CastExpr::cast_or_return(syntax).map(|x| Expr::CastExpr(x)),
+            REF_EXPR => RefExpr::cast_or_return(syntax).map(|x| Expr::RefExpr(x)),
+            PREFIX_EXPR => PrefixExpr::cast_or_return(syntax).map(|x| Expr::PrefixExpr(x)),
+            RANGE_EXPR => RangeExpr::cast_or_return(syntax).map(|x| Expr::RangeExpr(x)),
+            BIN_EXPR => BinExpr::cast_or_return(syntax).map(|x| Expr::BinExpr(x)),
+            LITERAL => Literal::cast_or_return(syntax).map(|x| Expr::Literal(x)),
+            MACRO_CALL => MacroCall::cast_or_return(syntax).map(|x| Expr::MacroCall(x)),
+            BOX_EXPR => BoxExpr::cast_or_return(syntax).map(|x| Expr::BoxExpr(x)),
+            _ => Err(syntax),
+        }
     }
     fn syntax(&self) -> &SyntaxNode {
         match self {
-            Expr::TupleExpr(it) => &it.syntax,
-            Expr::ArrayExpr(it) => &it.syntax,
-            Expr::ParenExpr(it) => &it.syntax,
-            Expr::PathExpr(it) => &it.syntax,
-            Expr::LambdaExpr(it) => &it.syntax,
-            Expr::IfExpr(it) => &it.syntax,
-            Expr::LoopExpr(it) => &it.syntax,
-            Expr::ForExpr(it) => &it.syntax,
-            Expr::WhileExpr(it) => &it.syntax,
-            Expr::ContinueExpr(it) => &it.syntax,
-            Expr::BreakExpr(it) => &it.syntax,
-            Expr::Label(it) => &it.syntax,
-            Expr::BlockExpr(it) => &it.syntax,
-            Expr::ReturnExpr(it) => &it.syntax,
-            Expr::MatchExpr(it) => &it.syntax,
-            Expr::RecordLit(it) => &it.syntax,
-            Expr::CallExpr(it) => &it.syntax,
-            Expr::IndexExpr(it) => &it.syntax,
-            Expr::MethodCallExpr(it) => &it.syntax,
-            Expr::FieldExpr(it) => &it.syntax,
-            Expr::AwaitExpr(it) => &it.syntax,
-            Expr::TryExpr(it) => &it.syntax,
-            Expr::TryBlockExpr(it) => &it.syntax,
-            Expr::CastExpr(it) => &it.syntax,
-            Expr::RefExpr(it) => &it.syntax,
-            Expr::PrefixExpr(it) => &it.syntax,
-            Expr::RangeExpr(it) => &it.syntax,
-            Expr::BinExpr(it) => &it.syntax,
-            Expr::Literal(it) => &it.syntax,
-            Expr::MacroCall(it) => &it.syntax,
-            Expr::BoxExpr(it) => &it.syntax,
+            Expr::TupleExpr(it) => it.syntax(),
+            Expr::ArrayExpr(it) => it.syntax(),
+            Expr::ParenExpr(it) => it.syntax(),
+            Expr::PathExpr(it) => it.syntax(),
+            Expr::LambdaExpr(it) => it.syntax(),
+            Expr::IfExpr(it) => it.syntax(),
+            Expr::LoopExpr(it) => it.syntax(),
+            Expr::ForExpr(it) => it.syntax(),
+            Expr::WhileExpr(it) => it.syntax(),
+            Expr::ContinueExpr(it) => it.syntax(),
+            Expr::BreakExpr(it) => it.syntax(),
+            Expr::Label(it) => it.syntax(),
+            Expr::BlockExpr(it) => it.syntax(),
+            Expr::ReturnExpr(it) => it.syntax(),
+            Expr::MatchExpr(it) => it.syntax(),
+            Expr::RecordLit(it) => it.syntax(),
+            Expr::CallExpr(it) => it.syntax(),
+            Expr::IndexExpr(it) => it.syntax(),
+            Expr::MethodCallExpr(it) => it.syntax(),
+            Expr::FieldExpr(it) => it.syntax(),
+            Expr::AwaitExpr(it) => it.syntax(),
+            Expr::TryExpr(it) => it.syntax(),
+            Expr::TryBlockExpr(it) => it.syntax(),
+            Expr::CastExpr(it) => it.syntax(),
+            Expr::RefExpr(it) => it.syntax(),
+            Expr::PrefixExpr(it) => it.syntax(),
+            Expr::RangeExpr(it) => it.syntax(),
+            Expr::BinExpr(it) => it.syntax(),
+            Expr::Literal(it) => it.syntax(),
+            Expr::MacroCall(it) => it.syntax(),
+            Expr::BoxExpr(it) => it.syntax(),
+        }
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        match self {
+            Expr::TupleExpr(it) => it.into_syntax(),
+            Expr::ArrayExpr(it) => it.into_syntax(),
+            Expr::ParenExpr(it) => it.into_syntax(),
+            Expr::PathExpr(it) => it.into_syntax(),
+            Expr::LambdaExpr(it) => it.into_syntax(),
+            Expr::IfExpr(it) => it.into_syntax(),
+            Expr::LoopExpr(it) => it.into_syntax(),
+            Expr::ForExpr(it) => it.into_syntax(),
+            Expr::WhileExpr(it) => it.into_syntax(),
+            Expr::ContinueExpr(it) => it.into_syntax(),
+            Expr::BreakExpr(it) => it.into_syntax(),
+            Expr::Label(it) => it.into_syntax(),
+            Expr::BlockExpr(it) => it.into_syntax(),
+            Expr::ReturnExpr(it) => it.into_syntax(),
+            Expr::MatchExpr(it) => it.into_syntax(),
+            Expr::RecordLit(it) => it.into_syntax(),
+            Expr::CallExpr(it) => it.into_syntax(),
+            Expr::IndexExpr(it) => it.into_syntax(),
+            Expr::MethodCallExpr(it) => it.into_syntax(),
+            Expr::FieldExpr(it) => it.into_syntax(),
+            Expr::AwaitExpr(it) => it.into_syntax(),
+            Expr::TryExpr(it) => it.into_syntax(),
+            Expr::TryBlockExpr(it) => it.into_syntax(),
+            Expr::CastExpr(it) => it.into_syntax(),
+            Expr::RefExpr(it) => it.into_syntax(),
+            Expr::PrefixExpr(it) => it.into_syntax(),
+            Expr::RangeExpr(it) => it.into_syntax(),
+            Expr::BinExpr(it) => it.into_syntax(),
+            Expr::Literal(it) => it.into_syntax(),
+            Expr::MacroCall(it) => it.into_syntax(),
+            Expr::BoxExpr(it) => it.into_syntax(),
+        }
+    }
+}
+impl AstElement for Expr {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            ARRAY_EXPR | AWAIT_EXPR | BIN_EXPR | BLOCK_EXPR | BOX_EXPR | BREAK_EXPR | CALL_EXPR
+            | CAST_EXPR | CONTINUE_EXPR | FIELD_EXPR | FOR_EXPR | IF_EXPR | INDEX_EXPR | LABEL
+            | LAMBDA_EXPR | LITERAL | LOOP_EXPR | MACRO_CALL | MATCH_EXPR | METHOD_CALL_EXPR
+            | PAREN_EXPR | PATH_EXPR | PREFIX_EXPR | RANGE_EXPR | RECORD_LIT | REF_EXPR
+            | RETURN_EXPR | TRY_BLOCK_EXPR | TRY_EXPR | TUPLE_EXPR | WHILE_EXPR => true,
+            _ => false,
+        }
+    }
+    #[allow(unreachable_patterns)]
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        match syntax.kind() {
+            TUPLE_EXPR => TupleExpr::cast_or_return_element(syntax).map(|x| Expr::TupleExpr(x)),
+            ARRAY_EXPR => ArrayExpr::cast_or_return_element(syntax).map(|x| Expr::ArrayExpr(x)),
+            PAREN_EXPR => ParenExpr::cast_or_return_element(syntax).map(|x| Expr::ParenExpr(x)),
+            PATH_EXPR => PathExpr::cast_or_return_element(syntax).map(|x| Expr::PathExpr(x)),
+            LAMBDA_EXPR => LambdaExpr::cast_or_return_element(syntax).map(|x| Expr::LambdaExpr(x)),
+            IF_EXPR => IfExpr::cast_or_return_element(syntax).map(|x| Expr::IfExpr(x)),
+            LOOP_EXPR => LoopExpr::cast_or_return_element(syntax).map(|x| Expr::LoopExpr(x)),
+            FOR_EXPR => ForExpr::cast_or_return_element(syntax).map(|x| Expr::ForExpr(x)),
+            WHILE_EXPR => WhileExpr::cast_or_return_element(syntax).map(|x| Expr::WhileExpr(x)),
+            CONTINUE_EXPR => {
+                ContinueExpr::cast_or_return_element(syntax).map(|x| Expr::ContinueExpr(x))
+            }
+            BREAK_EXPR => BreakExpr::cast_or_return_element(syntax).map(|x| Expr::BreakExpr(x)),
+            LABEL => Label::cast_or_return_element(syntax).map(|x| Expr::Label(x)),
+            BLOCK_EXPR => BlockExpr::cast_or_return_element(syntax).map(|x| Expr::BlockExpr(x)),
+            RETURN_EXPR => ReturnExpr::cast_or_return_element(syntax).map(|x| Expr::ReturnExpr(x)),
+            MATCH_EXPR => MatchExpr::cast_or_return_element(syntax).map(|x| Expr::MatchExpr(x)),
+            RECORD_LIT => RecordLit::cast_or_return_element(syntax).map(|x| Expr::RecordLit(x)),
+            CALL_EXPR => CallExpr::cast_or_return_element(syntax).map(|x| Expr::CallExpr(x)),
+            INDEX_EXPR => IndexExpr::cast_or_return_element(syntax).map(|x| Expr::IndexExpr(x)),
+            METHOD_CALL_EXPR => {
+                MethodCallExpr::cast_or_return_element(syntax).map(|x| Expr::MethodCallExpr(x))
+            }
+            FIELD_EXPR => FieldExpr::cast_or_return_element(syntax).map(|x| Expr::FieldExpr(x)),
+            AWAIT_EXPR => AwaitExpr::cast_or_return_element(syntax).map(|x| Expr::AwaitExpr(x)),
+            TRY_EXPR => TryExpr::cast_or_return_element(syntax).map(|x| Expr::TryExpr(x)),
+            TRY_BLOCK_EXPR => {
+                TryBlockExpr::cast_or_return_element(syntax).map(|x| Expr::TryBlockExpr(x))
+            }
+            CAST_EXPR => CastExpr::cast_or_return_element(syntax).map(|x| Expr::CastExpr(x)),
+            REF_EXPR => RefExpr::cast_or_return_element(syntax).map(|x| Expr::RefExpr(x)),
+            PREFIX_EXPR => PrefixExpr::cast_or_return_element(syntax).map(|x| Expr::PrefixExpr(x)),
+            RANGE_EXPR => RangeExpr::cast_or_return_element(syntax).map(|x| Expr::RangeExpr(x)),
+            BIN_EXPR => BinExpr::cast_or_return_element(syntax).map(|x| Expr::BinExpr(x)),
+            LITERAL => Literal::cast_or_return_element(syntax).map(|x| Expr::Literal(x)),
+            MACRO_CALL => MacroCall::cast_or_return_element(syntax).map(|x| Expr::MacroCall(x)),
+            BOX_EXPR => BoxExpr::cast_or_return_element(syntax).map(|x| Expr::BoxExpr(x)),
+            _ => Err(syntax),
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        match self {
+            Expr::TupleExpr(it) => it.syntax_element(),
+            Expr::ArrayExpr(it) => it.syntax_element(),
+            Expr::ParenExpr(it) => it.syntax_element(),
+            Expr::PathExpr(it) => it.syntax_element(),
+            Expr::LambdaExpr(it) => it.syntax_element(),
+            Expr::IfExpr(it) => it.syntax_element(),
+            Expr::LoopExpr(it) => it.syntax_element(),
+            Expr::ForExpr(it) => it.syntax_element(),
+            Expr::WhileExpr(it) => it.syntax_element(),
+            Expr::ContinueExpr(it) => it.syntax_element(),
+            Expr::BreakExpr(it) => it.syntax_element(),
+            Expr::Label(it) => it.syntax_element(),
+            Expr::BlockExpr(it) => it.syntax_element(),
+            Expr::ReturnExpr(it) => it.syntax_element(),
+            Expr::MatchExpr(it) => it.syntax_element(),
+            Expr::RecordLit(it) => it.syntax_element(),
+            Expr::CallExpr(it) => it.syntax_element(),
+            Expr::IndexExpr(it) => it.syntax_element(),
+            Expr::MethodCallExpr(it) => it.syntax_element(),
+            Expr::FieldExpr(it) => it.syntax_element(),
+            Expr::AwaitExpr(it) => it.syntax_element(),
+            Expr::TryExpr(it) => it.syntax_element(),
+            Expr::TryBlockExpr(it) => it.syntax_element(),
+            Expr::CastExpr(it) => it.syntax_element(),
+            Expr::RefExpr(it) => it.syntax_element(),
+            Expr::PrefixExpr(it) => it.syntax_element(),
+            Expr::RangeExpr(it) => it.syntax_element(),
+            Expr::BinExpr(it) => it.syntax_element(),
+            Expr::Literal(it) => it.syntax_element(),
+            Expr::MacroCall(it) => it.syntax_element(),
+            Expr::BoxExpr(it) => it.syntax_element(),
+        }
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        match self {
+            Expr::TupleExpr(it) => it.into_syntax_element(),
+            Expr::ArrayExpr(it) => it.into_syntax_element(),
+            Expr::ParenExpr(it) => it.into_syntax_element(),
+            Expr::PathExpr(it) => it.into_syntax_element(),
+            Expr::LambdaExpr(it) => it.into_syntax_element(),
+            Expr::IfExpr(it) => it.into_syntax_element(),
+            Expr::LoopExpr(it) => it.into_syntax_element(),
+            Expr::ForExpr(it) => it.into_syntax_element(),
+            Expr::WhileExpr(it) => it.into_syntax_element(),
+            Expr::ContinueExpr(it) => it.into_syntax_element(),
+            Expr::BreakExpr(it) => it.into_syntax_element(),
+            Expr::Label(it) => it.into_syntax_element(),
+            Expr::BlockExpr(it) => it.into_syntax_element(),
+            Expr::ReturnExpr(it) => it.into_syntax_element(),
+            Expr::MatchExpr(it) => it.into_syntax_element(),
+            Expr::RecordLit(it) => it.into_syntax_element(),
+            Expr::CallExpr(it) => it.into_syntax_element(),
+            Expr::IndexExpr(it) => it.into_syntax_element(),
+            Expr::MethodCallExpr(it) => it.into_syntax_element(),
+            Expr::FieldExpr(it) => it.into_syntax_element(),
+            Expr::AwaitExpr(it) => it.into_syntax_element(),
+            Expr::TryExpr(it) => it.into_syntax_element(),
+            Expr::TryBlockExpr(it) => it.into_syntax_element(),
+            Expr::CastExpr(it) => it.into_syntax_element(),
+            Expr::RefExpr(it) => it.into_syntax_element(),
+            Expr::PrefixExpr(it) => it.into_syntax_element(),
+            Expr::RangeExpr(it) => it.into_syntax_element(),
+            Expr::BinExpr(it) => it.into_syntax_element(),
+            Expr::Literal(it) => it.into_syntax_element(),
+            Expr::MacroCall(it) => it.into_syntax_element(),
+            Expr::BoxExpr(it) => it.into_syntax_element(),
         }
     }
 }
@@ -4673,54 +13524,161 @@ impl From<LiteralPat> for Pat {
 }
 impl std::fmt::Display for Pat {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        std::fmt::Display::fmt(self.syntax(), f)
+        match self {
+            Pat::OrPat(it) => std::fmt::Display::fmt(it, f),
+            Pat::ParenPat(it) => std::fmt::Display::fmt(it, f),
+            Pat::RefPat(it) => std::fmt::Display::fmt(it, f),
+            Pat::BoxPat(it) => std::fmt::Display::fmt(it, f),
+            Pat::BindPat(it) => std::fmt::Display::fmt(it, f),
+            Pat::PlaceholderPat(it) => std::fmt::Display::fmt(it, f),
+            Pat::DotDotPat(it) => std::fmt::Display::fmt(it, f),
+            Pat::PathPat(it) => std::fmt::Display::fmt(it, f),
+            Pat::RecordPat(it) => std::fmt::Display::fmt(it, f),
+            Pat::TupleStructPat(it) => std::fmt::Display::fmt(it, f),
+            Pat::TuplePat(it) => std::fmt::Display::fmt(it, f),
+            Pat::SlicePat(it) => std::fmt::Display::fmt(it, f),
+            Pat::RangePat(it) => std::fmt::Display::fmt(it, f),
+            Pat::LiteralPat(it) => std::fmt::Display::fmt(it, f),
+        }
     }
 }
 impl AstNode for Pat {
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
-            OR_PAT | PAREN_PAT | REF_PAT | BOX_PAT | BIND_PAT | PLACEHOLDER_PAT | DOT_DOT_PAT
-            | PATH_PAT | RECORD_PAT | TUPLE_STRUCT_PAT | TUPLE_PAT | SLICE_PAT | RANGE_PAT
-            | LITERAL_PAT => true,
+            BIND_PAT | BOX_PAT | DOT_DOT_PAT | LITERAL_PAT | OR_PAT | PAREN_PAT | PATH_PAT
+            | PLACEHOLDER_PAT | RANGE_PAT | RECORD_PAT | REF_PAT | SLICE_PAT | TUPLE_PAT
+            | TUPLE_STRUCT_PAT => true,
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
-        let res = match syntax.kind() {
-            OR_PAT => Pat::OrPat(OrPat { syntax }),
-            PAREN_PAT => Pat::ParenPat(ParenPat { syntax }),
-            REF_PAT => Pat::RefPat(RefPat { syntax }),
-            BOX_PAT => Pat::BoxPat(BoxPat { syntax }),
-            BIND_PAT => Pat::BindPat(BindPat { syntax }),
-            PLACEHOLDER_PAT => Pat::PlaceholderPat(PlaceholderPat { syntax }),
-            DOT_DOT_PAT => Pat::DotDotPat(DotDotPat { syntax }),
-            PATH_PAT => Pat::PathPat(PathPat { syntax }),
-            RECORD_PAT => Pat::RecordPat(RecordPat { syntax }),
-            TUPLE_STRUCT_PAT => Pat::TupleStructPat(TupleStructPat { syntax }),
-            TUPLE_PAT => Pat::TuplePat(TuplePat { syntax }),
-            SLICE_PAT => Pat::SlicePat(SlicePat { syntax }),
-            RANGE_PAT => Pat::RangePat(RangePat { syntax }),
-            LITERAL_PAT => Pat::LiteralPat(LiteralPat { syntax }),
-            _ => return None,
-        };
-        Some(res)
+    #[allow(unreachable_patterns)]
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
+        match syntax.kind() {
+            OR_PAT => OrPat::cast_or_return(syntax).map(|x| Pat::OrPat(x)),
+            PAREN_PAT => ParenPat::cast_or_return(syntax).map(|x| Pat::ParenPat(x)),
+            REF_PAT => RefPat::cast_or_return(syntax).map(|x| Pat::RefPat(x)),
+            BOX_PAT => BoxPat::cast_or_return(syntax).map(|x| Pat::BoxPat(x)),
+            BIND_PAT => BindPat::cast_or_return(syntax).map(|x| Pat::BindPat(x)),
+            PLACEHOLDER_PAT => {
+                PlaceholderPat::cast_or_return(syntax).map(|x| Pat::PlaceholderPat(x))
+            }
+            DOT_DOT_PAT => DotDotPat::cast_or_return(syntax).map(|x| Pat::DotDotPat(x)),
+            PATH_PAT => PathPat::cast_or_return(syntax).map(|x| Pat::PathPat(x)),
+            RECORD_PAT => RecordPat::cast_or_return(syntax).map(|x| Pat::RecordPat(x)),
+            TUPLE_STRUCT_PAT => {
+                TupleStructPat::cast_or_return(syntax).map(|x| Pat::TupleStructPat(x))
+            }
+            TUPLE_PAT => TuplePat::cast_or_return(syntax).map(|x| Pat::TuplePat(x)),
+            SLICE_PAT => SlicePat::cast_or_return(syntax).map(|x| Pat::SlicePat(x)),
+            RANGE_PAT => RangePat::cast_or_return(syntax).map(|x| Pat::RangePat(x)),
+            LITERAL_PAT => LiteralPat::cast_or_return(syntax).map(|x| Pat::LiteralPat(x)),
+            _ => Err(syntax),
+        }
     }
     fn syntax(&self) -> &SyntaxNode {
         match self {
-            Pat::OrPat(it) => &it.syntax,
-            Pat::ParenPat(it) => &it.syntax,
-            Pat::RefPat(it) => &it.syntax,
-            Pat::BoxPat(it) => &it.syntax,
-            Pat::BindPat(it) => &it.syntax,
-            Pat::PlaceholderPat(it) => &it.syntax,
-            Pat::DotDotPat(it) => &it.syntax,
-            Pat::PathPat(it) => &it.syntax,
-            Pat::RecordPat(it) => &it.syntax,
-            Pat::TupleStructPat(it) => &it.syntax,
-            Pat::TuplePat(it) => &it.syntax,
-            Pat::SlicePat(it) => &it.syntax,
-            Pat::RangePat(it) => &it.syntax,
-            Pat::LiteralPat(it) => &it.syntax,
+            Pat::OrPat(it) => it.syntax(),
+            Pat::ParenPat(it) => it.syntax(),
+            Pat::RefPat(it) => it.syntax(),
+            Pat::BoxPat(it) => it.syntax(),
+            Pat::BindPat(it) => it.syntax(),
+            Pat::PlaceholderPat(it) => it.syntax(),
+            Pat::DotDotPat(it) => it.syntax(),
+            Pat::PathPat(it) => it.syntax(),
+            Pat::RecordPat(it) => it.syntax(),
+            Pat::TupleStructPat(it) => it.syntax(),
+            Pat::TuplePat(it) => it.syntax(),
+            Pat::SlicePat(it) => it.syntax(),
+            Pat::RangePat(it) => it.syntax(),
+            Pat::LiteralPat(it) => it.syntax(),
+        }
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        match self {
+            Pat::OrPat(it) => it.into_syntax(),
+            Pat::ParenPat(it) => it.into_syntax(),
+            Pat::RefPat(it) => it.into_syntax(),
+            Pat::BoxPat(it) => it.into_syntax(),
+            Pat::BindPat(it) => it.into_syntax(),
+            Pat::PlaceholderPat(it) => it.into_syntax(),
+            Pat::DotDotPat(it) => it.into_syntax(),
+            Pat::PathPat(it) => it.into_syntax(),
+            Pat::RecordPat(it) => it.into_syntax(),
+            Pat::TupleStructPat(it) => it.into_syntax(),
+            Pat::TuplePat(it) => it.into_syntax(),
+            Pat::SlicePat(it) => it.into_syntax(),
+            Pat::RangePat(it) => it.into_syntax(),
+            Pat::LiteralPat(it) => it.into_syntax(),
+        }
+    }
+}
+impl AstElement for Pat {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            BIND_PAT | BOX_PAT | DOT_DOT_PAT | LITERAL_PAT | OR_PAT | PAREN_PAT | PATH_PAT
+            | PLACEHOLDER_PAT | RANGE_PAT | RECORD_PAT | REF_PAT | SLICE_PAT | TUPLE_PAT
+            | TUPLE_STRUCT_PAT => true,
+            _ => false,
+        }
+    }
+    #[allow(unreachable_patterns)]
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        match syntax.kind() {
+            OR_PAT => OrPat::cast_or_return_element(syntax).map(|x| Pat::OrPat(x)),
+            PAREN_PAT => ParenPat::cast_or_return_element(syntax).map(|x| Pat::ParenPat(x)),
+            REF_PAT => RefPat::cast_or_return_element(syntax).map(|x| Pat::RefPat(x)),
+            BOX_PAT => BoxPat::cast_or_return_element(syntax).map(|x| Pat::BoxPat(x)),
+            BIND_PAT => BindPat::cast_or_return_element(syntax).map(|x| Pat::BindPat(x)),
+            PLACEHOLDER_PAT => {
+                PlaceholderPat::cast_or_return_element(syntax).map(|x| Pat::PlaceholderPat(x))
+            }
+            DOT_DOT_PAT => DotDotPat::cast_or_return_element(syntax).map(|x| Pat::DotDotPat(x)),
+            PATH_PAT => PathPat::cast_or_return_element(syntax).map(|x| Pat::PathPat(x)),
+            RECORD_PAT => RecordPat::cast_or_return_element(syntax).map(|x| Pat::RecordPat(x)),
+            TUPLE_STRUCT_PAT => {
+                TupleStructPat::cast_or_return_element(syntax).map(|x| Pat::TupleStructPat(x))
+            }
+            TUPLE_PAT => TuplePat::cast_or_return_element(syntax).map(|x| Pat::TuplePat(x)),
+            SLICE_PAT => SlicePat::cast_or_return_element(syntax).map(|x| Pat::SlicePat(x)),
+            RANGE_PAT => RangePat::cast_or_return_element(syntax).map(|x| Pat::RangePat(x)),
+            LITERAL_PAT => LiteralPat::cast_or_return_element(syntax).map(|x| Pat::LiteralPat(x)),
+            _ => Err(syntax),
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        match self {
+            Pat::OrPat(it) => it.syntax_element(),
+            Pat::ParenPat(it) => it.syntax_element(),
+            Pat::RefPat(it) => it.syntax_element(),
+            Pat::BoxPat(it) => it.syntax_element(),
+            Pat::BindPat(it) => it.syntax_element(),
+            Pat::PlaceholderPat(it) => it.syntax_element(),
+            Pat::DotDotPat(it) => it.syntax_element(),
+            Pat::PathPat(it) => it.syntax_element(),
+            Pat::RecordPat(it) => it.syntax_element(),
+            Pat::TupleStructPat(it) => it.syntax_element(),
+            Pat::TuplePat(it) => it.syntax_element(),
+            Pat::SlicePat(it) => it.syntax_element(),
+            Pat::RangePat(it) => it.syntax_element(),
+            Pat::LiteralPat(it) => it.syntax_element(),
+        }
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        match self {
+            Pat::OrPat(it) => it.into_syntax_element(),
+            Pat::ParenPat(it) => it.into_syntax_element(),
+            Pat::RefPat(it) => it.into_syntax_element(),
+            Pat::BoxPat(it) => it.into_syntax_element(),
+            Pat::BindPat(it) => it.into_syntax_element(),
+            Pat::PlaceholderPat(it) => it.into_syntax_element(),
+            Pat::DotDotPat(it) => it.into_syntax_element(),
+            Pat::PathPat(it) => it.into_syntax_element(),
+            Pat::RecordPat(it) => it.into_syntax_element(),
+            Pat::TupleStructPat(it) => it.into_syntax_element(),
+            Pat::TuplePat(it) => it.into_syntax_element(),
+            Pat::SlicePat(it) => it.into_syntax_element(),
+            Pat::RangePat(it) => it.into_syntax_element(),
+            Pat::LiteralPat(it) => it.into_syntax_element(),
         }
     }
 }
@@ -4741,7 +13699,10 @@ impl From<TokenTree> for AttrInput {
 }
 impl std::fmt::Display for AttrInput {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        std::fmt::Display::fmt(self.syntax(), f)
+        match self {
+            AttrInput::Literal(it) => std::fmt::Display::fmt(it, f),
+            AttrInput::TokenTree(it) => std::fmt::Display::fmt(it, f),
+        }
     }
 }
 impl AstNode for AttrInput {
@@ -4751,18 +13712,54 @@ impl AstNode for AttrInput {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
-        let res = match syntax.kind() {
-            LITERAL => AttrInput::Literal(Literal { syntax }),
-            TOKEN_TREE => AttrInput::TokenTree(TokenTree { syntax }),
-            _ => return None,
-        };
-        Some(res)
+    #[allow(unreachable_patterns)]
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
+        match syntax.kind() {
+            LITERAL => Literal::cast_or_return(syntax).map(|x| AttrInput::Literal(x)),
+            TOKEN_TREE => TokenTree::cast_or_return(syntax).map(|x| AttrInput::TokenTree(x)),
+            _ => Err(syntax),
+        }
     }
     fn syntax(&self) -> &SyntaxNode {
         match self {
-            AttrInput::Literal(it) => &it.syntax,
-            AttrInput::TokenTree(it) => &it.syntax,
+            AttrInput::Literal(it) => it.syntax(),
+            AttrInput::TokenTree(it) => it.syntax(),
+        }
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        match self {
+            AttrInput::Literal(it) => it.into_syntax(),
+            AttrInput::TokenTree(it) => it.into_syntax(),
+        }
+    }
+}
+impl AstElement for AttrInput {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            LITERAL | TOKEN_TREE => true,
+            _ => false,
+        }
+    }
+    #[allow(unreachable_patterns)]
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        match syntax.kind() {
+            LITERAL => Literal::cast_or_return_element(syntax).map(|x| AttrInput::Literal(x)),
+            TOKEN_TREE => {
+                TokenTree::cast_or_return_element(syntax).map(|x| AttrInput::TokenTree(x))
+            }
+            _ => Err(syntax),
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        match self {
+            AttrInput::Literal(it) => it.syntax_element(),
+            AttrInput::TokenTree(it) => it.syntax_element(),
+        }
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        match self {
+            AttrInput::Literal(it) => it.into_syntax_element(),
+            AttrInput::TokenTree(it) => it.into_syntax_element(),
         }
     }
 }
@@ -4783,7 +13780,10 @@ impl From<LetStmt> for Stmt {
 }
 impl std::fmt::Display for Stmt {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        std::fmt::Display::fmt(self.syntax(), f)
+        match self {
+            Stmt::ExprStmt(it) => std::fmt::Display::fmt(it, f),
+            Stmt::LetStmt(it) => std::fmt::Display::fmt(it, f),
+        }
     }
 }
 impl AstNode for Stmt {
@@ -4793,18 +13793,52 @@ impl AstNode for Stmt {
             _ => false,
         }
     }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
-        let res = match syntax.kind() {
-            EXPR_STMT => Stmt::ExprStmt(ExprStmt { syntax }),
-            LET_STMT => Stmt::LetStmt(LetStmt { syntax }),
-            _ => return None,
-        };
-        Some(res)
+    #[allow(unreachable_patterns)]
+    fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
+        match syntax.kind() {
+            EXPR_STMT => ExprStmt::cast_or_return(syntax).map(|x| Stmt::ExprStmt(x)),
+            LET_STMT => LetStmt::cast_or_return(syntax).map(|x| Stmt::LetStmt(x)),
+            _ => Err(syntax),
+        }
     }
     fn syntax(&self) -> &SyntaxNode {
         match self {
-            Stmt::ExprStmt(it) => &it.syntax,
-            Stmt::LetStmt(it) => &it.syntax,
+            Stmt::ExprStmt(it) => it.syntax(),
+            Stmt::LetStmt(it) => it.syntax(),
+        }
+    }
+    fn into_syntax(self) -> SyntaxNode {
+        match self {
+            Stmt::ExprStmt(it) => it.into_syntax(),
+            Stmt::LetStmt(it) => it.into_syntax(),
+        }
+    }
+}
+impl AstElement for Stmt {
+    fn can_cast_element(kind: SyntaxKind) -> bool {
+        match kind {
+            EXPR_STMT | LET_STMT => true,
+            _ => false,
+        }
+    }
+    #[allow(unreachable_patterns)]
+    fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+        match syntax.kind() {
+            EXPR_STMT => ExprStmt::cast_or_return_element(syntax).map(|x| Stmt::ExprStmt(x)),
+            LET_STMT => LetStmt::cast_or_return_element(syntax).map(|x| Stmt::LetStmt(x)),
+            _ => Err(syntax),
+        }
+    }
+    fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+        match self {
+            Stmt::ExprStmt(it) => it.syntax_element(),
+            Stmt::LetStmt(it) => it.syntax_element(),
+        }
+    }
+    fn into_syntax_element(self) -> SyntaxElement {
+        match self {
+            Stmt::ExprStmt(it) => it.into_syntax_element(),
+            Stmt::LetStmt(it) => it.into_syntax_element(),
         }
     }
 }

--- a/crates/ra_syntax/src/ast/generated.rs
+++ b/crates/ra_syntax/src/ast/generated.rs
@@ -14853,6 +14853,7 @@ pub enum Pat {
     SlicePat(SlicePat),
     RangePat(RangePat),
     LiteralPat(LiteralPat),
+    MacroCall(MacroCall),
 }
 impl From<OrPat> for Pat {
     fn from(node: OrPat) -> Pat {
@@ -14924,6 +14925,11 @@ impl From<LiteralPat> for Pat {
         Pat::LiteralPat(node)
     }
 }
+impl From<MacroCall> for Pat {
+    fn from(node: MacroCall) -> Pat {
+        Pat::MacroCall(node)
+    }
+}
 impl std::fmt::Display for Pat {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
@@ -14941,15 +14947,16 @@ impl std::fmt::Display for Pat {
             Pat::SlicePat(it) => std::fmt::Display::fmt(it, f),
             Pat::RangePat(it) => std::fmt::Display::fmt(it, f),
             Pat::LiteralPat(it) => std::fmt::Display::fmt(it, f),
+            Pat::MacroCall(it) => std::fmt::Display::fmt(it, f),
         }
     }
 }
 impl AstNode for Pat {
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
-            BIND_PAT | BOX_PAT | DOT_DOT_PAT | LITERAL_PAT | OR_PAT | PAREN_PAT | PATH_PAT
-            | PLACEHOLDER_PAT | RANGE_PAT | RECORD_PAT | REF_PAT | SLICE_PAT | TUPLE_PAT
-            | TUPLE_STRUCT_PAT => true,
+            BIND_PAT | BOX_PAT | DOT_DOT_PAT | LITERAL_PAT | MACRO_CALL | OR_PAT | PAREN_PAT
+            | PATH_PAT | PLACEHOLDER_PAT | RANGE_PAT | RECORD_PAT | REF_PAT | SLICE_PAT
+            | TUPLE_PAT | TUPLE_STRUCT_PAT => true,
             _ => false,
         }
     }
@@ -14974,6 +14981,7 @@ impl AstNode for Pat {
             SLICE_PAT => SlicePat::cast_or_return(syntax).map(|x| Pat::SlicePat(x)),
             RANGE_PAT => RangePat::cast_or_return(syntax).map(|x| Pat::RangePat(x)),
             LITERAL_PAT => LiteralPat::cast_or_return(syntax).map(|x| Pat::LiteralPat(x)),
+            MACRO_CALL => MacroCall::cast_or_return(syntax).map(|x| Pat::MacroCall(x)),
             _ => Err(syntax),
         }
     }
@@ -14993,6 +15001,7 @@ impl AstNode for Pat {
             Pat::SlicePat(it) => it.syntax(),
             Pat::RangePat(it) => it.syntax(),
             Pat::LiteralPat(it) => it.syntax(),
+            Pat::MacroCall(it) => it.syntax(),
         }
     }
     fn into_syntax(self) -> SyntaxNode {
@@ -15011,15 +15020,16 @@ impl AstNode for Pat {
             Pat::SlicePat(it) => it.into_syntax(),
             Pat::RangePat(it) => it.into_syntax(),
             Pat::LiteralPat(it) => it.into_syntax(),
+            Pat::MacroCall(it) => it.into_syntax(),
         }
     }
 }
 impl AstElement for Pat {
     fn can_cast_element(kind: SyntaxKind) -> bool {
         match kind {
-            BIND_PAT | BOX_PAT | DOT_DOT_PAT | LITERAL_PAT | OR_PAT | PAREN_PAT | PATH_PAT
-            | PLACEHOLDER_PAT | RANGE_PAT | RECORD_PAT | REF_PAT | SLICE_PAT | TUPLE_PAT
-            | TUPLE_STRUCT_PAT => true,
+            BIND_PAT | BOX_PAT | DOT_DOT_PAT | LITERAL_PAT | MACRO_CALL | OR_PAT | PAREN_PAT
+            | PATH_PAT | PLACEHOLDER_PAT | RANGE_PAT | RECORD_PAT | REF_PAT | SLICE_PAT
+            | TUPLE_PAT | TUPLE_STRUCT_PAT => true,
             _ => false,
         }
     }
@@ -15044,6 +15054,7 @@ impl AstElement for Pat {
             SLICE_PAT => SlicePat::cast_or_return_element(syntax).map(|x| Pat::SlicePat(x)),
             RANGE_PAT => RangePat::cast_or_return_element(syntax).map(|x| Pat::RangePat(x)),
             LITERAL_PAT => LiteralPat::cast_or_return_element(syntax).map(|x| Pat::LiteralPat(x)),
+            MACRO_CALL => MacroCall::cast_or_return_element(syntax).map(|x| Pat::MacroCall(x)),
             _ => Err(syntax),
         }
     }
@@ -15063,6 +15074,7 @@ impl AstElement for Pat {
             Pat::SlicePat(it) => it.syntax_element(),
             Pat::RangePat(it) => it.syntax_element(),
             Pat::LiteralPat(it) => it.syntax_element(),
+            Pat::MacroCall(it) => it.syntax_element(),
         }
     }
     fn into_syntax_element(self) -> SyntaxElement {
@@ -15081,6 +15093,7 @@ impl AstElement for Pat {
             Pat::SlicePat(it) => it.into_syntax_element(),
             Pat::RangePat(it) => it.into_syntax_element(),
             Pat::LiteralPat(it) => it.into_syntax_element(),
+            Pat::MacroCall(it) => it.into_syntax_element(),
         }
     }
 }

--- a/crates/ra_syntax/src/ast/tokens.rs
+++ b/crates/ra_syntax/src/ast/tokens.rs
@@ -1,25 +1,9 @@
 //! There are many AstNodes, but only a few tokens, so we hand-write them here.
 
 use crate::{
-    ast::AstToken,
-    SyntaxKind::{COMMENT, RAW_STRING, STRING, WHITESPACE},
-    SyntaxToken, TextRange, TextUnit,
+    ast::{AstToken, Comment, RawString, String, Whitespace},
+    TextRange, TextUnit,
 };
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Comment(SyntaxToken);
-
-impl AstToken for Comment {
-    fn cast(token: SyntaxToken) -> Option<Self> {
-        match token.kind() {
-            COMMENT => Some(Comment(token)),
-            _ => None,
-        }
-    }
-    fn syntax(&self) -> &SyntaxToken {
-        &self.0
-    }
-}
 
 impl Comment {
     pub fn kind(&self) -> CommentKind {
@@ -89,20 +73,6 @@ fn prefix_by_kind(kind: CommentKind) -> &'static str {
     unreachable!()
 }
 
-pub struct Whitespace(SyntaxToken);
-
-impl AstToken for Whitespace {
-    fn cast(token: SyntaxToken) -> Option<Self> {
-        match token.kind() {
-            WHITESPACE => Some(Whitespace(token)),
-            _ => None,
-        }
-    }
-    fn syntax(&self) -> &SyntaxToken {
-        &self.0
-    }
-}
-
 impl Whitespace {
     pub fn spans_multiple_lines(&self) -> bool {
         let text = self.text();
@@ -168,20 +138,6 @@ pub trait HasStringValue: HasQuotes {
     fn value(&self) -> Option<std::string::String>;
 }
 
-pub struct String(SyntaxToken);
-
-impl AstToken for String {
-    fn cast(token: SyntaxToken) -> Option<Self> {
-        match token.kind() {
-            STRING => Some(String(token)),
-            _ => None,
-        }
-    }
-    fn syntax(&self) -> &SyntaxToken {
-        &self.0
-    }
-}
-
 impl HasStringValue for String {
     fn value(&self) -> Option<std::string::String> {
         let text = self.text().as_str();
@@ -198,20 +154,6 @@ impl HasStringValue for String {
             return None;
         }
         Some(buf)
-    }
-}
-
-pub struct RawString(SyntaxToken);
-
-impl AstToken for RawString {
-    fn cast(token: SyntaxToken) -> Option<Self> {
-        match token.kind() {
-            RAW_STRING => Some(RawString(token)),
-            _ => None,
-        }
-    }
-    fn syntax(&self) -> &SyntaxToken {
-        &self.0
     }
 }
 

--- a/crates/ra_syntax/src/lib.rs
+++ b/crates/ra_syntax/src/lib.rs
@@ -19,6 +19,8 @@
 //! [RFC]: <https://github.com/rust-lang/rfcs/pull/2256>
 //! [Swift]: <https://github.com/apple/swift/blob/13d593df6f359d0cb2fc81cfaac273297c539455/lib/Syntax/README.md>
 
+#![allow(elided_lifetimes_in_paths)]
+
 mod syntax_node;
 mod syntax_error;
 mod parsing;

--- a/crates/ra_syntax/test_data/parser/ok/0065_plus_after_fn_trait_bound.rs
+++ b/crates/ra_syntax/test_data/parser/ok/0065_plus_after_fn_trait_bound.rs
@@ -1,0 +1,1 @@
+fn f<T>() where T: Fn() -> u8 + Send {}

--- a/crates/ra_syntax/test_data/parser/ok/0065_plus_after_fn_trait_bound.txt
+++ b/crates/ra_syntax/test_data/parser/ok/0065_plus_after_fn_trait_bound.txt
@@ -1,0 +1,61 @@
+SOURCE_FILE@[0; 40)
+  FN_DEF@[0; 39)
+    FN_KW@[0; 2) "fn"
+    WHITESPACE@[2; 3) " "
+    NAME@[3; 4)
+      IDENT@[3; 4) "f"
+    TYPE_PARAM_LIST@[4; 7)
+      L_ANGLE@[4; 5) "<"
+      TYPE_PARAM@[5; 6)
+        NAME@[5; 6)
+          IDENT@[5; 6) "T"
+      R_ANGLE@[6; 7) ">"
+    PARAM_LIST@[7; 9)
+      L_PAREN@[7; 8) "("
+      R_PAREN@[8; 9) ")"
+    WHITESPACE@[9; 10) " "
+    WHERE_CLAUSE@[10; 36)
+      WHERE_KW@[10; 15) "where"
+      WHITESPACE@[15; 16) " "
+      WHERE_PRED@[16; 36)
+        PATH_TYPE@[16; 17)
+          PATH@[16; 17)
+            PATH_SEGMENT@[16; 17)
+              NAME_REF@[16; 17)
+                IDENT@[16; 17) "T"
+        COLON@[17; 18) ":"
+        WHITESPACE@[18; 19) " "
+        TYPE_BOUND_LIST@[19; 36)
+          TYPE_BOUND@[19; 29)
+            PATH_TYPE@[19; 29)
+              PATH@[19; 29)
+                PATH_SEGMENT@[19; 29)
+                  NAME_REF@[19; 21)
+                    IDENT@[19; 21) "Fn"
+                  PARAM_LIST@[21; 23)
+                    L_PAREN@[21; 22) "("
+                    R_PAREN@[22; 23) ")"
+                  WHITESPACE@[23; 24) " "
+                  RET_TYPE@[24; 29)
+                    THIN_ARROW@[24; 26) "->"
+                    WHITESPACE@[26; 27) " "
+                    PATH_TYPE@[27; 29)
+                      PATH@[27; 29)
+                        PATH_SEGMENT@[27; 29)
+                          NAME_REF@[27; 29)
+                            IDENT@[27; 29) "u8"
+          WHITESPACE@[29; 30) " "
+          PLUS@[30; 31) "+"
+          WHITESPACE@[31; 32) " "
+          TYPE_BOUND@[32; 36)
+            PATH_TYPE@[32; 36)
+              PATH@[32; 36)
+                PATH_SEGMENT@[32; 36)
+                  NAME_REF@[32; 36)
+                    IDENT@[32; 36) "Send"
+    WHITESPACE@[36; 37) " "
+    BLOCK_EXPR@[37; 39)
+      BLOCK@[37; 39)
+        L_CURLY@[37; 38) "{"
+        R_CURLY@[38; 39) "}"
+  WHITESPACE@[39; 40) "\n"

--- a/xtask/src/ast_src.rs
+++ b/xtask/src/ast_src.rs
@@ -70,7 +70,7 @@ pub(crate) const KINDS_SRC: KindsSrc = KindsSrc {
         "match", "mod", "move", "mut", "pub", "ref", "return", "self", "static", "struct", "super",
         "trait", "true", "try", "type", "unsafe", "use", "where", "while",
     ],
-    contextual_keywords: &["auto", "default", "existential", "union"],
+    contextual_keywords: &["auto", "default", "existential", "union", "raw"],
     literals: &[
         "INT_NUMBER",
         "FLOAT_NUMBER",
@@ -296,234 +296,310 @@ macro_rules! ast_enums {
 
 pub(crate) const AST_SRC: AstSrc = AstSrc {
     nodes: &ast_nodes! {
-        struct SourceFile: ModuleItemOwner, FnDefOwner {
+        struct SourceFile: ModuleItemOwner, FnDefOwner, AttrsOwner {
             modules: [Module],
         }
 
         struct FnDef: VisibilityOwner, NameOwner, TypeParamsOwner, DocCommentsOwner, AttrsOwner {
+            Abi,
+            ConstKw,
+            DefaultKw,
+            AsyncKw,
+            UnsafeKw,
+            FnKw,
             ParamList,
             RetType,
             body: BlockExpr,
+            Semi
         }
 
-        struct RetType { TypeRef }
+        struct RetType { ThinArrow, TypeRef }
 
         struct StructDef: VisibilityOwner, NameOwner, TypeParamsOwner, AttrsOwner, DocCommentsOwner {
+            StructKw,
+            FieldDefList,
+            Semi
         }
 
         struct UnionDef: VisibilityOwner, NameOwner, TypeParamsOwner, AttrsOwner, DocCommentsOwner {
+            UnionKw,
             RecordFieldDefList,
         }
 
-        struct RecordFieldDefList { fields: [RecordFieldDef] }
+        struct RecordFieldDefList { LCurly, fields: [RecordFieldDef], RCurly }
         struct RecordFieldDef: VisibilityOwner, NameOwner, AttrsOwner, DocCommentsOwner, TypeAscriptionOwner { }
 
-        struct TupleFieldDefList { fields: [TupleFieldDef] }
+        struct TupleFieldDefList { LParen, fields: [TupleFieldDef], RParen }
         struct TupleFieldDef: VisibilityOwner, AttrsOwner {
             TypeRef,
         }
 
         struct EnumDef: VisibilityOwner, NameOwner, TypeParamsOwner, AttrsOwner, DocCommentsOwner {
+            EnumKw,
             variant_list: EnumVariantList,
         }
         struct EnumVariantList {
+            LCurly,
             variants: [EnumVariant],
+            RCurly
         }
-        struct EnumVariant: NameOwner, DocCommentsOwner, AttrsOwner {
+        struct EnumVariant: VisibilityOwner, NameOwner, DocCommentsOwner, AttrsOwner {
+            FieldDefList,
+            Eq,
             Expr
         }
 
         struct TraitDef: VisibilityOwner, NameOwner, AttrsOwner, DocCommentsOwner, TypeParamsOwner, TypeBoundsOwner {
+            UnsafeKw,
+            AutoKw,
+            TraitKw,
             ItemList,
         }
 
         struct Module: VisibilityOwner, NameOwner, AttrsOwner, DocCommentsOwner {
+            ModKw,
             ItemList,
+            Semi
         }
 
         struct ItemList: FnDefOwner, ModuleItemOwner {
+            LCurly,
             impl_items: [ImplItem],
+            RCurly
         }
 
         struct ConstDef: VisibilityOwner, NameOwner, TypeParamsOwner, AttrsOwner, DocCommentsOwner, TypeAscriptionOwner {
+            DefaultKw,
+            ConstKw,
+            Eq,
             body: Expr,
+            Semi
         }
 
         struct StaticDef: VisibilityOwner, NameOwner, TypeParamsOwner, AttrsOwner, DocCommentsOwner, TypeAscriptionOwner {
+            StaticKw,
+            MutKw,
+            Eq,
             body: Expr,
+            Semi
         }
 
         struct TypeAliasDef: VisibilityOwner, NameOwner, TypeParamsOwner, AttrsOwner, DocCommentsOwner, TypeBoundsOwner {
+            DefaultKw,
+            TypeKw,
+            Eq,
             TypeRef,
+            Semi
         }
 
         struct ImplDef: TypeParamsOwner, AttrsOwner {
+            DefaultKw,
+            ConstKw,
+            UnsafeKw,
+            ImplKw,
+            Excl,
+            ForKw,
             ItemList,
         }
 
-        struct ParenType { TypeRef }
-        struct TupleType { fields: [TypeRef] }
-        struct NeverType { }
+        struct ParenType { LParen, TypeRef, RParen }
+        struct TupleType { LParen, fields: [TypeRef], RParen }
+        struct NeverType { Excl }
         struct PathType { Path }
-        struct PointerType { TypeRef }
-        struct ArrayType { TypeRef, Expr }
-        struct SliceType { TypeRef }
-        struct ReferenceType { TypeRef }
-        struct PlaceholderType {  }
-        struct FnPointerType { ParamList, RetType }
-        struct ForType { TypeRef }
-        struct ImplTraitType: TypeBoundsOwner {}
-        struct DynTraitType: TypeBoundsOwner {}
+        struct PointerType { Star, ConstKw, TypeRef }
+        struct ArrayType { LBrack, TypeRef, Semi, Expr, RBrack }
+        struct SliceType { LBrack, TypeRef, RBrack }
+        struct ReferenceType { Amp, Lifetime, MutKw, TypeRef }
+        struct PlaceholderType { Underscore }
+        struct FnPointerType { Abi, UnsafeKw, FnKw, ParamList, RetType }
+        struct ForType { ForKw, TypeParamList, TypeRef }
+        struct ImplTraitType: TypeBoundsOwner { ImplKw }
+        struct DynTraitType: TypeBoundsOwner { DynKw }
 
-        struct TupleExpr { exprs: [Expr] }
-        struct ArrayExpr { exprs: [Expr] }
-        struct ParenExpr { Expr }
+        struct TupleExpr: AttrsOwner { LParen, exprs: [Expr], RParen }
+        struct ArrayExpr: AttrsOwner { LBrack, exprs: [Expr], Semi, RBrack }
+        struct ParenExpr: AttrsOwner { LParen, Expr, RParen }
         struct PathExpr  { Path }
-        struct LambdaExpr {
+        struct LambdaExpr: AttrsOwner {
+            StaticKw,
+            AsyncKw,
+            MoveKw,
             ParamList,
             RetType,
             body: Expr,
         }
-        struct IfExpr { Condition }
-        struct LoopExpr: LoopBodyOwner { }
-        struct TryBlockExpr { body: BlockExpr }
-        struct ForExpr: LoopBodyOwner {
+        struct IfExpr: AttrsOwner { IfKw, Condition }
+        struct LoopExpr: AttrsOwner, LoopBodyOwner { LoopKw }
+        struct TryBlockExpr: AttrsOwner { TryKw, body: BlockExpr }
+        struct ForExpr: AttrsOwner, LoopBodyOwner {
+            ForKw,
             Pat,
+            InKw,
             iterable: Expr,
         }
-        struct WhileExpr: LoopBodyOwner { Condition }
-        struct ContinueExpr {}
-        struct BreakExpr { Expr }
-        struct Label {}
-        struct BlockExpr { Block  }
-        struct ReturnExpr { Expr }
+        struct WhileExpr: AttrsOwner, LoopBodyOwner { WhileKw, Condition }
+        struct ContinueExpr: AttrsOwner { ContinueKw, Lifetime }
+        struct BreakExpr: AttrsOwner { BreakKw, Lifetime, Expr }
+        struct Label { Lifetime }
+        struct BlockExpr: AttrsOwner { Label, UnsafeKw, Block  }
+        struct ReturnExpr: AttrsOwner { Expr }
         struct CallExpr: ArgListOwner { Expr }
-        struct MethodCallExpr: ArgListOwner {
-            Expr, NameRef, TypeArgList,
+        struct MethodCallExpr: AttrsOwner, ArgListOwner {
+            Expr, Dot, NameRef, TypeArgList,
         }
-        struct IndexExpr {}
-        struct FieldExpr { Expr, NameRef }
-        struct AwaitExpr { Expr }
-        struct TryExpr { Expr }
-        struct CastExpr { Expr, TypeRef }
-        struct RefExpr { Expr }
-        struct PrefixExpr { Expr }
-        struct BoxExpr { Expr }
-        struct RangeExpr {}
-        struct BinExpr {}
-        struct Literal {}
+        struct IndexExpr: AttrsOwner { LBrack, RBrack }
+        struct FieldExpr: AttrsOwner { Expr, Dot, NameRef }
+        struct AwaitExpr: AttrsOwner { Expr, Dot, AwaitKw }
+        struct TryExpr: AttrsOwner { TryKw, Expr }
+        struct CastExpr: AttrsOwner { Expr, AsKw, TypeRef }
+        struct RefExpr: AttrsOwner { Amp, RawKw, MutKw, Expr }
+        struct PrefixExpr: AttrsOwner { PrefixOp, Expr }
+        struct BoxExpr: AttrsOwner { BoxKw, Expr }
+        struct RangeExpr: AttrsOwner { RangeOp }
+        struct BinExpr: AttrsOwner { BinOp }
+        struct Literal { LiteralToken }
 
-        struct MatchExpr { Expr, MatchArmList }
-        struct MatchArmList: AttrsOwner { arms: [MatchArm] }
+        struct MatchExpr: AttrsOwner { MatchKw, Expr, MatchArmList }
+        struct MatchArmList: AttrsOwner { LCurly, arms: [MatchArm], RCurly }
         struct MatchArm: AttrsOwner {
             pat: Pat,
             guard: MatchGuard,
+            FatArrow,
             Expr,
         }
-        struct MatchGuard { Expr }
+        struct MatchGuard { IfKw, Expr }
 
-        struct RecordLit { Path, RecordFieldList }
+        struct RecordLit { Path, RecordFieldList}
         struct RecordFieldList {
+            LCurly,
             fields: [RecordField],
+            Dotdot,
             spread: Expr,
+            RCurly
         }
-        struct RecordField { NameRef, Expr }
+        struct RecordField: AttrsOwner { NameRef, Colon, Expr }
 
         struct OrPat { pats: [Pat] }
-        struct ParenPat { Pat }
-        struct RefPat { Pat }
-        struct BoxPat { Pat }
-        struct BindPat: NameOwner { Pat }
-        struct PlaceholderPat { }
-        struct DotDotPat { }
+        struct ParenPat { LParen, Pat, RParen }
+        struct RefPat { Amp, MutKw, Pat }
+        struct BoxPat { BoxKw, Pat }
+        struct BindPat: AttrsOwner, NameOwner { RefKw, MutKw, Pat }
+        struct PlaceholderPat { Underscore }
+        struct DotDotPat { Dotdot }
         struct PathPat { Path }
-        struct SlicePat { args: [Pat] }
-        struct RangePat {}
+        struct SlicePat { LBrack, args: [Pat], RBrack }
+        struct RangePat { RangeSeparator }
         struct LiteralPat { Literal }
 
         struct RecordPat { RecordFieldPatList, Path }
         struct RecordFieldPatList {
+            LCurly,
+            pats: [RecordInnerPat],
             record_field_pats: [RecordFieldPat],
             bind_pats: [BindPat],
+            Dotdot,
+            RCurly
         }
-        struct RecordFieldPat: NameOwner { Pat }
+        struct RecordFieldPat: AttrsOwner, NameOwner { Colon, Pat }
 
-        struct TupleStructPat { Path, args: [Pat] }
-        struct TuplePat { args: [Pat] }
+        struct TupleStructPat { Path, LParen, args: [Pat], RParen }
+        struct TuplePat { LParen, args: [Pat], RParen }
 
-        struct Visibility {}
-        struct Name {}
-        struct NameRef {}
+        struct Visibility { PubKw, SuperKw, SelfKw, CrateKw }
+        struct Name { Ident }
+        struct NameRef { NameRefToken }
 
         struct MacroCall: NameOwner, AttrsOwner,DocCommentsOwner {
-            TokenTree, Path
+            Path, Excl, TokenTree, Semi
         }
-        struct Attr { Path, input: AttrInput }
+        struct Attr { Pound, Excl, LBrack, Path, Eq, input: AttrInput, RBrack }
         struct TokenTree {}
         struct TypeParamList {
+            LAngle,
+            generic_params: [GenericParam],
             type_params: [TypeParam],
             lifetime_params: [LifetimeParam],
+            const_params: [ConstParam],
+            RAngle
         }
         struct TypeParam: NameOwner, AttrsOwner, TypeBoundsOwner {
+            Eq,
             default_type: TypeRef,
         }
         struct ConstParam: NameOwner, AttrsOwner, TypeAscriptionOwner {
+            Eq,
             default_val: Expr,
         }
-        struct LifetimeParam: AttrsOwner { }
-        struct TypeBound { TypeRef}
+        struct LifetimeParam: AttrsOwner { Lifetime}
+        struct TypeBound { Lifetime, /* Question,  */ ConstKw, /* Question,  */ TypeRef}
         struct TypeBoundList { bounds: [TypeBound] }
-        struct WherePred: TypeBoundsOwner { TypeRef }
-        struct WhereClause { predicates: [WherePred] }
-        struct ExprStmt { Expr }
-        struct LetStmt: TypeAscriptionOwner {
+        struct WherePred: TypeBoundsOwner { Lifetime, TypeRef }
+        struct WhereClause { WhereKw, predicates: [WherePred] }
+        struct Abi { String }
+        struct ExprStmt: AttrsOwner { Expr, Semi }
+        struct LetStmt: AttrsOwner, TypeAscriptionOwner {
+            LetKw,
             Pat,
+            Eq,
             initializer: Expr,
         }
-        struct Condition { Pat, Expr }
+        struct Condition { LetKw, Pat, Eq, Expr }
         struct Block: AttrsOwner, ModuleItemOwner {
+            LCurly,
             statements: [Stmt],
+            statements_or_semi: [StmtOrSemi],
             Expr,
+            RCurly,
         }
         struct ParamList {
+            LParen,
             SelfParam,
             params: [Param],
+            RParen
         }
-        struct SelfParam: TypeAscriptionOwner, AttrsOwner { }
+        struct SelfParam: TypeAscriptionOwner, AttrsOwner { Amp, Lifetime, SelfKw }
         struct Param: TypeAscriptionOwner, AttrsOwner {
             Pat,
+            Dotdotdot
         }
         struct UseItem: AttrsOwner, VisibilityOwner {
+            UseKw,
             UseTree,
         }
         struct UseTree {
-            Path, UseTreeList, Alias
+            Path, Star, UseTreeList, Alias
         }
-        struct Alias: NameOwner { }
-        struct UseTreeList { use_trees: [UseTree] }
+        struct Alias: NameOwner { AsKw }
+        struct UseTreeList { LCurly, use_trees: [UseTree], RCurly }
         struct ExternCrateItem: AttrsOwner, VisibilityOwner {
-            NameRef, Alias,
+            ExternKw, CrateKw, NameRef, Alias,
         }
         struct ArgList {
+            LParen,
             args: [Expr],
+            RParen
         }
         struct Path {
             segment: PathSegment,
             qualifier: Path,
         }
         struct PathSegment {
-            NameRef, TypeArgList, ParamList, RetType, PathType,
+            Coloncolon, LAngle, NameRef, TypeArgList, ParamList, RetType, PathType, RAngle
         }
         struct TypeArgList {
+            Coloncolon,
+            LAngle,
+            generic_args: [GenericArg],
             type_args: [TypeArg],
             lifetime_args: [LifetimeArg],
             assoc_type_args: [AssocTypeArg],
-            const_arg: [ConstArg],
+            const_args: [ConstArg],
+            RAngle
         }
         struct TypeArg { TypeRef }
-        struct AssocTypeArg { NameRef, TypeRef }
-        struct LifetimeArg {}
-        struct ConstArg { Literal, BlockExpr }
+        struct AssocTypeArg : TypeBoundsOwner { NameRef, Eq, TypeRef }
+        struct LifetimeArg { Lifetime }
+        struct ConstArg { Literal, Eq, BlockExpr }
 
         struct MacroItems: ModuleItemOwner, FnDefOwner { }
 
@@ -531,10 +607,42 @@ pub(crate) const AST_SRC: AstSrc = AstSrc {
             statements: [Stmt],
             Expr,
         }
+
+        struct ExternItemList: FnDefOwner, ModuleItemOwner {
+            LCurly,
+            extern_items: [ExternItem],
+            RCurly
+        }
+
+        struct ExternBlock {
+            Abi,
+            ExternItemList
+        }
+
+        struct MetaItem {
+            Path, Eq, AttrInput, nested_meta_items: [MetaItem]
+        }
+
+        struct MacroDef {
+            Name, TokenTree
+        }
     },
     enums: &ast_enums! {
         enum NominalDef: NameOwner, TypeParamsOwner, AttrsOwner {
             StructDef, EnumDef, UnionDef,
+        }
+
+        enum GenericParam {
+            LifetimeParam,
+            TypeParam,
+            ConstParam
+        }
+
+        enum GenericArg {
+            LifetimeArg,
+            TypeArg,
+            ConstArg,
+            AssocTypeArg
         }
 
         enum TypeRef {
@@ -553,7 +661,7 @@ pub(crate) const AST_SRC: AstSrc = AstSrc {
             DynTraitType,
         }
 
-        enum ModuleItem: AttrsOwner, VisibilityOwner {
+        enum ModuleItem: NameOwner, AttrsOwner, VisibilityOwner {
             StructDef,
             UnionDef,
             EnumDef,
@@ -567,13 +675,20 @@ pub(crate) const AST_SRC: AstSrc = AstSrc {
             StaticDef,
             Module,
             MacroCall,
+            ExternBlock
         }
 
-        enum ImplItem: AttrsOwner {
-            FnDef, TypeAliasDef, ConstDef,
+        /* impl blocks can also contain MacroCall */
+        enum ImplItem: NameOwner, AttrsOwner {
+            FnDef, TypeAliasDef, ConstDef
         }
 
-        enum Expr {
+        /* extern blocks can also contain MacroCall */
+        enum ExternItem: NameOwner, AttrsOwner, VisibilityOwner {
+            FnDef, StaticDef
+        }
+
+        enum Expr: AttrsOwner {
             TupleExpr,
             ArrayExpr,
             ParenExpr,
@@ -624,7 +739,93 @@ pub(crate) const AST_SRC: AstSrc = AstSrc {
             LiteralPat,
         }
 
+        enum RecordInnerPat {
+            RecordFieldPat,
+            BindPat
+        }
+
         enum AttrInput { Literal, TokenTree }
-        enum Stmt { ExprStmt, LetStmt }
+        enum Stmt {
+            ModuleItem,
+            LetStmt,
+            ExprStmt,
+            // macro calls are parsed as expression statements */
+        }
+        enum StmtOrSemi {Stmt, Semi}
+
+        enum LeftDelimiter { LParen, LBrack, LCurly }
+        enum RightDelimiter { RParen, RBrack, RCurly }
+        enum RangeSeparator { Dotdot, Dotdotdot, Dotdoteq}
+
+        enum BinOp {
+            Pipepipe,
+            Ampamp,
+            Eqeq,
+            Neq,
+            Lteq,
+            Gteq,
+            LAngle,
+            RAngle,
+            Plus,
+            Star,
+            Minus,
+            Slash,
+            Percent,
+            Shl,
+            Shr,
+            Caret,
+            Pipe,
+            Amp,
+            Eq,
+            Pluseq,
+            Slasheq,
+            Stareq,
+            Percenteq,
+            Shreq,
+            Shleq,
+            Minuseq,
+            Pipeeq,
+            Ampeq,
+            Careteq,
+        }
+
+        enum PrefixOp {
+            Minus,
+            Excl,
+            Star
+        }
+
+        enum RangeOp {
+            Dotdot,
+            Dotdoteq
+        }
+
+        enum LiteralToken {
+            IntNumber,
+            FloatNumber,
+            String,
+            RawString,
+            TrueKw,
+            FalseKw,
+            ByteString,
+            RawByteString,
+            Char,
+            Byte
+        }
+
+        enum NameRefToken {
+            Ident,
+            IntNumber
+        }
+
+        enum FieldDefList {
+            RecordFieldDefList,
+            TupleFieldDefList,
+        }
+
+        enum AttrOrComment {
+            Attr,
+            Comment
+        }
     },
 };

--- a/xtask/src/ast_src.rs
+++ b/xtask/src/ast_src.rs
@@ -748,6 +748,7 @@ pub(crate) const AST_SRC: AstSrc = AstSrc {
             SlicePat,
             RangePat,
             LiteralPat,
+            MacroCall
         }
 
         enum RecordInnerPat {

--- a/xtask/src/ast_src.rs
+++ b/xtask/src/ast_src.rs
@@ -353,7 +353,7 @@ pub(crate) const AST_SRC: AstSrc = AstSrc {
         }
         struct EnumVariant: VisibilityOwner, NameOwner, DocCommentsOwner, AttrsOwner {
             FieldDefList,
-            Eq,
+            #[sep] Eq,
             Expr
         }
 
@@ -379,7 +379,7 @@ pub(crate) const AST_SRC: AstSrc = AstSrc {
         struct ConstDef: VisibilityOwner, NameOwner, TypeParamsOwner, AttrsOwner, DocCommentsOwner, TypeAscriptionOwner {
             DefaultKw,
             ConstKw,
-            Eq,
+            #[sep] Eq,
             body: Expr,
             Semi
         }
@@ -387,7 +387,7 @@ pub(crate) const AST_SRC: AstSrc = AstSrc {
         struct StaticDef: VisibilityOwner, NameOwner, TypeParamsOwner, AttrsOwner, DocCommentsOwner, TypeAscriptionOwner {
             StaticKw,
             MutKw,
-            Eq,
+            #[sep] Eq,
             body: Expr,
             Semi
         }
@@ -395,7 +395,7 @@ pub(crate) const AST_SRC: AstSrc = AstSrc {
         struct TypeAliasDef: VisibilityOwner, NameOwner, TypeParamsOwner, AttrsOwner, DocCommentsOwner, TypeBoundsOwner {
             DefaultKw,
             TypeKw,
-            Eq,
+            #[sep] Eq,
             TypeRef,
             Semi
         }
@@ -442,7 +442,7 @@ pub(crate) const AST_SRC: AstSrc = AstSrc {
         struct ForExpr: AttrsOwner, LoopBodyOwner {
             ForKw,
             Pat,
-            InKw,
+            #[sep] InKw,
             iterable: Expr,
         }
         struct WhileExpr: AttrsOwner, LoopBodyOwner { WhileKw, Condition }
@@ -472,7 +472,7 @@ pub(crate) const AST_SRC: AstSrc = AstSrc {
         struct MatchArm: AttrsOwner {
             pat: Pat,
             guard: MatchGuard,
-            FatArrow,
+            #[sep] FatArrow,
             Expr,
         }
         struct MatchGuard { IfKw, Expr }
@@ -548,10 +548,13 @@ pub(crate) const AST_SRC: AstSrc = AstSrc {
         struct LetStmt: AttrsOwner, TypeAscriptionOwner {
             LetKw,
             Pat,
-            Eq,
+            #[sep] Eq,
             initializer: Expr,
         }
-        struct Condition { LetKw, Pat, Eq, Expr }
+        struct Condition {
+            LetKw,
+            Eq
+        }
         struct Block: AttrsOwner, ModuleItemOwner {
             LCurly,
             statements: [Stmt],

--- a/xtask/src/ast_src.rs
+++ b/xtask/src/ast_src.rs
@@ -231,7 +231,7 @@ pub(crate) struct AstSrc<'a> {
 pub(crate) struct AstNodeSrc<'a> {
     pub(crate) name: &'a str,
     pub(crate) traits: &'a [&'a str],
-    pub(crate) fields: &'a [(&'a str, FieldSrc<&'a str>)],
+    pub(crate) fields: &'a [(&'a str, FieldSrc<&'a str>, bool)],
 }
 
 pub(crate) enum FieldSrc<T> {
@@ -246,10 +246,19 @@ pub(crate) struct AstEnumSrc<'a> {
     pub(crate) variants: &'a [&'a str],
 }
 
+macro_rules! is_sep {
+    (sep) => {
+        true
+    };
+    ($meta:ident) => {
+        false
+    };
+}
+
 macro_rules! ast_nodes {
     ($(
         struct $name:ident$(: $($trait:ident),*)? {
-            $($field_name:ident $(: $ty:tt)?),*$(,)?
+            $($(#[$meta:ident])* $field_name:ident $(: $ty:tt)?),*$(,)?
         }
     )*) => {
         [$(
@@ -257,9 +266,8 @@ macro_rules! ast_nodes {
                 name: stringify!($name),
                 traits: &[$($(stringify!($trait)),*)?],
                 fields: &[$(
-                    (stringify!($field_name), field_ty!($field_name $($ty)?))
+                    (stringify!($field_name), field_ty!($field_name $($ty)?), false $(| is_sep!($meta))*)
                 ),*],
-
             }
         ),*]
     };

--- a/xtask/src/codegen/gen_syntax.rs
+++ b/xtask/src/codegen/gen_syntax.rs
@@ -5,6 +5,8 @@
 
 use proc_macro2::{Punct, Spacing};
 use quote::{format_ident, quote};
+use std::borrow::Cow;
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 use crate::{
     ast_src::{AstSrc, FieldSrc, KindsSrc, AST_SRC, KINDS_SRC},
@@ -18,13 +20,125 @@ pub fn generate_syntax(mode: Mode) -> Result<()> {
     update(syntax_kinds_file.as_path(), &syntax_kinds, mode)?;
 
     let ast_file = project_root().join(codegen::AST);
-    let ast = generate_ast(AST_SRC)?;
+    let ast = generate_ast(KINDS_SRC, AST_SRC)?;
     update(ast_file.as_path(), &ast, mode)?;
 
     Ok(())
 }
 
-fn generate_ast(grammar: AstSrc<'_>) -> Result<String> {
+#[derive(Debug, Default, Clone)]
+struct ElementKinds {
+    kinds: BTreeSet<proc_macro2::Ident>,
+    has_nodes: bool,
+    has_tokens: bool,
+}
+
+fn generate_ast(kinds: KindsSrc<'_>, grammar: AstSrc<'_>) -> Result<String> {
+    let all_token_kinds: Vec<_> = kinds
+        .punct
+        .into_iter()
+        .map(|(_, kind)| kind)
+        .copied()
+        .map(|x| x.into())
+        .chain(
+            kinds
+                .keywords
+                .into_iter()
+                .chain(kinds.contextual_keywords.into_iter())
+                .map(|name| Cow::Owned(format!("{}_KW", to_upper_snake_case(&name)))),
+        )
+        .chain(kinds.literals.into_iter().copied().map(|x| x.into()))
+        .chain(kinds.tokens.into_iter().copied().map(|x| x.into()))
+        .collect();
+
+    let mut element_kinds_map = HashMap::new();
+    for kind in &all_token_kinds {
+        let kind = &**kind;
+        let name = to_pascal_case(kind);
+        element_kinds_map.insert(
+            name,
+            ElementKinds {
+                kinds: Some(format_ident!("{}", kind)).into_iter().collect(),
+                has_nodes: false,
+                has_tokens: true,
+            },
+        );
+    }
+
+    for kind in kinds.nodes {
+        let name = to_pascal_case(kind);
+        element_kinds_map.insert(
+            name,
+            ElementKinds {
+                kinds: Some(format_ident!("{}", *kind)).into_iter().collect(),
+                has_nodes: true,
+                has_tokens: false,
+            },
+        );
+    }
+
+    for en in grammar.enums {
+        let mut element_kinds: ElementKinds = Default::default();
+        for variant in en.variants {
+            if let Some(variant_element_kinds) = element_kinds_map.get(*variant) {
+                element_kinds.kinds.extend(variant_element_kinds.kinds.iter().cloned());
+                element_kinds.has_tokens |= variant_element_kinds.has_tokens;
+                element_kinds.has_nodes |= variant_element_kinds.has_nodes;
+            } else {
+                panic!("Enum variant has type that does not exist or was not declared before the enum: {}", *variant);
+            }
+        }
+        element_kinds_map.insert(en.name.to_string(), element_kinds);
+    }
+
+    let tokens = all_token_kinds.iter().map(|kind_str| {
+        let kind_str = &**kind_str;
+        let kind = format_ident!("{}", kind_str);
+        let name = format_ident!("{}", to_pascal_case(kind_str));
+        quote! {
+            #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+            pub struct #name(SyntaxToken);
+
+            impl std::fmt::Display for #name {
+                fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                    std::fmt::Display::fmt(self.syntax(), f)
+                }
+            }
+
+            impl AstToken for #name {
+                fn can_cast(kind: SyntaxKind) -> bool {
+                    match kind {
+                        #kind => true,
+                        _ => false,
+                    }
+                }
+                fn cast_or_return(syntax: SyntaxToken) -> Result<Self, SyntaxToken> {
+                    if Self::can_cast(syntax.kind()) { Ok(Self(syntax)) } else { Err(syntax) }
+                }
+                fn syntax(&self) -> &SyntaxToken { &self.0 }
+                fn into_syntax(self) -> SyntaxToken { self.0 }
+            }
+
+            impl AstElement for #name {
+                fn can_cast_element(kind: SyntaxKind) -> bool {
+                    match kind {
+                        #kind => true,
+                        _ => false,
+                    }
+                }
+                fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+                    if Self::can_cast_element(syntax.kind()) { Ok(Self(syntax.into_token().unwrap())) } else { Err(syntax) }
+                }
+                fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+                    NodeOrToken::Token(&self.0)
+                }
+                fn into_syntax_element(self) -> SyntaxElement {
+                    NodeOrToken::Token(self.0)
+                }
+            }
+        }
+    });
+
     let nodes = grammar.nodes.iter().map(|node| {
         let name = format_ident!("{}", node.name);
         let kind = format_ident!("{}", to_upper_snake_case(&name.to_string()));
@@ -42,20 +156,28 @@ fn generate_ast(grammar: AstSrc<'_>) -> Result<String> {
                 FieldSrc::Optional(ty) | FieldSrc::Many(ty) => ty,
                 FieldSrc::Shorthand => name,
             };
+            let element_kinds = &element_kinds_map.get(*ty).unwrap_or_else(|| panic!("type not found: {}", *ty));
+            let iter = if !element_kinds.has_tokens {
+                format_ident!("AstChildren")
+            } else if !element_kinds.has_nodes {
+                format_ident!("AstChildTokens")
+            } else {
+                format_ident!("AstChildElements")
+            };
             let ty = format_ident!("{}", ty);
 
             match field {
                 FieldSrc::Many(_) => {
                     quote! {
-                        pub fn #method_name(&self) -> AstChildren<#ty> {
-                            AstChildren::new(&self.syntax)
+                        pub fn #method_name(&self) -> #iter<#ty> {
+                            #iter::new(&self.syntax)
                         }
                     }
                 }
                 FieldSrc::Optional(_) | FieldSrc::Shorthand => {
                     quote! {
                         pub fn #method_name(&self) -> Option<#ty> {
-                            AstChildren::new(&self.syntax).next()
+                            #iter::new(&self.syntax).next()
                         }
                     }
                 }
@@ -81,11 +203,31 @@ fn generate_ast(grammar: AstSrc<'_>) -> Result<String> {
                         _ => false,
                     }
                 }
-                fn cast(syntax: SyntaxNode) -> Option<Self> {
-                    if Self::can_cast(syntax.kind()) { Some(Self { syntax }) } else { None }
+                fn cast_or_return(syntax: SyntaxNode) -> Result<Self, SyntaxNode> {
+                    if Self::can_cast(syntax.kind()) { Ok(Self { syntax }) } else { Err(syntax) }
                 }
                 fn syntax(&self) -> &SyntaxNode { &self.syntax }
+                fn into_syntax(self) -> SyntaxNode { self.syntax }
             }
+
+            impl AstElement for #name {
+                fn can_cast_element(kind: SyntaxKind) -> bool {
+                    match kind {
+                        #kind => true,
+                        _ => false,
+                    }
+                }
+                fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+                    if Self::can_cast_element(syntax.kind()) { Ok(Self { syntax: syntax.into_node().unwrap() }) } else { Err(syntax) }
+                }
+                fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
+                    NodeOrToken::Node(&self.syntax)
+                }
+                fn into_syntax_element(self) -> SyntaxElement {
+                    NodeOrToken::Node(self.syntax)
+                }
+            }
+
             #(#traits)*
 
             impl #name {
@@ -96,15 +238,70 @@ fn generate_ast(grammar: AstSrc<'_>) -> Result<String> {
 
     let enums = grammar.enums.iter().map(|en| {
         let variants = en.variants.iter().map(|var| format_ident!("{}", var)).collect::<Vec<_>>();
+        let element_kinds = &element_kinds_map[&en.name.to_string()];
         let name = format_ident!("{}", en.name);
-        let kinds = variants
+        let kinds = en.variants
             .iter()
-            .map(|name| format_ident!("{}", to_upper_snake_case(&name.to_string())))
+            .map(|name| {
+                element_kinds_map[*name].kinds.iter().collect::<Vec<_>>()
+            })
             .collect::<Vec<_>>();
         let traits = en.traits.iter().map(|trait_name| {
             let trait_name = format_ident!("{}", trait_name);
             quote!(impl ast::#trait_name for #name {})
         });
+
+        let all_kinds = &element_kinds.kinds;
+
+        let specific_ast_trait = if element_kinds.has_nodes != element_kinds.has_tokens {
+            let (ast_trait, syntax_type) = if element_kinds.has_tokens {
+                (
+                    quote!(AstToken),
+                    quote!(SyntaxToken),
+                )
+            } else {
+                (
+                    quote!(AstNode),
+                    quote!(SyntaxNode),
+                )
+            };
+
+            quote! {
+                impl #ast_trait for #name {
+                    fn can_cast(kind: SyntaxKind) -> bool {
+                        match kind {
+                            #(#all_kinds)|* => true,
+                            _ => false,
+                        }
+                    }
+                    #[allow(unreachable_patterns)]
+                    fn cast_or_return(syntax: #syntax_type) -> Result<Self, #syntax_type> {
+                        match syntax.kind() {
+                            #(
+                            #(#kinds)|* => #variants::cast_or_return(syntax).map(|x| #name::#variants(x)),
+                            )*
+                            _ => Err(syntax),
+                        }
+                    }
+                    fn syntax(&self) -> &#syntax_type {
+                        match self {
+                            #(
+                            #name::#variants(it) => it.syntax(),
+                            )*
+                        }
+                    }
+                    fn into_syntax(self) -> #syntax_type {
+                        match self {
+                            #(
+                            #name::#variants(it) => it.into_syntax(),
+                            )*
+                        }
+                    }
+                }
+            }
+        } else {
+            Default::default()
+        };
 
         quote! {
             #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -122,44 +319,71 @@ fn generate_ast(grammar: AstSrc<'_>) -> Result<String> {
 
             impl std::fmt::Display for #name {
                 fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                    std::fmt::Display::fmt(self.syntax(), f)
+                    match self {
+                        #(
+                        #name::#variants(it) => std::fmt::Display::fmt(it, f),
+                        )*
+                    }
                 }
             }
 
-            impl AstNode for #name {
-                fn can_cast(kind: SyntaxKind) -> bool {
+            #specific_ast_trait
+
+            impl AstElement for #name {
+                fn can_cast_element(kind: SyntaxKind) -> bool {
                     match kind {
-                        #(#kinds)|* => true,
+                        #(#all_kinds)|* => true,
                         _ => false,
                     }
                 }
-                fn cast(syntax: SyntaxNode) -> Option<Self> {
-                    let res = match syntax.kind() {
+                #[allow(unreachable_patterns)]
+                fn cast_or_return_element(syntax: SyntaxElement) -> Result<Self, SyntaxElement> {
+                    match syntax.kind() {
                         #(
-                        #kinds => #name::#variants(#variants { syntax }),
+                        #(#kinds)|* => #variants::cast_or_return_element(syntax).map(|x| #name::#variants(x)),
                         )*
-                        _ => return None,
-                    };
-                    Some(res)
+                        _ => Err(syntax),
+                    }
                 }
-                fn syntax(&self) -> &SyntaxNode {
+                fn syntax_element(&self) -> NodeOrToken<&SyntaxNode, &SyntaxToken> {
                     match self {
                         #(
-                        #name::#variants(it) => &it.syntax,
+                        #name::#variants(it) => it.syntax_element(),
+                        )*
+                    }
+                }
+                fn into_syntax_element(self) -> SyntaxElement {
+                    match self {
+                        #(
+                        #name::#variants(it) => it.into_syntax_element(),
                         )*
                     }
                 }
             }
+
             #(#traits)*
         }
     });
 
+    let defined_nodes: HashSet<_> = grammar.nodes.iter().map(|node| node.name).collect();
+
+    for node in kinds
+        .nodes
+        .iter()
+        .map(|kind| to_pascal_case(*kind))
+        .filter(|name| !defined_nodes.contains(&**name))
+    {
+        eprintln!("Warning: node {} not defined in ast source", node);
+    }
+
     let ast = quote! {
+        #[allow(unused_imports)]
         use crate::{
-            SyntaxNode, SyntaxKind::{self, *},
-            ast::{self, AstNode, AstChildren},
+            SyntaxNode, SyntaxToken, SyntaxElement, NodeOrToken, SyntaxKind::{self, *},
+            ast::{self, AstNode, AstToken, AstElement, AstChildren, AstChildTokens, AstChildElements},
         };
 
+        #(#tokens)*
         #(#nodes)*
         #(#enums)*
     };
@@ -282,12 +506,12 @@ fn generate_syntax_kinds(grammar: KindsSrc<'_>) -> Result<String> {
 
 fn to_upper_snake_case(s: &str) -> String {
     let mut buf = String::with_capacity(s.len());
-    let mut prev_is_upper = None;
+    let mut prev = false;
     for c in s.chars() {
-        if c.is_ascii_uppercase() && prev_is_upper == Some(false) {
+        if c.is_ascii_uppercase() && prev {
             buf.push('_')
         }
-        prev_is_upper = Some(c.is_ascii_uppercase());
+        prev = true;
 
         buf.push(c.to_ascii_uppercase());
     }
@@ -296,14 +520,30 @@ fn to_upper_snake_case(s: &str) -> String {
 
 fn to_lower_snake_case(s: &str) -> String {
     let mut buf = String::with_capacity(s.len());
-    let mut prev_is_upper = None;
+    let mut prev = false;
     for c in s.chars() {
-        if c.is_ascii_uppercase() && prev_is_upper == Some(false) {
+        if c.is_ascii_uppercase() && prev {
             buf.push('_')
         }
-        prev_is_upper = Some(c.is_ascii_uppercase());
+        prev = true;
 
         buf.push(c.to_ascii_lowercase());
+    }
+    buf
+}
+
+fn to_pascal_case(s: &str) -> String {
+    let mut buf = String::with_capacity(s.len());
+    let mut prev_is_underscore = true;
+    for c in s.chars() {
+        if c == '_' {
+            prev_is_underscore = true;
+        } else if prev_is_underscore {
+            buf.push(c.to_ascii_uppercase());
+            prev_is_underscore = false;
+        } else {
+            buf.push(c.to_ascii_lowercase());
+        }
     }
     buf
 }


### PR DESCRIPTION
This is a set of improvements that I done while creating a rustc branch that can use rust-analyzer to parse code and convert the rust-analyzer AST to rustc's internal AST format, found at https://github.com/rust-lang/rust/pull/70745

The goal is to extend the helper classes implementing AstNode and similar classes so that the AST can be examined solely using them.
