### PR TITLE
Fix double comma when merge imports on second line

### DIFF
--- a/crates/ra_assists/src/handlers/merge_imports.rs
+++ b/crates/ra_assists/src/handlers/merge_imports.rs
@@ -3,8 +3,7 @@ use std::iter::successors;
 use ra_syntax::{
     algo::{neighbor, SyntaxRewriter},
     ast::{self, edit::AstNodeEdit, make},
-    AstNode, Direction, InsertPosition, NodeOrToken, SyntaxElement, SyntaxKind, SyntaxToken, Token,
-    T,
+    AstNode, Direction, InsertPosition, NodeOrToken, SyntaxElement, T,
 };
 
 use crate::{Assist, AssistCtx, AssistId};
@@ -269,15 +268,15 @@ use {
         check_assist(
             merge_imports,
             r"
-use hyper::service::make_service_fn;
-use hyper::<|>{
-    StatusCode,
+use foo::bar::baz;
+use foo::<|>{
+    FooBar,
 };
 ",
             r"
-use hyper::{<|>
-    StatusCode,
-service::make_service_fn};
+use foo::{<|>
+    FooBar,
+bar::baz};
 ",
         )
     }


### PR DESCRIPTION
This fixes the bug when merging imports from the second line when it already has a comma it would previously insert a comma.

There's probably a better way to check for a COMMA. 

This also ends up with a weird indentation, but rust-fmt can easily deal with it so I'm not sure how to resolve that.

Closes #3832