### PR TITLE
Fix YouComplteMe instructions link

### DIFF
--- a/docs/user/readme.adoc
+++ b/docs/user/readme.adoc
@@ -195,7 +195,7 @@ let g:LanguageClient_serverCommands = {
 ==== YouCompleteMe
 
 1. Install YouCompleteMe by following the instructions
-  https://ycm-core.github.io/YouCompleteMe/#rust-semantic-completion[here]
+  https://github.com/ycm-core/lsp-examples#rust-rust-analyzer[here]
 
 2. Configure by adding this to your vim/neovim config file (replacing the existing Rust-specific line if it exists):
 +


### PR DESCRIPTION
Like I mentioned in #4098, the link to the instructions is for setting up RLS. This pull request fixes that mistake.