### PR TITLE
Improve formatting of analyzer status text

### DIFF
--- a/crates/rust-analyzer/src/main_loop/handlers.rs
+++ b/crates/rust-analyzer/src/main_loop/handlers.rs
@@ -46,11 +46,11 @@ use crate::{
 pub fn handle_analyzer_status(world: WorldSnapshot, _: ()) -> Result<String> {
     let _p = profile("handle_analyzer_status");
     let mut buf = world.status();
-    format_to!(buf, "\n\nrequests:");
+    format_to!(buf, "\n\nrequests:\n");
     let requests = world.latest_requests.read();
     for (is_last, r) in requests.iter() {
         let mark = if is_last { "*" } else { " " };
-        format_to!(buf, "{}{:4} {:<36}{}ms", mark, r.id, r.method, r.duration.as_millis());
+        format_to!(buf, "{}{:4} {:<36}{}ms\n", mark, r.id, r.method, r.duration.as_millis());
     }
     Ok(buf)
 }


### PR DESCRIPTION
The old formatting had everything on 1 line, making it quite hard to read:

    requests:    1 textDocument/documentSymbol         2ms    2 textDocument/codeAction             2ms    3 rust-analyzer/inlayHints            20ms    4 textDocument/foldingRange           108ms    6 textDocument/codeLens               66ms    5 textDocument/semanticTokens/range   76ms    8 rust-analyzer/inlayHints            195ms    7 textDocument/semanticTokens         250ms    9 textDocument/semanticTokens/range   108ms


It now looks like this:

```
requests:
*   1 textDocument/documentSymbol         11ms
    2 textDocument/codeAction             15ms
    3 rust-analyzer/inlayHints            4ms
    5 textDocument/foldingRange           3ms
    4 textDocument/semanticTokens/range   45ms
    6 textDocument/codeLens               182ms
    8 rust-analyzer/inlayHints            124ms
    7 textDocument/semanticTokens         127ms
    9 textDocument/documentHighlight      2ms
   10 textDocument/codeAction             3ms
```