### PR TITLE
Implement return position impl trait / opaque type support

### DIFF
--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -18,8 +18,8 @@ pub use hir_ty::db::{
     GenericDefaultsQuery, GenericPredicatesForParamQuery, GenericPredicatesQuery, HirDatabase,
     HirDatabaseStorage, ImplDatumQuery, ImplSelfTyQuery, ImplTraitQuery, ImplsForTraitQuery,
     ImplsInCrateQuery, InferQueryQuery, InternAssocTyValueQuery, InternChalkImplQuery,
-    InternTypeCtorQuery, InternTypeParamIdQuery, StructDatumQuery, TraitDatumQuery,
-    TraitSolveQuery, TyQuery, ValueTyQuery,
+    InternTypeCtorQuery, InternTypeParamIdQuery, ReturnTypeImplTraitsQuery, StructDatumQuery,
+    TraitDatumQuery, TraitSolveQuery, TyQuery, ValueTyQuery,
 };
 
 #[test]

--- a/crates/ra_hir_ty/src/display.rs
+++ b/crates/ra_hir_ty/src/display.rs
@@ -4,7 +4,7 @@ use std::fmt;
 
 use crate::{
     db::HirDatabase, utils::generics, ApplicationTy, CallableDef, FnSig, GenericPredicate,
-    Obligation, ProjectionTy, Substs, TraitRef, Ty, TypeCtor,
+    Obligation, OpaqueTyId, ProjectionTy, Substs, TraitRef, Ty, TypeCtor,
 };
 use hir_def::{
     find_path, generics::TypeParamProvenance, item_scope::ItemInNs, AdtId, AssocContainerId,
@@ -361,7 +361,7 @@ impl HirDisplay for ApplicationTy {
             }
             TypeCtor::OpaqueType(opaque_ty_id) => {
                 let bounds = match opaque_ty_id {
-                    crate::OpaqueTyId::ReturnTypeImplTrait(func, idx) => {
+                    OpaqueTyId::ReturnTypeImplTrait(func, idx) => {
                         let datas =
                             f.db.return_type_impl_traits(func).expect("impl trait id without data");
                         let data = (*datas)
@@ -448,7 +448,7 @@ impl HirDisplay for Ty {
             }
             Ty::Opaque(opaque_ty) => {
                 let bounds = match opaque_ty.opaque_ty_id {
-                    crate::OpaqueTyId::ReturnTypeImplTrait(func, idx) => {
+                    OpaqueTyId::ReturnTypeImplTrait(func, idx) => {
                         let datas =
                             f.db.return_type_impl_traits(func).expect("impl trait id without data");
                         let data = (*datas)

--- a/crates/ra_hir_ty/src/infer.rs
+++ b/crates/ra_hir_ty/src/infer.rs
@@ -39,8 +39,8 @@ use ra_syntax::SmolStr;
 use super::{
     primitive::{FloatTy, IntTy},
     traits::{Guidance, Obligation, ProjectionPredicate, Solution},
-    ApplicationTy, GenericPredicate, InEnvironment, ProjectionTy, Substs, TraitEnvironment,
-    TraitRef, Ty, TypeCtor, TypeWalk, Uncertain,
+    ApplicationTy, InEnvironment, ProjectionTy, Substs, TraitEnvironment, TraitRef, Ty, TypeCtor,
+    TypeWalk, Uncertain,
 };
 use crate::{
     db::HirDatabase, infer::diagnostics::InferenceDiagnostic, lower::ImplTraitLoweringMode,
@@ -383,25 +383,6 @@ impl<'a> InferenceContext<'a> {
     ) -> Ty {
         match assoc_ty {
             Some(res_assoc_ty) => {
-                // FIXME:
-                // Check if inner_ty is is `impl Trait` and contained input TypeAlias id
-                // this is a workaround while Chalk assoc type projection doesn't always work yet,
-                // but once that is fixed I don't think we should keep this
-                // (we'll probably change how associated types are resolved anyway)
-                if let Ty::Opaque(ref predicates) = inner_ty {
-                    for p in predicates.iter() {
-                        if let GenericPredicate::Projection(projection) = p {
-                            if projection.projection_ty.associated_ty == res_assoc_ty {
-                                if let ty_app!(_, params) = &projection.ty {
-                                    if params.len() == 0 {
-                                        return projection.ty.clone();
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-
                 let ty = self.table.new_type_var();
                 let builder = Substs::build_for_def(self.db, res_assoc_ty)
                     .push(inner_ty)

--- a/crates/ra_hir_ty/src/tests/traits.rs
+++ b/crates/ra_hir_ty/src/tests/traits.rs
@@ -1160,7 +1160,37 @@ fn test(x: impl Trait<u64>, y: &impl Trait<u64>) {
 }
 
 #[test]
-fn return_pos_impl_trait() {
+fn simple_return_pos_impl_trait() {
+    mark::check!(lower_rpit);
+    assert_snapshot!(
+        infer(r#"
+trait Trait<T> {
+    fn foo(&self) -> T;
+}
+fn bar() -> impl Trait<u64> { loop {} }
+
+fn test() {
+    let a = bar();
+    a.foo();
+}
+"#),
+        @r###"
+    30..34 'self': &Self
+    72..83 '{ loop {} }': !
+    74..81 'loop {}': !
+    79..81 '{}': ()
+    95..130 '{     ...o(); }': ()
+    105..106 'a': impl Trait<u64>
+    109..112 'bar': fn bar() -> impl Trait<u64>
+    109..114 'bar()': impl Trait<u64>
+    120..121 'a': impl Trait<u64>
+    120..127 'a.foo()': u64
+    "###
+    );
+}
+
+#[test]
+fn more_return_pos_impl_trait() {
     assert_snapshot!(
         infer(r#"
 trait Iterator {
@@ -1174,12 +1204,12 @@ fn bar() -> (impl Iterator<Item = impl Trait<u32>>, impl Trait<u64>) { loop {} }
 fn baz<T>(t: T) -> (impl Iterator<Item = impl Trait<T>>, impl Trait<T>) { loop {} }
 
 fn test() {
-    // let (a, b) = bar();
-    // a.next().foo();
-    // b.foo();
+    let (a, b) = bar();
+    a.next().foo();
+    b.foo();
     let (c, d) = baz(1u128);
-    c.next();//.foo();
-    // d.foo();
+    c.next().foo();
+    d.foo();
 }
 "#),
         @r###"
@@ -1192,15 +1222,28 @@ fn test() {
     269..280 '{ loop {} }': ({unknown}, {unknown})
     271..278 'loop {}': !
     276..278 '{}': ()
-    292..429 '{     ...o(); }': ()
-    368..374 '(c, d)': (impl Iterator<Item = impl Trait<u128>>, impl Trait<u128>)
-    369..370 'c': impl Iterator<Item = impl Trait<u128>>
-    372..373 'd': impl Trait<u128>
-    377..380 'baz': fn baz<u128>(u128) -> (impl Iterator<Item = impl Trait<u128>>, impl Trait<u128>)
-    377..387 'baz(1u128)': (impl Iterator<Item = impl Trait<u128>>, impl Trait<u128>)
-    381..386 '1u128': u128
-    393..394 'c': impl Iterator<Item = impl Trait<u128>>
-    393..401 'c.next()': impl Trait<u128>
+    292..414 '{     ...o(); }': ()
+    302..308 '(a, b)': (impl Iterator<Item = impl Trait<u32>>, impl Trait<u64>)
+    303..304 'a': impl Iterator<Item = impl Trait<u32>>
+    306..307 'b': impl Trait<u64>
+    311..314 'bar': fn bar() -> (impl Iterator<Item = impl Trait<u32>>, impl Trait<u64>)
+    311..316 'bar()': (impl Iterator<Item = impl Trait<u32>>, impl Trait<u64>)
+    322..323 'a': impl Iterator<Item = impl Trait<u32>>
+    322..330 'a.next()': impl Trait<u32>
+    322..336 'a.next().foo()': u32
+    342..343 'b': impl Trait<u64>
+    342..349 'b.foo()': u64
+    359..365 '(c, d)': (impl Iterator<Item = impl Trait<u128>>, impl Trait<u128>)
+    360..361 'c': impl Iterator<Item = impl Trait<u128>>
+    363..364 'd': impl Trait<u128>
+    368..371 'baz': fn baz<u128>(u128) -> (impl Iterator<Item = impl Trait<u128>>, impl Trait<u128>)
+    368..378 'baz(1u128)': (impl Iterator<Item = impl Trait<u128>>, impl Trait<u128>)
+    372..377 '1u128': u128
+    384..385 'c': impl Iterator<Item = impl Trait<u128>>
+    384..392 'c.next()': impl Trait<u128>
+    384..398 'c.next().foo()': u128
+    404..405 'd': impl Trait<u128>
+    404..411 'd.foo()': u128
     "###
     );
 }

--- a/crates/ra_hir_ty/src/traits/chalk/interner.rs
+++ b/crates/ra_hir_ty/src/traits/chalk/interner.rs
@@ -22,6 +22,8 @@ pub type AssociatedTyValueId = chalk_solve::rust_ir::AssociatedTyValueId<Interne
 pub type AssociatedTyValue = chalk_solve::rust_ir::AssociatedTyValue<Interner>;
 pub type FnDefId = chalk_ir::FnDefId<Interner>;
 pub type FnDefDatum = chalk_solve::rust_ir::FnDefDatum<Interner>;
+pub type OpaqueTyId = chalk_ir::OpaqueTyId<Interner>;
+pub type OpaqueTyDatum = chalk_solve::rust_ir::OpaqueTyDatum<Interner>;
 
 impl chalk_ir::interner::Interner for Interner {
     type InternedType = Box<chalk_ir::TyData<Self>>; // FIXME use Arc?

--- a/crates/ra_hir_ty/src/traits/chalk/tls.rs
+++ b/crates/ra_hir_ty/src/traits/chalk/tls.rs
@@ -69,6 +69,11 @@ impl DebugContext<'_> {
                 let name = self.0.type_alias_data(type_alias).name.clone();
                 write!(f, "{}::{}", trait_name, name)?;
             }
+            TypeCtor::OpaqueType(opaque_ty_id) => match opaque_ty_id {
+                crate::OpaqueTyId::ReturnTypeImplTrait(func, idx) => {
+                    write!(f, "{{impl trait {} of {:?}}}", idx, func)?;
+                }
+            },
             TypeCtor::Closure { def, expr } => {
                 write!(f, "{{closure {:?} in ", expr.into_raw())?;
                 match def {

--- a/crates/ra_ide_db/src/change.rs
+++ b/crates/ra_ide_db/src/change.rs
@@ -369,6 +369,7 @@ impl RootDatabase {
             hir::db::ImplDatumQuery
             hir::db::AssociatedTyValueQuery
             hir::db::TraitSolveQuery
+            hir::db::ReturnTypeImplTraitsQuery
 
             // SymbolsDatabase
             crate::symbol_index::FileSymbolsQuery


### PR DESCRIPTION
This is working, but I'm not that happy with how the lowering works. We might need an additional representation between `TypeRef` and `Ty` where names are resolved and `impl Trait` bounds are separated out, but things like inference variables don't exist and `impl Trait` is always represented the same way.

Also note that this doesn't implement correct handling of RPIT *inside* the function (which involves turning the `impl Trait`s into variables and creating obligations for them). That intermediate representation might help there as well.