### PR TITLE
Speedup VFS::partition

### DIFF
--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -2,7 +2,7 @@
 //! relative paths.
 use std::{
     convert::{TryFrom, TryInto},
-    ops,
+    io, ops,
     path::{Component, Path, PathBuf},
 };
 
@@ -46,6 +46,9 @@ impl TryFrom<&str> for AbsPathBuf {
 }
 
 impl AbsPathBuf {
+    pub fn canonicalized(path: &Path) -> io::Result<AbsPathBuf> {
+        path.canonicalize().map(|it| AbsPathBuf::try_from(it).unwrap())
+    }
     pub fn as_path(&self) -> &AbsPath {
         AbsPath::new_unchecked(self.0.as_path())
     }

--- a/crates/stdx/src/lib.rs
+++ b/crates/stdx/src/lib.rs
@@ -1,5 +1,4 @@
 //! Missing batteries for standard libraries.
-
 use std::{cell::Cell, fmt, time::Instant};
 
 #[inline(always)]

--- a/crates/vfs/src/lib.rs
+++ b/crates/vfs/src/lib.rs
@@ -79,6 +79,9 @@ pub enum ChangeKind {
 }
 
 impl Vfs {
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
     pub fn file_id(&self, path: &VfsPath) -> Option<FileId> {
         self.interner.get(path).filter(|&it| self.get(it).is_some())
     }


### PR DESCRIPTION
The task of `partition` function is to bin the flat list of paths into
disjoint filesets. Ideally, it should be incremental -- each new file
should be added to a specific fileset.

However, preliminary measurnments show that it is actually fast enough
if we just optimize this to use a binary search instead of a linear
scan.



bors r+
🤖