### PR TITLE
Always derive from `process.env` when spawning a child process/shell execution

### DIFF
--- a/editors/code/src/run.ts
+++ b/editors/code/src/run.ts
@@ -177,7 +177,7 @@ export function createTask(spec: ra.Runnable): vscode.Task {
         label: spec.label,
         command: spec.bin,
         args: spec.extraArgs ? [...spec.args, '--', ...spec.extraArgs] : spec.args,
-        env: spec.env,
+        env: Object.assign({}, process.env, spec.env),
     };
 
     const execOption: vscode.ShellExecutionOptions = {


### PR DESCRIPTION
This is useful when an extension (e.g. [Nix Environment Selector](https://marketplace.visualstudio.com/items?itemName=arrterian.nix-env-selector)) or [launch
configuration](https://stackoverflow.com/questions/57641460/set-env-var-for-node-js-when-launching-through-vs-code) sets one or more environment variables.

When `env` is not explicitly specified in the options passed to
`child_process.spawn()` or `vscode.ShellExecution()`, then `process.env` gets
applied automatically. But when an explicit `env` is set, it should inherit from
`process.env` rather than replace it completely.