### PR TITLE
do not suggest duplicate completion items

### DIFF
--- a/crates/ra_ide/src/completion/complete_unqualified_path.rs
+++ b/crates/ra_ide/src/completion/complete_unqualified_path.rs
@@ -171,6 +171,42 @@ mod tests {
     }
 
     #[test]
+    fn completes_multiple_let() {
+        assert_debug_snapshot!(
+            do_reference_completion(
+                r"
+                fn main() {
+                    let y: usize = 92;
+                    let y: i32 = 85;
+                    1 + <|>;
+                }
+                "
+            ),
+            @r###"
+        [
+            CompletionItem {
+                label: "main()",
+                source_range: 129..129,
+                delete: 129..129,
+                insert: "main()$0",
+                kind: Function,
+                lookup: "main",
+                detail: "fn main()",
+            },
+            CompletionItem {
+                label: "y",
+                source_range: 129..129,
+                delete: 129..129,
+                insert: "y",
+                kind: Binding,
+                detail: "i32",
+            },
+        ]
+        "###
+        );
+    }
+
+    #[test]
     fn completes_bindings_from_let() {
         assert_debug_snapshot!(
             do_reference_completion(


### PR DESCRIPTION
Do not suggest multiple times the same variable names when it's redeclared like this:
```rust
fn main() {
    let y: usize = 92;
    let y: i32 = 85;
    1 + <|>;
}
```
