### PR TITLE
Add multi project support vscode with single server

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -360,6 +360,11 @@
                     "default": true,
                     "description": "Whether to ask for permission before downloading any files from the Internet"
                 },
+                "rust-analyzer.server.autoRestartOnNew": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "automatically restarts rust-analyzer server when a new project is discovered"
+                },
                 "rust-analyzer.serverPath": {
                     "type": [
                         "null",

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -11,6 +11,7 @@ export async function createClient(serverPath: string, cwd: string): Promise<lc.
 
     const run: lc.Executable = {
         command: serverPath,
+        args: ["--roots"].concat(projectFolders),
         options: { cwd },
     };
     const serverOptions: lc.ServerOptions = {

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 import { CallHierarchyFeature } from 'vscode-languageclient/lib/callHierarchy.proposed';
 import { SemanticTokensFeature, DocumentSemanticsTokensSignature } from 'vscode-languageclient/lib/semanticTokens.proposed';
 
-export async function createClient(serverPath: string, cwd: string): Promise<lc.LanguageClient> {
+export async function createClient(serverPath: string, cwd: string, projectFolders: string[]): Promise<lc.LanguageClient> {
     // '.' Is the fallback if no folder is open
     // TODO?: Workspace folders support Uri's (eg: file://test.txt).
     // It might be a good idea to test if the uri points to a file.

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -91,6 +91,8 @@ export class Config {
     get askBeforeDownload() { return this.get<boolean>("updates.askBeforeDownload"); }
     get traceExtension() { return this.get<boolean>("trace.extension"); }
 
+    get autoRestartOnNew() { return this.get<boolean>("server.autoRestartOnNew"); }
+
 
     get inlayHints() {
         return {

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -20,8 +20,9 @@ export class Ctx {
         extCtx: vscode.ExtensionContext,
         serverPath: string,
         cwd: string,
+        projectFolders: string[],
     ): Promise<Ctx> {
-        const client = await createClient(serverPath, cwd);
+        const client = await createClient(serverPath, cwd, projectFolders);
         const res = new Ctx(config, extCtx, client, serverPath);
         res.pushCleanup(client.start());
         await client.onReady();

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -143,7 +143,9 @@ export async function startRA(context: vscode.ExtensionContext) {
     ctx.registerCommand('applySourceChange', commands.applySourceChange);
     ctx.registerCommand('selectAndApplySourceChange', commands.selectAndApplySourceChange);
 
-    ctx.pushCleanup(activateTaskProvider(workspaceFolder));
+    for (const project of foundProjects) {
+        ctx.pushCleanup(activateTaskProvider(createWorkspaceWithNewLocation(workspaceFolder, vscode.Uri.file(project))));
+    }
 
     activateStatusDisplay(ctx);
 

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -15,11 +15,11 @@ import { spawnSync } from 'child_process';
 import { activateTaskProvider } from './tasks';
 
 let ctx: Ctx | undefined;
-let foundProjects: Set<string> = new Set();
+const foundProjects: Set<string> = new Set();
 let config: Config | undefined = undefined;
 
-async function locate_rust_projects(root: vscode.Uri) {
-    let cargoRoots = await Promise.all(vscode.workspace.textDocuments.map((doc) => nearestParentWithCargoToml(root, doc.uri)));
+async function locateRustProjects(root: vscode.Uri) {
+    const cargoRoots = await Promise.all(vscode.workspace.textDocuments.map((doc) => nearestParentWithCargoToml(root, doc.uri)));
     for (const cargoRoot of cargoRoots) {
         if (cargoRoot != null) {
             foundProjects.add(cargoRoot.fsPath);
@@ -33,7 +33,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
     if (workspaceFolder !== undefined) {
-        await locate_rust_projects(workspaceFolder.uri)
+        await locateRustProjects(workspaceFolder.uri);
     }
 
     vscode.workspace.onDidOpenTextDocument(async (doc) => {

--- a/editors/code/src/tasks.ts
+++ b/editors/code/src/tasks.ts
@@ -42,7 +42,7 @@ function getStandardCargoTasks(target: vscode.WorkspaceFolder): vscode.Task[] {
                 `cargo ${command}`,
                 'rust',
                 // What to do when this command is executed.
-                new vscode.ShellExecution('cargo', [command]),
+                new vscode.ShellExecution('cargo', [command], { cwd: target.uri.fsPath}),
                 // Problem matchers.
                 ['$rustc'],
             );

--- a/editors/code/src/tasks.ts
+++ b/editors/code/src/tasks.ts
@@ -42,7 +42,7 @@ function getStandardCargoTasks(target: vscode.WorkspaceFolder): vscode.Task[] {
                 `cargo ${command}`,
                 'rust',
                 // What to do when this command is executed.
-                new vscode.ShellExecution('cargo', [command], { cwd: target.uri.fsPath}),
+                new vscode.ShellExecution('cargo', [command], { cwd: target.uri.fsPath }),
                 // Problem matchers.
                 ['$rustc'],
             );

--- a/editors/code/src/util.ts
+++ b/editors/code/src/util.ts
@@ -103,13 +103,11 @@ export async function nearestParentWithCargoToml(
     const file_exists: (path: fs.PathLike) => Promise<boolean> = util.promisify(fs.exists);
     // check that the workspace folder already contains the "Cargo.toml"
     const workspaceRoot = workspaceRootUri.fsPath;
-    const rootManifest = path.join(workspaceRoot, 'Cargo.toml');
-    if (await file_exists(rootManifest)) {
-      return workspaceRootUri;
-    }
-
     // algorithm that will strip one folder at a time and check if that folder contains "Cargo.toml"
     let current = fileLoc.fsPath;
+    if (fileLoc.fsPath.substring(0,workspaceRoot.length) !== workspaceRoot) {
+        return null;
+    }
     while (true) {
       const old = current;
       current = path.dirname(current);

--- a/editors/code/src/util.ts
+++ b/editors/code/src/util.ts
@@ -92,43 +92,43 @@ export function createWorkspaceWithNewLocation(workspace: vscode.WorkspaceFolder
         ...workspace,
         name: path.basename(newLoc.fsPath),
         uri: newLoc,
-      };
+    };
 }
 
 // searches up the folder structure until it finds a Cargo.toml
 export async function nearestParentWithCargoToml(
     workspaceRootUri: vscode.Uri,
     fileLoc: vscode.Uri,
-  ): Promise<vscode.Uri | null> {
-    const file_exists: (path: fs.PathLike) => Promise<boolean> = util.promisify(fs.exists);
+): Promise<vscode.Uri | null> {
+    const fileExists: (path: fs.PathLike) => Promise<boolean> = util.promisify(fs.exists);
     // check that the workspace folder already contains the "Cargo.toml"
     const workspaceRoot = workspaceRootUri.fsPath;
     // algorithm that will strip one folder at a time and check if that folder contains "Cargo.toml"
     let current = fileLoc.fsPath;
-    if (fileLoc.fsPath.substring(0,workspaceRoot.length) !== workspaceRoot) {
+    if (fileLoc.fsPath.substring(0, workspaceRoot.length) !== workspaceRoot) {
         return null;
     }
     while (true) {
-      const old = current;
-      current = path.dirname(current);
+        const old = current;
+        current = path.dirname(current);
 
-      // break in case there is a bug that could result in a busy loop
-      if (old === current) {
-        break;
-      }
+        // break in case there is a bug that could result in a busy loop
+        if (old === current) {
+            break;
+        }
 
-      // break in case the strip folder reached the workspace root
-      if (workspaceRoot === current) {
-        break;
-      }
+        // break in case the strip folder reached the workspace root
+        if (workspaceRoot === current) {
+            break;
+        }
 
-      // check if "Cargo.toml" is present in the parent folder
-      const cargoPath = path.join(current, 'Cargo.toml');
-      if (await file_exists(cargoPath)) {
-        // ghetto change the uri on Workspace folder to make vscode think it's located elsewhere
-        return vscode.Uri.file(current);
-      }
+        // check if "Cargo.toml" is present in the parent folder
+        const cargoPath = path.join(current, 'Cargo.toml');
+        if (await fileExists(cargoPath)) {
+            // ghetto change the uri on Workspace folder to make vscode think it's located elsewhere
+            return vscode.Uri.file(current);
+        }
     }
 
     return null;
-  }
+}


### PR DESCRIPTION
Redesign based on discussion from: <https://github.com/rust-analyzer/rust-analyzer/pull/3972>

## Redesigned multi project support entails:

* Check all open .rs files for a `Cargo.toml` and start Rust-Analyzer with all their roots at activation time
* Attach hooks on `onDidOpenTextDocument` and inform user to restart if a new Rust Project have been found (with option to auto restart Rust-Analyzer).
* All the hassle with running multiple Language Servers is gone (thank god)

## Some caveats

* I couldn't find an option in VSCode to specify the root folders, so I had to add a CLI flag for Rust-Analyzer to override it, it could also be an ENV for a less intrusive design. (That said if someone finds the proper way `git revert 53ed3831dd296edd660aeea7d6508e53f263c650` should get rid of this change)
* "Check all open .rs files" only works on files the user have opened in that session, so starting a new VScode with 100s of files will only activate Rust-Analyzer for the file that is active. (see: https://github.com/microsoft/vscode/issues/15178)
* This rust analyzer repo have a `Cargo.toml` in the root, with this implementation that would be ignored since every project in `crates/*` have their own `Cargo.toml` which would take priority, I did try adding both the projects `Cargo.toml` and the root's `Cargo.toml`. But that seems to make Rust-Analyzer generate double outputs on highlight.
* For each newly found project to be added to the rust analyzer it will have to restart, making the load time O(n^2). That said you can always just open one file for each project and restart Rust-Analyzer once.

## Future work

* Finish Dynamic Project Load #3715 
* One thing I found annoying is the lack of feedback when Rust-Analyzer is loading, this becomes even more of an issue when it loads more.



