### PR TITLE
Unsquish parameter types in tooltips for macro-generated functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,6 +1639,7 @@ dependencies = [
  "relative-path",
  "rustc-hash",
  "serde_json",
+ "stdx",
  "text-size",
 ]
 

--- a/crates/ra_ide/src/display/function_signature.rs
+++ b/crates/ra_ide/src/display/function_signature.rs
@@ -10,7 +10,7 @@ use std::{
 use hir::{Docs, Documentation, HasSource, HirDisplay};
 use ra_ide_db::RootDatabase;
 use ra_syntax::ast::{self, AstNode, NameOwner, VisibilityOwner};
-use stdx::SepBy;
+use stdx::{split1, SepBy};
 
 use crate::display::{generic_parameters, where_predicates};
 
@@ -210,10 +210,8 @@ impl From<&'_ ast::FnDef> for FunctionSignature {
                 // macro-generated functions are missing whitespace
                 fn fmt_param(param: ast::Param) -> String {
                     let text = param.syntax().text().to_string();
-                    match text.find(':') {
-                        Some(pos) if 1 + pos < text.len() => {
-                            format!("{} {}", &text[0..1 + pos].trim(), &text[1 + pos..].trim())
-                        }
+                    match split1(&text, ':') {
+                        Some((left, right)) => format!("{}: {}", left.trim(), right.trim()),
                         _ => text,
                     }
                 }

--- a/crates/ra_ide/src/display/function_signature.rs
+++ b/crates/ra_ide/src/display/function_signature.rs
@@ -207,7 +207,18 @@ impl From<&'_ ast::FnDef> for FunctionSignature {
                     res.push(raw_param);
                 }
 
-                res.extend(param_list.params().map(|param| param.syntax().text().to_string()));
+                // macro-generated functions are missing whitespace
+                fn fmt_param(param: ast::Param) -> String {
+                    let text = param.syntax().text().to_string();
+                    match text.find(':') {
+                        Some(pos) if 1 + pos < text.len() => {
+                            format!("{} {}", &text[0..1 + pos].trim(), &text[1 + pos..].trim())
+                        }
+                        _ => text,
+                    }
+                }
+
+                res.extend(param_list.params().map(fmt_param));
                 res_types.extend(param_list.params().map(|param| {
                     let param_text = param.syntax().text().to_string();
                     match param_text.split(':').nth(1).and_then(|it| it.get(1..)) {

--- a/crates/stdx/src/lib.rs
+++ b/crates/stdx/src/lib.rs
@@ -124,3 +124,8 @@ pub fn replace(buf: &mut String, from: char, to: &str) {
     // FIXME: do this in place.
     *buf = buf.replace(from, to)
 }
+
+pub fn split1(haystack: &str, delim: char) -> Option<(&str, &str)> {
+    let idx = haystack.find(delim)?;
+    Some((&haystack[..idx], &haystack[idx + delim.len_utf8()..]))
+}

--- a/crates/test_utils/Cargo.toml
+++ b/crates/test_utils/Cargo.toml
@@ -15,3 +15,4 @@ relative-path = "1.0.0"
 rustc-hash = "1.1.0"
 
 ra_cfg = { path = "../ra_cfg" }
+stdx = { path = "../stdx" }

--- a/crates/test_utils/src/lib.rs
+++ b/crates/test_utils/src/lib.rs
@@ -15,6 +15,7 @@ use std::{
 };
 
 pub use ra_cfg::CfgOptions;
+use stdx::split1;
 
 pub use relative_path::{RelativePath, RelativePathBuf};
 pub use rustc_hash::FxHashMap;
@@ -330,11 +331,6 @@ fn parse_meta(meta: &str) -> FixtureMeta {
     }
 
     FixtureMeta::File(FileMeta { path, crate_name: krate, deps, edition, cfg, env })
-}
-
-fn split1(haystack: &str, delim: char) -> Option<(&str, &str)> {
-    let idx = haystack.find(delim)?;
-    Some((&haystack[..idx], &haystack[idx + delim.len_utf8()..]))
 }
 
 /// Adjusts the indentation of the first line to the minimum indentation of the rest of the lines.


### PR DESCRIPTION
Note the missing whitespace between `:` and the parameter type.

Before:
![image](https://user-images.githubusercontent.com/221559/83364680-faf13d80-a370-11ea-96b7-a041969a4954.png)

After:
![image](https://user-images.githubusercontent.com/221559/83364685-03e20f00-a371-11ea-9668-4e6ebcb81947.png)
