### PR TITLE
Fix type inference failure when built with log/kv_unstable

### DIFF
--- a/crates/ra_hir_def/src/path.rs
+++ b/crates/ra_hir_def/src/path.rs
@@ -273,7 +273,7 @@ impl From<Name> for ModPath {
 impl Display for ModPath {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut first_segment = true;
-        let mut add_segment = |s| {
+        let mut add_segment = |s| -> fmt::Result {
             if !first_segment {
                 f.write_str("::")?;
             }


### PR DESCRIPTION
This code is broken by an `impl From<kv::Error> for fmt::Error` in the log crate when building in a codebase that has the log/kv_unstable feature enabled.

```console
$ cargo check --manifest-path crates/ra_hir_def/Cargo.toml
    Checking ra_hir_def v0.1.0
    Finished dev [unoptimized] target(s) in 0.75s

$ cargo check --manifest-path crates/ra_hir_def/Cargo.toml --features log/kv_unstable
    Checking ra_hir_def v0.1.0
error[E0282]: type annotations needed for the closure `fn(&str) -> std::result::Result<(), _>`
   --> crates/ra_hir_def/src/path.rs:278:17
    |
278 |                 f.write_str("::")?;
    |                 ^^^^^^^^^^^^^^^^^^ cannot infer type
    |
help: give this closure an explicit return type without `_` placeholders
    |
276 |         let mut add_segment = |s| -> std::result::Result<(), _> {
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

https://github.com/rust-lang/log/issues/397