### PR TITLE
Fix wrong substitution code

### DIFF
--- a/crates/ra_hir_ty/src/lib.rs
+++ b/crates/ra_hir_ty/src/lib.rs
@@ -863,7 +863,7 @@ pub trait TypeWalk {
             &mut |ty, binders| {
                 if let &mut Ty::Bound(bound) = ty {
                     if bound.debruijn >= binders {
-                        *ty = substs.0[bound.index].clone();
+                        *ty = substs.0[bound.index].clone().shift_bound_vars(binders);
                     }
                 }
             },


### PR DESCRIPTION
We need to shift in when we're substituting inside a binder.

This should fix #4053 (it doesn't fix the occasional overflow that also occurs on the Diesel codebase though).