### PR TITLE
Make control token modifier less ambiguous

### DIFF
--- a/crates/ra_ide/src/syntax_highlighting.rs
+++ b/crates/ra_ide/src/syntax_highlighting.rs
@@ -232,7 +232,7 @@ fn highlight_element(
                 | T![loop]
                 | T![match]
                 | T![return]
-                | T![while] => h | HighlightModifier::Control,
+                | T![while] => h | HighlightModifier::ControlFlow,
                 T![unsafe] => h | HighlightModifier::Unsafe,
                 _ => h,
             }

--- a/crates/ra_ide/src/syntax_highlighting/tags.rs
+++ b/crates/ra_ide/src/syntax_highlighting/tags.rs
@@ -44,7 +44,7 @@ pub enum HighlightTag {
 #[repr(u8)]
 pub enum HighlightModifier {
     /// Used with keywords like `if` and `break`.
-    Control = 0,
+    ControlFlow = 0,
     /// `foo` in `fn foo(x: i32)` is a definition, `foo` in `foo(90 + 2)` is
     /// not.
     Definition,
@@ -91,7 +91,7 @@ impl fmt::Display for HighlightTag {
 
 impl HighlightModifier {
     const ALL: &'static [HighlightModifier] = &[
-        HighlightModifier::Control,
+        HighlightModifier::ControlFlow,
         HighlightModifier::Definition,
         HighlightModifier::Mutable,
         HighlightModifier::Unsafe,
@@ -99,7 +99,7 @@ impl HighlightModifier {
 
     fn as_str(self) -> &'static str {
         match self {
-            HighlightModifier::Control => "control",
+            HighlightModifier::ControlFlow => "control",
             HighlightModifier::Definition => "declaration",
             HighlightModifier::Mutable => "mutable",
             HighlightModifier::Unsafe => "unsafe",

--- a/crates/rust-analyzer/src/conv.rs
+++ b/crates/rust-analyzer/src/conv.rs
@@ -20,7 +20,7 @@ use ra_vfs::LineEndings;
 
 use crate::{
     req,
-    semantic_tokens::{self, ModifierSet, CONSTANT, CONTROL, MUTABLE, UNSAFE},
+    semantic_tokens::{self, ModifierSet, CONSTANT, CONTROL_FLOW, MUTABLE, UNSAFE},
     world::WorldSnapshot,
     Result,
 };
@@ -378,7 +378,7 @@ impl Conv for Highlight {
         for modifier in self.modifiers.iter() {
             let modifier = match modifier {
                 HighlightModifier::Definition => SemanticTokenModifier::DECLARATION,
-                HighlightModifier::Control => CONTROL,
+                HighlightModifier::ControlFlow => CONTROL_FLOW,
                 HighlightModifier::Mutable => MUTABLE,
                 HighlightModifier::Unsafe => UNSAFE,
             };

--- a/crates/rust-analyzer/src/semantic_tokens.rs
+++ b/crates/rust-analyzer/src/semantic_tokens.rs
@@ -12,7 +12,7 @@ pub(crate) const TYPE_ALIAS: SemanticTokenType = SemanticTokenType::new("typeAli
 pub(crate) const UNION: SemanticTokenType = SemanticTokenType::new("union");
 
 pub(crate) const CONSTANT: SemanticTokenModifier = SemanticTokenModifier::new("constant");
-pub(crate) const CONTROL: SemanticTokenModifier = SemanticTokenModifier::new("control");
+pub(crate) const CONTROL_FLOW: SemanticTokenModifier = SemanticTokenModifier::new("controlFlow");
 pub(crate) const MUTABLE: SemanticTokenModifier = SemanticTokenModifier::new("mutable");
 pub(crate) const UNSAFE: SemanticTokenModifier = SemanticTokenModifier::new("unsafe");
 
@@ -56,7 +56,7 @@ pub(crate) const SUPPORTED_MODIFIERS: &[SemanticTokenModifier] = &[
     CONSTANT,
     MUTABLE,
     UNSAFE,
-    CONTROL,
+    CONTROL_FLOW,
 ];
 
 #[derive(Default)]

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -512,7 +512,7 @@
                 "description": "Style for compile-time constants"
             },
             {
-                "id": "control",
+                "id": "controlFlow",
                 "description": "Style for control flow keywords"
             },
             {
@@ -545,9 +545,6 @@
                     ],
                     "keyword.unsafe": [
                         "keyword.other.unsafe"
-                    ],
-                    "keyword.control": [
-                        "keyword.control"
                     ],
                     "variable.constant": [
                         "entity.name.constant"


### PR DESCRIPTION
In textmate, keyword.control is used for all kinds of things; in fact,
the default scope mapping for keyword is keyword.control!

So let's add a less ambiguous controlFlow modifier

See Microsoft/vscode#9367



bors r+
🤖