### PR TITLE
Add multi project support vscode

### DIFF
--- a/crates/rust-analyzer/src/bin/args.rs
+++ b/crates/rust-analyzer/src/bin/args.rs
@@ -11,6 +11,7 @@ use std::{fmt::Write, path::PathBuf};
 
 pub(crate) struct Args {
     pub(crate) verbosity: Verbosity,
+    pub(crate) use_cwd: bool,
     pub(crate) command: Command,
 }
 
@@ -43,9 +44,15 @@ impl Args {
     pub(crate) fn parse() -> Result<Result<Args, HelpPrinted>> {
         let mut matches = Arguments::from_env();
 
+        let use_cwd = matches.contains("--use-cwd");
+
         if matches.contains("--version") {
             matches.finish().or_else(handle_extra_flags)?;
-            return Ok(Ok(Args { verbosity: Verbosity::Normal, command: Command::Version }));
+            return Ok(Ok(Args {
+                verbosity: Verbosity::Normal,
+                use_cwd,
+                command: Command::Version,
+            }));
         }
 
         let verbosity = match (
@@ -65,7 +72,7 @@ impl Args {
             Some(it) => it,
             None => {
                 matches.finish().or_else(handle_extra_flags)?;
-                return Ok(Ok(Args { verbosity, command: Command::RunServer }));
+                return Ok(Ok(Args { verbosity, use_cwd, command: Command::RunServer }));
             }
         };
         let command = match subcommand.as_str() {
@@ -230,7 +237,7 @@ SUBCOMMANDS:
                 return Ok(Err(HelpPrinted));
             }
         };
-        Ok(Ok(Args { verbosity, command }))
+        Ok(Ok(Args { verbosity, use_cwd, command }))
     }
 }
 

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -12,7 +12,7 @@ export async function createClient(serverPath: string, cwd: vscode.WorkspaceFold
     const run: lc.Executable = {
         command: serverPath,
         args: ["--use-cwd"],
-        options: { cwd: cwd.uri.fsPath  },
+        options: { cwd: cwd.uri.fsPath },
     };
     const serverOptions: lc.ServerOptions = {
         run,

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -69,7 +69,7 @@ export class Ctx {
     }
 
     dispose() {
-        for (let d of this.subscriptions) {
+        for (const d of this.subscriptions) {
             d.dispose();
         }
     }

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -4,6 +4,8 @@ import * as lc from 'vscode-languageclient';
 import { Config } from './config';
 import { createClient } from './client';
 import { isRustEditor, RustEditor } from './util';
+import { StatusDisplay } from './status_display';
+import { WorkDoneProgress } from 'vscode-languageclient';
 
 export class Ctx {
     private constructor(
@@ -12,6 +14,7 @@ export class Ctx {
         readonly client: lc.LanguageClient,
         readonly serverPath: string,
         readonly subscriptions: Disposable[],
+        private readonly status: StatusDisplay,
     ) {
 
     }
@@ -20,12 +23,24 @@ export class Ctx {
         config: Config,
         extCtx: vscode.ExtensionContext,
         serverPath: string,
-        cwd: string,
+        cwd: vscode.WorkspaceFolder,
     ): Promise<Ctx> {
         const client = await createClient(serverPath, cwd);
-        const res = new Ctx(config, extCtx, client, serverPath, []);
+
+        const statusDisplay = new StatusDisplay(config.checkOnSave.command);
+        const res = new Ctx(config, extCtx, client, serverPath, [], statusDisplay);
+
         res.pushCleanup(client.start());
         await client.onReady();
+
+        res.pushCleanup(res.status);
+        if (client != null) {
+            res.pushCleanup(client.onProgress(
+                WorkDoneProgress.type,
+                'rustAnalyzer/cargoWatcher',
+                params => res.status.handleProgressNotification(params)
+            ));
+        }
         return res;
     }
 
@@ -43,6 +58,14 @@ export class Ctx {
 
     get globalState(): vscode.Memento {
         return this.extCtx.globalState;
+    }
+
+    show() {
+        this.status.statusBarItem.show();
+    }
+
+    hide() {
+        this.status.statusBarItem.hide();
     }
 
     dispose() {

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -17,6 +17,23 @@ import { activateTaskProvider } from './tasks';
 let ctx: Ctx | undefined;
 const ctxes: Map<string, Ctx> = new Map();
 
+
+function registerCtxCommand(name: string, factory: (ctx: Ctx) =>  Cmd, fallback: Cmd | undefined, context: vscode.ExtensionContext) {
+    const fullName = `rust-analyzer.${name}`;
+
+    async function wrapped_cmd(...args: any[]): Promise<unknown> {
+        if (ctx) {
+            let cmd = factory(ctx);
+            return await cmd(args);
+        } else if (fallback) {
+            return await fallback(args);
+        }
+        return;
+    }
+
+    const d = vscode.commands.registerCommand(fullName, wrapped_cmd);
+    context.subscriptions.push(d);
+}
 export async function activate(context: vscode.ExtensionContext) {
     // Register a "dumb" onEnter command for the case where server fails to
 

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -155,7 +155,10 @@ export async function activate(context: vscode.ExtensionContext) {
 }
 
 export async function deactivate() {
-    await ctx?.client.stop();
+    for (let ctx of ctxes.values()) {
+        await ctx.dispose();
+    }
+    ctxes.clear();
     ctx = undefined;
 }
 

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -64,6 +64,8 @@ async function whenOpeningTextDocument(doc: vscode.TextDocument, context: vscode
 
 }
 
+async function activate_new(workspaceFolder: vscode.WorkspaceFolder, context: vscode.ExtensionContext): Promise<Ctx> {
+// Register a "dumb" onEnter command for the case where server fails to
     // start.
     //
     // FIXME: refactor command registration code such that commands are
@@ -83,7 +85,15 @@ async function whenOpeningTextDocument(doc: vscode.TextDocument, context: vscode
     const serverPath = await bootstrap(config, state);
 
 
+    let ctx = await Ctx.create(config, context, serverPath, workspaceFolder);
 
+    context.subscriptions.push(activateTaskProvider(workspaceFolder));
+
+
+    activateInlayHints(ctx);
+
+    return ctx;
+}
 
 export async function activate(context: vscode.ExtensionContext) {
 

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -5,10 +5,9 @@ import { promises as fs } from "fs";
 
 import * as commands from './commands';
 import { activateInlayHints } from './inlay_hints';
-import { activateStatusDisplay } from './status_display';
-import { Ctx } from './ctx';
+import { Ctx,Cmd } from './ctx';
 import { Config, NIGHTLY_TAG } from './config';
-import { log, assert } from './util';
+import { log, assert, isRustDocument, nearestParentWithCargoToml, createWorkspaceWithNewLocation } from './util';
 import { PersistentState } from './persistent_state';
 import { fetchRelease, download } from './net';
 import { spawnSync } from 'child_process';
@@ -51,6 +50,7 @@ async function whenOpeningTextDocument(doc: vscode.TextDocument, context: vscode
         return;
     }
 
+    ctx?.hide();
 
     if (ctxes.has(cargoRoot.path)) {
         ctx = ctxes.get(cargoRoot.path);
@@ -61,6 +61,7 @@ async function whenOpeningTextDocument(doc: vscode.TextDocument, context: vscode
         ctxes.set(cargoRoot.path, newCtx);
         ctx = newCtx;
     }
+    ctx?.show();
 
 }
 

--- a/editors/code/src/status_display.ts
+++ b/editors/code/src/status_display.ts
@@ -1,29 +1,16 @@
 import * as vscode from 'vscode';
 
-import { WorkDoneProgress, WorkDoneProgressBegin, WorkDoneProgressReport, WorkDoneProgressEnd, Disposable } from 'vscode-languageclient';
-
-import { Ctx } from './ctx';
+import { WorkDoneProgressBegin, WorkDoneProgressReport, WorkDoneProgressEnd, Disposable } from 'vscode-languageclient';
 
 const spinnerFrames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 
-export function activateStatusDisplay(ctx: Ctx) {
-    const statusDisplay = new StatusDisplay(ctx.config.checkOnSave.command);
-    ctx.pushCleanup(statusDisplay);
-    const client = ctx.client;
-    if (client != null) {
-        ctx.pushCleanup(client.onProgress(
-            WorkDoneProgress.type,
-            'rustAnalyzer/cargoWatcher',
-            params => statusDisplay.handleProgressNotification(params)
-        ));
-    }
-}
 
-class StatusDisplay implements Disposable {
+
+export class StatusDisplay implements Disposable {
     packageName?: string;
 
     private i: number = 0;
-    private statusBarItem: vscode.StatusBarItem;
+    public statusBarItem: vscode.StatusBarItem;
     private command: string;
     private timer?: NodeJS.Timeout;
 
@@ -33,7 +20,7 @@ class StatusDisplay implements Disposable {
             10,
         );
         this.command = command;
-        this.statusBarItem.hide();
+        this.statusBarItem.show();
     }
 
     show() {

--- a/editors/code/src/tasks.ts
+++ b/editors/code/src/tasks.ts
@@ -42,7 +42,7 @@ function getStandardCargoTasks(target: vscode.WorkspaceFolder): vscode.Task[] {
                 `cargo ${command}`,
                 'rust',
                 // What to do when this command is executed.
-                new vscode.ShellExecution('cargo', [command]),
+                new vscode.ShellExecution('cargo', [command], { cwd: target.uri.fsPath } ),
                 // Problem matchers.
                 ['$rustc'],
             );

--- a/editors/code/src/tasks.ts
+++ b/editors/code/src/tasks.ts
@@ -42,7 +42,7 @@ function getStandardCargoTasks(target: vscode.WorkspaceFolder): vscode.Task[] {
                 `cargo ${command}`,
                 'rust',
                 // What to do when this command is executed.
-                new vscode.ShellExecution('cargo', [command], { cwd: target.uri.fsPath } ),
+                new vscode.ShellExecution('cargo', [command], { cwd: target.uri.fsPath }),
                 // Problem matchers.
                 ['$rustc'],
             );

--- a/editors/code/src/util.ts
+++ b/editors/code/src/util.ts
@@ -92,45 +92,45 @@ export function createWorkspaceWithNewLocation(workspace: vscode.WorkspaceFolder
         ...workspace,
         name: path.basename(newLoc.fsPath),
         uri: newLoc,
-      };
+    };
 }
 
 // searches up the folder structure until it finds a Cargo.toml
 export async function nearestParentWithCargoToml(
     workspaceRootUri: vscode.Uri,
     fileLoc: vscode.Uri,
-  ): Promise<vscode.Uri | null> {
-    const file_exists: (path: fs.PathLike) => Promise<boolean> = util.promisify(fs.exists);
+): Promise<vscode.Uri | null> {
+    const fileExists: (path: fs.PathLike) => Promise<boolean> = util.promisify(fs.exists);
     // check that the workspace folder already contains the "Cargo.toml"
     const workspaceRoot = workspaceRootUri.fsPath;
     const rootManifest = path.join(workspaceRoot, 'Cargo.toml');
-    if (await file_exists(rootManifest)) {
-      return workspaceRootUri;
+    if (await fileExists(rootManifest)) {
+        return workspaceRootUri;
     }
 
     // algorithm that will strip one folder at a time and check if that folder contains "Cargo.toml"
     let current = fileLoc.fsPath;
     while (true) {
-      const old = current;
-      current = path.dirname(current);
+        const old = current;
+        current = path.dirname(current);
 
-      // break in case there is a bug that could result in a busy loop
-      if (old === current) {
-        break;
-      }
+        // break in case there is a bug that could result in a busy loop
+        if (old === current) {
+            break;
+        }
 
-      // break in case the strip folder reached the workspace root
-      if (workspaceRoot === current) {
-        break;
-      }
+        // break in case the strip folder reached the workspace root
+        if (workspaceRoot === current) {
+            break;
+        }
 
-      // check if "Cargo.toml" is present in the parent folder
-      const cargoPath = path.join(current, 'Cargo.toml');
-      if (await file_exists(cargoPath)) {
-        // ghetto change the uri on Workspace folder to make vscode think it's located elsewhere
-        return vscode.Uri.file(current);
-      }
+        // check if "Cargo.toml" is present in the parent folder
+        const cargoPath = path.join(current, 'Cargo.toml');
+        if (await fileExists(cargoPath)) {
+            // ghetto change the uri on Workspace folder to make vscode think it's located elsewhere
+            return vscode.Uri.file(current);
+        }
     }
 
     return null;
-  }
+}


### PR DESCRIPTION
This pr adds multi project support for vscode. 

Some time ago I added this for the RLS vscode plugin: https://github.com/rust-lang/rls-vscode/pull/638
And since I had some time I decided to implement it for rust-analyzer aswell.

The design is simple (can be expanded upon):

* every time you open a document it will locate the `Cargo.toml` file, and create an RA-server, if another document shares the same `Cargo.toml` then it will also share that RA-server, otherwise a new will be spawned.
* Commands are shared but it will depend on the active `Ctx`.
* The status display will also be created for each Ctx and will just be hidden/shown depending on which Ctx is in focus.
* Tasks (Cargo build etc..) will run depending on the file you have open.

Some caveats / things that could be done better or different:

* I added a CLI flag to RA-server to force it to use cwd
* If a project contains other projects then there might be double reporting (needs more advanced document filter)
* the current multi workspace impl is effectively not active anymore (for vscode)
* I don't know if it would be favorable to run just 1 RA-server, but in that case there needs support for dynamic loading / unloading of workspaces.
* This a lot, so I expect there to be some things I have overlooked, when I did it for the RLS I put this behind a feature flag, that said I've learned a lot from all the little things that came up on that project. But I am sure there are some things I've overlooked. And the design for this was much deeper given how much more complex RA is, so adding a 1000+ conditions on whether this is active or not is probably a bad Idea.

Also I haven't been part of any design discussions so if this had already been decided against for other reasons that's fair :) 





