### PR TITLE
Fix non canonicallized path from metadata

### DIFF
--- a/crates/rust-analyzer/src/cli/load_cargo.rs
+++ b/crates/rust-analyzer/src/cli/load_cargo.rs
@@ -152,7 +152,9 @@ pub(crate) fn load(
         &extern_source_roots,
         proc_macro_client,
         &mut |path: &Path| {
-            let vfs_file = vfs.load(path);
+            // Some path from metadata will be non canonicalized, e.g. /foo/../bar/lib.rs
+            let path = path.canonicalize().ok()?;
+            let vfs_file = vfs.load(&path);
             log::debug!("vfs file {:?} -> {:?}", path, vfs_file);
             vfs_file.map(vfs_file_to_id)
         },

--- a/crates/rust-analyzer/src/world.rs
+++ b/crates/rust-analyzer/src/world.rs
@@ -139,7 +139,9 @@ impl WorldState {
         // Create crate graph from all the workspaces
         let mut crate_graph = CrateGraph::default();
         let mut load = |path: &std::path::Path| {
-            let vfs_file = vfs.load(path);
+            // Some path from metadata will be non canonicalized, e.g. /foo/../bar/lib.rs
+            let path = path.canonicalize().ok()?;
+            let vfs_file = vfs.load(&path);
             vfs_file.map(|f| FileId(f.0))
         };
 


### PR DESCRIPTION
Crate root path obtained from cargo-metadata may contains non-canonicalized path (e.g. `/foo/../libcore/tests/lib.rs`), such that `vfs::load` will find a incorrect root. 

This PR try to fix that by canonicalize it before passing to vfs.