### PR TITLE
Fix VSCode settings

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -487,10 +487,7 @@
                     "default": true
                 },
                 "rust-analyzer.linkedProjects": {
-                    "markdownDescription": [
-                        "Disable project auto-discovery in favor of explicitly specified set of projects.",
-                        "Elements must be paths pointing to Cargo.toml, rust-project.json, or JSON objects in rust-project.json format"
-                    ],
+                    "markdownDescription": "Disable project auto-discovery in favor of explicitly specified set of projects.  \nElements must be paths pointing to Cargo.toml, rust-project.json, or JSON objects in rust-project.json format",
                     "type": "array",
                     "items": {
                         "type": [


### PR DESCRIPTION
closes #4779

#4779 was reproducing every time, so doing a bisect I found out the problem to be coming from #4730.
The only change to the extension that #4730 included was changes to editors/code/package.json.
So I tried modifying those changes a bit and got it working.