### PR TITLE
Use a flat play icon instead of the blue emoji with test code lens

### DIFF
--- a/crates/rust-analyzer/src/main_loop/handlers.rs
+++ b/crates/rust-analyzer/src/main_loop/handlers.rs
@@ -802,11 +802,11 @@ pub fn handle_code_lens(
         for runnable in world.analysis().runnables(file_id)? {
             let (run_title, debugee) = match &runnable.kind {
                 RunnableKind::Test { .. } | RunnableKind::TestMod { .. } => {
-                    ("▶️\u{fe0e}Run Test", true)
+                    ("▶\u{fe0e} Run Test", true)
                 }
                 RunnableKind::DocTest { .. } => {
                     // cargo does not support -no-run for doctests
-                    ("▶️\u{fe0e}Run Doctest", false)
+                    ("▶\u{fe0e} Run Doctest", false)
                 }
                 RunnableKind::Bench { .. } => {
                     // Nothing wrong with bench debugging


### PR DESCRIPTION
@lnicola 

Restores this commit:
https://github.com/rust-analyzer/rust-analyzer/commit/55e914a2a179aba63bd9948d6e0cf3e2a4bf5960

That was effectively wiped out by this code formatting commit:
https://github.com/rust-analyzer/rust-analyzer/commit/dc217bdf90d555eaa1780041fc3a14e64173994d
https://github.com/rust-analyzer/rust-analyzer/commit/3d445256fe56f4a7ead64514fb57b79079973d84