### PR TITLE
Use Chalk's built-in representations for fn items and pointers

### DIFF
--- a/crates/ra_hir_ty/src/db.rs
+++ b/crates/ra_hir_ty/src/db.rs
@@ -76,6 +76,8 @@ pub trait HirDatabase: DefDatabase + Upcast<dyn DefDatabase> {
     #[salsa::interned]
     fn intern_type_ctor(&self, type_ctor: TypeCtor) -> crate::TypeCtorId;
     #[salsa::interned]
+    fn intern_callable_def(&self, callable_def: CallableDef) -> crate::CallableDefId;
+    #[salsa::interned]
     fn intern_type_param_id(&self, param_id: TypeParamId) -> GlobalTypeParamId;
     #[salsa::interned]
     fn intern_chalk_impl(&self, impl_: Impl) -> crate::traits::GlobalImplId;
@@ -93,6 +95,9 @@ pub trait HirDatabase: DefDatabase + Upcast<dyn DefDatabase> {
 
     #[salsa::invoke(crate::traits::chalk::impl_datum_query)]
     fn impl_datum(&self, krate: CrateId, impl_id: chalk::ImplId) -> Arc<chalk::ImplDatum>;
+
+    #[salsa::invoke(crate::traits::chalk::fn_def_datum_query)]
+    fn fn_def_datum(&self, krate: CrateId, fn_def_id: chalk::FnDefId) -> Arc<chalk::FnDefDatum>;
 
     #[salsa::invoke(crate::traits::chalk::associated_ty_value_query)]
     fn associated_ty_value(

--- a/crates/ra_hir_ty/src/lib.rs
+++ b/crates/ra_hir_ty/src/lib.rs
@@ -159,6 +159,12 @@ pub enum TypeCtor {
 pub struct TypeCtorId(salsa::InternId);
 impl_intern_key!(TypeCtorId);
 
+/// This exists just for Chalk, because Chalk just has a single `FnDefId` where
+/// we have different IDs for struct and enum variant constructors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
+pub struct CallableDefId(salsa::InternId);
+impl_intern_key!(CallableDefId);
+
 impl TypeCtor {
     pub fn num_ty_params(self, db: &dyn HirDatabase) -> usize {
         match self {

--- a/crates/ra_hir_ty/src/tests/traits.rs
+++ b/crates/ra_hir_ty/src/tests/traits.rs
@@ -2686,6 +2686,38 @@ fn test() {
 }
 
 #[test]
+fn builtin_fn_ptr_copy() {
+    assert_snapshot!(
+        infer_with_mismatches(r#"
+#[lang = "copy"]
+trait Copy {}
+
+trait Test { fn test(&self) -> bool; }
+impl<T: Copy> Test for T {}
+
+fn test(f1: fn(), f2: fn(usize) -> u8, f3: fn(u8, u8) -> &u8) {
+    f1.test();
+    f2.test();
+    f3.test();
+}
+"#, true),
+        @r###"
+    55..59 'self': &Self
+    109..111 'f1': fn()
+    119..121 'f2': fn(usize) -> u8
+    140..142 'f3': fn(u8, u8) -> &u8
+    163..211 '{     ...t(); }': ()
+    169..171 'f1': fn()
+    169..178 'f1.test()': bool
+    184..186 'f2': fn(usize) -> u8
+    184..193 'f2.test()': bool
+    199..201 'f3': fn(u8, u8) -> &u8
+    199..208 'f3.test()': bool
+    "###
+    );
+}
+
+#[test]
 fn builtin_sized() {
     assert_snapshot!(
         infer_with_mismatches(r#"

--- a/crates/ra_hir_ty/src/traits/chalk/interner.rs
+++ b/crates/ra_hir_ty/src/traits/chalk/interner.rs
@@ -20,6 +20,8 @@ pub type ImplId = chalk_ir::ImplId<Interner>;
 pub type ImplDatum = chalk_rust_ir::ImplDatum<Interner>;
 pub type AssociatedTyValueId = chalk_rust_ir::AssociatedTyValueId<Interner>;
 pub type AssociatedTyValue = chalk_rust_ir::AssociatedTyValue<Interner>;
+pub type FnDefId = chalk_ir::FnDefId<Interner>;
+pub type FnDefDatum = chalk_rust_ir::FnDefDatum<Interner>;
 
 impl chalk_ir::interner::Interner for Interner {
     type InternedType = Box<chalk_ir::TyData<Self>>; // FIXME use Arc?


### PR DESCRIPTION
The `TypeName::FnDef` was just added; the function pointer variant has existed for a while, I just forgot about it because it's special (because fn pointers can be higher-ranked over lifetimes).

We *could* also make `FnPtr` a separate `Ty` variant instead of a `TypeCtor` variant, which would make the conversion code a bit less special-casey, but it doesn't seem worth doing right now.