### PR TITLE
infer: Make expected rhs type for plain assign the lhs type

### DIFF
--- a/crates/ra_hir_ty/src/op.rs
+++ b/crates/ra_hir_ty/src/op.rs
@@ -30,7 +30,8 @@ pub(super) fn binary_op_return_ty(op: BinaryOp, lhs_ty: Ty, rhs_ty: Ty) -> Ty {
 pub(super) fn binary_op_rhs_expectation(op: BinaryOp, lhs_ty: Ty) -> Ty {
     match op {
         BinaryOp::LogicOp(..) => Ty::simple(TypeCtor::Bool),
-        BinaryOp::Assignment { op: None } | BinaryOp::CmpOp(CmpOp::Eq { .. }) => match lhs_ty {
+        BinaryOp::Assignment { op: None } => lhs_ty,
+        BinaryOp::CmpOp(CmpOp::Eq { .. }) => match lhs_ty {
             Ty::Apply(ApplicationTy { ctor, .. }) => match ctor {
                 TypeCtor::Int(..)
                 | TypeCtor::Float(..)

--- a/crates/ra_hir_ty/src/tests/simple.rs
+++ b/crates/ra_hir_ty/src/tests/simple.rs
@@ -1787,3 +1787,32 @@ fn main() {
     "###
     )
 }
+
+#[test]
+fn infer_generic_from_later_assignment() {
+    assert_snapshot!(
+        infer(r#"
+enum Option<T> { Some(T), None }
+use Option::*;
+
+fn test() {
+    let mut end = None;
+    loop {
+        end = Some(true);
+    }
+}
+"#),
+        @r###"
+    60..130 '{     ...   } }': ()
+    70..77 'mut end': Option<bool>
+    80..84 'None': Option<bool>
+    90..128 'loop {...     }': !
+    95..128 '{     ...     }': ()
+    105..108 'end': Option<bool>
+    105..121 'end = ...(true)': ()
+    111..115 'Some': Some<bool>(bool) -> Option<bool>
+    111..121 'Some(true)': Option<bool>
+    116..120 'true': bool
+    "###
+    );
+}


### PR DESCRIPTION
This fixes an issue where the following code sample would fail to infer
the type contained in the option:
```rust
fn main() {
    let mut end = None; // Was Option<{unknown}>, is now Option<bool>
    loop {
        end = Some(true);
    }
}
```