### PR TITLE
Include correct item path for variant completions

### DIFF
--- a/crates/ra_ide/src/completion/complete_unqualified_path.rs
+++ b/crates/ra_ide/src/completion/complete_unqualified_path.rs
@@ -38,7 +38,15 @@ fn complete_enum_variants(acc: &mut Completions, ctx: &CompletionContext) {
     if let Some(ty) = ctx.expected_type_of(&ctx.token.parent()) {
         if let Some(Adt::Enum(enum_data)) = ty.as_adt() {
             let variants = enum_data.variants(ctx.db);
-            let module = enum_data.module(ctx.db);
+
+            let module = if let Some(module) = ctx.scope().module() {
+                // Compute path from the completion site if available.
+                module
+            } else {
+                // Otherwise fall back to the enum's definition site.
+                enum_data.module(ctx.db)
+            };
+
             for variant in variants {
                 if let Some(path) = module.find_use_path(ctx.db, ModuleDef::from(variant)) {
                     // Variants with trivial paths are already added by the existing completion logic,
@@ -1303,6 +1311,49 @@ mod tests {
                 kind: Function,
                 lookup: "main",
                 detail: "fn main()",
+            },
+        ]
+        "###
+        )
+    }
+
+    #[test]
+    fn completes_enum_variant_from_module() {
+        assert_debug_snapshot!(
+            do_reference_completion(
+                r"
+                mod m { pub enum E { V } }
+
+                fn f() -> m::E {
+                    V<|>
+                }
+                "
+            ),
+            @r###"
+        [
+            CompletionItem {
+                label: "f()",
+                source_range: [98; 99),
+                delete: [98; 99),
+                insert: "f()$0",
+                kind: Function,
+                lookup: "f",
+                detail: "fn f() -> m::E",
+            },
+            CompletionItem {
+                label: "m",
+                source_range: [98; 99),
+                delete: [98; 99),
+                insert: "m",
+                kind: Module,
+            },
+            CompletionItem {
+                label: "m::E::V",
+                source_range: [98; 99),
+                delete: [98; 99),
+                insert: "m::E::V",
+                kind: EnumVariant,
+                detail: "()",
             },
         ]
         "###


### PR DESCRIPTION
The test would previously suggest `E::V`, which is not enough to name the variant as the enum is in a module. Now it correctly suggests the full path `m::E::V`.