### PR TITLE
Remove unneeded "./" prefix affecting error messages

### DIFF
--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -10,7 +10,7 @@ doctest = false
 
 [[bin]]
 name = "rust-analyzer"
-path = "./src/bin/main.rs"
+path = "src/bin/main.rs"
 
 [dependencies]
 anyhow = "1.0.26"


### PR DESCRIPTION
I noticed this in the error in the commit message of https://github.com/rust-analyzer/rust-analyzer/pull/4739.

Before:

```console
error[E0599]: no method named `initialize_finish` found for struct `lsp_server::Connection` in the current scope
  --> crates/rust-analyzer/./src/bin/main.rs:99:16
   |
99 |     connection.initialize_finish(initialize_id, initialize_result)?;
   |                ^^^^^^^^^^^^^^^^^ method not found in `lsp_server::Connection`
```

After:

```console
error[E0599]: no method named `initialize_finish` found for struct `lsp_server::Connection` in the current scope
  --> crates/rust-analyzer/src/bin/main.rs:99:16
   |
99 |     connection.initialize_finish(initialize_id, initialize_result)?;
   |                ^^^^^^^^^^^^^^^^^ method not found in `lsp_server::Connection`
```

```diff
-   --> crates/rust-analyzer/./src/bin/main.rs:99:16
+   --> crates/rust-analyzer/src/bin/main.rs:99:16
```