### PR TITLE
For associated type shorthand (T::Item), use the substs from the where clause

### DIFF
--- a/crates/ra_hir_ty/src/lib.rs
+++ b/crates/ra_hir_ty/src/lib.rs
@@ -487,6 +487,18 @@ impl<T> Binders<T> {
     pub fn new(num_binders: usize, value: T) -> Self {
         Self { num_binders, value }
     }
+
+    pub fn as_ref(&self) -> Binders<&T> {
+        Binders { num_binders: self.num_binders, value: &self.value }
+    }
+
+    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> Binders<U> {
+        Binders { num_binders: self.num_binders, value: f(self.value) }
+    }
+
+    pub fn filter_map<U>(self, f: impl FnOnce(T) -> Option<U>) -> Option<Binders<U>> {
+        Some(Binders { num_binders: self.num_binders, value: f(self.value)? })
+    }
 }
 
 impl<T: Clone> Binders<&T> {

--- a/crates/ra_hir_ty/src/tests/traits.rs
+++ b/crates/ra_hir_ty/src/tests/traits.rs
@@ -1898,6 +1898,36 @@ fn test() {
 }
 
 #[test]
+fn unselected_projection_chalk_fold() {
+    let t = type_at(
+        r#"
+//- /main.rs
+trait Interner {}
+trait Fold<I: Interner, TI = I> {
+    type Result;
+}
+
+struct Ty<I: Interner> {}
+impl<I: Interner, TI: Interner> Fold<I, TI> for Ty<I> {
+    type Result = Ty<TI>;
+}
+
+fn fold<I: Interner, T>(interner: &I, t: T) -> T::Result
+where
+    T: Fold<I, I>,
+{
+    loop {}
+}
+
+fn foo<I: Interner>(interner: &I, t: Ty<I>) {
+    fold(interner, t)<|>;
+}
+"#,
+    );
+    assert_eq!(t, "Ty<I>");
+}
+
+#[test]
 fn trait_impl_self_ty() {
     let t = type_at(
         r#"


### PR DESCRIPTION
So e.g. if we have `fn foo<T: SomeTrait<u32>>() -> T::Item`, we want to lower that to `<T as SomeTrait<u32>>::Item` and not `<T as SomeTrait<_>>::Item`.