### PR TITLE
Support local_inner_macros

### DIFF
--- a/crates/ra_hir/src/semantics/source_to_def.rs
+++ b/crates/ra_hir/src/semantics/source_to_def.rs
@@ -151,7 +151,7 @@ impl SourceToDefCtx<'_, '_> {
         let krate = self.file_to_def(file_id)?.krate;
         let file_ast_id = self.db.ast_id_map(src.file_id).ast_id(&src.value);
         let ast_id = Some(AstId::new(src.file_id, file_ast_id));
-        Some(MacroDefId { krate: Some(krate), ast_id, kind })
+        Some(MacroDefId { krate: Some(krate), ast_id, kind, local_inner: false })
     }
 
     pub(super) fn find_container(&mut self, src: InFile<&SyntaxNode>) -> Option<ChildContainer> {

--- a/crates/ra_hir_def/src/attr.rs
+++ b/crates/ra_hir_def/src/attr.rs
@@ -140,6 +140,7 @@ impl Attr {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
 pub struct AttrQuery<'a> {
     attrs: &'a Attrs,
     key: &'static str,

--- a/crates/ra_hir_def/src/body/lower.rs
+++ b/crates/ra_hir_def/src/body/lower.rs
@@ -430,6 +430,7 @@ impl ExprCollector<'_> {
                         krate: Some(self.expander.module.krate),
                         ast_id: Some(self.expander.ast_id(&e)),
                         kind: MacroDefKind::Declarative,
+                        local_inner: false,
                     };
                     self.body.item_scope.define_legacy_macro(name, mac);
 

--- a/crates/ra_hir_def/src/nameres/collector.rs
+++ b/crates/ra_hir_def/src/nameres/collector.rs
@@ -204,6 +204,7 @@ impl DefCollector<'_> {
                 ast_id: None,
                 krate: Some(krate),
                 kind: MacroDefKind::CustomDerive(expander),
+                local_inner: false,
             };
 
             self.define_proc_macro(name.clone(), macro_id);
@@ -941,6 +942,7 @@ impl ModCollector<'_, '_> {
                     ast_id: Some(ast_id.ast_id),
                     krate: Some(self.def_collector.def_map.krate),
                     kind: MacroDefKind::Declarative,
+                    local_inner: mac.local_inner,
                 };
                 self.def_collector.define_macro(self.module_id, name.clone(), macro_id, mac.export);
             }

--- a/crates/ra_hir_def/src/nameres/raw.rs
+++ b/crates/ra_hir_def/src/nameres/raw.rs
@@ -404,16 +404,20 @@ impl RawItemsCollector {
         let ast_id = self.source_ast_id_map.ast_id(&m);
 
         // FIXME: cfg_attr
-        let export = attrs.by_key("macro_export").exists();
-        let local_inner =
-            attrs.by_key("macro_export").tt_values().map(|it| &it.token_trees).flatten().any(
-                |it| match it {
-                    tt::TokenTree::Leaf(tt::Leaf::Ident(ident)) => {
-                        ident.text.contains("local_inner_macros")
-                    }
-                    _ => false,
-                },
-            );
+        let export_attr = attrs.by_key("macro_export");
+
+        let export = export_attr.exists();
+        let local_inner = if export {
+            export_attr.tt_values().map(|it| &it.token_trees).flatten().any(|it| match it {
+                tt::TokenTree::Leaf(tt::Leaf::Ident(ident)) => {
+                    ident.text.contains("local_inner_macros")
+                }
+                _ => false,
+            })
+        } else {
+            false
+        };
+
         let builtin = attrs.by_key("rustc_builtin_macro").exists();
 
         let m = self.raw_items.macros.alloc(MacroData {

--- a/crates/ra_hir_expand/src/builtin_derive.rs
+++ b/crates/ra_hir_expand/src/builtin_derive.rs
@@ -38,7 +38,7 @@ macro_rules! register_builtin {
                  _ => return None,
             };
 
-            Some(MacroDefId { krate: None, ast_id: None, kind: MacroDefKind::BuiltInDerive(kind),local_inner:false })
+            Some(MacroDefId { krate: None, ast_id: None, kind: MacroDefKind::BuiltInDerive(kind), local_inner: false })
         }
     };
 }

--- a/crates/ra_hir_expand/src/builtin_derive.rs
+++ b/crates/ra_hir_expand/src/builtin_derive.rs
@@ -38,7 +38,7 @@ macro_rules! register_builtin {
                  _ => return None,
             };
 
-            Some(MacroDefId { krate: None, ast_id: None, kind: MacroDefKind::BuiltInDerive(kind) })
+            Some(MacroDefId { krate: None, ast_id: None, kind: MacroDefKind::BuiltInDerive(kind),local_inner:false })
         }
     };
 }

--- a/crates/ra_hir_expand/src/builtin_macro.rs
+++ b/crates/ra_hir_expand/src/builtin_macro.rs
@@ -73,11 +73,13 @@ pub fn find_builtin_macro(
             krate: Some(krate),
             ast_id: Some(ast_id),
             kind: MacroDefKind::BuiltIn(kind),
+            local_inner: false,
         }),
         Either::Right(kind) => Some(MacroDefId {
             krate: Some(krate),
             ast_id: Some(ast_id),
             kind: MacroDefKind::BuiltInEager(kind),
+            local_inner: false,
         }),
     }
 }
@@ -406,6 +408,7 @@ mod tests {
                     krate: Some(CrateId(0)),
                     ast_id: Some(AstId::new(file_id.into(), ast_id_map.ast_id(&macro_calls[0]))),
                     kind: MacroDefKind::BuiltIn(expander),
+                    local_inner: false,
                 };
 
                 let loc = MacroCallLoc {
@@ -425,6 +428,7 @@ mod tests {
                     krate: Some(CrateId(0)),
                     ast_id: Some(AstId::new(file_id.into(), ast_id_map.ast_id(&macro_calls[0]))),
                     kind: MacroDefKind::BuiltInEager(expander),
+                    local_inner: false,
                 };
 
                 let args = macro_calls[1].token_tree().unwrap();

--- a/crates/ra_hir_expand/src/lib.rs
+++ b/crates/ra_hir_expand/src/lib.rs
@@ -204,6 +204,8 @@ pub struct MacroDefId {
     pub krate: Option<CrateId>,
     pub ast_id: Option<AstId<ast::MacroCall>>,
     pub kind: MacroDefKind,
+
+    pub local_inner: bool,
 }
 
 impl MacroDefId {

--- a/crates/ra_hir_ty/src/tests/macros.rs
+++ b/crates/ra_hir_ty/src/tests/macros.rs
@@ -388,6 +388,32 @@ fn main() {
 }
 
 #[test]
+fn infer_local_inner_macros() {
+    let (db, pos) = TestDB::with_position(
+        r#"
+//- /main.rs crate:main deps:foo
+fn test() {
+    let x = foo::foo!(1);
+    x<|>;
+}
+
+//- /lib.rs crate:foo
+#[macro_export(local_inner_macros)]
+macro_rules! foo {
+    (1) => { bar!() };
+}
+
+#[macro_export]
+macro_rules! bar {
+    () => { 42 }
+}
+
+"#,
+    );
+    assert_eq!("i32", type_at_pos(&db, pos));
+}
+
+#[test]
 fn infer_builtin_macros_line() {
     assert_snapshot!(
         infer(r#"

--- a/crates/ra_syntax/src/ast/extensions.rs
+++ b/crates/ra_syntax/src/ast/extensions.rs
@@ -423,6 +423,10 @@ impl ast::MacroCall {
             None
         }
     }
+
+    pub fn is_bang(&self) -> bool {
+        self.is_macro_rules().is_none()
+    }
 }
 
 impl ast::LifetimeParam {


### PR DESCRIPTION
This PR implements `#[macro_export(local_inner_macros)]` support. 

Note that the rustc implementation is quite [hacky][1] too. :)

[1]: https://github.com/rust-lang/rust/blob/614f273e9388ddd7804d5cbc80b8865068a3744e/src/librustc_resolve/macros.rs#L456