### PR TITLE
:arrow_up: ra_vfs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1221,9 +1221,9 @@ dependencies = [
 
 [[package]]
 name = "ra_vfs"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcaa5615f420134aea7667253db101d03a5c5f300eac607872dc2a36407b2ac9"
+checksum = "cbf31a173fc77ec59c27cf39af6baa137b40f4dbd45a8b3eccb1b2e4cfc922c1"
 dependencies = [
  "crossbeam-channel",
  "jod-thread",


### PR DESCRIPTION
Fix a critical bug where \r\n line endings would accidentally sneak in
after in-memory overlay removal.



bors r+
🤖