### PR TITLE
Rebuild rust-analyzer when launching in VS Code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -41,7 +41,7 @@
       "outFiles": [
         "${workspaceFolder}/editors/code/out/**/*.js"
       ],
-      "preLaunchTask": "Build Extension",
+      "preLaunchTask": "Build Server",
       "skipFiles": [
         "<node_internals>/**/*.js"
       ],
@@ -62,7 +62,7 @@
       "outFiles": [
         "${workspaceFolder}/editors/code/out/**/*.js"
       ],
-      "preLaunchTask": "Build Extension",
+      "preLaunchTask": "Build Server (Release)",
       "skipFiles": [
         "<node_internals>/**/*.js"
       ],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -41,7 +41,7 @@
       "outFiles": [
         "${workspaceFolder}/editors/code/out/**/*.js"
       ],
-      "preLaunchTask": "Build Server",
+      "preLaunchTask": "Build Server and Extension",
       "skipFiles": [
         "<node_internals>/**/*.js"
       ],
@@ -62,7 +62,7 @@
       "outFiles": [
         "${workspaceFolder}/editors/code/out/**/*.js"
       ],
-      "preLaunchTask": "Build Server (Release)",
+      "preLaunchTask": "Build Server (Release) and Extension",
       "skipFiles": [
         "<node_internals>/**/*.js"
       ],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "Build Extension",
+      "label": "Build Extension in Background",
       "group": "build",
       "type": "npm",
       "script": "watch",
@@ -14,6 +14,17 @@
         "fileLocation": ["relative", "${workspaceFolder}/editors/code/"]
       },
       "isBackground": true,
+    },
+    {
+      "label": "Build Extension",
+      "group": "build",
+      "type": "npm",
+      "script": "build",
+      "path": "editors/code/",
+      "problemMatcher": {
+        "base": "$tsc",
+        "fileLocation": ["relative", "${workspaceFolder}/editors/code/"]
+      },
     },
     {
       "label": "Build Server",
@@ -29,5 +40,16 @@
       "command": "cargo build --release --package rust-analyzer",
       "problemMatcher": "$rustc"
     },
+
+    {
+      "label": "Build Server and Extension",
+      "dependsOn": ["Build Server", "Build Extension"],
+      "problemMatcher": "$rustc"
+    },
+    {
+      "label": "Build Server (Release) and Extension",
+      "dependsOn": ["Build Server (Release)", "Build Extension"],
+      "problemMatcher": "$rustc"
+    }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -22,5 +22,12 @@
       "command": "cargo build --package rust-analyzer",
       "problemMatcher": "$rustc"
     },
+    {
+      "label": "Build Server (Release)",
+      "group": "build",
+      "type": "shell",
+      "command": "cargo build --release --package rust-analyzer",
+      "problemMatcher": "$rustc"
+    },
   ]
 }

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -27,6 +27,7 @@
     "scripts": {
         "vscode:prepublish": "tsc && rollup -c",
         "package": "vsce package -o rust-analyzer.vsix",
+        "build": "tsc",
         "watch": "tsc --watch",
         "lint": "tsfmt --verify && eslint -c .eslintrc.js --ext ts ./src",
         "fix": " tsfmt -r       && eslint -c .eslintrc.js --ext ts ./src --fix"


### PR DESCRIPTION
This is usually the right thing, and previously would launch a stale r-a server.