### PR TITLE
Find references to a function outside module

### DIFF
--- a/crates/ra_ide/src/references.rs
+++ b/crates/ra_ide/src/references.rs
@@ -593,6 +593,31 @@ mod tests {
         check_result(refs, "i BIND_PAT FileId(1) 36..37 Other", &["FileId(1) 51..52 Other Write"]);
     }
 
+    #[test]
+    fn test_find_struct_function_refs_outside_module() {
+        let code = r#"
+        mod foo {
+            pub struct Foo;
+
+            impl Foo {
+                pub fn new<|>() -> Foo {
+                    Foo
+                }
+            }
+        }
+
+        fn main() {
+            let _f = foo::Foo::new();
+        }"#;
+
+        let refs = get_all_refs(code);
+        check_result(
+            refs,
+            "new FN_DEF FileId(1) 87..150 94..97 Other",
+            &["FileId(1) 227..230 StructLiteral"],
+        );
+    }
+
     fn get_all_refs(text: &str) -> ReferenceSearchResult {
         let (analysis, position) = single_file_with_position(text);
         analysis.find_all_refs(position, None).unwrap().unwrap()

--- a/crates/ra_ide_db/src/defs.rs
+++ b/crates/ra_ide_db/src/defs.rs
@@ -53,6 +53,8 @@ impl Definition {
                     module?.visibility_of(db, &ModuleDef::Adt(Adt::Enum(parent)))
                 }
                 ModuleDef::Function(f) => Some(f.visibility(db)),
+                ModuleDef::Const(c) => Some(c.visibility(db)),
+                ModuleDef::TypeAlias(t) => Some(t.visibility(db)),
                 _ => module?.visibility_of(db, def),
             },
             Definition::SelfType(_) => None,

--- a/crates/ra_ide_db/src/defs.rs
+++ b/crates/ra_ide_db/src/defs.rs
@@ -6,7 +6,7 @@
 // FIXME: this badly needs rename/rewrite (matklad, 2020-02-06).
 
 use hir::{
-    Adt, Field, HasVisibility, ImplDef, Local, MacroDef, Module, ModuleDef, Name, PathResolution,
+    Field, HasVisibility, ImplDef, Local, MacroDef, Module, ModuleDef, Name, PathResolution,
     Semantics, TypeParam, Visibility,
 };
 use ra_prof::profile;
@@ -42,21 +42,10 @@ impl Definition {
     }
 
     pub fn visibility(&self, db: &RootDatabase) -> Option<Visibility> {
-        let module = self.module(db);
-
         match self {
             Definition::Macro(_) => None,
             Definition::Field(sf) => Some(sf.visibility(db)),
-            Definition::ModuleDef(def) => match def {
-                ModuleDef::EnumVariant(id) => {
-                    let parent = id.parent_enum(db);
-                    module?.visibility_of(db, &ModuleDef::Adt(Adt::Enum(parent)))
-                }
-                ModuleDef::Function(f) => Some(f.visibility(db)),
-                ModuleDef::Const(c) => Some(c.visibility(db)),
-                ModuleDef::TypeAlias(t) => Some(t.visibility(db)),
-                _ => module?.visibility_of(db, def),
-            },
+            Definition::ModuleDef(def) => def.definition_visibility(db),
             Definition::SelfType(_) => None,
             Definition::Local(_) => None,
             Definition::TypeParam(_) => None,

--- a/crates/ra_ide_db/src/defs.rs
+++ b/crates/ra_ide_db/src/defs.rs
@@ -52,6 +52,7 @@ impl Definition {
                     let parent = id.parent_enum(db);
                     module?.visibility_of(db, &ModuleDef::Adt(Adt::Enum(parent)))
                 }
+                ModuleDef::Function(f) => Some(f.visibility(db)),
                 _ => module?.visibility_of(db, def),
             },
             Definition::SelfType(_) => None,


### PR DESCRIPTION
Fixes #4188 

Yet again, it looks like although the code in 
https://github.com/rust-analyzer/rust-analyzer/blob/da1f316b0246ce41d7cb8560181e294089f06ef3/crates/ra_ide_db/src/search.rs#L128-L132

may be wrong, it is not hit since the `vis` is `None` at this point. The fix is similar to the #4237 case: just add another special case to `Definition::visibility()`.