### PR TITLE
Create LowerCtx on the fly

### DIFF
--- a/crates/ra_hir_ty/src/tests/regression.rs
+++ b/crates/ra_hir_ty/src/tests/regression.rs
@@ -564,6 +564,37 @@ fn main() {
 }
 
 #[test]
+fn issue_4465_dollar_crate_at_type() {
+    assert_snapshot!(
+        infer(r#"
+pub struct Foo {}
+pub fn anything<T>() -> T {
+    loop {}
+}
+macro_rules! foo {
+    () => {{
+        let r: $crate::Foo = anything();
+        r
+    }};
+}
+fn main() {
+    let _a = foo!();
+}
+"#), @r###"
+    45..60 '{     loop {} }': T
+    51..58 'loop {}': !
+    56..58 '{}': ()
+    !0..31 '{letr:...g();r}': Foo
+    !4..5 'r': Foo
+    !18..26 'anything': fn anything<Foo>() -> Foo
+    !18..28 'anything()': Foo
+    !29..30 'r': Foo
+    164..188 '{     ...!(); }': ()
+    174..176 '_a': Foo
+"###);
+}
+
+#[test]
 fn issue_4053_diesel_where_clauses() {
     assert_snapshot!(
         infer(r#"


### PR DESCRIPTION
Previously we create `LowerCtx` at the beginning of lowering, however, the hygiene content is in fact changing between macro expression expanding. 

This PR change it to create the `LowerCtx` on the fly to fix above bug.

However, #4465 is not fixed by this PR, the goto-def is still not work yet. It only fixed the infer part. 