### PR TITLE
Hotfix skipping the first chunks of the artifacts

### DIFF
--- a/editors/code/src/net.ts
+++ b/editors/code/src/net.ts
@@ -114,15 +114,16 @@ async function downloadFile(
 
     log.debug("Downloading file of", totalBytes, "bytes size from", url, "to", destFilePath);
 
-    let readBytes = 0;
-    res.body.on("data", (chunk: Buffer) => {
-        readBytes += chunk.length;
-        onProgress(readBytes, totalBytes);
-    });
-
     // Put the artifact into a temporary folder to prevent partially downloaded files when user kills vscode
     await withTempFile(async tempFilePath => {
         const destFileStream = fs.createWriteStream(tempFilePath, { mode });
+
+        let readBytes = 0;
+        res.body.on("data", (chunk: Buffer) => {
+            readBytes += chunk.length;
+            onProgress(readBytes, totalBytes);
+        });
+
         await pipeline(res.body, destFileStream);
         await new Promise<void>(resolve => {
             destFileStream.on("close", resolve);


### PR DESCRIPTION
Quick hotfix.
fixes: #4986, #4987


The stream starts being consumed once we put a handler for `data` event.
When extracting `stream.pipeline()` under `withTempFile` in #4963 I didn't move it into the scope too, which due to preliminary awaiting for async operations with the file system allowed for the first chunks of the file to be skipped