### PR TITLE
Remove `workspaceLoaded` setting

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -49,7 +49,6 @@ pub enum FilesWatcher {
 
 #[derive(Debug, Clone)]
 pub struct NotificationsConfig {
-    pub workspace_loaded: bool,
     pub cargo_toml_not_found: bool,
 }
 
@@ -83,10 +82,7 @@ impl Default for Config {
             lru_capacity: None,
             proc_macro_srv: None,
             files: FilesConfig { watcher: FilesWatcher::Notify, exclude: Vec::new() },
-            notifications: NotificationsConfig {
-                workspace_loaded: true,
-                cargo_toml_not_found: true,
-            },
+            notifications: NotificationsConfig { cargo_toml_not_found: true },
 
             cargo: CargoConfig::default(),
             rustfmt: RustfmtConfig::Rustfmt { extra_args: Vec::new() },
@@ -129,7 +125,6 @@ impl Config {
             Some("client") => FilesWatcher::Client,
             Some("notify") | _ => FilesWatcher::Notify
         };
-        set(value, "/notifications/workspaceLoaded", &mut self.notifications.workspace_loaded);
         set(value, "/notifications/cargoTomlNotFound", &mut self.notifications.cargo_toml_not_found);
 
         set(value, "/cargo/noDefaultFeatures", &mut self.cargo.no_default_features);

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -415,8 +415,7 @@ fn loop_turn(
         });
     }
 
-    let show_progress =
-        !loop_state.workspace_loaded && world_state.config.notifications.workspace_loaded;
+    let show_progress = !loop_state.workspace_loaded;
 
     if !loop_state.workspace_loaded
         && loop_state.roots_scanned == loop_state.roots_total

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -205,11 +205,6 @@
                     "default": [],
                     "description": "Paths to exclude from analysis."
                 },
-                "rust-analyzer.notifications.workspaceLoaded": {
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Whether to show `workspace loaded` message."
-                },
                 "rust-analyzer.notifications.cargoTomlNotFound": {
                     "type": "boolean",
                     "default": true,


### PR DESCRIPTION
The `workspaceLoaded` notification setting was originally designed to
control the display of a popup message that said:

    "workspace loaded, {} rust packages"

This popup was removed and replaced by a much sleeker message in the
VSCode status bar that provides a real-time status while loading:

    rust-analyzer: {}/{} packages

This was done as part of #3587

The change in this PR simply renames this setting from `workspaceLoaded` to
`progress` to better describe what it actually controls.  At the moment,
the only type of progress message that is controlled by this setting is
the initial load messages, but in theory other messages could also be
controlled by this setting.


Reviewer notes:

* If we didn't like the idea of causing minor breaking to user's config, we could keep the setting name as `workspaceLoaded`
* I think we can now close both #2719 and #3176 since the notification dialog in question no longer exists (actually I think you can close those issues even if you reject this PR 😄 )