### PR TITLE
Fix syntax highlighting of recursive macros

### DIFF
--- a/crates/ra_ide/src/snapshots/highlighting.html
+++ b/crates/ra_ide/src/snapshots/highlighting.html
@@ -62,6 +62,12 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
     }
 }
 
+<span class="macro">macro_rules!</span> <span class="macro declaration">noop</span> {
+    ($expr:expr) =&gt; {
+        $expr
+    }
+}
+
 <span class="comment">// comment</span>
 <span class="keyword">fn</span> <span class="function declaration">main</span>() {
     <span class="macro">println!</span>(<span class="string_literal">"Hello, {}!"</span>, <span class="numeric_literal">92</span>);
@@ -79,6 +85,8 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
     <span class="keyword control">for</span> <span class="variable declaration">e</span> <span class="keyword control">in</span> <span class="variable mutable">vec</span> {
         <span class="comment">// Do nothing</span>
     }
+
+    <span class="macro">noop!</span>(<span class="macro">noop</span><span class="macro">!</span>(<span class="numeric_literal">1</span>));
 
     <span class="keyword">let</span> <span class="keyword">mut</span> <span class="variable declaration mutable">x</span> = <span class="numeric_literal">42</span>;
     <span class="keyword">let</span> <span class="variable declaration mutable">y</span> = &<span class="keyword">mut</span> <span class="variable mutable">x</span>;

--- a/crates/ra_ide/src/syntax_highlighting/tests.rs
+++ b/crates/ra_ide/src/syntax_highlighting/tests.rs
@@ -43,6 +43,12 @@ def_fn! {
     }
 }
 
+macro_rules! noop {
+    ($expr:expr) => {
+        $expr
+    }
+}
+
 // comment
 fn main() {
     println!("Hello, {}!", 92);
@@ -60,6 +66,8 @@ fn main() {
     for e in vec {
         // Do nothing
     }
+
+    noop!(noop!(1));
 
     let mut x = 42;
     let y = &mut x;


### PR DESCRIPTION
Add syntax highlighting for the BANG (`!`) token if the parent is `MACRO_CALL`.

Before:
<img width="514" alt="before" src="https://user-images.githubusercontent.com/201808/84595030-11f65c00-ae56-11ea-9bb2-b1abe2236990.png">

After:
<img width="516" alt="recursive-macro" src="https://user-images.githubusercontent.com/201808/84594981-d196de00-ae55-11ea-8636-f877d5d795ff.png">


Fixes #4694.