### PR TITLE
Use hir in fill match arms build pat

### DIFF
--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -54,14 +54,14 @@ pub use crate::{
         Adt, AsAssocItem, AssocItem, AssocItemContainer, AttrDef, Const, Crate, CrateDependency,
         DefWithBody, Docs, Enum, EnumVariant, FieldSource, Function, GenericDef, HasAttrs,
         HasVisibility, ImplDef, Local, MacroDef, Module, ModuleDef, ScopeDef, Static, Struct,
-        StructField, Trait, Type, TypeAlias, TypeParam, Union, VariantDef, Visibility,
+        StructField, StructKind, Trait, Type, TypeAlias, TypeParam, Union, VariantDef, Visibility,
     },
     has_source::HasSource,
     semantics::{original_range, PathResolution, Semantics, SemanticsScope},
 };
 
 pub use hir_def::{
-    adt::StructKind,
+    adt::VariantData,
     body::scope::ExprScopes,
     builtin_type::BuiltinType,
     docs::Documentation,

--- a/crates/ra_ide/src/completion/presentation.rs
+++ b/crates/ra_ide/src/completion/presentation.rs
@@ -273,12 +273,12 @@ impl Completions {
             .map(|field| (field.name(ctx.db), field.signature_ty(ctx.db)));
         let variant_kind = variant.kind(ctx.db);
         let detail = match variant_kind {
-            StructKind::Tuple | StructKind::Unit => detail_types
+            StructKind::Tuple(_) | StructKind::Unit => detail_types
                 .map(|(_, t)| t.display(ctx.db).to_string())
                 .sep_by(", ")
                 .surround_with("(", ")")
                 .to_string(),
-            StructKind::Record => detail_types
+            StructKind::Record(_) => detail_types
                 .map(|(n, t)| format!("{}: {}", n, t.display(ctx.db).to_string()))
                 .sep_by(", ")
                 .surround_with("{ ", " }")
@@ -291,7 +291,7 @@ impl Completions {
                 .set_deprecated(is_deprecated)
                 .detail(detail);
 
-        if variant_kind == StructKind::Tuple {
+        if matches!(variant_kind, StructKind::Tuple(_)) {
             let params = Params::Anonymous(variant.fields(ctx.db).len());
             res = res.add_call_parens(ctx, name, params)
         }

--- a/crates/ra_syntax/src/ast/make.rs
+++ b/crates/ra_syntax/src/ast/make.rs
@@ -4,6 +4,7 @@ use itertools::Itertools;
 use stdx::format_to;
 
 use crate::{ast, AstNode, SourceFile, SyntaxKind, SyntaxNode, SyntaxToken};
+use std::fmt;
 
 pub fn name(text: &str) -> ast::Name {
     ast_from_text(&format!("mod {};", text))
@@ -142,12 +143,8 @@ pub fn condition(expr: ast::Expr, pattern: Option<ast::Pat>) -> ast::Condition {
     }
 }
 
-pub fn bind_pat(name: ast::Name) -> ast::BindPat {
-    return from_text(name.text());
-
-    fn from_text(text: &str) -> ast::BindPat {
-        ast_from_text(&format!("fn f({}: ())", text))
-    }
+pub fn bind_pat(name: impl fmt::Display) -> ast::BindPat {
+    ast_from_text(&format!("fn f({}: ())", name))
 }
 
 pub fn placeholder_pat() -> ast::PlaceholderPat {


### PR DESCRIPTION
This fixes a `fixme` in the fill match arms assist about using the HIR in the pattern building process. 