### PR TITLE
CodeLens configuration options

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -244,35 +244,35 @@ impl Config {
     pub fn update_caps(&mut self, caps: &ClientCapabilities) {
         if let Some(doc_caps) = caps.text_document.as_ref() {
             if let Some(value) = doc_caps.definition.as_ref().and_then(|it| it.link_support) {
-            self.client_caps.location_link = value;
-        }
+                self.client_caps.location_link = value;
+            }
             if let Some(value) = doc_caps.folding_range.as_ref().and_then(|it| it.line_folding_only)
             {
-            self.client_caps.line_folding_only = value
-        }
+                self.client_caps.line_folding_only = value
+            }
             if let Some(value) = doc_caps
                 .document_symbol
                 .as_ref()
                 .and_then(|it| it.hierarchical_document_symbol_support)
-        {
-            self.client_caps.hierarchical_symbols = value
-        }
+            {
+                self.client_caps.hierarchical_symbols = value
+            }
             if let Some(value) = doc_caps
                 .code_action
                 .as_ref()
                 .and_then(|it| Some(it.code_action_literal_support.is_some()))
-        {
-            self.client_caps.code_action_literals = value;
-        }
-        self.completion.allow_snippets(false);
+            {
+                self.client_caps.code_action_literals = value;
+            }
+            self.completion.allow_snippets(false);
             if let Some(completion) = &doc_caps.completion {
-            if let Some(completion_item) = &completion.completion_item {
-                if let Some(value) = completion_item.snippet_support {
-                    self.completion.allow_snippets(value);
+                if let Some(completion_item) = &completion.completion_item {
+                    if let Some(value) = completion_item.snippet_support {
+                        self.completion.allow_snippets(value);
+                    }
                 }
             }
         }
-    }
 
         if let Some(window_caps) = caps.window.as_ref() {
             if let Some(value) = window_caps.work_done_progress {

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -50,6 +50,8 @@ impl Default for LensConfig {
 }
 
 impl LensConfig {
+    pub const NO_LENS: LensConfig = Self { run: false, debug: false, impementations: false };
+
     pub fn any(&self) -> bool {
         self.impementations || self.runnable()
     }
@@ -224,9 +226,16 @@ impl Config {
         set(value, "/completion/addCallParenthesis", &mut self.completion.add_call_parenthesis);
         set(value, "/completion/addCallArgumentSnippets", &mut self.completion.add_call_argument_snippets);
         set(value, "/callInfo/full", &mut self.call_info_full);
-        set(value, "/lens/run", &mut self.lens.run);
-        set(value, "/lens/debug", &mut self.lens.debug);
-        set(value, "/lens/implementations", &mut self.lens.impementations);
+
+        let mut lens_enabled = true;
+        set(value, "/lens/enable", &mut lens_enabled);
+        if lens_enabled {
+            set(value, "/lens/run", &mut self.lens.run);
+            set(value, "/lens/debug", &mut self.lens.debug);
+            set(value, "/lens/implementations", &mut self.lens.impementations);
+        } else {
+            self.lens = LensConfig::NO_LENS;
+        }
 
         log::info!("Config::update() = {:#?}", self);
 

--- a/crates/rust-analyzer/src/main_loop/handlers.rs
+++ b/crates/rust-analyzer/src/main_loop/handlers.rs
@@ -826,16 +826,18 @@ pub fn handle_code_lens(
     if world.config.lens.runnable() {
         // Gather runnables
         for runnable in world.analysis().runnables(file_id)? {
-            let (run_title, debugee ) = match &runnable.kind {
-                RunnableKind::Test { .. } | RunnableKind::TestMod { .. } => ("▶️\u{fe0e}Run Test", true),
-                RunnableKind::DocTest { .. } => { 
+            let (run_title, debugee) = match &runnable.kind {
+                RunnableKind::Test { .. } | RunnableKind::TestMod { .. } => {
+                    ("▶️\u{fe0e}Run Test", true)
+                }
+                RunnableKind::DocTest { .. } => {
                     // cargo does not support -no-run for doctests
                     ("▶️\u{fe0e}Run Doctest", false)
                 }
                 RunnableKind::Bench { .. } => {
                     // Nothing wrong with bench debugging
                     ("Run Bench", true)
-                },
+                }
                 RunnableKind::Bin => {
                     // Do not suggest binary run on other target than binary
                     match &cargo_spec {

--- a/crates/rust-analyzer/src/main_loop/handlers.rs
+++ b/crates/rust-analyzer/src/main_loop/handlers.rs
@@ -812,88 +812,106 @@ pub fn handle_code_lens(
     params: lsp_types::CodeLensParams,
 ) -> Result<Option<Vec<CodeLens>>> {
     let _p = profile("handle_code_lens");
-    let file_id = from_proto::file_id(&world, &params.text_document.uri)?;
-    let line_index = world.analysis().file_line_index(file_id)?;
-
     let mut lenses: Vec<CodeLens> = Default::default();
 
-    let cargo_spec = CargoTargetSpec::for_file(&world, file_id)?;
-    // Gather runnables
-    for runnable in world.analysis().runnables(file_id)? {
-        let title = match &runnable.kind {
-            RunnableKind::Test { .. } | RunnableKind::TestMod { .. } => "▶\u{fe0e} Run Test",
-            RunnableKind::DocTest { .. } => "▶\u{fe0e} Run Doctest",
-            RunnableKind::Bench { .. } => "Run Bench",
-            RunnableKind::Bin => {
-                // Do not suggest binary run on other target than binary
-                match &cargo_spec {
-                    Some(spec) => match spec.target_kind {
-                        TargetKind::Bin => "Run",
-                        _ => continue,
-                    },
-                    None => continue,
-                }
-            }
-        }
-        .to_string();
-        let mut r = to_lsp_runnable(&world, file_id, runnable)?;
-        let lens = CodeLens {
-            range: r.range,
-            command: Some(Command {
-                title,
-                command: "rust-analyzer.runSingle".into(),
-                arguments: Some(vec![to_value(&r).unwrap()]),
-            }),
-            data: None,
-        };
-        lenses.push(lens);
-
-        if r.args[0] == "run" {
-            r.args[0] = "build".into();
-        } else {
-            r.args.push("--no-run".into());
-        }
-        let debug_lens = CodeLens {
-            range: r.range,
-            command: Some(Command {
-                title: "Debug".into(),
-                command: "rust-analyzer.debugSingle".into(),
-                arguments: Some(vec![to_value(r).unwrap()]),
-            }),
-            data: None,
-        };
-        lenses.push(debug_lens);
+    if world.config.lens.none() {
+        // early return before any db query!
+        return Ok(Some(lenses));
     }
 
-    // Handle impls
-    lenses.extend(
-        world
-            .analysis()
-            .file_structure(file_id)?
-            .into_iter()
-            .filter(|it| match it.kind {
-                SyntaxKind::TRAIT_DEF | SyntaxKind::STRUCT_DEF | SyntaxKind::ENUM_DEF => true,
-                _ => false,
-            })
-            .map(|it| {
-                let range = to_proto::range(&line_index, it.node_range);
-                let pos = range.start;
-                let lens_params = lsp_types::request::GotoImplementationParams {
-                    text_document_position_params: lsp_types::TextDocumentPositionParams::new(
-                        params.text_document.clone(),
-                        pos,
-                    ),
-                    work_done_progress_params: Default::default(),
-                    partial_result_params: Default::default(),
-                };
-                CodeLens {
-                    range,
-                    command: None,
-                    data: Some(to_value(CodeLensResolveData::Impls(lens_params)).unwrap()),
-                }
-            }),
-    );
+    let file_id = from_proto::file_id(&world, &params.text_document.uri)?;
+    let line_index = world.analysis().file_line_index(file_id)?;
+    let cargo_spec = CargoTargetSpec::for_file(&world, file_id)?;
 
+    if world.config.lens.runnable() {
+        // Gather runnables
+        for runnable in world.analysis().runnables(file_id)? {
+            let (run_title, debugee ) = match &runnable.kind {
+                RunnableKind::Test { .. } | RunnableKind::TestMod { .. } => ("▶️\u{fe0e}Run Test", true),
+                RunnableKind::DocTest { .. } => { 
+                    // cargo does not support -no-run for doctests
+                    ("▶️\u{fe0e}Run Doctest", false)
+                }
+                RunnableKind::Bench { .. } => {
+                    // Nothing wrong with bench debugging
+                    ("Run Bench", true)
+                },
+                RunnableKind::Bin => {
+                    // Do not suggest binary run on other target than binary
+                    match &cargo_spec {
+                        Some(spec) => match spec.target_kind {
+                            TargetKind::Bin => ("Run", true),
+                            _ => continue,
+                        },
+                        None => continue,
+                    }
+                }
+            };
+
+            let mut r = to_lsp_runnable(&world, file_id, runnable)?;
+            if world.config.lens.run {
+                let lens = CodeLens {
+                    range: r.range,
+                    command: Some(Command {
+                        title: run_title.to_string(),
+                        command: "rust-analyzer.runSingle".into(),
+                        arguments: Some(vec![to_value(&r).unwrap()]),
+                    }),
+                    data: None,
+                };
+                lenses.push(lens);
+            }
+
+            if debugee && world.config.lens.debug {
+                if r.args[0] == "run" {
+                    r.args[0] = "build".into();
+                } else {
+                    r.args.push("--no-run".into());
+                }
+                let debug_lens = CodeLens {
+                    range: r.range,
+                    command: Some(Command {
+                        title: "Debug".into(),
+                        command: "rust-analyzer.debugSingle".into(),
+                        arguments: Some(vec![to_value(r).unwrap()]),
+                    }),
+                    data: None,
+                };
+                lenses.push(debug_lens);
+            }
+        }
+    }
+
+    if world.config.lens.impementations {
+        // Handle impls
+        lenses.extend(
+            world
+                .analysis()
+                .file_structure(file_id)?
+                .into_iter()
+                .filter(|it| match it.kind {
+                    SyntaxKind::TRAIT_DEF | SyntaxKind::STRUCT_DEF | SyntaxKind::ENUM_DEF => true,
+                    _ => false,
+                })
+                .map(|it| {
+                    let range = to_proto::range(&line_index, it.node_range);
+                    let pos = range.start;
+                    let lens_params = lsp_types::request::GotoImplementationParams {
+                        text_document_position_params: lsp_types::TextDocumentPositionParams::new(
+                            params.text_document.clone(),
+                            pos,
+                        ),
+                        work_done_progress_params: Default::default(),
+                        partial_result_params: Default::default(),
+                    };
+                    CodeLens {
+                        range,
+                        command: None,
+                        data: Some(to_value(CodeLensResolveData::Impls(lens_params)).unwrap()),
+                    }
+                }),
+        );
+    }
     Ok(Some(lenses))
 }
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -443,6 +443,21 @@
                     "type": "object",
                     "default": {},
                     "description": "Optional settings passed to the debug engine. Example:\n{ \"lldb\": { \"terminal\":\"external\"} }"
+                },
+                "rust-analyzer.lens.run": {
+                    "description": "Whether to show Run lens.",
+                    "type": "boolean",
+                    "default": true
+                },
+                "rust-analyzer.lens.debug": {
+                    "description": "Whether to show Debug lens.",
+                    "type": "boolean",
+                    "default": true
+                },
+                "rust-analyzer.lens.implementations": {
+                    "description": "Whether to show Implementations lens.",
+                    "type": "boolean",
+                    "default": true
                 }
             }
         },

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -444,18 +444,23 @@
                     "default": {},
                     "description": "Optional settings passed to the debug engine. Example:\n{ \"lldb\": { \"terminal\":\"external\"} }"
                 },
+                "rust-analyzer.lens.enable": {
+                    "description": "Whether to show CodeLens in Rust files.",
+                    "type": "boolean",
+                    "default": true
+                },
                 "rust-analyzer.lens.run": {
-                    "description": "Whether to show Run lens.",
+                    "markdownDescription": "Whether to show Run lens. Only applies when `#rust-analyzer.lens.enable#` is set.",
                     "type": "boolean",
                     "default": true
                 },
                 "rust-analyzer.lens.debug": {
-                    "description": "Whether to show Debug lens.",
+                    "markdownDescription": "Whether to show Debug lens. Only applies when `#rust-analyzer.lens.enable#` is set.",
                     "type": "boolean",
                     "default": true
                 },
                 "rust-analyzer.lens.implementations": {
-                    "description": "Whether to show Implementations lens.",
+                    "markdownDescription": "Whether to show Implementations lens. Only applies when `#rust-analyzer.lens.enable#` is set.",
                     "type": "boolean",
                     "default": true
                 }

--- a/editors/code/src/commands/runnables.ts
+++ b/editors/code/src/commands/runnables.ts
@@ -40,7 +40,7 @@ async function selectRunnable(ctx: Ctx, prevRunnable?: RunnableQuickPick, debugg
         items.push(new RunnableQuickPick(r));
     }
 
-    if( items.length === 0 ) {
+    if (items.length === 0) {
         // it is the debug case, run always has at least 'cargo check ...'
         // see crates\rust-analyzer\src\main_loop\handlers.rs, handle_runnables
         vscode.window.showErrorMessage("There's no debug target!");

--- a/editors/code/src/commands/runnables.ts
+++ b/editors/code/src/commands/runnables.ts
@@ -7,7 +7,7 @@ import { startDebugSession, getDebugConfiguration } from '../debug';
 
 const quickPickButtons = [{ iconPath: new vscode.ThemeIcon("save"), tooltip: "Save as a launch.json configurtation." }];
 
-async function selectRunnable(ctx: Ctx, prevRunnable?: RunnableQuickPick, showButtons: boolean = true): Promise<RunnableQuickPick | undefined> {
+async function selectRunnable(ctx: Ctx, prevRunnable?: RunnableQuickPick, debuggeeOnly = false, showButtons: boolean = true): Promise<RunnableQuickPick | undefined> {
     const editor = ctx.activeRustEditor;
     const client = ctx.client;
     if (!editor || !client) return;
@@ -33,7 +33,18 @@ async function selectRunnable(ctx: Ctx, prevRunnable?: RunnableQuickPick, showBu
         ) {
             continue;
         }
+
+        if (debuggeeOnly && (r.label.startsWith('doctest') || r.label.startsWith('cargo'))) {
+            continue;
+        }
         items.push(new RunnableQuickPick(r));
+    }
+
+    if( items.length === 0 ) {
+        // it is the debug case, run always has at least 'cargo check ...'
+        // see crates\rust-analyzer\src\main_loop\handlers.rs, handle_runnables
+        vscode.window.showErrorMessage("There's no debug target!");
+        return;
     }
 
     return await new Promise((resolve) => {
@@ -107,7 +118,7 @@ export function debug(ctx: Ctx): Cmd {
     let prevDebuggee: RunnableQuickPick | undefined;
 
     return async () => {
-        const item = await selectRunnable(ctx, prevDebuggee);
+        const item = await selectRunnable(ctx, prevDebuggee, true);
         if (!item) return;
 
         item.detail = 'restart';
@@ -147,7 +158,7 @@ async function makeDebugConfig(ctx: Ctx, item: RunnableQuickPick): Promise<void>
 
 export function newDebugConfig(ctx: Ctx): Cmd {
     return async () => {
-        const item = await selectRunnable(ctx, undefined, false);
+        const item = await selectRunnable(ctx, undefined, true, false);
         if (!item) return;
 
         await makeDebugConfig(ctx, item);

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -16,6 +16,7 @@ export class Config {
         "files",
         "highlighting",
         "updates.channel",
+        "lens.enable",
         "lens.run",
         "lens.debug",
         "lens.implementations",
@@ -125,6 +126,7 @@ export class Config {
 
     get lens() {
         return {
+            enable: this.get<boolean>("lens.enable"),
             run: this.get<boolean>("lens.run"),
             debug: this.get<boolean>("lens.debug"),
             implementations: this.get<boolean>("lens.implementations"),

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -16,6 +16,9 @@ export class Config {
         "files",
         "highlighting",
         "updates.channel",
+        "lens.run",
+        "lens.debug",
+        "lens.implementations",
     ]
         .map(opt => `${this.rootSection}.${opt}`);
 
@@ -117,6 +120,14 @@ export class Config {
             engineSettings: this.get<object>("debug.engineSettings"),
             openUpDebugPane: this.get<boolean>("debug.openUpDebugPane"),
             sourceFileMap: sourceFileMap
+        };
+    }
+
+    get lens() {
+        return {
+            run: this.get<boolean>("lens.run"),
+            debug: this.get<boolean>("lens.debug"),
+            implementations: this.get<boolean>("lens.implementations"),
         };
     }
 }


### PR DESCRIPTION
This PR
- adds an option to granularly enable\disable all CodeLens, just like the TypeScript extension.
- fixes a minor bug for doctests. It makes no sense to show `Debug` lens for them as cargo `Can't skip running doc tests with --no-run`.