### PR TITLE
Fix path for proc-macro in nightly / stable release

### DIFF
--- a/crates/rust-analyzer/src/cli/load_cargo.rs
+++ b/crates/rust-analyzer/src/cli/load_cargo.rs
@@ -73,9 +73,7 @@ pub(crate) fn load_cargo(
     let proc_macro_client = if !with_proc_macro {
         ProcMacroClient::dummy()
     } else {
-        let mut path = std::env::current_exe()?;
-        path.pop();
-        path.push("rust-analyzer");
+        let path = std::env::current_exe()?;
         ProcMacroClient::extern_process(&path, &["proc-macro"]).unwrap()
     };
     let host = load(&source_roots, ws, &mut vfs, receiver, extern_dirs, &proc_macro_client);

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -134,9 +134,7 @@ impl Config {
 
         match get::<bool>(value, "/procMacro/enabled") {
             Some(true) => {
-                if let Ok(mut path) = std::env::current_exe() {
-                    path.pop();
-                    path.push("rust-analyzer");
+                if let Ok(path) = std::env::current_exe() {
                     self.proc_macro_srv = Some((path.to_string_lossy().to_string(), vec!["proc-macro".to_string()]));
                 }
             }


### PR DESCRIPTION
I messed up that I forget we use different executable names for nightly / stable release, I changed to use the current executable name instead.