### PR TITLE
Add L_DOLLAR for TYPE_RECOVERY_SET

### DIFF
--- a/crates/ra_mbe/src/tests.rs
+++ b/crates/ra_mbe/src/tests.rs
@@ -1615,6 +1615,23 @@ fn test_issue_2520() {
 }
 
 #[test]
+fn test_issue_3861() {
+    let macro_fixture = parse_macro(
+        r#"
+        macro_rules! rgb_color {
+            ($p:expr, $t: ty) => {
+                pub fn new() {
+                    let _ = 0 as $t << $p;
+                }
+            };
+        }
+    "#,
+    );
+
+    macro_fixture.expand_items(r#"rgb_color!(8 + 8, u32);"#);
+}
+
+#[test]
 fn test_repeat_bad_var() {
     // FIXME: the second rule of the macro should be removed and an error about
     // `$( $c )+` raised

--- a/crates/ra_parser/src/grammar/types.rs
+++ b/crates/ra_parser/src/grammar/types.rs
@@ -7,7 +7,7 @@ pub(super) const TYPE_FIRST: TokenSet = paths::PATH_FIRST.union(token_set![
     DYN_KW, L_ANGLE,
 ]);
 
-const TYPE_RECOVERY_SET: TokenSet = token_set![R_PAREN, COMMA];
+const TYPE_RECOVERY_SET: TokenSet = token_set![R_PAREN, COMMA, L_DOLLAR];
 
 pub(crate) fn type_(p: &mut Parser) {
     type_with_bounds_cond(p, true);


### PR DESCRIPTION
This PR is a hot fix for issue #3861 that just prevent it make the parser being stuck.

The actual problem described in https://github.com/rust-analyzer/rust-analyzer/pull/3873#issuecomment-610208693 is a very deep rabbit hole I don't want to dig right now :(