### PR TITLE
proc_macro: fix current nightly/future stable ABI incompatibility

### DIFF
--- a/crates/ra_proc_macro_srv/src/proc_macro/bridge/client.rs
+++ b/crates/ra_proc_macro_srv/src/proc_macro/bridge/client.rs
@@ -18,7 +18,7 @@ macro_rules! define_handles {
         }
 
         impl HandleCounters {
-            // FIXME(eddyb) use a reference to the `static COUNTERS`, intead of
+            // FIXME(eddyb) use a reference to the `static COUNTERS`, instead of
             // a wrapper `fn` pointer, once `const fn` can reference `static`s.
             extern "C" fn get() -> &'static Self {
                 static COUNTERS: HandleCounters = HandleCounters {
@@ -205,10 +205,16 @@ impl Clone for Literal {
     }
 }
 
-// FIXME(eddyb) `Literal` should not expose internal `Debug` impls.
 impl fmt::Debug for Literal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.debug())
+        f.debug_struct("Literal")
+            // format the kind without quotes, as in `kind: Float`
+            // .field("kind", &format_args!("{}", &self.debug_kind()))
+            .field("symbol", &self.symbol())
+            // format `Some("...")` on one line even in {:#?} mode
+            // .field("suffix", &format_args!("{:?}", &self.suffix()))
+            .field("span", &self.span())
+            .finish()
     }
 }
 
@@ -339,7 +345,7 @@ impl Bridge<'_> {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct Client<F> {
-    // FIXME(eddyb) use a reference to the `static COUNTERS`, intead of
+    // FIXME(eddyb) use a reference to the `static COUNTERS`, instead of
     // a wrapper `fn` pointer, once `const fn` can reference `static`s.
     pub(super) get_handle_counters: extern "C" fn() -> &'static HandleCounters,
     pub(super) run: extern "C" fn(Bridge<'_>, F) -> Buffer<u8>,

--- a/crates/ra_proc_macro_srv/src/proc_macro/bridge/closure.rs
+++ b/crates/ra_proc_macro_srv/src/proc_macro/bridge/closure.rs
@@ -11,6 +11,9 @@ pub struct Closure<'a, A, R> {
 
 struct Env;
 
+// impl<'a, A, R> !Sync for Closure<'a, A, R> {}
+// impl<'a, A, R> !Send for Closure<'a, A, R> {}
+
 impl<'a, A, R, F: FnMut(A) -> R> From<&'a mut F> for Closure<'a, A, R> {
     fn from(f: &'a mut F) -> Self {
         unsafe extern "C" fn call<A, R, F: FnMut(A) -> R>(env: &mut Env, arg: A) -> R {

--- a/crates/ra_proc_macro_srv/src/proc_macro/bridge/mod.rs
+++ b/crates/ra_proc_macro_srv/src/proc_macro/bridge/mod.rs
@@ -108,8 +108,9 @@ macro_rules! with_api {
             Literal {
                 fn drop($self: $S::Literal);
                 fn clone($self: &$S::Literal) -> $S::Literal;
-                // FIXME(eddyb) `Literal` should not expose internal `Debug` impls.
-                fn debug($self: &$S::Literal) -> String;
+                fn debug_kind($self: &$S::Literal) -> String;
+                fn symbol($self: &$S::Literal) -> String;
+                fn suffix($self: &$S::Literal) -> Option<String>;
                 fn integer(n: &str) -> $S::Literal;
                 fn typed_integer(n: &str, kind: &str) -> $S::Literal;
                 fn float(n: &str) -> $S::Literal;
@@ -221,6 +222,9 @@ pub struct Bridge<'a> {
     /// Server-side function that the client uses to make requests.
     dispatch: closure::Closure<'a, Buffer<u8>, Buffer<u8>>,
 }
+
+// impl<'a> !Sync for Bridge<'a> {}
+// impl<'a> !Send for Bridge<'a> {}
 
 #[forbid(unsafe_code)]
 #[allow(non_camel_case_types)]

--- a/crates/ra_proc_macro_srv/src/rustc_server.rs
+++ b/crates/ra_proc_macro_srv/src/rustc_server.rs
@@ -463,9 +463,16 @@ impl server::Ident for Rustc {
 }
 
 impl server::Literal for Rustc {
-    // FIXME(eddyb) `Literal` should not expose internal `Debug` impls.
-    fn debug(&mut self, literal: &Self::Literal) -> String {
-        format!("{:?}", literal)
+    fn debug_kind(&mut self, _literal: &Self::Literal) -> String {
+        // r-a: debug_kind and suffix are unsupported; corresponding client code has been changed to not call these.
+        // They must still be present to be ABI-compatible and work with upstream proc_macro.
+        "".to_owned()
+    }
+    fn symbol(&mut self, literal: &Self::Literal) -> String {
+        literal.text.to_string()
+    }
+    fn suffix(&mut self, _literal: &Self::Literal) -> Option<String> {
+        None
     }
 
     fn integer(&mut self, n: &str) -> Self::Literal {


### PR DESCRIPTION
With rust-lang/rust#72233, the proc_macro ABI has changed, leading to the `test_derive_serialize_proc_macro` test believing that `serde` wants to pass the struct name as a byte string literal instead of a string literal.

Fixes #4866.