### PR TITLE
Introduce `toggle inlay hints` vscode command

### DIFF
--- a/docs/user/features.md
+++ b/docs/user/features.md
@@ -93,6 +93,12 @@ Shows internal statistic about memory usage of rust-analyzer.
 
 Show current rust-analyzer version.
 
+#### Toggle inlay hints
+
+Toggle inlay hints view for the current workspace.
+It is recommended to assign a shortcut for this command to quickly turn off
+inlay hints when they prevent you from reading/writing the code.
+
 #### Run Garbage Collection
 
 Manually triggers GC.

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -166,6 +166,11 @@
                 "command": "rust-analyzer.serverVersion",
                 "title": "Show RA Version",
                 "category": "Rust Analyzer"
+            },
+            {
+                "command": "rust-analyzer.toggleInlayHints",
+                "title": "Toggle inlay hints",
+                "category": "Rust Analyzer"
             }
         ],
         "keybindings": [

--- a/editors/code/src/commands/index.ts
+++ b/editors/code/src/commands/index.ts
@@ -16,6 +16,7 @@ export * from './expand_macro';
 export * from './runnables';
 export * from './ssr';
 export * from './server_version';
+export * from './toggle_inlay_hints';
 
 export function collectGarbage(ctx: Ctx): Cmd {
     return async () => ctx.client.sendRequest(ra.collectGarbage, null);

--- a/editors/code/src/commands/toggle_inlay_hints.ts
+++ b/editors/code/src/commands/toggle_inlay_hints.ts
@@ -1,0 +1,11 @@
+import * as vscode from 'vscode';
+import { Ctx, Cmd } from '../ctx';
+
+export function toggleInlayHints(ctx: Ctx): Cmd {
+    return async () => {
+        await vscode
+            .workspace
+            .getConfiguration(`${ctx.config.rootSection}.inlayHints`)
+            .update('enable', !ctx.config.inlayHints.enable, vscode.ConfigurationTarget.Workspace);
+    };
+}

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -8,7 +8,7 @@ export const NIGHTLY_TAG = "nightly";
 export class Config {
     readonly extensionId = "matklad.rust-analyzer";
 
-    private readonly rootSection = "rust-analyzer";
+    readonly rootSection = "rust-analyzer";
     private readonly requiresReloadOpts = [
         "serverPath",
         "cargo",

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -86,6 +86,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     ctx.registerCommand('ssr', commands.ssr);
     ctx.registerCommand('serverVersion', commands.serverVersion);
+    ctx.registerCommand('toggleInlayHints', commands.toggleInlayHints);
 
     // Internal commands which are invoked by the server.
     ctx.registerCommand('runSingle', commands.runSingle);


### PR DESCRIPTION
Users now can assign a shortcut for this command
via the general vscode
keybindings ui or `keybindings.json` file

<details>
<summary>Demo</summary>

![demo](https://user-images.githubusercontent.com/36276403/82768941-b4fd1c80-9e3a-11ea-9d5b-a40fa1e4dbc6.gif)

</details>

<details>
<summary>Howto assign a shortcut</summary>

![demo2](https://user-images.githubusercontent.com/36276403/82769350-c8a98280-9e3c-11ea-8a95-1266a539826d.gif)


</details>

Closes: #4599