### PR TITLE
Syntax highlighting for documentation comments on macro definitions

### DIFF
--- a/crates/ra_ide/src/snapshots/highlight_doctest.html
+++ b/crates/ra_ide/src/snapshots/highlight_doctest.html
@@ -84,4 +84,13 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
     <span class="keyword">pub</span> <span class="keyword">fn</span> <span class="function declaration">foo</span>(&<span class="self_keyword">self</span>) -&gt; <span class="builtin_type">bool</span> {
         <span class="bool_literal">true</span>
     }
+}
+
+<span class="comment documentation">/// ```</span>
+<span class="comment documentation">/// </span><span class="macro">noop!</span>(<span class="numeric_literal">1</span>);
+<span class="comment documentation">/// ```</span>
+<span class="macro">macro_rules!</span> <span class="macro declaration">noop</span> {
+    ($expr:expr) =&gt; {
+        $expr
+    }
 }</code></pre>

--- a/crates/ra_ide/src/syntax_highlighting.rs
+++ b/crates/ra_ide/src/syntax_highlighting.rs
@@ -121,7 +121,6 @@ pub(crate) fn highlight(
                 assert!(current_macro_call == Some(mc));
                 current_macro_call = None;
                 format_string = None;
-                continue;
             }
             _ => (),
         }
@@ -150,7 +149,7 @@ pub(crate) fn highlight(
 
         let range = element.text_range();
 
-        let element_to_highlight = if current_macro_call.is_some() {
+        let element_to_highlight = if current_macro_call.is_some() && element.kind() != COMMENT {
             // Inside a macro -- expand it first
             let token = match element.clone().into_token() {
                 Some(it) if it.parent().kind() == TOKEN_TREE => it,

--- a/crates/ra_ide/src/syntax_highlighting/tests.rs
+++ b/crates/ra_ide/src/syntax_highlighting/tests.rs
@@ -344,6 +344,15 @@ impl Foo {
         true
     }
 }
+
+/// ```
+/// noop!(1);
+/// ```
+macro_rules! noop {
+    ($expr:expr) => {
+        $expr
+    }
+}
 "#
         .trim(),
         "crates/ra_ide/src/snapshots/highlight_doctest.html",


### PR DESCRIPTION
Two minor changes with regards to syntax highlighting of comments attached to macro definitions.

Before
<img width="290" alt="Bildschirmfoto 2020-06-20 um 00 05 19" src="https://user-images.githubusercontent.com/201808/85182705-c561b500-b289-11ea-944e-0bdf6508a44f.png">

After
<img width="288" alt="Bildschirmfoto 2020-06-20 um 00 03 36" src="https://user-images.githubusercontent.com/201808/85182727-d90d1b80-b289-11ea-9d2d-234731f19302.png">
Fixes #4949