### PR TITLE
add diagnostics subcommand to rust-analyzer CLI

### DIFF
--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -25,7 +25,7 @@ use hir_ty::{
     autoderef, display::HirFormatter, expr::ExprValidator, method_resolution, ApplicationTy,
     Canonical, InEnvironment, Substs, TraitEnvironment, Ty, TyDefId, TypeCtor,
 };
-use ra_db::{CrateId, Edition, FileId};
+use ra_db::{CrateId, CrateName, Edition, FileId};
 use ra_prof::profile;
 use ra_syntax::{
     ast::{self, AttrsOwner, NameOwner},
@@ -89,6 +89,10 @@ impl Crate {
 
     pub fn edition(self, db: &dyn HirDatabase) -> Edition {
         db.crate_graph()[self.id].edition
+    }
+
+    pub fn display_name(self, db: &dyn HirDatabase) -> Option<CrateName> {
+        db.crate_graph()[self.id].display_name.as_ref().cloned()
     }
 
     pub fn all(db: &dyn HirDatabase) -> Vec<Crate> {

--- a/crates/rust-analyzer/src/bin/args.rs
+++ b/crates/rust-analyzer/src/bin/args.rs
@@ -38,6 +38,9 @@ pub(crate) enum Command {
     Diagnostics {
         path: PathBuf,
         load_output_dirs: bool,
+        /// Include files which are not modules. In rust-analyzer
+        /// this would include the parser test files.
+        all: bool,
     },
     RunServer,
     Version,
@@ -225,6 +228,7 @@ USAGE:
 FLAGS:
     -h, --help              Prints help information
         --load-output-dirs  Load OUT_DIR values by running `cargo check` before analysis
+        --all               Include all files rather than only modules
 
 ARGS:
     <PATH>"
@@ -233,6 +237,7 @@ ARGS:
                 }
 
                 let load_output_dirs = matches.contains("--load-output-dirs");
+                let all = matches.contains("--all");
                 let path = {
                     let mut trailing = matches.free()?;
                     if trailing.len() != 1 {
@@ -241,7 +246,7 @@ ARGS:
                     trailing.pop().unwrap().into()
                 };
 
-                Command::Diagnostics { path, load_output_dirs }
+                Command::Diagnostics { path, load_output_dirs, all }
             }
             _ => {
                 eprintln!(

--- a/crates/rust-analyzer/src/bin/args.rs
+++ b/crates/rust-analyzer/src/bin/args.rs
@@ -35,6 +35,10 @@ pub(crate) enum Command {
         what: BenchWhat,
         load_output_dirs: bool,
     },
+    Diagnostics {
+        path: PathBuf,
+        load_output_dirs: bool,
+    },
     RunServer,
     Version,
 }
@@ -208,6 +212,36 @@ ARGS:
                 };
                 let load_output_dirs = matches.contains("--load-output-dirs");
                 Command::Bench { path, what, load_output_dirs }
+            }
+            "diagnostics" => {
+                if matches.contains(["-h", "--help"]) {
+                    eprintln!(
+                        "\
+ra-cli-diagnostics
+
+USAGE:
+    rust-analyzer diagnostics [FLAGS] [PATH]
+
+FLAGS:
+    -h, --help              Prints help information
+        --load-output-dirs  Load OUT_DIR values by running `cargo check` before analysis
+
+ARGS:
+    <PATH>"
+                    );
+                    return Ok(Err(HelpPrinted));
+                }
+
+                let load_output_dirs = matches.contains("--load-output-dirs");
+                let path = {
+                    let mut trailing = matches.free()?;
+                    if trailing.len() != 1 {
+                        bail!("Invalid flags");
+                    }
+                    trailing.pop().unwrap().into()
+                };
+
+                Command::Diagnostics { path, load_output_dirs }
             }
             _ => {
                 eprintln!(

--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -39,8 +39,8 @@ fn main() -> Result<()> {
             cli::analysis_bench(args.verbosity, path.as_ref(), what, load_output_dirs)?
         }
 
-        args::Command::Diagnostics { path, load_output_dirs } => {
-            cli::diagnostics(path.as_ref(), load_output_dirs)?
+        args::Command::Diagnostics { path, load_output_dirs, all } => {
+            cli::diagnostics(path.as_ref(), load_output_dirs, all)?
         }
 
         args::Command::RunServer => run_server()?,

--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -39,6 +39,10 @@ fn main() -> Result<()> {
             cli::analysis_bench(args.verbosity, path.as_ref(), what, load_output_dirs)?
         }
 
+        args::Command::Diagnostics { path, load_output_dirs } => {
+            cli::diagnostics(path.as_ref(), load_output_dirs)?
+        }
+
         args::Command::RunServer => run_server()?,
         args::Command::Version => println!("rust-analyzer {}", env!("REV")),
     }

--- a/crates/rust-analyzer/src/cli.rs
+++ b/crates/rust-analyzer/src/cli.rs
@@ -3,6 +3,7 @@
 mod load_cargo;
 mod analysis_stats;
 mod analysis_bench;
+mod diagnostics;
 mod progress_report;
 
 use std::io::Read;
@@ -11,6 +12,10 @@ use anyhow::Result;
 use ra_ide::{file_structure, Analysis};
 use ra_prof::profile;
 use ra_syntax::{AstNode, SourceFile};
+
+pub use analysis_bench::{analysis_bench, BenchWhat, Position};
+pub use analysis_stats::analysis_stats;
+pub use diagnostics::diagnostics;
 
 #[derive(Clone, Copy)]
 pub enum Verbosity {
@@ -59,9 +64,6 @@ pub fn highlight(rainbow: bool) -> Result<()> {
     println!("{}", html);
     Ok(())
 }
-
-pub use analysis_bench::{analysis_bench, BenchWhat, Position};
-pub use analysis_stats::analysis_stats;
 
 fn file() -> Result<SourceFile> {
     let text = read_stdin()?;

--- a/crates/rust-analyzer/src/cli/diagnostics.rs
+++ b/crates/rust-analyzer/src/cli/diagnostics.rs
@@ -1,0 +1,74 @@
+//! Analyze all files in project for diagnostics. Exits with a non-zero status
+//! code if any errors are found.
+
+use anyhow::anyhow;
+use ra_db::{SourceDatabaseExt, SourceRootId};
+use ra_ide::{Analysis, Severity};
+use std::{collections::HashSet, path::Path};
+
+use crate::cli::{load_cargo::load_cargo, Result};
+use hir::{db::HirDatabase, Crate, Module};
+
+pub fn diagnostics(path: &Path, load_output_dirs: bool) -> Result<()> {
+    let (host, roots) = load_cargo(path, load_output_dirs)?;
+    let db = host.raw_database();
+    let analysis = host.analysis();
+    let members = roots
+        .into_iter()
+        .filter_map(
+            |(source_root_id, project_root)| {
+                if project_root.is_member() {
+                    Some(source_root_id)
+                } else {
+                    None
+                }
+            },
+        )
+        .collect::<HashSet<_>>();
+
+    let mut found_error = false;
+    let mut visited_modules = HashSet::new();
+    for krate in Crate::all(db) {
+        let module = krate.root_module(db).expect("crate without root module");
+        check_module(module, db, &mut visited_modules, &members, &analysis, &mut found_error);
+    }
+
+    println!();
+    println!("diagnostic scan complete");
+
+    if found_error {
+        println!();
+        Err(anyhow!("diagnostic error detected"))
+    } else {
+        Ok(())
+    }
+}
+
+fn check_module(
+    module: Module,
+    db: &(impl HirDatabase + SourceDatabaseExt),
+    visited_modules: &mut HashSet<Module>,
+    members: &HashSet<SourceRootId>,
+    analysis: &Analysis,
+    found_error: &mut bool,
+) {
+    let file_id = module.definition_source(db).file_id.original_file(db);
+    if !visited_modules.contains(&module) {
+        if members.contains(&db.file_source_root(file_id)) {
+            println!("processing: {}", db.file_relative_path(file_id));
+            for diagnostic in analysis.diagnostics(file_id).unwrap() {
+                if matches!(diagnostic.severity, Severity::Error) {
+                    *found_error = true;
+                }
+
+                println!("{:?}", diagnostic);
+            }
+        }
+
+        visited_modules.insert(module);
+
+        for child_module in module.children(db) {
+            check_module(child_module, db, visited_modules, members, analysis, found_error);
+        }
+    }
+}

--- a/crates/rust-analyzer/src/cli/diagnostics.rs
+++ b/crates/rust-analyzer/src/cli/diagnostics.rs
@@ -1,36 +1,61 @@
-//! Analyze all files in project for diagnostics. Exits with a non-zero status
+//! Analyze all modules in a project for diagnostics. Exits with a non-zero status
 //! code if any errors are found.
 
 use anyhow::anyhow;
-use ra_db::{SourceDatabaseExt, SourceRootId};
-use ra_ide::{Analysis, Severity};
+use ra_db::{SourceDatabase, SourceDatabaseExt};
+use ra_ide::Severity;
 use std::{collections::HashSet, path::Path};
 
 use crate::cli::{load_cargo::load_cargo, Result};
-use hir::{db::HirDatabase, Crate, Module};
+use hir::Semantics;
 
-pub fn diagnostics(path: &Path, load_output_dirs: bool) -> Result<()> {
+pub fn diagnostics(path: &Path, load_output_dirs: bool, all: bool) -> Result<()> {
     let (host, roots) = load_cargo(path, load_output_dirs)?;
     let db = host.raw_database();
     let analysis = host.analysis();
+    let semantics = Semantics::new(db);
     let members = roots
         .into_iter()
-        .filter_map(
-            |(source_root_id, project_root)| {
-                if project_root.is_member() {
-                    Some(source_root_id)
-                } else {
-                    None
-                }
-            },
-        )
+        .filter_map(|(source_root_id, project_root)| {
+            // filter out dependencies
+            if project_root.is_member() {
+                Some(source_root_id)
+            } else {
+                None
+            }
+        })
         .collect::<HashSet<_>>();
 
     let mut found_error = false;
-    let mut visited_modules = HashSet::new();
-    for krate in Crate::all(db) {
-        let module = krate.root_module(db).expect("crate without root module");
-        check_module(module, db, &mut visited_modules, &members, &analysis, &mut found_error);
+    let mut visited_files = HashSet::new();
+    let crate_graph = db.crate_graph();
+    for crate_id in crate_graph.iter() {
+        let krate = &crate_graph[crate_id];
+        if let Some(crate_name) = &krate.display_name {
+            println!("processing crate: {}", crate_name);
+        } else {
+            println!("processing crate: unknown");
+        }
+        for file_id in db.source_root(db.file_source_root(krate.root_file_id)).walk() {
+            // Filter out files which are not actually modules (unless `--all` flag is
+            // passed). In the rust-analyzer repository this filters out the parser test files.
+            if semantics.to_module_def(file_id).is_some() || all {
+                if !visited_files.contains(&file_id) {
+                    if members.contains(&db.file_source_root(file_id)) {
+                        println!("processing module: {}", db.file_relative_path(file_id));
+                        for diagnostic in analysis.diagnostics(file_id).unwrap() {
+                            if matches!(diagnostic.severity, Severity::Error) {
+                                found_error = true;
+                            }
+
+                            println!("{:?}", diagnostic);
+                        }
+                    }
+
+                    visited_files.insert(file_id);
+                }
+            }
+        }
     }
 
     println!();
@@ -41,34 +66,5 @@ pub fn diagnostics(path: &Path, load_output_dirs: bool) -> Result<()> {
         Err(anyhow!("diagnostic error detected"))
     } else {
         Ok(())
-    }
-}
-
-fn check_module(
-    module: Module,
-    db: &(impl HirDatabase + SourceDatabaseExt),
-    visited_modules: &mut HashSet<Module>,
-    members: &HashSet<SourceRootId>,
-    analysis: &Analysis,
-    found_error: &mut bool,
-) {
-    let file_id = module.definition_source(db).file_id.original_file(db);
-    if !visited_modules.contains(&module) {
-        if members.contains(&db.file_source_root(file_id)) {
-            println!("processing: {}", db.file_relative_path(file_id));
-            for diagnostic in analysis.diagnostics(file_id).unwrap() {
-                if matches!(diagnostic.severity, Severity::Error) {
-                    *found_error = true;
-                }
-
-                println!("{:?}", diagnostic);
-            }
-        }
-
-        visited_modules.insert(module);
-
-        for child_module in module.children(db) {
-            check_module(child_module, db, visited_modules, members, analysis, found_error);
-        }
     }
 }


### PR DESCRIPTION
This PR adds a `diagnostics` subcommand to the rust-analyzer CLI. The intent is to detect all diagnostics on a workspace. It returns a non-zero status code if any error diagnostics are detected. Ideally I'd like to run this in CI against the rust analyzer project as a guard against false positives.

```
$ cargo run --release --bin rust-analyzer -- diagnostics .
```

Questions for reviewers:

1. Is this the proper way to get all diagnostics for a workspace? It seems there are at least a few ways this can be done, and I'm not sure if this is the most appropriate mechanism to do this.
2. It currently prints out the relative file path as it is collecting diagnostics, but it doesn't print the crate name. Since the file name is relative to the crate there can be repeated names, so it would be nice to print some identifier for the crate as well, but it wasn't clear to me how best to accomplish this. 