### PR TITLE
Handle `Self` in values and patterns

### DIFF
--- a/crates/ra_hir/src/source_analyzer.rs
+++ b/crates/ra_hir/src/source_analyzer.rs
@@ -417,6 +417,7 @@ pub(crate) fn resolve_hir_path(
                 ValueNs::StaticId(it) => PathResolution::Def(Static::from(it).into()),
                 ValueNs::StructId(it) => PathResolution::Def(Struct::from(it).into()),
                 ValueNs::EnumVariantId(it) => PathResolution::Def(EnumVariant::from(it).into()),
+                ValueNs::ImplSelf(impl_id) => PathResolution::SelfType(impl_id.into()),
             };
             Some(res)
         });

--- a/crates/ra_hir_ty/src/tests/patterns.rs
+++ b/crates/ra_hir_ty/src/tests/patterns.rs
@@ -369,6 +369,45 @@ fn test() {
 }
 
 #[test]
+fn enum_variant_through_self_in_pattern() {
+    assert_snapshot!(
+        infer(r#"
+enum E {
+    A { x: usize },
+    B(usize),
+    C
+}
+
+impl E {
+    fn test() {
+        match (loop {}) {
+            Self::A { x } => { x; },
+            Self::B(x) => { x; },
+            Self::C => {},
+        };
+    }
+}
+"#),
+        @r###"
+    76..218 '{     ...     }': ()
+    86..211 'match ...     }': ()
+    93..100 'loop {}': !
+    98..100 '{}': ()
+    116..129 'Self::A { x }': E
+    126..127 'x': usize
+    133..139 '{ x; }': ()
+    135..136 'x': usize
+    153..163 'Self::B(x)': E
+    161..162 'x': usize
+    167..173 '{ x; }': ()
+    169..170 'x': usize
+    187..194 'Self::C': E
+    198..200 '{}': ()
+    "###
+    );
+}
+
+#[test]
 fn infer_generics_in_patterns() {
     assert_snapshot!(
         infer(r#"

--- a/crates/ra_hir_ty/src/tests/simple.rs
+++ b/crates/ra_hir_ty/src/tests/simple.rs
@@ -576,6 +576,50 @@ impl S {
 }
 
 #[test]
+fn infer_self_as_path() {
+    assert_snapshot!(
+        infer(r#"
+struct S1;
+struct S2(isize);
+enum E {
+    V1,
+    V2(u32),
+}
+
+impl S1 {
+    fn test() {
+        Self;
+    }
+}
+impl S2 {
+    fn test() {
+        Self(1);
+    }
+}
+impl E {
+    fn test() {
+        Self::V1;
+        Self::V2(1);
+    }
+}
+"#),
+        @r###"
+    87..108 '{     ...     }': ()
+    97..101 'Self': S1
+    135..159 '{     ...     }': ()
+    145..149 'Self': S2(isize) -> S2
+    145..152 'Self(1)': S2
+    150..151 '1': isize
+    185..231 '{     ...     }': ()
+    195..203 'Self::V1': E
+    213..221 'Self::V2': V2(u32) -> E
+    213..224 'Self::V2(1)': E
+    222..223 '1': u32
+    "###
+    );
+}
+
+#[test]
 fn infer_binary_op() {
     assert_snapshot!(
         infer(r#"


### PR DESCRIPTION
I.e.
 - `Self(x)` or `Self` in tuple/unit struct impls
 - `Self::Variant(x)` or `Self::Variant` in enum impls
 - the same in patterns

Fixes #4454.