### PR TITLE
Declare required lsp-server dependency of rust-analyzer crate

### DIFF
--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -32,7 +32,7 @@ threadpool = "1.7.1"
 
 stdx = { path = "../stdx" }
 
-lsp-server = "0.3.1"
+lsp-server = "0.3.2"
 ra_flycheck = { path = "../ra_flycheck" }
 ra_ide = { path = "../ra_ide" }
 ra_prof = { path = "../ra_prof" }


### PR DESCRIPTION
My codebase already depended on lsp-server and introducing a dependency on rust-analyzer failed at first because it assumes some functions that were first present in lsp-server 0.3.2.

Without this change:

```console
error[E0599]: no method named `initialize_start` found for struct `lsp_server::Connection` in the current scope
  --> crates/rust-analyzer/./src/bin/main.rs:83:57
   |
83 |     let (initialize_id, initialize_params) = connection.initialize_start()?;
   |                                                         ^^^^^^^^^^^^^^^^ method not found in `lsp_server::Connection`

error[E0599]: no method named `initialize_finish` found for struct `lsp_server::Connection` in the current scope
  --> crates/rust-analyzer/./src/bin/main.rs:99:16
   |
99 |     connection.initialize_finish(initialize_id, initialize_result)?;
   |                ^^^^^^^^^^^^^^^^^ method not found in `lsp_server::Connection`
```