### PR TITLE
Look for `cargo`, `rustc`, and `rustup` in standard installation path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,6 +1000,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ra_env"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "dirs",
+]
+
+[[package]]
 name = "ra_flycheck"
 version = "0.1.0"
 dependencies = [
@@ -1009,6 +1017,7 @@ dependencies = [
  "jod-thread",
  "log",
  "lsp-types",
+ "ra_env",
  "serde_json",
 ]
 
@@ -1209,11 +1218,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
- "dirs",
  "log",
  "ra_arena",
  "ra_cfg",
  "ra_db",
+ "ra_env",
  "ra_proc_macro",
  "rustc-hash",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33954243bd79057c2de7338850b85983a44588021f8a5fee574a8888c6de4344"
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +74,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
+
+[[package]]
+name = "base64"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5ca2cd0adc3f48f9e9ea5a6bbdf9ccc0bfade884847e484d452414c7ccffb3"
@@ -77,6 +89,17 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "blake2b_simd"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
 
 [[package]]
 name = "bstr"
@@ -213,6 +236,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
 name = "crossbeam"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +317,28 @@ name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+
+[[package]]
+name = "dirs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
+dependencies = [
+ "cfg-if",
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_users",
+ "winapi 0.3.8",
+]
 
 [[package]]
 name = "drop_bomb"
@@ -659,7 +710,7 @@ version = "0.74.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0e6a2b8837d27b29deb3f3e6dc1c6d2f57947677f9be1024e482ec5b59525"
 dependencies = [
- "base64",
+ "base64 0.12.0",
  "bitflags",
  "serde",
  "serde_json",
@@ -1158,6 +1209,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
+ "dirs",
  "log",
  "ra_arena",
  "ra_cfg",
@@ -1299,6 +1351,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
+name = "redox_users"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "rust-argon2",
+]
+
+[[package]]
 name = "regex"
 version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,6 +1443,18 @@ dependencies = [
  "test_utils",
  "threadpool",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "rust-argon2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
+dependencies = [
+ "base64 0.11.0",
+ "blake2b_simd",
+ "constant_time_eq",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,12 +22,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33954243bd79057c2de7338850b85983a44588021f8a5fee574a8888c6de4344"
 
 [[package]]
-name = "arrayref"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
-
-[[package]]
 name = "arrayvec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,12 +68,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
-
-[[package]]
-name = "base64"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5ca2cd0adc3f48f9e9ea5a6bbdf9ccc0bfade884847e484d452414c7ccffb3"
@@ -89,17 +77,6 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
-name = "blake2b_simd"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
 
 [[package]]
 name = "bstr"
@@ -236,12 +213,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
 name = "crossbeam"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,28 +288,6 @@ name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
-
-[[package]]
-name = "dirs"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
-dependencies = [
- "cfg-if",
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_users",
- "winapi 0.3.8",
-]
 
 [[package]]
 name = "drop_bomb"
@@ -513,6 +462,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "home"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
+dependencies = [
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -710,7 +668,7 @@ version = "0.74.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0e6a2b8837d27b29deb3f3e6dc1c6d2f57947677f9be1024e482ec5b59525"
 dependencies = [
- "base64 0.12.0",
+ "base64",
  "bitflags",
  "serde",
  "serde_json",
@@ -1004,7 +962,7 @@ name = "ra_env"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "dirs",
+ "home",
 ]
 
 [[package]]
@@ -1360,17 +1318,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
-name = "redox_users"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431"
-dependencies = [
- "getrandom",
- "redox_syscall",
- "rust-argon2",
-]
-
-[[package]]
 name = "regex"
 version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,18 +1399,6 @@ dependencies = [
  "test_utils",
  "threadpool",
  "winapi 0.3.8",
-]
-
-[[package]]
-name = "rust-argon2"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
-dependencies = [
- "base64 0.11.0",
- "blake2b_simd",
- "constant_time_eq",
- "crossbeam-utils",
 ]
 
 [[package]]

--- a/crates/ra_env/Cargo.toml
+++ b/crates/ra_env/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["rust-analyzer developers"]
 
 [dependencies]
 anyhow = "1.0.26"
-dirs = "2.0"
+home = "0.5.3"

--- a/crates/ra_env/Cargo.toml
+++ b/crates/ra_env/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+edition = "2018"
+name = "ra_env"
+version = "0.1.0"
+authors = ["rust-analyzer developers"]
+
+[dependencies]
+anyhow = "1.0.26"
+dirs = "2.0"

--- a/crates/ra_env/src/lib.rs
+++ b/crates/ra_env/src/lib.rs
@@ -33,31 +33,24 @@ pub fn get_path_for_executable(executable_name: impl AsRef<str>) -> Result<Strin
             )))
         }
     } else {
-        let final_path: Option<String> = if is_valid_executable(executable_name) {
-            Some(executable_name.to_owned())
-        } else {
-            if let Some(mut path) = dirs::home_dir() {
-                path.push(".cargo");
-                path.push("bin");
-                path.push(executable_name);
-                if is_valid_executable(&path) {
-                    Some(path.into_os_string().into_string().expect("Invalid Unicode in path"))
-                } else {
-                    None
-                }
-            } else {
-                None
+        if is_valid_executable(executable_name) {
+            return Ok(executable_name.to_owned());
+        }
+        if let Some(mut path) = dirs::home_dir() {
+            path.push(".cargo");
+            path.push("bin");
+            path.push(executable_name);
+            if is_valid_executable(&path) {
+                return Ok(path.into_os_string().into_string().expect("Invalid Unicode in path"));
             }
-        };
-        final_path.ok_or(
-            // This error message may also be caused by $PATH or $CARGO/$RUSTC/etc not being set correctly
-            // for VSCode, even if they are set correctly in a terminal.
-            // On macOS in particular, launching VSCode from terminal with `code <dirname>` causes VSCode
-            // to inherit environment variables including $PATH, $CARGO, $RUSTC, etc from that terminal;
-            // but launching VSCode from Dock does not inherit environment variables from a terminal.
-            // For more discussion, see #3118.
-            Error::msg(format!("Failed to find `{}` executable. Make sure `{}` is in `$PATH`, or set `${}` to point to a valid executable.", executable_name, executable_name, env_var))
-        )
+        }
+        // This error message may also be caused by $PATH or $CARGO/$RUSTC/etc not being set correctly
+        // for VSCode, even if they are set correctly in a terminal.
+        // On macOS in particular, launching VSCode from terminal with `code <dirname>` causes VSCode
+        // to inherit environment variables including $PATH, $CARGO, $RUSTC, etc from that terminal;
+        // but launching VSCode from Dock does not inherit environment variables from a terminal.
+        // For more discussion, see #3118.
+        Err(Error::msg(format!("Failed to find `{}` executable. Make sure `{}` is in `$PATH`, or set `${}` to point to a valid executable.", executable_name, executable_name, env_var)))
     }
 }
 

--- a/crates/ra_env/src/lib.rs
+++ b/crates/ra_env/src/lib.rs
@@ -23,7 +23,10 @@ pub fn get_path_for_executable(executable_name: impl AsRef<str>) -> Result<Strin
         if is_valid_executable(&path) {
             Ok(path)
         } else {
-            Err(Error::msg(format!("`{}` environment variable points to something that's not a valid executable", env_var)))
+            Err(Error::msg(format!(
+                "`{}` environment variable points to something that's not a valid executable",
+                env_var
+            )))
         }
     } else {
         let final_path: Option<String> = if is_valid_executable(executable_name) {

--- a/crates/ra_env/src/lib.rs
+++ b/crates/ra_env/src/lib.rs
@@ -13,7 +13,7 @@ pub fn get_path_for_executable(executable_name: impl AsRef<str>) -> Result<Strin
     // 1) Appropriate environment variable (erroring if this is set but not a usable executable)
     //      example: for cargo, this checks $CARGO environment variable; for rustc, $RUSTC; etc
     // 2) `<executable_name>`
-    //      example: for cargo, this tries just `cargo`, which will succeed if `cargo` in on the $PATH
+    //      example: for cargo, this tries just `cargo`, which will succeed if `cargo` is on the $PATH
     // 3) `~/.cargo/bin/<executable_name>`
     //      example: for cargo, this tries ~/.cargo/bin/cargo
     //      It seems that this is a reasonable place to try for cargo, rustc, and rustup

--- a/crates/ra_env/src/lib.rs
+++ b/crates/ra_env/src/lib.rs
@@ -36,7 +36,7 @@ pub fn get_path_for_executable(executable_name: impl AsRef<str>) -> Result<PathB
         if is_valid_executable(executable_name) {
             return Ok(executable_name.into());
         }
-        if let Some(mut path) = dirs::home_dir() {
+        if let Some(mut path) = ::home::home_dir() {
             path.push(".cargo");
             path.push("bin");
             path.push(executable_name);

--- a/crates/ra_env/src/lib.rs
+++ b/crates/ra_env/src/lib.rs
@@ -1,3 +1,7 @@
+//! This crate contains a single public function
+//! [`get_path_for_executable`](fn.get_path_for_executable.html).
+//! See docs there for more information.
+
 use anyhow::{Error, Result};
 use std::env;
 use std::path::Path;

--- a/crates/ra_env/src/lib.rs
+++ b/crates/ra_env/src/lib.rs
@@ -2,7 +2,7 @@
 //! [`get_path_for_executable`](fn.get_path_for_executable.html).
 //! See docs there for more information.
 
-use anyhow::{Error, Result};
+use anyhow::{bail, Result};
 use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -27,10 +27,10 @@ pub fn get_path_for_executable(executable_name: impl AsRef<str>) -> Result<PathB
         if is_valid_executable(&path) {
             Ok(path.into())
         } else {
-            Err(Error::msg(format!(
+            bail!(
                 "`{}` environment variable points to something that's not a valid executable",
                 env_var
-            )))
+            )
         }
     } else {
         if is_valid_executable(executable_name) {
@@ -50,7 +50,10 @@ pub fn get_path_for_executable(executable_name: impl AsRef<str>) -> Result<PathB
         // to inherit environment variables including $PATH, $CARGO, $RUSTC, etc from that terminal;
         // but launching VSCode from Dock does not inherit environment variables from a terminal.
         // For more discussion, see #3118.
-        Err(Error::msg(format!("Failed to find `{}` executable. Make sure `{}` is in `$PATH`, or set `${}` to point to a valid executable.", executable_name, executable_name, env_var)))
+        bail!(
+            "Failed to find `{}` executable. Make sure `{}` is in `$PATH`, or set `${}` to point to a valid executable.",
+            executable_name, executable_name, env_var
+        )
     }
 }
 

--- a/crates/ra_flycheck/Cargo.toml
+++ b/crates/ra_flycheck/Cargo.toml
@@ -14,6 +14,7 @@ log = "0.4.8"
 cargo_metadata = "0.9.1"
 serde_json = "1.0.48"
 jod-thread = "0.1.1"
+ra_env = { path = "../ra_env" }
 
 [dev-dependencies]
 insta = "0.16.0"

--- a/crates/ra_flycheck/src/lib.rs
+++ b/crates/ra_flycheck/src/lib.rs
@@ -4,7 +4,6 @@
 mod conv;
 
 use std::{
-    env,
     io::{self, BufRead, BufReader},
     path::PathBuf,
     process::{Command, Stdio},
@@ -17,6 +16,7 @@ use lsp_types::{
     CodeAction, CodeActionOrCommand, Diagnostic, Url, WorkDoneProgress, WorkDoneProgressBegin,
     WorkDoneProgressEnd, WorkDoneProgressReport,
 };
+use ra_env::get_path_for_executable;
 
 use crate::conv::{map_rust_diagnostic_to_lsp, MappedRustDiagnostic};
 
@@ -216,7 +216,7 @@ impl FlycheckThread {
 
         let mut cmd = match &self.config {
             FlycheckConfig::CargoCommand { command, all_targets, all_features, extra_args } => {
-                let mut cmd = Command::new(cargo_binary());
+                let mut cmd = Command::new(get_path_for_executable("cargo").unwrap());
                 cmd.arg(command);
                 cmd.args(&["--workspace", "--message-format=json", "--manifest-path"]);
                 cmd.arg(self.workspace_root.join("Cargo.toml"));
@@ -336,8 +336,4 @@ fn run_cargo(
     }
 
     Ok(())
-}
-
-fn cargo_binary() -> String {
-    env::var("CARGO").unwrap_or_else(|_| "cargo".to_string())
 }

--- a/crates/ra_project_model/Cargo.toml
+++ b/crates/ra_project_model/Cargo.toml
@@ -22,3 +22,5 @@ serde = { version = "1.0.106", features = ["derive"] }
 serde_json = "1.0.48"
 
 anyhow = "1.0.26"
+
+dirs = "2.0"

--- a/crates/ra_project_model/Cargo.toml
+++ b/crates/ra_project_model/Cargo.toml
@@ -14,13 +14,12 @@ rustc-hash = "1.1.0"
 cargo_metadata = "0.9.1"
 
 ra_arena = { path = "../ra_arena" }
-ra_db = { path = "../ra_db" }
 ra_cfg = { path = "../ra_cfg" }
+ra_db = { path = "../ra_db" }
+ra_env = { path = "../ra_env" }
 ra_proc_macro =  { path = "../ra_proc_macro" }
 
 serde = { version = "1.0.106", features = ["derive"] }
 serde_json = "1.0.48"
 
 anyhow = "1.0.26"
-
-dirs = "2.0"

--- a/crates/ra_project_model/src/cargo_workspace.rs
+++ b/crates/ra_project_model/src/cargo_workspace.rs
@@ -7,11 +7,11 @@ use std::{
     process::Command,
 };
 
-use super::find_executables::get_path_for_executable;
 use anyhow::{Context, Result};
 use cargo_metadata::{BuildScript, CargoOpt, Message, MetadataCommand, PackageId};
 use ra_arena::{Arena, Idx};
 use ra_db::Edition;
+use ra_env::get_path_for_executable;
 use rustc_hash::FxHashMap;
 
 /// `CargoWorkspace` represents the logical structure of, well, a Cargo

--- a/crates/ra_project_model/src/cargo_workspace.rs
+++ b/crates/ra_project_model/src/cargo_workspace.rs
@@ -8,7 +8,7 @@ use std::{
     process::Command,
 };
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Error, Result};
 use cargo_metadata::{BuildScript, CargoOpt, Message, MetadataCommand, PackageId};
 use ra_arena::{Arena, Idx};
 use ra_db::Edition;
@@ -145,12 +145,8 @@ impl CargoWorkspace {
         cargo_toml: &Path,
         cargo_features: &CargoConfig,
     ) -> Result<CargoWorkspace> {
-        let _ = Command::new(cargo_binary())
-            .arg("--version")
-            .output()
-            .context("failed to run `cargo --version`, is `cargo` in PATH?")?;
-
         let mut meta = MetadataCommand::new();
+        meta.cargo_path(cargo_binary()?);
         meta.manifest_path(cargo_toml);
         if cargo_features.all_features {
             meta.features(CargoOpt::AllFeatures);
@@ -288,7 +284,7 @@ pub fn load_extern_resources(
     cargo_toml: &Path,
     cargo_features: &CargoConfig,
 ) -> Result<ExternResources> {
-    let mut cmd = Command::new(cargo_binary());
+    let mut cmd = Command::new(cargo_binary()?);
     cmd.args(&["check", "--message-format=json", "--manifest-path"]).arg(cargo_toml);
     if cargo_features.all_features {
         cmd.arg("--all-features");
@@ -337,6 +333,51 @@ fn is_dylib(path: &Path) -> bool {
     }
 }
 
-fn cargo_binary() -> String {
-    env::var("CARGO").unwrap_or_else(|_| "cargo".to_string())
+/// Return a `String` to use for executable `cargo`.
+///
+/// E.g., this may just be `cargo` if that gives a valid Cargo executable; or it
+/// may be a full path to a valid Cargo.
+fn cargo_binary() -> Result<String> {
+    // The current implementation checks three places for a `cargo` to use:
+    // 1) $CARGO environment variable (erroring if this is set but not a usable Cargo)
+    // 2) `cargo`
+    // 3) `~/.cargo/bin/cargo`
+    if let Ok(path) = env::var("CARGO") {
+        if is_valid_cargo(&path) {
+            Ok(path)
+        } else {
+            Err(Error::msg("`CARGO` environment variable points to something that's not a valid Cargo executable"))
+        }
+    } else {
+        let final_path: Option<String> = if is_valid_cargo("cargo") {
+            Some("cargo".to_owned())
+        } else {
+            if let Some(mut path) = dirs::home_dir() {
+                path.push(".cargo");
+                path.push("bin");
+                path.push("cargo");
+                if is_valid_cargo(&path) {
+                    Some(path.into_os_string().into_string().expect("Invalid Unicode in path"))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        };
+        final_path.ok_or(
+            // This error message may also be caused by $PATH or $CARGO not being set correctly for VSCode,
+            // even if they are set correctly in a terminal.
+            // On macOS in particular, launching VSCode from terminal with `code <dirname>` causes VSCode
+            // to inherit environment variables including $PATH and $CARGO from that terminal; but
+            // launching VSCode from Dock does not inherit environment variables from a terminal.
+            // For more discussion, see #3118.
+            Error::msg("Failed to find `cargo` executable. Make sure `cargo` is in `$PATH`, or set `$CARGO` to point to a valid Cargo executable.")
+        )
+    }
+}
+
+/// Does the given `Path` point to a usable `Cargo`?
+fn is_valid_cargo(p: impl AsRef<Path>) -> bool {
+    Command::new(p.as_ref()).arg("--version").output().is_ok()
 }

--- a/crates/ra_project_model/src/find_executables.rs
+++ b/crates/ra_project_model/src/find_executables.rs
@@ -1,0 +1,63 @@
+use anyhow::{Error, Result};
+use std::env;
+use std::path::Path;
+use std::process::Command;
+
+/// Return a `String` to use for the given executable.
+///
+/// E.g., `get_path_for_executable("cargo")` may return just `cargo` if that
+/// gives a valid Cargo executable; or it may return a full path to a valid
+/// Cargo.
+pub fn get_path_for_executable(executable_name: impl AsRef<str>) -> Result<String> {
+    // The current implementation checks three places for an executable to use:
+    // 1) Appropriate environment variable (erroring if this is set but not a usable executable)
+    //      example: for cargo, this checks $CARGO environment variable; for rustc, $RUSTC; etc
+    // 2) `<executable_name>`
+    //      example: for cargo, this tries just `cargo`, which will succeed if `cargo` in on the $PATH
+    // 3) `~/.cargo/bin/<executable_name>`
+    //      example: for cargo, this tries ~/.cargo/bin/cargo
+    //      It seems that this is a reasonable place to try for cargo, rustc, and rustup
+    let executable_name = executable_name.as_ref();
+    let env_var = executable_name.to_ascii_uppercase();
+    if let Ok(path) = env::var(&env_var) {
+        if is_valid_executable(&path) {
+            Ok(path)
+        } else {
+            Err(Error::msg(format!("`{}` environment variable points to something that's not a valid executable", env_var)))
+        }
+    } else {
+        let final_path: Option<String> = if is_valid_executable(executable_name) {
+            Some(executable_name.to_owned())
+        } else {
+            if let Some(mut path) = dirs::home_dir() {
+                path.push(".cargo");
+                path.push("bin");
+                path.push(executable_name);
+                if is_valid_executable(&path) {
+                    Some(path.into_os_string().into_string().expect("Invalid Unicode in path"))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        };
+        final_path.ok_or(
+            // This error message may also be caused by $PATH or $CARGO/$RUSTC/etc not being set correctly
+            // for VSCode, even if they are set correctly in a terminal.
+            // On macOS in particular, launching VSCode from terminal with `code <dirname>` causes VSCode
+            // to inherit environment variables including $PATH, $CARGO, $RUSTC, etc from that terminal;
+            // but launching VSCode from Dock does not inherit environment variables from a terminal.
+            // For more discussion, see #3118.
+            Error::msg(format!("Failed to find `{}` executable. Make sure `{}` is in `$PATH`, or set `${}` to point to a valid executable.", executable_name, executable_name, env_var))
+        )
+    }
+}
+
+/// Does the given `Path` point to a usable executable?
+///
+/// (assumes the executable takes a `--version` switch and writes to stdout,
+/// which is true for `cargo`, `rustc`, and `rustup`)
+fn is_valid_executable(p: impl AsRef<Path>) -> bool {
+    Command::new(p.as_ref()).arg("--version").output().is_ok()
+}

--- a/crates/ra_project_model/src/lib.rs
+++ b/crates/ra_project_model/src/lib.rs
@@ -1,7 +1,6 @@
 //! FIXME: write short doc here
 
 mod cargo_workspace;
-mod find_executables;
 mod json_project;
 mod sysroot;
 
@@ -15,6 +14,7 @@ use std::{
 use anyhow::{bail, Context, Result};
 use ra_cfg::CfgOptions;
 use ra_db::{CrateGraph, CrateName, Edition, Env, ExternSource, ExternSourceId, FileId};
+use ra_env::get_path_for_executable;
 use rustc_hash::FxHashMap;
 use serde_json::from_reader;
 
@@ -559,7 +559,7 @@ pub fn get_rustc_cfg_options(target: Option<&String>) -> CfgOptions {
 
     match (|| -> Result<String> {
         // `cfg(test)` and `cfg(debug_assertion)` are handled outside, so we suppress them here.
-        let mut cmd = Command::new("rustc");
+        let mut cmd = Command::new(get_path_for_executable("rustc")?);
         cmd.args(&["--print", "cfg", "-O"]);
         if let Some(target) = target {
             cmd.args(&["--target", target.as_str()]);

--- a/crates/ra_project_model/src/lib.rs
+++ b/crates/ra_project_model/src/lib.rs
@@ -1,6 +1,7 @@
 //! FIXME: write short doc here
 
 mod cargo_workspace;
+mod find_executables;
 mod json_project;
 mod sysroot;
 

--- a/crates/ra_project_model/src/sysroot.rs
+++ b/crates/ra_project_model/src/sysroot.rs
@@ -89,7 +89,11 @@ fn create_command_text(program: &str, args: &[&str]) -> String {
     format!("{} {}", program, args.join(" "))
 }
 
-fn run_command_in_cargo_dir(cargo_toml: impl AsRef<Path>, program: impl AsRef<Path>, args: &[&str]) -> Result<Output> {
+fn run_command_in_cargo_dir(
+    cargo_toml: impl AsRef<Path>,
+    program: impl AsRef<Path>,
+    args: &[&str],
+) -> Result<Output> {
     let program = program.as_ref().as_os_str().to_str().expect("Invalid Unicode in path");
     let output = Command::new(program)
         .current_dir(cargo_toml.as_ref().parent().unwrap())

--- a/crates/ra_project_model/src/sysroot.rs
+++ b/crates/ra_project_model/src/sysroot.rs
@@ -1,6 +1,5 @@
 //! FIXME: write short doc here
 
-use super::find_executables::get_path_for_executable;
 use anyhow::{bail, Context, Result};
 use std::{
     env, ops,
@@ -9,6 +8,7 @@ use std::{
 };
 
 use ra_arena::{Arena, Idx};
+use ra_env::get_path_for_executable;
 
 #[derive(Default, Debug, Clone)]
 pub struct Sysroot {
@@ -122,7 +122,8 @@ fn get_or_install_rust_src(cargo_toml: &Path) -> Result<PathBuf> {
     let src_path = sysroot_path.join("lib/rustlib/src/rust/src");
 
     if !src_path.exists() {
-        run_command_in_cargo_dir(cargo_toml, "rustup", &["component", "add", "rust-src"])?;
+        let rustup = get_path_for_executable("rustup")?;
+        run_command_in_cargo_dir(cargo_toml, &rustup, &["component", "add", "rust-src"])?;
     }
     if !src_path.exists() {
         bail!(

--- a/crates/ra_project_model/src/sysroot.rs
+++ b/crates/ra_project_model/src/sysroot.rs
@@ -89,9 +89,10 @@ fn create_command_text(program: &str, args: &[&str]) -> String {
     format!("{} {}", program, args.join(" "))
 }
 
-fn run_command_in_cargo_dir(cargo_toml: &Path, program: &str, args: &[&str]) -> Result<Output> {
+fn run_command_in_cargo_dir(cargo_toml: impl AsRef<Path>, program: impl AsRef<Path>, args: &[&str]) -> Result<Output> {
+    let program = program.as_ref().as_os_str().to_str().expect("Invalid Unicode in path");
     let output = Command::new(program)
-        .current_dir(cargo_toml.parent().unwrap())
+        .current_dir(cargo_toml.as_ref().parent().unwrap())
         .args(args)
         .output()
         .context(format!("{} failed", create_command_text(program, args)))?;

--- a/crates/ra_project_model/src/sysroot.rs
+++ b/crates/ra_project_model/src/sysroot.rs
@@ -1,5 +1,6 @@
 //! FIXME: write short doc here
 
+use super::find_executables::get_path_for_executable;
 use anyhow::{bail, Context, Result};
 use std::{
     env, ops,
@@ -114,7 +115,8 @@ fn get_or_install_rust_src(cargo_toml: &Path) -> Result<PathBuf> {
     if let Ok(path) = env::var("RUST_SRC_PATH") {
         return Ok(path.into());
     }
-    let rustc_output = run_command_in_cargo_dir(cargo_toml, "rustc", &["--print", "sysroot"])?;
+    let rustc = get_path_for_executable("rustc")?;
+    let rustc_output = run_command_in_cargo_dir(cargo_toml, &rustc, &["--print", "sysroot"])?;
     let stdout = String::from_utf8(rustc_output.stdout)?;
     let sysroot_path = Path::new(stdout.trim());
     let src_path = sysroot_path.join("lib/rustlib/src/rust/src");

--- a/editors/code/src/commands/runnables.ts
+++ b/editors/code/src/commands/runnables.ts
@@ -119,8 +119,11 @@ export function debugSingle(ctx: Ctx): Cmd {
         }
 
         if (!debugEngine) {
-            vscode.window.showErrorMessage(`Install [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=${lldbId})`
-                + ` or [MS C++ tools](https://marketplace.visualstudio.com/items?itemName=${cpptoolsId}) extension for debugging.`);
+            vscode.window.showErrorMessage(
+                `Install [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=${lldbId}) ` +
+                `or [MS C++ tools](https://marketplace.visualstudio.com/items?itemName=${cpptoolsId}) ` +
+                `extension for debugging.`
+            );
             return;
         }
 

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -8,10 +8,9 @@ import { activateInlayHints } from './inlay_hints';
 import { activateStatusDisplay } from './status_display';
 import { Ctx } from './ctx';
 import { Config, NIGHTLY_TAG } from './config';
-import { log, assert } from './util';
+import { log, assert, isValidExecutable } from './util';
 import { PersistentState } from './persistent_state';
 import { fetchRelease, download } from './net';
-import { spawnSync } from 'child_process';
 import { activateTaskProvider } from './tasks';
 
 let ctx: Ctx | undefined;
@@ -179,10 +178,7 @@ async function bootstrapServer(config: Config, state: PersistentState): Promise<
 
     log.debug("Using server binary at", path);
 
-    const res = spawnSync(path, ["--version"], { encoding: 'utf8' });
-    log.debug("Checked binary availability via --version", res);
-    log.debug(res, "--version output:", res.output);
-    if (res.status !== 0) {
+    if (!isValidExecutable(path)) {
         throw new Error(`Failed to execute ${path} --version`);
     }
 

--- a/editors/code/src/util.ts
+++ b/editors/code/src/util.ts
@@ -1,6 +1,7 @@
 import * as lc from "vscode-languageclient";
 import * as vscode from "vscode";
 import { strict as nativeAssert } from "assert";
+import { spawnSync } from "child_process";
 
 export function assert(condition: boolean, explanation: string): asserts condition {
     try {
@@ -81,4 +82,14 @@ export function isRustDocument(document: vscode.TextDocument): document is RustD
 
 export function isRustEditor(editor: vscode.TextEditor): editor is RustEditor {
     return isRustDocument(editor.document);
+}
+
+export function isValidExecutable(path: string): boolean {
+    log.debug("Checking availability of a binary at", path);
+
+    const res = spawnSync(path, ["--version"], { encoding: 'utf8' });
+
+    log.debug(res, "--version output:", res.output);
+
+    return res.status === 0;
 }


### PR DESCRIPTION
Discussed in #3118.  This is approximately a 90% fix for the issue described there.

This PR creates a new crate `ra_env` with a function `get_path_for_executable()`; see docs there.  `get_path_for_executable()` improves and generalizes the function `cargo_binary()` which was previously duplicated in the `ra_project_model` and `ra_flycheck` crates.  (Both of those crates now depend on the new `ra_env` crate.)  The new function checks (e.g.) `$CARGO` and `$PATH`, but also falls back on `~/.cargo/bin` manually before erroring out.  This should allow most users to not have to worry about setting the `$CARGO` or `$PATH` variables for VSCode, which can be difficult e.g. on macOS as discussed in #3118.

I've attempted to replace all calls to `cargo`, `rustc`, and `rustup` in rust-analyzer with appropriate invocations of `get_path_for_executable()`; I don't think I've missed any in Rust code, but there is at least one invocation in TypeScript code which I haven't fixed.  (I'm not sure whether it's affected by the same problem or not.) https://github.com/rust-analyzer/rust-analyzer/blob/a4778ddb7a00f552a8e653bbf56ae9fd69cfe1d3/editors/code/src/cargo.ts#L79

I'm sure this PR could be improved a bunch, so I'm happy to take feedback/suggestions on how to solve this problem better, or just bikeshedding variable/function/crate names etc.

cc @Veetaha 

Fixes #3118.