### PR TITLE
"fill match arms" assist: Match on bind patterns

### DIFF
--- a/crates/ra_assists/src/handlers/fill_match_arms.rs
+++ b/crates/ra_assists/src/handlers/fill_match_arms.rs
@@ -351,6 +351,40 @@ mod tests {
     }
 
     #[test]
+    fn partial_fill_bind_pat() {
+        check_assist(
+            fill_match_arms,
+            r#"
+            enum A {
+                As,
+                Bs,
+                Cs(Option<i32>),
+            }
+            fn main() {
+                match A::As<|> {
+                    A::As(_) => {}
+                    a @ A::Bs(_) => {}
+                }
+            }
+            "#,
+            r#"
+            enum A {
+                As,
+                Bs,
+                Cs(Option<i32>),
+            }
+            fn main() {
+                match A::As {
+                    A::As(_) => {}
+                    a @ A::Bs(_) => {}
+                    $0A::Cs(_) => {}
+                }
+            }
+            "#,
+        );
+    }
+
+    #[test]
     fn fill_match_arms_empty_body() {
         check_assist(
             fill_match_arms,

--- a/crates/ra_assists/src/handlers/fill_match_arms.rs
+++ b/crates/ra_assists/src/handlers/fill_match_arms.rs
@@ -136,8 +136,20 @@ fn is_variant_missing(existing_arms: &mut Vec<MatchArm>, var: &Pat) -> bool {
 }
 
 fn does_pat_match_variant(pat: &Pat, var: &Pat) -> bool {
-    let pat_head = pat.syntax().first_child().map(|node| node.text());
-    let var_head = var.syntax().first_child().map(|node| node.text());
+    let first_node_text = |pat: &Pat| pat.syntax().first_child().map(|node| node.text());
+
+    let pat_head = match pat {
+        Pat::BindPat(bind_pat) => {
+            if let Some(p) = bind_pat.pat() {
+                first_node_text(&p)
+            } else {
+                return false;
+            }
+        }
+        pat => first_node_text(pat),
+    };
+
+    let var_head = first_node_text(var);
 
     pat_head == var_head
 }


### PR DESCRIPTION
This prevents duplication of match arms where the pre-existing arm is a bind pattern.