### PR TITLE
Hover tooltip module name is monospace once again

### DIFF
--- a/crates/ra_ide/src/display.rs
+++ b/crates/ra_ide/src/display.rs
@@ -83,12 +83,13 @@ pub(crate) fn rust_code_markup_with_doc(
 
     if let Some(mod_path) = mod_path {
         if !mod_path.is_empty() {
-            format_to!(buf, "{}\n___\n\n", mod_path);
+            format_to!(buf, "```rust\n{}\n```\n\n", mod_path);
         }
     }
     format_to!(buf, "```rust\n{}\n```", code);
 
     if let Some(doc) = doc {
+        format_to!(buf, "\n___");
         format_to!(buf, "\n\n{}", doc);
     }
 

--- a/crates/ra_ide/src/hover.rs
+++ b/crates/ra_ide/src/hover.rs
@@ -405,7 +405,7 @@ mod tests {
                 };
             }
         "#,
-            &["Foo\n___\n\n```rust\nfield_a: u32"],
+            &["Foo\n```\n\n```rust\nfield_a: u32"],
         );
 
         // Hovering over the field in the definition
@@ -422,7 +422,7 @@ mod tests {
                 };
             }
         "#,
-            &["Foo\n___\n\n```rust\nfield_a: u32"],
+            &["Foo\n```\n\n```rust\nfield_a: u32"],
         );
     }
 
@@ -475,7 +475,7 @@ fn main() {
             ",
         );
         let hover = analysis.hover(position).unwrap().unwrap();
-        assert_eq!(trim_markup_opt(hover.info.first()), Some("Option\n___\n\n```rust\nSome"));
+        assert_eq!(trim_markup_opt(hover.info.first()), Some("Option\n```\n\n```rust\nSome"));
 
         let (analysis, position) = single_file_with_position(
             "
@@ -503,11 +503,12 @@ fn main() {
         "#,
             &["
 Option
-___
+```
 
 ```rust
 None
 ```
+___
 
 The None variant
             "
@@ -527,11 +528,12 @@ The None variant
         "#,
             &["
 Option
-___
+```
 
 ```rust
 Some
 ```
+___
 
 The Some variant
             "
@@ -614,7 +616,7 @@ fn func(foo: i32) { if true { <|>foo; }; }
         let hover = analysis.hover(position).unwrap().unwrap();
         assert_eq!(
             trim_markup_opt(hover.info.first()),
-            Some("wrapper::Thing\n___\n\n```rust\nfn new() -> Thing")
+            Some("wrapper::Thing\n```\n\n```rust\nfn new() -> Thing")
         );
     }
 
@@ -891,7 +893,7 @@ fn func(foo: i32) { if true { <|>foo; }; }
                 fo<|>o();
             }
             ",
-            &["fn foo()\n```\n\n<- `\u{3000}` here"],
+            &["fn foo()\n```\n___\n\n<- `\u{3000}` here"],
         );
     }
 

--- a/crates/rust-analyzer/tests/heavy_tests/main.rs
+++ b/crates/rust-analyzer/tests/heavy_tests/main.rs
@@ -756,5 +756,5 @@ pub fn foo(_input: TokenStream) -> TokenStream {
     });
 
     let value = res.get("contents").unwrap().get("value").unwrap().to_string();
-    assert_eq!(value, r#""foo::Bar\n___\n\n```rust\nfn bar()\n```""#)
+    assert_eq!(value, r#""```rust\nfoo::Bar\n```\n\n```rust\nfn bar()\n```""#)
 }


### PR DESCRIPTION
The line separator is also moved below the function signature to split regions between the docs. This is very similar to how IntelliJ displays tooltips. Adding an additional separator between the module name and function signature currently has rendering issues.

Fixes #4594
Alternative to #4615

@kjeremy @Veetaha 

Note that I have semantic coloring disabled so ignore any differences due to that.

![image](https://user-images.githubusercontent.com/221559/82857507-30180e80-9edf-11ea-903a-f25c60055a93.png)

![image](https://user-images.githubusercontent.com/221559/82857407-e6c7bf00-9ede-11ea-9ae0-d348279552e7.png)
