### PR TITLE
Infer return type of loops with value breaks

### DIFF
--- a/crates/ra_hir_ty/src/_match.rs
+++ b/crates/ra_hir_ty/src/_match.rs
@@ -1946,6 +1946,23 @@ mod tests {
 
         check_no_diagnostic(content);
     }
+
+    #[test]
+    fn expr_diverges_missing_arm() {
+        let content = r"
+            enum Either {
+                A,
+                B,
+            }
+            fn test_fn() {
+                match loop {} {
+                    Either::A => (),
+                }
+            }
+        ";
+
+        check_no_diagnostic(content);
+    }
 }
 
 #[cfg(test)]
@@ -1998,26 +2015,6 @@ mod false_negatives {
     }
 
     #[test]
-    fn expr_diverges_missing_arm() {
-        let content = r"
-            enum Either {
-                A,
-                B,
-            }
-            fn test_fn() {
-                match loop {} {
-                    Either::A => (),
-                }
-            }
-        ";
-
-        // This is a false negative.
-        // Even though the match expression diverges, rustc fails
-        // to compile here since `Either::B` is missing.
-        check_no_diagnostic(content);
-    }
-
-    #[test]
     fn expr_loop_missing_arm() {
         let content = r"
             enum Either {
@@ -2035,7 +2032,7 @@ mod false_negatives {
         // We currently infer the type of `loop { break Foo::A }` to `!`, which
         // causes us to skip the diagnostic since `Either::A` doesn't type check
         // with `!`.
-        check_no_diagnostic(content);
+        check_diagnostic(content);
     }
 
     #[test]

--- a/crates/ra_hir_ty/src/infer.rs
+++ b/crates/ra_hir_ty/src/infer.rs
@@ -218,6 +218,7 @@ struct InferenceContext<'a> {
 #[derive(Clone, Debug)]
 struct BreakableContext {
     pub may_break: bool,
+    pub break_ty: Ty,
 }
 
 impl<'a> InferenceContext<'a> {

--- a/crates/ra_hir_ty/src/tests/simple.rs
+++ b/crates/ra_hir_ty/src/tests/simple.rs
@@ -1860,3 +1860,66 @@ fn test() {
     "###
     );
 }
+
+#[test]
+fn infer_loop_break_with_val() {
+    assert_snapshot!(
+        infer(r#"
+enum Option<T> { Some(T), None }
+use Option::*;
+
+fn test() {
+    let x = loop {
+        if false {
+            break None;
+        }
+
+        break Some(true);
+    };
+}
+"#),
+        @r###"
+    60..169 '{     ...  }; }': ()
+    70..71 'x': Option<bool>
+    74..166 'loop {...     }': Option<bool>
+    79..166 '{     ...     }': ()
+    89..133 'if fal...     }': ()
+    92..97 'false': bool
+    98..133 '{     ...     }': ()
+    112..122 'break None': !
+    118..122 'None': Option<bool>
+    143..159 'break ...(true)': !
+    149..153 'Some': Some<bool>(bool) -> Option<bool>
+    149..159 'Some(true)': Option<bool>
+    154..158 'true': bool
+    "###
+    );
+}
+
+#[test]
+fn infer_loop_break_without_val() {
+    assert_snapshot!(
+        infer(r#"
+enum Option<T> { Some(T), None }
+use Option::*;
+
+fn test() {
+    let x = loop {
+        if false {
+            break;
+        }
+    };
+}
+"#),
+        @r###"
+    60..137 '{     ...  }; }': ()
+    70..71 'x': ()
+    74..134 'loop {...     }': ()
+    79..134 '{     ...     }': ()
+    89..128 'if fal...     }': ()
+    92..97 'false': bool
+    98..128 '{     ...     }': ()
+    112..117 'break': !
+    "###
+    );
+}


### PR DESCRIPTION
Creates a type variable to represent the return value of the loop.
Uses `coerce_merge_branch` on each break with the previous value, to determine the actual return value of the loop.

Resolves: https://github.com/rust-analyzer/rust-analyzer/issues/4492 , https://github.com/rust-analyzer/rust-analyzer/issues/4512