### PR TITLE
Strip leading underscores of argument names in function/method

### DIFF
--- a/crates/ra_ide/src/completion/presentation.rs
+++ b/crates/ra_ide/src/completion/presentation.rs
@@ -211,7 +211,7 @@ impl Completions {
             .parameter_names
             .iter()
             .skip(if function_signature.has_self_param { 1 } else { 0 })
-            .cloned()
+            .map(|name| name.trim_start_matches('_').into())
             .collect();
 
         builder = builder.add_call_parens(ctx, name, Params::Named(params));

--- a/crates/ra_ide/src/completion/presentation.rs
+++ b/crates/ra_ide/src/completion/presentation.rs
@@ -641,7 +641,7 @@ mod tests {
         assert_debug_snapshot!(
             do_reference_completion(
                 r"
-                fn with_args(x: i32, y: String) {}
+                fn with_args(x: i32, y: String, _z: bool) {}
                 fn main() { with_<|> }
                 "
             ),
@@ -649,8 +649,8 @@ mod tests {
         [
             CompletionItem {
                 label: "main()",
-                source_range: 80..85,
-                delete: 80..85,
+                source_range: 90..95,
+                delete: 90..95,
                 insert: "main()$0",
                 kind: Function,
                 lookup: "main",
@@ -658,12 +658,12 @@ mod tests {
             },
             CompletionItem {
                 label: "with_args(…)",
-                source_range: 80..85,
-                delete: 80..85,
-                insert: "with_args(${1:x}, ${2:y})$0",
+                source_range: 90..95,
+                delete: 90..95,
+                insert: "with_args(${1:x}, ${2:y}, ${3:z})$0",
                 kind: Function,
                 lookup: "with_args",
-                detail: "fn with_args(x: i32, y: String)",
+                detail: "fn with_args(x: i32, y: String, _z: bool)",
                 trigger_call_info: true,
             },
         ]

--- a/crates/ra_ide/src/completion/presentation.rs
+++ b/crates/ra_ide/src/completion/presentation.rs
@@ -672,7 +672,7 @@ mod tests {
         assert_debug_snapshot!(
             do_reference_completion(
                 r"
-                fn with_ignored_args(_foo: i32, b_a_r_: bool) {}
+                fn with_ignored_args(_foo: i32, ___bar: bool, ho_ge_: String) {}
                 fn main() { with_<|> }
                 "
             ),
@@ -680,8 +680,8 @@ mod tests {
         [
             CompletionItem {
                 label: "main()",
-                source_range: 94..99,
-                delete: 94..99,
+                source_range: 110..115,
+                delete: 110..115,
                 insert: "main()$0",
                 kind: Function,
                 lookup: "main",
@@ -689,12 +689,12 @@ mod tests {
             },
             CompletionItem {
                 label: "with_ignored_args(…)",
-                source_range: 94..99,
-                delete: 94..99,
-                insert: "with_ignored_args(${1:foo}, ${2:b_a_r_})$0",
+                source_range: 110..115,
+                delete: 110..115,
+                insert: "with_ignored_args(${1:foo}, ${2:bar}, ${3:ho_ge_})$0",
                 kind: Function,
                 lookup: "with_ignored_args",
-                detail: "fn with_ignored_args(_foo: i32, b_a_r_: bool)",
+                detail: "fn with_ignored_args(_foo: i32, ___bar: bool, ho_ge_: String)",
                 trigger_call_info: true,
             },
         ]

--- a/crates/ra_ide/src/completion/presentation.rs
+++ b/crates/ra_ide/src/completion/presentation.rs
@@ -641,7 +641,7 @@ mod tests {
         assert_debug_snapshot!(
             do_reference_completion(
                 r"
-                fn with_args(x: i32, y: String, _z: bool) {}
+                fn with_args(x: i32, y: String) {}
                 fn main() { with_<|> }
                 "
             ),
@@ -649,8 +649,8 @@ mod tests {
         [
             CompletionItem {
                 label: "main()",
-                source_range: 90..95,
-                delete: 90..95,
+                source_range: 80..85,
+                delete: 80..85,
                 insert: "main()$0",
                 kind: Function,
                 lookup: "main",
@@ -658,12 +658,43 @@ mod tests {
             },
             CompletionItem {
                 label: "with_args(…)",
-                source_range: 90..95,
-                delete: 90..95,
-                insert: "with_args(${1:x}, ${2:y}, ${3:z})$0",
+                source_range: 80..85,
+                delete: 80..85,
+                insert: "with_args(${1:x}, ${2:y})$0",
                 kind: Function,
                 lookup: "with_args",
-                detail: "fn with_args(x: i32, y: String, _z: bool)",
+                detail: "fn with_args(x: i32, y: String)",
+                trigger_call_info: true,
+            },
+        ]
+        "###
+        );
+        assert_debug_snapshot!(
+            do_reference_completion(
+                r"
+                fn with_ignored_args(_foo: i32, b_a_r_: bool) {}
+                fn main() { with_<|> }
+                "
+            ),
+            @r###"
+        [
+            CompletionItem {
+                label: "main()",
+                source_range: 94..99,
+                delete: 94..99,
+                insert: "main()$0",
+                kind: Function,
+                lookup: "main",
+                detail: "fn main()",
+            },
+            CompletionItem {
+                label: "with_ignored_args(…)",
+                source_range: 94..99,
+                delete: 94..99,
+                insert: "with_ignored_args(${1:foo}, ${2:b_a_r_})$0",
+                kind: Function,
+                lookup: "with_ignored_args",
+                detail: "fn with_ignored_args(_foo: i32, b_a_r_: bool)",
                 trigger_call_info: true,
             },
         ]
@@ -691,6 +722,33 @@ mod tests {
                 kind: Method,
                 lookup: "foo",
                 detail: "fn foo(&self)",
+            },
+        ]
+        "###
+        );
+        assert_debug_snapshot!(
+            do_reference_completion(
+                r"
+                struct S {}
+                impl S {
+                    fn foo_ignored_args(&self, _a: bool, b: i32) {}
+                }
+                fn bar(s: &S) {
+                    s.f<|>
+                }
+                "
+            ),
+            @r###"
+        [
+            CompletionItem {
+                label: "foo_ignored_args(…)",
+                source_range: 194..195,
+                delete: 194..195,
+                insert: "foo_ignored_args(${1:a}, ${2:b})$0",
+                kind: Method,
+                lookup: "foo_ignored_args",
+                detail: "fn foo_ignored_args(&self, _a: bool, b: i32)",
+                trigger_call_info: true,
             },
         ]
         "###

--- a/crates/ra_ide/src/display/function_signature.rs
+++ b/crates/ra_ide/src/display/function_signature.rs
@@ -187,14 +187,6 @@ impl FunctionSignature {
 
 impl From<&'_ ast::FnDef> for FunctionSignature {
     fn from(node: &ast::FnDef) -> FunctionSignature {
-        fn strip_leading_underscore(name: String) -> String {
-            if name.starts_with("_") {
-                name.get(1..).unwrap_or_default().to_string()
-            } else {
-                name
-            }
-        }
-
         fn param_list(node: &ast::FnDef) -> (bool, Vec<String>, Vec<String>) {
             let mut res = vec![];
             let mut res_types = vec![];
@@ -238,15 +230,17 @@ impl From<&'_ ast::FnDef> for FunctionSignature {
                     param_list
                         .params()
                         .map(|param| {
-                            Some(strip_leading_underscore(
+                            Some(
                                 param
                                     .pat()?
                                     .syntax()
                                     .descendants()
                                     .find_map(ast::Name::cast)?
                                     .text()
-                                    .to_string(),
-                            ))
+                                    .to_string()
+                                    .trim_start_matches('_')
+                                    .into(),
+                            )
                         })
                         .map(|param| param.unwrap_or_default()),
                 );

--- a/crates/ra_ide/src/display/function_signature.rs
+++ b/crates/ra_ide/src/display/function_signature.rs
@@ -237,9 +237,7 @@ impl From<&'_ ast::FnDef> for FunctionSignature {
                                     .descendants()
                                     .find_map(ast::Name::cast)?
                                     .text()
-                                    .to_string()
-                                    .trim_start_matches('_')
-                                    .into(),
+                                    .to_string(),
                             )
                         })
                         .map(|param| param.unwrap_or_default()),

--- a/crates/ra_ide/src/display/function_signature.rs
+++ b/crates/ra_ide/src/display/function_signature.rs
@@ -187,6 +187,14 @@ impl FunctionSignature {
 
 impl From<&'_ ast::FnDef> for FunctionSignature {
     fn from(node: &ast::FnDef) -> FunctionSignature {
+        fn strip_leading_underscore(name: String) -> String {
+            if name.starts_with("_") {
+                name.get(1..).unwrap_or_default().to_string()
+            } else {
+                name
+            }
+        }
+
         fn param_list(node: &ast::FnDef) -> (bool, Vec<String>, Vec<String>) {
             let mut res = vec![];
             let mut res_types = vec![];
@@ -230,7 +238,7 @@ impl From<&'_ ast::FnDef> for FunctionSignature {
                     param_list
                         .params()
                         .map(|param| {
-                            Some(
+                            Some(strip_leading_underscore(
                                 param
                                     .pat()?
                                     .syntax()
@@ -238,7 +246,7 @@ impl From<&'_ ast::FnDef> for FunctionSignature {
                                     .find_map(ast::Name::cast)?
                                     .text()
                                     .to_string(),
-                            )
+                            ))
                         })
                         .map(|param| param.unwrap_or_default()),
                 );


### PR DESCRIPTION
Closes #4510 

### Goal

When I select a function/method from completions, I get a snippet that doesn't contain leading underscores of argument names.

### Solution

- Option 1: All signatures don't contain underscores
- Option 2: Keep same signature, but inserted snippet doesn't contain underscores

I choose Option 2 because I think that leading underscores is a part of "signature". Users should get correct signatures. On the other hand, trimming underscores is an assist by IDE.

### Other impls.

rls: Complete argument names with underscores (same as actual ra)
IntelliJ Rust: Doesn't complete argument names
VSCode (TypeScript): Doesn't complete argument names

### Working example

![Screen Shot 2020-05-25 at 0 03 21](https://user-images.githubusercontent.com/151614/82757771-a05e5b80-9e1d-11ea-9dbc-1263c960e2ae.png)
