### PR TITLE
KISS SourceChange

### DIFF
--- a/crates/ra_ide/src/lib.rs
+++ b/crates/ra_ide/src/lib.rs
@@ -97,8 +97,22 @@ pub type Cancelable<T> = Result<T, Canceled>;
 pub struct Diagnostic {
     pub message: String,
     pub range: TextRange,
-    pub fix: Option<SourceChange>,
     pub severity: Severity,
+    pub fix: Option<Fix>,
+}
+
+#[derive(Debug)]
+pub struct Fix {
+    pub label: String,
+    pub source_change: SourceChange,
+}
+
+impl Fix {
+    pub fn new(label: impl Into<String>, source_change: SourceChange) -> Self {
+        let label = label.into();
+        assert!(label.starts_with(char::is_uppercase) && !label.ends_with('.'));
+        Self { label, source_change }
+    }
 }
 
 /// Info associated with a text range.
@@ -493,7 +507,7 @@ impl Analysis {
     ) -> Cancelable<Result<SourceChange, SsrError>> {
         self.with_db(|db| {
             let edits = ssr::parse_search_replace(query, parse_only, db)?;
-            Ok(SourceChange::source_file_edits("Structural Search Replace", edits))
+            Ok(SourceChange::source_file_edits(edits))
         })
     }
 

--- a/crates/ra_ide/src/references/rename.rs
+++ b/crates/ra_ide/src/references/rename.rs
@@ -128,7 +128,7 @@ fn rename_mod(
         source_file_edits.extend(ref_edits);
     }
 
-    Some(SourceChange::from_edits("Rename", source_file_edits, file_system_edits))
+    Some(SourceChange::from_edits(source_file_edits, file_system_edits))
 }
 
 fn rename_to_self(db: &RootDatabase, position: FilePosition) -> Option<RangeInfo<SourceChange>> {
@@ -171,7 +171,7 @@ fn rename_to_self(db: &RootDatabase, position: FilePosition) -> Option<RangeInfo
         ),
     });
 
-    Some(RangeInfo::new(range, SourceChange::source_file_edits("Rename", edits)))
+    Some(RangeInfo::new(range, SourceChange::source_file_edits(edits)))
 }
 
 fn text_edit_from_self_param(
@@ -234,7 +234,7 @@ fn rename_self_to_param(
     let range = ast::SelfParam::cast(self_token.parent())
         .map_or(self_token.text_range(), |p| p.syntax().text_range());
 
-    Some(RangeInfo::new(range, SourceChange::source_file_edits("Rename", edits)))
+    Some(RangeInfo::new(range, SourceChange::source_file_edits(edits)))
 }
 
 fn rename_reference(
@@ -253,7 +253,7 @@ fn rename_reference(
         return None;
     }
 
-    Some(RangeInfo::new(range, SourceChange::source_file_edits("Rename", edit)))
+    Some(RangeInfo::new(range, SourceChange::source_file_edits(edit)))
 }
 
 #[cfg(test)]
@@ -642,7 +642,6 @@ mod tests {
             RangeInfo {
                 range: 4..7,
                 info: SourceChange {
-                    label: "Rename",
                     source_file_edits: [
                         SourceFileEdit {
                             file_id: FileId(
@@ -694,7 +693,6 @@ mod tests {
             RangeInfo {
                 range: 4..7,
                 info: SourceChange {
-                    label: "Rename",
                     source_file_edits: [
                         SourceFileEdit {
                             file_id: FileId(
@@ -777,7 +775,6 @@ mod tests {
             RangeInfo {
                 range: 8..11,
                 info: SourceChange {
-                    label: "Rename",
                     source_file_edits: [
                         SourceFileEdit {
                             file_id: FileId(

--- a/crates/ra_ide/src/typing/on_enter.rs
+++ b/crates/ra_ide/src/typing/on_enter.rs
@@ -41,10 +41,7 @@ pub(crate) fn on_enter(db: &RootDatabase, position: FilePosition) -> Option<Sour
     let inserted = format!("\n{}{} $0", indent, prefix);
     let edit = TextEdit::insert(position.offset, inserted);
 
-    let mut res = SourceChange::source_file_edit(
-        "On enter",
-        SourceFileEdit { edit, file_id: position.file_id },
-    );
+    let mut res = SourceChange::from(SourceFileEdit { edit, file_id: position.file_id });
     res.is_snippet = true;
     Some(res)
 }

--- a/crates/ra_ide_db/src/source_change.rs
+++ b/crates/ra_ide_db/src/source_change.rs
@@ -8,8 +8,6 @@ use ra_text_edit::TextEdit;
 
 #[derive(Debug, Clone)]
 pub struct SourceChange {
-    /// For display in the undo log in the editor
-    pub label: String,
     pub source_file_edits: Vec<SourceFileEdit>,
     pub file_system_edits: Vec<FileSystemEdit>,
     pub is_snippet: bool,
@@ -18,63 +16,22 @@ pub struct SourceChange {
 impl SourceChange {
     /// Creates a new SourceChange with the given label
     /// from the edits.
-    pub fn from_edits<L: Into<String>>(
-        label: L,
+    pub fn from_edits(
         source_file_edits: Vec<SourceFileEdit>,
         file_system_edits: Vec<FileSystemEdit>,
     ) -> Self {
-        SourceChange {
-            label: label.into(),
-            source_file_edits,
-            file_system_edits,
-            is_snippet: false,
-        }
+        SourceChange { source_file_edits, file_system_edits, is_snippet: false }
     }
 
     /// Creates a new SourceChange with the given label,
     /// containing only the given `SourceFileEdits`.
-    pub fn source_file_edits<L: Into<String>>(label: L, edits: Vec<SourceFileEdit>) -> Self {
-        let label = label.into();
-        assert!(label.starts_with(char::is_uppercase));
-        SourceChange {
-            label: label,
-            source_file_edits: edits,
-            file_system_edits: vec![],
-            is_snippet: false,
-        }
+    pub fn source_file_edits(edits: Vec<SourceFileEdit>) -> Self {
+        SourceChange { source_file_edits: edits, file_system_edits: vec![], is_snippet: false }
     }
-
-    /// Creates a new SourceChange with the given label,
-    /// containing only the given `FileSystemEdits`.
-    pub(crate) fn file_system_edits<L: Into<String>>(label: L, edits: Vec<FileSystemEdit>) -> Self {
-        SourceChange {
-            label: label.into(),
-            source_file_edits: vec![],
-            file_system_edits: edits,
-            is_snippet: false,
-        }
-    }
-
-    /// Creates a new SourceChange with the given label,
-    /// containing only a single `SourceFileEdit`.
-    pub fn source_file_edit<L: Into<String>>(label: L, edit: SourceFileEdit) -> Self {
-        SourceChange::source_file_edits(label, vec![edit])
-    }
-
     /// Creates a new SourceChange with the given label
     /// from the given `FileId` and `TextEdit`
-    pub fn source_file_edit_from<L: Into<String>>(
-        label: L,
-        file_id: FileId,
-        edit: TextEdit,
-    ) -> Self {
-        SourceChange::source_file_edit(label, SourceFileEdit { file_id, edit })
-    }
-
-    /// Creates a new SourceChange with the given label
-    /// from the given `FileId` and `TextEdit`
-    pub fn file_system_edit<L: Into<String>>(label: L, edit: FileSystemEdit) -> Self {
-        SourceChange::file_system_edits(label, vec![edit])
+    pub fn source_file_edit_from(file_id: FileId, edit: TextEdit) -> Self {
+        SourceFileEdit { file_id, edit }.into()
     }
 }
 
@@ -84,23 +41,27 @@ pub struct SourceFileEdit {
     pub edit: TextEdit,
 }
 
+impl From<SourceFileEdit> for SourceChange {
+    fn from(edit: SourceFileEdit) -> SourceChange {
+        SourceChange {
+            source_file_edits: vec![edit],
+            file_system_edits: Vec::new(),
+            is_snippet: false,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum FileSystemEdit {
     CreateFile { source_root: SourceRootId, path: RelativePathBuf },
     MoveFile { src: FileId, dst_source_root: SourceRootId, dst_path: RelativePathBuf },
 }
 
-pub struct SingleFileChange {
-    pub label: String,
-    pub edit: TextEdit,
-}
-
-impl SingleFileChange {
-    pub fn into_source_change(self, file_id: FileId) -> SourceChange {
+impl From<FileSystemEdit> for SourceChange {
+    fn from(edit: FileSystemEdit) -> SourceChange {
         SourceChange {
-            label: self.label,
-            source_file_edits: vec![SourceFileEdit { file_id, edit: self.edit }],
-            file_system_edits: Vec::new(),
+            source_file_edits: Vec::new(),
+            file_system_edits: vec![edit],
             is_snippet: false,
         }
     }

--- a/crates/rust-analyzer/src/main_loop/handlers.rs
+++ b/crates/rust-analyzer/src/main_loop/handlers.rs
@@ -731,9 +731,9 @@ pub fn handle_code_action(
         .filter(|(diag_range, _fix)| diag_range.intersect(range).is_some())
         .map(|(_range, fix)| fix);
 
-    for source_edit in fixes_from_diagnostics {
-        let title = source_edit.label.clone();
-        let edit = to_proto::snippet_workspace_edit(&world, source_edit)?;
+    for fix in fixes_from_diagnostics {
+        let title = fix.label;
+        let edit = to_proto::snippet_workspace_edit(&world, fix.source_change)?;
         let action =
             lsp_ext::CodeAction { title, group: None, kind: None, edit: Some(edit), command: None };
         res.push(action);


### PR DESCRIPTION
The idea behind requiring the label is a noble one, but we are not
really using it consistently anyway, and it should be easy to retrofit
later, should we need it.

bors r+