### PR TITLE
Special-case try macro_rules

### DIFF
--- a/crates/ra_parser/src/grammar/items.rs
+++ b/crates/ra_parser/src/grammar/items.rs
@@ -415,6 +415,17 @@ pub(super) fn macro_call_after_excl(p: &mut Parser) -> BlockLike {
     if p.at(IDENT) {
         name(p);
     }
+    // Special-case `macro_rules! try`.
+    // This is a hack until we do proper edition support
+
+    // test try_macro_rules
+    // macro_rules! try { () => {} }
+    if p.at(T![try]) {
+        let m = p.start();
+        p.bump_remap(IDENT);
+        m.complete(p, NAME);
+    }
+
     match p.current() {
         T!['{'] => {
             token_tree(p);

--- a/crates/ra_syntax/test_data/parser/inline/ok/0160_try_macro_rules.rast
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0160_try_macro_rules.rast
@@ -1,0 +1,27 @@
+SOURCE_FILE@0..30
+  MACRO_CALL@0..29
+    PATH@0..11
+      PATH_SEGMENT@0..11
+        NAME_REF@0..11
+          IDENT@0..11 "macro_rules"
+    BANG@11..12 "!"
+    WHITESPACE@12..13 " "
+    NAME@13..16
+      IDENT@13..16 "try"
+    WHITESPACE@16..17 " "
+    TOKEN_TREE@17..29
+      L_CURLY@17..18 "{"
+      WHITESPACE@18..19 " "
+      TOKEN_TREE@19..21
+        L_PAREN@19..20 "("
+        R_PAREN@20..21 ")"
+      WHITESPACE@21..22 " "
+      EQ@22..23 "="
+      R_ANGLE@23..24 ">"
+      WHITESPACE@24..25 " "
+      TOKEN_TREE@25..27
+        L_CURLY@25..26 "{"
+        R_CURLY@26..27 "}"
+      WHITESPACE@27..28 " "
+      R_CURLY@28..29 "}"
+  WHITESPACE@29..30 "\n"

--- a/crates/ra_syntax/test_data/parser/inline/ok/0160_try_macro_rules.rs
+++ b/crates/ra_syntax/test_data/parser/inline/ok/0160_try_macro_rules.rs
@@ -1,0 +1,1 @@
+macro_rules! try { () => {} }


### PR DESCRIPTION
Similar to #4221, but for `macro_rules! try {}`