### PR TITLE
Introduce hover actions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -120,6 +120,16 @@
       "sourceMaps": true,
       "outFiles": [ "${workspaceFolder}/editors/code/out/tests/unit/**/*.js" ],
       "preLaunchTask": "Pretest"
+    },
+    {
+      // Don't forget to set `debug = 2` in `Cargo.toml` before building the server
+      "name": "Win Attach To Server",
+      "type": "cppvsdbg",
+      "request": "attach",
+      "processId":"${command:pickProcess}",
+      "sourceFileMap": {
+          "/rustc/8d69840ab92ea7f4d323420088dd8c9775f180cd": "${env:USERPROFILE}/.rustup/toolchains/stable-x86_64-pc-windows-msvc/lib/rustlib/src/rust"
+      }
     }
   ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,6 +1349,7 @@ dependencies = [
  "lsp-server",
  "lsp-types",
  "parking_lot",
+ "percent-encoding",
  "pico-args",
  "ra_cfg",
  "ra_db",

--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -1333,6 +1333,11 @@ impl Type {
         Some(adt.into())
     }
 
+    pub fn substs(&self) -> Option<Substs> {
+        let (_adt, subst) = self.ty.value.as_adt()?;
+        Some(subst.clone())
+    }
+
     // FIXME: provide required accessors such that it becomes implementable from outside.
     pub fn is_equal_for_find_impls(&self, other: &Type) -> bool {
         match (&self.ty.value, &other.ty.value) {

--- a/crates/ra_hir/src/lib.rs
+++ b/crates/ra_hir/src/lib.rs
@@ -74,4 +74,4 @@ pub use hir_expand::{
     hygiene::Hygiene, name::Name, HirFileId, InFile, MacroCallId, MacroCallLoc, MacroDefId,
     MacroFile, Origin,
 };
-pub use hir_ty::{display::HirDisplay, CallableDef};
+pub use hir_ty::{display::HirDisplay, CallableDef, Substs};

--- a/crates/ra_ide/src/hover.rs
+++ b/crates/ra_ide/src/hover.rs
@@ -19,7 +19,8 @@ use ra_syntax::{
 
 use crate::{
     display::{macro_label, rust_code_markup, rust_code_markup_with_doc, ShortLabel},
-    FilePosition, RangeInfo,
+    runnables::runnable,
+    FileId, FilePosition, RangeInfo, Runnable,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -40,12 +41,26 @@ impl HoverConfig {
     pub fn runnable(&self) -> bool {
         self.run || self.debug
     }
+
+    pub fn any(&self) -> bool {
+        self.goto_type_def || self.runnable()
+    }
+
+    pub fn none(&self) -> bool {
+        !self.any()
+    }
+}
+
+#[derive(Debug)]
+pub enum HoverAction {
+    Runnable(Runnable),
 }
 
 /// Contains the results when hovering over an item
 #[derive(Debug, Default)]
 pub struct HoverResult {
     results: Vec<String>,
+    actions: Vec<HoverAction>,
 }
 
 impl HoverResult {
@@ -73,68 +88,21 @@ impl HoverResult {
         &self.results
     }
 
+    pub fn actions(&self) -> &[HoverAction] {
+        &self.actions
+    }
+
+    pub fn append_action(&mut self, action: HoverAction) {
+        self.actions.push(action);
+    }
+
     /// Returns the results converted into markup
     /// for displaying in a UI
+    /// 
+    /// Does not proces actions!
     pub fn to_markup(&self) -> String {
         self.results.join("\n\n---\n")
     }
-}
-
-// Feature: Hover
-//
-// Shows additional information, like type of an expression or documentation for definition when "focusing" code.
-// Focusing is usually hovering with a mouse, but can also be triggered with a shortcut.
-pub(crate) fn hover(db: &RootDatabase, position: FilePosition) -> Option<RangeInfo<HoverResult>> {
-    let sema = Semantics::new(db);
-    let file = sema.parse(position.file_id).syntax().clone();
-    let token = pick_best(file.token_at_offset(position.offset))?;
-    let token = sema.descend_into_macros(token);
-
-    let mut res = HoverResult::new();
-
-    if let Some((node, name_kind)) = match_ast! {
-        match (token.parent()) {
-            ast::NameRef(name_ref) => {
-                classify_name_ref(&sema, &name_ref).map(|d| (name_ref.syntax().clone(), d.definition()))
-            },
-            ast::Name(name) => {
-                classify_name(&sema, &name).map(|d| (name.syntax().clone(), d.definition()))
-            },
-            _ => None,
-        }
-    } {
-        let range = sema.original_range(&node).range;
-        res.extend(hover_text_from_name_kind(db, name_kind));
-
-        if !res.is_empty() {
-            return Some(RangeInfo::new(range, res));
-        }
-    }
-
-    let node = token
-        .ancestors()
-        .find(|n| ast::Expr::cast(n.clone()).is_some() || ast::Pat::cast(n.clone()).is_some())?;
-
-    let ty = match_ast! {
-        match node {
-            ast::MacroCall(_it) => {
-                // If this node is a MACRO_CALL, it means that `descend_into_macros` failed to resolve.
-                // (e.g expanding a builtin macro). So we give up here.
-                return None;
-            },
-            ast::Expr(it) => {
-                sema.type_of_expr(&it)
-            },
-            ast::Pat(it) => {
-                sema.type_of_pat(&it)
-            },
-            _ => None,
-        }
-    }?;
-
-    res.extend(Some(rust_code_markup(&ty.display(db))));
-    let range = sema.original_range(&node).range;
-    Some(RangeInfo::new(range, res))
 }
 
 fn hover_text(
@@ -216,7 +184,7 @@ fn hover_text_from_name_kind(db: &RootDatabase, def: Definition) -> Option<Strin
             ModuleDef::Static(it) => from_def_source(db, it, mod_path),
             ModuleDef::Trait(it) => from_def_source(db, it, mod_path),
             ModuleDef::TypeAlias(it) => from_def_source(db, it, mod_path),
-            ModuleDef::BuiltinType(it) => Some(it.to_string()),
+            ModuleDef::BuiltinType(it) => Some( it.to_string() ),
         },
         Definition::Local(it) => Some(rust_code_markup(&it.ty(db).display(db))),
         Definition::TypeParam(_) | Definition::SelfType(_) => {
@@ -234,6 +202,63 @@ fn hover_text_from_name_kind(db: &RootDatabase, def: Definition) -> Option<Strin
         hover_text(src.value.doc_comment_text(), src.value.short_label(), mod_path)
     }
 }
+
+fn runnable_action(
+    sema: &Semantics<RootDatabase>,
+    def: Definition,
+    file_id: FileId,
+) -> Option<HoverAction> {
+    return match def {
+        Definition::ModuleDef(it) => match it {
+            ModuleDef::Module(it) => match it.definition_source(sema.db).value {
+                ModuleSource::Module(it) => {
+                    runnable(&sema, it.syntax().clone(), file_id).map(|it| HoverAction::Runnable(it))
+                }
+                _ => None,
+            },
+            ModuleDef::Function(it) => {
+                runnable(&sema, it.source(sema.db).value.syntax().clone(), file_id)
+                    .map(|it| HoverAction::Runnable(it))
+            }
+            _ => None,
+        },
+        _ => None,
+    };
+}
+
+// Feature: Hover
+//
+// Shows additional information, like type of an expression or documentation for definition when "focusing" code.
+// Focusing is usually hovering with a mouse, but can also be triggered with a shortcut.
+pub(crate) fn hover(db: &RootDatabase, position: FilePosition) -> Option<RangeInfo<HoverResult>> {
+    let sema = Semantics::new(db);
+    let file = sema.parse(position.file_id).syntax().clone();
+    let token = pick_best(file.token_at_offset(position.offset))?;
+    let token = sema.descend_into_macros(token);
+
+    let mut res = HoverResult::new();
+
+    if let Some((node, name_kind)) = match_ast! {
+        match (token.parent()) {
+            ast::NameRef(name_ref) => {
+                classify_name_ref(&sema, &name_ref).map(|d| (name_ref.syntax().clone(), d.definition()))
+            },
+            ast::Name(name) => {
+                classify_name(&sema, &name).map(|d| (name.syntax().clone(), d.definition()))
+            },
+            _ => None,
+        }
+    } {
+        let range = sema.original_range(&node).range;
+        res.extend(hover_text_from_name_kind(db, name_kind));
+        if let Some(action) = runnable_action(&sema, name_kind, position.file_id) {
+            res.append_action(action);
+        }
+
+        if !res.is_empty() {
+            return Some(RangeInfo::new(range, res));
+        }
+    }
 
 fn pick_best(tokens: TokenAtOffset<SyntaxToken>) -> Option<SyntaxToken> {
     return tokens.max_by_key(priority);

--- a/crates/ra_ide/src/hover.rs
+++ b/crates/ra_ide/src/hover.rs
@@ -54,8 +54,8 @@ impl HoverConfig {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct HoverGotoTypeData {
-    pub hint: String,
-    pub link: NavigationTarget,
+    pub tooltip: String,
+    pub nav: NavigationTarget,
 }
 
 impl HoverGotoTypeData {
@@ -107,7 +107,7 @@ impl HoverResult {
         &self.actions
     }
 
-    pub fn append_action(&mut self, action: HoverAction) {
+    pub fn push_action(&mut self, action: HoverAction) {
         self.actions.push(action);
     }
 

--- a/crates/ra_ide/src/hover.rs
+++ b/crates/ra_ide/src/hover.rs
@@ -116,7 +116,7 @@ impl HoverResult {
     ///
     /// Does not process actions!
     pub fn to_markup(&self) -> String {
-        self.results.join("\n\n---\n")
+        self.results.join("\n\n___\n")
     }
 }
 

--- a/crates/ra_ide/src/hover.rs
+++ b/crates/ra_ide/src/hover.rs
@@ -98,8 +98,8 @@ impl HoverResult {
 
     /// Returns the results converted into markup
     /// for displaying in a UI
-    /// 
-    /// Does not proces actions!
+    ///
+    /// Does not process actions!
     pub fn to_markup(&self) -> String {
         self.results.join("\n\n---\n")
     }
@@ -184,7 +184,7 @@ fn hover_text_from_name_kind(db: &RootDatabase, def: Definition) -> Option<Strin
             ModuleDef::Static(it) => from_def_source(db, it, mod_path),
             ModuleDef::Trait(it) => from_def_source(db, it, mod_path),
             ModuleDef::TypeAlias(it) => from_def_source(db, it, mod_path),
-            ModuleDef::BuiltinType(it) => Some( it.to_string() ),
+            ModuleDef::BuiltinType(it) => Some(it.to_string()),
         },
         Definition::Local(it) => Some(rust_code_markup(&it.ty(db).display(db))),
         Definition::TypeParam(_) | Definition::SelfType(_) => {
@@ -211,9 +211,8 @@ fn runnable_action(
     return match def {
         Definition::ModuleDef(it) => match it {
             ModuleDef::Module(it) => match it.definition_source(sema.db).value {
-                ModuleSource::Module(it) => {
-                    runnable(&sema, it.syntax().clone(), file_id).map(|it| HoverAction::Runnable(it))
-                }
+                ModuleSource::Module(it) => runnable(&sema, it.syntax().clone(), file_id)
+                    .map(|it| HoverAction::Runnable(it)),
                 _ => None,
             },
             ModuleDef::Function(it) => {

--- a/crates/ra_ide/src/hover.rs
+++ b/crates/ra_ide/src/hover.rs
@@ -231,14 +231,14 @@ fn goto_type_action(db: &RootDatabase, def: Definition) -> Option<HoverAction> {
     ) {
         if let Some(substs) = substs {
             for ty in substs.iter() {
-                if let Some((adt_id, s)) = ty.strip_references().as_adt() {
+                if let Some((adt_id, adt_params)) = ty.strip_references().as_adt() {
                     let adt = Adt::from(adt_id);
                     let mod_path = adt_mod_path(db, &adt);
                     let item = HoverGotoTypeData::new(mod_path, adt.to_nav(db));
                     if !targets.contains(&item) {
                         targets.push(item);
                     }
-                    add_subst_targets(db, Some(s), targets);
+                    add_subst_targets(db, Some(adt_params), targets);
                 }
             }
         }
@@ -270,14 +270,6 @@ fn goto_type_action(db: &RootDatabase, def: Definition) -> Option<HoverAction> {
         },
         _ => None,
     }
-
-    /*
-    FilePosition
-    let nav_info = match world.analysis().goto_implementation(position)? {
-        None => return Ok(None),
-        Some(it) => it,
-    };
-    */
 }
 
 fn runnable_action(
@@ -465,7 +457,6 @@ mod tests {
         );
 
         assert_eq!(1, actions.len());
-        println!("{:?}", &actions[0]);
         assert_goto_action(
             &actions[0],
             &[("FakeIter", 62), ("Scan", 7), ("OtherStruct", 99)], // OtherStruct only once!

--- a/crates/ra_ide/src/hover.rs
+++ b/crates/ra_ide/src/hover.rs
@@ -22,6 +22,26 @@ use crate::{
     FilePosition, RangeInfo,
 };
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HoverConfig {
+    pub run: bool,
+    pub debug: bool,
+    pub goto_type_def: bool,
+}
+
+impl Default for HoverConfig {
+    fn default() -> Self {
+        // A client should explicitly specify if it supports hover actions!
+        Self { run: false, debug: false, goto_type_def: false }
+    }
+}
+
+impl HoverConfig {
+    pub fn runnable(&self) -> bool {
+        self.run || self.debug
+    }
+}
+
 /// Contains the results when hovering over an item
 #[derive(Debug, Default)]
 pub struct HoverResult {

--- a/crates/ra_ide/src/lib.rs
+++ b/crates/ra_ide/src/lib.rs
@@ -66,7 +66,7 @@ pub use crate::{
     display::{file_structure, FunctionSignature, NavigationTarget, StructureNode},
     expand_macro::ExpandedMacro,
     folding_ranges::{Fold, FoldKind},
-    hover::HoverResult,
+    hover::{HoverConfig, HoverResult},
     inlay_hints::{InlayHint, InlayHintsConfig, InlayKind},
     references::{Declaration, Reference, ReferenceAccess, ReferenceKind, ReferenceSearchResult},
     runnables::{Runnable, RunnableKind, TestId},

--- a/crates/ra_ide/src/lib.rs
+++ b/crates/ra_ide/src/lib.rs
@@ -66,7 +66,7 @@ pub use crate::{
     display::{file_structure, FunctionSignature, NavigationTarget, StructureNode},
     expand_macro::ExpandedMacro,
     folding_ranges::{Fold, FoldKind},
-    hover::{HoverAction, HoverConfig, HoverResult},
+    hover::{HoverGotoTypeData, HoverAction, HoverConfig, HoverResult},
     inlay_hints::{InlayHint, InlayHintsConfig, InlayKind},
     references::{Declaration, Reference, ReferenceAccess, ReferenceKind, ReferenceSearchResult},
     runnables::{Runnable, RunnableKind, TestId},

--- a/crates/ra_ide/src/lib.rs
+++ b/crates/ra_ide/src/lib.rs
@@ -66,7 +66,7 @@ pub use crate::{
     display::{file_structure, FunctionSignature, NavigationTarget, StructureNode},
     expand_macro::ExpandedMacro,
     folding_ranges::{Fold, FoldKind},
-    hover::{HoverConfig, HoverResult, HoverAction},
+    hover::{HoverAction, HoverConfig, HoverResult},
     inlay_hints::{InlayHint, InlayHintsConfig, InlayKind},
     references::{Declaration, Reference, ReferenceAccess, ReferenceKind, ReferenceSearchResult},
     runnables::{Runnable, RunnableKind, TestId},

--- a/crates/ra_ide/src/lib.rs
+++ b/crates/ra_ide/src/lib.rs
@@ -66,7 +66,7 @@ pub use crate::{
     display::{file_structure, FunctionSignature, NavigationTarget, StructureNode},
     expand_macro::ExpandedMacro,
     folding_ranges::{Fold, FoldKind},
-    hover::{HoverGotoTypeData, HoverAction, HoverConfig, HoverResult},
+    hover::{HoverAction, HoverConfig, HoverGotoTypeData, HoverResult},
     inlay_hints::{InlayHint, InlayHintsConfig, InlayKind},
     references::{Declaration, Reference, ReferenceAccess, ReferenceKind, ReferenceSearchResult},
     runnables::{Runnable, RunnableKind, TestId},

--- a/crates/ra_ide/src/lib.rs
+++ b/crates/ra_ide/src/lib.rs
@@ -66,7 +66,7 @@ pub use crate::{
     display::{file_structure, FunctionSignature, NavigationTarget, StructureNode},
     expand_macro::ExpandedMacro,
     folding_ranges::{Fold, FoldKind},
-    hover::{HoverConfig, HoverResult},
+    hover::{HoverConfig, HoverResult, HoverAction},
     inlay_hints::{InlayHint, InlayHintsConfig, InlayKind},
     references::{Declaration, Reference, ReferenceAccess, ReferenceKind, ReferenceSearchResult},
     runnables::{Runnable, RunnableKind, TestId},

--- a/crates/ra_ide/src/runnables.rs
+++ b/crates/ra_ide/src/runnables.rs
@@ -241,7 +241,7 @@ mod tests {
 
     use crate::mock_analysis::analysis_and_position;
 
-    use super::{RunnableAction, Runnable, BENCH, BIN, DOCTEST, TEST};
+    use super::{Runnable, RunnableAction, BENCH, BIN, DOCTEST, TEST};
 
     fn assert_actions(runnables: &[Runnable], actions: &[&RunnableAction]) {
         assert_eq!(
@@ -264,6 +264,9 @@ mod tests {
         #[test]
         #[ignore]
         fn test_foo() {}
+
+        #[bench]
+        fn bench() {}
         "#,
         );
         let runnables = analysis.runnables(pos.file_id).unwrap();
@@ -299,10 +302,19 @@ mod tests {
                 },
                 cfg_exprs: [],
             },
+            Runnable {
+                range: 82..104,
+                kind: Bench {
+                    test_id: Path(
+                        "bench",
+                    ),
+                },
+                cfg_exprs: [],
+            },
         ]
         "###
                 );
-        assert_actions(&runnables, &[&BIN, &TEST, &TEST]);
+        assert_actions(&runnables, &[&BIN, &TEST, &TEST, &BENCH]);
     }
 
     #[test]

--- a/crates/ra_ide/src/runnables.rs
+++ b/crates/ra_ide/src/runnables.rs
@@ -20,14 +20,14 @@ pub struct Runnable {
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct RunnableAction {
-    pub title: &'static str,
+    pub run_title: &'static str,
     pub debugee: bool,
 }
 
-const TEST: RunnableAction = RunnableAction { title: "▶\u{fe0e} Run Test", debugee: true };
-const DOCTEST: RunnableAction = RunnableAction { title: "▶\u{fe0e} Run Doctest", debugee: false };
-const BENCH: RunnableAction = RunnableAction { title: "▶\u{fe0e} Run Bench", debugee: true };
-const BIN: RunnableAction = RunnableAction { title: "▶\u{fe0e} Run", debugee: true };
+const TEST: RunnableAction = RunnableAction { run_title: "▶\u{fe0e} Run Test", debugee: true };
+const DOCTEST: RunnableAction = RunnableAction { run_title: "▶\u{fe0e} Run Doctest", debugee: false };
+const BENCH: RunnableAction = RunnableAction { run_title: "▶\u{fe0e} Run Bench", debugee: true };
+const BIN: RunnableAction = RunnableAction { run_title: "▶\u{fe0e} Run", debugee: true };
 
 impl Runnable {
     // test package::module::testname
@@ -94,7 +94,7 @@ pub(crate) fn runnables(db: &RootDatabase, file_id: FileId) -> Vec<Runnable> {
     source_file.syntax().descendants().filter_map(|i| runnable(&sema, i, file_id)).collect()
 }
 
-fn runnable(sema: &Semantics<RootDatabase>, item: SyntaxNode, file_id: FileId) -> Option<Runnable> {
+pub(crate) fn runnable(sema: &Semantics<RootDatabase>, item: SyntaxNode, file_id: FileId) -> Option<Runnable> {
     match_ast! {
         match item {
             ast::FnDef(it) => runnable_fn(sema, it, file_id),

--- a/crates/ra_ide/src/runnables.rs
+++ b/crates/ra_ide/src/runnables.rs
@@ -25,7 +25,8 @@ pub struct RunnableAction {
 }
 
 const TEST: RunnableAction = RunnableAction { run_title: "▶\u{fe0e} Run Test", debugee: true };
-const DOCTEST: RunnableAction = RunnableAction { run_title: "▶\u{fe0e} Run Doctest", debugee: false };
+const DOCTEST: RunnableAction =
+    RunnableAction { run_title: "▶\u{fe0e} Run Doctest", debugee: false };
 const BENCH: RunnableAction = RunnableAction { run_title: "▶\u{fe0e} Run Bench", debugee: true };
 const BIN: RunnableAction = RunnableAction { run_title: "▶\u{fe0e} Run", debugee: true };
 
@@ -94,7 +95,11 @@ pub(crate) fn runnables(db: &RootDatabase, file_id: FileId) -> Vec<Runnable> {
     source_file.syntax().descendants().filter_map(|i| runnable(&sema, i, file_id)).collect()
 }
 
-pub(crate) fn runnable(sema: &Semantics<RootDatabase>, item: SyntaxNode, file_id: FileId) -> Option<Runnable> {
+pub(crate) fn runnable(
+    sema: &Semantics<RootDatabase>,
+    item: SyntaxNode,
+    file_id: FileId,
+) -> Option<Runnable> {
     match_ast! {
         match item {
             ast::FnDef(it) => runnable_fn(sema, it, file_id),

--- a/crates/ra_ide/src/runnables.rs
+++ b/crates/ra_ide/src/runnables.rs
@@ -11,7 +11,7 @@ use ast::DocCommentsOwner;
 use ra_cfg::CfgExpr;
 use std::fmt::Display;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Runnable {
     pub range: TextRange,
     pub kind: RunnableKind,
@@ -54,7 +54,7 @@ impl Runnable {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum TestId {
     Name(String),
     Path(String),
@@ -69,7 +69,7 @@ impl Display for TestId {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum RunnableKind {
     Test { test_id: TestId, attr: TestAttr },
     TestMod { path: String },
@@ -174,7 +174,7 @@ fn runnable_fn(
     Some(Runnable { range: fn_def.syntax().text_range(), kind, cfg_exprs })
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct TestAttr {
     pub ignore: bool,
 }

--- a/crates/ra_ide_db/src/defs.rs
+++ b/crates/ra_ide_db/src/defs.rs
@@ -18,7 +18,7 @@ use ra_syntax::{
 use crate::RootDatabase;
 
 // FIXME: a more precise name would probably be `Symbol`?
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum Definition {
     Macro(MacroDef),
     Field(Field),

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -29,6 +29,7 @@ rustc-hash = "1.1.0"
 serde = { version = "1.0.106", features = ["derive"] }
 serde_json = "1.0.48"
 threadpool = "1.7.1"
+percent-encoding = "2.1.0"
 
 stdx = { path = "../stdx" }
 

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -104,6 +104,7 @@ pub struct ClientCapsConfig {
     pub code_action_literals: bool,
     pub work_done_progress: bool,
     pub code_action_group: bool,
+    pub hover_actions: bool,
 }
 
 impl Default for Config {
@@ -309,7 +310,11 @@ impl Config {
 
             let code_action_group =
                 experimental.get("codeActionGroup").and_then(|it| it.as_bool()) == Some(true);
-            self.client_caps.code_action_group = code_action_group
+            self.client_caps.code_action_group = code_action_group;
+
+            let hover_actions =
+                experimental.get("hoverActions").and_then(|it| it.as_bool()) == Some(true);
+            self.client_caps.hover_actions = hover_actions;
         }
     }
 }

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -11,7 +11,7 @@ use std::{ffi::OsString, path::PathBuf};
 
 use lsp_types::ClientCapabilities;
 use ra_flycheck::FlycheckConfig;
-use ra_ide::{AssistConfig, CompletionConfig, InlayHintsConfig};
+use ra_ide::{AssistConfig, CompletionConfig, HoverConfig, InlayHintsConfig};
 use ra_project_model::CargoConfig;
 use serde::Deserialize;
 
@@ -35,6 +35,7 @@ pub struct Config {
     pub assist: AssistConfig,
     pub call_info_full: bool,
     pub lens: LensConfig,
+    pub hover: HoverConfig,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -141,6 +142,7 @@ impl Default for Config {
             assist: AssistConfig::default(),
             call_info_full: true,
             lens: LensConfig::default(),
+            hover: HoverConfig::default(),
         }
     }
 }
@@ -240,6 +242,13 @@ impl Config {
             self.lens = LensConfig::NO_LENS;
         }
 
+        let mut use_hover_actions = false;
+        set(value, "/hoverActions/enable", &mut use_hover_actions);
+        if use_hover_actions {
+            set(value, "/hoverActions/run", &mut self.hover.run);
+            set(value, "/hoverActions/debug", &mut self.hover.debug);
+            set(value, "/hoverActions/gotoTypeDef", &mut self.hover.goto_type_def);
+        }
         log::info!("Config::update() = {:#?}", self);
 
         fn get<'a, T: Deserialize<'a>>(value: &'a serde_json::Value, pointer: &str) -> Option<T> {

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -248,6 +248,7 @@ impl Config {
             set(value, "/hoverActions/run", &mut self.hover.run);
             set(value, "/hoverActions/debug", &mut self.hover.debug);
             set(value, "/hoverActions/gotoTypeDef", &mut self.hover.goto_type_def);
+            set(value, "/hoverActions/implementations", &mut self.hover.implementations);
         }
         log::info!("Config::update() = {:#?}", self);
 

--- a/crates/rust-analyzer/src/lsp_ext.rs
+++ b/crates/rust-analyzer/src/lsp_ext.rs
@@ -252,11 +252,13 @@ pub struct CommandLinkGroup {
     pub commands: Vec<CommandLink>,
 }
 
+// LSP v3.15 Command does not have a `tooltip` field, vscode supports one.
 #[derive(Debug, PartialEq, Eq, Clone, Default, Deserialize, Serialize)]
 pub struct CommandLink {
     pub title: String,
     pub command: String,
-    pub tooltip: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tooltip: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub arguments: Option<Vec<serde_json::Value>>,
 }

--- a/crates/rust-analyzer/src/lsp_ext.rs
+++ b/crates/rust-analyzer/src/lsp_ext.rs
@@ -228,3 +228,35 @@ pub struct SnippetTextEdit {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub insert_text_format: Option<lsp_types::InsertTextFormat>,
 }
+
+pub enum HoverRequest {}
+
+impl Request for HoverRequest {
+    type Params = lsp_types::HoverParams;
+    type Result = Option<Hover>;
+    const METHOD: &'static str = "textDocument/hover";
+}
+
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+pub struct Hover {
+    pub contents: lsp_types::HoverContents,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub range: Option<Range>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actions: Option<Vec<CommandLinkGroup>>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Default, Deserialize, Serialize)]
+pub struct CommandLinkGroup {
+    pub title: Option<String>,
+    pub commands: Vec<CommandLink>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Default, Deserialize, Serialize)]
+pub struct CommandLink {
+    pub title: String,
+    pub command: String,
+    pub tooltip: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arguments: Option<Vec<serde_json::Value>>,
+}

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -517,6 +517,7 @@ fn on_request(
         .on::<lsp_ext::Runnables>(handlers::handle_runnables)?
         .on::<lsp_ext::InlayHints>(handlers::handle_inlay_hints)?
         .on::<lsp_ext::CodeActionRequest>(handlers::handle_code_action)?
+        .on::<lsp_ext::HoverRequest>(handlers::handle_hover)?
         .on::<lsp_types::request::OnTypeFormatting>(handlers::handle_on_type_formatting)?
         .on::<lsp_types::request::DocumentSymbolRequest>(handlers::handle_document_symbol)?
         .on::<lsp_types::request::WorkspaceSymbol>(handlers::handle_workspace_symbol)?
@@ -528,7 +529,6 @@ fn on_request(
         .on::<lsp_types::request::CodeLensResolve>(handlers::handle_code_lens_resolve)?
         .on::<lsp_types::request::FoldingRangeRequest>(handlers::handle_folding_range)?
         .on::<lsp_types::request::SignatureHelpRequest>(handlers::handle_signature_help)?
-        .on::<lsp_types::request::HoverRequest>(handlers::handle_hover)?
         .on::<lsp_types::request::PrepareRenameRequest>(handlers::handle_prepare_rename)?
         .on::<lsp_types::request::Rename>(handlers::handle_rename)?
         .on::<lsp_types::request::References>(handlers::handle_references)?

--- a/crates/rust-analyzer/src/main_loop/handlers.rs
+++ b/crates/rust-analyzer/src/main_loop/handlers.rs
@@ -986,7 +986,6 @@ fn to_show_references_command(
     position: lsp_types::Position,
     locations: Vec<lsp_types::Location>,
 ) -> Command {
-
     let title = {
         if locations.len() == 1 {
             "1 implementation".into()
@@ -994,7 +993,7 @@ fn to_show_references_command(
             format!("{} implementations", locations.len())
         }
     };
-    
+
     // We cannot use the 'editor.action.showReferences' command directly
     // because that command requires vscode types which we convert in the handler
     // on the client side.

--- a/crates/rust-analyzer/src/main_loop/handlers.rs
+++ b/crates/rust-analyzer/src/main_loop/handlers.rs
@@ -545,7 +545,7 @@ pub fn handle_hover(world: WorldSnapshot, params: lsp_types::HoverParams) -> Res
     let mut value = crate::markdown::format_docs(&info.info.to_markup());
     let actions = render_hover_actions(&world, position.file_id, info.info.actions());
     if !actions.is_empty() {
-        value += "\n---\n";
+        value += "\n___\n";
         value += &actions;
     }
     let res = Hover {

--- a/docs/user/generated_features.adoc
+++ b/docs/user/generated_features.adoc
@@ -76,7 +76,7 @@ Navigates to the type of an identifier.
 
 
 === Hover
-**Source:** https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/ra_ide/src/hover.rs#L63[hover.rs]
+**Source:** https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/ra_ide/src/hover.rs#L123[hover.rs]
 
 Shows additional information, like type of an expression or documentation for definition when "focusing" code.
 Focusing is usually hovering with a mouse, but can also be triggered with a shortcut.
@@ -199,7 +199,7 @@ Navigates to the parent module of the current module.
 
 
 === Run
-**Source:** https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/ra_ide/src/runnables.rs#L45[runnables.rs]
+**Source:** https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/ra_ide/src/runnables.rs#L81[runnables.rs]
 
 Shows a popup suggesting to run a test/benchmark/binary **at the current cursor
 location**. Super useful for repeatedly running just a single test. Do bind this

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -495,6 +495,11 @@
                     "markdownDescription": "Whether to show `Go to Type Definition` action. Only applies when `#rust-analyzer.hoverActions.enable#` is set.",
                     "type": "boolean",
                     "default": true
+                },
+                "rust-analyzer.hoverActions.implementations": {
+                    "markdownDescription": "Whether to show `Implementations` action. Only applies when `#rust-analyzer.hoverActions.enable#` is set.",
+                    "type": "boolean",
+                    "default": true
                 }
             }
         },

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -462,17 +462,37 @@
                     "default": true
                 },
                 "rust-analyzer.lens.run": {
-                    "markdownDescription": "Whether to show Run lens. Only applies when `#rust-analyzer.lens.enable#` is set.",
+                    "markdownDescription": "Whether to show `Run` lens. Only applies when `#rust-analyzer.lens.enable#` is set.",
                     "type": "boolean",
                     "default": true
                 },
                 "rust-analyzer.lens.debug": {
-                    "markdownDescription": "Whether to show Debug lens. Only applies when `#rust-analyzer.lens.enable#` is set.",
+                    "markdownDescription": "Whether to show `Debug` lens. Only applies when `#rust-analyzer.lens.enable#` is set.",
                     "type": "boolean",
                     "default": true
                 },
                 "rust-analyzer.lens.implementations": {
-                    "markdownDescription": "Whether to show Implementations lens. Only applies when `#rust-analyzer.lens.enable#` is set.",
+                    "markdownDescription": "Whether to show `Implementations` lens. Only applies when `#rust-analyzer.lens.enable#` is set.",
+                    "type": "boolean",
+                    "default": true
+                },
+                "rust-analyzer.hoverActions.enable": {
+                    "description": "Whether to show HoverActions in Rust files.",
+                    "type": "boolean",
+                    "default": true
+                },
+                "rust-analyzer.hoverActions.run": {
+                    "markdownDescription": "Whether to show `Run` action. Only applies when `#rust-analyzer.hoverActions.enable#` is set.",
+                    "type": "boolean",
+                    "default": true
+                },
+                "rust-analyzer.hoverActions.debug": {
+                    "markdownDescription": "Whether to show `Debug` action. Only applies when `#rust-analyzer.hoverActions.enable#` is set.",
+                    "type": "boolean",
+                    "default": true
+                },
+                "rust-analyzer.hoverActions.gotoTypeDef": {
+                    "markdownDescription": "Whether to show `Go to Type Definition` action. Only applies when `#rust-analyzer.hoverActions.enable#` is set.",
                     "type": "boolean",
                     "default": true
                 }

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -167,6 +167,7 @@ class ExperimentalFeatures implements lc.StaticFeature {
         const caps: any = capabilities.experimental ?? {};
         caps.snippetTextEdit = true;
         caps.codeActionGroup = true;
+        caps.hoverActions = true;
         capabilities.experimental = caps;
     }
     initialize(_capabilities: lc.ServerCapabilities<any>, _documentSelector: lc.DocumentSelector | undefined): void {

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -355,6 +355,20 @@ export function showReferences(ctx: Ctx): Cmd {
     };
 }
 
+export function gotoLocation(ctx: Ctx): Cmd {
+    return async (locationLink: lc.LocationLink) => {
+        const client = ctx.client;
+        if (client) {
+            const uri = client.protocol2CodeConverter.asUri(locationLink.targetUri);
+            let range = client.protocol2CodeConverter.asRange(locationLink.targetSelectionRange);
+            // collapse the range to a cursor position
+            range = range.with({end: range.start});
+            
+            await vscode.window.showTextDocument(uri, {selection: range});
+        }
+    }
+}
+
 export function applyActionGroup(_ctx: Ctx): Cmd {
     return async (actions: { label: string; edit: vscode.WorkspaceEdit }[]) => {
         const selectedAction = await vscode.window.showQuickPick(actions);

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -362,11 +362,11 @@ export function gotoLocation(ctx: Ctx): Cmd {
             const uri = client.protocol2CodeConverter.asUri(locationLink.targetUri);
             let range = client.protocol2CodeConverter.asRange(locationLink.targetSelectionRange);
             // collapse the range to a cursor position
-            range = range.with({end: range.start});
-            
-            await vscode.window.showTextDocument(uri, {selection: range});
+            range = range.with({ end: range.start });
+
+            await vscode.window.showTextDocument(uri, { selection: range });
         }
-    }
+    };
 }
 
 export function applyActionGroup(_ctx: Ctx): Cmd {

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -16,10 +16,8 @@ export class Config {
         "files",
         "highlighting",
         "updates.channel",
-        "lens.enable",
-        "lens.run",
-        "lens.debug",
-        "lens.implementations",
+        "lens", // works as lens.*
+        "hoverActions", // works as hoverActions.*
     ]
         .map(opt => `${this.rootSection}.${opt}`);
 
@@ -130,6 +128,15 @@ export class Config {
             run: this.get<boolean>("lens.run"),
             debug: this.get<boolean>("lens.debug"),
             implementations: this.get<boolean>("lens.implementations"),
+        };
+    }
+
+    get hoverActions() {
+        return {
+            enable: this.get<boolean>("hoverActions.enable"),
+            run: this.get<boolean>("hoverActions.run"),
+            debug: this.get<boolean>("hoverActions.debug"),
+            gotoTypeDef: this.get<boolean>("lens.gotoTypeDef"),
         };
     }
 }

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -136,7 +136,8 @@ export class Config {
             enable: this.get<boolean>("hoverActions.enable"),
             run: this.get<boolean>("hoverActions.run"),
             debug: this.get<boolean>("hoverActions.debug"),
-            gotoTypeDef: this.get<boolean>("lens.gotoTypeDef"),
+            gotoTypeDef: this.get<boolean>("hoverActions.gotoTypeDef"),
+            implementations: this.get<boolean>("hoverActions.implementations"),
         };
     }
 }

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -99,6 +99,7 @@ export async function activate(context: vscode.ExtensionContext) {
     ctx.registerCommand('showReferences', commands.showReferences);
     ctx.registerCommand('applySnippetWorkspaceEdit', commands.applySnippetWorkspaceEditCommand);
     ctx.registerCommand('applyActionGroup', commands.applyActionGroup);
+    ctx.registerCommand('gotoLocation', commands.gotoLocation);
 
     ctx.pushCleanup(activateTaskProvider(workspaceFolder));
 


### PR DESCRIPTION
The idea discussed on [Zulip](https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Fwg-rls-2.2E0/topic/Hover.20actions)

Screencasts:
1) Runnable actions
![hover_actions_run](https://user-images.githubusercontent.com/62505555/83335644-dfc1f780-a2b6-11ea-820b-ccaa82290e7d.gif)

2) Go to Type Definition:
![hover_actions_goto](https://user-images.githubusercontent.com/62505555/83335671-0122e380-a2b7-11ea-9922-fbdcfb11a7f3.gif)

3) And to be able to completely disable code lenses I've added a `Go to Implementations` action:
![hover_actions_impl](https://user-images.githubusercontent.com/62505555/83335732-6d9de280-a2b7-11ea-8cc3-75253d062fe0.gif)

P.S. I don't forget about ```struct Markdown(String)```. It's just that such a change affects much more code than I expected, and I think it's better to do it in a separate PR.