### PR TITLE
Compress `PerNs` representation in `ItemScope`

### DIFF
--- a/crates/ra_hir_def/src/per_ns.rs
+++ b/crates/ra_hir_def/src/per_ns.rs
@@ -96,10 +96,10 @@ impl PerNs {
 }
 
 #[derive(Clone, Eq, PartialEq)]
-pub struct Compressed(Repr);
+pub struct Compressed(CompressedRepr);
 
 #[derive(Clone, Eq, PartialEq)]
-enum Repr {
+enum CompressedRepr {
     /// No namespace in use.
     None,
     /// Only in type namespace.
@@ -114,7 +114,7 @@ enum Repr {
 
 impl Default for Compressed {
     fn default() -> Self {
-        Compressed(Repr::None)
+        Compressed(CompressedRepr::None)
     }
 }
 
@@ -122,13 +122,13 @@ impl From<PerNs> for Compressed {
     fn from(per_ns: PerNs) -> Self {
         let (t, v, m) = (per_ns.types, per_ns.values, per_ns.macros);
         match (t, v, m) {
-            (None, None, None) => Compressed(Repr::None),
-            (Some((t, v)), None, None) => Compressed(Repr::Ty(t, v)),
-            (None, Some((val, vis)), None) => Compressed(Repr::Val(val, vis)),
+            (None, None, None) => Compressed(CompressedRepr::None),
+            (Some((t, v)), None, None) => Compressed(CompressedRepr::Ty(t, v)),
+            (None, Some((val, vis)), None) => Compressed(CompressedRepr::Val(val, vis)),
             (Some((ty, tvis)), Some((val, vvis)), None) if ty == val && tvis == vvis => {
-                Compressed(Repr::TyVal(ty, tvis))
+                Compressed(CompressedRepr::TyVal(ty, tvis))
             }
-            _ => Compressed(Repr::Other(Box::new(per_ns))),
+            _ => Compressed(CompressedRepr::Other(Box::new(per_ns))),
         }
     }
 }
@@ -136,11 +136,11 @@ impl From<PerNs> for Compressed {
 impl From<Compressed> for PerNs {
     fn from(comp: Compressed) -> Self {
         match comp.0 {
-            Repr::None => PerNs::none(),
-            Repr::Ty(t, v) => PerNs::types(t, v),
-            Repr::Val(t, v) => PerNs::values(t, v),
-            Repr::TyVal(t, v) => PerNs::both(t, t, v),
-            Repr::Other(o) => *o,
+            CompressedRepr::None => PerNs::none(),
+            CompressedRepr::Ty(t, v) => PerNs::types(t, v),
+            CompressedRepr::Val(t, v) => PerNs::values(t, v),
+            CompressedRepr::TyVal(t, v) => PerNs::both(t, t, v),
+            CompressedRepr::Other(o) => *o,
         }
     }
 }
@@ -148,11 +148,11 @@ impl From<Compressed> for PerNs {
 impl<'a> From<&'a Compressed> for PerNs {
     fn from(comp: &'a Compressed) -> Self {
         match &comp.0 {
-            Repr::None => PerNs::none(),
-            Repr::Ty(t, v) => PerNs::types(*t, *v),
-            Repr::Val(t, v) => PerNs::values(*t, *v),
-            Repr::TyVal(t, v) => PerNs::both(*t, *t, *v),
-            Repr::Other(o) => **o,
+            CompressedRepr::None => PerNs::none(),
+            CompressedRepr::Ty(t, v) => PerNs::types(*t, *v),
+            CompressedRepr::Val(t, v) => PerNs::values(*t, *v),
+            CompressedRepr::TyVal(t, v) => PerNs::both(*t, *t, *v),
+            CompressedRepr::Other(o) => **o,
         }
     }
 }


### PR DESCRIPTION
`PerNs` is 100 Bytes and makes up most of the data in `CrateDefMap` due to the many names that are in scope at any time. Add a compressed representation that is 32 Bytes in size and spills to the heap for rarer `PerNs` instances (macros, value-only resolutions, etc.).

This saves >100 MB in CrateDefMap data for analysis-stats on rust-analyzer, but trades some performance for that.

Maybe an alternative solution would be to split `CrateDefMap` into a map for use by downstream crates, containing only publicly visible items, and the "full" def map for use inside the crate. I'm not quite sure how to avoid duplication there though, and it's a fairly large change.

Before:
```
Total: 34.129799209s, 1552mb allocated 1602mb resident
   250mb CrateDefMapQueryQuery
```

After:
```
Total: 35.000492939s, 1446mb allocated 1499mb resident
   134mb CrateDefMapQueryQuery
```