### PR TITLE
Accept relative paths in rust-project.json

### DIFF
--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -108,11 +108,11 @@ fn run_server() -> Result<()> {
             config.update(value);
         }
         config.update_caps(&initialize_params.capabilities);
+        let cwd = std::env::current_dir()?;
+        config.root_path =
+            initialize_params.root_uri.and_then(|it| it.to_file_path().ok()).unwrap_or(cwd);
 
         if config.linked_projects.is_empty() {
-            let cwd = std::env::current_dir()?;
-            let root =
-                initialize_params.root_uri.and_then(|it| it.to_file_path().ok()).unwrap_or(cwd);
             let workspace_roots = initialize_params
                 .workspace_folders
                 .map(|workspaces| {
@@ -122,7 +122,7 @@ fn run_server() -> Result<()> {
                         .collect::<Vec<_>>()
                 })
                 .filter(|workspaces| !workspaces.is_empty())
-                .unwrap_or_else(|| vec![root]);
+                .unwrap_or_else(|| vec![config.root_path.clone()]);
 
             config.linked_projects = ProjectManifest::discover_all(&workspace_roots)
                 .into_iter()

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -38,12 +38,13 @@ pub struct Config {
 
     pub with_sysroot: bool,
     pub linked_projects: Vec<LinkedProject>,
+    pub root_path: PathBuf,
 }
 
 #[derive(Debug, Clone)]
 pub enum LinkedProject {
     ProjectManifest(ProjectManifest),
-    JsonProject(JsonProject),
+    InlineJsonProject(JsonProject),
 }
 
 impl From<ProjectManifest> for LinkedProject {
@@ -54,7 +55,7 @@ impl From<ProjectManifest> for LinkedProject {
 
 impl From<JsonProject> for LinkedProject {
     fn from(v: JsonProject) -> Self {
-        LinkedProject::JsonProject(v)
+        LinkedProject::InlineJsonProject(v)
     }
 }
 
@@ -167,6 +168,7 @@ impl Default for Config {
             lens: LensConfig::default(),
             hover: HoverConfig::default(),
             linked_projects: Vec::new(),
+            root_path: PathBuf::new(),
         }
     }
 }

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -121,7 +121,12 @@ pub fn main_loop(config: Config, connection: Connection) -> Result<()> {
                         })
                         .ok()
                     }
-                    LinkedProject::JsonProject(it) => Some(it.clone().into()),
+                    LinkedProject::InlineJsonProject(it) => {
+                        Some(ra_project_model::ProjectWorkspace::Json {
+                            project: it.clone(),
+                            project_location: config.root_path.clone(),
+                        })
+                    }
                 })
                 .collect::<Vec<_>>()
         };


### PR DESCRIPTION
If a relative path is found as part of Crate.root_module or Root.path, interpret it as relative to the location of the rust-project.json file.

Fixes: #4816 