### PR TITLE
Fix emojified "|> Run test" arrow (thanks to hhiraba)

### DIFF
--- a/crates/rust-analyzer/src/main_loop/handlers.rs
+++ b/crates/rust-analyzer/src/main_loop/handlers.rs
@@ -847,8 +847,8 @@ pub fn handle_code_lens(
     // Gather runnables
     for runnable in world.analysis().runnables(file_id)? {
         let title = match &runnable.kind {
-            RunnableKind::Test { .. } | RunnableKind::TestMod { .. } => "▶️\u{fe0e}Run Test",
-            RunnableKind::DocTest { .. } => "▶️\u{fe0e}Run Doctest",
+            RunnableKind::Test { .. } | RunnableKind::TestMod { .. } => "\u{25b6} Run Test",
+            RunnableKind::DocTest { .. } => "\u{25b6} Run Doctest",
             RunnableKind::Bench { .. } => "Run Bench",
             RunnableKind::Bin => {
                 // Do not suggest binary run on other target than binary


### PR DESCRIPTION
Addresses #3091, thanks to @hhiraba!

Before:
![image](https://user-images.githubusercontent.com/36276403/81819846-8462dc00-9538-11ea-9ff1-76534e5cf14a.png)
After:
![image](https://user-images.githubusercontent.com/36276403/81819793-757c2980-9538-11ea-8449-ad9dbb53863d.png)

*Tested this only in vscode :P*