### PR TITLE
Use specific pattern when translating if-let-else to match

### DIFF
--- a/crates/ra_assists/src/handlers/replace_let_with_if_let.rs
+++ b/crates/ra_assists/src/handlers/replace_let_with_if_let.rs
@@ -1,6 +1,5 @@
 use std::iter::once;
 
-use hir::Adt;
 use ra_syntax::{
     ast::{
         self,
@@ -12,6 +11,7 @@ use ra_syntax::{
 
 use crate::{
     assist_ctx::{Assist, AssistCtx},
+    utils::happy_try_variant,
     AssistId,
 };
 
@@ -45,20 +45,10 @@ pub(crate) fn replace_let_with_if_let(ctx: AssistCtx) -> Option<Assist> {
     let init = let_stmt.initializer()?;
     let original_pat = let_stmt.pat()?;
     let ty = ctx.sema.type_of_expr(&init)?;
-    let enum_ = match ty.as_adt() {
-        Some(Adt::Enum(it)) => it,
-        _ => return None,
-    };
-    let happy_case =
-        [("Result", "Ok"), ("Option", "Some")].iter().find_map(|(known_type, happy_case)| {
-            if &enum_.name(ctx.db).to_string() == known_type {
-                return Some(happy_case);
-            }
-            None
-        });
+    let happy_variant = happy_try_variant(ctx.sema, &ty);
 
     ctx.add_assist(AssistId("replace_let_with_if_let"), "Replace with if-let", |edit| {
-        let with_placeholder: ast::Pat = match happy_case {
+        let with_placeholder: ast::Pat = match happy_variant {
             None => make::placeholder_pat().into(),
             Some(var_name) => make::tuple_struct_pat(
                 make::path_unqualified(make::path_segment(make::name_ref(var_name))),

--- a/crates/ra_assists/src/handlers/replace_let_with_if_let.rs
+++ b/crates/ra_assists/src/handlers/replace_let_with_if_let.rs
@@ -11,7 +11,7 @@ use ra_syntax::{
 
 use crate::{
     assist_ctx::{Assist, AssistCtx},
-    utils::happy_try_variant,
+    utils::TryEnum,
     AssistId,
 };
 
@@ -45,7 +45,7 @@ pub(crate) fn replace_let_with_if_let(ctx: AssistCtx) -> Option<Assist> {
     let init = let_stmt.initializer()?;
     let original_pat = let_stmt.pat()?;
     let ty = ctx.sema.type_of_expr(&init)?;
-    let happy_variant = happy_try_variant(ctx.sema, &ty);
+    let happy_variant = TryEnum::from_ty(ctx.sema, &ty).map(|it| it.happy_case());
 
     ctx.add_assist(AssistId("replace_let_with_if_let"), "Replace with if-let", |edit| {
         let with_placeholder: ast::Pat = match happy_variant {

--- a/crates/ra_assists/src/handlers/replace_unwrap_with_match.rs
+++ b/crates/ra_assists/src/handlers/replace_unwrap_with_match.rs
@@ -5,7 +5,7 @@ use ra_syntax::{
     AstNode,
 };
 
-use crate::{utils::happy_try_variant, Assist, AssistCtx, AssistId};
+use crate::{utils::TryEnum, Assist, AssistCtx, AssistId};
 
 // Assist: replace_unwrap_with_match
 //
@@ -37,7 +37,7 @@ pub(crate) fn replace_unwrap_with_match(ctx: AssistCtx) -> Option<Assist> {
     }
     let caller = method_call.expr()?;
     let ty = ctx.sema.type_of_expr(&caller)?;
-    let happy_variant = happy_try_variant(ctx.sema, &ty)?;
+    let happy_variant = TryEnum::from_ty(ctx.sema, &ty)?.happy_case();
 
     ctx.add_assist(AssistId("replace_unwrap_with_match"), "Replace unwrap with match", |edit| {
         let ok_path = make::path_unqualified(make::path_segment(make::name_ref(happy_variant)));


### PR DESCRIPTION
We *probably* should actually use the same machinery here, as we do
for fill match arms, but just special-casing options and results seems
to be a good first step.



bors r+
🤖