### PR TITLE
Hide squiggly for unused and unnecessary diagnostics

### DIFF
--- a/crates/rust-analyzer/src/diagnostics/snapshots/rust_analyzer__diagnostics__to_proto__tests__snap_rustc_unused_variable.snap
+++ b/crates/rust-analyzer/src/diagnostics/snapshots/rust_analyzer__diagnostics__to_proto__tests__snap_rustc_unused_variable.snap
@@ -29,7 +29,7 @@ expression: diag
                 },
             },
             severity: Some(
-                Warning,
+                Hint,
             ),
             code: Some(
                 String(

--- a/crates/rust-analyzer/src/diagnostics/to_proto.rs
+++ b/crates/rust-analyzer/src/diagnostics/to_proto.rs
@@ -183,7 +183,7 @@ pub(crate) fn map_rust_diagnostic_to_lsp(
         return Vec::new();
     }
 
-    let severity = map_level_to_severity(rd.level);
+    let mut severity = map_level_to_severity(rd.level);
 
     let mut source = String::from("rustc");
     let mut code = rd.code.as_ref().map(|c| c.code.clone());
@@ -225,6 +225,7 @@ pub(crate) fn map_rust_diagnostic_to_lsp(
     }
 
     if is_unused_or_unnecessary(rd) {
+        severity = Some(DiagnosticSeverity::Hint);
         tags.push(DiagnosticTag::Unnecessary);
     }
 


### PR DESCRIPTION
Fixes #4229 

When working with JavaScript or TypeScript in VSCode unused valiables are faded but don't have a squiggle. This PR makes rust-analyzer work similarly by setting the severity to hint when applying the unnecessary tag.

VSCode usually shows a squiggle for error, warning and information and shows three dots for hint. When the unnecessary tag is present the squiggles will still show up but the three dots will not.

This is my first contribution to open source. Please tell me if i need to do anything more to get this PR considered.