### PR TITLE
Improve error recovery for unclosed `use` tree lists.

### DIFF
--- a/crates/ra_syntax/src/parsing/reparsing.rs
+++ b/crates/ra_syntax/src/parsing/reparsing.rs
@@ -289,7 +289,6 @@ impl IntoIterator<Item=i32> for Foo {
             "n next(",
             9,
         );
-        do_check(r"use a::b::{foo,<|>,bar<|>};", "baz", 10);
         do_check(
             r"
 pub enum A {

--- a/crates/ra_syntax/test_data/parser/err/0036_partial_use.rast
+++ b/crates/ra_syntax/test_data/parser/err/0036_partial_use.rast
@@ -1,14 +1,14 @@
 SOURCE_FILE@0..37
-  USE_ITEM@0..36
+  USE_ITEM@0..23
     USE_KW@0..3 "use"
     WHITESPACE@3..4 " "
-    USE_TREE@4..36
+    USE_TREE@4..22
       PATH@4..7
         PATH_SEGMENT@4..7
           NAME_REF@4..7
             IDENT@4..7 "std"
       COLON2@7..9 "::"
-      USE_TREE_LIST@9..36
+      USE_TREE_LIST@9..22
         L_CURLY@9..10 "{"
         USE_TREE@10..22
           PATH@10..22
@@ -20,32 +20,22 @@ SOURCE_FILE@0..37
             PATH_SEGMENT@17..22
               NAME_REF@17..22
                 IDENT@17..22 "Error"
-        ERROR@22..23
-          SEMICOLON@22..23 ";"
-        WHITESPACE@23..24 "\n"
-        ERROR@24..27
-          USE_KW@24..27 "use"
-        WHITESPACE@27..28 " "
-        USE_TREE@28..35
-          PATH@28..35
-            PATH@28..31
-              PATH_SEGMENT@28..31
-                NAME_REF@28..31
-                  IDENT@28..31 "std"
-            COLON2@31..33 "::"
-            PATH_SEGMENT@33..35
-              NAME_REF@33..35
-                IDENT@33..35 "io"
-        ERROR@35..36
-          SEMICOLON@35..36 ";"
+    SEMICOLON@22..23 ";"
+  WHITESPACE@23..24 "\n"
+  USE_ITEM@24..36
+    USE_KW@24..27 "use"
+    WHITESPACE@27..28 " "
+    USE_TREE@28..35
+      PATH@28..35
+        PATH@28..31
+          PATH_SEGMENT@28..31
+            NAME_REF@28..31
+              IDENT@28..31 "std"
+        COLON2@31..33 "::"
+        PATH_SEGMENT@33..35
+          NAME_REF@33..35
+            IDENT@33..35 "io"
+    SEMICOLON@35..36 ";"
   WHITESPACE@36..37 "\n"
-error 22..22: expected COMMA
-error 22..22: expected one of `*`, `::`, `{`, `self`, `super` or an identifier
-error 23..23: expected COMMA
-error 24..24: expected one of `*`, `::`, `{`, `self`, `super` or an identifier
-error 27..27: expected COMMA
-error 35..35: expected COMMA
-error 35..35: expected one of `*`, `::`, `{`, `self`, `super` or an identifier
-error 36..36: expected COMMA
-error 36..36: expected R_CURLY
-error 36..36: expected SEMICOLON
+error 22..22: Expected one of `,` or `}`
+error 22..22: expected R_CURLY

--- a/crates/ra_syntax/test_data/parser/err/0043_unclosed_use.rast
+++ b/crates/ra_syntax/test_data/parser/err/0043_unclosed_use.rast
@@ -1,0 +1,53 @@
+SOURCE_FILE@0..51
+  USE_ITEM@0..17
+    USE_KW@0..3 "use"
+    WHITESPACE@3..4 " "
+    USE_TREE@4..17
+      PATH@4..7
+        PATH_SEGMENT@4..7
+          NAME_REF@4..7
+            IDENT@4..7 "std"
+      COLON2@7..9 "::"
+      USE_TREE_LIST@9..17
+        L_CURLY@9..10 "{"
+        USE_TREE@10..16
+          PATH@10..16
+            PATH_SEGMENT@10..16
+              NAME_REF@10..16
+                IDENT@10..16 "thread"
+        COMMA@16..17 ","
+  WHITESPACE@17..18 "\n"
+  USE_ITEM@18..33
+    USE_KW@18..21 "use"
+    WHITESPACE@21..22 " "
+    USE_TREE@22..32
+      PATH@22..32
+        PATH@22..26
+          PATH_SEGMENT@22..26
+            NAME_REF@22..26
+              IDENT@22..26 "some"
+        COLON2@26..28 "::"
+        PATH_SEGMENT@28..32
+          NAME_REF@28..32
+            IDENT@28..32 "name"
+    SEMICOLON@32..33 ";"
+  WHITESPACE@33..34 "\n"
+  USE_ITEM@34..50
+    USE_KW@34..37 "use"
+    WHITESPACE@37..38 " "
+    USE_TREE@38..49
+      PATH@38..49
+        PATH@38..43
+          PATH_SEGMENT@38..43
+            NAME_REF@38..43
+              IDENT@38..43 "other"
+        COLON2@43..45 "::"
+        PATH_SEGMENT@45..49
+          NAME_REF@45..49
+            IDENT@45..49 "name"
+    SEMICOLON@49..50 ";"
+  WHITESPACE@50..51 "\n"
+error 17..17: expected one of `*`, `::`, `{`, `self`, `super` or an identifier
+error 17..17: Expected one of `,` or `}`
+error 17..17: expected R_CURLY
+error 17..17: expected SEMICOLON

--- a/crates/ra_syntax/test_data/parser/err/0043_unclosed_use.rs
+++ b/crates/ra_syntax/test_data/parser/err/0043_unclosed_use.rs
@@ -1,0 +1,3 @@
+use std::{thread,
+use some::name;
+use other::name;

--- a/crates/ra_syntax/test_data/parser/err/0044_bad_use_tree_list.rast
+++ b/crates/ra_syntax/test_data/parser/err/0044_bad_use_tree_list.rast
@@ -1,0 +1,72 @@
+SOURCE_FILE@0..58
+  USE_ITEM@0..16
+    USE_KW@0..3 "use"
+    WHITESPACE@3..4 " "
+    USE_TREE@4..16
+      PATH@4..7
+        PATH_SEGMENT@4..7
+          NAME_REF@4..7
+            IDENT@4..7 "std"
+      COLON2@7..9 "::"
+      USE_TREE_LIST@9..16
+        L_CURLY@9..10 "{"
+        USE_TREE@10..16
+          PATH@10..16
+            PATH_SEGMENT@10..16
+              NAME_REF@10..16
+                IDENT@10..16 "thread"
+  ERROR@16..17
+    COLON@16..17 ":"
+  ERROR@17..18
+    COMMA@17..18 ","
+  WHITESPACE@18..19 " "
+  MACRO_CALL@19..22
+    PATH@19..22
+      PATH_SEGMENT@19..22
+        NAME_REF@19..22
+          IDENT@19..22 "mem"
+  ERROR@22..23
+    R_CURLY@22..23 "}"
+  ERROR@23..24
+    SEMICOLON@23..24 ";"
+  WHITESPACE@24..25 "\n"
+  USE_ITEM@25..40
+    USE_KW@25..28 "use"
+    WHITESPACE@28..29 " "
+    USE_TREE@29..39
+      PATH@29..39
+        PATH@29..33
+          PATH_SEGMENT@29..33
+            NAME_REF@29..33
+              IDENT@29..33 "some"
+        COLON2@33..35 "::"
+        PATH_SEGMENT@35..39
+          NAME_REF@35..39
+            IDENT@35..39 "name"
+    SEMICOLON@39..40 ";"
+  WHITESPACE@40..41 "\n"
+  USE_ITEM@41..57
+    USE_KW@41..44 "use"
+    WHITESPACE@44..45 " "
+    USE_TREE@45..56
+      PATH@45..56
+        PATH@45..50
+          PATH_SEGMENT@45..50
+            NAME_REF@45..50
+              IDENT@45..50 "other"
+        COLON2@50..52 "::"
+        PATH_SEGMENT@52..56
+          NAME_REF@52..56
+            IDENT@52..56 "name"
+    SEMICOLON@56..57 ";"
+  WHITESPACE@57..58 "\n"
+error 16..16: Expected one of `,` or `}`
+error 16..16: expected R_CURLY
+error 16..16: expected SEMICOLON
+error 16..16: expected an item
+error 17..17: expected an item
+error 22..22: expected BANG
+error 22..22: expected `{`, `[`, `(`
+error 22..22: expected SEMICOLON
+error 22..22: unmatched `}`
+error 23..23: expected an item

--- a/crates/ra_syntax/test_data/parser/err/0044_bad_use_tree_list.rs
+++ b/crates/ra_syntax/test_data/parser/err/0044_bad_use_tree_list.rs
@@ -1,0 +1,3 @@
+use std::{thread:, mem};
+use some::name;
+use other::name;

--- a/crates/ra_syntax/test_data/parser/ok/0066_use_items_trailing_comma.rast
+++ b/crates/ra_syntax/test_data/parser/ok/0066_use_items_trailing_comma.rast
@@ -1,0 +1,28 @@
+SOURCE_FILE@0..39
+  USE_ITEM@0..38
+    USE_KW@0..3 "use"
+    WHITESPACE@3..4 " "
+    USE_TREE@4..37
+      PATH@4..13
+        PATH_SEGMENT@4..13
+          NAME_REF@4..13
+            IDENT@4..13 "ra_syntax"
+      COLON2@13..15 "::"
+      USE_TREE_LIST@15..37
+        L_CURLY@15..16 "{"
+        USE_TREE@16..24
+          PATH@16..24
+            PATH_SEGMENT@16..24
+              NAME_REF@16..24
+                IDENT@16..24 "TextSize"
+        COMMA@24..25 ","
+        WHITESPACE@25..26 " "
+        USE_TREE@26..35
+          PATH@26..35
+            PATH_SEGMENT@26..35
+              NAME_REF@26..35
+                IDENT@26..35 "TextRange"
+        COMMA@35..36 ","
+        R_CURLY@36..37 "}"
+    SEMICOLON@37..38 ";"
+  WHITESPACE@38..39 "\n"

--- a/crates/ra_syntax/test_data/parser/ok/0066_use_items_trailing_comma.rs
+++ b/crates/ra_syntax/test_data/parser/ok/0066_use_items_trailing_comma.rs
@@ -1,0 +1,1 @@
+use ra_syntax::{TextSize, TextRange,};


### PR DESCRIPTION
Previously, given an unclosed `use name::{…}` would result in the
entire rest of the file being parsed as part of the `use_tree_list`,
generating errors on virtually every token in the file. This spew of
errors is unhelpful, can slow down editors, and in the case of emacs
lsp-mode + flycheck (my environment), will cause the editor to stop
displaying errors entirely under the assumption that the checker must
be broken.

We solve this by bailing out of the `use_tree_list` as soon as we
encounter a token that isn't a `,` or `}` between or after items.

This has the downside that we now do a slightly worse job of
recovering from syntax errors _inside_ of a balanced `use_tree_list`,
for instance, in `use std::{thread, , mem}`. Previously, we would
report one syntax error and then correct emit a `use_tree` for `mem`
and close the list; now we'll bail early and emit errors until the
semicolon, at which point we resync.

This represents a fundamental tradeoff (as best I can tell) in doing
error-recover without lookahead; when we encounter that first parse
error, we have to either guess that we should continue the
`use_tree_list`, or that we should bail. I believe that bailing is
superior because it avoids the unbounded desync, and because it vastly
improves the common case of adding a new `use` clause from scratch
near the top of an existing file.

We could potentially improve the other case slightly by discarding
tokens until we find something in `ITEM_RECOVERY_SET`, which would
reduce the number of errors we spew, but that didn't seem to be a
pre-existing idiom in the code base.