### PR TITLE
Add more heuristics for hiding obvious param hints

### DIFF
--- a/crates/ra_ide/src/inlay_hints.rs
+++ b/crates/ra_ide/src/inlay_hints.rs
@@ -235,7 +235,15 @@ fn should_show_param_hint(
     param_name: &str,
     argument: &ast::Expr,
 ) -> bool {
-    let argument_string = argument.syntax().to_string();
+    let argument_string = {
+        let arg_string = argument.syntax().to_string();
+        let arg_split: Vec<char> = arg_string.chars().collect();
+        match arg_split.as_slice() {
+            ['&', 'm', 'u', 't', ' ', arg_name @ ..] => arg_name.into_iter().collect::<String>(),
+            ['&', arg_name @ ..] => arg_name.into_iter().collect::<String>(),
+            _ => arg_string,
+        }
+    };
     if param_name.is_empty()
         || argument_string.ends_with(&param_name)
         || argument_string.starts_with(&param_name)
@@ -1077,7 +1085,8 @@ impl Test {
 
 struct Param {}
 
-fn different_order(param: Param) {}
+fn different_order(param: &Param) {}
+fn different_order_mut(param: &mut Param) {}
 
 fn main() {
     let container: TestVarContainer = TestVarContainer { test_var: 42 };
@@ -1093,7 +1102,8 @@ fn main() {
     test_processed.no_hints_expected(33, container.test_var);
 
     let param_begin: Param = Param {};
-    different_order(param_begin);
+    different_order(&param_begin);
+    different_order(&mut param_begin);
 
     let a: f64 = 7.0;
     let b: f64 = 4.0;

--- a/crates/ra_ide/src/inlay_hints.rs
+++ b/crates/ra_ide/src/inlay_hints.rs
@@ -236,13 +236,13 @@ fn should_show_param_hint(
     argument: &ast::Expr,
 ) -> bool {
     let argument_string = {
-        let arg_string = argument.syntax().to_string();
-        let arg_split: Vec<char> = arg_string.chars().collect();
-        match arg_split.as_slice() {
-            ['&', 'm', 'u', 't', ' ', arg_name @ ..] => arg_name.into_iter().collect::<String>(),
-            ['&', arg_name @ ..] => arg_name.into_iter().collect::<String>(),
-            _ => arg_string,
+        let mut arg_string = argument.syntax().to_string();
+        if arg_string.get(0..5) == Some("&mut ") {
+            arg_string = arg_string[5..].to_string();
+        } else if arg_string.get(0..1) == Some("&") {
+            arg_string = arg_string[1..].to_string();
         }
+        arg_string
     };
     if param_name.is_empty()
         || argument_string.ends_with(&param_name)

--- a/crates/ra_ide/src/inlay_hints.rs
+++ b/crates/ra_ide/src/inlay_hints.rs
@@ -251,7 +251,6 @@ fn should_show_param_hint(
 
     // avoid displaying hints for common functions like map, filter, etc.
     // or other obvious words used in std
-    // TODO ignore "bytes" if the type is [u8; n]
     let is_obvious_param_name = match param_name {
         "predicate" | "value" | "pat" | "rhs" | "other" => true,
         _ => false,

--- a/crates/ra_ide/src/inlay_hints.rs
+++ b/crates/ra_ide/src/inlay_hints.rs
@@ -254,12 +254,17 @@ fn should_show_param_hint(
 }
 
 fn is_argument_similar_to_param(argument: &ast::Expr, param_name: &str) -> bool {
-    let argument_string = if let ast::Expr::RefExpr(ref_expr) = argument {
-        ref_expr.syntax().last_token().expect("RefExpr should have a last_token").to_string()
-    } else {
-        argument.syntax().to_string()
-    };
+    let argument_string = remove_ref(argument.clone()).syntax().to_string();
     argument_string.starts_with(&param_name) || argument_string.ends_with(&param_name)
+}
+
+fn remove_ref(expr: ast::Expr) -> ast::Expr {
+    if let ast::Expr::RefExpr(ref_expr) = &expr {
+        if let Some(inner) = ref_expr.expr() {
+            return inner;
+        }
+    }
+    expr
 }
 
 fn is_obvious_param(param_name: &str) -> bool {


### PR DESCRIPTION
This will now hide `value`, `pat`, `rhs` and `other`. These words were selected from the std because they are used in commonly used functions with only a single param and are obvious by their use.

It will also hide the hint if the passed param **starts** or end with the param_name. Maybe we could also split on '_' and check if one of the string is the param_name.

I think it would be good to also hide `bytes` if the type is `[u8; n]` but I'm not sure how to get the param type signature.

Closes #3900 

