### PR TITLE
Enhanced coloring

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -623,6 +623,12 @@
                     ],
                     "formatSpecifier": [
                         "punctuation.section.embedded.rust"
+                    ],
+                    "*.mutable": [
+                        "markup.underline"
+                    ],
+                    "*.static": [
+                        "markup.italic"
                     ]
                 }
             }

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -626,9 +626,6 @@
                     ],
                     "*.mutable": [
                         "markup.underline"
-                    ],
-                    "*.static": [
-                        "markup.italic"
                     ]
                 }
             }


### PR DESCRIPTION
This PR builds on #4397 to enhance the existing syntax coloring. 

## Underline mutable variables

The textmate scope `markup.underline` underlines identifiers, which is a nice way to make mutable vars stand out:

<img width="327" alt="Screen Shot 2020-05-09 at 1 18 55 PM" src="https://user-images.githubusercontent.com/1369240/81484179-8bb47d80-91f8-11ea-997d-1dcffbe44aa7.png">

## Italicize static variables

The textmate scope `markup.italic` italicizes identifiers. Italic = static is a common convention in IDEs like IntelliJ:

<img width="288" alt="Screen Shot 2020-05-09 at 1 19 14 PM" src="https://user-images.githubusercontent.com/1369240/81484236-cd452880-91f8-11ea-8478-505ee49bc8b3.png">
