### PR TITLE
Update cargo-metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e3374c604fb39d1a2f35ed5e4a4e30e60d01fab49446e08f1b3e9a90aef202"
+checksum = "b8de60b887edf6d74370fc8eb177040da4847d971d6234c7b13a6da324ef0caf"
 dependencies = [
  "semver",
  "serde",
@@ -1515,18 +1515,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
+checksum = "eba7550f2cdf88ffc23ab0f1607133486c390a8c0f89b57e589b9654ee15e04d"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
+checksum = "10be45e22e5597d4b88afcc71f9d7bfadcd604bf0c78a3ab4582b8d2b37f39f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/ra_flycheck/Cargo.toml
+++ b/crates/ra_flycheck/Cargo.toml
@@ -11,7 +11,7 @@ doctest = false
 crossbeam-channel = "0.4.0"
 lsp-types = { version = "0.74.0", features = ["proposed"] }
 log = "0.4.8"
-cargo_metadata = "0.9.1"
+cargo_metadata = "0.10.0"
 serde_json = "1.0.48"
 jod-thread = "0.1.1"
 ra_env = { path = "../ra_env" }

--- a/crates/ra_flycheck/src/lib.rs
+++ b/crates/ra_flycheck/src/lib.rs
@@ -205,6 +205,8 @@ impl FlycheckThread {
             }
 
             CheckEvent::Msg(Message::BuildScriptExecuted(_msg)) => {}
+            CheckEvent::Msg(Message::BuildFinished(_)) => {}
+            CheckEvent::Msg(Message::TextLine(_)) => {}
             CheckEvent::Msg(Message::Unknown) => {}
         }
     }

--- a/crates/ra_proc_macro_srv/Cargo.toml
+++ b/crates/ra_proc_macro_srv/Cargo.toml
@@ -18,7 +18,7 @@ memmap = "0.7"
 test_utils = { path = "../test_utils" }
 
 [dev-dependencies]
-cargo_metadata = "0.9.1"
+cargo_metadata = "0.10.0"
 difference = "2.0.0"
 # used as proc macro test target
-serde_derive = "=1.0.106"
+serde_derive = "1.0.106"

--- a/crates/ra_proc_macro_srv/src/tests/fixtures/test_serialize_proc_macro.txt
+++ b/crates/ra_proc_macro_srv/src/tests/fixtures/test_serialize_proc_macro.txt
@@ -23,23 +23,12 @@ SUBTREE $
     SUBTREE [] 4294967295
       IDENT   allow 4294967295
       SUBTREE () 4294967295
-        IDENT   unknown_lints 4294967295
-    PUNCH   # [alone] 4294967295
-    SUBTREE [] 4294967295
-      IDENT   cfg_attr 4294967295
-      SUBTREE () 4294967295
-        IDENT   feature 4294967295
-        PUNCH   = [alone] 4294967295
-        LITERAL "cargo-clippy" 0
-        PUNCH   , [alone] 4294967295
-        IDENT   allow 4294967295
-        SUBTREE () 4294967295
-          IDENT   useless_attribute 4294967295
-    PUNCH   # [alone] 4294967295
-    SUBTREE [] 4294967295
-      IDENT   allow 4294967295
-      SUBTREE () 4294967295
         IDENT   rust_2018_idioms 4294967295
+        PUNCH   , [alone] 4294967295
+        IDENT   clippy 4294967295
+        PUNCH   : [joint] 4294967295
+        PUNCH   : [alone] 4294967295
+        IDENT   useless_attribute 4294967295
     IDENT   extern 4294967295
     IDENT   crate 4294967295
     IDENT   serde 4294967295

--- a/crates/ra_proc_macro_srv/src/tests/mod.rs
+++ b/crates/ra_proc_macro_srv/src/tests/mod.rs
@@ -10,7 +10,7 @@ fn test_derive_serialize_proc_macro() {
     assert_expand(
         "serde_derive",
         "Serialize",
-        "1.0.106",
+        "1.0",
         r##"struct Foo {}"##,
         include_str!("fixtures/test_serialize_proc_macro.txt"),
     );
@@ -21,7 +21,7 @@ fn test_derive_serialize_proc_macro_failed() {
     assert_expand(
         "serde_derive",
         "Serialize",
-        "1.0.106",
+        "1.0",
         r##"
     struct {}
 "##,
@@ -37,7 +37,7 @@ SUBTREE $
 
 #[test]
 fn test_derive_proc_macro_list() {
-    let res = list("serde_derive", "1.0.106").join("\n");
+    let res = list("serde_derive", "1.0").join("\n");
 
     assert_eq_text!(
         &res,

--- a/crates/ra_proc_macro_srv/src/tests/utils.rs
+++ b/crates/ra_proc_macro_srv/src/tests/utils.rs
@@ -24,7 +24,7 @@ mod fixtures {
                 Message::CompilerArtifact(artifact) => {
                     if artifact.target.kind.contains(&"proc-macro".to_string()) {
                         let repr = format!("{} {}", crate_name, version);
-                        if artifact.package_id.repr.starts_with(dbg!(&repr)) {
+                        if artifact.package_id.repr.starts_with(&repr) {
                             return artifact.filenames[0].clone();
                         }
                     }

--- a/crates/ra_proc_macro_srv/src/tests/utils.rs
+++ b/crates/ra_proc_macro_srv/src/tests/utils.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 use test_utils::assert_eq_text;
 
 mod fixtures {
-    use cargo_metadata::{parse_messages, Message};
+    use cargo_metadata::Message;
     use std::process::Command;
 
     // Use current project metadata to get the proc-macro dylib path
@@ -19,12 +19,12 @@ mod fixtures {
             .unwrap()
             .stdout;
 
-        for message in parse_messages(command.as_slice()) {
+        for message in Message::parse_stream(command.as_slice()) {
             match message.unwrap() {
                 Message::CompilerArtifact(artifact) => {
                     if artifact.target.kind.contains(&"proc-macro".to_string()) {
                         let repr = format!("{} {}", crate_name, version);
-                        if artifact.package_id.repr.starts_with(&repr) {
+                        if artifact.package_id.repr.starts_with(dbg!(&repr)) {
                             return artifact.filenames[0].clone();
                         }
                     }

--- a/crates/ra_project_model/Cargo.toml
+++ b/crates/ra_project_model/Cargo.toml
@@ -11,7 +11,7 @@ doctest = false
 log = "0.4.8"
 rustc-hash = "1.1.0"
 
-cargo_metadata = "0.9.1"
+cargo_metadata = "0.10.0"
 
 ra_arena = { path = "../ra_arena" }
 ra_cfg = { path = "../ra_cfg" }


### PR DESCRIPTION
This PR update `cargo-metadata` to  0.10.0 and it also relax the` serde-derive` deps to 1.0 for tests in `proc-macro-srv`.

cc @robojumper 

r= @matklad  , I think you would have something to say related to https://github.com/serde-rs/json/issues/647#issue-593788429 ?



