### PR TITLE
Make `find_path_inner` a query

### DIFF
--- a/crates/ra_hir_def/src/db.rs
+++ b/crates/ra_hir_def/src/db.rs
@@ -17,6 +17,7 @@ use crate::{
     item_scope::ItemInNs,
     lang_item::{LangItemTarget, LangItems},
     nameres::{raw::RawItems, CrateDefMap},
+    path::ModPath,
     visibility::Visibility,
     AttrDefId, ConstId, ConstLoc, DefWithBodyId, EnumId, EnumLoc, FunctionId, FunctionLoc,
     GenericDefId, ImplId, ImplLoc, ModuleId, StaticId, StaticLoc, StructId, StructLoc, TraitId,
@@ -118,6 +119,9 @@ pub trait DefDatabase: InternDatabase + AstDatabase + Upcast<dyn AstDatabase> {
         item: ItemInNs,
         krate: CrateId,
     ) -> Arc<[(ModuleId, Name, Visibility)]>;
+
+    #[salsa::invoke(find_path::find_path_inner_query)]
+    fn find_path_inner(&self, item: ItemInNs, from: ModuleId, max_len: usize) -> Option<ModPath>;
 }
 
 fn crate_def_map_wait(db: &impl DefDatabase, krate: CrateId) -> Arc<CrateDefMap> {

--- a/crates/ra_hir_def/src/find_path.rs
+++ b/crates/ra_hir_def/src/find_path.rs
@@ -20,7 +20,7 @@ use crate::{
 /// *from where* you're referring to the item, hence the `from` parameter.
 pub fn find_path(db: &dyn DefDatabase, item: ItemInNs, from: ModuleId) -> Option<ModPath> {
     let _p = profile("find_path");
-    find_path_inner(db, item, from, MAX_PATH_LEN)
+    db.find_path_inner(item, from, MAX_PATH_LEN)
 }
 
 const MAX_PATH_LEN: usize = 15;
@@ -49,7 +49,7 @@ impl ModPath {
     }
 }
 
-fn find_path_inner(
+pub(crate) fn find_path_inner_query(
     db: &dyn DefDatabase,
     item: ItemInNs,
     from: ModuleId,
@@ -140,8 +140,7 @@ fn find_path_inner(
     let mut best_path = None;
     let mut best_path_len = max_len;
     for (module_id, name) in importable_locations {
-        let mut path = match find_path_inner(
-            db,
+        let mut path = match db.find_path_inner(
             ItemInNs::Types(ModuleDefId::ModuleId(module_id)),
             from,
             best_path_len - 1,


### PR DESCRIPTION
This eliminates the remaining performance problems in the "Implement default members" assist (at least those that I've found).

Closes https://github.com/rust-analyzer/rust-analyzer/issues/4498