### PR TITLE
Add highlighting support for doc comments

### DIFF
--- a/crates/ra_ide/src/snapshots/highlight_doctest.html
+++ b/crates/ra_ide/src/snapshots/highlight_doctest.html
@@ -38,48 +38,48 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 <span class="keyword">impl</span> <span class="struct">Foo</span> {
     <span class="keyword">pub</span> <span class="keyword">const</span> <span class="constant declaration">bar</span>: <span class="builtin_type">bool</span> = <span class="bool_literal">true</span>;
 
-    <span class="comment">/// Constructs a new `Foo`.</span>
-    <span class="comment">///</span>
-    <span class="comment">/// # Examples</span>
-    <span class="comment">///</span>
-    <span class="comment">/// ```</span>
-    <span class="comment">/// #</span> <span class="attribute">#![</span><span class="function attribute">allow</span><span class="attribute">(unused_mut)]</span>
-    <span class="comment">/// </span><span class="keyword">let</span> <span class="keyword">mut</span> <span class="variable declaration mutable">foo</span>: <span class="struct">Foo</span> = <span class="struct">Foo</span>::<span class="function">new</span>();
-    <span class="comment">/// ```</span>
+    <span class="comment documentation">/// Constructs a new `Foo`.</span>
+    <span class="comment documentation">///</span>
+    <span class="comment documentation">/// # Examples</span>
+    <span class="comment documentation">///</span>
+    <span class="comment documentation">/// ```</span>
+    <span class="comment documentation">/// #</span> <span class="attribute">#![</span><span class="function attribute">allow</span><span class="attribute">(unused_mut)]</span>
+    <span class="comment documentation">/// </span><span class="keyword">let</span> <span class="keyword">mut</span> <span class="variable declaration mutable">foo</span>: <span class="struct">Foo</span> = <span class="struct">Foo</span>::<span class="function">new</span>();
+    <span class="comment documentation">/// ```</span>
     <span class="keyword">pub</span> <span class="keyword">const</span> <span class="keyword">fn</span> <span class="function declaration">new</span>() -&gt; <span class="struct">Foo</span> {
         <span class="struct">Foo</span> { <span class="field">bar</span>: <span class="bool_literal">true</span> }
     }
 
-    <span class="comment">/// `bar` method on `Foo`.</span>
-    <span class="comment">///</span>
-    <span class="comment">/// # Examples</span>
-    <span class="comment">///</span>
-    <span class="comment">/// ```</span>
-    <span class="comment">/// </span><span class="keyword">use</span> <span class="module">x</span>::<span class="module">y</span>;
-    <span class="comment">///</span>
-    <span class="comment">/// </span><span class="keyword">let</span> <span class="variable declaration">foo</span> = <span class="struct">Foo</span>::<span class="function">new</span>();
-    <span class="comment">///</span>
-    <span class="comment">/// </span><span class="comment">// calls bar on foo</span>
-    <span class="comment">/// </span><span class="macro">assert!</span>(foo.bar());
-    <span class="comment">///</span>
-    <span class="comment">/// </span><span class="keyword">let</span> <span class="variable declaration">bar</span> = <span class="variable">foo</span>.<span class="field">bar</span> || <span class="struct">Foo</span>::<span class="constant">bar</span>;
-    <span class="comment">///</span>
-    <span class="comment">/// </span><span class="comment">/* multi-line
-    </span><span class="comment">/// </span><span class="comment">       comment */</span>
-    <span class="comment">///</span>
-    <span class="comment">/// </span><span class="keyword">let</span> <span class="variable declaration">multi_line_string</span> = <span class="string_literal">"Foo
-    </span><span class="comment">/// </span><span class="string_literal">  bar
-    </span><span class="comment">/// </span><span class="string_literal">         "</span>;
-    <span class="comment">///</span>
-    <span class="comment">/// ```</span>
-    <span class="comment">///</span>
-    <span class="comment">/// ```rust,no_run</span>
-    <span class="comment">/// </span><span class="keyword">let</span> <span class="variable declaration">foobar</span> = <span class="struct">Foo</span>::<span class="function">new</span>().<span class="function">bar</span>();
-    <span class="comment">/// ```</span>
-    <span class="comment">///</span>
-    <span class="comment">/// ```sh</span>
-    <span class="comment">/// echo 1</span>
-    <span class="comment">/// ```</span>
+    <span class="comment documentation">/// `bar` method on `Foo`.</span>
+    <span class="comment documentation">///</span>
+    <span class="comment documentation">/// # Examples</span>
+    <span class="comment documentation">///</span>
+    <span class="comment documentation">/// ```</span>
+    <span class="comment documentation">/// </span><span class="keyword">use</span> <span class="module">x</span>::<span class="module">y</span>;
+    <span class="comment documentation">///</span>
+    <span class="comment documentation">/// </span><span class="keyword">let</span> <span class="variable declaration">foo</span> = <span class="struct">Foo</span>::<span class="function">new</span>();
+    <span class="comment documentation">///</span>
+    <span class="comment documentation">/// </span><span class="comment">// calls bar on foo</span>
+    <span class="comment documentation">/// </span><span class="macro">assert!</span>(foo.bar());
+    <span class="comment documentation">///</span>
+    <span class="comment documentation">/// </span><span class="keyword">let</span> <span class="variable declaration">bar</span> = <span class="variable">foo</span>.<span class="field">bar</span> || <span class="struct">Foo</span>::<span class="constant">bar</span>;
+    <span class="comment documentation">///</span>
+    <span class="comment documentation">/// </span><span class="comment">/* multi-line
+    </span><span class="comment documentation">/// </span><span class="comment">       comment */</span>
+    <span class="comment documentation">///</span>
+    <span class="comment documentation">/// </span><span class="keyword">let</span> <span class="variable declaration">multi_line_string</span> = <span class="string_literal">"Foo
+    </span><span class="comment documentation">/// </span><span class="string_literal">  bar
+    </span><span class="comment documentation">/// </span><span class="string_literal">         "</span>;
+    <span class="comment documentation">///</span>
+    <span class="comment documentation">/// ```</span>
+    <span class="comment documentation">///</span>
+    <span class="comment documentation">/// ```rust,no_run</span>
+    <span class="comment documentation">/// </span><span class="keyword">let</span> <span class="variable declaration">foobar</span> = <span class="struct">Foo</span>::<span class="function">new</span>().<span class="function">bar</span>();
+    <span class="comment documentation">/// ```</span>
+    <span class="comment documentation">///</span>
+    <span class="comment documentation">/// ```sh</span>
+    <span class="comment documentation">/// echo 1</span>
+    <span class="comment documentation">/// ```</span>
     <span class="keyword">pub</span> <span class="keyword">fn</span> <span class="function declaration">foo</span>(&<span class="self_keyword">self</span>) -&gt; <span class="builtin_type">bool</span> {
         <span class="bool_literal">true</span>
     }

--- a/crates/ra_ide/src/snapshots/highlight_doctest.html
+++ b/crates/ra_ide/src/snapshots/highlight_doctest.html
@@ -43,8 +43,8 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
     <span class="comment documentation">/// # Examples</span>
     <span class="comment documentation">///</span>
     <span class="comment documentation">/// ```</span>
-    <span class="comment documentation">/// #</span> <span class="attribute">#![</span><span class="function attribute">allow</span><span class="attribute">(unused_mut)]</span>
-    <span class="comment documentation">/// </span><span class="keyword">let</span> <span class="keyword">mut</span> <span class="variable declaration mutable">foo</span>: <span class="struct">Foo</span> = <span class="struct">Foo</span>::<span class="function">new</span>();
+    <span class="comment documentation">/// #</span> <span class="attribute documentation">#![</span><span class="function attribute documentation">allow</span><span class="attribute documentation">(unused_mut)]</span>
+    <span class="comment documentation">/// </span><span class="keyword documentation">let</span> <span class="keyword documentation">mut</span> <span class="variable declaration documentation mutable">foo</span>: <span class="struct documentation">Foo</span> = <span class="struct documentation">Foo</span>::<span class="function documentation">new</span>();
     <span class="comment documentation">/// ```</span>
     <span class="keyword">pub</span> <span class="keyword">const</span> <span class="keyword">fn</span> <span class="function declaration">new</span>() -&gt; <span class="struct">Foo</span> {
         <span class="struct">Foo</span> { <span class="field">bar</span>: <span class="bool_literal">true</span> }
@@ -55,26 +55,26 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
     <span class="comment documentation">/// # Examples</span>
     <span class="comment documentation">///</span>
     <span class="comment documentation">/// ```</span>
-    <span class="comment documentation">/// </span><span class="keyword">use</span> <span class="module">x</span>::<span class="module">y</span>;
+    <span class="comment documentation">/// </span><span class="keyword documentation">use</span> <span class="module documentation">x</span>::<span class="module documentation">y</span>;
     <span class="comment documentation">///</span>
-    <span class="comment documentation">/// </span><span class="keyword">let</span> <span class="variable declaration">foo</span> = <span class="struct">Foo</span>::<span class="function">new</span>();
+    <span class="comment documentation">/// </span><span class="keyword documentation">let</span> <span class="variable declaration documentation">foo</span> = <span class="struct documentation">Foo</span>::<span class="function documentation">new</span>();
     <span class="comment documentation">///</span>
-    <span class="comment documentation">/// </span><span class="comment">// calls bar on foo</span>
-    <span class="comment documentation">/// </span><span class="macro">assert!</span>(foo.bar());
+    <span class="comment documentation">/// </span><span class="comment documentation">// calls bar on foo</span>
+    <span class="comment documentation">/// </span><span class="macro documentation">assert!</span>(foo.bar());
     <span class="comment documentation">///</span>
-    <span class="comment documentation">/// </span><span class="keyword">let</span> <span class="variable declaration">bar</span> = <span class="variable">foo</span>.<span class="field">bar</span> || <span class="struct">Foo</span>::<span class="constant">bar</span>;
+    <span class="comment documentation">/// </span><span class="keyword documentation">let</span> <span class="variable declaration documentation">bar</span> = <span class="variable documentation">foo</span>.<span class="field documentation">bar</span> || <span class="struct documentation">Foo</span>::<span class="constant documentation">bar</span>;
     <span class="comment documentation">///</span>
-    <span class="comment documentation">/// </span><span class="comment">/* multi-line
-    </span><span class="comment documentation">/// </span><span class="comment">       comment */</span>
+    <span class="comment documentation">/// </span><span class="comment documentation">/* multi-line
+    </span><span class="comment documentation">/// </span><span class="comment documentation">       comment */</span>
     <span class="comment documentation">///</span>
-    <span class="comment documentation">/// </span><span class="keyword">let</span> <span class="variable declaration">multi_line_string</span> = <span class="string_literal">"Foo
-    </span><span class="comment documentation">/// </span><span class="string_literal">  bar
-    </span><span class="comment documentation">/// </span><span class="string_literal">         "</span>;
+    <span class="comment documentation">/// </span><span class="keyword documentation">let</span> <span class="variable declaration documentation">multi_line_string</span> = <span class="string_literal documentation">"Foo
+    </span><span class="comment documentation">/// </span><span class="string_literal documentation">  bar
+    </span><span class="comment documentation">/// </span><span class="string_literal documentation">         "</span>;
     <span class="comment documentation">///</span>
     <span class="comment documentation">/// ```</span>
     <span class="comment documentation">///</span>
     <span class="comment documentation">/// ```rust,no_run</span>
-    <span class="comment documentation">/// </span><span class="keyword">let</span> <span class="variable declaration">foobar</span> = <span class="struct">Foo</span>::<span class="function">new</span>().<span class="function">bar</span>();
+    <span class="comment documentation">/// </span><span class="keyword documentation">let</span> <span class="variable declaration documentation">foobar</span> = <span class="struct documentation">Foo</span>::<span class="function documentation">new</span>().<span class="function documentation">bar</span>();
     <span class="comment documentation">/// ```</span>
     <span class="comment documentation">///</span>
     <span class="comment documentation">/// ```sh</span>

--- a/crates/ra_ide/src/snapshots/highlight_doctest.html
+++ b/crates/ra_ide/src/snapshots/highlight_doctest.html
@@ -43,8 +43,8 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
     <span class="comment documentation">/// # Examples</span>
     <span class="comment documentation">///</span>
     <span class="comment documentation">/// ```</span>
-    <span class="comment documentation">/// #</span> <span class="attribute documentation">#![</span><span class="function attribute documentation">allow</span><span class="attribute documentation">(unused_mut)]</span>
-    <span class="comment documentation">/// </span><span class="keyword documentation">let</span> <span class="keyword documentation">mut</span> <span class="variable declaration documentation mutable">foo</span>: <span class="struct documentation">Foo</span> = <span class="struct documentation">Foo</span>::<span class="function documentation">new</span>();
+    <span class="comment documentation">/// #</span> <span class="attribute">#![</span><span class="function attribute">allow</span><span class="attribute">(unused_mut)]</span>
+    <span class="comment documentation">/// </span><span class="keyword">let</span> <span class="keyword">mut</span> <span class="variable declaration mutable">foo</span>: <span class="struct">Foo</span> = <span class="struct">Foo</span>::<span class="function">new</span>();
     <span class="comment documentation">/// ```</span>
     <span class="keyword">pub</span> <span class="keyword">const</span> <span class="keyword">fn</span> <span class="function declaration">new</span>() -&gt; <span class="struct">Foo</span> {
         <span class="struct">Foo</span> { <span class="field">bar</span>: <span class="bool_literal">true</span> }
@@ -55,26 +55,26 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
     <span class="comment documentation">/// # Examples</span>
     <span class="comment documentation">///</span>
     <span class="comment documentation">/// ```</span>
-    <span class="comment documentation">/// </span><span class="keyword documentation">use</span> <span class="module documentation">x</span>::<span class="module documentation">y</span>;
+    <span class="comment documentation">/// </span><span class="keyword">use</span> <span class="module">x</span>::<span class="module">y</span>;
     <span class="comment documentation">///</span>
-    <span class="comment documentation">/// </span><span class="keyword documentation">let</span> <span class="variable declaration documentation">foo</span> = <span class="struct documentation">Foo</span>::<span class="function documentation">new</span>();
+    <span class="comment documentation">/// </span><span class="keyword">let</span> <span class="variable declaration">foo</span> = <span class="struct">Foo</span>::<span class="function">new</span>();
     <span class="comment documentation">///</span>
-    <span class="comment documentation">/// </span><span class="comment documentation">// calls bar on foo</span>
-    <span class="comment documentation">/// </span><span class="macro documentation">assert!</span>(foo.bar());
+    <span class="comment documentation">/// </span><span class="comment">// calls bar on foo</span>
+    <span class="comment documentation">/// </span><span class="macro">assert!</span>(foo.bar());
     <span class="comment documentation">///</span>
-    <span class="comment documentation">/// </span><span class="keyword documentation">let</span> <span class="variable declaration documentation">bar</span> = <span class="variable documentation">foo</span>.<span class="field documentation">bar</span> || <span class="struct documentation">Foo</span>::<span class="constant documentation">bar</span>;
+    <span class="comment documentation">/// </span><span class="keyword">let</span> <span class="variable declaration">bar</span> = <span class="variable">foo</span>.<span class="field">bar</span> || <span class="struct">Foo</span>::<span class="constant">bar</span>;
     <span class="comment documentation">///</span>
-    <span class="comment documentation">/// </span><span class="comment documentation">/* multi-line
-    </span><span class="comment documentation">/// </span><span class="comment documentation">       comment */</span>
+    <span class="comment documentation">/// </span><span class="comment">/* multi-line
+    </span><span class="comment documentation">/// </span><span class="comment">       comment */</span>
     <span class="comment documentation">///</span>
-    <span class="comment documentation">/// </span><span class="keyword documentation">let</span> <span class="variable declaration documentation">multi_line_string</span> = <span class="string_literal documentation">"Foo
-    </span><span class="comment documentation">/// </span><span class="string_literal documentation">  bar
-    </span><span class="comment documentation">/// </span><span class="string_literal documentation">         "</span>;
+    <span class="comment documentation">/// </span><span class="keyword">let</span> <span class="variable declaration">multi_line_string</span> = <span class="string_literal">"Foo
+    </span><span class="comment documentation">/// </span><span class="string_literal">  bar
+    </span><span class="comment documentation">/// </span><span class="string_literal">         "</span>;
     <span class="comment documentation">///</span>
     <span class="comment documentation">/// ```</span>
     <span class="comment documentation">///</span>
     <span class="comment documentation">/// ```rust,no_run</span>
-    <span class="comment documentation">/// </span><span class="keyword documentation">let</span> <span class="variable declaration documentation">foobar</span> = <span class="struct documentation">Foo</span>::<span class="function documentation">new</span>().<span class="function documentation">bar</span>();
+    <span class="comment documentation">/// </span><span class="keyword">let</span> <span class="variable declaration">foobar</span> = <span class="struct">Foo</span>::<span class="function">new</span>().<span class="function">bar</span>();
     <span class="comment documentation">/// ```</span>
     <span class="comment documentation">///</span>
     <span class="comment documentation">/// ```sh</span>

--- a/crates/ra_ide/src/syntax_highlighting.rs
+++ b/crates/ra_ide/src/syntax_highlighting.rs
@@ -475,7 +475,14 @@ fn highlight_element(
         }
 
         // Simple token-based highlighting
-        COMMENT => HighlightTag::Comment.into(),
+        COMMENT => {
+            let comment = element.into_token().and_then(ast::Comment::cast)?;
+            if comment.kind().doc.is_some() {
+                Highlight::from(HighlightTag::Comment) | HighlightModifier::Documentation
+            } else {
+                HighlightTag::Comment.into()
+            }
+        }
         STRING | RAW_STRING | RAW_BYTE_STRING | BYTE_STRING => HighlightTag::StringLiteral.into(),
         ATTR => HighlightTag::Attribute.into(),
         INT_NUMBER | FLOAT_NUMBER => HighlightTag::NumericLiteral.into(),

--- a/crates/ra_ide/src/syntax_highlighting.rs
+++ b/crates/ra_ide/src/syntax_highlighting.rs
@@ -477,10 +477,10 @@ fn highlight_element(
         // Simple token-based highlighting
         COMMENT => {
             let comment = element.into_token().and_then(ast::Comment::cast)?;
-            if comment.kind().doc.is_some() {
-                Highlight::from(HighlightTag::Comment) | HighlightModifier::Documentation
-            } else {
-                HighlightTag::Comment.into()
+            let h = HighlightTag::Comment;
+            match comment.kind().doc {
+                Some(_) => h | HighlightModifier::Documentation,
+                None => h.into(),
             }
         }
         STRING | RAW_STRING | RAW_BYTE_STRING | BYTE_STRING => HighlightTag::StringLiteral.into(),

--- a/crates/ra_ide/src/syntax_highlighting/injection.rs
+++ b/crates/ra_ide/src/syntax_highlighting/injection.rs
@@ -8,8 +8,8 @@ use ra_syntax::{ast, AstToken, SyntaxNode, SyntaxToken, TextRange, TextSize};
 use stdx::SepBy;
 
 use crate::{
-    call_info::ActiveParameter, Analysis, Highlight, HighlightModifier, HighlightTag,
-    HighlightedRange, RootDatabase,
+    call_info::ActiveParameter, Analysis, HighlightModifier, HighlightTag, HighlightedRange,
+    RootDatabase,
 };
 
 use super::HighlightedRangeStack;
@@ -121,8 +121,7 @@ pub(super) fn extract_doc_comments(
                     range.start(),
                     range.start() + TextSize::try_from(pos).unwrap(),
                 ),
-                highlight: Highlight::from(HighlightTag::Comment)
-                    | HighlightModifier::Documentation,
+                highlight: HighlightTag::Comment | HighlightModifier::Documentation,
                 binding_hash: None,
             });
             line_start += range.len() - TextSize::try_from(pos).unwrap();
@@ -168,6 +167,8 @@ pub(super) fn highlight_doc_comment(
                 h.range.start() + start_offset,
                 h.range.end() + end_offset.unwrap_or(start_offset),
             );
+
+            h.highlight |= HighlightModifier::Documentation;
             stack.add(h);
         }
     }

--- a/crates/ra_ide/src/syntax_highlighting/injection.rs
+++ b/crates/ra_ide/src/syntax_highlighting/injection.rs
@@ -7,7 +7,10 @@ use hir::Semantics;
 use ra_syntax::{ast, AstToken, SyntaxNode, SyntaxToken, TextRange, TextSize};
 use stdx::SepBy;
 
-use crate::{call_info::ActiveParameter, Analysis, HighlightTag, HighlightedRange, RootDatabase};
+use crate::{
+    call_info::ActiveParameter, Analysis, Highlight, HighlightModifier, HighlightTag,
+    HighlightedRange, RootDatabase,
+};
 
 use super::HighlightedRangeStack;
 
@@ -118,7 +121,8 @@ pub(super) fn extract_doc_comments(
                     range.start(),
                     range.start() + TextSize::try_from(pos).unwrap(),
                 ),
-                highlight: HighlightTag::Comment.into(),
+                highlight: Highlight::from(HighlightTag::Comment)
+                    | HighlightModifier::Documentation,
                 binding_hash: None,
             });
             line_start += range.len() - TextSize::try_from(pos).unwrap();

--- a/crates/ra_ide/src/syntax_highlighting/injection.rs
+++ b/crates/ra_ide/src/syntax_highlighting/injection.rs
@@ -168,7 +168,6 @@ pub(super) fn highlight_doc_comment(
                 h.range.end() + end_offset.unwrap_or(start_offset),
             );
 
-            h.highlight |= HighlightModifier::Documentation;
             stack.add(h);
         }
     }

--- a/crates/ra_ide/src/syntax_highlighting/tags.rs
+++ b/crates/ra_ide/src/syntax_highlighting/tags.rs
@@ -55,6 +55,7 @@ pub enum HighlightModifier {
     /// `foo` in `fn foo(x: i32)` is a definition, `foo` in `foo(90 + 2)` is
     /// not.
     Definition,
+    Documentation,
     Mutable,
     Unsafe,
 }
@@ -106,6 +107,7 @@ impl HighlightModifier {
         HighlightModifier::Attribute,
         HighlightModifier::ControlFlow,
         HighlightModifier::Definition,
+        HighlightModifier::Documentation,
         HighlightModifier::Mutable,
         HighlightModifier::Unsafe,
     ];
@@ -115,6 +117,7 @@ impl HighlightModifier {
             HighlightModifier::Attribute => "attribute",
             HighlightModifier::ControlFlow => "control",
             HighlightModifier::Definition => "declaration",
+            HighlightModifier::Documentation => "documentation",
             HighlightModifier::Mutable => "mutable",
             HighlightModifier::Unsafe => "unsafe",
         }

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -330,6 +330,7 @@ fn semantic_token_type_and_modifiers(
         let modifier = match modifier {
             HighlightModifier::Attribute => semantic_tokens::ATTRIBUTE_MODIFIER,
             HighlightModifier::Definition => lsp_types::SemanticTokenModifier::DECLARATION,
+            HighlightModifier::Documentation => lsp_types::SemanticTokenModifier::DOCUMENTATION,
             HighlightModifier::ControlFlow => semantic_tokens::CONTROL_FLOW,
             HighlightModifier::Mutable => semantic_tokens::MUTABLE,
             HighlightModifier::Unsafe => semantic_tokens::UNSAFE,


### PR DESCRIPTION
The language server protocol includes a semantic modifier for documentation. This change exports that modifier for doc comments so users can choose to highlight them differently compared to regular comments.

Example:
<img width="375" alt="Screen Shot 2020-06-16 at 10 34 14 AM" src="https://user-images.githubusercontent.com/1673130/84788271-f6599580-afbc-11ea-96e5-7a0215da620b.png">

CC @woody77 