### PR TITLE
Test fixtures parsing improvements

### DIFF
--- a/crates/ra_db/src/fixture.rs
+++ b/crates/ra_db/src/fixture.rs
@@ -254,20 +254,14 @@ impl From<&FixtureMeta> for ParsedMeta {
             }
             FixtureMeta::File(f) => Self::File(FileMeta {
                 path: f.path.to_owned().into(),
-                krate: f.krate.to_owned().into(),
+                krate: f.crate_name.to_owned().into(),
                 deps: f.deps.to_owned(),
                 cfg: f.cfg.to_owned(),
                 edition: f
                     .edition
                     .as_ref()
                     .map_or(Edition::Edition2018, |v| Edition::from_str(&v).unwrap()),
-                env: {
-                    let mut env = Env::default();
-                    for (k, v) in &f.env {
-                        env.set(&k, v.to_owned());
-                    }
-                    env
-                },
+                env: Env::from(f.env.iter()),
             }),
         }
     }

--- a/crates/ra_db/src/fixture.rs
+++ b/crates/ra_db/src/fixture.rs
@@ -99,7 +99,7 @@ fn with_single_file(db: &mut dyn SourceDatabaseExt, ra_fixture: &str) -> FileId 
     let fixture = parse_single_fixture(ra_fixture);
 
     let crate_graph = if let Some(entry) = fixture {
-        let meta = match ParsedMeta::from(&entry.parsed_meta) {
+        let meta = match ParsedMeta::from(&entry.meta) {
             ParsedMeta::File(it) => it,
             _ => panic!("with_single_file only support file meta"),
         };
@@ -156,7 +156,7 @@ fn with_files(db: &mut dyn SourceDatabaseExt, fixture: &str) -> Option<FilePosit
     let mut file_position = None;
 
     for entry in fixture.iter() {
-        let meta = match ParsedMeta::from(&entry.parsed_meta) {
+        let meta = match ParsedMeta::from(&entry.meta) {
             ParsedMeta::Root { path } => {
                 let source_root = std::mem::replace(&mut source_root, SourceRoot::new_local());
                 db.set_source_root(source_root_id, Arc::new(source_root));

--- a/crates/ra_db/src/input.rs
+++ b/crates/ra_db/src/input.rs
@@ -311,6 +311,21 @@ impl fmt::Display for Edition {
     }
 }
 
+impl<'a, T> From<T> for Env
+where
+    T: Iterator<Item = (&'a String, &'a String)>,
+{
+    fn from(iter: T) -> Self {
+        let mut result = Self::default();
+
+        for (k, v) in iter {
+            result.entries.insert(k.to_owned(), v.to_owned());
+        }
+
+        result
+    }
+}
+
 impl Env {
     pub fn set(&mut self, env: &str, value: String) {
         self.entries.insert(env.to_owned(), value);

--- a/crates/ra_ide/src/call_hierarchy.rs
+++ b/crates/ra_ide/src/call_hierarchy.rs
@@ -246,6 +246,35 @@ mod tests {
     }
 
     #[test]
+    fn test_call_hierarchy_in_tests_mod() {
+        check_hierarchy(
+            r#"
+            //- /lib.rs cfg:test
+            fn callee() {}
+            fn caller1() {
+                call<|>ee();
+            }
+
+            #[cfg(test)]
+            mod tests {
+                use super::*;
+
+                #[test]
+                fn test_caller() {
+                    callee();
+                }
+            }
+            "#,
+            "callee FN_DEF FileId(1) 0..14 3..9",
+            &[
+                "caller1 FN_DEF FileId(1) 15..45 18..25 : [34..40]",
+                "test_caller FN_DEF FileId(1) 93..147 108..119 : [132..138]",
+            ],
+            &[],
+        );
+    }
+
+    #[test]
     fn test_call_hierarchy_in_different_files() {
         check_hierarchy(
             r#"

--- a/crates/ra_ide/src/mock_analysis.rs
+++ b/crates/ra_ide/src/mock_analysis.rs
@@ -35,7 +35,7 @@ impl MockAnalysis {
     pub fn with_files(fixture: &str) -> MockAnalysis {
         let mut res = MockAnalysis::new();
         for entry in parse_fixture(fixture) {
-            res.add_file(&entry.meta, &entry.text);
+            res.add_file(entry.meta.path().as_str(), &entry.text);
         }
         res
     }
@@ -48,9 +48,10 @@ impl MockAnalysis {
         for entry in parse_fixture(fixture) {
             if entry.text.contains(CURSOR_MARKER) {
                 assert!(position.is_none(), "only one marker (<|>) per fixture is allowed");
-                position = Some(res.add_file_with_position(&entry.meta, &entry.text));
+                position =
+                    Some(res.add_file_with_position(&entry.meta.path().as_str(), &entry.text));
             } else {
-                res.add_file(&entry.meta, &entry.text);
+                res.add_file(&entry.meta.path().as_str(), &entry.text);
             }
         }
         let position = position.expect("expected a marker (<|>)");

--- a/crates/ra_ide/src/mock_analysis.rs
+++ b/crates/ra_ide/src/mock_analysis.rs
@@ -4,18 +4,61 @@ use std::sync::Arc;
 
 use ra_cfg::CfgOptions;
 use ra_db::{CrateName, Env, RelativePathBuf};
-use test_utils::{extract_offset, extract_range, parse_fixture, CURSOR_MARKER};
+use test_utils::{extract_offset, extract_range, parse_fixture, FixtureEntry, CURSOR_MARKER};
 
 use crate::{
     Analysis, AnalysisChange, AnalysisHost, CrateGraph, Edition::Edition2018, FileId, FilePosition,
     FileRange, SourceRootId,
 };
 
+#[derive(Debug)]
+enum MockFileData {
+    Plain { path: String, content: String },
+    Fixture(FixtureEntry),
+}
+
+impl MockFileData {
+    fn new(path: String, content: String) -> Self {
+        // `Self::Plain` causes a false warning: 'variant is never constructed: `Plain` '
+        // see https://github.com/rust-lang/rust/issues/69018
+        MockFileData::Plain { path, content }
+    }
+
+    fn path(&self) -> &str {
+        match self {
+            MockFileData::Plain { path, .. } => path.as_str(),
+            MockFileData::Fixture(f) => f.meta.path().as_str(),
+        }
+    }
+
+    fn content(&self) -> &str {
+        match self {
+            MockFileData::Plain { content, .. } => content,
+            MockFileData::Fixture(f) => f.text.as_str(),
+        }
+    }
+
+    fn cfg_options(&self) -> CfgOptions {
+        match self {
+            MockFileData::Fixture(f) => {
+                f.meta.cfg_options().map_or_else(Default::default, |o| o.clone())
+            }
+            _ => CfgOptions::default(),
+        }
+    }
+}
+
+impl From<FixtureEntry> for MockFileData {
+    fn from(fixture: FixtureEntry) -> Self {
+        Self::Fixture(fixture)
+    }
+}
+
 /// Mock analysis is used in test to bootstrap an AnalysisHost/Analysis
 /// from a set of in-memory files.
 #[derive(Debug, Default)]
 pub struct MockAnalysis {
-    files: Vec<(String, String)>,
+    files: Vec<MockFileData>,
 }
 
 impl MockAnalysis {
@@ -35,7 +78,7 @@ impl MockAnalysis {
     pub fn with_files(fixture: &str) -> MockAnalysis {
         let mut res = MockAnalysis::new();
         for entry in parse_fixture(fixture) {
-            res.add_file(entry.meta.path().as_str(), &entry.text);
+            res.add_file_fixture(entry);
         }
         res
     }
@@ -48,31 +91,44 @@ impl MockAnalysis {
         for entry in parse_fixture(fixture) {
             if entry.text.contains(CURSOR_MARKER) {
                 assert!(position.is_none(), "only one marker (<|>) per fixture is allowed");
-                position =
-                    Some(res.add_file_with_position(&entry.meta.path().as_str(), &entry.text));
+                position = Some(res.add_file_fixture_with_position(entry));
             } else {
-                res.add_file(&entry.meta.path().as_str(), &entry.text);
+                res.add_file_fixture(entry);
             }
         }
         let position = position.expect("expected a marker (<|>)");
         (res, position)
     }
 
+    pub fn add_file_fixture(&mut self, fixture: FixtureEntry) -> FileId {
+        let file_id = self.next_id();
+        self.files.push(MockFileData::from(fixture));
+        file_id
+    }
+
+    pub fn add_file_fixture_with_position(&mut self, mut fixture: FixtureEntry) -> FilePosition {
+        let (offset, text) = extract_offset(&fixture.text);
+        fixture.text = text;
+        let file_id = self.next_id();
+        self.files.push(MockFileData::from(fixture));
+        FilePosition { file_id, offset }
+    }
+
     pub fn add_file(&mut self, path: &str, text: &str) -> FileId {
-        let file_id = FileId((self.files.len() + 1) as u32);
-        self.files.push((path.to_string(), text.to_string()));
+        let file_id = self.next_id();
+        self.files.push(MockFileData::new(path.to_string(), text.to_string()));
         file_id
     }
     pub fn add_file_with_position(&mut self, path: &str, text: &str) -> FilePosition {
         let (offset, text) = extract_offset(text);
-        let file_id = FileId((self.files.len() + 1) as u32);
-        self.files.push((path.to_string(), text));
+        let file_id = self.next_id();
+        self.files.push(MockFileData::new(path.to_string(), text));
         FilePosition { file_id, offset }
     }
     pub fn add_file_with_range(&mut self, path: &str, text: &str) -> FileRange {
         let (range, text) = extract_range(text);
-        let file_id = FileId((self.files.len() + 1) as u32);
-        self.files.push((path.to_string(), text));
+        let file_id = self.next_id();
+        self.files.push(MockFileData::new(path.to_string(), text));
         FileRange { file_id, range }
     }
     pub fn id_of(&self, path: &str) -> FileId {
@@ -80,7 +136,7 @@ impl MockAnalysis {
             .files
             .iter()
             .enumerate()
-            .find(|(_, (p, _text))| path == p)
+            .find(|(_, data)| path == data.path())
             .expect("no file in this mock");
         FileId(idx as u32 + 1)
     }
@@ -91,11 +147,12 @@ impl MockAnalysis {
         change.add_root(source_root, true);
         let mut crate_graph = CrateGraph::default();
         let mut root_crate = None;
-        for (i, (path, contents)) in self.files.into_iter().enumerate() {
+        for (i, data) in self.files.into_iter().enumerate() {
+            let path = data.path();
             assert!(path.starts_with('/'));
             let path = RelativePathBuf::from_path(&path[1..]).unwrap();
+            let cfg_options = data.cfg_options();
             let file_id = FileId(i as u32 + 1);
-            let cfg_options = CfgOptions::default();
             if path == "/lib.rs" || path == "/main.rs" {
                 root_crate = Some(crate_graph.add_crate_root(
                     file_id,
@@ -123,7 +180,7 @@ impl MockAnalysis {
                         .unwrap();
                 }
             }
-            change.add_file(source_root, file_id, path, Arc::new(contents));
+            change.add_file(source_root, file_id, path, Arc::new(data.content().to_owned()));
         }
         change.set_crate_graph(crate_graph);
         host.apply_change(change);
@@ -131,6 +188,10 @@ impl MockAnalysis {
     }
     pub fn analysis(self) -> Analysis {
         self.analysis_host().analysis()
+    }
+
+    fn next_id(&self) -> FileId {
+        FileId((self.files.len() + 1) as u32)
     }
 }
 

--- a/crates/rust-analyzer/tests/heavy_tests/support.rs
+++ b/crates/rust-analyzer/tests/heavy_tests/support.rs
@@ -68,7 +68,7 @@ impl<'a> Project<'a> {
         let mut paths = vec![];
 
         for entry in parse_fixture(self.fixture) {
-            let path = tmp_dir.path().join(entry.meta);
+            let path = tmp_dir.path().join(entry.meta.path().as_str());
             fs::create_dir_all(path.parent().unwrap()).unwrap();
             fs::write(path.as_path(), entry.text.as_bytes()).unwrap();
             paths.push((path, entry.text));

--- a/crates/test_utils/Cargo.toml
+++ b/crates/test_utils/Cargo.toml
@@ -11,3 +11,7 @@ doctest = false
 difference = "2.0.0"
 text-size = "1.0.0"
 serde_json = "1.0.48"
+relative-path = "1.0.0"
+rustc-hash = "1.1.0"
+
+ra_cfg = { path = "../ra_cfg" }

--- a/crates/test_utils/src/lib.rs
+++ b/crates/test_utils/src/lib.rs
@@ -176,7 +176,7 @@ pub struct FileMeta {
     pub path: RelativePathBuf,
     pub krate: Option<String>,
     pub deps: Vec<String>,
-    pub cfg: ra_cfg::CfgOptions,
+    pub cfg: CfgOptions,
     pub edition: Option<String>,
     pub env: FxHashMap<String, String>,
 }
@@ -186,6 +186,13 @@ impl FixtureMeta {
         match self {
             FixtureMeta::Root { path } => &path,
             FixtureMeta::File(f) => &f.path,
+        }
+    }
+
+    pub fn cfg_options(&self) -> Option<&CfgOptions> {
+        match self {
+            FixtureMeta::File(f) => Some(&f.cfg),
+            _ => None,
         }
     }
 }

--- a/crates/test_utils/src/lib.rs
+++ b/crates/test_utils/src/lib.rs
@@ -245,8 +245,8 @@ impl FixtureMeta {
 ///  line 2
 ///  // - other meta
 ///  ```
-pub fn parse_fixture(fixture: &str) -> Vec<FixtureEntry> {
-    let fixture = indent_first_line(fixture);
+pub fn parse_fixture(ra_fixture: &str) -> Vec<FixtureEntry> {
+    let fixture = indent_first_line(ra_fixture);
     let margin = fixture_margin(&fixture);
 
     let mut lines = fixture
@@ -418,14 +418,16 @@ struct Bar;
 
 #[test]
 fn parse_fixture_gets_full_meta() {
-    let fixture = r"
+    let parsed = parse_fixture(
+        r"
     //- /lib.rs crate:foo deps:bar,baz cfg:foo=a,bar=b,atom env:OUTDIR=path/to,OTHER=foo
-    ";
-    let parsed = parse_fixture(fixture);
+    mod m;
+    ",
+    );
     assert_eq!(1, parsed.len());
 
     let parsed = &parsed[0];
-    assert_eq!("\n", parsed.text);
+    assert_eq!("mod m;\n\n", parsed.text);
 
     let meta = &parsed.meta;
     assert_eq!("foo", meta.crate_name().unwrap());
@@ -435,12 +437,12 @@ fn parse_fixture_gets_full_meta() {
 }
 
 /// Same as `parse_fixture`, except it allow empty fixture
-pub fn parse_single_fixture(fixture: &str) -> Option<FixtureEntry> {
-    if !fixture.lines().any(|it| it.trim_start().starts_with("//-")) {
+pub fn parse_single_fixture(ra_fixture: &str) -> Option<FixtureEntry> {
+    if !ra_fixture.lines().any(|it| it.trim_start().starts_with("//-")) {
         return None;
     }
 
-    let fixtures = parse_fixture(fixture);
+    let fixtures = parse_fixture(ra_fixture);
     if fixtures.len() > 1 {
         panic!("too many fixtures");
     }

--- a/crates/test_utils/src/lib.rs
+++ b/crates/test_utils/src/lib.rs
@@ -161,10 +161,8 @@ pub fn add_cursor(text: &str, offset: TextSize) -> String {
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct FixtureEntry {
-    pub meta: String,
+    pub meta: FixtureMeta,
     pub text: String,
-
-    pub parsed_meta: FixtureMeta,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -231,8 +229,8 @@ The offending line: {:?}"#,
     for line in lines.by_ref() {
         if line.starts_with("//-") {
             let meta = line["//-".len()..].trim().to_string();
-            let parsed_meta = parse_meta(&meta);
-            res.push(FixtureEntry { meta, parsed_meta, text: String::new() })
+            let meta = parse_meta(&meta);
+            res.push(FixtureEntry { meta, text: String::new() })
         } else if let Some(entry) = res.last_mut() {
             entry.text.push_str(line);
             entry.text.push('\n');

--- a/crates/test_utils/src/lib.rs
+++ b/crates/test_utils/src/lib.rs
@@ -426,6 +426,12 @@ fn parse_fixture_gets_full_meta() {
 
     let parsed = &parsed[0];
     assert_eq!("\n", parsed.text);
+
+    let meta = &parsed.meta;
+    assert_eq!("foo", meta.crate_name().unwrap());
+    assert_eq!("/lib.rs", meta.path());
+    assert!(meta.cfg_options().is_some());
+    assert_eq!(2, meta.env().count());
 }
 
 /// Same as `parse_fixture`, except it allow empty fixture

--- a/crates/test_utils/src/lib.rs
+++ b/crates/test_utils/src/lib.rs
@@ -16,10 +16,10 @@ use std::{
 
 pub use ra_cfg::CfgOptions;
 
-use serde_json::Value;
-use text_size::{TextRange, TextSize};
 pub use relative_path::{RelativePath, RelativePathBuf};
 pub use rustc_hash::FxHashMap;
+use serde_json::Value;
+use text_size::{TextRange, TextSize};
 
 pub use difference::Changeset as __Changeset;
 
@@ -291,7 +291,6 @@ fn split1(haystack: &str, delim: char) -> Option<(&str, &str)> {
     let idx = haystack.find(delim)?;
     Some((&haystack[..idx], &haystack[idx + delim.len_utf8()..]))
 }
-
 
 /// Adjusts the indentation of the first line to the minimum indentation of the rest of the lines.
 /// This allows fixtures to start off in a different indentation, e.g. to align the first line with


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/4480

- All fixture parsing code moved to the test_utils crate.
- ra_ide::MockAnalysis uses metadata from fixtures