### PR TITLE
Use the same toolchain target in ci worflow as in release workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,7 @@ jobs:
         toolchain: stable
         profile: minimal
         override: true
+        target: x86_64-unknown-linux-musl
         components: rustfmt, rust-src
 
     - if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
[The initial problem](https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Fwg-rls-2.2E0/topic/proc-macro/near/195287524) is that `musl` target doesn't support dynamic loading but CI doesn't detect this error as it apparently uses a different stdlib impl