### PR TITLE
Cache proc-macro dlls

### DIFF
--- a/crates/ra_proc_macro_srv/src/cli.rs
+++ b/crates/ra_proc_macro_srv/src/cli.rs
@@ -1,15 +1,17 @@
 //! Driver for proc macro server
 
-use crate::{expand_task, list_macros};
+use crate::ProcMacroSrv;
 use ra_proc_macro::msg::{self, Message};
 use std::io;
 
 pub fn run() -> io::Result<()> {
+    let mut srv = ProcMacroSrv::default();
+
     while let Some(req) = read_request()? {
         let res = match req {
-            msg::Request::ListMacro(task) => Ok(msg::Response::ListMacro(list_macros(&task))),
+            msg::Request::ListMacro(task) => srv.list_macros(&task).map(msg::Response::ListMacro),
             msg::Request::ExpansionMacro(task) => {
-                expand_task(&task).map(msg::Response::ExpansionMacro)
+                srv.expand(&task).map(msg::Response::ExpansionMacro)
             }
         };
 

--- a/crates/ra_proc_macro_srv/src/dylib.rs
+++ b/crates/ra_proc_macro_srv/src/dylib.rs
@@ -199,6 +199,7 @@ impl Expander {
     }
 }
 
+#[cfg(windows)]
 fn copy_to_temp_dir(path: &Path) -> io::Result<PathBuf> {
     let mut to = std::env::temp_dir();
     let file_name = path.file_name().ok_or_else(|| {
@@ -211,4 +212,9 @@ fn copy_to_temp_dir(path: &Path) -> io::Result<PathBuf> {
     to.push(file_name);
     std::fs::copy(path, &to)?;
     Ok(to)
+}
+
+#[cfg(unix)]
+fn copy_to_temp_dir(path: &Path) -> io::Result<PathBuf> {
+    Ok(path.to_path_buf())
 }

--- a/crates/ra_proc_macro_srv/src/lib.rs
+++ b/crates/ra_proc_macro_srv/src/lib.rs
@@ -23,7 +23,7 @@ use proc_macro::bridge::client::TokenStream;
 use ra_proc_macro::{ExpansionResult, ExpansionTask, ListMacrosResult, ListMacrosTask};
 use std::{
     collections::{hash_map::Entry, HashMap},
-    fs::metadata,
+    fs,
     path::{Path, PathBuf},
     time::SystemTime,
 };
@@ -50,9 +50,9 @@ impl ProcMacroSrv {
     }
 
     fn expander(&mut self, path: &Path) -> Result<&dylib::Expander, String> {
-        let time = metadata(path)
-            .and_then(|it| it.modified())
-            .map_err(|err| format!("Failed to file metadata for {}: {:?}", path.display(), err))?;
+        let time = fs::metadata(path).and_then(|it| it.modified()).map_err(|err| {
+            format!("Failed to get file metadata for {}: {:?}", path.display(), err)
+        })?;
 
         Ok(match self.expanders.entry((path.to_path_buf(), time)) {
             Entry::Vacant(v) => v.insert(dylib::Expander::new(path).map_err(|err| {

--- a/crates/ra_proc_macro_srv/src/tests/utils.rs
+++ b/crates/ra_proc_macro_srv/src/tests/utils.rs
@@ -1,7 +1,7 @@
 //! utils used in proc-macro tests
 
 use crate::dylib;
-use crate::list_macros;
+use crate::ProcMacroSrv;
 pub use difference::Changeset as __Changeset;
 use ra_proc_macro::ListMacrosTask;
 use std::str::FromStr;
@@ -59,7 +59,7 @@ pub fn assert_expand(
 pub fn list(crate_name: &str, version: &str) -> Vec<String> {
     let path = fixtures::dylib_path(crate_name, version);
     let task = ListMacrosTask { lib: path };
-
-    let res = list_macros(&task);
+    let mut srv = ProcMacroSrv::default();
+    let res = srv.list_macros(&task).unwrap();
     res.macros.into_iter().map(|(name, kind)| format!("{} [{:?}]", name, kind)).collect()
 }


### PR DESCRIPTION
This PR try to fix a deadlock in proc-macro srv by not unloading dlls.

Currently we load and unload dlls for each request, however rustc TLS is leaky , such that if we do it a lot of times, all TLS index will be consumed and it will be deadlocked inside panic (it is because panic itself is using TLS too).
