### PR TITLE
Include function qualifiers in signature

### DIFF
--- a/crates/ra_ide/src/hover.rs
+++ b/crates/ra_ide/src/hover.rs
@@ -844,4 +844,29 @@ fn func(foo: i32) { if true { <|>foo; }; }
             &["fn foo()\n```\n\n<- `\u{3000}` here"],
         );
     }
+
+    #[test]
+    fn test_hover_function_show_qualifiers() {
+        check_hover_result(
+            "
+            //- /lib.rs
+            async fn foo<|>() {}
+            ",
+            &["async fn foo()"],
+        );
+        check_hover_result(
+            "
+            //- /lib.rs
+            pub const unsafe fn foo<|>() {}
+            ",
+            &["pub const unsafe fn foo()"],
+        );
+        check_hover_result(
+            r#"
+            //- /lib.rs
+            pub(crate) async unsafe extern "C" fn foo<|>() {}
+            "#,
+            &[r#"pub(crate) async unsafe extern "C" fn foo()"#],
+        );
+    }
 }


### PR DESCRIPTION
Fixes #2450

It seems there's no test for `ra_ide/display/{short_label,function_signature}`. I'm not sure how to setup it.

Manually tested:
<img width="428" alt="Screenshot_20200430_004434" src="https://user-images.githubusercontent.com/14816024/80622769-d6f1c200-8a7b-11ea-91f3-e94bfb2703c5.png">
