### PR TITLE
More detailed Sublime Text install instructions

### DIFF
--- a/docs/user/readme.adoc
+++ b/docs/user/readme.adoc
@@ -192,7 +192,7 @@ You also need the `LSP` package. To install it:
    * Type `Install Package Control`, press enter
 2. In the command palette, run `Package control: Install package`, and in the list that pops up, type `LSP` and press enter.
 
-Finally, with your Rust project open, in the command palette, run `LSP: Enable Language Server In Project` or `LSP: Enable Language Server Globally`, then select `rust-analyzer` in the list that pops up enable to enable the rust-analyzer LSP. The latter means that rust-analzyer is enabled by default in Rust projects.
+Finally, with your Rust project open, in the command palette, run `LSP: Enable Language Server In Project` or `LSP: Enable Language Server Globally`, then select `rust-analyzer` in the list that pops up to enable the rust-analyzer LSP. The latter means that rust-analzyer is enabled by default in Rust projects.
 
 If it worked, you should see "rust-analzyer, Line X, Column Y" on the left side of the bottom bar, and after waiting a bit, functionality like tooltips on hovering over variables should become available.
 

--- a/docs/user/readme.adoc
+++ b/docs/user/readme.adoc
@@ -196,7 +196,7 @@ Finally, with your Rust project open, in the command palette, run `LSP: Enable L
 
 If it worked, you should see "rust-analzyer, Line X, Column Y" on the left side of the bottom bar, and after waiting a bit, functionality like tooltips on hovering over variables should become available.
 
-If you get an error saying `No such file or directory: 'rust-analyzer'` even though the binary is on your `$PATH`, there is likely a problem where Sublime doesn't see the same `$PATH` as your shell, see https://github.com/rust-analyzer/rust-analyzer/issues/1811[this issue]. On Unix, if you installed Rust with `rustup`, moving the binary to `$HOME/.cargo/bin` should help.
+If you get an error saying `No such file or directory: 'rust-analyzer'` even though the binary is on your `$PATH`, the likely explanation is that Sublime doesn't see the same `$PATH` as the shell, see https://github.com/rust-analyzer/rust-analyzer/issues/1811[this issue]. On Unix, running the editor from a shell or changing the `.desktop` file to set the environment, should help.
 
 == Usage
 

--- a/docs/user/readme.adoc
+++ b/docs/user/readme.adoc
@@ -14,9 +14,9 @@
 // Master copy of this document lives in the https://github.com/rust-analyzer/rust-analyzer repository
 
 At its core, rust-analyzer is a *library* for semantic analysis of Rust code as it changes over time.
-This manual focuses on a specific usage of the library -- the implementation of
-https://microsoft.github.io/language-server-protocol/[Language Server Protocol].
-LSP allows various code editors, like VS Code, Emacs or Vim, to implement semantic features like completion or goto definition by talking to an external language server process.
+This manual focuses on a specific usage of the library -- running it as part of a server that implements the
+https://microsoft.github.io/language-server-protocol/[Language Server Protocol] (LSP).
+The LSP allows various code editors, like VS Code, Emacs or Vim, to implement semantic features like completion or goto definition by talking to an external language server process.
 
 To improve this document, send a pull request against
 https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/user/readme.adoc[this file].
@@ -26,7 +26,7 @@ https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/user/readme.adoc
 In theory, one should be able to just install the server binary and have it automatically work with any editor.
 We are not there yet, so some editor specific setup is required.
 
-Additionally, rust-analyzer needs sources of the standard library.
+Additionally, rust-analyzer needs the sources of the standard library.
 If the source code is not present, rust-analyzer will attempt to install it automatically.
 
 To add the sources manually, run the following command:
@@ -38,7 +38,7 @@ $ rustup component add rust-src
 === VS Code
 
 This is the best supported editor at the moment.
-rust-analyzer plugin for VS Code is maintained
+The rust-analyzer plugin for VS Code is maintained
 https://github.com/rust-analyzer/rust-analyzer/tree/master/editors/code[in tree].
 
 You can install the latest release of the plugin from
@@ -74,7 +74,7 @@ We ship nightly releases for VS Code. To help us out with testing the newest cod
 { "rust-analyzer.updates.channel": "nightly" }
 ----
 
-You will be prompted to install the `nightly` extension version. Just click `Download now` and from that moment you will get automatic updates each 24 hours.
+You will be prompted to install the `nightly` extension version. Just click `Download now` and from that moment you will get automatic updates every 24 hours.
 
 If you don't want to be asked for `Download now` every day when the new nightly version is released add the following to your `settings.json`:
 [source,json]
@@ -110,10 +110,10 @@ Here are some useful self-diagnostic commands:
 
 === Language Server Binary
 
-Other editors generally require `rust-analyzer` binary to be in `$PATH`.
-You can download the pre-built binary from
-https://github.com/rust-analyzer/rust-analyzer/releases[releases]
-page, or you can install it from source using the following command:
+Other editors generally require the `rust-analyzer` binary to be in `$PATH`.
+You can download the pre-built binary from the https://github.com/rust-analyzer/rust-analyzer/releases[releases] page. Typically, you then need to rename the binary for your platform, e.g. `rust-analyzer-mac` if you're on Mac OS, to `rust-analzyer` and make it executable in addition to moving it into a directory in your `$PATH`.
+
+Alternatively, you can install it from source using the following command:
 
 [source,bash]
 ----
@@ -122,7 +122,7 @@ $ cargo xtask install --server
 
 ==== Arch Linux
 
-`rust-analyzer` binary can be installed from AUR (Arch User Repository):
+The `rust-analyzer` binary can be installed from AUR (Arch User Repository):
 
 - https://aur.archlinux.org/packages/rust-analyzer-bin[`rust-analyzer-bin`] (binary from GitHub releases)
 - https://aur.archlinux.org/packages/rust-analyzer[`rust-analyzer`] (built from latest tagged source)
@@ -183,11 +183,20 @@ Once `neovim/nvim-lsp` is installed, use `+lua require'nvim_lsp'.rust_analyzer.s
 
 === Sublime Text 3
 
-Prerequisites:
+Prerequisites: You have installed the <<language-server-binary,`rust-analyzer` binary>>.
 
-`LSP` package.
+You also need the `LSP` package. To install it:
 
-Invoke the command palette (`ctrl+shift+p`) and type LSP enable to locally/globally enable the rust-analyzer LSP (type LSP enable, then choose either locally or globally, then select rust-analyzer)
+1. If you've never installed a Sublime Text package, install Package Control:
+   * Open the command palette (Win/Linux: `ctrl+shift+p`, Mac: `cmd+shift+p`)
+   * Type `Install Package Control`, press enter
+2. In the command palette, run `Package control: Install package`, and in the list that pops up, type `LSP` and press enter.
+
+Finally, with your Rust project open, in the command palette, run `LSP: Enable Language Server In Project` or `LSP: Enable Language Server Globally`, then select `rust-analyzer` in the list that pops up enable to enable the rust-analyzer LSP. The latter means that rust-analzyer is enabled by default in Rust projects.
+
+If it worked, you should see "rust-analzyer, Line X, Column Y" on the left side of the bottom bar, and after waiting a bit, functionality like tooltips on hovering over variables should become available.
+
+If you get an error saying `No such file or directory: 'rust-analyzer'` even though the binary is on your `$PATH`, there is likely a problem where Sublime doesn't see the same `$PATH` as your shell, see https://github.com/rust-analyzer/rust-analyzer/issues/1811[this issue]. On Unix, if you installed Rust with `rustup`, moving the binary to `$HOME/.cargo/bin` should help.
 
 == Usage
 

--- a/docs/user/readme.adoc
+++ b/docs/user/readme.adoc
@@ -196,7 +196,7 @@ Finally, with your Rust project open, in the command palette, run `LSP: Enable L
 
 If it worked, you should see "rust-analzyer, Line X, Column Y" on the left side of the bottom bar, and after waiting a bit, functionality like tooltips on hovering over variables should become available.
 
-If you get an error saying `No such file or directory: 'rust-analyzer'` even though the binary is on your `$PATH`, the likely explanation is that Sublime doesn't see the same `$PATH` as the shell, see https://github.com/rust-analyzer/rust-analyzer/issues/1811[this issue]. On Unix, running the editor from a shell or changing the `.desktop` file to set the environment, should help.
+If you get an error saying `No such file or directory: 'rust-analyzer'` even though the binary is on your `$PATH`, the likely explanation is that Sublime doesn't see the same `$PATH` as the shell, see https://github.com/rust-analyzer/rust-analyzer/issues/1811[this issue]. On Unix, running the editor from a shell or changing the `.desktop` file to set the environment should help.
 
 == Usage
 

--- a/docs/user/readme.adoc
+++ b/docs/user/readme.adoc
@@ -120,6 +120,8 @@ Alternatively, you can install it from source using the following command:
 $ cargo xtask install --server
 ----
 
+If your editor can't find the binary even though the binary is on your `$PATH`, the likely explanation is that it doesn't see the same `$PATH` as the shell, see https://github.com/rust-analyzer/rust-analyzer/issues/1811[this issue]. On Unix, running the editor from a shell or changing the `.desktop` file to set the environment should help.
+
 ==== Arch Linux
 
 The `rust-analyzer` binary can be installed from AUR (Arch User Repository):
@@ -196,7 +198,7 @@ Finally, with your Rust project open, in the command palette, run `LSP: Enable L
 
 If it worked, you should see "rust-analzyer, Line X, Column Y" on the left side of the bottom bar, and after waiting a bit, functionality like tooltips on hovering over variables should become available.
 
-If you get an error saying `No such file or directory: 'rust-analyzer'` even though the binary is on your `$PATH`, the likely explanation is that Sublime doesn't see the same `$PATH` as the shell, see https://github.com/rust-analyzer/rust-analyzer/issues/1811[this issue]. On Unix, running the editor from a shell or changing the `.desktop` file to set the environment should help.
+If you get an error saying `No such file or directory: 'rust-analyzer'`, see the <<language-server-binary,section on installing the language server binary>>.
 
 == Usage
 


### PR DESCRIPTION
* People might typically jump directly to their editor and wonder where the part about installing rust-analyzer is – at least I did. I added a link to the relevant section for ST.
* Make ST instructions more detailed and user friendly (especially beginners), include troubleshooting tips.
* Minor grammar improvements throughout.