### PR TITLE
Correct "debug_assertion" to "debug_assertions" to match the cfg that the rust debug assert macros use.

### DIFF
--- a/crates/ra_project_model/src/lib.rs
+++ b/crates/ra_project_model/src/lib.rs
@@ -600,7 +600,7 @@ fn get_rustc_cfg_options(target: Option<&str>) -> CfgOptions {
         Err(e) => log::error!("failed to get rustc cfgs: {:#}", e),
     }
 
-    cfg_options.insert_atom("debug_assertion".into());
+    cfg_options.insert_atom("debug_assertions".into());
 
     cfg_options
 }


### PR DESCRIPTION
This is for #4823.