### PR TITLE
Color attribute functions

### DIFF
--- a/crates/ra_ide/src/snapshots/highlighting.html
+++ b/crates/ra_ide/src/snapshots/highlighting.html
@@ -27,7 +27,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .keyword.unsafe     { color: #BC8383; font-weight: bold; }
 .control            { font-style: italic; }
 </style>
-<pre><code><span class="attribute">#[derive(Clone, Debug)]</span>
+<pre><code><span class="attribute">#[</span><span class="function attribute">derive</span><span class="attribute">(Clone, Debug)]</span>
 <span class="keyword">struct</span> <span class="struct declaration">Foo</span> {
     <span class="keyword">pub</span> <span class="field declaration">x</span>: <span class="builtin_type">i32</span>,
     <span class="keyword">pub</span> <span class="field declaration">y</span>: <span class="builtin_type">i32</span>,

--- a/crates/ra_ide/src/syntax_highlighting.rs
+++ b/crates/ra_ide/src/syntax_highlighting.rs
@@ -361,7 +361,9 @@ fn highlight_element(
         }
 
         // Highlight references like the definitions they resolve to
-        NAME_REF if element.ancestors().any(|it| it.kind() == ATTR) => return None,
+        NAME_REF if element.ancestors().any(|it| it.kind() == ATTR) => {
+            Highlight::from(HighlightTag::Function) | HighlightModifier::Attribute
+        }
         NAME_REF => {
             let name_ref = element.into_node().and_then(ast::NameRef::cast).unwrap();
             match classify_name_ref(sema, &name_ref) {

--- a/crates/ra_ide/src/syntax_highlighting/tags.rs
+++ b/crates/ra_ide/src/syntax_highlighting/tags.rs
@@ -45,8 +45,10 @@ pub enum HighlightTag {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[repr(u8)]
 pub enum HighlightModifier {
+    /// Used to differentiate individual elements within attributes.
+    Attribute = 0,
     /// Used with keywords like `if` and `break`.
-    ControlFlow = 0,
+    ControlFlow,
     /// `foo` in `fn foo(x: i32)` is a definition, `foo` in `foo(90 + 2)` is
     /// not.
     Definition,
@@ -95,6 +97,7 @@ impl fmt::Display for HighlightTag {
 
 impl HighlightModifier {
     const ALL: &'static [HighlightModifier] = &[
+        HighlightModifier::Attribute,
         HighlightModifier::ControlFlow,
         HighlightModifier::Definition,
         HighlightModifier::Mutable,
@@ -103,6 +106,7 @@ impl HighlightModifier {
 
     fn as_str(self) -> &'static str {
         match self {
+            HighlightModifier::Attribute => "attribute",
             HighlightModifier::ControlFlow => "control",
             HighlightModifier::Definition => "declaration",
             HighlightModifier::Mutable => "mutable",

--- a/crates/rust-analyzer/src/semantic_tokens.rs
+++ b/crates/rust-analyzer/src/semantic_tokens.rs
@@ -67,6 +67,7 @@ define_semantic_token_modifiers![
     (CONTROL_FLOW, "controlFlow"),
     (MUTABLE, "mutable"),
     (UNSAFE, "unsafe"),
+    (ATTRIBUTE_MODIFIER, "attribute"),
 ];
 
 #[derive(Default)]

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -296,6 +296,7 @@ fn semantic_token_type_and_modifiers(
 
     for modifier in highlight.modifiers.iter() {
         let modifier = match modifier {
+            HighlightModifier::Attribute => semantic_tokens::ATTRIBUTE_MODIFIER,
             HighlightModifier::Definition => lsp_types::SemanticTokenModifier::DECLARATION,
             HighlightModifier::ControlFlow => semantic_tokens::CONTROL_FLOW,
             HighlightModifier::Mutable => semantic_tokens::MUTABLE,

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -604,6 +604,10 @@
         ],
         "semanticTokenModifiers": [
             {
+                "id": "attribute",
+                "description": "Style for elements within attributes"
+            },
+            {
                 "id": "constant",
                 "description": "Style for compile-time constants"
             },
@@ -629,6 +633,9 @@
                     ],
                     "attribute": [
                         "meta.attribute.rust"
+                    ],
+                    "function.attribute": [
+                        "entity.name.function.attribute.rust"
                     ],
                     "builtinType": [
                         "support.type.primitive.rust"

--- a/editors/code/rust.tmGrammar.json
+++ b/editors/code/rust.tmGrammar.json
@@ -75,8 +75,13 @@
 		{
 			"comment": "Attribute",
 			"name": "meta.attribute.rust",
-			"begin": "#\\!?\\[",
+			"begin": "#\\!?\\[(\\w*)",
 			"end": "\\]",
+			"captures": {
+				"1": {
+					"name": "entity.name.function.attribute.rust"
+				}
+			},
 			"patterns": [
 				{
 					"include": "#string_literal"


### PR DESCRIPTION
Right now, only literals are colored within Rust attributes:

<img width="491" alt="Screen Shot 2020-05-15 at 7 38 00 PM" src="https://user-images.githubusercontent.com/1369240/82108506-c67c5100-96e3-11ea-98b2-08397984231a.png">

To me, attributes look weirdly blank, and it seems like we should make *some* attempt to color them. I gathered some feedback on Zulip and in #4430. This PR colors the outer function that's present in every attribute as a function:

<img width="448" alt="Screen Shot 2020-05-15 at 7 36 56 PM" src="https://user-images.githubusercontent.com/1369240/82108580-325eb980-96e4-11ea-9a26-ba450405f5ec.png">

I think this will be an uncontroversial improvement. I think it would also be popular if we colored type names in `#[derive(TypeName)]`, and perhaps some other special cases, but this would require ad-hoc special cases in `rust-analyzer`, which might be controversial, so I'm starting with the most obvious improvements in this PR.

Fixes #4430