### PR TITLE
Mark fixes from diagnostics as quick fixes

### DIFF
--- a/crates/rust-analyzer/src/main_loop/handlers.rs
+++ b/crates/rust-analyzer/src/main_loop/handlers.rs
@@ -730,8 +730,13 @@ pub fn handle_code_action(
     for fix in fixes_from_diagnostics {
         let title = fix.label;
         let edit = to_proto::snippet_workspace_edit(&snap, fix.source_change)?;
-        let action =
-            lsp_ext::CodeAction { title, group: None, kind: None, edit: Some(edit), command: None };
+        let action = lsp_ext::CodeAction {
+            title,
+            group: None,
+            kind: Some(lsp_types::code_action_kind::QUICKFIX.into()),
+            edit: Some(edit),
+            command: None,
+        };
         res.push(action);
     }
 

--- a/crates/rust-analyzer/tests/heavy_tests/main.rs
+++ b/crates/rust-analyzer/tests/heavy_tests/main.rs
@@ -298,6 +298,7 @@ fn main() {}
                 }
               ]
             },
+            "kind": "quickfix",
             "title": "Create module"
         }]),
     );
@@ -368,6 +369,7 @@ fn main() {{}}
                 }
               ]
             },
+            "kind": "quickfix",
             "title": "Create module"
         }]),
     );


### PR DESCRIPTION
Populates the diagnostic UI with fixes:

Before: 
![quickfix-before](https://user-images.githubusercontent.com/4325700/82165183-0e38df00-9882-11ea-96cf-7dab5faec4d4.PNG)

After:
![image](https://user-images.githubusercontent.com/4325700/82165193-1a24a100-9882-11ea-97d7-be1b64b135e0.png)
