### PR TITLE
Clean up handling of int/float literal types

### DIFF
--- a/crates/ra_hir_ty/src/infer.rs
+++ b/crates/ra_hir_ty/src/infer.rs
@@ -39,8 +39,7 @@ use ra_syntax::SmolStr;
 use super::{
     primitive::{FloatTy, IntTy},
     traits::{Guidance, Obligation, ProjectionPredicate, Solution},
-    ApplicationTy, InEnvironment, ProjectionTy, Substs, TraitEnvironment, TraitRef, Ty, TypeCtor,
-    TypeWalk, Uncertain,
+    InEnvironment, ProjectionTy, Substs, TraitEnvironment, TraitRef, Ty, TypeCtor, TypeWalk,
 };
 use crate::{
     db::HirDatabase, infer::diagnostics::InferenceDiagnostic, lower::ImplTraitLoweringMode,
@@ -312,12 +311,6 @@ impl<'a> InferenceContext<'a> {
     fn insert_type_vars_shallow(&mut self, ty: Ty) -> Ty {
         match ty {
             Ty::Unknown => self.table.new_type_var(),
-            Ty::Apply(ApplicationTy { ctor: TypeCtor::Int(Uncertain::Unknown), .. }) => {
-                self.table.new_integer_var()
-            }
-            Ty::Apply(ApplicationTy { ctor: TypeCtor::Float(Uncertain::Unknown), .. }) => {
-                self.table.new_float_var()
-            }
             _ => ty,
         }
     }
@@ -664,8 +657,8 @@ impl InferTy {
     fn fallback_value(self) -> Ty {
         match self {
             InferTy::TypeVar(..) => Ty::Unknown,
-            InferTy::IntVar(..) => Ty::simple(TypeCtor::Int(Uncertain::Known(IntTy::i32()))),
-            InferTy::FloatVar(..) => Ty::simple(TypeCtor::Float(Uncertain::Known(FloatTy::f64()))),
+            InferTy::IntVar(..) => Ty::simple(TypeCtor::Int(IntTy::i32())),
+            InferTy::FloatVar(..) => Ty::simple(TypeCtor::Float(FloatTy::f64())),
             InferTy::MaybeNeverTypeVar(..) => Ty::simple(TypeCtor::Never),
         }
     }

--- a/crates/ra_hir_ty/src/lib.rs
+++ b/crates/ra_hir_ty/src/lib.rs
@@ -58,7 +58,7 @@ use ra_db::{impl_intern_key, salsa, CrateId};
 
 use crate::{
     db::HirDatabase,
-    primitive::{FloatTy, IntTy, Uncertain},
+    primitive::{FloatTy, IntTy},
     utils::{generics, make_mut_slice, Generics},
 };
 use display::HirDisplay;
@@ -87,10 +87,10 @@ pub enum TypeCtor {
     Char,
 
     /// A primitive integer type. For example, `i32`.
-    Int(Uncertain<IntTy>),
+    Int(IntTy),
 
     /// A primitive floating-point type. For example, `f64`.
-    Float(Uncertain<FloatTy>),
+    Float(FloatTy),
 
     /// Structures, enumerations and unions.
     Adt(AdtId),

--- a/crates/ra_hir_ty/src/method_resolution.rs
+++ b/crates/ra_hir_ty/src/method_resolution.rs
@@ -16,12 +16,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::Substs;
 use crate::{
-    autoderef,
-    db::HirDatabase,
-    primitive::{FloatBitness, Uncertain},
-    utils::all_super_traits,
-    ApplicationTy, Canonical, DebruijnIndex, InEnvironment, TraitEnvironment, TraitRef, Ty,
-    TypeCtor, TypeWalk,
+    autoderef, db::HirDatabase, primitive::FloatBitness, utils::all_super_traits, ApplicationTy,
+    Canonical, DebruijnIndex, InEnvironment, TraitEnvironment, TraitRef, Ty, TypeCtor, TypeWalk,
 };
 
 /// This is used as a key for indexing impls.
@@ -147,12 +143,12 @@ impl Ty {
                 }
                 TypeCtor::Bool => lang_item_crate!("bool"),
                 TypeCtor::Char => lang_item_crate!("char"),
-                TypeCtor::Float(Uncertain::Known(f)) => match f.bitness {
+                TypeCtor::Float(f) => match f.bitness {
                     // There are two lang items: one in libcore (fXX) and one in libstd (fXX_runtime)
                     FloatBitness::X32 => lang_item_crate!("f32", "f32_runtime"),
                     FloatBitness::X64 => lang_item_crate!("f64", "f64_runtime"),
                 },
-                TypeCtor::Int(Uncertain::Known(i)) => lang_item_crate!(i.ty_to_string()),
+                TypeCtor::Int(i) => lang_item_crate!(i.ty_to_string()),
                 TypeCtor::Str => lang_item_crate!("str_alloc", "str"),
                 TypeCtor::Slice => lang_item_crate!("slice_alloc", "slice"),
                 TypeCtor::RawPtr(Mutability::Shared) => lang_item_crate!("const_ptr"),

--- a/crates/ra_hir_ty/src/primitive.rs
+++ b/crates/ra_hir_ty/src/primitive.rs
@@ -7,42 +7,6 @@ use std::fmt;
 
 pub use hir_def::builtin_type::{BuiltinFloat, BuiltinInt, FloatBitness, IntBitness, Signedness};
 
-#[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
-pub enum Uncertain<T> {
-    Unknown,
-    Known(T),
-}
-
-impl From<IntTy> for Uncertain<IntTy> {
-    fn from(ty: IntTy) -> Self {
-        Uncertain::Known(ty)
-    }
-}
-
-impl fmt::Display for Uncertain<IntTy> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Uncertain::Unknown => write!(f, "{{integer}}"),
-            Uncertain::Known(ty) => write!(f, "{}", ty),
-        }
-    }
-}
-
-impl From<FloatTy> for Uncertain<FloatTy> {
-    fn from(ty: FloatTy) -> Self {
-        Uncertain::Known(ty)
-    }
-}
-
-impl fmt::Display for Uncertain<FloatTy> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Uncertain::Unknown => write!(f, "{{float}}"),
-            Uncertain::Known(ty) => write!(f, "{}", ty),
-        }
-    }
-}
-
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct IntTy {
     pub signedness: Signedness,
@@ -171,23 +135,5 @@ impl From<BuiltinInt> for IntTy {
 impl From<BuiltinFloat> for FloatTy {
     fn from(t: BuiltinFloat) -> Self {
         FloatTy { bitness: t.bitness }
-    }
-}
-
-impl From<Option<BuiltinInt>> for Uncertain<IntTy> {
-    fn from(t: Option<BuiltinInt>) -> Self {
-        match t {
-            None => Uncertain::Unknown,
-            Some(t) => Uncertain::Known(t.into()),
-        }
-    }
-}
-
-impl From<Option<BuiltinFloat>> for Uncertain<FloatTy> {
-    fn from(t: Option<BuiltinFloat>) -> Self {
-        match t {
-            None => Uncertain::Unknown,
-            Some(t) => Uncertain::Known(t.into()),
-        }
     }
 }

--- a/crates/ra_hir_ty/src/traits/chalk/mapping.rs
+++ b/crates/ra_hir_ty/src/traits/chalk/mapping.rs
@@ -14,7 +14,7 @@ use ra_db::salsa::InternKey;
 
 use crate::{
     db::HirDatabase,
-    primitive::{FloatBitness, FloatTy, IntBitness, IntTy, Signedness, Uncertain},
+    primitive::{FloatBitness, FloatTy, IntBitness, IntTy, Signedness},
     traits::{builtin, AssocTyValue, Canonical, Impl, Obligation},
     ApplicationTy, CallableDef, GenericPredicate, InEnvironment, OpaqueTy, OpaqueTyId,
     ProjectionPredicate, ProjectionTy, Substs, TraitEnvironment, TraitRef, Ty, TypeCtor,
@@ -249,11 +249,11 @@ impl ToChalk for TypeCtor {
 
             TypeCtor::Bool => TypeName::Scalar(Scalar::Bool),
             TypeCtor::Char => TypeName::Scalar(Scalar::Char),
-            TypeCtor::Int(Uncertain::Known(int_ty)) => TypeName::Scalar(int_ty_to_chalk(int_ty)),
-            TypeCtor::Float(Uncertain::Known(FloatTy { bitness: FloatBitness::X32 })) => {
+            TypeCtor::Int(int_ty) => TypeName::Scalar(int_ty_to_chalk(int_ty)),
+            TypeCtor::Float(FloatTy { bitness: FloatBitness::X32 }) => {
                 TypeName::Scalar(Scalar::Float(chalk_ir::FloatTy::F32))
             }
-            TypeCtor::Float(Uncertain::Known(FloatTy { bitness: FloatBitness::X64 })) => {
+            TypeCtor::Float(FloatTy { bitness: FloatBitness::X64 }) => {
                 TypeName::Scalar(Scalar::Float(chalk_ir::FloatTy::F64))
             }
 
@@ -268,9 +268,7 @@ impl ToChalk for TypeCtor {
             }
             TypeCtor::Never => TypeName::Never,
 
-            TypeCtor::Int(Uncertain::Unknown)
-            | TypeCtor::Float(Uncertain::Unknown)
-            | TypeCtor::Adt(_)
+            TypeCtor::Adt(_)
             | TypeCtor::Array
             | TypeCtor::FnPtr { .. }
             | TypeCtor::Closure { .. } => {
@@ -291,19 +289,19 @@ impl ToChalk for TypeCtor {
 
             TypeName::Scalar(Scalar::Bool) => TypeCtor::Bool,
             TypeName::Scalar(Scalar::Char) => TypeCtor::Char,
-            TypeName::Scalar(Scalar::Int(int_ty)) => TypeCtor::Int(Uncertain::Known(IntTy {
+            TypeName::Scalar(Scalar::Int(int_ty)) => TypeCtor::Int(IntTy {
                 signedness: Signedness::Signed,
                 bitness: bitness_from_chalk_int(int_ty),
-            })),
-            TypeName::Scalar(Scalar::Uint(uint_ty)) => TypeCtor::Int(Uncertain::Known(IntTy {
+            }),
+            TypeName::Scalar(Scalar::Uint(uint_ty)) => TypeCtor::Int(IntTy {
                 signedness: Signedness::Unsigned,
                 bitness: bitness_from_chalk_uint(uint_ty),
-            })),
+            }),
             TypeName::Scalar(Scalar::Float(chalk_ir::FloatTy::F32)) => {
-                TypeCtor::Float(Uncertain::Known(FloatTy { bitness: FloatBitness::X32 }))
+                TypeCtor::Float(FloatTy { bitness: FloatBitness::X32 })
             }
             TypeName::Scalar(Scalar::Float(chalk_ir::FloatTy::F64)) => {
-                TypeCtor::Float(Uncertain::Known(FloatTy { bitness: FloatBitness::X64 }))
+                TypeCtor::Float(FloatTy { bitness: FloatBitness::X64 })
             }
             TypeName::Tuple(cardinality) => TypeCtor::Tuple { cardinality: cardinality as u16 },
             TypeName::Raw(mutability) => TypeCtor::RawPtr(from_chalk(db, mutability)),


### PR DESCRIPTION
'Unknown' int/float types actually never exist as such, they get replaced by type variables immediately. So the whole `Uncertain<IntTy>` thing was unnecessary and just led to a bunch of match branches that were never hit.