### PR TITLE
Launch rust-analyzer and other rust tool invocations via rustup

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -172,6 +172,41 @@
             "type": "object",
             "title": "Rust Analyzer",
             "properties": {
+                "rust-analyzer.rustupPath": {
+                    "type": "string",
+                    "default": "rustup",
+                    "description": "Path to rustup executable. Ignored if rustup is disabled.",
+                    "scope": "machine"
+                },
+                "rust-analyzer.rustupChannel": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "string",
+                            "enum": [
+                                "default",
+                                "stable",
+                                "beta",
+                                "nightly"
+                            ],
+                            "enumDescriptions": [
+                                "Uses the same channel as your currently open project",
+                                "Explicitly use the `stable` channel",
+                                "Explicitly use the `beta` channel",
+                                "Explicitly use the `nightly` channel"
+                            ]
+                        }
+                    ],
+                    "default": "default",
+                    "description": "Rust channel to invoke rustup with. Ignored if rustup is disabled. By default, uses the same channel as your currently open project."
+                },
+                "rust-analyzer.disableRustup": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Disable usage of rustup and use rustc/cargo from PATH."
+                },
                 "rust-analyzer.diagnostics.enable": {
                     "type": "boolean",
                     "default": true,

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -3,16 +3,21 @@ import * as vscode from 'vscode';
 
 import { CallHierarchyFeature } from 'vscode-languageclient/lib/callHierarchy.proposed';
 import { SemanticTokensFeature, DocumentSemanticsTokensSignature } from 'vscode-languageclient/lib/semanticTokens.proposed';
+import { Config } from './config';
 
-export function createClient(serverPath: string, cwd: string): lc.LanguageClient {
+export function createClient(serverPath: string, cwd: string, config: Config): lc.LanguageClient {
     // '.' Is the fallback if no folder is open
     // TODO?: Workspace folders support Uri's (eg: file://test.txt).
     // It might be a good idea to test if the uri points to a file.
 
-    const run: lc.Executable = {
+    const run: lc.Executable = config.rustupDisabled ? {
         command: serverPath,
         options: { cwd },
-    };
+    } : {
+            command: config.rustupPath,
+            args: ["run", config.getRustupChannel(cwd), serverPath],
+            options: { cwd },
+        };
     const serverOptions: lc.ServerOptions = {
         run,
         debug: run,

--- a/editors/code/src/commands/runnables.ts
+++ b/editors/code/src/commands/runnables.ts
@@ -5,6 +5,7 @@ import * as os from "os";
 
 import { Ctx, Cmd } from '../ctx';
 import { Cargo } from '../cargo';
+import { Config } from '../config';
 
 export function run(ctx: Ctx): Cmd {
     let prevRunnable: RunnableQuickPick | undefined;
@@ -91,8 +92,8 @@ function getCppvsDebugConfig(config: ra.Runnable, executable: string, sourceFile
 
 const debugOutput = vscode.window.createOutputChannel("Debug");
 
-async function getDebugExecutable(config: ra.Runnable): Promise<string> {
-    const cargo = new Cargo(config.cwd || '.', debugOutput);
+async function getDebugExecutable(config: ra.Runnable, extensionConfig: Config): Promise<string> {
+    const cargo = new Cargo(config.cwd || '.', debugOutput, extensionConfig);
     const executable = await cargo.executableFromArgs(config.args);
 
     // if we are here, there were no compilation errors.
@@ -134,7 +135,7 @@ export function debugSingle(ctx: Ctx): Cmd {
             debugOutput.show(true);
         }
 
-        const executable = await getDebugExecutable(config);
+        const executable = await getDebugExecutable(config, ctx.config);
         const debugConfig = knownEngines[debugEngine.id](config, executable, debugOptions.sourceFileMap);
         if (debugConfig.type in debugOptions.engineSettings) {
             const settingsMap = (debugOptions.engineSettings as any)[debugConfig.type];

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -21,7 +21,7 @@ export class Ctx {
         serverPath: string,
         cwd: string,
     ): Promise<Ctx> {
-        const client = createClient(serverPath, cwd);
+        const client = createClient(serverPath, cwd, config);
         const res = new Ctx(config, extCtx, client, serverPath);
         res.pushCleanup(client.start());
         await client.onReady();


### PR DESCRIPTION
This is a first pass at resolving #3154.

Some notes:
* There were some comments within #3154 suggesting fixup within the rust binary, but I instead mimicked the approach taken by the rls-vscode extension, which is to have the vscode extension launch the binary within the correct environment. (Indeed, much of the config.ts/package.json changes are shamelessly copied from rls-vscode, which shares the same licensing)
* While the disableRustup configuration option was copied over, the default configuration is such that the extension now attempts to launch everything via rustup where it did not before.