### PR TITLE
Use .rust suffix on scopes

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -595,34 +595,34 @@
                 "language": "rust",
                 "scopes": {
                     "attribute": [
-                        "meta.attribute"
+                        "meta.attribute.rust"
                     ],
                     "builtinType": [
-                        "support.type.primitive"
+                        "support.type.primitive.rust"
                     ],
                     "lifetime": [
                         "storage.modifier.lifetime.rust"
                     ],
                     "typeAlias": [
-                        "entity.name.type.typeAlias"
+                        "entity.name.type.typeAlias.rust"
                     ],
                     "union": [
-                        "entity.name.type.union"
+                        "entity.name.type.union.rust"
                     ],
                     "struct": [
-                        "entity.name.type.struct"
+                        "entity.name.type.struct.rust"
                     ],
                     "keyword": [
-                        "keyword.other"
+                        "keyword.other.rust"
                     ],
                     "keyword.controlFlow": [
-                        "keyword.control"
+                        "keyword.control.rust"
                     ],
                     "variable.constant": [
-                        "variable.other.constant"
+                        "variable.other.constant.rust"
                     ],
                     "formatSpecifier": [
-                        "punctuation.section.embedded"
+                        "punctuation.section.embedded.rust"
                     ]
                 }
             }

--- a/editors/code/rust.tmGrammar.json
+++ b/editors/code/rust.tmGrammar.json
@@ -597,7 +597,7 @@
 		},
 		"core_types": {
 			"comment": "Built-in/core type",
-			"name": "support.type.primitive",
+			"name": "support.type.primitive.rust",
 			"match": "\\b(bool|char|usize|isize|u8|u16|u32|u64|u128|i8|i16|i32|i64|i128|f32|f64|str|Self)\\b"
 		},
 		"core_vars": {


### PR DESCRIPTION
This PR should have no effect on people using any of the default themes, but it is possible there are people with custom themes that rely on the .rust suffix on textmate scopes, which I neglected to use consistently in #4397.