### PR TITLE
Support returning non-hierarchical symbols

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -69,6 +69,7 @@ pub enum RustfmtConfig {
 pub struct ClientCapsConfig {
     pub location_link: bool,
     pub line_folding_only: bool,
+    pub hierarchical_symbols: bool,
 }
 
 impl Default for Config {
@@ -214,6 +215,11 @@ impl Config {
         }
         if let Some(value) = caps.folding_range.as_ref().and_then(|it| it.line_folding_only) {
             self.client_caps.line_folding_only = value
+        }
+        if let Some(value) =
+            caps.document_symbol.as_ref().and_then(|it| it.hierarchical_document_symbol_support)
+        {
+            self.client_caps.hierarchical_symbols = value
         }
         self.completion.allow_snippets(false);
         if let Some(completion) = &caps.completion {


### PR DESCRIPTION
If `hierarchicalDocumentSymbolSupport` is not true in the client capabilites
then it does not support the `DocumentSymbol[]` return type from the
`textDocument/documentSymbol` request and we must fall back to `SymbolInformation[]`.

This is one of the few requests that use the client capabilities to
differentiate between return types and could cause problems for clients.

See https://github.com/microsoft/language-server-protocol/pull/538#issuecomment-442510767 for more context.

Found while looking at #144