### PR TITLE
Color macros

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -604,6 +604,9 @@
             {
                 "language": "rust",
                 "scopes": {
+                    "macro": [
+                        "entity.name.function.macro.rust"
+                    ],
                     "attribute": [
                         "meta.attribute.rust"
                     ],


### PR DESCRIPTION
Adds a fallback scope for macros. Before:

<img width="359" alt="Screen Shot 2020-05-15 at 7 31 03 PM" src="https://user-images.githubusercontent.com/1369240/82108339-a304d680-96e2-11ea-9521-e95d5d330c32.png">

After:

<img width="373" alt="Screen Shot 2020-05-15 at 7 29 58 PM" src="https://user-images.githubusercontent.com/1369240/82108308-81a3ea80-96e2-11ea-8660-7f6979df59bf.png">

Note how `hashset` in `maplit::hashset` is now yellow.

Fixes #4462