### PR TITLE
Make bootstrap error message more informative and better-fitting

### DIFF
--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -43,12 +43,16 @@ export async function activate(context: vscode.ExtensionContext) {
     const config = new Config(context);
     const state = new PersistentState(context.globalState);
     const serverPath = await bootstrap(config, state).catch(err => {
-        let message = "Failed to bootstrap rust-analyzer.";
+        let message = "bootstrap error. ";
+
         if (err.code === "EBUSY" || err.code === "ETXTBSY") {
-            message += " Other vscode windows might be using rust-analyzer, " +
-                "you should close them and reload this window to retry.";
+            message += "Other vscode windows might be using rust-analyzer, ";
+            message += "you should close them and reload this window to retry. ";
         }
-        message += " Open \"Help > Toggle Developer Tools > Console\" to see the logs";
+
+        message += 'Open "Help > Toggle Developer Tools > Console" to see the logs ';
+        message += '(enable verbose logs with "rust-analyzer.trace.extension")';
+
         log.error("Bootstrap error", err);
         throw new Error(message);
     });


### PR DESCRIPTION
Now this better fits standard vscode extension activation failure message and suggests enabling verbose logs.

![image](https://user-images.githubusercontent.com/36276403/85321828-ffbb9400-b4cd-11ea-8adf-4032b1f62dfd.png)
