### PR TITLE
Improve derive macro completion

### DIFF
--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -19,7 +19,7 @@ use hir_def::{
 use hir_expand::{
     diagnostics::DiagnosticSink,
     name::{name, AsName},
-    MacroDefId,
+    MacroDefId, MacroDefKind,
 };
 use hir_ty::{
     autoderef, display::HirFormatter, expr::ExprValidator, method_resolution, ApplicationTy,
@@ -762,13 +762,12 @@ impl MacroDef {
 
     /// Indicate it is a proc-macro
     pub fn is_proc_macro(&self) -> bool {
-        match self.id.kind {
-            hir_expand::MacroDefKind::Declarative => false,
-            hir_expand::MacroDefKind::BuiltIn(_) => false,
-            hir_expand::MacroDefKind::BuiltInDerive(_) => false,
-            hir_expand::MacroDefKind::BuiltInEager(_) => false,
-            hir_expand::MacroDefKind::CustomDerive(_) => true,
-        }
+        matches!(self.id.kind, MacroDefKind::CustomDerive(_))
+    }
+
+    /// Indicate it is a derive macro
+    pub fn is_derive_macro(&self) -> bool {
+        matches!(self.id.kind, MacroDefKind::CustomDerive(_) | MacroDefKind::BuiltInDerive(_))
     }
 }
 

--- a/crates/ra_ide/src/completion.rs
+++ b/crates/ra_ide/src/completion.rs
@@ -65,21 +65,23 @@ pub(crate) fn completions(
     let ctx = CompletionContext::new(db, position, config)?;
 
     let mut acc = Completions::default();
-
-    complete_fn_param::complete_fn_param(&mut acc, &ctx);
-    complete_keyword::complete_expr_keyword(&mut acc, &ctx);
-    complete_keyword::complete_use_tree_keyword(&mut acc, &ctx);
-    complete_snippet::complete_expr_snippet(&mut acc, &ctx);
-    complete_snippet::complete_item_snippet(&mut acc, &ctx);
-    complete_qualified_path::complete_qualified_path(&mut acc, &ctx);
-    complete_unqualified_path::complete_unqualified_path(&mut acc, &ctx);
-    complete_dot::complete_dot(&mut acc, &ctx);
-    complete_record::complete_record(&mut acc, &ctx);
-    complete_pattern::complete_pattern(&mut acc, &ctx);
-    complete_postfix::complete_postfix(&mut acc, &ctx);
-    complete_macro_in_item_position::complete_macro_in_item_position(&mut acc, &ctx);
-    complete_trait_impl::complete_trait_impl(&mut acc, &ctx);
-    complete_attribute::complete_attribute(&mut acc, &ctx);
+    if ctx.attribute_under_caret.is_some() {
+        complete_attribute::complete_attribute(&mut acc, &ctx);
+    } else {
+        complete_fn_param::complete_fn_param(&mut acc, &ctx);
+        complete_keyword::complete_expr_keyword(&mut acc, &ctx);
+        complete_keyword::complete_use_tree_keyword(&mut acc, &ctx);
+        complete_snippet::complete_expr_snippet(&mut acc, &ctx);
+        complete_snippet::complete_item_snippet(&mut acc, &ctx);
+        complete_qualified_path::complete_qualified_path(&mut acc, &ctx);
+        complete_unqualified_path::complete_unqualified_path(&mut acc, &ctx);
+        complete_dot::complete_dot(&mut acc, &ctx);
+        complete_record::complete_record(&mut acc, &ctx);
+        complete_pattern::complete_pattern(&mut acc, &ctx);
+        complete_postfix::complete_postfix(&mut acc, &ctx);
+        complete_macro_in_item_position::complete_macro_in_item_position(&mut acc, &ctx);
+        complete_trait_impl::complete_trait_impl(&mut acc, &ctx);
+    }
 
     Some(acc)
 }

--- a/crates/ra_ide/src/completion/completion_context.rs
+++ b/crates/ra_ide/src/completion/completion_context.rs
@@ -58,7 +58,7 @@ pub(crate) struct CompletionContext<'a> {
     pub(super) is_macro_call: bool,
     pub(super) is_path_type: bool,
     pub(super) has_type_args: bool,
-    pub(super) is_attribute: bool,
+    pub(super) attribute_under_caret: Option<ast::Attr>,
 }
 
 impl<'a> CompletionContext<'a> {
@@ -116,7 +116,7 @@ impl<'a> CompletionContext<'a> {
             is_path_type: false,
             has_type_args: false,
             dot_receiver_is_ambiguous_float_literal: false,
-            is_attribute: false,
+            attribute_under_caret: None,
         };
 
         let mut original_file = original_file.syntax().clone();
@@ -200,6 +200,7 @@ impl<'a> CompletionContext<'a> {
                 Some(ty)
             })
             .flatten();
+        self.attribute_under_caret = find_node_at_offset(&file_with_fake_ident, offset);
 
         // First, let's try to complete a reference to some declaration.
         if let Some(name_ref) = find_node_at_offset::<ast::NameRef>(&file_with_fake_ident, offset) {
@@ -318,7 +319,6 @@ impl<'a> CompletionContext<'a> {
                 .and_then(|it| it.syntax().parent().and_then(ast::CallExpr::cast))
                 .is_some();
             self.is_macro_call = path.syntax().parent().and_then(ast::MacroCall::cast).is_some();
-            self.is_attribute = path.syntax().parent().and_then(ast::Attr::cast).is_some();
 
             self.is_path_type = path.syntax().parent().and_then(ast::PathType::cast).is_some();
             self.has_type_args = segment.type_arg_list().is_some();

--- a/crates/ra_syntax/src/ast/extensions.rs
+++ b/crates/ra_syntax/src/ast/extensions.rs
@@ -467,7 +467,7 @@ impl ast::TokenTree {
 
     pub fn right_delimiter_token(&self) -> Option<SyntaxToken> {
         self.syntax().last_child_or_token()?.into_token().filter(|it| match it.kind() {
-            T!['{'] | T!['('] | T!['['] => true,
+            T!['}'] | T![')'] | T![']'] => true,
             _ => false,
         })
     }


### PR DESCRIPTION
* Adds completions for standard derive macros (considering their dependencies on each other, so we don't get compile errors)
* Adds completions for custom derive macros that are in scope, if the proc macro feature is enabled in the settings
* Separates macro completion from other completions to avoid incorrect completion propositions