### PR TITLE
Allow overriding rust-analyzer display version

### DIFF
--- a/crates/rust-analyzer/build.rs
+++ b/crates/rust-analyzer/build.rs
@@ -5,7 +5,8 @@ use std::{env, path::PathBuf, process::Command};
 fn main() {
     set_rerun();
 
-    let rev = env::var("RUST_ANALYZER_REV").ok().or_else(rev).unwrap_or_else(|| "???????".to_string());
+    let rev =
+        env::var("RUST_ANALYZER_REV").ok().or_else(rev).unwrap_or_else(|| "???????".to_string());
     println!("cargo:rustc-env=REV={}", rev)
 }
 

--- a/crates/rust-analyzer/build.rs
+++ b/crates/rust-analyzer/build.rs
@@ -5,11 +5,13 @@ use std::{env, path::PathBuf, process::Command};
 fn main() {
     set_rerun();
 
-    let rev = rev().unwrap_or_else(|| "???????".to_string());
+    let rev = env::var("RUST_ANALYZER_REV").ok().or_else(rev).unwrap_or_else(|| "???????".to_string());
     println!("cargo:rustc-env=REV={}", rev)
 }
 
 fn set_rerun() {
+    println!("cargo:rerun-if-env-changed=RUST_ANALYZER_REV");
+
     let mut manifest_dir = PathBuf::from(
         env::var("CARGO_MANIFEST_DIR").expect("`CARGO_MANIFEST_DIR` is always set by cargo."),
     );


### PR DESCRIPTION
The build script invokes `git` for version information which is displayed when rust-analyzer is called with `--version`. But in build environment without `git` or when the source code is not a git repo, there's no way to manually specify the version information.

This patch respects environment variable ~`REV`~ `RUST_ANALYZER_REV` in compile time for overriding.

Related: https://github.com/NixOS/nixpkgs/pull/90976