### PR TITLE
fix missing match arm false positive

### DIFF
--- a/crates/ra_hir_ty/src/_match.rs
+++ b/crates/ra_hir_ty/src/_match.rs
@@ -1315,8 +1315,9 @@ mod tests {
             }
         ";
 
-        // Match arms with the incorrect type are filtered out.
-        check_diagnostic(content);
+        // Match statements with arms that don't match the
+        // expression pattern do not fire this diagnostic.
+        check_no_diagnostic(content);
     }
 
     #[test]
@@ -1330,8 +1331,9 @@ mod tests {
             }
         ";
 
-        // Match arms with the incorrect type are filtered out.
-        check_diagnostic(content);
+        // Match statements with arms that don't match the
+        // expression pattern do not fire this diagnostic.
+        check_no_diagnostic(content);
     }
 
     #[test]
@@ -1344,8 +1346,9 @@ mod tests {
             }
         ";
 
-        // Match arms with the incorrect type are filtered out.
-        check_diagnostic(content);
+        // Match statements with arms that don't match the
+        // expression pattern do not fire this diagnostic.
+        check_no_diagnostic(content);
     }
 
     #[test]

--- a/crates/ra_hir_ty/src/_match.rs
+++ b/crates/ra_hir_ty/src/_match.rs
@@ -1422,6 +1422,27 @@ mod tests {
 
         check_no_diagnostic(content);
     }
+
+    #[test]
+    fn expr_partially_diverges() {
+        let content = r"
+            enum Either<T> {
+                A(T),
+                B,
+            }
+            fn foo() -> Either<!> {
+                Either::B
+            }
+            fn test_fn() -> u32 {
+                match foo() {
+                    Either::A(val) => val,
+                    Either::B => 0,
+                }
+            }
+        ";
+
+        check_no_diagnostic(content);
+    }
 }
 
 #[cfg(test)]

--- a/crates/ra_hir_ty/src/_match.rs
+++ b/crates/ra_hir_ty/src/_match.rs
@@ -973,6 +973,47 @@ mod tests {
     }
 
     #[test]
+    fn tuple_of_bools_with_ellipsis_at_end_no_diagnostic() {
+        let content = r"
+            fn test_fn() {
+                match (false, true, false) {
+                    (false, ..) => {},
+                    (true, ..) => {},
+                }
+            }
+        ";
+
+        check_no_diagnostic(content);
+    }
+
+    #[test]
+    fn tuple_of_bools_with_ellipsis_at_beginning_no_diagnostic() {
+        let content = r"
+            fn test_fn() {
+                match (false, true, false) {
+                    (.., false) => {},
+                    (.., true) => {},
+                }
+            }
+        ";
+
+        check_no_diagnostic(content);
+    }
+
+    #[test]
+    fn tuple_of_bools_with_ellipsis_no_diagnostic() {
+        let content = r"
+            fn test_fn() {
+                match (false, true, false) {
+                    (..) => {},
+                }
+            }
+        ";
+
+        check_no_diagnostic(content);
+    }
+
+    #[test]
     fn tuple_of_tuple_and_bools_no_arms() {
         let content = r"
             fn test_fn() {
@@ -1551,6 +1592,40 @@ mod false_negatives {
         // We currently infer the type of `loop { break Foo::A }` to `!`, which
         // causes us to skip the diagnostic since `Either::A` doesn't type check
         // with `!`.
+        check_no_diagnostic(content);
+    }
+
+    #[test]
+    fn tuple_of_bools_with_ellipsis_at_end_missing_arm() {
+        let content = r"
+            fn test_fn() {
+                match (false, true, false) {
+                    (false, ..) => {},
+                }
+            }
+        ";
+
+        // This is a false negative.
+        // The `..` pattern is currently lowered to a single `Pat::Wild`
+        // no matter how many fields the `..` pattern is covering. This
+        // causes the match arm in this test not to type check against
+        // the match expression, which causes this diagnostic not to
+        // fire.
+        check_no_diagnostic(content);
+    }
+
+    #[test]
+    fn tuple_of_bools_with_ellipsis_at_beginning_missing_arm() {
+        let content = r"
+            fn test_fn() {
+                match (false, true, false) {
+                    (.., false) => {},
+                }
+            }
+        ";
+
+        // This is a false negative.
+        // See comments on `tuple_of_bools_with_ellipsis_at_end_missing_arm`.
         check_no_diagnostic(content);
     }
 }

--- a/crates/ra_hir_ty/src/expr.rs
+++ b/crates/ra_hir_ty/src/expr.rs
@@ -163,12 +163,6 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
 
         let mut seen = Matrix::empty();
         for pat in pats {
-            // We skip any patterns whose type we cannot resolve.
-            //
-            // This could lead to false positives in this diagnostic, so
-            // it might be better to skip the entire diagnostic if we either
-            // cannot resolve a match arm or determine that the match arm has
-            // the wrong type.
             if let Some(pat_ty) = infer.type_of_pat.get(pat) {
                 // We only include patterns whose type matches the type
                 // of the match expression. If we had a InvalidMatchArmPattern
@@ -191,8 +185,15 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
                     // to the matrix here.
                     let v = PatStack::from_pattern(pat);
                     seen.push(&cx, v);
+                    continue;
                 }
             }
+
+            // If we can't resolve the type of a pattern, or the pattern type doesn't
+            // fit the match expression, we skip this diagnostic. Skipping the entire
+            // diagnostic rather than just not including this match arm is preferred
+            // to avoid the chance of false positives.
+            return;
         }
 
         match is_useful(&cx, &seen, &PatStack::from_wild()) {


### PR DESCRIPTION
This fixes #3932 by skipping the missing match arm diagnostic in the case any of the match arms don't type check properly against the match expression. 

I think this is the appropriate behavior for this diagnostic, since `is_useful` relies on all match arms being well formed, and the case of a malformed match arm should probably be handled by a different diagnostic.