### PR TITLE
Make known paths use `core` instead of `std`

### DIFF
--- a/crates/ra_hir_def/src/data.rs
+++ b/crates/ra_hir_def/src/data.rs
@@ -99,7 +99,7 @@ impl FunctionData {
 }
 
 fn desugar_future_path(orig: TypeRef) -> Path {
-    let path = path![std::future::Future];
+    let path = path![core::future::Future];
     let mut generic_args: Vec<_> = std::iter::repeat(None).take(path.segments.len() - 1).collect();
     let mut last = GenericArgs::empty();
     last.bindings.push(AssociatedTypeBinding {

--- a/crates/ra_hir_def/src/path.rs
+++ b/crates/ra_hir_def/src/path.rs
@@ -323,16 +323,16 @@ pub use hir_expand::name as __name;
 
 #[macro_export]
 macro_rules! __known_path {
-    (std::iter::IntoIterator) => {};
-    (std::result::Result) => {};
-    (std::ops::Range) => {};
-    (std::ops::RangeFrom) => {};
-    (std::ops::RangeFull) => {};
-    (std::ops::RangeTo) => {};
-    (std::ops::RangeToInclusive) => {};
-    (std::ops::RangeInclusive) => {};
-    (std::future::Future) => {};
-    (std::ops::Try) => {};
+    (core::iter::IntoIterator) => {};
+    (core::result::Result) => {};
+    (core::ops::Range) => {};
+    (core::ops::RangeFrom) => {};
+    (core::ops::RangeFull) => {};
+    (core::ops::RangeTo) => {};
+    (core::ops::RangeToInclusive) => {};
+    (core::ops::RangeInclusive) => {};
+    (core::future::Future) => {};
+    (core::ops::Try) => {};
     ($path:path) => {
         compile_error!("Please register your known path in the path module")
     };

--- a/crates/ra_hir_ty/src/expr.rs
+++ b/crates/ra_hir_ty/src/expr.rs
@@ -226,17 +226,19 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
             None => return,
         };
 
-        let std_result_path = path![std::result::Result];
+        let core_result_path = path![core::result::Result];
 
         let resolver = self.func.resolver(db.upcast());
-        let std_result_enum = match resolver.resolve_known_enum(db.upcast(), &std_result_path) {
+        let core_result_enum = match resolver.resolve_known_enum(db.upcast(), &core_result_path) {
             Some(it) => it,
             _ => return,
         };
 
-        let std_result_ctor = TypeCtor::Adt(AdtId::EnumId(std_result_enum));
+        let core_result_ctor = TypeCtor::Adt(AdtId::EnumId(core_result_enum));
         let params = match &mismatch.expected {
-            Ty::Apply(ApplicationTy { ctor, parameters }) if ctor == &std_result_ctor => parameters,
+            Ty::Apply(ApplicationTy { ctor, parameters }) if ctor == &core_result_ctor => {
+                parameters
+            }
             _ => return,
         };
 

--- a/crates/ra_hir_ty/src/infer.rs
+++ b/crates/ra_hir_ty/src/infer.rs
@@ -555,13 +555,13 @@ impl<'a> InferenceContext<'a> {
     }
 
     fn resolve_into_iter_item(&self) -> Option<TypeAliasId> {
-        let path = path![std::iter::IntoIterator];
+        let path = path![core::iter::IntoIterator];
         let trait_ = self.resolver.resolve_known_trait(self.db.upcast(), &path)?;
         self.db.trait_data(trait_).associated_type_by_name(&name![Item])
     }
 
     fn resolve_ops_try_ok(&self) -> Option<TypeAliasId> {
-        let path = path![std::ops::Try];
+        let path = path![core::ops::Try];
         let trait_ = self.resolver.resolve_known_trait(self.db.upcast(), &path)?;
         self.db.trait_data(trait_).associated_type_by_name(&name![Ok])
     }
@@ -587,37 +587,37 @@ impl<'a> InferenceContext<'a> {
     }
 
     fn resolve_range_full(&self) -> Option<AdtId> {
-        let path = path![std::ops::RangeFull];
+        let path = path![core::ops::RangeFull];
         let struct_ = self.resolver.resolve_known_struct(self.db.upcast(), &path)?;
         Some(struct_.into())
     }
 
     fn resolve_range(&self) -> Option<AdtId> {
-        let path = path![std::ops::Range];
+        let path = path![core::ops::Range];
         let struct_ = self.resolver.resolve_known_struct(self.db.upcast(), &path)?;
         Some(struct_.into())
     }
 
     fn resolve_range_inclusive(&self) -> Option<AdtId> {
-        let path = path![std::ops::RangeInclusive];
+        let path = path![core::ops::RangeInclusive];
         let struct_ = self.resolver.resolve_known_struct(self.db.upcast(), &path)?;
         Some(struct_.into())
     }
 
     fn resolve_range_from(&self) -> Option<AdtId> {
-        let path = path![std::ops::RangeFrom];
+        let path = path![core::ops::RangeFrom];
         let struct_ = self.resolver.resolve_known_struct(self.db.upcast(), &path)?;
         Some(struct_.into())
     }
 
     fn resolve_range_to(&self) -> Option<AdtId> {
-        let path = path![std::ops::RangeTo];
+        let path = path![core::ops::RangeTo];
         let struct_ = self.resolver.resolve_known_struct(self.db.upcast(), &path)?;
         Some(struct_.into())
     }
 
     fn resolve_range_to_inclusive(&self) -> Option<AdtId> {
-        let path = path![std::ops::RangeToInclusive];
+        let path = path![core::ops::RangeToInclusive];
         let struct_ = self.resolver.resolve_known_struct(self.db.upcast(), &path)?;
         Some(struct_.into())
     }

--- a/crates/ra_hir_ty/src/tests/simple.rs
+++ b/crates/ra_hir_ty/src/tests/simple.rs
@@ -95,7 +95,7 @@ fn foo() {
 fn infer_ranges() {
     let (db, pos) = TestDB::with_position(
         r#"
-//- /main.rs crate:main deps:std
+//- /main.rs crate:main deps:core
 fn test() {
     let a = ..;
     let b = 1..;
@@ -108,7 +108,7 @@ fn test() {
     t<|>;
 }
 
-//- /std.rs crate:std
+//- /core.rs crate:core
 #[prelude_import] use prelude::*;
 mod prelude {}
 

--- a/crates/ra_hir_ty/src/tests/traits.rs
+++ b/crates/ra_hir_ty/src/tests/traits.rs
@@ -10,7 +10,7 @@ use super::{infer, infer_with_mismatches, type_at, type_at_pos};
 fn infer_await() {
     let (db, pos) = TestDB::with_position(
         r#"
-//- /main.rs crate:main deps:std
+//- /main.rs crate:main deps:core
 
 struct IntFuture;
 
@@ -24,7 +24,7 @@ fn test() {
     v<|>;
 }
 
-//- /std.rs crate:std
+//- /core.rs crate:core
 #[prelude_import] use future::*;
 mod future {
     #[lang = "future_trait"]
@@ -42,7 +42,7 @@ mod future {
 fn infer_async() {
     let (db, pos) = TestDB::with_position(
         r#"
-//- /main.rs crate:main deps:std
+//- /main.rs crate:main deps:core
 
 async fn foo() -> u64 {
     128
@@ -54,7 +54,7 @@ fn test() {
     v<|>;
 }
 
-//- /std.rs crate:std
+//- /core.rs crate:core
 #[prelude_import] use future::*;
 mod future {
     #[lang = "future_trait"]
@@ -72,7 +72,7 @@ mod future {
 fn infer_desugar_async() {
     let (db, pos) = TestDB::with_position(
         r#"
-//- /main.rs crate:main deps:std
+//- /main.rs crate:main deps:core
 
 async fn foo() -> u64 {
     128
@@ -83,7 +83,7 @@ fn test() {
     r<|>;
 }
 
-//- /std.rs crate:std
+//- /core.rs crate:core
 #[prelude_import] use future::*;
 mod future {
     trait Future {
@@ -100,7 +100,7 @@ mod future {
 fn infer_try() {
     let (db, pos) = TestDB::with_position(
         r#"
-//- /main.rs crate:main deps:std
+//- /main.rs crate:main deps:core
 
 fn test() {
     let r: Result<i32, u64> = Result::Ok(1);
@@ -108,7 +108,7 @@ fn test() {
     v<|>;
 }
 
-//- /std.rs crate:std
+//- /core.rs crate:core
 
 #[prelude_import] use ops::*;
 mod ops {
@@ -140,9 +140,9 @@ mod result {
 fn infer_for_loop() {
     let (db, pos) = TestDB::with_position(
         r#"
-//- /main.rs crate:main deps:std
+//- /main.rs crate:main deps:core,alloc
 
-use std::collections::Vec;
+use alloc::collections::Vec;
 
 fn test() {
     let v = Vec::new();
@@ -152,7 +152,7 @@ fn test() {
     }
 }
 
-//- /std.rs crate:std
+//- /core.rs crate:core
 
 #[prelude_import] use iter::*;
 mod iter {
@@ -161,6 +161,8 @@ mod iter {
     }
 }
 
+//- /alloc.rs crate:alloc deps:core
+
 mod collections {
     struct Vec<T> {}
     impl<T> Vec<T> {
@@ -168,7 +170,7 @@ mod collections {
         fn push(&mut self, t: T) { }
     }
 
-    impl<T> crate::iter::IntoIterator for Vec<T> {
+    impl<T> IntoIterator for Vec<T> {
         type Item=T;
     }
 }
@@ -2846,12 +2848,12 @@ fn test() {
 fn integer_range_iterate() {
     let t = type_at(
         r#"
-//- /main.rs crate:main deps:std
+//- /main.rs crate:main deps:core
 fn test() {
     for x in 0..100 { x<|>; }
 }
 
-//- /std.rs crate:std
+//- /core.rs crate:core
 pub mod ops {
     pub struct Range<Idx> {
         pub start: Idx,

--- a/crates/ra_ide/src/diagnostics.rs
+++ b/crates/ra_ide/src/diagnostics.rs
@@ -321,29 +321,26 @@ mod tests {
     fn test_wrap_return_type() {
         let before = r#"
             //- /main.rs
-            use core::{string::String, result::Result::{self, Ok, Err}};
+            use core::result::Result::{self, Ok, Err};
 
-            fn div(x: i32, y: i32) -> Result<i32, String> {
+            fn div(x: i32, y: i32) -> Result<i32, ()> {
                 if y == 0 {
-                    return Err("div by zero".into());
+                    return Err(());
                 }
                 x / y<|>
             }
 
             //- /core/lib.rs
-            pub mod string {
-                pub struct String { }
-            }
             pub mod result {
                 pub enum Result<T, E> { Ok(T), Err(E) }
             }
         "#;
         let after = r#"
-            use core::{string::String, result::Result::{self, Ok, Err}};
+            use core::result::Result::{self, Ok, Err};
 
-            fn div(x: i32, y: i32) -> Result<i32, String> {
+            fn div(x: i32, y: i32) -> Result<i32, ()> {
                 if y == 0 {
-                    return Err("div by zero".into());
+                    return Err(());
                 }
                 Ok(x / y)
             }
@@ -386,32 +383,29 @@ mod tests {
     fn test_wrap_return_type_handles_type_aliases() {
         let before = r#"
             //- /main.rs
-            use core::{string::String, result::Result::{self, Ok, Err}};
+            use core::result::Result::{self, Ok, Err};
 
-            type MyResult<T> = Result<T, String>;
+            type MyResult<T> = Result<T, ()>;
 
             fn div(x: i32, y: i32) -> MyResult<i32> {
                 if y == 0 {
-                    return Err("div by zero".into());
+                    return Err(());
                 }
                 x <|>/ y
             }
 
             //- /core/lib.rs
-            pub mod string {
-                pub struct String { }
-            }
             pub mod result {
                 pub enum Result<T, E> { Ok(T), Err(E) }
             }
         "#;
         let after = r#"
-            use core::{string::String, result::Result::{self, Ok, Err}};
+            use core::result::Result::{self, Ok, Err};
 
-            type MyResult<T> = Result<T, String>;
+            type MyResult<T> = Result<T, ()>;
             fn div(x: i32, y: i32) -> MyResult<i32> {
                 if y == 0 {
-                    return Err("div by zero".into());
+                    return Err(());
                 }
                 Ok(x / y)
             }
@@ -423,16 +417,13 @@ mod tests {
     fn test_wrap_return_type_not_applicable_when_expr_type_does_not_match_ok_type() {
         let content = r#"
             //- /main.rs
-            use std::{string::String, result::Result::{self, Ok, Err}};
+            use core::result::Result::{self, Ok, Err};
 
-            fn foo() -> Result<String, i32> {
+            fn foo() -> Result<(), i32> {
                 0<|>
             }
 
-            //- /std/lib.rs
-            pub mod string {
-                pub struct String { }
-            }
+            //- /core/lib.rs
             pub mod result {
                 pub enum Result<T, E> { Ok(T), Err(E) }
             }
@@ -444,7 +435,7 @@ mod tests {
     fn test_wrap_return_type_not_applicable_when_return_type_is_not_result() {
         let content = r#"
             //- /main.rs
-            use std::{string::String, result::Result::{self, Ok, Err}};
+            use core::result::Result::{self, Ok, Err};
 
             enum SomeOtherEnum {
                 Ok(i32),
@@ -455,10 +446,7 @@ mod tests {
                 0<|>
             }
 
-            //- /std/lib.rs
-            pub mod string {
-                pub struct String { }
-            }
+            //- /core/lib.rs
             pub mod result {
                 pub enum Result<T, E> { Ok(T), Err(E) }
             }

--- a/crates/ra_ide/src/diagnostics.rs
+++ b/crates/ra_ide/src/diagnostics.rs
@@ -321,7 +321,7 @@ mod tests {
     fn test_wrap_return_type() {
         let before = r#"
             //- /main.rs
-            use std::{string::String, result::Result::{self, Ok, Err}};
+            use core::{string::String, result::Result::{self, Ok, Err}};
 
             fn div(x: i32, y: i32) -> Result<i32, String> {
                 if y == 0 {
@@ -330,7 +330,7 @@ mod tests {
                 x / y<|>
             }
 
-            //- /std/lib.rs
+            //- /core/lib.rs
             pub mod string {
                 pub struct String { }
             }
@@ -339,7 +339,7 @@ mod tests {
             }
         "#;
         let after = r#"
-            use std::{string::String, result::Result::{self, Ok, Err}};
+            use core::{string::String, result::Result::{self, Ok, Err}};
 
             fn div(x: i32, y: i32) -> Result<i32, String> {
                 if y == 0 {
@@ -355,7 +355,7 @@ mod tests {
     fn test_wrap_return_type_handles_generic_functions() {
         let before = r#"
             //- /main.rs
-            use std::result::Result::{self, Ok, Err};
+            use core::result::Result::{self, Ok, Err};
 
             fn div<T>(x: T) -> Result<T, i32> {
                 if x == 0 {
@@ -364,13 +364,13 @@ mod tests {
                 <|>x
             }
 
-            //- /std/lib.rs
+            //- /core/lib.rs
             pub mod result {
                 pub enum Result<T, E> { Ok(T), Err(E) }
             }
         "#;
         let after = r#"
-            use std::result::Result::{self, Ok, Err};
+            use core::result::Result::{self, Ok, Err};
 
             fn div<T>(x: T) -> Result<T, i32> {
                 if x == 0 {
@@ -386,7 +386,7 @@ mod tests {
     fn test_wrap_return_type_handles_type_aliases() {
         let before = r#"
             //- /main.rs
-            use std::{string::String, result::Result::{self, Ok, Err}};
+            use core::{string::String, result::Result::{self, Ok, Err}};
 
             type MyResult<T> = Result<T, String>;
 
@@ -397,7 +397,7 @@ mod tests {
                 x <|>/ y
             }
 
-            //- /std/lib.rs
+            //- /core/lib.rs
             pub mod string {
                 pub struct String { }
             }
@@ -406,7 +406,7 @@ mod tests {
             }
         "#;
         let after = r#"
-            use std::{string::String, result::Result::{self, Ok, Err}};
+            use core::{string::String, result::Result::{self, Ok, Err}};
 
             type MyResult<T> = Result<T, String>;
             fn div(x: i32, y: i32) -> MyResult<i32> {


### PR DESCRIPTION
I'm not sure if this causes problems today, but it seems like it easily could, if rust-analyzer processes the libstd sources for the right `--target` and that target is a `#![no_std]`-only target.