### PR TITLE
Fix Chalk panic

### DIFF
--- a/crates/ra_hir_ty/src/lib.rs
+++ b/crates/ra_hir_ty/src/lib.rs
@@ -860,7 +860,8 @@ pub trait TypeWalk {
         );
         self
     }
-    // /// Shifts up debruijn indices of `Ty::Bound` vars by `n`.
+
+    /// Shifts up debruijn indices of `Ty::Bound` vars by `n`.
     fn shift_bound_vars(self, n: DebruijnIndex) -> Self
     where
         Self: Sized,

--- a/crates/ra_hir_ty/src/tests/traits.rs
+++ b/crates/ra_hir_ty/src/tests/traits.rs
@@ -2021,3 +2021,28 @@ fn main() {
     "###
     );
 }
+
+#[test]
+fn dyn_trait_through_chalk() {
+    let t = type_at(
+        r#"
+//- /main.rs
+struct Box<T> {}
+#[lang = "deref"]
+trait Deref {
+    type Target;
+}
+impl<T> Deref for Box<T> {
+    type Target = T;
+}
+trait Trait {
+    fn foo(&self);
+}
+
+fn test(x: Box<dyn Trait>) {
+    x.foo()<|>;
+}
+"#,
+    );
+    assert_eq!(t, "()");
+}

--- a/crates/ra_hir_ty/src/traits/chalk.rs
+++ b/crates/ra_hir_ty/src/traits/chalk.rs
@@ -427,7 +427,12 @@ impl ToChalk for GenericPredicate {
         db: &dyn HirDatabase,
         where_clause: chalk_ir::QuantifiedWhereClause<Interner>,
     ) -> GenericPredicate {
-        match where_clause.value {
+        // we don't produce any where clauses with binders and can't currently deal with them
+        match where_clause
+            .value
+            .shifted_out(&Interner)
+            .expect("unexpected bound vars in where clause")
+        {
             chalk_ir::WhereClause::Implemented(tr) => {
                 GenericPredicate::Implemented(from_chalk(db, tr))
             }


### PR DESCRIPTION
Fixes #3865. Basically I forgot to shift 'back' when we got `dyn Trait`s back from Chalk, so after going through Chalk a few times, the panic happened.

And yes, I did run `analysis-stats` now ;)

cc @edwin0cheng 