### PR TITLE
Fix accidently quadratic behavior when processing include!

### DIFF
--- a/crates/ra_hir_def/src/lang_item.rs
+++ b/crates/ra_hir_def/src/lang_item.rs
@@ -4,6 +4,7 @@
 //! features, such as Fn family of traits.
 use std::sync::Arc;
 
+use ra_prof::profile;
 use ra_syntax::SmolStr;
 use rustc_hash::FxHashMap;
 
@@ -78,6 +79,8 @@ impl LangItems {
 
     /// Salsa query. This will look for lang items in a specific crate.
     pub(crate) fn crate_lang_items_query(db: &dyn DefDatabase, krate: CrateId) -> Arc<LangItems> {
+        let _p = profile("crate_lang_items_query");
+
         let mut lang_items = LangItems::default();
 
         let crate_def_map = db.crate_def_map(krate);
@@ -95,6 +98,7 @@ impl LangItems {
         db: &dyn DefDatabase,
         module: ModuleId,
     ) -> Option<Arc<LangItems>> {
+        let _p = profile("module_lang_items_query");
         let mut lang_items = LangItems::default();
         lang_items.collect_lang_items(db, module);
         if lang_items.items.is_empty() {
@@ -111,6 +115,7 @@ impl LangItems {
         start_crate: CrateId,
         item: SmolStr,
     ) -> Option<LangItemTarget> {
+        let _p = profile("lang_item_query");
         let lang_items = db.crate_lang_items(start_crate);
         let start_crate_target = lang_items.items.get(&item);
         if let Some(target) = start_crate_target {

--- a/crates/ra_prof/src/lib.rs
+++ b/crates/ra_prof/src/lib.rs
@@ -113,21 +113,6 @@ pub fn profile(label: Label) -> Profiler {
     })
 }
 
-pub fn print_time(label: Label) -> impl Drop {
-    struct Guard {
-        label: Label,
-        start: Instant,
-    }
-
-    impl Drop for Guard {
-        fn drop(&mut self) {
-            eprintln!("{}: {:?}", self.label, self.start.elapsed())
-        }
-    }
-
-    Guard { label, start: Instant::now() }
-}
-
 pub struct Profiler {
     label: Option<Label>,
     detail: Option<String>,

--- a/crates/stdx/src/lib.rs
+++ b/crates/stdx/src/lib.rs
@@ -1,6 +1,6 @@
 //! Missing batteries for standard libraries.
 
-use std::{cell::Cell, fmt};
+use std::{cell::Cell, fmt, time::Instant};
 
 #[inline(always)]
 pub fn is_ci() -> bool {
@@ -87,4 +87,18 @@ where
         f.write_str(self.suffix)?;
         Ok(())
     }
+}
+pub fn timeit(label: &'static str) -> impl Drop {
+    struct Guard {
+        label: &'static str,
+        start: Instant,
+    }
+
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            eprintln!("{}: {:?}", self.label, self.start.elapsed())
+        }
+    }
+
+    Guard { label, start: Instant::now() }
 }


### PR DESCRIPTION
This fixes the immediate problem behind #3927. It doesn't yet fix the deeper problem with `to_node` being quadratic (hence the test is ignored), but it is a good start anyway.

bors r+