### PR TITLE
Make some stuff public so that they can be reused by other tools

### DIFF
--- a/crates/ra_ide/src/lib.rs
+++ b/crates/ra_ide/src/lib.rs
@@ -176,14 +176,10 @@ impl AnalysisHost {
     pub fn request_cancellation(&mut self) {
         self.db.request_cancellation();
     }
-    pub fn raw_database(
-        &self,
-    ) -> &(impl hir::db::HirDatabase + salsa::Database + ra_db::SourceDatabaseExt) {
+    pub fn raw_database(&self) -> &RootDatabase {
         &self.db
     }
-    pub fn raw_database_mut(
-        &mut self,
-    ) -> &mut (impl hir::db::HirDatabase + salsa::Database + ra_db::SourceDatabaseExt) {
+    pub fn raw_database_mut(&mut self) -> &mut RootDatabase {
         &mut self.db
     }
 }

--- a/crates/ra_project_model/src/lib.rs
+++ b/crates/ra_project_model/src/lib.rs
@@ -35,7 +35,7 @@ pub enum ProjectWorkspace {
 /// `PackageRoot` describes a package root folder.
 /// Which may be an external dependency, or a member of
 /// the current workspace.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct PackageRoot {
     /// Path to the root folder
     path: PathBuf,

--- a/crates/ra_text_edit/src/lib.rs
+++ b/crates/ra_text_edit/src/lib.rs
@@ -21,7 +21,7 @@ pub struct TextEdit {
     indels: Vec<Indel>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct TextEditBuilder {
     indels: Vec<Indel>,
 }

--- a/crates/rust-analyzer/src/cli.rs
+++ b/crates/rust-analyzer/src/cli.rs
@@ -16,6 +16,7 @@ use ra_syntax::{AstNode, SourceFile};
 pub use analysis_bench::{analysis_bench, BenchWhat, Position};
 pub use analysis_stats::analysis_stats;
 pub use diagnostics::diagnostics;
+pub use load_cargo::load_cargo;
 
 #[derive(Clone, Copy)]
 pub enum Verbosity {

--- a/crates/rust-analyzer/src/cli/load_cargo.rs
+++ b/crates/rust-analyzer/src/cli/load_cargo.rs
@@ -22,7 +22,7 @@ fn vfs_root_to_id(r: ra_vfs::VfsRoot) -> SourceRootId {
     SourceRootId(r.0)
 }
 
-pub(crate) fn load_cargo(
+pub fn load_cargo(
     root: &Path,
     load_out_dirs_from_check: bool,
     with_proc_macro: bool,

--- a/editors/code/src/commands/ssr.ts
+++ b/editors/code/src/commands/ssr.ts
@@ -11,7 +11,7 @@ export function ssr(ctx: Ctx): Cmd {
 
         const options: vscode.InputBoxOptions = {
             value: "() ==>> ()",
-            prompt: "EnteR request, for example 'Foo($a:expr) ==> Foo::new($a)' ",
+            prompt: "Enter request, for example 'Foo($a:expr) ==> Foo::new($a)' ",
             validateInput: async (x: string) => {
                 try {
                     await client.sendRequest(ra.ssr, { query: x, parseOnly: true });


### PR DESCRIPTION
So, my little experiment of building a code analysis tool using rust-analyzer is successful. I am going to proceed to build the tool now. This PR makes the needed things public.

I know there were some things about trying to change stuff regarding loading workspaces, which would make it more easier for other tools to reuse. But, until then, it should be okay using this `load_cargo` fn.

Btw, if I were publish my tool, I would need the `ra` crates to be released. Since @matklad told me that he doesn't want to care about breaking stuff, I would propose the following.

Every monday, during the weekly release, we release a new pre v1 minor version of all the crates. That way, we don't need to care about breaking stuff but still have rust-analyzer on crates.io.

I made https://github.com/pksunkara/cargo-workspaces to help release workspace crates easily.

So, coming week, we start with `0.1.0`, then week after that, we release `0.2.0` and then `0.3.0` etc.. until we decide on `1.0.0` which is probably when the compiler team also starts using the crates. There is no limit to the minor versions (we can even have `0.150.0` or `0.1500.0`), so I don't see anything wrong with this strategy.