### PR TITLE
Make ra_syntax::{SyntaxNodeChildren, SyntaxElementChildren} public.

### DIFF
--- a/crates/ra_syntax/src/lib.rs
+++ b/crates/ra_syntax/src/lib.rs
@@ -51,7 +51,8 @@ pub use crate::{
     ptr::{AstPtr, SyntaxNodePtr},
     syntax_error::SyntaxError,
     syntax_node::{
-        Direction, NodeOrToken, SyntaxElement, SyntaxNode, SyntaxToken, SyntaxTreeBuilder,
+        Direction, NodeOrToken, SyntaxElement, SyntaxElementChildren, SyntaxNode,
+        SyntaxNodeChildren, SyntaxToken, SyntaxTreeBuilder,
     },
 };
 pub use ra_parser::{SyntaxKind, T};


### PR DESCRIPTION
SyntaxNode::children and SyntaxNode::children_with_tokens return these types, but there's currently no way AFAIK to name them.