### PR TITLE
Fix names of launch configuration in dev docs

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -74,7 +74,7 @@ relevant test and execute it (VS Code includes an action for running a single
 test).
 
 However, launching a VS Code instance with locally build language server is
-possible. There's **"Run Extension (Dev Server)"** launch configuration for this.
+possible. There's **"Run Extension (Debug Build)"** launch configuration for this.
 
 In general, I use one of the following workflows for fixing bugs and
 implementing features.
@@ -86,7 +86,7 @@ then just do printf-driven development/debugging. As a sanity check after I'm
 done, I use `cargo xtask install --server` and **Reload Window** action in VS
 Code to sanity check that the thing works as I expect.
 
-If the problem concerns only the VS Code extension, I use **Run Extension**
+If the problem concerns only the VS Code extension, I use **Run Installed Extension**
 launch configuration from `launch.json`. Notably, this uses the usual
 `rust-analyzer` binary from `PATH`. For this it is important to have the following
 in `setting.json` file:

--- a/docs/dev/debugging.md
+++ b/docs/dev/debugging.md
@@ -22,8 +22,8 @@ where **only** the `rust-analyzer` extension being debugged is enabled.
 
 ## Debug TypeScript VSCode extension
 
-- `Run Extension` - runs the extension with the globally installed `rust-analyzer` binary.
-- `Run Extension (Dev Server)` - runs extension with the locally built LSP server (`target/debug/rust-analyzer`).
+- `Run Installed Extension` - runs the extension with the globally installed `rust-analyzer` binary.
+- `Run Extension (Debug Build)` - runs extension with the locally built LSP server (`target/debug/rust-analyzer`).
 
 TypeScript debugging is configured to watch your source edits and recompile.
 To apply changes to an already running debug process, press <kbd>Ctrl+Shift+P</kbd> and run the following command in your `[Extension Development Host]`
@@ -47,7 +47,7 @@ To apply changes to an already running debug process, press <kbd>Ctrl+Shift+P</k
     debug = 2
   ```
 
-- Select `Run Extension (Dev Server)` to run your locally built `target/debug/rust-analyzer`.
+- Select `Run Extension (Debug Build)` to run your locally built `target/debug/rust-analyzer`.
 
 - In the original VSCode window once again select the `Attach To Server` debug configuration.
 


### PR DESCRIPTION
Follows renaming of launch configurations in https://github.com/rust-analyzer/rust-analyzer/commit/80a42a0628f7655c3299fbf4c5a15e31990b35d3