### PR TITLE
Fix incorrect order of syntax highlight ranges

### DIFF
--- a/crates/ra_ide/src/syntax_highlighting.rs
+++ b/crates/ra_ide/src/syntax_highlighting.rs
@@ -174,7 +174,8 @@ pub(crate) fn highlight(
     }
 
     assert_eq!(res.len(), 1, "after DFS traversal, the stack should only contain a single element");
-    let res = res.pop().unwrap();
+    let mut res = res.pop().unwrap();
+    res.sort_by_key(|range| range.range.start());
     // Check that ranges are sorted and disjoint
     assert!(res
         .iter()

--- a/crates/ra_ide/src/syntax_highlighting/tests.rs
+++ b/crates/ra_ide/src/syntax_highlighting/tests.rs
@@ -156,3 +156,15 @@ fn main() {
     fs::write(dst_file, &actual_html).unwrap();
     assert_eq_text!(expected_html, actual_html);
 }
+
+#[test]
+fn ranges_sorted() {
+    let (analysis, file_id) = single_file(
+        r#"
+#[foo(bar = "bar")]
+macro_rules! test {}
+}"#
+        .trim(),
+    );
+    let _ = analysis.highlight(file_id).unwrap();
+}


### PR DESCRIPTION
A fix for the bug #4013 which is caused by a difference between tree traversal order and text representation order. In the case of #4013, the attributes of a macro were visited after the macro definition which caused the syntax highlight ranges to be in wrong order. The fix is to sort the ranges before returning. 