### PR TITLE
Generate configuration for launch.json

### DIFF
--- a/crates/rust-analyzer/src/main_loop/handlers.rs
+++ b/crates/rust-analyzer/src/main_loop/handlers.rs
@@ -1020,7 +1020,7 @@ fn to_lsp_runnable(
         RunnableKind::Bench { test_id } => format!("bench {}", test_id),
         RunnableKind::DocTest { test_id, .. } => format!("doctest {}", test_id),
         RunnableKind::Bin => {
-            target.map_or_else(|| "run binary".to_string(), |t| format!("run binary '{}'", t))
+            target.map_or_else(|| "run binary".to_string(), |t| format!("run {}", t))
         }
     };
     Ok(lsp_ext::Runnable {

--- a/crates/rust-analyzer/src/main_loop/handlers.rs
+++ b/crates/rust-analyzer/src/main_loop/handlers.rs
@@ -1011,6 +1011,7 @@ fn to_lsp_runnable(
     runnable: Runnable,
 ) -> Result<lsp_ext::Runnable> {
     let spec = CargoTargetSpec::for_file(world, file_id)?;
+    let target = spec.as_ref().map(|s| s.target.clone());
     let (args, extra_args) = CargoTargetSpec::runnable_args(spec, &runnable.kind)?;
     let line_index = world.analysis().file_line_index(file_id)?;
     let label = match &runnable.kind {
@@ -1018,7 +1019,9 @@ fn to_lsp_runnable(
         RunnableKind::TestMod { path } => format!("test-mod {}", path),
         RunnableKind::Bench { test_id } => format!("bench {}", test_id),
         RunnableKind::DocTest { test_id, .. } => format!("doctest {}", test_id),
-        RunnableKind::Bin => "run binary".to_string(),
+        RunnableKind::Bin => {
+            target.map_or_else(|| "run binary".to_string(), |t| format!("run binary '{}'", t))
+        }
     };
     Ok(lsp_ext::Runnable {
         range: to_proto::range(&line_index, runnable.range),

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -126,6 +126,11 @@
                 "category": "Rust Analyzer"
             },
             {
+                "command": "rust-analyzer.newDebugConfig",
+                "title": "Generate launch configuration",
+                "category": "Rust Analyzer"
+            },
+            {
                 "command": "rust-analyzer.analyzerStatus",
                 "title": "Status",
                 "category": "Rust Analyzer"

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -121,6 +121,11 @@
                 "category": "Rust Analyzer"
             },
             {
+                "command": "rust-analyzer.debug",
+                "title": "Debug",
+                "category": "Rust Analyzer"
+            },
+            {
                 "command": "rust-analyzer.analyzerStatus",
                 "title": "Status",
                 "category": "Rust Analyzer"

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -443,6 +443,11 @@
                     "type": "object",
                     "default": {},
                     "description": "Optional settings passed to the debug engine. Example:\n{ \"lldb\": { \"terminal\":\"external\"} }"
+                },
+                "rust-analyzer.debug.useLaunchJson": {
+                    "description": "Whether to use existing configurations from launch.json.",
+                    "type": "boolean",
+                    "default": false
                 }
             }
         },

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -443,11 +443,6 @@
                     "type": "object",
                     "default": {},
                     "description": "Optional settings passed to the debug engine. Example:\n{ \"lldb\": { \"terminal\":\"external\"} }"
-                },
-                "rust-analyzer.debug.useLaunchJson": {
-                    "description": "Whether to use existing configurations from launch.json.",
-                    "type": "boolean",
-                    "default": false
                 }
             }
         },

--- a/editors/code/src/cargo.ts
+++ b/editors/code/src/cargo.ts
@@ -48,12 +48,17 @@ export class Cargo {
 
     async executableFromArgs(args: readonly string[]): Promise<string> {
         const cargoArgs = [...args, "--message-format=json"];
-        if( cargoArgs[0] == "run" ) {
+        if (cargoArgs[0] === "run") {
             // a runnable from the quick pick.
             cargoArgs[0] = "build";
         }
 
-        const artifacts = await this.artifactsFromArgs(cargoArgs);
+        let artifacts = await this.artifactsFromArgs(cargoArgs);
+        if (cargoArgs[0] === "test") {
+            // for instance, `crates\rust-analyzer\tests\heavy_tests\main.rs` tests
+            // produce 2 artifacts: {"kind": "bin"} and {"kind": "test"}
+            artifacts = artifacts.filter(a => a.isTest);
+        }
 
         if (artifacts.length === 0) {
             throw new Error('No compilation artifacts');

--- a/editors/code/src/cargo.ts
+++ b/editors/code/src/cargo.ts
@@ -48,9 +48,13 @@ export class Cargo {
 
     async executableFromArgs(args: readonly string[]): Promise<string> {
         const cargoArgs = [...args, "--message-format=json"];
+
+        // arguments for a runnable from the quick pick should be updated.
+        // see crates\rust-analyzer\src\main_loop\handlers.rs, handle_code_lens
         if (cargoArgs[0] === "run") {
-            // a runnable from the quick pick.
             cargoArgs[0] = "build";
+        } else if (cargoArgs.indexOf("--no-run") === -1) {
+            cargoArgs.push("--no-run");
         }
 
         let artifacts = await this.artifactsFromArgs(cargoArgs);

--- a/editors/code/src/cargo.ts
+++ b/editors/code/src/cargo.ts
@@ -48,6 +48,10 @@ export class Cargo {
 
     async executableFromArgs(args: readonly string[]): Promise<string> {
         const cargoArgs = [...args, "--message-format=json"];
+        if( cargoArgs[0] == "run" ) {
+            // a runnable from the quick pick.
+            cargoArgs[0] = "build";
+        }
 
         const artifacts = await this.artifactsFromArgs(cargoArgs);
 

--- a/editors/code/src/commands/runnables.ts
+++ b/editors/code/src/commands/runnables.ts
@@ -1,43 +1,46 @@
 import * as vscode from 'vscode';
 import * as lc from 'vscode-languageclient';
 import * as ra from '../rust-analyzer-api';
-import * as os from "os";
 
 import { Ctx, Cmd } from '../ctx';
-import { Cargo } from '../cargo';
+import { startDebugSession } from '../debug';
+
+async function selectRunnable(ctx: Ctx, prevRunnable: RunnableQuickPick | undefined): Promise<RunnableQuickPick | undefined> {
+    const editor = ctx.activeRustEditor;
+    const client = ctx.client;
+    if (!editor || !client) return;
+
+    const textDocument: lc.TextDocumentIdentifier = {
+        uri: editor.document.uri.toString(),
+    };
+
+    const runnables = await client.sendRequest(ra.runnables, {
+        textDocument,
+        position: client.code2ProtocolConverter.asPosition(
+            editor.selection.active,
+        ),
+    });
+    const items: RunnableQuickPick[] = [];
+    if (prevRunnable) {
+        items.push(prevRunnable);
+    }
+    for (const r of runnables) {
+        if (
+            prevRunnable &&
+            JSON.stringify(prevRunnable.runnable) === JSON.stringify(r)
+        ) {
+            continue;
+        }
+        items.push(new RunnableQuickPick(r));
+    }
+    return await vscode.window.showQuickPick(items);
+}
 
 export function run(ctx: Ctx): Cmd {
     let prevRunnable: RunnableQuickPick | undefined;
 
     return async () => {
-        const editor = ctx.activeRustEditor;
-        const client = ctx.client;
-        if (!editor || !client) return;
-
-        const textDocument: lc.TextDocumentIdentifier = {
-            uri: editor.document.uri.toString(),
-        };
-
-        const runnables = await client.sendRequest(ra.runnables, {
-            textDocument,
-            position: client.code2ProtocolConverter.asPosition(
-                editor.selection.active,
-            ),
-        });
-        const items: RunnableQuickPick[] = [];
-        if (prevRunnable) {
-            items.push(prevRunnable);
-        }
-        for (const r of runnables) {
-            if (
-                prevRunnable &&
-                JSON.stringify(prevRunnable.runnable) === JSON.stringify(r)
-            ) {
-                continue;
-            }
-            items.push(new RunnableQuickPick(r));
-        }
-        const item = await vscode.window.showQuickPick(items);
+        const item = await selectRunnable(ctx, prevRunnable);
         if (!item) return;
 
         item.detail = 'rerun';
@@ -64,88 +67,22 @@ export function runSingle(ctx: Ctx): Cmd {
     };
 }
 
-function getLldbDebugConfig(config: ra.Runnable, executable: string, sourceFileMap?: Record<string, string>): vscode.DebugConfiguration {
-    return {
-        type: "lldb",
-        request: "launch",
-        name: config.label,
-        program: executable,
-        args: config.extraArgs,
-        cwd: config.cwd,
-        sourceMap: sourceFileMap,
-        sourceLanguages: ["rust"]
+export function debug(ctx: Ctx): Cmd {
+    let prevDebuggee: RunnableQuickPick | undefined;
+
+    return async () => {
+        const item = await selectRunnable(ctx, prevDebuggee);
+        if (!item) return;
+
+        item.detail = 'restart';
+        prevDebuggee = item;
+        return await startDebugSession(ctx, item.runnable);
     };
 }
-
-function getCppvsDebugConfig(config: ra.Runnable, executable: string, sourceFileMap?: Record<string, string>): vscode.DebugConfiguration {
-    return {
-        type: (os.platform() === "win32") ? "cppvsdbg" : 'cppdbg',
-        request: "launch",
-        name: config.label,
-        program: executable,
-        args: config.extraArgs,
-        cwd: config.cwd,
-        sourceFileMap: sourceFileMap,
-    };
-}
-
-const debugOutput = vscode.window.createOutputChannel("Debug");
-
-async function getDebugExecutable(config: ra.Runnable): Promise<string> {
-    const cargo = new Cargo(config.cwd || '.', debugOutput);
-    const executable = await cargo.executableFromArgs(config.args);
-
-    // if we are here, there were no compilation errors.
-    return executable;
-}
-
-type DebugConfigProvider = (config: ra.Runnable, executable: string, sourceFileMap?: Record<string, string>) => vscode.DebugConfiguration;
 
 export function debugSingle(ctx: Ctx): Cmd {
     return async (config: ra.Runnable) => {
-        const editor = ctx.activeRustEditor;
-        if (!editor) return;
-
-        const knownEngines: Record<string, DebugConfigProvider> = {
-            "vadimcn.vscode-lldb": getLldbDebugConfig,
-            "ms-vscode.cpptools": getCppvsDebugConfig
-        };
-        const debugOptions = ctx.config.debug;
-
-        let debugEngine = null;
-        if (debugOptions.engine === "auto") {
-            for (var engineId in knownEngines) {
-                debugEngine = vscode.extensions.getExtension(engineId);
-                if (debugEngine) break;
-            }
-        }
-        else {
-            debugEngine = vscode.extensions.getExtension(debugOptions.engine);
-        }
-
-        if (!debugEngine) {
-            vscode.window.showErrorMessage(`Install [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb)`
-                + ` or [MS C++ tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) extension for debugging.`);
-            return;
-        }
-
-        debugOutput.clear();
-        if (ctx.config.debug.openUpDebugPane) {
-            debugOutput.show(true);
-        }
-
-        const executable = await getDebugExecutable(config);
-        const debugConfig = knownEngines[debugEngine.id](config, executable, debugOptions.sourceFileMap);
-        if (debugConfig.type in debugOptions.engineSettings) {
-            const settingsMap = (debugOptions.engineSettings as any)[debugConfig.type];
-            for (var key in settingsMap) {
-                debugConfig[key] = settingsMap[key];
-            }
-        }
-
-        debugOutput.appendLine("Launching debug configuration:");
-        debugOutput.appendLine(JSON.stringify(debugConfig, null, 2));
-        return vscode.debug.startDebugging(undefined, debugConfig);
+        await startDebugSession(ctx, config);
     };
 }
 

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -117,6 +117,7 @@ export class Config {
             engineSettings: this.get<object>("debug.engineSettings"),
             openUpDebugPane: this.get<boolean>("debug.openUpDebugPane"),
             sourceFileMap: sourceFileMap,
+            useLaunchJson: this.get<object>("debug.useLaunchJson"),
         };
     }
 }

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -116,8 +116,7 @@ export class Config {
             engine: this.get<string>("debug.engine"),
             engineSettings: this.get<object>("debug.engineSettings"),
             openUpDebugPane: this.get<boolean>("debug.openUpDebugPane"),
-            sourceFileMap: sourceFileMap,
-            useLaunchJson: this.get<object>("debug.useLaunchJson"),
+            sourceFileMap: sourceFileMap
         };
     }
 }

--- a/editors/code/src/debug.ts
+++ b/editors/code/src/debug.ts
@@ -87,6 +87,11 @@ export async function getDebugConfiguration(ctx: Ctx, config: ra.Runnable): Prom
         }
     }
 
+    if (debugConfig.name === "run binary") {
+        // A workaround for multiple binaries. It would be better to get proper names on the LSP side.
+        debugConfig.name = `run binary [${path.basename(executable)}]`;
+    }
+
     if (debugConfig.cwd) {
         debugConfig.cwd = simplifyPath(debugConfig.cwd);
     }

--- a/editors/code/src/debug.ts
+++ b/editors/code/src/debug.ts
@@ -1,0 +1,95 @@
+import * as os from "os";
+import * as vscode from 'vscode';
+import * as ra from './rust-analyzer-api';
+
+import { Cargo } from './cargo';
+import { Ctx } from "./ctx";
+
+const debugOutput = vscode.window.createOutputChannel("Debug");
+type DebugConfigProvider = (config: ra.Runnable, executable: string, sourceFileMap?: Record<string, string>) => vscode.DebugConfiguration;
+
+function getLldbDebugConfig(config: ra.Runnable, executable: string, sourceFileMap?: Record<string, string>): vscode.DebugConfiguration {
+    return {
+        type: "lldb",
+        request: "launch",
+        name: config.label,
+        program: executable,
+        args: config.extraArgs,
+        cwd: config.cwd,
+        sourceMap: sourceFileMap,
+        sourceLanguages: ["rust"]
+    };
+}
+
+function getCppvsDebugConfig(config: ra.Runnable, executable: string, sourceFileMap?: Record<string, string>): vscode.DebugConfiguration {
+    return {
+        type: (os.platform() === "win32") ? "cppvsdbg" : "cppdbg",
+        request: "launch",
+        name: config.label,
+        program: executable,
+        args: config.extraArgs,
+        cwd: config.cwd,
+        sourceFileMap: sourceFileMap,
+    };
+}
+
+async function getDebugExecutable(config: ra.Runnable): Promise<string> {
+    const cargo = new Cargo(config.cwd || '.', debugOutput);
+    const executable = await cargo.executableFromArgs(config.args);
+
+    // if we are here, there were no compilation errors.
+    return executable;
+}
+
+export async function getDebugConfiguration(ctx: Ctx, config: ra.Runnable): Promise<vscode.DebugConfiguration | undefined> {
+    const editor = ctx.activeRustEditor;
+    if (!editor) return;
+
+    const knownEngines: Record<string, DebugConfigProvider> = {
+        "vadimcn.vscode-lldb": getLldbDebugConfig,
+        "ms-vscode.cpptools": getCppvsDebugConfig
+    };
+    const debugOptions = ctx.config.debug;
+
+    let debugEngine = null;
+    if (debugOptions.engine === "auto") {
+        for (var engineId in knownEngines) {
+            debugEngine = vscode.extensions.getExtension(engineId);
+            if (debugEngine) break;
+        }
+    }
+    else {
+        debugEngine = vscode.extensions.getExtension(debugOptions.engine);
+    }
+
+    if (!debugEngine) {
+        vscode.window.showErrorMessage(`Install [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb)`
+            + ` or [MS C++ tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) extension for debugging.`);
+        return;
+    }
+
+    debugOutput.clear();
+    if (ctx.config.debug.openUpDebugPane) {
+        debugOutput.show(true);
+    }
+
+    const executable = await getDebugExecutable(config);
+    const debugConfig = knownEngines[debugEngine.id](config, executable, debugOptions.sourceFileMap);
+    if (debugConfig.type in debugOptions.engineSettings) {
+        const settingsMap = (debugOptions.engineSettings as any)[debugConfig.type];
+        for (var key in settingsMap) {
+            debugConfig[key] = settingsMap[key];
+        }
+    }
+
+    return debugConfig;
+}
+
+export async function startDebugSession(ctx: Ctx, config: ra.Runnable): Promise<boolean> {
+    const debugConfig = await getDebugConfiguration(ctx, config);
+    if (!debugConfig) return false;
+
+    debugOutput.appendLine("Launching debug configuration:");
+    debugOutput.appendLine(JSON.stringify(debugConfig, null, 2));
+    return vscode.debug.startDebugging(undefined, debugConfig);
+}

--- a/editors/code/src/debug.ts
+++ b/editors/code/src/debug.ts
@@ -98,18 +98,15 @@ export async function startDebugSession(ctx: Ctx, config: ra.Runnable): Promise<
     let debugConfig: vscode.DebugConfiguration | undefined = undefined;
     let message = "";
 
-    if (ctx.config.debug.useLaunchJson) {
-        const wsLaunchSection = vscode.workspace.getConfiguration("launch");
-        const configurations = wsLaunchSection.get<any[]>("configurations") || [];
+    const wsLaunchSection = vscode.workspace.getConfiguration("launch");
+    const configurations = wsLaunchSection.get<any[]>("configurations") || [];
 
-        const index = configurations.findIndex(c => c.name === config.label);
-        if (-1 !== index) {
-            debugConfig = configurations[index];
-            message = " (from launch.json)";
-            debugOutput.clear();
-        }
-    }
-    if (!debugConfig) {
+    const index = configurations.findIndex(c => c.name === config.label);
+    if (-1 !== index) {
+        debugConfig = configurations[index];
+        message = " (from launch.json)";
+        debugOutput.clear();
+    } else {
         debugConfig = await getDebugConfiguration(ctx, config);
     }
 

--- a/editors/code/src/debug.ts
+++ b/editors/code/src/debug.ts
@@ -88,8 +88,9 @@ export async function getDebugConfiguration(ctx: Ctx, config: ra.Runnable): Prom
     }
 
     if (debugConfig.name === "run binary") {
-        // A workaround for multiple binaries. It would be better to get proper names on the LSP side.
-        debugConfig.name = `run binary [${path.basename(executable)}]`;
+        // The LSP side: crates\rust-analyzer\src\main_loop\handlers.rs,
+        // fn to_lsp_runnable(...) with RunnableKind::Bin
+        debugConfig.name = `run binary '${path.basename(executable)}'`;
     }
 
     if (debugConfig.cwd) {

--- a/editors/code/src/debug.ts
+++ b/editors/code/src/debug.ts
@@ -90,7 +90,7 @@ export async function getDebugConfiguration(ctx: Ctx, config: ra.Runnable): Prom
     if (debugConfig.name === "run binary") {
         // The LSP side: crates\rust-analyzer\src\main_loop\handlers.rs,
         // fn to_lsp_runnable(...) with RunnableKind::Bin
-        debugConfig.name = `run binary '${path.basename(executable)}'`;
+        debugConfig.name = `run ${path.basename(executable)}`;
     }
 
     if (debugConfig.cwd) {

--- a/editors/code/src/debug.ts
+++ b/editors/code/src/debug.ts
@@ -57,8 +57,7 @@ export async function getDebugConfiguration(ctx: Ctx, config: ra.Runnable): Prom
             debugEngine = vscode.extensions.getExtension(engineId);
             if (debugEngine) break;
         }
-    }
-    else {
+    } else {
         debugEngine = vscode.extensions.getExtension(debugOptions.engine);
     }
 

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -77,6 +77,7 @@ export async function activate(context: vscode.ExtensionContext) {
     ctx.registerCommand('syntaxTree', commands.syntaxTree);
     ctx.registerCommand('expandMacro', commands.expandMacro);
     ctx.registerCommand('run', commands.run);
+    ctx.registerCommand('debug', commands.debug);
 
     defaultOnEnter.dispose();
     ctx.registerCommand('onEnter', commands.onEnter);

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -78,6 +78,7 @@ export async function activate(context: vscode.ExtensionContext) {
     ctx.registerCommand('expandMacro', commands.expandMacro);
     ctx.registerCommand('run', commands.run);
     ctx.registerCommand('debug', commands.debug);
+    ctx.registerCommand('newDebugConfig', commands.newDebugConfig);
 
     defaultOnEnter.dispose();
     ctx.registerCommand('onEnter', commands.onEnter);


### PR DESCRIPTION
This PR adds two new commands: `"rust-analyzer.debug"` and `"rust-analyzer.newDebugConfig"`. The former is a supplement to the existing `"rust-analyzer.run"` command and works the same way: asks for a runnable and starts new debug session. The latter allows adding a new configuration to **launch.json** (or to update an existing one).

If the new option `"rust-analyzer.debug.useLaunchJson"` is set to true then `"rust-analyzer.debug"` and Debug Lens will first look for existing debug configuration in **launch.json**. That is, it has become possible to specify startup arguments, env variables, etc.

`"rust-analyzer.debug.useLaunchJson"` is false by default, but it might be worth making true the default value. Personally I prefer true, but I'm not sure if it is good for all value.

----
I think that this PR also solves https://github.com/rust-analyzer/rust-analyzer/issues/3441.
Both methods to update launch.json mentioned in the issue do not work:
1. Menu. It is only possible to add a launch.json configuration template via a debug adapter. And anyway it's only a template and it is impossible to specify arguments from an extension.

2. DebugConfigurationProvider. The exact opposite situation: it is possible to specify all debug session settings, but it is impossible to export these settings to launch.json.

Separate `"rust-analyzer.newDebugConfig"` command looks better for me.

----
Fixes #4450
Fixes #3441