### PR TITLE
Use RA_LOG instead of RUST_LOG for logging

### DIFF
--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -60,7 +60,7 @@ fn main() -> Result<()> {
 
 fn setup_logging() -> Result<()> {
     std::env::set_var("RUST_BACKTRACE", "short");
-    env_logger::try_init()?;
+    env_logger::try_init_from_env("RA_LOG")?;
     ra_prof::init();
     Ok(())
 }

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -134,7 +134,7 @@ To log all communication between the server and the client, there are two choice
 
 * you can log on the server side, by running something like
   ```
-  env RUST_LOG=gen_lsp_server=trace code .
+  env RA_LOG=gen_lsp_server=trace code .
   ```
 
 * you can log on the client side, by enabling `"rust-analyzer.trace.server":

--- a/docs/user/readme.adoc
+++ b/docs/user/readme.adoc
@@ -108,7 +108,7 @@ Here are some useful self-diagnostic commands:
 
 * **Rust Analyzer: Show RA Version** shows the version of `rust-analyzer` binary
 * **Rust Analyzer: Status** prints some statistics about the server, like the few latest LSP requests
-* To enable server-side logging, run with `env RUST_LOG=info` and see `Output > Rust Analyzer Language Server` in VS Code's panel.
+* To enable server-side logging, run with `env RA_LOG=info` and see `Output > Rust Analyzer Language Server` in VS Code's panel.
 * To log all LSP requests, add `"rust-analyzer.trace.server": "verbose"` to the settings and look for `Server Trace` in the panel.
 * To enable client-side logging, add `"rust-analyzer.trace.extension": true` to the settings and open the `Console` tab of VS Code developer tools.
 


### PR DESCRIPTION
RUST_LOG might be set up for debugging the user's problem, slowing
down rust-analyzer considerably. That's the same reason why rustc uses
RUSTC_LOG.



bors r+
🤖