### PR TITLE
Allow calling dyn trait super trait methods without the super trait in scope

### DIFF
--- a/crates/ra_hir_ty/src/lib.rs
+++ b/crates/ra_hir_ty/src/lib.rs
@@ -808,15 +808,13 @@ impl Ty {
         }
     }
 
-    /// If this is an `impl Trait` or `dyn Trait`, returns that trait.
-    pub fn inherent_trait(&self) -> Option<TraitId> {
+    /// If this is a `dyn Trait`, returns that trait.
+    pub fn dyn_trait(&self) -> Option<TraitId> {
         match self {
-            Ty::Dyn(predicates) | Ty::Opaque(predicates) => {
-                predicates.iter().find_map(|pred| match pred {
-                    GenericPredicate::Implemented(tr) => Some(tr.trait_),
-                    _ => None,
-                })
-            }
+            Ty::Dyn(predicates) => predicates.iter().find_map(|pred| match pred {
+                GenericPredicate::Implemented(tr) => Some(tr.trait_),
+                _ => None,
+            }),
             _ => None,
         }
     }

--- a/crates/ra_hir_ty/src/tests/method_resolution.rs
+++ b/crates/ra_hir_ty/src/tests/method_resolution.rs
@@ -1096,3 +1096,34 @@ fn test() { (S {}).method()<|>; }
     );
     assert_eq!(t, "()");
 }
+
+#[test]
+fn dyn_trait_super_trait_not_in_scope() {
+    assert_snapshot!(
+        infer(r#"
+mod m {
+    pub trait SuperTrait {
+        fn foo(&self) -> u32 { 0 }
+    }
+}
+trait Trait: m::SuperTrait {}
+
+struct S;
+impl m::SuperTrait for S {}
+impl Trait for S {}
+
+fn test(d: &dyn Trait) {
+    d.foo();
+}
+"#),
+        @r###"
+    52..56 'self': &Self
+    65..70 '{ 0 }': u32
+    67..68 '0': u32
+    177..178 'd': &dyn Trait
+    192..208 '{     ...o(); }': ()
+    198..199 'd': &dyn Trait
+    198..205 'd.foo()': u32
+    "###
+    );
+}


### PR DESCRIPTION
This also removes some vestiges of the old impl trait support which I think aren't currently in use.