### PR TITLE
Disrecommend trace.server: "verbose" for regular users

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -426,7 +426,7 @@
                         "Full log"
                     ],
                     "default": "off",
-                    "description": "Trace requests to the rust-analyzer"
+                    "description": "Trace requests to the rust-analyzer (this is usually overly verbose and not recommended for regular users)"
                 },
                 "rust-analyzer.trace.extension": {
                     "description": "Enable logging of VS Code extensions itself",


### PR DESCRIPTION
This option has never been useful for me, I wonder if anyone finds regular users can use this for sending logs