### PR TITLE
Enable the SemanticTokensFeature by default

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -21,7 +21,7 @@
         "Programming Languages"
     ],
     "engines": {
-        "vscode": "^1.43.0"
+        "vscode": "^1.44.0"
     },
     "enableProposedApi": true,
     "scripts": {
@@ -341,11 +341,6 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Show function name and docs in parameter hints"
-                },
-                "rust-analyzer.highlighting.semanticTokens": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Use proposed semantic tokens API for syntax highlighting"
                 },
                 "rust-analyzer.updates.channel": {
                     "type": "string",

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -1,11 +1,10 @@
 import * as lc from 'vscode-languageclient';
 import * as vscode from 'vscode';
 
-import { Config } from './config';
 import { CallHierarchyFeature } from 'vscode-languageclient/lib/callHierarchy.proposed';
 import { SemanticTokensFeature, DocumentSemanticsTokensSignature } from 'vscode-languageclient/lib/semanticTokens.proposed';
 
-export async function createClient(config: Config, serverPath: string, cwd: string): Promise<lc.LanguageClient> {
+export async function createClient(serverPath: string, cwd: string): Promise<lc.LanguageClient> {
     // '.' Is the fallback if no folder is open
     // TODO?: Workspace folders support Uri's (eg: file://test.txt).
     // It might be a good idea to test if the uri points to a file.
@@ -73,15 +72,12 @@ export async function createClient(config: Config, serverPath: string, cwd: stri
     };
 
     // To turn on all proposed features use: res.registerProposedFeatures();
-    // Here we want to just enable CallHierarchyFeature since it is available on stable.
-    // Note that while the CallHierarchyFeature is stable the LSP protocol is not.
+    // Here we want to enable CallHierarchyFeature and SemanticTokensFeature
+    // since they are available on stable.
+    // Note that while these features are stable in vscode their LSP protocol
+    // implementations are still in the "proposed" category for 3.16.
     res.registerFeature(new CallHierarchyFeature(res));
-
-    if (config.package.enableProposedApi) {
-        if (config.highlightingSemanticTokens) {
-            res.registerFeature(new SemanticTokensFeature(res));
-        }
-    }
+    res.registerFeature(new SemanticTokensFeature(res));
 
     return res;
 }

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -69,7 +69,6 @@ export class Config {
     get serverPath() { return this.cfg.get<null | string>("serverPath")!; }
     get channel() { return this.cfg.get<UpdatesChannel>("updates.channel")!; }
     get askBeforeDownload() { return this.cfg.get<boolean>("updates.askBeforeDownload")!; }
-    get highlightingSemanticTokens() { return this.cfg.get<boolean>("highlighting.semanticTokens")!; }
     get traceExtension() { return this.cfg.get<boolean>("trace.extension")!; }
 
     get inlayHints() {

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -21,7 +21,7 @@ export class Ctx {
         serverPath: string,
         cwd: string,
     ): Promise<Ctx> {
-        const client = await createClient(config, serverPath, cwd);
+        const client = await createClient(serverPath, cwd);
         const res = new Ctx(config, extCtx, client, serverPath);
         res.pushCleanup(client.start());
         await client.onReady();


### PR DESCRIPTION
This is covered under vscode's "editor.semanticHighlighting.enabled"
setting plus the user has to have a theme that has opted into highlighting.

Bumps required vscode stable to 1.44

Closes #3773 