### PR TITLE
add assist to surround with block

### DIFF
--- a/crates/ra_assists/src/assist_context.rs
+++ b/crates/ra_assists/src/assist_context.rs
@@ -81,6 +81,11 @@ impl<'a> AssistContext<'a> {
     pub(crate) fn covering_element(&self) -> SyntaxElement {
         find_covering_element(self.source_file.syntax(), self.frange.range)
     }
+    pub(crate) fn covering_element_raw_string(&self) -> String {
+        self.source_file.syntax().to_string()
+            [usize::from(self.frange.range.start())..usize::from(self.frange.range.end())]
+            .to_string()
+    }
     // FIXME: remove
     pub(crate) fn covering_node_for_range(&self, range: TextRange) -> SyntaxElement {
         find_covering_element(self.source_file.syntax(), range)

--- a/crates/ra_assists/src/handlers/surround_with_block.rs
+++ b/crates/ra_assists/src/handlers/surround_with_block.rs
@@ -40,7 +40,7 @@ pub(crate) fn surround_with_block(acc: &mut Assists, ctx: &AssistContext) -> Opt
     };
     let target = covering_node.text_range();
 
-    acc.add(AssistId("surrounding_with_block"), "Surrounding with block", target, |edit| {
+    acc.add(AssistId("surround_with_block"), "Surround with block", target, |edit| {
         edit.set_cursor(ctx.frange.range.start());
         let indent_str = "    ";
         let mut inner_expr_lines = ctx
@@ -120,6 +120,24 @@ fn main() {
         bar();
     }
 }"#,
+        );
+
+        check_assist(
+            surround_with_block,
+            r#####"
+fn foo() {
+    <|>println!("foo");
+    println!("bar");<|>
+}
+"#####,
+            r#####"
+fn foo() {
+    <|>{
+        println!("foo");
+        println!("bar");
+    }
+}
+"#####,
         );
     }
 

--- a/crates/ra_assists/src/handlers/surround_with_block.rs
+++ b/crates/ra_assists/src/handlers/surround_with_block.rs
@@ -1,0 +1,210 @@
+use crate::{AssistContext, AssistId, Assists};
+
+use ast::edit::IndentLevel;
+use ra_syntax::{ast, AstNode};
+
+// Assist: surround_with_block
+//
+// This assist surround expressions with a block expression.
+//
+// ```
+// fn foo() {
+//     <|>println!("foo");
+//     println!("bar");<|>
+// }
+// ```
+// ->
+// ```
+// fn foo() {
+//     {
+//         println!("foo");
+//         println!("bar");
+//     }
+// }
+// ```
+pub(crate) fn surround_with_block(acc: &mut Assists, ctx: &AssistContext) -> Option<()> {
+    if ctx.frange.range.is_empty() {
+        return None;
+    }
+    let node: ast::Expr = ctx.find_node_at_offset()?;
+    let child = node.syntax().children_with_tokens().find_map(|elt| match elt {
+        ra_syntax::NodeOrToken::Node(node) => Some(node),
+        ra_syntax::NodeOrToken::Token(_) => None,
+    });
+    let indent_level = IndentLevel::from_node(&child?);
+
+    let covering_elt = ctx.covering_element();
+    let covering_node = match covering_elt {
+        ra_syntax::NodeOrToken::Node(node) => node,
+        ra_syntax::NodeOrToken::Token(_) => return None,
+    };
+    let target = covering_node.text_range();
+
+    acc.add(AssistId("surrounding_with_block"), "Surrounding with block", target, |edit| {
+        edit.set_cursor(ctx.frange.range.start());
+        let indent_str = "    ";
+        let mut inner_expr_lines = ctx
+            .covering_element_raw_string()
+            .trim_start()
+            .lines()
+            .enumerate()
+            .map(|(line_idx, line)| {
+                if line.is_empty() {
+                    return line.to_string();
+                }
+                let line = if line_idx == 0 && indent_level.0 != 0 {
+                    indent_str.repeat(indent_level.0 as usize) + line
+                } else {
+                    line.to_string()
+                };
+                format!("{}{}", indent_str, line)
+            })
+            .collect::<Vec<String>>();
+        inner_expr_lines.push(format!("{}}}", indent_str.repeat(indent_level.0 as usize)));
+
+        edit.replace(ctx.frange.range, format!("{{\n{}", inner_expr_lines.join("\n")));
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::{check_assist, check_assist_not_applicable};
+
+    use super::*;
+
+    #[test]
+    fn not_applicable() {
+        check_assist_not_applicable(
+            surround_with_block,
+            r#"
+            fn main() {
+                bar();
+                <|>foo();
+
+                //comment
+                bar();
+            }"#,
+        );
+
+        check_assist_not_applicable(
+            surround_with_block,
+            r#"
+            fn main() {
+                bar();
+                <|>fo<|>o();
+
+                //comment
+                bar();
+            }"#,
+        );
+    }
+    #[test]
+    fn simple_statements() {
+        check_assist(
+            surround_with_block,
+            r#"
+fn main() {
+    bar();
+    <|>foo();
+
+    //comment
+    bar();<|>
+}"#,
+            r#"
+fn main() {
+    bar();
+    <|>{
+        foo();
+
+        //comment
+        bar();
+    }
+}"#,
+        );
+    }
+
+    #[test]
+    fn simple_let() {
+        check_assist(
+            surround_with_block,
+            r#"
+fn main() {
+    bar();
+    let info = <|>foo();
+
+    //comment
+    bar();<|>
+}"#,
+            r#"
+fn main() {
+    bar();
+    let info = <|>{
+        foo();
+
+        //comment
+        bar();
+    }
+}"#,
+        );
+    }
+
+    #[test]
+    fn simple_in_loop() {
+        check_assist(
+            surround_with_block,
+            r#"
+fn main() {
+    bar();
+    loop {
+        <|>foo();
+
+        //comment
+        bar();<|>
+    }
+}"#,
+            r#"
+fn main() {
+    bar();
+    loop {
+        <|>{
+            foo();
+
+            //comment
+            bar();
+        }
+    }
+}"#,
+        );
+    }
+
+    #[test]
+    fn stmt_with_let() {
+        check_assist(
+            surround_with_block,
+            r#"
+fn main() {
+    if true {
+        println!("test");
+        <|>let bar();
+        foo();
+
+        //comment
+        bar();<|>
+    }
+}"#,
+            r#"
+fn main() {
+    if true {
+        println!("test");
+        <|>{
+            let bar();
+            foo();
+
+            //comment
+            bar();
+        }
+    }
+}"#,
+        );
+    }
+}

--- a/crates/ra_assists/src/lib.rs
+++ b/crates/ra_assists/src/lib.rs
@@ -128,6 +128,7 @@ mod handlers {
     mod replace_qualified_name_with_use;
     mod replace_unwrap_with_match;
     mod split_import;
+    mod surround_with_block;
     mod unwrap_block;
 
     pub(crate) fn all() -> &'static [Handler] {
@@ -169,6 +170,7 @@ mod handlers {
             replace_qualified_name_with_use::replace_qualified_name_with_use,
             replace_unwrap_with_match::replace_unwrap_with_match,
             split_import::split_import,
+            surround_with_block::surround_with_block,
             unwrap_block::unwrap_block,
             // These are manually sorted for better priorities
             add_missing_impl_members::add_missing_impl_members,

--- a/crates/ra_assists/src/tests/generated.rs
+++ b/crates/ra_assists/src/tests/generated.rs
@@ -743,6 +743,27 @@ use std::{collections::HashMap};
 }
 
 #[test]
+fn doctest_surround_with_block() {
+    check_doc_test(
+        "surround_with_block",
+        r#####"
+fn foo() {
+    <|>println!("foo");
+    println!("bar");<|>
+}
+"#####,
+        r#####"
+fn foo() {
+    {
+        println!("foo");
+        println!("bar");
+    }
+}
+"#####,
+    )
+}
+
+#[test]
 fn doctest_unwrap_block() {
     check_doc_test(
         "unwrap_block",

--- a/docs/user/assists.md
+++ b/docs/user/assists.md
@@ -710,6 +710,26 @@ use std::┃collections::HashMap;
 use std::{collections::HashMap};
 ```
 
+## `surround_with_block`
+
+This assist surround expressions with a block expression.
+
+```rust
+// BEFORE
+fn foo() {
+    ┃println!("foo");
+    println!("bar");┃
+}
+
+// AFTER
+fn foo() {
+    {
+        println!("foo");
+        println!("bar");
+    }
+}
+```
+
 ## `unwrap_block`
 
 This assist removes if...else, for, while and loop control statements to just keep the body.


### PR DESCRIPTION
After browsing the features for Intellij Rust I found this kind of feature. It could be interesting when you want to surround expressions inside if block or something similar.

Anyway I think it could be also interesting as a starting point to an assist to create a new function from a selection.

Here is a preview:
![surround_with_block](https://user-images.githubusercontent.com/5719034/81612260-d7278100-93dc-11ea-9a70-74f5c3979927.gif)

