### PR TITLE
Panic proc macro srv if read request failed

### DIFF
--- a/crates/ra_proc_macro_srv/src/cli.rs
+++ b/crates/ra_proc_macro_srv/src/cli.rs
@@ -8,8 +8,9 @@ pub fn run() {
     loop {
         let req = match read_request() {
             Err(err) => {
-                eprintln!("Read message error on ra_proc_macro_srv: {}", err);
-                continue;
+                // Panic here, as the stdin pipe may be closed.
+                // Otherwise, client will be restart the service anyway.
+                panic!("Read message error on ra_proc_macro_srv: {}", err);
             }
             Ok(None) => continue,
             Ok(Some(req)) => req,

--- a/crates/ra_proc_macro_srv/src/cli.rs
+++ b/crates/ra_proc_macro_srv/src/cli.rs
@@ -4,16 +4,13 @@ use crate::{expand_task, list_macros};
 use ra_proc_macro::msg::{self, Message};
 use std::io;
 
-pub fn run() {
+pub fn run() -> io::Result<()> {
     loop {
-        let req = match read_request() {
-            Err(err) => {
-                // Panic here, as the stdin pipe may be closed.
-                // Otherwise, client will be restarted the service anyway.
-                panic!("Read message error on ra_proc_macro_srv: {}", err);
-            }
-            Ok(None) => continue,
-            Ok(Some(req)) => req,
+        // bubble up the error for read request,
+        // as the stdin pipe may be closed.
+        let req = match read_request()? {
+            None => continue,
+            Some(req) => req,
         };
 
         let res = match req {

--- a/crates/ra_proc_macro_srv/src/cli.rs
+++ b/crates/ra_proc_macro_srv/src/cli.rs
@@ -5,14 +5,7 @@ use ra_proc_macro::msg::{self, Message};
 use std::io;
 
 pub fn run() -> io::Result<()> {
-    loop {
-        // bubble up the error for read request,
-        // as the stdin pipe may be closed.
-        let req = match read_request()? {
-            None => continue,
-            Some(req) => req,
-        };
-
+    while let Some(req) = read_request()? {
         let res = match req {
             msg::Request::ListMacro(task) => Ok(msg::Response::ListMacro(list_macros(&task))),
             msg::Request::ExpansionMacro(task) => {
@@ -31,6 +24,8 @@ pub fn run() -> io::Result<()> {
             eprintln!("Write message error: {}", err);
         }
     }
+
+    Ok(())
 }
 
 fn read_request() -> io::Result<Option<msg::Request>> {

--- a/crates/ra_proc_macro_srv/src/cli.rs
+++ b/crates/ra_proc_macro_srv/src/cli.rs
@@ -9,7 +9,7 @@ pub fn run() {
         let req = match read_request() {
             Err(err) => {
                 // Panic here, as the stdin pipe may be closed.
-                // Otherwise, client will be restart the service anyway.
+                // Otherwise, client will be restarted the service anyway.
                 panic!("Read message error on ra_proc_macro_srv: {}", err);
             }
             Ok(None) => continue,

--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -66,7 +66,7 @@ fn setup_logging() -> Result<()> {
 }
 
 fn run_proc_macro_srv() -> Result<()> {
-    ra_proc_macro_srv::cli::run();
+    ra_proc_macro_srv::cli::run()?;
     Ok(())
 }
 


### PR DESCRIPTION
This PR fixed a bug when the rust-analyzer is killed suddenly, the `rust-analyzer proc-macro` will become stale.