### PR TITLE
Warnings as hint or info

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -9,6 +9,7 @@
 
 use std::{ffi::OsString, path::PathBuf};
 
+use crate::diagnostics::DiagnosticsConfig;
 use lsp_types::ClientCapabilities;
 use ra_flycheck::FlycheckConfig;
 use ra_ide::{AssistConfig, CompletionConfig, HoverConfig, InlayHintsConfig};
@@ -20,6 +21,7 @@ pub struct Config {
     pub client_caps: ClientCapsConfig,
 
     pub publish_diagnostics: bool,
+    pub diagnostics: DiagnosticsConfig,
     pub lru_capacity: Option<usize>,
     pub proc_macro_srv: Option<(PathBuf, Vec<OsString>)>,
     pub files: FilesConfig,
@@ -136,6 +138,7 @@ impl Default for Config {
 
             with_sysroot: true,
             publish_diagnostics: true,
+            diagnostics: DiagnosticsConfig::default(),
             lru_capacity: None,
             proc_macro_srv: None,
             files: FilesConfig { watcher: FilesWatcher::Notify, exclude: Vec::new() },
@@ -184,6 +187,8 @@ impl Config {
 
         set(value, "/withSysroot", &mut self.with_sysroot);
         set(value, "/diagnostics/enable", &mut self.publish_diagnostics);
+        set(value, "/diagnostics/warningsAsInfo", &mut self.diagnostics.warnings_as_info);
+        set(value, "/diagnostics/warningsAsHint", &mut self.diagnostics.warnings_as_hint);
         set(value, "/lruCapacity", &mut self.lru_capacity);
         self.files.watcher = match get(value, "/files/watcher") {
             Some("client") => FilesWatcher::Client,

--- a/crates/rust-analyzer/src/diagnostics.rs
+++ b/crates/rust-analyzer/src/diagnostics.rs
@@ -11,6 +11,12 @@ use crate::lsp_ext;
 pub type CheckFixes = Arc<HashMap<FileId, Vec<Fix>>>;
 
 #[derive(Debug, Default, Clone)]
+pub struct DiagnosticsConfig {
+    pub warnings_as_info: Vec<String>,
+    pub warnings_as_hint: Vec<String>,
+}
+
+#[derive(Debug, Default, Clone)]
 pub struct DiagnosticCollection {
     pub native: HashMap<FileId, Vec<Diagnostic>>,
     pub check: HashMap<FileId, Vec<Diagnostic>>,

--- a/crates/rust-analyzer/src/diagnostics/snapshots/rust_analyzer__diagnostics__to_proto__tests__snap_rustc_unused_variable_as_hint.snap
+++ b/crates/rust-analyzer/src/diagnostics/snapshots/rust_analyzer__diagnostics__to_proto__tests__snap_rustc_unused_variable_as_hint.snap
@@ -1,0 +1,86 @@
+---
+source: crates/rust-analyzer/src/diagnostics/to_proto.rs
+expression: diag
+---
+[
+    MappedRustDiagnostic {
+        location: Location {
+            uri: "file:///test/driver/subcommand/repl.rs",
+            range: Range {
+                start: Position {
+                    line: 290,
+                    character: 8,
+                },
+                end: Position {
+                    line: 290,
+                    character: 11,
+                },
+            },
+        },
+        diagnostic: Diagnostic {
+            range: Range {
+                start: Position {
+                    line: 290,
+                    character: 8,
+                },
+                end: Position {
+                    line: 290,
+                    character: 11,
+                },
+            },
+            severity: Some(
+                Hint,
+            ),
+            code: Some(
+                String(
+                    "unused_variables",
+                ),
+            ),
+            source: Some(
+                "rustc",
+            ),
+            message: "unused variable: `foo`\n#[warn(unused_variables)] on by default",
+            related_information: None,
+            tags: Some(
+                [
+                    Unnecessary,
+                ],
+            ),
+        },
+        fixes: [
+            CodeAction {
+                title: "consider prefixing with an underscore",
+                id: None,
+                group: None,
+                kind: Some(
+                    "quickfix",
+                ),
+                command: None,
+                edit: Some(
+                    SnippetWorkspaceEdit {
+                        changes: Some(
+                            {
+                                "file:///test/driver/subcommand/repl.rs": [
+                                    TextEdit {
+                                        range: Range {
+                                            start: Position {
+                                                line: 290,
+                                                character: 8,
+                                            },
+                                            end: Position {
+                                                line: 290,
+                                                character: 11,
+                                            },
+                                        },
+                                        new_text: "_foo",
+                                    },
+                                ],
+                            },
+                        ),
+                        document_changes: None,
+                    },
+                ),
+            },
+        ],
+    },
+]

--- a/crates/rust-analyzer/src/diagnostics/snapshots/rust_analyzer__diagnostics__to_proto__tests__snap_rustc_unused_variable_as_info.snap
+++ b/crates/rust-analyzer/src/diagnostics/snapshots/rust_analyzer__diagnostics__to_proto__tests__snap_rustc_unused_variable_as_info.snap
@@ -1,0 +1,86 @@
+---
+source: crates/rust-analyzer/src/diagnostics/to_proto.rs
+expression: diag
+---
+[
+    MappedRustDiagnostic {
+        location: Location {
+            uri: "file:///test/driver/subcommand/repl.rs",
+            range: Range {
+                start: Position {
+                    line: 290,
+                    character: 8,
+                },
+                end: Position {
+                    line: 290,
+                    character: 11,
+                },
+            },
+        },
+        diagnostic: Diagnostic {
+            range: Range {
+                start: Position {
+                    line: 290,
+                    character: 8,
+                },
+                end: Position {
+                    line: 290,
+                    character: 11,
+                },
+            },
+            severity: Some(
+                Information,
+            ),
+            code: Some(
+                String(
+                    "unused_variables",
+                ),
+            ),
+            source: Some(
+                "rustc",
+            ),
+            message: "unused variable: `foo`\n#[warn(unused_variables)] on by default",
+            related_information: None,
+            tags: Some(
+                [
+                    Unnecessary,
+                ],
+            ),
+        },
+        fixes: [
+            CodeAction {
+                title: "consider prefixing with an underscore",
+                id: None,
+                group: None,
+                kind: Some(
+                    "quickfix",
+                ),
+                command: None,
+                edit: Some(
+                    SnippetWorkspaceEdit {
+                        changes: Some(
+                            {
+                                "file:///test/driver/subcommand/repl.rs": [
+                                    TextEdit {
+                                        range: Range {
+                                            start: Position {
+                                                line: 290,
+                                                character: 8,
+                                            },
+                                            end: Position {
+                                                line: 290,
+                                                character: 11,
+                                            },
+                                        },
+                                        new_text: "_foo",
+                                    },
+                                ],
+                            },
+                        ),
+                        document_changes: None,
+                    },
+                ),
+            },
+        ],
+    },
+]

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -734,6 +734,7 @@ fn on_check_task(
 
         CheckTask::AddDiagnostic { workspace_root, diagnostic } => {
             let diagnostics = crate::diagnostics::to_proto::map_rust_diagnostic_to_lsp(
+                &global_state.config.diagnostics,
                 &diagnostic,
                 &workspace_root,
             );

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -525,6 +525,24 @@
                     "markdownDescription": "Internal config for debugging, disables loading of sysroot crates",
                     "type": "boolean",
                     "default": true
+                },
+                "rust-analyzer.diagnostics.warningsAsInfo": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "List of warnings that should be displayed with info severity.\nThe warnings will be indicated by a blue squiggly underline in code and a blue icon in the problems panel.",
+                    "default": []
+                },
+                "rust-analyzer.diagnostics.warningsAsHint": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "List of warnings warnings that should be displayed with hint severity.\nThe warnings will be indicated by faded text or three dots in code and will not show up in te problems panel.",
+                    "default": []
                 }
             }
         },


### PR DESCRIPTION
Fixes #4229 

This PR is my second attempt at providing a solution to the above issue. My last PR(#4721) had to be rolled back(#4862) due to it overriding behavior many users expected. This PR solves a broader problem while trying to minimize surprises for the users. 

### Problem description
The underlying problem this PR tries to solve is the mismatch between [Rustc lint levels](https://doc.rust-lang.org/rustc/lints/levels.html) and [LSP diagnostic severity](https://microsoft.github.io/language-server-protocol/specification#diagnostic). Rustc currently doesn't have a lint level less severe than warning forcing the user to disable warnings if they think they get to noisy. LSP however provides two severitys below warning, information and hint. This allows editors like VSCode to provide more fine grained control over how prominently to show different diagnostics.

Info severity shows a blue squiggly underline in code and can be filtered separately from errors and warnings in the problems panel.
![image](https://user-images.githubusercontent.com/13839236/84830640-0bb8d900-b02a-11ea-9e2f-0561b0e8f1ef.png)
![image](https://user-images.githubusercontent.com/13839236/84826931-ffca1880-b023-11ea-8080-5e5b91a6ac0d.png)

Hint severity doesn't show up in the problems panel at all and only show three dots under the affected code or just faded text if the diagnostic also has the unnecessary tag.
![image](https://user-images.githubusercontent.com/13839236/84827165-55062a00-b024-11ea-8bd6-bdbf1217c4c5.png)

### Solution
The solution provided by this PR allows the user to configure lists of of warnings to report as info severity and hint severity respectively. I purposefully only convert warnings and not errors as i believe it's a good idea to have the editor show the same severity as the compiler as much as possible.
![image](https://user-images.githubusercontent.com/13839236/84829609-50437500-b028-11ea-80a8-1bbd05680ba7.png)

### Open questions
#### Discoverability
How do we teach this to new and existing users? Should a section be added to the user manual? If so  where and what should it say?

#### Defaults
Other languages such as TypeScript report unused code as hint by default. Should rust-analyzer similarly report some problems as hint/info by default?