### PR TITLE
Implement inline associated type bounds

### DIFF
--- a/crates/ra_hir_def/src/data.rs
+++ b/crates/ra_hir_def/src/data.rs
@@ -15,7 +15,7 @@ use ra_syntax::ast::{
 use crate::{
     attr::Attrs,
     db::DefDatabase,
-    path::{path, GenericArgs, Path},
+    path::{path, AssociatedTypeBinding, GenericArgs, Path},
     src::HasSource,
     type_ref::{Mutability, TypeBound, TypeRef},
     visibility::RawVisibility,
@@ -95,7 +95,11 @@ fn desugar_future_path(orig: TypeRef) -> Path {
     let path = path![std::future::Future];
     let mut generic_args: Vec<_> = std::iter::repeat(None).take(path.segments.len() - 1).collect();
     let mut last = GenericArgs::empty();
-    last.bindings.push((name![Output], orig));
+    last.bindings.push(AssociatedTypeBinding {
+        name: name![Output],
+        type_ref: Some(orig),
+        bounds: Vec::new(),
+    });
     generic_args.push(Some(Arc::new(last)));
 
     Path::from_known_path(path, generic_args)

--- a/crates/ra_hir_def/src/path.rs
+++ b/crates/ra_hir_def/src/path.rs
@@ -14,7 +14,10 @@ use hir_expand::{
 use ra_db::CrateId;
 use ra_syntax::ast;
 
-use crate::{type_ref::TypeRef, InFile};
+use crate::{
+    type_ref::{TypeBound, TypeRef},
+    InFile,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ModPath {
@@ -111,7 +114,21 @@ pub struct GenericArgs {
     /// is left out.
     pub has_self_type: bool,
     /// Associated type bindings like in `Iterator<Item = T>`.
-    pub bindings: Vec<(Name, TypeRef)>,
+    pub bindings: Vec<AssociatedTypeBinding>,
+}
+
+/// An associated type binding like in `Iterator<Item = T>`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AssociatedTypeBinding {
+    /// The name of the associated type.
+    pub name: Name,
+    /// The type bound to this associated type (in `Item = T`, this would be the
+    /// `T`). This can be `None` if there are bounds instead.
+    pub type_ref: Option<TypeRef>,
+    /// Bounds for the associated type, like in `Iterator<Item:
+    /// SomeOtherTrait>`. (This is the unstable `associated_type_bounds`
+    /// feature.)
+    pub bounds: Vec<TypeBound>,
 }
 
 /// A single generic argument.

--- a/crates/ra_hir_def/src/type_ref.rs
+++ b/crates/ra_hir_def/src/type_ref.rs
@@ -163,8 +163,16 @@ impl TypeRef {
                         let crate::path::GenericArg::Type(type_ref) = arg;
                         go(type_ref, f);
                     }
-                    for (_, type_ref) in &args_and_bindings.bindings {
-                        go(type_ref, f);
+                    for binding in &args_and_bindings.bindings {
+                        if let Some(type_ref) = &binding.type_ref {
+                            go(type_ref, f);
+                        }
+                        for bound in &binding.bounds {
+                            match bound {
+                                TypeBound::Path(path) => go_path(path, f),
+                                TypeBound::Error => (),
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Like `Iterator<Item: SomeTrait>`.

This is an unstable feature, but it's used in the standard library e.g. in the definition of Flatten, so we can't get away with not implementing it :)

(This is cherry-picked from my recursive solver branch, where it works better, but I did manage to write a test that works with the current Chalk solver as well...)