### PR TITLE
Introduce HirDisplay method for rendering source code & use it in add_function assist

### DIFF
--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -22,8 +22,11 @@ use hir_expand::{
     MacroDefId, MacroDefKind,
 };
 use hir_ty::{
-    autoderef, display::HirFormatter, expr::ExprValidator, method_resolution, ApplicationTy,
-    Canonical, InEnvironment, Substs, TraitEnvironment, Ty, TyDefId, TypeCtor,
+    autoderef,
+    display::{HirDisplayError, HirFormatter},
+    expr::ExprValidator,
+    method_resolution, ApplicationTy, Canonical, InEnvironment, Substs, TraitEnvironment, Ty,
+    TyDefId, TypeCtor,
 };
 use ra_db::{CrateId, CrateName, Edition, FileId};
 use ra_prof::profile;
@@ -1319,7 +1322,7 @@ impl Type {
 }
 
 impl HirDisplay for Type {
-    fn hir_fmt(&self, f: &mut HirFormatter) -> std::fmt::Result {
+    fn hir_fmt(&self, f: &mut HirFormatter) -> Result<(), HirDisplayError> {
         self.ty.value.hir_fmt(f)
     }
 }

--- a/crates/ra_hir_ty/src/tests/display_source_code.rs
+++ b/crates/ra_hir_ty/src/tests/display_source_code.rs
@@ -1,0 +1,23 @@
+use super::displayed_source_at_pos;
+use crate::test_db::TestDB;
+use ra_db::fixture::WithFixture;
+
+#[test]
+fn qualify_path_to_submodule() {
+    let (db, pos) = TestDB::with_position(
+        r#"
+//- /main.rs
+
+mod foo {
+    pub struct Foo;
+}
+
+fn bar() {
+    let foo: foo::Foo = foo::Foo;
+    foo<|>
+}
+
+"#,
+    );
+    assert_eq!("foo::Foo", displayed_source_at_pos(&db, pos));
+}


### PR DESCRIPTION
Next feature for #3639.

So far the only change in the new `HirDisplay` method is that paths are qualified, but more changes will be necessary (omitting the function name from function types, returning an error instead of printing `"{unknown}"`, probably more).

Is that approach okay?