### PR TITLE
fix typo unimplementated -> unimplemented

### DIFF
--- a/crates/ra_hir_expand/src/builtin_macro.rs
+++ b/crates/ra_hir_expand/src/builtin_macro.rs
@@ -360,7 +360,7 @@ fn env_expand(
     // However, we cannot use an empty string here, because for
     // `include!(concat!(env!("OUT_DIR"), "/foo.rs"))` will become
     // `include!("foo.rs"), which might go to infinite loop
-    let s = get_env_inner(db, arg_id, &key).unwrap_or_else(|| "__RA_UNIMPLEMENTATED__".to_string());
+    let s = get_env_inner(db, arg_id, &key).unwrap_or_else(|| "__RA_UNIMPLEMENTED__".to_string());
     let expanded = quote! { #s };
 
     Ok((expanded, FragmentKind::Expr))
@@ -508,7 +508,7 @@ mod tests {
             "#,
         );
 
-        assert_eq!(expanded, "\"__RA_UNIMPLEMENTATED__\"");
+        assert_eq!(expanded, "\"__RA_UNIMPLEMENTED__\"");
     }
 
     #[test]


### PR DESCRIPTION
Pretty harmless typo, but it does get exposed in lsp-rust-analyzer-expand-macro.