### PR TITLE
fix: inlay hints config desyncronization between the frontend and the backend

### DIFF
--- a/editors/code/src/inlay_hints.ts
+++ b/editors/code/src/inlay_hints.ts
@@ -3,13 +3,13 @@ import * as vscode from 'vscode';
 import * as ra from './rust-analyzer-api';
 
 import { Ctx, Disposable } from './ctx';
-import { sendRequestWithRetry, isRustDocument, RustDocument, RustEditor } from './util';
+import { sendRequestWithRetry, isRustDocument, RustDocument, RustEditor, sleep } from './util';
 
 
 export function activateInlayHints(ctx: Ctx) {
     const maybeUpdater = {
         updater: null as null | HintsUpdater,
-        onConfigChange() {
+        async onConfigChange() {
             if (
                 !ctx.config.inlayHints.typeHints &&
                 !ctx.config.inlayHints.parameterHints &&
@@ -17,6 +17,7 @@ export function activateInlayHints(ctx: Ctx) {
             ) {
                 return this.dispose();
             }
+            await sleep(100);
             if (this.updater) {
                 this.updater.syncCacheAndRenderHints();
             } else {


### PR DESCRIPTION
See the explanation in the issue comment:
https://github.com/rust-analyzer/rust-analyzer/issues/3924#issuecomment-612444566

Workaround-ly fixes: #3924