### PR TITLE
Use back ticks instead of single quotes around code

### DIFF
--- a/crates/ra_assists/src/handlers/add_custom_impl.rs
+++ b/crates/ra_assists/src/handlers/add_custom_impl.rs
@@ -49,7 +49,7 @@ pub(crate) fn add_custom_impl(acc: &mut Assists, ctx: &AssistContext) -> Option<
     let start_offset = annotated.syntax().parent()?.text_range().end();
 
     let label =
-        format!("Add custom impl '{}' for '{}'", trait_token.text().as_str(), annotated_name);
+        format!("Add custom impl `{}` for `{}`", trait_token.text().as_str(), annotated_name);
 
     let target = attr.syntax().text_range();
     acc.add(AssistId("add_custom_impl"), label, target, |edit| {

--- a/crates/ra_assists/src/handlers/add_explicit_type.rs
+++ b/crates/ra_assists/src/handlers/add_explicit_type.rs
@@ -61,7 +61,7 @@ pub(crate) fn add_explicit_type(acc: &mut Assists, ctx: &AssistContext) -> Optio
     let inferred_type = ty.display_source_code(ctx.db, module.into()).ok()?;
     acc.add(
         AssistId("add_explicit_type"),
-        format!("Insert explicit type '{}'", inferred_type),
+        format!("Insert explicit type `{}`", inferred_type),
         pat_range,
         |builder| match ascribed_ty {
             Some(ascribed_ty) => {

--- a/crates/ra_flycheck/src/lib.rs
+++ b/crates/ra_flycheck/src/lib.rs
@@ -157,7 +157,7 @@ impl FlycheckThread {
             CheckEvent::Begin => {
                 task_send
                     .send(CheckTask::Status(WorkDoneProgress::Begin(WorkDoneProgressBegin {
-                        title: "Running 'cargo check'".to_string(),
+                        title: "Running `cargo check`".to_string(),
                         cancellable: Some(false),
                         message: None,
                         percentage: None,

--- a/crates/ra_syntax/src/validation.rs
+++ b/crates/ra_syntax/src/validation.rs
@@ -54,7 +54,7 @@ fn rustc_unescape_error_to_string(err: unescape::EscapeError) -> &'static str {
             "Unicode escape must not be empty"
         }
         EE::UnclosedUnicodeEscape => {
-            "Missing '}' to terminate the unicode escape"
+            "Missing `}` to terminate the unicode escape"
         }
         EE::LeadingUnderscoreUnicodeEscape => {
             "Unicode escape code must not begin with an underscore"


### PR DESCRIPTION
Also, use back ticks instead of single quotes in `rustc_unescape_error_to_string` for `EE:UnclosedUnicodeEscape`.