### PR TITLE
Fix type parameter defaults

### DIFF
--- a/crates/ra_assists/src/handlers/add_explicit_type.rs
+++ b/crates/ra_assists/src/handlers/add_explicit_type.rs
@@ -195,7 +195,7 @@ struct Test<K, T = u8> {
 }
 
 fn main() {
-    let test<|> = Test { t: 23, k: 33 };
+    let test<|> = Test { t: 23u8, k: 33 };
 }"#,
             r#"
 struct Test<K, T = u8> {
@@ -204,7 +204,7 @@ struct Test<K, T = u8> {
 }
 
 fn main() {
-    let test: Test<i32> = Test { t: 23, k: 33 };
+    let test: Test<i32> = Test { t: 23u8, k: 33 };
 }"#,
         );
     }

--- a/crates/ra_hir_ty/src/infer.rs
+++ b/crates/ra_hir_ty/src/infer.rs
@@ -439,13 +439,13 @@ impl<'a> InferenceContext<'a> {
             };
         return match resolution {
             TypeNs::AdtId(AdtId::StructId(strukt)) => {
-                let substs = Ty::substs_from_path(&ctx, path, strukt.into());
+                let substs = Ty::substs_from_path(&ctx, path, strukt.into(), true);
                 let ty = self.db.ty(strukt.into());
                 let ty = self.insert_type_vars(ty.subst(&substs));
                 forbid_unresolved_segments((ty, Some(strukt.into())), unresolved)
             }
             TypeNs::EnumVariantId(var) => {
-                let substs = Ty::substs_from_path(&ctx, path, var.into());
+                let substs = Ty::substs_from_path(&ctx, path, var.into(), true);
                 let ty = self.db.ty(var.parent.into());
                 let ty = self.insert_type_vars(ty.subst(&substs));
                 forbid_unresolved_segments((ty, Some(var.into())), unresolved)

--- a/crates/ra_hir_ty/src/infer/path.rs
+++ b/crates/ra_hir_ty/src/infer/path.rs
@@ -95,7 +95,7 @@ impl<'a> InferenceContext<'a> {
         // self_subst is just for the parent
         let parent_substs = self_subst.unwrap_or_else(Substs::empty);
         let ctx = crate::lower::TyLoweringContext::new(self.db, &self.resolver);
-        let substs = Ty::substs_from_path(&ctx, path, typable);
+        let substs = Ty::substs_from_path(&ctx, path, typable, true);
         let full_substs = Substs::builder(substs.len())
             .use_parent_substs(&parent_substs)
             .fill(substs.0[parent_substs.len()..].iter().cloned())
@@ -141,6 +141,7 @@ impl<'a> InferenceContext<'a> {
                     def,
                     resolved_segment,
                     remaining_segments_for_ty,
+                    true,
                 );
                 if let Ty::Unknown = ty {
                     return None;

--- a/crates/ra_hir_ty/src/tests/display_source_code.rs
+++ b/crates/ra_hir_ty/src/tests/display_source_code.rs
@@ -29,7 +29,7 @@ fn omit_default_type_parameters() {
         //- /main.rs
         struct Foo<T = u8> { t: T }
         fn main() {
-            let foo = Foo { t: 5 };
+            let foo = Foo { t: 5u8 };
             foo<|>;
         }
         ",
@@ -41,7 +41,7 @@ fn omit_default_type_parameters() {
         //- /main.rs
         struct Foo<K, T = u8> { k: K, t: T }
         fn main() {
-            let foo = Foo { k: 400, t: 5 };
+            let foo = Foo { k: 400, t: 5u8 };
             foo<|>;
         }
         ",

--- a/crates/ra_hir_ty/src/tests/method_resolution.rs
+++ b/crates/ra_hir_ty/src/tests/method_resolution.rs
@@ -184,60 +184,6 @@ fn test() {
 }
 
 #[test]
-fn infer_associated_method_generics_with_default_param() {
-    assert_snapshot!(
-        infer(r#"
-struct Gen<T=u32> {
-    val: T
-}
-
-impl<T> Gen<T> {
-    pub fn make() -> Gen<T> {
-        loop { }
-    }
-}
-
-fn test() {
-    let a = Gen::make();
-}
-"#),
-        @r###"
-    80..104 '{     ...     }': Gen<T>
-    90..98 'loop { }': !
-    95..98 '{ }': ()
-    118..146 '{     ...e(); }': ()
-    128..129 'a': Gen<u32>
-    132..141 'Gen::make': fn make<u32>() -> Gen<u32>
-    132..143 'Gen::make()': Gen<u32>
-    "###
-    );
-}
-
-#[test]
-fn infer_associated_method_generics_with_default_tuple_param() {
-    let t = type_at(
-        r#"
-//- /main.rs
-struct Gen<T=()> {
-    val: T
-}
-
-impl<T> Gen<T> {
-    pub fn make() -> Gen<T> {
-        loop { }
-    }
-}
-
-fn test() {
-    let a = Gen::make();
-    a.val<|>;
-}
-"#,
-    );
-    assert_eq!(t, "()");
-}
-
-#[test]
 fn infer_associated_method_generics_without_args() {
     assert_snapshot!(
         infer(r#"

--- a/crates/ra_hir_ty/src/tests/traits.rs
+++ b/crates/ra_hir_ty/src/tests/traits.rs
@@ -1806,33 +1806,33 @@ fn test() {
 }
 "#),
         @r###"
-65..69 'self': &Self
-166..170 'self': Self
-172..176 'args': Args
-240..244 'self': &Foo
-255..257 '{}': ()
-335..336 'f': F
-355..357 '{}': ()
-444..690 '{     ...o(); }': ()
-454..459 'lazy1': Lazy<Foo, fn() -> T>
-476..485 'Lazy::new': fn new<Foo, fn() -> T>(fn() -> T) -> Lazy<Foo, fn() -> T>
-476..493 'Lazy::...| Foo)': Lazy<Foo, fn() -> T>
-486..492 '|| Foo': || -> T
-489..492 'Foo': Foo
-503..505 'r1': {unknown}
-508..513 'lazy1': Lazy<Foo, fn() -> T>
-508..519 'lazy1.foo()': {unknown}
-561..576 'make_foo_fn_ptr': fn() -> Foo
-592..603 'make_foo_fn': fn make_foo_fn() -> Foo
-613..618 'lazy2': Lazy<Foo, fn() -> T>
-635..644 'Lazy::new': fn new<Foo, fn() -> T>(fn() -> T) -> Lazy<Foo, fn() -> T>
-635..661 'Lazy::...n_ptr)': Lazy<Foo, fn() -> T>
-645..660 'make_foo_fn_ptr': fn() -> Foo
-671..673 'r2': {unknown}
-676..681 'lazy2': Lazy<Foo, fn() -> T>
-676..687 'lazy2.foo()': {unknown}
-550..552 '{}': ()
-"###
+    65..69 'self': &Self
+    166..170 'self': Self
+    172..176 'args': Args
+    240..244 'self': &Foo
+    255..257 '{}': ()
+    335..336 'f': F
+    355..357 '{}': ()
+    444..690 '{     ...o(); }': ()
+    454..459 'lazy1': Lazy<Foo, || -> Foo>
+    476..485 'Lazy::new': fn new<Foo, || -> Foo>(|| -> Foo) -> Lazy<Foo, || -> Foo>
+    476..493 'Lazy::...| Foo)': Lazy<Foo, || -> Foo>
+    486..492 '|| Foo': || -> Foo
+    489..492 'Foo': Foo
+    503..505 'r1': usize
+    508..513 'lazy1': Lazy<Foo, || -> Foo>
+    508..519 'lazy1.foo()': usize
+    561..576 'make_foo_fn_ptr': fn() -> Foo
+    592..603 'make_foo_fn': fn make_foo_fn() -> Foo
+    613..618 'lazy2': Lazy<Foo, fn() -> Foo>
+    635..644 'Lazy::new': fn new<Foo, fn() -> Foo>(fn() -> Foo) -> Lazy<Foo, fn() -> Foo>
+    635..661 'Lazy::...n_ptr)': Lazy<Foo, fn() -> Foo>
+    645..660 'make_foo_fn_ptr': fn() -> Foo
+    671..673 'r2': {unknown}
+    676..681 'lazy2': Lazy<Foo, fn() -> Foo>
+    676..687 'lazy2.foo()': {unknown}
+    550..552 '{}': ()
+    "###
     );
 }
 

--- a/crates/ra_ide/src/hover.rs
+++ b/crates/ra_ide/src/hover.rs
@@ -529,7 +529,7 @@ struct Test<K, T = u8> {
 }
 
 fn main() {
-    let zz<|> = Test { t: 23, k: 33 };
+    let zz<|> = Test { t: 23u8, k: 33 };
 }"#,
             &["Test<i32, u8>"],
         );

--- a/crates/ra_ide/src/inlay_hints.rs
+++ b/crates/ra_ide/src/inlay_hints.rs
@@ -415,7 +415,7 @@ struct Test<K, T = u8> {
 }
 
 fn main() {
-    let zz = Test { t: 23, k: 33 };
+    let zz = Test { t: 23u8, k: 33 };
     let zz_ref = &zz;
 }"#,
         );
@@ -428,7 +428,7 @@ fn main() {
                 label: "Test<i32>",
             },
             InlayHint {
-                range: 105..111,
+                range: 107..113,
                 kind: TypeHint,
                 label: "&Test<i32>",
             },


### PR DESCRIPTION
They should not be applied in expression or pattern contexts, unless there are other explicitly given type args.

(The existing tests about this were actually wrong.)