### PR TITLE
Shift bound variables correctly when using assoc type shorthand

### DIFF
--- a/crates/ra_hir_ty/src/lower.rs
+++ b/crates/ra_hir_ty/src/lower.rs
@@ -467,6 +467,9 @@ impl Ty {
                             }
                             TypeParamLoweringMode::Variable => t.substs.clone(),
                         };
+                        // We need to shift in the bound vars, since
+                        // associated_type_shorthand_candidates does not do that
+                        let substs = substs.shift_bound_vars(ctx.in_binders);
                         // FIXME handle type parameters on the segment
                         return Some(Ty::Projection(ProjectionTy {
                             associated_ty,


### PR DESCRIPTION
Fixes #4885.
Fixes #4800.