### PR TITLE
Complete assoc. types on paths without a trait

### DIFF
--- a/crates/ra_hir_ty/src/method_resolution.rs
+++ b/crates/ra_hir_ty/src/method_resolution.rs
@@ -532,7 +532,10 @@ fn is_valid_candidate(
             let data = db.const_data(c);
             name.map_or(true, |name| data.name.as_ref() == Some(name)) && receiver_ty.is_none()
         }
-        _ => false,
+        AssocItemId::TypeAliasId(t) => {
+            let data = db.type_alias_data(t);
+            name.map_or(true, |name| data.name == *name) && receiver_ty.is_none()
+        }
     }
 }
 


### PR DESCRIPTION
There might be a reason for why this was not done before, so maybe this broke something subtle?