### PR TITLE
Fix parentModule shortcut conflict

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -154,7 +154,7 @@
         "keybindings": [
             {
                 "command": "rust-analyzer.parentModule",
-                "key": "ctrl+u",
+                "key": "ctrl+shift+u",
                 "when": "editorTextFocus && editorLangId == rust"
             },
             {


### PR DESCRIPTION
The default parentModule shortcut conflicts with VSCode's built-in undo selection