### PR TITLE
Special case for empty comments in doc comment kind 

### DIFF
--- a/crates/ra_mbe/src/tests.rs
+++ b/crates/ra_mbe/src/tests.rs
@@ -1849,3 +1849,16 @@ fn test_expand_bad_literal() {
     )
     .assert_expand_err(r#"foo!(&k");"#, &ExpandError::BindingError("".into()));
 }
+
+#[test]
+fn test_empty_comments() {
+    parse_macro(
+        r#"
+        macro_rules! one_arg_macro { ($fmt:expr) => (); }        
+    "#,
+    )
+    .assert_expand_err(
+        r#"one_arg_macro!(/**/)"#,
+        &ExpandError::BindingError("expected Expr".into()),
+    );
+}

--- a/crates/ra_mbe/src/tests.rs
+++ b/crates/ra_mbe/src/tests.rs
@@ -1854,7 +1854,7 @@ fn test_expand_bad_literal() {
 fn test_empty_comments() {
     parse_macro(
         r#"
-        macro_rules! one_arg_macro { ($fmt:expr) => (); }        
+        macro_rules! one_arg_macro { ($fmt:expr) => (); }
     "#,
     )
     .assert_expand_err(

--- a/crates/ra_syntax/src/ast/tokens.rs
+++ b/crates/ra_syntax/src/ast/tokens.rs
@@ -56,6 +56,9 @@ const COMMENT_PREFIX_TO_KIND: &[(&str, CommentKind)] = {
 };
 
 fn kind_by_prefix(text: &str) -> CommentKind {
+    if text == "/**/" {
+        return CommentKind { shape: CommentShape::Block, doc: None };
+    }
     for (prefix, kind) in COMMENT_PREFIX_TO_KIND.iter() {
         if text.starts_with(prefix) {
             return *kind;


### PR DESCRIPTION
Part of #4103

Fix `ui/empty/empty-comment.rs macros`