### PR TITLE
feat: run ignored tests

### DIFF
--- a/crates/rust-analyzer/src/cargo_target_spec.rs
+++ b/crates/rust-analyzer/src/cargo_target_spec.rs
@@ -23,7 +23,7 @@ impl CargoTargetSpec {
         let mut args = Vec::new();
         let mut extra_args = Vec::new();
         match kind {
-            RunnableKind::Test { test_id } => {
+            RunnableKind::Test { test_id, attr } => {
                 args.push("test".to_string());
                 if let Some(spec) = spec {
                     spec.push_to(&mut args);
@@ -33,6 +33,9 @@ impl CargoTargetSpec {
                     extra_args.push("--exact".to_string());
                 }
                 extra_args.push("--nocapture".to_string());
+                if attr.ignore {
+                    extra_args.push("--ignored".to_string())
+                }
             }
             RunnableKind::TestMod { path } => {
                 args.push("test".to_string());

--- a/crates/rust-analyzer/src/main_loop/handlers.rs
+++ b/crates/rust-analyzer/src/main_loop/handlers.rs
@@ -968,7 +968,7 @@ fn to_lsp_runnable(
     let (args, extra_args) = CargoTargetSpec::runnable_args(spec, &runnable.kind)?;
     let line_index = world.analysis().file_line_index(file_id)?;
     let label = match &runnable.kind {
-        RunnableKind::Test { test_id } => format!("test {}", test_id),
+        RunnableKind::Test { test_id, .. } => format!("test {}", test_id),
         RunnableKind::TestMod { path } => format!("test-mod {}", path),
         RunnableKind::Bench { test_id } => format!("bench {}", test_id),
         RunnableKind::Bin => "run binary".to_string(),


### PR DESCRIPTION
I started making some exercices on https://exercism.io/ and a lot of test have the `#[ignore]` attribute.
The `Run Test|Debug` code lens show up, but running the test results in:

```
running 1 test
test test_one_piece ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 5 filtered out
```

This pull request adds the `--ignored` flag if needed.