### PR TITLE
Self variant enum res fix

### DIFF
--- a/crates/ra_ide/src/goto_definition.rs
+++ b/crates/ra_ide/src/goto_definition.rs
@@ -908,4 +908,84 @@ mod tests {
             "x: i32|x",
         );
     }
+
+    #[test]
+    fn goto_def_for_enum_variant_self_pattern_const() {
+        check_goto(
+            "
+            //- /lib.rs
+            enum Foo {
+                Bar,
+            }
+            impl Foo {
+                fn baz(self) {
+                    match self {
+                        Self::Bar<|> => {}
+                    }
+                }
+            }
+            ",
+            "Bar ENUM_VARIANT FileId(1) 15..18 15..18",
+            "Bar|Bar",
+        );
+    }
+
+    #[test]
+    fn goto_def_for_enum_variant_self_pattern_record() {
+        check_goto(
+            "
+            //- /lib.rs
+            enum Foo {
+                Bar { val: i32 },
+            }
+            impl Foo {
+                fn baz(self) -> i32 {
+                    match self {
+                        Self::Bar<|> { val } => {}
+                    }
+                }
+            }
+            ",
+            "Bar ENUM_VARIANT FileId(1) 15..31 15..18",
+            "Bar { val: i32 }|Bar",
+        );
+    }
+
+    #[test]
+    fn goto_def_for_enum_variant_self_expr_const() {
+        check_goto(
+            "
+            //- /lib.rs
+            enum Foo {
+                Bar,
+            }
+            impl Foo {
+                fn baz(self) {
+                    Self::Bar<|>;
+                }
+            }
+            ",
+            "Bar ENUM_VARIANT FileId(1) 15..18 15..18",
+            "Bar|Bar",
+        );
+    }
+
+    #[test]
+    fn goto_def_for_enum_variant_self_expr_record() {
+        check_goto(
+            "
+            //- /lib.rs
+            enum Foo {
+                Bar { val: i32 },
+            }
+            impl Foo {
+                fn baz(self) {
+                    Self::Bar<|> {val: 4};
+                }
+            }
+            ",
+            "Bar ENUM_VARIANT FileId(1) 15..31 15..18",
+            "Bar { val: i32 }|Bar",
+        );
+    }
 }


### PR DESCRIPTION
Fixes #4789.

This is my first PR for this project, so it's probably worth giving it an extra close look.

A few things that I wasn't sure about:
- Is `resolve_path` really the best place to perform this check? It seemed like a natural place, but perhaps there's a better place?
- When handling the new variant `PathResolution::VariantDef`, I couldn't see an obvious variant of `TypeNs` to return in `in_type_ns` for Unions and Structs.