### PR TITLE
Show unsafe trait in hover

### DIFF
--- a/crates/ra_ide/src/display/short_label.rs
+++ b/crates/ra_ide/src/display/short_label.rs
@@ -33,7 +33,11 @@ impl ShortLabel for ast::EnumDef {
 
 impl ShortLabel for ast::TraitDef {
     fn short_label(&self) -> Option<String> {
-        short_label_from_node(self, "trait ")
+        if self.unsafe_token().is_some() {
+            short_label_from_node(self, "unsafe trait ")
+        } else {
+            short_label_from_node(self, "trait ")
+        }
     }
 }
 

--- a/crates/ra_ide/src/hover.rs
+++ b/crates/ra_ide/src/hover.rs
@@ -869,4 +869,15 @@ fn func(foo: i32) { if true { <|>foo; }; }
             &[r#"pub(crate) async unsafe extern "C" fn foo()"#],
         );
     }
+
+    #[test]
+    fn test_hover_trait_show_qualifiers() {
+        check_hover_result(
+            "
+            //- /lib.rs
+            unsafe trait foo<|>() {}
+            ",
+            &["unsafe trait foo"],
+        );
+    }
 }


### PR DESCRIPTION
Following on #2450 and #4210, for traits.
`unsafe` is the only qualifier they can have, though.