### PR TITLE
Add documents owner for ImplDef and SourceFile

### DIFF
--- a/crates/ra_syntax/src/ast/generated/nodes.rs
+++ b/crates/ra_syntax/src/ast/generated/nodes.rs
@@ -12,6 +12,7 @@ pub struct SourceFile {
 }
 impl ast::ModuleItemOwner for SourceFile {}
 impl ast::AttrsOwner for SourceFile {}
+impl ast::DocCommentsOwner for SourceFile {}
 impl SourceFile {
     pub fn modules(&self) -> AstChildren<Module> { support::children(&self.syntax) }
 }
@@ -259,6 +260,7 @@ pub struct ImplDef {
 }
 impl ast::TypeParamsOwner for ImplDef {}
 impl ast::AttrsOwner for ImplDef {}
+impl ast::DocCommentsOwner for ImplDef {}
 impl ImplDef {
     pub fn default_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![default]) }
     pub fn const_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![const]) }

--- a/xtask/src/ast_src.rs
+++ b/xtask/src/ast_src.rs
@@ -305,7 +305,7 @@ macro_rules! ast_enums {
 pub(crate) const AST_SRC: AstSrc = AstSrc {
     tokens: &["Whitespace", "Comment", "String", "RawString"],
     nodes: &ast_nodes! {
-        struct SourceFile: ModuleItemOwner, AttrsOwner {
+        struct SourceFile: ModuleItemOwner, AttrsOwner, DocCommentsOwner {
             modules: [Module],
         }
 
@@ -401,7 +401,7 @@ pub(crate) const AST_SRC: AstSrc = AstSrc {
             T![;]
         }
 
-        struct ImplDef: TypeParamsOwner, AttrsOwner {
+        struct ImplDef: TypeParamsOwner, AttrsOwner, DocCommentsOwner {
             T![default],
             T![const],
             T![unsafe],


### PR DESCRIPTION
When working on #3182, I found that `ImplDef` and `SourceFile` do not implemet `DocCommentsOwer` trait, and I tested it in `cargo doc` that `impl` could has some doc-comments.

I am not so sure about `SourceFile` case, but in theory if that file is a crate root, the doc comment of it should represent the whole crate documentation, right ?