### PR TITLE
Add `inRustProject` when-clause for commands in vscode

### DIFF
--- a/docs/user/readme.adoc
+++ b/docs/user/readme.adoc
@@ -65,6 +65,16 @@ The server binary is stored in:
 
 Note that we only support two most recent versions of VS Code.
 
+==== Special `when` clause context for keybindings.
+You may use `inRustProject` context to configure keybindings for rust projects only. For example:
+[source,json]
+----
+{ "key": "ctrl+shift+f5", "command": "workbench.action.debug.restart", "when": "inDebugMode && !inRustProject"},
+{ "key": "ctrl+shift+f5", "command": "rust-analyzer.debug", "when": "inRustProject"},
+{ "key": "ctrl+i", "command": "rust-analyzer.toggleInlayHints", "when": "inRustProject" }
+----
+More about `when` clause contexts https://code.visualstudio.com/docs/getstarted/keybindings#_when-clause-contexts[here].
+
 ==== Updates
 
 The extension will be updated automatically as new versions become available. It will ask your permission to download the matching language server version binary if needed.

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -694,6 +694,70 @@
                     ]
                 }
             }
-        ]
+        ],
+        "menus": {
+            "commandPalette": [
+                {
+                    "command": "rust-analyzer.syntaxTree",
+                    "when": "inRustProject"
+                },
+                {
+                    "command": "rust-analyzer.expandMacro",
+                    "when": "inRustProject"
+                },
+                {
+                    "command": "rust-analyzer.matchingBrace",
+                    "when": "inRustProject"
+                },
+                {
+                    "command": "rust-analyzer.parentModule",
+                    "when": "inRustProject"
+                },
+                {
+                    "command": "rust-analyzer.joinLines",
+                    "when": "inRustProject"
+                },
+                {
+                    "command": "rust-analyzer.run",
+                    "when": "inRustProject"
+                },
+                {
+                    "command": "rust-analyzer.debug",
+                    "when": "inRustProject"
+                },
+                {
+                    "command": "rust-analyzer.newDebugConfig",
+                    "when": "inRustProject"
+                },
+                {
+                    "command": "rust-analyzer.analyzerStatus",
+                    "when": "inRustProject"
+                },
+                {
+                    "command": "rust-analyzer.collectGarbage",
+                    "when": "inRustProject"
+                },
+                {
+                    "command": "rust-analyzer.reload",
+                    "when": "inRustProject"
+                },
+                {
+                    "command": "rust-analyzer.onEnter",
+                    "when": "inRustProject"
+                },
+                {
+                    "command": "rust-analyzer.ssr",
+                    "when": "inRustProject"
+                },
+                {
+                    "command": "rust-analyzer.serverVersion",
+                    "when": "inRustProject"
+                },
+                {
+                    "command": "rust-analyzer.toggleInlayHints",
+                    "when": "inRustProject"
+                }
+            ]
+        }
     }
 }

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -12,9 +12,12 @@ import { log, assert, isValidExecutable } from './util';
 import { PersistentState } from './persistent_state';
 import { fetchRelease, download } from './net';
 import { activateTaskProvider } from './tasks';
+import { setContextValue } from './util';
 import { exec } from 'child_process';
 
 let ctx: Ctx | undefined;
+
+const RUST_PROJECT_CONTEXT_NAME = "inRustProject";
 
 export async function activate(context: vscode.ExtensionContext) {
     // Register a "dumb" onEnter command for the case where server fails to
@@ -53,6 +56,8 @@ export async function activate(context: vscode.ExtensionContext) {
     //
     // This a horribly, horribly wrong way to deal with this problem.
     ctx = await Ctx.create(config, context, serverPath, workspaceFolder.uri.fsPath);
+
+    setContextValue(RUST_PROJECT_CONTEXT_NAME, true);
 
     // Commands which invokes manually via command palette, shortcut, etc.
 
@@ -109,6 +114,7 @@ export async function activate(context: vscode.ExtensionContext) {
 }
 
 export async function deactivate() {
+    setContextValue(RUST_PROJECT_CONTEXT_NAME, undefined);
     await ctx?.client.stop();
     ctx = undefined;
 }

--- a/editors/code/src/util.ts
+++ b/editors/code/src/util.ts
@@ -94,3 +94,8 @@ export function isValidExecutable(path: string): boolean {
 
     return res.status === 0;
 }
+
+/** Sets ['when'](https://code.visualstudio.com/docs/getstarted/keybindings#_when-clause-contexts) clause contexts */
+export function setContextValue(key: string, value: any): Thenable<void> {
+    return vscode.commands.executeCommand('setContext', key, value);
+}


### PR DESCRIPTION
At the moment all rust-analyzer commands always visible in the command palette, even if there is no rust project opened.

This PR adds special [when-clause](https://code.visualstudio.com/docs/getstarted/keybindings#_when-clause-contexts) context. This context also might be used in key bindings.
