### PR TITLE
Introduce C/C++ for Visual Studio Code extension as an alternative debug engine for Debug Code lens.

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -390,22 +390,25 @@
                     "default": false
                 },
                 "rust-analyzer.debug.engine": {
-                    "type": [
-                        "null",
-                        "string"
-                    ],
+                    "type": "string",
                     "enum": [
-                        "ms-vscode.cpptools",
-                        "vadimcn.vscode-lldb"
+                        "auto",
+                        "vadimcn.vscode-lldb",
+                        "ms-vscode.cpptools"
                     ],
-                    "default": null,
-                    "description": "Preffered debug engine."
+                    "default": "auto",
+                    "description": "Preffered debug engine.",
+                    "markdownEnumDescriptions": [
+                        "First try to use [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb), if it's not installed use [MS C++ tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools).",
+                        "Use [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb)",
+                        "Use [MS C++ tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)"
+                    ]
                 },
-                "rust-analyzer.debug.sourceFileMap" : {
-                    "type":"object",
+                "rust-analyzer.debug.sourceFileMap": {
+                    "type": "object",
                     "description": "Optional source file mappings passed to the debug engine.",
                     "default": {
-                        "<source-path>": "<target-path>"
+                        "/rustc/<id>": "${env:USERPROFILE}/.rustup/toolchains/<toolchain-id>/lib/rustlib/src/rust"
                     }
                 }
             }

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -388,6 +388,25 @@
                     "description": "Enable Proc macro support, cargo.loadOutDirsFromCheck must be enabled.",
                     "type": "boolean",
                     "default": false
+                },
+                "rust-analyzer.debug.engine": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "enum": [
+                        "ms-vscode.cpptools",
+                        "vadimcn.vscode-lldb"
+                    ],
+                    "default": null,
+                    "description": "Preffered debug engine."
+                },
+                "rust-analyzer.debug.sourceFileMap" : {
+                    "type":"object",
+                    "description": "Optional source file mappings passed to the debug engine.",
+                    "default": {
+                        "<source-path>": "<target-path>"
+                    }
                 }
             }
         },

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -399,7 +399,7 @@
                     "default": "auto",
                     "description": "Preffered debug engine.",
                     "markdownEnumDescriptions": [
-                        "First try to use [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb), if it's not installed use [MS C++ tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools).",
+                        "First try to use [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb), if it's not installed try to use [MS C++ tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools).",
                         "Use [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb)",
                         "Use [MS C++ tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)"
                     ]

--- a/editors/code/src/cargo.ts
+++ b/editors/code/src/cargo.ts
@@ -56,7 +56,7 @@ export class Cargo {
     }
 
     public async executableFromArgs(args: string[]): Promise<string> {
-        let cargoArgs = [...args]; // to remain  args unchanged
+        const cargoArgs = [...args]; // to remain  args unchanged
         cargoArgs.push("--message-format=json");
 
         const artifacts = await this.artifactsFromArgs(cargoArgs);

--- a/editors/code/src/cargo.ts
+++ b/editors/code/src/cargo.ts
@@ -55,12 +55,9 @@ export class Cargo {
         return artifacts;
     }
 
-    public async executableFromArgs(cargoArgs: string[], extraArgs?: string[]): Promise<string> {
+    public async executableFromArgs(args: string[]): Promise<string> {
+        let cargoArgs = [...args]; // to remain  args unchanged
         cargoArgs.push("--message-format=json");
-        if (extraArgs) {
-            cargoArgs.push('--');
-            cargoArgs.push(...extraArgs);
-        }
 
         const artifacts = await this.artifactsFromArgs(cargoArgs);
 

--- a/editors/code/src/cargo.ts
+++ b/editors/code/src/cargo.ts
@@ -21,24 +21,24 @@ export class Cargo {
     }
 
     public async artifactsFromArgs(cargoArgs: string[]): Promise<CompilationArtifact[]> {
-        let artifacts: CompilationArtifact[] = [];
+        const artifacts: CompilationArtifact[] = [];
 
         try {
             await this.runCargo(cargoArgs,
                 message => {
-                    if (message.reason == 'compiler-artifact' && message.executable) {
-                        let isBinary = message.target.crate_types.includes('bin');
-                        let isBuildScript = message.target.kind.includes('custom-build');
+                    if (message.reason === 'compiler-artifact' && message.executable) {
+                        const isBinary = message.target.crate_types.includes('bin');
+                        const isBuildScript = message.target.kind.includes('custom-build');
                         if ((isBinary && !isBuildScript) || message.profile.test) {
                             artifacts.push({
                                 fileName: message.executable,
                                 name: message.target.name,
                                 kind: message.target.kind[0],
                                 isTest: message.profile.test
-                            })
+                            });
                         }
                     }
-                    else if( message.reason == 'compiler-message') {
+                    else if (message.reason === 'compiler-message') {
                         this.output.append(message.message.rendered);
                     }
                 },
@@ -62,9 +62,9 @@ export class Cargo {
             cargoArgs.push(...extraArgs);
         }
 
-        let artifacts = await this.artifactsFromArgs(cargoArgs);
+        const artifacts = await this.artifactsFromArgs(cargoArgs);
 
-        if (artifacts.length == 0 ) {
+        if (artifacts.length === 0) {
             throw new Error('No compilation artifacts');
         } else if (artifacts.length > 1) {
             throw new Error('Multiple compilation artifacts are not supported.');
@@ -79,7 +79,7 @@ export class Cargo {
         onStderrString: (data: string) => void
     ): Promise<number> {
         return new Promise<number>((resolve, reject) => {
-            let cargo = cp.spawn('cargo', cargoArgs, {
+            const cargo = cp.spawn('cargo', cargoArgs, {
                 stdio: ['ignore', 'pipe', 'pipe'],
                 cwd: this.rootFolder,
                 env: this.env,
@@ -92,14 +92,14 @@ export class Cargo {
                 onStderrString(chunk.toString());
             });
 
-            let rl = readline.createInterface({ input: cargo.stdout });
+            const rl = readline.createInterface({ input: cargo.stdout });
             rl.on('line', line => {
-                let message = JSON.parse(line);
+                const message = JSON.parse(line);
                 onStdoutJson(message);
             });
 
             cargo.on('exit', (exitCode, _) => {
-                if (exitCode == 0)
+                if (exitCode === 0)
                     resolve(exitCode);
                 else
                     reject(new Error(`exit code: ${exitCode}.`));

--- a/editors/code/src/cargo.ts
+++ b/editors/code/src/cargo.ts
@@ -1,4 +1,3 @@
-import { window } from 'vscode';
 import * as cp from 'child_process';
 import * as readline from 'readline';
 

--- a/editors/code/src/cargo.ts
+++ b/editors/code/src/cargo.ts
@@ -1,0 +1,103 @@
+import { window } from 'vscode';
+import * as cp from 'child_process';
+import * as readline from 'readline';
+
+interface CompilationArtifact {
+    fileName: string;
+    name: string;
+    kind: string;
+    isTest: boolean;
+}
+
+export class Cargo {
+    rootFolder: string;
+    env?: { [key: string]: string };
+
+    public constructor(cargoTomlFolder: string) {
+        this.rootFolder = cargoTomlFolder;
+    }
+
+    public async artifactsFromArgs(cargoArgs: string[]): Promise<CompilationArtifact[]> {
+        let artifacts: CompilationArtifact[] = [];
+
+        try {
+            await this.runCargo(cargoArgs,
+                message => {
+                    if (message.reason == 'compiler-artifact' && message.executable) {
+                        let isBinary = message.target.crate_types.includes('bin');
+                        let isBuildScript = message.target.kind.includes('custom-build');
+                        if ((isBinary && !isBuildScript) || message.profile.test) {
+                            artifacts.push({
+                                fileName: message.executable,
+                                name: message.target.name,
+                                kind: message.target.kind[0],
+                                isTest: message.profile.test
+                            })
+                        }
+                    }
+                },
+                _stderr => {
+                    // TODO: to output
+                }
+            );
+        }
+        catch (err) {
+            // TODO: to output
+            throw new Error(`Cargo invocation has failed: ${err}`);
+        }
+
+        return artifacts;
+    }
+
+    public async executableFromArgs(cargoArgs: string[], extraArgs?: string[]): Promise<string> {
+        cargoArgs.push("--message-format=json");
+        if (extraArgs) {
+            cargoArgs.push('--');
+            cargoArgs.push(...extraArgs);
+        }
+
+        let artifacts = await this.artifactsFromArgs(cargoArgs);
+
+        if (artifacts.length == 0 ) {
+            throw new Error('No compilation artifacts');
+        } else if (artifacts.length > 1) {
+            throw new Error('Multiple compilation artifacts are not supported.');
+        }
+
+        return artifacts[0].fileName;
+    }
+
+    runCargo(
+        cargoArgs: string[],
+        onStdoutJson: (obj: any) => void,
+        onStderrString: (data: string) => void
+    ): Promise<number> {
+        return new Promise<number>((resolve, reject) => {
+            let cargo = cp.spawn('cargo', cargoArgs, {
+                stdio: ['ignore', 'pipe', 'pipe'],
+                cwd: this.rootFolder,
+                env: this.env,
+            });
+
+            cargo.on('error', err => {
+                reject(new Error(`could not launch cargo: ${err}`));
+            });
+            cargo.stderr.on('data', chunk => {
+                onStderrString(chunk.toString());
+            });
+
+            let rl = readline.createInterface({ input: cargo.stdout });
+            rl.on('line', line => {
+                let message = JSON.parse(line);
+                onStdoutJson(message);
+            });
+
+            cargo.on('exit', (exitCode, _) => {
+                if (exitCode == 0)
+                    resolve(exitCode);
+                else
+                    reject(new Error(`exit code: ${exitCode}.`));
+            });
+        });
+    }
+}

--- a/editors/code/src/commands/runnables.ts
+++ b/editors/code/src/commands/runnables.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as lc from 'vscode-languageclient';
 import * as ra from '../rust-analyzer-api';
+import * as os from "os";
 
 import { Ctx, Cmd } from '../ctx';
 import { Cargo } from '../cargo';
@@ -82,7 +83,7 @@ async function getCppvsDebugConfig(config: ra.Runnable, sourceFileMap: Record<st
     let executable = await cargo.executableFromArgs(config.args, config.extraArgs);
 
     return {
-        type: "cppvsdbg",
+        type: (os.platform() === "win32") ? "cppvsdbg" : 'cppdbg',
         request: "launch",
         name: config.label,
         program: executable,

--- a/editors/code/src/commands/runnables.ts
+++ b/editors/code/src/commands/runnables.ts
@@ -82,9 +82,9 @@ const debugOutput = vscode.window.createOutputChannel("Debug");
 
 async function getCppvsDebugConfig(config: ra.Runnable, sourceFileMap: Record<string, string>): Promise<vscode.DebugConfiguration> {
     debugOutput.clear();
-    
-    let cargo = new Cargo(config.cwd || '.', debugOutput);
-    let executable = await cargo.executableFromArgs(config.args, config.extraArgs);
+
+    const cargo = new Cargo(config.cwd || '.', debugOutput);
+    const executable = await cargo.executableFromArgs(config.args, config.extraArgs);
 
     // if we are here, there were no compilation errors.
     return {
@@ -106,9 +106,9 @@ export function debugSingle(ctx: Ctx): Cmd {
         const lldbId = "vadimcn.vscode-lldb";
         const cpptoolsId = "ms-vscode.cpptools";
 
-        let debugEngineId = ctx.config.debug.engine;
+        const debugEngineId = ctx.config.debug.engine;
         let debugEngine = null;
-        if ( debugEngineId === "auto" ) {
+        if (debugEngineId === "auto") {
             debugEngine = vscode.extensions.getExtension(lldbId);
             if (!debugEngine) {
                 debugEngine = vscode.extensions.getExtension(cpptoolsId);
@@ -120,11 +120,11 @@ export function debugSingle(ctx: Ctx): Cmd {
 
         if (!debugEngine) {
             vscode.window.showErrorMessage(`Install [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=${lldbId})`
-            + ` or [MS C++ tools](https://marketplace.visualstudio.com/items?itemName=${cpptoolsId}) extension for debugging.`);
+                + ` or [MS C++ tools](https://marketplace.visualstudio.com/items?itemName=${cpptoolsId}) extension for debugging.`);
             return;
         }
 
-        const debugConfig = lldbId == debugEngine.id
+        const debugConfig = lldbId === debugEngine.id
             ? getLldbDebugConfig(config, ctx.config.debug.sourceFileMap)
             : await getCppvsDebugConfig(config, ctx.config.debug.sourceFileMap);
 

--- a/editors/code/src/commands/runnables.ts
+++ b/editors/code/src/commands/runnables.ts
@@ -78,10 +78,15 @@ function getLldbDebugConfig(config: ra.Runnable, sourceFileMap: Record<string, s
     };
 }
 
+const debugOutput = vscode.window.createOutputChannel("Debug");
+
 async function getCppvsDebugConfig(config: ra.Runnable, sourceFileMap: Record<string, string>): Promise<vscode.DebugConfiguration> {
-    let cargo = new Cargo(config.cwd || '.');
+    debugOutput.clear();
+    
+    let cargo = new Cargo(config.cwd || '.', debugOutput);
     let executable = await cargo.executableFromArgs(config.args, config.extraArgs);
 
+    // if we are here, there were no compilation errors.
     return {
         type: (os.platform() === "win32") ? "cppvsdbg" : 'cppdbg',
         request: "launch",

--- a/editors/code/src/commands/runnables.ts
+++ b/editors/code/src/commands/runnables.ts
@@ -84,7 +84,7 @@ async function getCppvsDebugConfig(config: ra.Runnable, sourceFileMap: Record<st
     debugOutput.clear();
 
     const cargo = new Cargo(config.cwd || '.', debugOutput);
-    const executable = await cargo.executableFromArgs(config.args, config.extraArgs);
+    const executable = await cargo.executableFromArgs(config.args);
 
     // if we are here, there were no compilation errors.
     return {

--- a/editors/code/src/commands/runnables.ts
+++ b/editors/code/src/commands/runnables.ts
@@ -102,7 +102,7 @@ export function debugSingle(ctx: Ctx): Cmd {
 
         let debugEngineId = ctx.config.debug.engine;
         let debugEngine = null;
-        if (!debugEngineId) {
+        if ( debugEngineId === "auto" ) {
             debugEngine = vscode.extensions.getExtension(lldbId);
             if (!debugEngine) {
                 debugEngine = vscode.extensions.getExtension(cpptoolsId);

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -92,7 +92,6 @@ export class Config {
     get askBeforeDownload() { return this.get<boolean>("updates.askBeforeDownload"); }
     get traceExtension() { return this.get<boolean>("trace.extension"); }
 
-
     get inlayHints() {
         return {
             typeHints: this.get<boolean>("inlayHints.typeHints"),
@@ -107,4 +106,12 @@ export class Config {
             command: this.get<string>("checkOnSave.command"),
         };
     }
+
+    get debug() {
+        return {
+            engine: this.get<null | string>("debug.engine"),
+            sourceFileMap: this.get<Record<string, string>>("debug.sourceFileMap"),
+        };
+    }
+
 }

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -109,7 +109,7 @@ export class Config {
 
     get debug() {
         return {
-            engine: this.get<null | string>("debug.engine"),
+            engine: this.get<string>("debug.engine"),
             sourceFileMap: this.get<Record<string, string>>("debug.sourceFileMap"),
         };
     }


### PR DESCRIPTION
At the moment Debug Code Lens can use only one debug engine: lldb via [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb) extension.

This PR adds support of the debug engine from the [MS C++ tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) extension, as well as the configuration option. If both extensions are installed, `CodeLLDB` will be used by default.

Another new option `rust-analyzer.debug.sourceFileMap` allows, for example, to step into Rust std library during debugging. Works only with `MS C++ tools`.

On Windows: 
```json
"rust-analyzer.debug.sourceFileMap": {
    "/rustc/4fb7144ed159f94491249e86d5bbd033b5d60550": "${env:USERPROFILE}/.rustup/toolchains/stable-x86_64-pc-windows-msvc/lib/rustlib/src/rust"
}
```
On Linux:
```json
"rust-analyzer.debug.sourceFileMap": {
    "/rustc/4fb7144ed159f94491249e86d5bbd033b5d60550": "~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust"
}
```