### PR TITLE
Cleanup proc_macro config

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -7,6 +7,8 @@
 //! configure the server itself, feature flags are passed into analysis, and
 //! tweak things like automatic insertion of `()` in completions.
 
+use std::{ffi::OsString, path::PathBuf};
+
 use lsp_types::TextDocumentClientCapabilities;
 use ra_flycheck::FlycheckConfig;
 use ra_ide::{CompletionConfig, InlayHintsConfig};
@@ -20,7 +22,7 @@ pub struct Config {
     pub with_sysroot: bool,
     pub publish_diagnostics: bool,
     pub lru_capacity: Option<usize>,
-    pub proc_macro_srv: Option<(String, Vec<String>)>,
+    pub proc_macro_srv: Option<(PathBuf, Vec<OsString>)>,
     pub files: FilesConfig,
     pub notifications: NotificationsConfig,
 
@@ -135,7 +137,7 @@ impl Config {
         match get(value, "/procMacro/enable") {
             Some(true) => {
                 if let Ok(path) = std::env::current_exe() {
-                    self.proc_macro_srv = Some((path.to_string_lossy().to_string(), vec!["proc-macro".to_string()]));
+                    self.proc_macro_srv = Some((path, vec!["proc-macro".into()]));
                 }
             }
             _ => self.proc_macro_srv = None,

--- a/crates/rust-analyzer/src/world.rs
+++ b/crates/rust-analyzer/src/world.rs
@@ -153,7 +153,7 @@ impl WorldState {
                 Err(err) => {
                     log::error!(
                         "Failed to run ra_proc_macro_srv from path {}, error: {:?}",
-                        path,
+                        path.display(),
                         err
                     );
                     ProcMacroClient::dummy()

--- a/crates/rust-analyzer/tests/heavy_tests/main.rs
+++ b/crates/rust-analyzer/tests/heavy_tests/main.rs
@@ -1,6 +1,6 @@
 mod support;
 
-use std::{collections::HashMap, time::Instant};
+use std::{collections::HashMap, path::PathBuf, time::Instant};
 
 use lsp_types::{
     CodeActionContext, DidOpenTextDocumentParams, DocumentFormattingParams, FormattingOptions,
@@ -692,15 +692,10 @@ pub fn foo(_input: TokenStream) -> TokenStream {
 "###,
     )
     .with_config(|config| {
-        // FIXME: Use env!("CARGO_BIN_EXE_ra-analyzer") instead after
-        // https://github.com/rust-lang/cargo/pull/7697 landed
-        let macro_srv_path = std::path::Path::new(std::env!("CARGO_MANIFEST_DIR"))
-            .join("../../target/debug/rust-analyzer")
-            .to_string_lossy()
-            .to_string();
+        let macro_srv_path = PathBuf::from(env!("CARGO_BIN_EXE_rust-analyzer"));
 
         config.cargo.load_out_dirs_from_check = true;
-        config.proc_macro_srv = Some((macro_srv_path, vec!["proc-macro".to_string()]));
+        config.proc_macro_srv = Some((macro_srv_path, vec!["proc-macro".into()]));
     })
     .root("foo")
     .root("bar")


### PR DESCRIPTION
In general, there should be no reason to call `.to_string_lossy`.
If you want to display the path, use `.display()`.
If you want to pass the path to an OS API (like std::process::Command)
than use `PathBuf` or `OsString`.



bors r+
🤖