### PR TITLE
Switch to Chalk recursive solver

### DIFF
--- a/crates/ra_hir_ty/src/infer/unify.rs
+++ b/crates/ra_hir_ty/src/infer/unify.rs
@@ -32,6 +32,7 @@ where
     var_stack: Vec<TypeVarId>,
 }
 
+#[derive(Debug)]
 pub(super) struct Canonicalized<T> {
     pub value: Canonical<T>,
     free_vars: Vec<InferTy>,

--- a/crates/ra_hir_ty/src/traits.rs
+++ b/crates/ra_hir_ty/src/traits.rs
@@ -16,10 +16,12 @@ use self::chalk::{from_chalk, Interner, ToChalk};
 pub(crate) mod chalk;
 mod builtin;
 
-/// This controls the maximum size of types Chalk considers. If we set this too
-/// high, we can run into slow edge cases; if we set it too low, Chalk won't
-/// find some solutions.
-const CHALK_SOLVER_MAX_SIZE: usize = 10;
+// This controls the maximum size of types Chalk considers. If we set this too
+// high, we can run into slow edge cases; if we set it too low, Chalk won't
+// find some solutions.
+// FIXME this is currently hardcoded in the recursive solver
+// const CHALK_SOLVER_MAX_SIZE: usize = 10;
+
 /// This controls how much 'time' we give the Chalk solver before giving up.
 const CHALK_SOLVER_FUEL: i32 = 100;
 
@@ -30,8 +32,7 @@ struct ChalkContext<'a> {
 }
 
 fn create_chalk_solver() -> chalk_solve::Solver<Interner> {
-    let solver_choice =
-        chalk_solve::SolverChoice::SLG { max_size: CHALK_SOLVER_MAX_SIZE, expected_answers: None };
+    let solver_choice = chalk_solve::SolverChoice::recursive();
     solver_choice.into_solver()
 }
 

--- a/crates/ra_hir_ty/src/traits/chalk.rs
+++ b/crates/ra_hir_ty/src/traits/chalk.rs
@@ -511,13 +511,13 @@ impl ToChalk for ProjectionTy {
 }
 
 impl ToChalk for super::ProjectionPredicate {
-    type Chalk = chalk_ir::Normalize<Interner>;
+    type Chalk = chalk_ir::AliasEq<Interner>;
 
-    fn to_chalk(self, db: &dyn HirDatabase) -> chalk_ir::Normalize<Interner> {
-        chalk_ir::Normalize { alias: self.projection_ty.to_chalk(db), ty: self.ty.to_chalk(db) }
+    fn to_chalk(self, db: &dyn HirDatabase) -> chalk_ir::AliasEq<Interner> {
+        chalk_ir::AliasEq { alias: self.projection_ty.to_chalk(db), ty: self.ty.to_chalk(db) }
     }
 
-    fn from_chalk(_db: &dyn HirDatabase, _normalize: chalk_ir::Normalize<Interner>) -> Self {
+    fn from_chalk(_db: &dyn HirDatabase, _normalize: chalk_ir::AliasEq<Interner>) -> Self {
         unimplemented!()
     }
 }


### PR DESCRIPTION
Before:
```
Expressions of unknown type: 5526 (3%)
Expressions of partially unknown type: 5415 (3%)
```
After:
```
Expressions of unknown type: 4600 (2%)
Expressions of partially unknown type: 4645 (2%)
```

On the other hand,
```
'./target/release/rust-analyzer analysis-stats -q . # old solver' ran
    1.24 ± 0.04 times faster than 'rust-analyzer analysis-stats -q . # new solver'
```
I think part of this just comes from the fact that we're inferring more types now; but apart from that, it should be possible to improve the performance a bunch, and I'll make looking into that a priority.