### PR TITLE
Disable onEnter command by default

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -166,11 +166,6 @@
                 "command": "rust-analyzer.joinLines",
                 "key": "ctrl+shift+j",
                 "when": "editorTextFocus && editorLangId == rust"
-            },
-            {
-                "command": "rust-analyzer.onEnter",
-                "key": "enter",
-                "when": "editorTextFocus && !suggestWidgetVisible && editorLangId == rust && !vim.active || vim.mode == 'Insert' && editorTextFocus && !suggestWidgetVisible && editorLangId == rust"
             }
         ],
         "configuration": {


### PR DESCRIPTION
We are transitioning from experimental to production-ready stance, so
it makes sense to disable potentially disruptive features by default.



bors r+
🤖