### PR TITLE
Trigger add_vis assist on paths/record fields as well

### DIFF
--- a/crates/ra_db/src/fixture.rs
+++ b/crates/ra_db/src/fixture.rs
@@ -2,7 +2,7 @@
 //! A fixture without metadata is parsed into a single source file.
 //! Use this to test functionality local to one file.
 //!
-//! Example:
+//! Simple Example:
 //! ```
 //! r#"
 //! fn main() {
@@ -15,7 +15,7 @@
 //! The basic form is specifying filenames,
 //! which is also how to define multiple files in a single test fixture
 //!
-//! Example:
+//! Example using two files in the same crate:
 //! ```
 //! "
 //! //- /main.rs
@@ -29,6 +29,20 @@
 //! "
 //! ```
 //!
+//! Example using two crates with one file each, with one crate depending on the other:
+//! ```
+//! r#"
+//! //- /main.rs crate:a deps:b
+//! fn main() {
+//!     b::foo();
+//! }
+//! //- /lib.rs crate:b
+//! pub fn b() {
+//!     println!("Hello World")
+//! }
+//! "#
+//! ```
+//!
 //! Metadata allows specifying all settings and variables
 //! that are available in a real rust project:
 //! - crate names via `crate:cratename`
@@ -36,7 +50,7 @@
 //! - configuration settings via `cfg:dbg=false,opt_level=2`
 //! - environment variables via `env:PATH=/bin,RUST_LOG=debug`
 //!
-//! Example:
+//! Example using all available metadata:
 //! ```
 //! "
 //! //- /lib.rs crate:foo deps:bar,baz cfg:foo=a,bar=b env:OUTDIR=path/to,OTHER=foo


### PR DESCRIPTION
Resolves #4037.

- [x] Function defs
- [x] ADT defs
- [x] Enum variants
- [x] Consts
- [x] Statics
- [x] Traits
- [x] Type aliases
- [x] Modules
- [x] Record fields (using different implementation)
    - [x] struct fields
    - [x] enum variant fields
    - :x:  union fields (`Semantics::resolve_record_field` seems to not work for union fields, so I think this can be handled in a future PR)
- [x] More tests? 
- [x] Improve test fixture code and documentation a bit (see [Zulip](https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Fwg-rls-2.2E0/topic/resolve_path.20between.20fixture.20files))