### PR TITLE
Partially fix displaying inlay hints in Github PR diff views

### DIFF
--- a/editors/code/src/util.ts
+++ b/editors/code/src/util.ts
@@ -74,10 +74,11 @@ export type RustDocument = vscode.TextDocument & { languageId: "rust" };
 export type RustEditor = vscode.TextEditor & { document: RustDocument };
 
 export function isRustDocument(document: vscode.TextDocument): document is RustDocument {
-    return document.languageId === 'rust'
-        // SCM diff views have the same URI as the on-disk document but not the same content
-        && document.uri.scheme !== 'git'
-        && document.uri.scheme !== 'svn';
+    // Prevent corrupted text (particularly via inlay hints) in diff views
+    // by allowing only `file` schemes
+    // unfortunately extensions that use diff views not always set this
+    // to something different than 'file' (see ongoing bug: #4608)
+    return document.languageId === 'rust' && document.uri.scheme === 'file';
 }
 
 export function isRustEditor(editor: vscode.TextEditor): editor is RustEditor {


### PR DESCRIPTION
See the comment in https://github.com/rust-analyzer/rust-analyzer/issues/4608#issuecomment-63424257

It partially fixes the left side of diff view (the one where old code is displayed), but the diff editor with new code changes still has `file` scheme and will proceed displaying inlay hints...