### PR TITLE
Fix Run lens.

### DIFF
--- a/editors/code/src/run.ts
+++ b/editors/code/src/run.ts
@@ -110,7 +110,7 @@ export function createTask(runnable: ra.Runnable): vscode.Task {
     switch (runnable.kind) {
         case "cargo": command = toolchain.getPathForExecutable("cargo");
     }
-    const args = runnable.args.cargoArgs;
+    const args = [...runnable.args.cargoArgs]; // should be a copy!
     if (runnable.args.executableArgs.length > 0) {
         args.push('--', ...runnable.args.executableArgs);
     }


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/rust-analyzer/rust-analyzer/pull/4710: second and all subsequent clicks on the Run lens produce invalid commands:

1. `cargo test --package ra_ide --lib -- hover::tests::test_hover_enum_has_impl_action --exact --nocapture`
2. `cargo test --package ra_ide --lib -- hover::tests::test_hover_enum_has_impl_action --exact --nocapture` **`-- hover::tests::test_hover_enum_has_impl_action --exact --nocapture`**
3. `cargo test --package ra_ide --lib -- hover::tests::test_hover_enum_has_impl_action --exact --nocapture` **`-- hover::tests::test_hover_enum_has_impl_action --exact --nocapture -- hover::tests::test_hover_enum_has_impl_action --exact --nocapture`**