### PR TITLE
Add an `ImportMap` and use it to resolve item paths in `find_path`

### DIFF
--- a/crates/ra_db/src/lib.rs
+++ b/crates/ra_db/src/lib.rs
@@ -11,8 +11,8 @@ use ra_syntax::{ast, Parse, SourceFile, TextRange, TextSize};
 pub use crate::{
     cancellation::Canceled,
     input::{
-        CrateGraph, CrateId, CrateName, Dependency, Edition, Env, ExternSource, ExternSourceId,
-        FileId, ProcMacroId, SourceRoot, SourceRootId,
+        CrateData, CrateGraph, CrateId, CrateName, Dependency, Edition, Env, ExternSource,
+        ExternSourceId, FileId, ProcMacroId, SourceRoot, SourceRootId,
     },
 };
 pub use relative_path::{RelativePath, RelativePathBuf};

--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -3,11 +3,11 @@
 pub use hir_def::db::{
     AttrsQuery, BodyQuery, BodyWithSourceMapQuery, ConstDataQuery, CrateDefMapQueryQuery,
     CrateLangItemsQuery, DefDatabase, DefDatabaseStorage, DocumentationQuery, EnumDataQuery,
-    ExprScopesQuery, FunctionDataQuery, GenericParamsQuery, ImplDataQuery, InternConstQuery,
-    InternDatabase, InternDatabaseStorage, InternEnumQuery, InternFunctionQuery, InternImplQuery,
-    InternStaticQuery, InternStructQuery, InternTraitQuery, InternTypeAliasQuery, InternUnionQuery,
-    LangItemQuery, ModuleLangItemsQuery, RawItemsQuery, StaticDataQuery, StructDataQuery,
-    TraitDataQuery, TypeAliasDataQuery, UnionDataQuery,
+    ExprScopesQuery, FunctionDataQuery, GenericParamsQuery, ImplDataQuery, ImportMapQuery,
+    InternConstQuery, InternDatabase, InternDatabaseStorage, InternEnumQuery, InternFunctionQuery,
+    InternImplQuery, InternStaticQuery, InternStructQuery, InternTraitQuery, InternTypeAliasQuery,
+    InternUnionQuery, LangItemQuery, ModuleLangItemsQuery, RawItemsQuery, StaticDataQuery,
+    StructDataQuery, TraitDataQuery, TypeAliasDataQuery, UnionDataQuery,
 };
 pub use hir_expand::db::{
     AstDatabase, AstDatabaseStorage, AstIdMapQuery, InternEagerExpansionQuery, InternMacroQuery,

--- a/crates/ra_hir_def/src/db.rs
+++ b/crates/ra_hir_def/src/db.rs
@@ -1,7 +1,7 @@
 //! Defines database & queries for name resolution.
 use std::sync::Arc;
 
-use hir_expand::{db::AstDatabase, name::Name, HirFileId};
+use hir_expand::{db::AstDatabase, HirFileId};
 use ra_db::{salsa, CrateId, SourceDatabase, Upcast};
 use ra_prof::profile;
 use ra_syntax::SmolStr;
@@ -12,14 +12,10 @@ use crate::{
     body::{scope::ExprScopes, Body, BodySourceMap},
     data::{ConstData, FunctionData, ImplData, StaticData, TraitData, TypeAliasData},
     docs::Documentation,
-    find_path,
     generics::GenericParams,
     import_map::ImportMap,
-    item_scope::ItemInNs,
     lang_item::{LangItemTarget, LangItems},
     nameres::{raw::RawItems, CrateDefMap},
-    path::ModPath,
-    visibility::Visibility,
     AttrDefId, ConstId, ConstLoc, DefWithBodyId, EnumId, EnumLoc, FunctionId, FunctionLoc,
     GenericDefId, ImplId, ImplLoc, ModuleId, StaticId, StaticLoc, StructId, StructLoc, TraitId,
     TraitLoc, TypeAliasId, TypeAliasLoc, UnionId, UnionLoc,
@@ -113,16 +109,6 @@ pub trait DefDatabase: InternDatabase + AstDatabase + Upcast<dyn AstDatabase> {
     // Remove this query completely, in favor of `Attrs::docs` method
     #[salsa::invoke(Documentation::documentation_query)]
     fn documentation(&self, def: AttrDefId) -> Option<Documentation>;
-
-    #[salsa::invoke(find_path::importable_locations_of_query)]
-    fn importable_locations_of(
-        &self,
-        item: ItemInNs,
-        krate: CrateId,
-    ) -> Arc<[(ModuleId, Name, Visibility)]>;
-
-    #[salsa::invoke(find_path::find_path_inner_query)]
-    fn find_path_inner(&self, item: ItemInNs, from: ModuleId, max_len: usize) -> Option<ModPath>;
 
     #[salsa::invoke(ImportMap::import_map_query)]
     fn import_map(&self, krate: CrateId) -> Arc<ImportMap>;

--- a/crates/ra_hir_def/src/db.rs
+++ b/crates/ra_hir_def/src/db.rs
@@ -14,6 +14,7 @@ use crate::{
     docs::Documentation,
     find_path,
     generics::GenericParams,
+    import_map::ImportMap,
     item_scope::ItemInNs,
     lang_item::{LangItemTarget, LangItems},
     nameres::{raw::RawItems, CrateDefMap},
@@ -122,6 +123,9 @@ pub trait DefDatabase: InternDatabase + AstDatabase + Upcast<dyn AstDatabase> {
 
     #[salsa::invoke(find_path::find_path_inner_query)]
     fn find_path_inner(&self, item: ItemInNs, from: ModuleId, max_len: usize) -> Option<ModPath>;
+
+    #[salsa::invoke(ImportMap::import_map_query)]
+    fn import_map(&self, krate: CrateId) -> Arc<ImportMap>;
 }
 
 fn crate_def_map_wait(db: &impl DefDatabase, krate: CrateId) -> Arc<CrateDefMap> {

--- a/crates/ra_hir_def/src/find_path.rs
+++ b/crates/ra_hir_def/src/find_path.rs
@@ -128,7 +128,7 @@ pub(crate) fn find_path_inner(
     let mut best_path = None;
     let mut best_path_len = max_len;
 
-    if item.defining_crate(db) == Some(from.krate) {
+    if item.krate(db) == Some(from.krate) {
         // Item was defined in the same crate that wants to import it. It cannot be found in any
         // dependency in this case.
 

--- a/crates/ra_hir_def/src/find_path.rs
+++ b/crates/ra_hir_def/src/find_path.rs
@@ -2,6 +2,7 @@
 
 use hir_expand::name::{known, AsName, Name};
 use ra_prof::profile;
+use rustc_hash::FxHashSet;
 use test_utils::mark;
 
 use crate::{
@@ -11,7 +12,6 @@ use crate::{
     visibility::Visibility,
     ModuleDefId, ModuleId,
 };
-use rustc_hash::FxHashSet;
 
 // FIXME: handle local items
 

--- a/crates/ra_hir_def/src/find_path.rs
+++ b/crates/ra_hir_def/src/find_path.rs
@@ -37,7 +37,7 @@ impl ModPath {
     }
 }
 
-pub(crate) fn find_path_inner(
+fn find_path_inner(
     db: &dyn DefDatabase,
     item: ItemInNs,
     from: ModuleId,

--- a/crates/ra_hir_def/src/import_map.rs
+++ b/crates/ra_hir_def/src/import_map.rs
@@ -78,7 +78,9 @@ impl ImportMap {
                         }
                     }
 
-                    // If we've just added a path to a module, descend into it.
+                    // If we've just added a path to a module, descend into it. We might traverse
+                    // modules multiple times, but only if the new path to it is shorter than the
+                    // first (else we `continue` above).
                     if let Some(ModuleDefId::ModuleId(mod_id)) = item.as_module_def_id() {
                         worklist.push((mod_id, mk_path()));
                     }

--- a/crates/ra_hir_def/src/import_map.rs
+++ b/crates/ra_hir_def/src/import_map.rs
@@ -1,5 +1,10 @@
 //! A map of all publicly exported items in a crate.
 
+use std::{collections::hash_map::Entry, sync::Arc};
+
+use ra_db::CrateId;
+use rustc_hash::FxHashMap;
+
 use crate::{
     db::DefDatabase,
     item_scope::ItemInNs,
@@ -7,9 +12,6 @@ use crate::{
     visibility::Visibility,
     ModuleDefId, ModuleId,
 };
-use ra_db::CrateId;
-use rustc_hash::FxHashMap;
-use std::{collections::hash_map::Entry, sync::Arc};
 
 /// A map from publicly exported items to the path needed to import/name them from a downstream
 /// crate.

--- a/crates/ra_hir_def/src/import_map.rs
+++ b/crates/ra_hir_def/src/import_map.rs
@@ -281,7 +281,7 @@ mod tests {
 
     #[test]
     fn cyclic_module_reexport() {
-        // Reexporting modules from a dependency adds all contents to the import map.
+        // A cyclic reexport does not hang.
         let map = import_map(
             r"
             //- /lib.rs crate:lib

--- a/crates/ra_hir_def/src/import_map.rs
+++ b/crates/ra_hir_def/src/import_map.rs
@@ -1,0 +1,323 @@
+//! A map of all publicly exported items in a crate.
+
+use crate::{
+    db::DefDatabase,
+    item_scope::ItemInNs,
+    path::{ModPath, PathKind},
+    visibility::Visibility,
+    ModuleDefId, ModuleId,
+};
+use ra_db::CrateId;
+use rustc_hash::FxHashMap;
+use std::{collections::hash_map::Entry, sync::Arc};
+
+/// A map from publicly exported items to the path needed to import/name them from a downstream
+/// crate.
+///
+/// Reexports of items are taken into account, ie. if something is exported under multiple
+/// names, the one with the shortest import path will be used.
+///
+/// Note that all paths are relative to the containing crate's root, so the crate name still needs
+/// to be prepended to the `ModPath` before the path is valid.
+#[derive(Debug, Eq, PartialEq)]
+pub struct ImportMap {
+    map: FxHashMap<ItemInNs, ModPath>,
+}
+
+impl ImportMap {
+    pub fn import_map_query(db: &dyn DefDatabase, krate: CrateId) -> Arc<Self> {
+        let _p = ra_prof::profile("import_map_query");
+        let def_map = db.crate_def_map(krate);
+        let mut import_map = FxHashMap::with_capacity_and_hasher(64, Default::default());
+
+        // We look only into modules that are public(ly reexported), starting with the crate root.
+        let empty = ModPath { kind: PathKind::Plain, segments: vec![] };
+        let root = ModuleId { krate, local_id: def_map.root };
+        let mut worklist = vec![(root, empty)];
+        while let Some((module, mod_path)) = worklist.pop() {
+            let ext_def_map;
+            let mod_data = if module.krate == krate {
+                &def_map[module.local_id]
+            } else {
+                // The crate might reexport a module defined in another crate.
+                ext_def_map = db.crate_def_map(module.krate);
+                &ext_def_map[module.local_id]
+            };
+
+            let visible_items = mod_data.scope.entries().filter_map(|(name, per_ns)| {
+                let per_ns = per_ns.filter_visibility(|vis| vis == Visibility::Public);
+                if per_ns.is_none() {
+                    None
+                } else {
+                    Some((name, per_ns))
+                }
+            });
+
+            for (name, per_ns) in visible_items {
+                let mk_path = || {
+                    let mut path = mod_path.clone();
+                    path.segments.push(name.clone());
+                    path
+                };
+
+                for item in per_ns.iter_items() {
+                    let path = mk_path();
+                    match import_map.entry(item) {
+                        Entry::Vacant(entry) => {
+                            entry.insert(path);
+                        }
+                        Entry::Occupied(mut entry) => {
+                            // If the new path is shorter, prefer that one.
+                            if path.len() < entry.get().len() {
+                                *entry.get_mut() = path;
+                            } else {
+                                continue;
+                            }
+                        }
+                    }
+
+                    // If we've just added a path to a module, descend into it.
+                    if let Some(ModuleDefId::ModuleId(mod_id)) = item.as_module_def_id() {
+                        worklist.push((mod_id, mk_path()));
+                    }
+                }
+            }
+        }
+
+        Arc::new(Self { map: import_map })
+    }
+
+    /// Returns the `ModPath` needed to import/mention `item`, relative to this crate's root.
+    pub fn path_of(&self, item: ItemInNs) -> Option<&ModPath> {
+        self.map.get(&item)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_db::TestDB;
+    use insta::assert_snapshot;
+    use ra_db::fixture::WithFixture;
+    use ra_db::SourceDatabase;
+
+    fn import_map(ra_fixture: &str) -> String {
+        let db = TestDB::with_files(ra_fixture);
+        let crate_graph = db.crate_graph();
+
+        let import_maps: Vec<_> = crate_graph
+            .iter()
+            .filter_map(|krate| {
+                let cdata = &crate_graph[krate];
+                let name = cdata.display_name.as_ref()?;
+
+                let map = db.import_map(krate);
+
+                let mut importable_paths: Vec<_> = map
+                    .map
+                    .iter()
+                    .map(|(item, modpath)| {
+                        let ns = match item {
+                            ItemInNs::Types(_) => "t",
+                            ItemInNs::Values(_) => "v",
+                            ItemInNs::Macros(_) => "m",
+                        };
+                        format!("- {} ({})", modpath, ns)
+                    })
+                    .collect();
+
+                importable_paths.sort();
+                let importable_paths = importable_paths.join("\n");
+
+                Some(format!("{}:\n{}", name, importable_paths))
+            })
+            .collect();
+
+        import_maps.join("\n")
+    }
+
+    #[test]
+    fn smoke() {
+        let map = import_map(
+            r"
+            //- /main.rs crate:main deps:lib
+
+            mod private {
+                pub use lib::Pub;
+                pub struct InPrivateModule;
+            }
+
+            pub mod publ1 {
+                use lib::Pub;
+            }
+
+            pub mod real_pub {
+                pub use lib::Pub;
+            }
+            pub mod real_pu2 { // same path length as above
+                pub use lib::Pub;
+            }
+
+            //- /lib.rs crate:lib
+            pub struct Pub {}
+            pub struct Pub2; // t + v
+            struct Priv;
+        ",
+        );
+
+        assert_snapshot!(map, @r###"
+        main:
+        - publ1 (t)
+        - real_pu2 (t)
+        - real_pub (t)
+        - real_pub::Pub (t)
+        lib:
+        - Pub (t)
+        - Pub2 (t)
+        - Pub2 (v)
+        "###);
+    }
+
+    #[test]
+    fn prefers_shortest_path() {
+        let map = import_map(
+            r"
+            //- /main.rs crate:main
+
+            pub mod sub {
+                pub mod subsub {
+                    pub struct Def {}
+                }
+
+                pub use super::sub::subsub::Def;
+            }
+        ",
+        );
+
+        assert_snapshot!(map, @r###"
+        main:
+        - sub (t)
+        - sub::Def (t)
+        - sub::subsub (t)
+        "###);
+    }
+
+    #[test]
+    fn type_reexport_cross_crate() {
+        // Reexports need to be visible from a crate, even if the original crate exports the item
+        // at a shorter path.
+        let map = import_map(
+            r"
+            //- /main.rs crate:main deps:lib
+            pub mod m {
+                pub use lib::S;
+            }
+            //- /lib.rs crate:lib
+            pub struct S;
+        ",
+        );
+
+        assert_snapshot!(map, @r###"
+        main:
+        - m (t)
+        - m::S (t)
+        - m::S (v)
+        lib:
+        - S (t)
+        - S (v)
+        "###);
+    }
+
+    #[test]
+    fn macro_reexport() {
+        let map = import_map(
+            r"
+            //- /main.rs crate:main deps:lib
+            pub mod m {
+                pub use lib::pub_macro;
+            }
+            //- /lib.rs crate:lib
+            #[macro_export]
+            macro_rules! pub_macro {
+                () => {};
+            }
+        ",
+        );
+
+        assert_snapshot!(map, @r###"
+        main:
+        - m (t)
+        - m::pub_macro (m)
+        lib:
+        - pub_macro (m)
+        "###);
+    }
+
+    #[test]
+    fn module_reexport() {
+        // Reexporting modules from a dependency adds all contents to the import map.
+        let map = import_map(
+            r"
+            //- /main.rs crate:main deps:lib
+            pub use lib::module as reexported_module;
+            //- /lib.rs crate:lib
+            pub mod module {
+                pub struct S;
+            }
+        ",
+        );
+
+        assert_snapshot!(map, @r###"
+        main:
+        - reexported_module (t)
+        - reexported_module::S (t)
+        - reexported_module::S (v)
+        lib:
+        - module (t)
+        - module::S (t)
+        - module::S (v)
+        "###);
+    }
+
+    #[test]
+    fn cyclic_module_reexport() {
+        // Reexporting modules from a dependency adds all contents to the import map.
+        let map = import_map(
+            r"
+            //- /lib.rs crate:lib
+            pub mod module {
+                pub struct S;
+                pub use super::sub::*;
+            }
+
+            pub mod sub {
+                pub use super::module;
+            }
+        ",
+        );
+
+        assert_snapshot!(map, @r###"
+        lib:
+        - module (t)
+        - module::S (t)
+        - module::S (v)
+        - sub (t)
+        "###);
+    }
+
+    #[test]
+    fn private_macro() {
+        let map = import_map(
+            r"
+            //- /lib.rs crate:lib
+            macro_rules! private_macro {
+                () => {};
+            }
+        ",
+        );
+
+        assert_snapshot!(map, @r###"
+        lib:
+        "###);
+    }
+}

--- a/crates/ra_hir_def/src/item_scope.rs
+++ b/crates/ra_hir_def/src/item_scope.rs
@@ -205,7 +205,8 @@ impl ItemInNs {
         }
     }
 
-    pub fn defining_crate(&self, db: &dyn DefDatabase) -> Option<CrateId> {
+    /// Returns the crate defining this item (or `None` if `self` is built-in).
+    pub fn krate(&self, db: &dyn DefDatabase) -> Option<CrateId> {
         Some(match self {
             ItemInNs::Types(did) | ItemInNs::Values(did) => match did {
                 ModuleDefId::ModuleId(id) => id.krate,

--- a/crates/ra_hir_def/src/item_scope.rs
+++ b/crates/ra_hir_def/src/item_scope.rs
@@ -3,13 +3,13 @@
 
 use hir_expand::name::Name;
 use once_cell::sync::Lazy;
+use ra_db::CrateId;
 use rustc_hash::FxHashMap;
 
 use crate::{
     db::DefDatabase, per_ns::PerNs, visibility::Visibility, AdtId, BuiltinType, HasModule, ImplId,
     Lookup, MacroDefId, ModuleDefId, TraitId,
 };
-use ra_db::CrateId;
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct ItemScope {

--- a/crates/ra_hir_def/src/lib.rs
+++ b/crates/ra_hir_def/src/lib.rs
@@ -43,6 +43,7 @@ pub mod child_by_source;
 
 pub mod visibility;
 pub mod find_path;
+pub mod import_map;
 
 #[cfg(test)]
 mod test_db;

--- a/crates/ra_hir_def/src/path.rs
+++ b/crates/ra_hir_def/src/path.rs
@@ -76,6 +76,19 @@ impl ModPath {
         }
     }
 
+    /// Returns the number of segments in the path (counting special segments like `$crate` and
+    /// `super`).
+    pub fn len(&self) -> usize {
+        self.segments.len()
+            + match self.kind {
+                PathKind::Plain => 0,
+                PathKind::Super(i) => i as usize,
+                PathKind::Crate => 1,
+                PathKind::Abs => 0,
+                PathKind::DollarCrate(_) => 1,
+            }
+    }
+
     pub fn is_ident(&self) -> bool {
         self.kind == PathKind::Plain && self.segments.len() == 1
     }

--- a/crates/ra_hir_def/src/per_ns.rs
+++ b/crates/ra_hir_def/src/per_ns.rs
@@ -5,7 +5,7 @@
 
 use hir_expand::MacroDefId;
 
-use crate::{visibility::Visibility, ModuleDefId};
+use crate::{item_scope::ItemInNs, visibility::Visibility, ModuleDefId};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct PerNs {
@@ -83,5 +83,13 @@ impl PerNs {
             values: self.values.or(other.values),
             macros: self.macros.or(other.macros),
         }
+    }
+
+    pub fn iter_items(self) -> impl Iterator<Item = ItemInNs> {
+        self.types
+            .map(|it| ItemInNs::Types(it.0))
+            .into_iter()
+            .chain(self.values.map(|it| ItemInNs::Values(it.0)).into_iter())
+            .chain(self.macros.map(|it| ItemInNs::Macros(it.0)).into_iter())
     }
 }

--- a/crates/ra_ide_db/src/change.rs
+++ b/crates/ra_ide_db/src/change.rs
@@ -334,6 +334,7 @@ impl RootDatabase {
             hir::db::CrateLangItemsQuery
             hir::db::LangItemQuery
             hir::db::DocumentationQuery
+            hir::db::ImportMapQuery
 
             // InternDatabase
             hir::db::InternFunctionQuery


### PR DESCRIPTION
Removes the "go faster" queries I added in https://github.com/rust-analyzer/rust-analyzer/pull/4501 and https://github.com/rust-analyzer/rust-analyzer/pull/4506. I've checked this PR on the rustc code base and the assists are still fast.

This should fix https://github.com/rust-analyzer/rust-analyzer/issues/4515.

Note that this does introduce a change in behavior: We now always refer to items defined in external crates using paths through the external crate. Previously we could also use a local path (if for example the extern crate was reexported locally), as seen in the changed test. If that is undesired I can fix that, but the test didn't say why the previous behavior would be preferable.