### PR TITLE
Add semantic highlight to ? operator

### DIFF
--- a/crates/ra_ide/src/syntax_highlighting.rs
+++ b/crates/ra_ide/src/syntax_highlighting.rs
@@ -391,6 +391,7 @@ fn highlight_element(
         INT_NUMBER | FLOAT_NUMBER => HighlightTag::NumericLiteral.into(),
         BYTE => HighlightTag::ByteLiteral.into(),
         CHAR => HighlightTag::CharLiteral.into(),
+        QUESTION => Highlight::new(HighlightTag::Operator) | HighlightModifier::ControlFlow,
         LIFETIME => {
             let h = Highlight::new(HighlightTag::Lifetime);
             match element.parent().map(|it| it.kind()) {

--- a/crates/ra_ide/src/syntax_highlighting/tags.rs
+++ b/crates/ra_ide/src/syntax_highlighting/tags.rs
@@ -42,6 +42,7 @@ pub enum HighlightTag {
     Local,
     UnresolvedReference,
     FormatSpecifier,
+    Operator,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -89,6 +90,7 @@ impl HighlightTag {
             HighlightTag::Local => "variable",
             HighlightTag::UnresolvedReference => "unresolved_reference",
             HighlightTag::FormatSpecifier => "format_specifier",
+            HighlightTag::Operator => "operator",
         }
     }
 }

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -317,6 +317,7 @@ fn semantic_token_type_and_modifiers(
         HighlightTag::Keyword => lsp_types::SemanticTokenType::KEYWORD,
         HighlightTag::UnresolvedReference => semantic_tokens::UNRESOLVED_REFERENCE,
         HighlightTag::FormatSpecifier => semantic_tokens::FORMAT_SPECIFIER,
+        HighlightTag::Operator => lsp_types::SemanticTokenType::OPERATOR,
     };
 
     for modifier in highlight.modifiers.iter() {


### PR DESCRIPTION
Made it an operator with controlFlow modifier.

To highlight in vscode as red:

```json
"editor.semanticTokenColorCustomizations": {
        "enabled": true,
        "rules": {
            "operator.controlFlow": "#ff0000",
        }
}
```

![Bildschirmfoto von 2020-05-29 21-32-06](https://user-images.githubusercontent.com/2522373/83297998-f3585a00-a1f3-11ea-9d14-4ef04b9b6b9a.png)

https://github.com/rust-analyzer/rust-analyzer/issues/4597
