### PR TITLE
Support local_inner_macros

### DIFF
--- a/crates/ra_hir_def/src/body.rs
+++ b/crates/ra_hir_def/src/body.rs
@@ -22,7 +22,7 @@ use crate::{
     item_scope::BuiltinShadowMode,
     item_scope::ItemScope,
     nameres::CrateDefMap,
-    path::{ModPath, Path},
+    path::{ModPath, Path, PathKind},
     src::HasSource,
     AsMacroCall, DefWithBodyId, HasModule, Lookup, ModuleId,
 };
@@ -152,8 +152,13 @@ impl Expander {
     }
 
     fn resolve_path_as_macro(&self, db: &dyn DefDatabase, path: &ModPath) -> Option<MacroDefId> {
+        let mut path = path.clone();
+        if let Some(crate_id) = self.cfg_expander.hygiene.implicit_dollar_crate() {
+            path.kind = PathKind::DollarCrate(crate_id);
+        }
+
         self.crate_def_map
-            .resolve_path(db, self.module.local_id, path, BuiltinShadowMode::Other)
+            .resolve_path(db, self.module.local_id, &path, BuiltinShadowMode::Other)
             .0
             .take_macros()
     }

--- a/crates/ra_hir_def/src/body/lower.rs
+++ b/crates/ra_hir_def/src/body/lower.rs
@@ -426,6 +426,7 @@ impl ExprCollector<'_> {
             }
             ast::Expr::MacroCall(e) => {
                 if let Some(name) = e.is_macro_rules().map(|it| it.as_name()) {
+                    // FIXME: `#[macro_export]` needs to be respected here too.
                     let mac = MacroDefId {
                         krate: Some(self.expander.module.krate),
                         ast_id: Some(self.expander.ast_id(&e)),

--- a/crates/ra_hir_def/src/nameres/tests/macros.rs
+++ b/crates/ra_hir_def/src/nameres/tests/macros.rs
@@ -136,6 +136,46 @@ fn macro_rules_export_with_local_inner_macros_are_visible() {
 }
 
 #[test]
+fn local_inner_macros_makes_local_macros_usable() {
+    let map = def_map(
+        "
+        //- /main.rs crate:main deps:foo
+        foo::structs!(Foo, Bar);
+        mod bar;
+
+        //- /bar.rs
+        use crate::*;
+
+        //- /lib.rs crate:foo
+        #[macro_export(local_inner_macros)]
+        macro_rules! structs {
+            ($($i:ident),*) => {
+                inner!($($i),*);
+            }
+        }
+
+        #[macro_export]
+        macro_rules! inner {
+            ($($i:ident),*) => {
+                $(struct $i { field: u32 } )*
+            }
+        }
+        ",
+    );
+    assert_snapshot!(map, @r###"
+   ⋮crate
+   ⋮Bar: t v
+   ⋮Foo: t v
+   ⋮bar: t
+   ⋮
+   ⋮crate::bar
+   ⋮Bar: t v
+   ⋮Foo: t v
+   ⋮bar: t
+    "###);
+}
+
+#[test]
 fn unexpanded_macro_should_expand_by_fixedpoint_loop() {
     let map = def_map(
         "

--- a/crates/ra_hir_def/src/resolver.rs
+++ b/crates/ra_hir_def/src/resolver.rs
@@ -2,6 +2,7 @@
 use std::sync::Arc;
 
 use hir_expand::{
+    hygiene::Hygiene,
     name::{name, Name},
     MacroDefId,
 };
@@ -380,9 +381,15 @@ impl Resolver {
         &self,
         db: &dyn DefDatabase,
         path: &ModPath,
+        hygiene: &Hygiene,
     ) -> Option<MacroDefId> {
+        let mut path = path.clone();
+        if let Some(crate_id) = hygiene.implicit_dollar_crate() {
+            path.kind = PathKind::DollarCrate(crate_id);
+        }
+
         // Search item scope legacy macro first
-        if let Some(def) = self.resolve_local_macro_def(path) {
+        if let Some(def) = self.resolve_local_macro_def(&path) {
             return Some(def);
         }
 

--- a/crates/ra_syntax/src/ast/extensions.rs
+++ b/crates/ra_syntax/src/ast/extensions.rs
@@ -87,10 +87,15 @@ impl ast::Attr {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PathSegmentKind {
+    /// A plain name, or `$crate`.
     Name(ast::NameRef),
+    /// A type or trait reference enclosed in `<` and `>`.
     Type { type_ref: Option<ast::TypeRef>, trait_ref: Option<ast::PathType> },
+    /// `self`
     SelfKw,
+    /// `super`
     SuperKw,
+    /// `crate`
     CrateKw,
 }
 


### PR DESCRIPTION
This gets us somewhat closer to completing definitions produced by `bitflags` and `lazy_static`. For example, idents that go into a macro and are used to define items are now colored correctly.

For some reason the produced definitions are not picked up correctly (the added test is still failing). I'd appreciate some ideas for possible causes.

r? @edwin0cheng 