### PR TITLE
Disable rust-analyzer.checkOnSave.allFeatures by default

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -122,7 +122,7 @@ impl Default for Config {
             check: Some(FlycheckConfig::CargoCommand {
                 command: "check".to_string(),
                 all_targets: true,
-                all_features: true,
+                all_features: false,
                 extra_args: Vec::new(),
             }),
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -319,7 +319,7 @@
                 },
                 "rust-analyzer.checkOnSave.allFeatures": {
                     "type": "boolean",
-                    "default": true,
+                    "default": false,
                     "markdownDescription": "Check with all features (will be passed as `--all-features`)"
                 },
                 "rust-analyzer.inlayHints.enable": {


### PR DESCRIPTION
Cargo features should be additive, but users keep running into problems with this, e.g. #4707, #4702, #4690, #4443. Let's disable it by default. We've seen:

 - incompatible features
 - features requiring a different toolchain (`nightly`)
 - features triggering the compilation of native code

CC @matprec, @17cupsofcoffee, @schungx.