### PR TITLE
Introduce LowerCtx

### DIFF
--- a/crates/ra_assists/src/assist_ctx.rs
+++ b/crates/ra_assists/src/assist_ctx.rs
@@ -1,12 +1,12 @@
 //! This module defines `AssistCtx` -- the API surface that is exposed to assists.
 use hir::Semantics;
-use ra_db::{FileRange, Upcast};
+use ra_db::FileRange;
 use ra_fmt::{leading_indent, reindent};
 use ra_ide_db::RootDatabase;
 use ra_syntax::{
     algo::{self, find_covering_element, find_node_at_offset},
-    ast, AstNode, SourceFile, SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken, TextRange,
-    TextSize, TokenAtOffset,
+    AstNode, SourceFile, SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken, TextRange, TextSize,
+    TokenAtOffset,
 };
 use ra_text_edit::TextEditBuilder;
 
@@ -135,9 +135,6 @@ impl<'a> AssistCtx<'a> {
     }
     pub(crate) fn covering_node_for_range(&self, range: TextRange) -> SyntaxElement {
         find_covering_element(self.source_file.syntax(), range)
-    }
-    pub(crate) fn lower_path(&self, path: ast::Path) -> Option<hir::Path> {
-        hir::Path::from_src(path, &hir::Hygiene::new(self.db.upcast(), self.frange.file_id.into()))
     }
 }
 

--- a/crates/ra_assists/src/assist_ctx.rs
+++ b/crates/ra_assists/src/assist_ctx.rs
@@ -1,12 +1,12 @@
 //! This module defines `AssistCtx` -- the API surface that is exposed to assists.
 use hir::Semantics;
-use ra_db::FileRange;
+use ra_db::{FileRange, Upcast};
 use ra_fmt::{leading_indent, reindent};
 use ra_ide_db::RootDatabase;
 use ra_syntax::{
     algo::{self, find_covering_element, find_node_at_offset},
-    AstNode, SourceFile, SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken, TextRange, TextSize,
-    TokenAtOffset,
+    ast, AstNode, SourceFile, SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken, TextRange,
+    TextSize, TokenAtOffset,
 };
 use ra_text_edit::TextEditBuilder;
 
@@ -135,6 +135,9 @@ impl<'a> AssistCtx<'a> {
     }
     pub(crate) fn covering_node_for_range(&self, range: TextRange) -> SyntaxElement {
         find_covering_element(self.source_file.syntax(), range)
+    }
+    pub(crate) fn lower_path(&self, path: ast::Path) -> Option<hir::Path> {
+        hir::Path::from_src(path, &hir::Hygiene::new(self.db.upcast(), self.frange.file_id.into()))
     }
 }
 

--- a/crates/ra_assists/src/ast_transform.rs
+++ b/crates/ra_assists/src/ast_transform.rs
@@ -85,6 +85,7 @@ impl<'a> SubstituteTypeParams<'a> {
             ast::TypeRef::PathType(path_type) => path_type.path()?,
             _ => return None,
         };
+        // FIXME: use `hir::Path::from_src` instead.
         let path = hir::Path::from_ast(path)?;
         let resolution = self.source_scope.resolve_hir_path(&path)?;
         match resolution {
@@ -128,6 +129,7 @@ impl<'a> QualifyPaths<'a> {
             // don't try to qualify `Fn(Foo) -> Bar` paths, they are in prelude anyway
             return None;
         }
+        // FIXME: use `hir::Path::from_src` instead.
         let hir_path = hir::Path::from_ast(p.clone());
         let resolution = self.source_scope.resolve_hir_path(&hir_path?)?;
         match resolution {

--- a/crates/ra_assists/src/handlers/replace_qualified_name_with_use.rs
+++ b/crates/ra_assists/src/handlers/replace_qualified_name_with_use.rs
@@ -27,7 +27,7 @@ pub(crate) fn replace_qualified_name_with_use(ctx: AssistCtx) -> Option<Assist> 
         return None;
     }
 
-    let hir_path = ctx.lower_path(path.clone())?;
+    let hir_path = ctx.sema.lower_path(&path)?;
     let segments = collect_hir_path_segments(&hir_path)?;
     if segments.len() < 2 {
         return None;

--- a/crates/ra_assists/src/handlers/replace_qualified_name_with_use.rs
+++ b/crates/ra_assists/src/handlers/replace_qualified_name_with_use.rs
@@ -27,7 +27,7 @@ pub(crate) fn replace_qualified_name_with_use(ctx: AssistCtx) -> Option<Assist> 
         return None;
     }
 
-    let hir_path = hir::Path::from_ast(path.clone())?;
+    let hir_path = ctx.lower_path(path.clone())?;
     let segments = collect_hir_path_segments(&hir_path)?;
     if segments.len() < 2 {
         return None;

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -70,6 +70,7 @@ pub use hir_def::{
     type_ref::Mutability,
 };
 pub use hir_expand::{
-    name::Name, HirFileId, InFile, MacroCallId, MacroCallLoc, MacroDefId, MacroFile, Origin,
+    hygiene::Hygiene, name::Name, HirFileId, InFile, MacroCallId, MacroCallLoc, MacroDefId,
+    MacroFile, Origin,
 };
 pub use hir_ty::{display::HirDisplay, CallableDef};

--- a/crates/ra_hir/src/semantics.rs
+++ b/crates/ra_hir/src/semantics.rs
@@ -8,7 +8,7 @@ use hir_def::{
     resolver::{self, HasResolver, Resolver},
     AsMacroCall, TraitId,
 };
-use hir_expand::ExpansionInfo;
+use hir_expand::{hygiene::Hygiene, ExpansionInfo};
 use hir_ty::associated_type_shorthand_candidates;
 use itertools::Itertools;
 use ra_db::{FileId, FileRange};
@@ -244,6 +244,11 @@ impl<'db, DB: HirDatabase> Semantics<'db, DB> {
 
     pub fn resolve_path(&self, path: &ast::Path) -> Option<PathResolution> {
         self.analyze(path.syntax()).resolve_path(self.db, path)
+    }
+
+    pub fn lower_path(&self, path: &ast::Path) -> Option<Path> {
+        let src = self.find_file(path.syntax().clone());
+        Path::from_src(path.clone(), &Hygiene::new(self.db.upcast(), src.file_id.into()))
     }
 
     pub fn resolve_bind_pat_to_const(&self, pat: &ast::BindPat) -> Option<ModuleDef> {

--- a/crates/ra_hir/src/source_analyzer.rs
+++ b/crates/ra_hir/src/source_analyzer.rs
@@ -224,7 +224,8 @@ impl SourceAnalyzer {
             }
         }
         // This must be a normal source file rather than macro file.
-        let hir_path = crate::Path::from_ast(path.clone())?;
+        let hir_path =
+            crate::Path::from_src(path.clone(), &Hygiene::new(db.upcast(), self.file_id))?;
         resolve_hir_path(db, &self.resolver, &hir_path)
     }
 

--- a/crates/ra_hir_def/src/body.rs
+++ b/crates/ra_hir_def/src/body.rs
@@ -15,6 +15,8 @@ use ra_prof::profile;
 use ra_syntax::{ast, AstNode, AstPtr};
 use rustc_hash::FxHashMap;
 
+pub(crate) use lower::LowerCtx;
+
 use crate::{
     attr::Attrs,
     db::DefDatabase,

--- a/crates/ra_hir_def/src/path.rs
+++ b/crates/ra_hir_def/src/path.rs
@@ -7,6 +7,7 @@ use std::{
     sync::Arc,
 };
 
+use crate::body::LowerCtx;
 use hir_expand::{
     hygiene::Hygiene,
     name::{AsName, Name},
@@ -244,8 +245,8 @@ impl<'a> PathSegments<'a> {
 }
 
 impl GenericArgs {
-    pub(crate) fn from_ast(node: ast::TypeArgList) -> Option<GenericArgs> {
-        lower::lower_generic_args(node)
+    pub(crate) fn from_ast(lower_ctx: &LowerCtx, node: ast::TypeArgList) -> Option<GenericArgs> {
+        lower::lower_generic_args(lower_ctx, node)
     }
 
     pub(crate) fn empty() -> GenericArgs {

--- a/crates/ra_hir_expand/src/hygiene.rs
+++ b/crates/ra_hir_expand/src/hygiene.rs
@@ -12,7 +12,7 @@ use crate::{
     HirFileId, HirFileIdRepr, MacroCallId, MacroDefKind,
 };
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Hygiene {
     // This is what `$crate` expands to
     def_crate: Option<CrateId>,


### PR DESCRIPTION
This PR introduces `LowerCtx` for path lowering. 

After this PR, there are only 2 places remains for using deprecated `Path::from_ast`, which is related to `AstTransform` I am not familiar. I would like to change these in another PR by others ;)

related disscusiion:  https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Fwg-rls-2.2E0/topic/Path.3A.3Afrom_src

And also fixed part of https://github.com/rust-analyzer/rust-analyzer/issues/4176#issuecomment-620672930