### PR TITLE
add ellipsis field to hir pat record

### DIFF
--- a/crates/ra_hir/src/source_analyzer.rs
+++ b/crates/ra_hir/src/source_analyzer.rs
@@ -255,7 +255,7 @@ impl SourceAnalyzer {
             _ => return None,
         };
 
-        let (variant, missing_fields) =
+        let (variant, missing_fields, _exhaustive) =
             record_pattern_missing_fields(db, infer, pat_id, &body[pat_id])?;
         let res = self.missing_fields(db, krate, substs, variant, missing_fields);
         Some(res)

--- a/crates/ra_hir_def/src/body/lower.rs
+++ b/crates/ra_hir_def/src/body/lower.rs
@@ -668,7 +668,9 @@ impl ExprCollector<'_> {
                 });
                 fields.extend(iter);
 
-                Pat::Record { path, args: fields }
+                let ellipsis = record_field_pat_list.dotdot_token().is_some();
+
+                Pat::Record { path, args: fields, ellipsis }
             }
             ast::Pat::SlicePat(p) => {
                 let SlicePatComponents { prefix, slice, suffix } = p.components();

--- a/crates/ra_hir_def/src/expr.rs
+++ b/crates/ra_hir_def/src/expr.rs
@@ -376,35 +376,14 @@ pub enum Pat {
     Wild,
     Tuple(Vec<PatId>),
     Or(Vec<PatId>),
-    Record {
-        path: Option<Path>,
-        args: Vec<RecordFieldPat>,
-        // FIXME: 'ellipsis' option
-    },
-    Range {
-        start: ExprId,
-        end: ExprId,
-    },
-    Slice {
-        prefix: Vec<PatId>,
-        slice: Option<PatId>,
-        suffix: Vec<PatId>,
-    },
+    Record { path: Option<Path>, args: Vec<RecordFieldPat>, ellipsis: bool },
+    Range { start: ExprId, end: ExprId },
+    Slice { prefix: Vec<PatId>, slice: Option<PatId>, suffix: Vec<PatId> },
     Path(Path),
     Lit(ExprId),
-    Bind {
-        mode: BindingAnnotation,
-        name: Name,
-        subpat: Option<PatId>,
-    },
-    TupleStruct {
-        path: Option<Path>,
-        args: Vec<PatId>,
-    },
-    Ref {
-        pat: PatId,
-        mutability: Mutability,
-    },
+    Bind { mode: BindingAnnotation, name: Name, subpat: Option<PatId> },
+    TupleStruct { path: Option<Path>, args: Vec<PatId> },
+    Ref { pat: PatId, mutability: Mutability },
 }
 
 impl Pat {

--- a/crates/ra_hir_ty/src/diagnostics.rs
+++ b/crates/ra_hir_ty/src/diagnostics.rs
@@ -63,6 +63,29 @@ impl AstDiagnostic for MissingFields {
 }
 
 #[derive(Debug)]
+pub struct MissingPatFields {
+    pub file: HirFileId,
+    pub field_list: AstPtr<ast::RecordFieldPatList>,
+    pub missed_fields: Vec<Name>,
+}
+
+impl Diagnostic for MissingPatFields {
+    fn message(&self) -> String {
+        let mut buf = String::from("Missing structure fields:\n");
+        for field in &self.missed_fields {
+            format_to!(buf, "- {}", field);
+        }
+        buf
+    }
+    fn source(&self) -> InFile<SyntaxNodePtr> {
+        InFile { file_id: self.file, value: self.field_list.into() }
+    }
+    fn as_any(&self) -> &(dyn Any + Send + 'static) {
+        self
+    }
+}
+
+#[derive(Debug)]
 pub struct MissingMatchArms {
     pub file: HirFileId,
     pub match_expr: AstPtr<ast::Expr>,

--- a/crates/ra_hir_ty/src/expr.rs
+++ b/crates/ra_hir_ty/src/expr.rs
@@ -9,7 +9,7 @@ use rustc_hash::FxHashSet;
 
 use crate::{
     db::HirDatabase,
-    diagnostics::{MissingFields, MissingMatchArms, MissingOkInTailExpr},
+    diagnostics::{MissingFields, MissingMatchArms, MissingOkInTailExpr, MissingPatFields},
     utils::variant_data,
     ApplicationTy, InferenceResult, Ty, TypeCtor,
     _match::{is_useful, MatchCheckCtx, Matrix, PatStack, Usefulness},
@@ -49,36 +49,94 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
             if let Some((variant_def, missed_fields, true)) =
                 record_literal_missing_fields(db, &self.infer, id, expr)
             {
-                // XXX: only look at source_map if we do have missing fields
-                let (_, source_map) = db.body_with_source_map(self.func.into());
-
-                if let Ok(source_ptr) = source_map.expr_syntax(id) {
-                    if let Some(expr) = source_ptr.value.left() {
-                        let root = source_ptr.file_syntax(db.upcast());
-                        if let ast::Expr::RecordLit(record_lit) = expr.to_node(&root) {
-                            if let Some(field_list) = record_lit.record_field_list() {
-                                let variant_data = variant_data(db.upcast(), variant_def);
-                                let missed_fields = missed_fields
-                                    .into_iter()
-                                    .map(|idx| variant_data.fields()[idx].name.clone())
-                                    .collect();
-                                self.sink.push(MissingFields {
-                                    file: source_ptr.file_id,
-                                    field_list: AstPtr::new(&field_list),
-                                    missed_fields,
-                                })
-                            }
-                        }
-                    }
-                }
+                self.create_record_literal_missing_fields_diagnostic(
+                    id,
+                    db,
+                    variant_def,
+                    missed_fields,
+                );
             }
             if let Expr::Match { expr, arms } = expr {
                 self.validate_match(id, *expr, arms, db, self.infer.clone());
             }
         }
+        for (id, pat) in body.pats.iter() {
+            if let Some((variant_def, missed_fields, true)) =
+                record_pattern_missing_fields(db, &self.infer, id, pat)
+            {
+                self.create_record_pattern_missing_fields_diagnostic(
+                    id,
+                    db,
+                    variant_def,
+                    missed_fields,
+                );
+            }
+        }
         let body_expr = &body[body.body_expr];
         if let Expr::Block { tail: Some(t), .. } = body_expr {
             self.validate_results_in_tail_expr(body.body_expr, *t, db);
+        }
+    }
+
+    fn create_record_literal_missing_fields_diagnostic(
+        &mut self,
+        id: ExprId,
+        db: &dyn HirDatabase,
+        variant_def: VariantId,
+        missed_fields: Vec<LocalStructFieldId>,
+    ) {
+        // XXX: only look at source_map if we do have missing fields
+        let (_, source_map) = db.body_with_source_map(self.func.into());
+
+        if let Ok(source_ptr) = source_map.expr_syntax(id) {
+            if let Some(expr) = source_ptr.value.left() {
+                let root = source_ptr.file_syntax(db.upcast());
+                if let ast::Expr::RecordLit(record_lit) = expr.to_node(&root) {
+                    if let Some(field_list) = record_lit.record_field_list() {
+                        let variant_data = variant_data(db.upcast(), variant_def);
+                        let missed_fields = missed_fields
+                            .into_iter()
+                            .map(|idx| variant_data.fields()[idx].name.clone())
+                            .collect();
+                        self.sink.push(MissingFields {
+                            file: source_ptr.file_id,
+                            field_list: AstPtr::new(&field_list),
+                            missed_fields,
+                        })
+                    }
+                }
+            }
+        }
+    }
+
+    fn create_record_pattern_missing_fields_diagnostic(
+        &mut self,
+        id: PatId,
+        db: &dyn HirDatabase,
+        variant_def: VariantId,
+        missed_fields: Vec<LocalStructFieldId>,
+    ) {
+        // XXX: only look at source_map if we do have missing fields
+        let (_, source_map) = db.body_with_source_map(self.func.into());
+
+        if let Ok(source_ptr) = source_map.pat_syntax(id) {
+            if let Some(expr) = source_ptr.value.left() {
+                let root = source_ptr.file_syntax(db.upcast());
+                if let ast::Pat::RecordPat(record_pat) = expr.to_node(&root) {
+                    if let Some(field_list) = record_pat.record_field_pat_list() {
+                        let variant_data = variant_data(db.upcast(), variant_def);
+                        let missed_fields = missed_fields
+                            .into_iter()
+                            .map(|idx| variant_data.fields()[idx].name.clone())
+                            .collect();
+                        self.sink.push(MissingPatFields {
+                            file: source_ptr.file_id,
+                            field_list: AstPtr::new(&field_list),
+                            missed_fields,
+                        })
+                    }
+                }
+            }
         }
     }
 
@@ -232,9 +290,9 @@ pub fn record_pattern_missing_fields(
     infer: &InferenceResult,
     id: PatId,
     pat: &Pat,
-) -> Option<(VariantId, Vec<LocalStructFieldId>)> {
-    let fields = match pat {
-        Pat::Record { path: _, args } => args,
+) -> Option<(VariantId, Vec<LocalStructFieldId>, /*exhaustive*/ bool)> {
+    let (fields, exhaustive) = match pat {
+        Pat::Record { path: _, args, ellipsis } => (args, !ellipsis),
         _ => return None,
     };
 
@@ -254,5 +312,5 @@ pub fn record_pattern_missing_fields(
     if missed_fields.is_empty() {
         return None;
     }
-    Some((variant_def, missed_fields))
+    Some((variant_def, missed_fields, exhaustive))
 }

--- a/crates/ra_hir_ty/src/infer/pat.rs
+++ b/crates/ra_hir_ty/src/infer/pat.rs
@@ -158,7 +158,7 @@ impl<'a> InferenceContext<'a> {
             Pat::TupleStruct { path: p, args: subpats } => {
                 self.infer_tuple_struct_pat(p.as_ref(), subpats, expected, default_bm, pat)
             }
-            Pat::Record { path: p, args: fields } => {
+            Pat::Record { path: p, args: fields, ellipsis: _ } => {
                 self.infer_record_pat(p.as_ref(), fields, expected, default_bm, pat)
             }
             Pat::Path(path) => {


### PR DESCRIPTION
This PR corrects a `fixme`, adding an `ellipsis` field to the hir `Pat::Record` type. It will also be unlock some useful follow on work for #3894.

Additionally it adds a diagnostic for missing fields in record patterns.

~~Marking as a draft because I don't have any tests, and a small amount of manual testing on my branch from #3894 suggests it might *not* be working. Any thoughts on how I can best test this, or else pointers on where I might be going wrong?~~