### PR TITLE
do not make an unwrap on the type parameter split

### DIFF
--- a/crates/ra_ide/src/completion/complete_postfix.rs
+++ b/crates/ra_ide/src/completion/complete_postfix.rs
@@ -473,4 +473,20 @@ mod tests {
         "###
         );
     }
+
+    #[test]
+    fn postfix_completion_dont_panic_for_type_parameter() {
+        // Just a test to check if it doesn't panic for now
+        do_postfix_completion(
+            r#"
+                fn foo(test: u32.<|>) {
+
+                }
+
+                fn main() {
+                    let bar = true;
+                }
+                "#,
+        );
+    }
 }

--- a/crates/ra_ide/src/display/function_signature.rs
+++ b/crates/ra_ide/src/display/function_signature.rs
@@ -201,8 +201,12 @@ impl From<&'_ ast::FnDef> for FunctionSignature {
                 }
 
                 res.extend(param_list.params().map(|param| param.syntax().text().to_string()));
-                res_types.extend(param_list.params().map(|param| {
-                    param.syntax().text().to_string().split(':').nth(1).unwrap()[1..].to_string()
+                res_types.extend(param_list.params().filter_map(|param| {
+                    let param_string = param.syntax().text().to_string();
+                    let param_splitted: Vec<&str> = param_string.split(':').collect();
+                    let param_type = param_splitted.get(1)?;
+
+                    Some(param_type[1..].to_string())
                 }));
             }
             (has_self_param, res, res_types)


### PR DESCRIPTION
after playing to reproduce the behavior of #4360 I discovered a panic. Here is the quick fix.