### PR TITLE
Remove RelativePathBuf from fixture

### DIFF
--- a/crates/ra_assists/src/handlers/add_from_impl_for_enum.rs
+++ b/crates/ra_assists/src/handlers/add_from_impl_for_enum.rs
@@ -128,7 +128,7 @@ impl From<foo::bar::baz::Boo> for A {
 
     fn check_not_applicable(ra_fixture: &str) {
         let fixture =
-            format!("//- main.rs crate:main deps:core\n{}\n{}", ra_fixture, FamousDefs::FIXTURE);
+            format!("//- /main.rs crate:main deps:core\n{}\n{}", ra_fixture, FamousDefs::FIXTURE);
         check_assist_not_applicable(add_from_impl_for_enum, &fixture)
     }
 

--- a/crates/ra_assists/src/handlers/extract_struct_from_enum_variant.rs
+++ b/crates/ra_assists/src/handlers/extract_struct_from_enum_variant.rs
@@ -301,7 +301,7 @@ fn another_fn() {
 
     fn check_not_applicable(ra_fixture: &str) {
         let fixture =
-            format!("//- main.rs crate:main deps:core\n{}\n{}", ra_fixture, FamousDefs::FIXTURE);
+            format!("//- /main.rs crate:main deps:core\n{}\n{}", ra_fixture, FamousDefs::FIXTURE);
         check_assist_not_applicable(extract_struct_from_enum_variant, &fixture)
     }
 

--- a/crates/ra_assists/src/handlers/fill_match_arms.rs
+++ b/crates/ra_assists/src/handlers/fill_match_arms.rs
@@ -765,7 +765,7 @@ fn foo(opt: Option<i32>) {
     }
 }"#;
         let before =
-            &format!("//- main.rs crate:main deps:core\n{}{}", before, FamousDefs::FIXTURE);
+            &format!("//- /main.rs crate:main deps:core\n{}{}", before, FamousDefs::FIXTURE);
 
         check_assist(
             fill_match_arms,

--- a/crates/ra_db/src/fixture.rs
+++ b/crates/ra_db/src/fixture.rs
@@ -164,7 +164,7 @@ fn with_files(db: &mut dyn SourceDatabaseExt, fixture: &str) -> Option<FilePosit
 
     let mut source_root = SourceRoot::new_local();
     let mut source_root_id = WORKSPACE;
-    let mut source_root_prefix: RelativePathBuf = "/".into();
+    let mut source_root_prefix = "/".to_string();
     let mut file_id = FileId(0);
 
     let mut file_position = None;
@@ -212,9 +212,9 @@ fn with_files(db: &mut dyn SourceDatabaseExt, fixture: &str) -> Option<FilePosit
         };
 
         db.set_file_text(file_id, Arc::new(text));
-        db.set_file_relative_path(file_id, meta.path.clone());
+        db.set_file_relative_path(file_id, meta.path.clone().into());
         db.set_file_source_root(file_id, source_root_id);
-        source_root.insert_file(meta.path, file_id);
+        source_root.insert_file(meta.path.into(), file_id);
 
         file_id.0 += 1;
     }
@@ -245,12 +245,12 @@ fn with_files(db: &mut dyn SourceDatabaseExt, fixture: &str) -> Option<FilePosit
 }
 
 enum ParsedMeta {
-    Root { path: RelativePathBuf },
+    Root { path: String },
     File(FileMeta),
 }
 
 struct FileMeta {
-    path: RelativePathBuf,
+    path: String,
     krate: Option<String>,
     deps: Vec<String>,
     cfg: CfgOptions,

--- a/crates/ra_hir_ty/src/tests/method_resolution.rs
+++ b/crates/ra_hir_ty/src/tests/method_resolution.rs
@@ -933,7 +933,7 @@ fn method_resolution_overloaded_method() {
     test_utils::mark::check!(impl_self_type_match_without_receiver);
     let t = type_at(
         r#"
-//- main.rs
+//- /main.rs
 struct Wrapper<T>(T);
 struct Foo<T>(T);
 struct Bar<T>(T);

--- a/crates/rust-analyzer/tests/heavy_tests/main.rs
+++ b/crates/rust-analyzer/tests/heavy_tests/main.rs
@@ -29,12 +29,12 @@ fn completes_items_from_standard_library() {
     let project_start = Instant::now();
     let server = Project::with_fixture(
         r#"
-//- Cargo.toml
+//- /Cargo.toml
 [package]
 name = "foo"
 version = "0.0.0"
 
-//- src/lib.rs
+//- /src/lib.rs
 use std::collections::Spam;
 "#,
     )
@@ -63,24 +63,24 @@ fn test_runnables_project() {
     }
 
     let code = r#"
-//- foo/Cargo.toml
+//- /foo/Cargo.toml
 [package]
 name = "foo"
 version = "0.0.0"
 
-//- foo/src/lib.rs
+//- /foo/src/lib.rs
 pub fn foo() {}
 
-//- foo/tests/spam.rs
+//- /foo/tests/spam.rs
 #[test]
 fn test_eggs() {}
 
-//- bar/Cargo.toml
+//- /bar/Cargo.toml
 [package]
 name = "bar"
 version = "0.0.0"
 
-//- bar/src/main.rs
+//- /bar/src/main.rs
 fn main() {}
 "#;
 
@@ -140,12 +140,12 @@ fn test_format_document() {
 
     let server = project(
         r#"
-//- Cargo.toml
+//- /Cargo.toml
 [package]
 name = "foo"
 version = "0.0.0"
 
-//- src/lib.rs
+//- /src/lib.rs
 mod bar;
 
 fn main() {
@@ -200,13 +200,13 @@ fn test_format_document_2018() {
 
     let server = project(
         r#"
-//- Cargo.toml
+//- /Cargo.toml
 [package]
 name = "foo"
 version = "0.0.0"
 edition = "2018"
 
-//- src/lib.rs
+//- /src/lib.rs
 mod bar;
 
 async fn test() {
@@ -266,12 +266,12 @@ fn test_missing_module_code_action() {
 
     let server = project(
         r#"
-//- Cargo.toml
+//- /Cargo.toml
 [package]
 name = "foo"
 version = "0.0.0"
 
-//- src/lib.rs
+//- /src/lib.rs
 mod bar;
 
 fn main() {}
@@ -335,10 +335,10 @@ fn test_missing_module_code_action_in_json_project() {
 
     let code = format!(
         r#"
-//- rust-project.json
+//- /rust-project.json
 {PROJECT}
 
-//- src/lib.rs
+//- /src/lib.rs
 mod bar;
 
 fn main() {{}}
@@ -391,15 +391,15 @@ fn diagnostics_dont_block_typing() {
     }
 
     let librs: String = (0..10).map(|i| format!("mod m{};", i)).collect();
-    let libs: String = (0..10).map(|i| format!("//- src/m{}.rs\nfn foo() {{}}\n\n", i)).collect();
+    let libs: String = (0..10).map(|i| format!("//- /src/m{}.rs\nfn foo() {{}}\n\n", i)).collect();
     let server = Project::with_fixture(&format!(
         r#"
-//- Cargo.toml
+//- /Cargo.toml
 [package]
 name = "foo"
 version = "0.0.0"
 
-//- src/lib.rs
+//- /src/lib.rs
 {}
 
 {}
@@ -449,12 +449,12 @@ fn preserves_dos_line_endings() {
 
     let server = Project::with_fixture(
         &"
-//- Cargo.toml
+//- /Cargo.toml
 [package]
 name = \"foo\"
 version = \"0.0.0\"
 
-//- src/main.rs
+//- /src/main.rs
 /// Some Docs\r\nfn main() {}
 ",
     )
@@ -484,12 +484,12 @@ fn out_dirs_check() {
 
     let server = Project::with_fixture(
         r###"
-//- Cargo.toml
+//- /Cargo.toml
 [package]
 name = "foo"
 version = "0.0.0"
 
-//- build.rs
+//- /build.rs
 use std::{env, fs, path::Path};
 
 fn main() {
@@ -504,7 +504,7 @@ fn main() {
     println!("cargo:rustc-cfg=featlike=\"set\"");
     println!("cargo:rerun-if-changed=build.rs");
 }
-//- src/main.rs
+//- /src/main.rs
 #[rustc_builtin_macro] macro_rules! include {}
 #[rustc_builtin_macro] macro_rules! concat {}
 #[rustc_builtin_macro] macro_rules! env {}
@@ -599,7 +599,7 @@ fn resolve_proc_macro() {
     }
     let server = Project::with_fixture(
         r###"
-//- foo/Cargo.toml
+//- /foo/Cargo.toml
 [package]
 name = "foo"
 version = "0.0.0"
@@ -607,7 +607,7 @@ edition = "2018"
 [dependencies]
 bar = {path = "../bar"}
 
-//- foo/src/main.rs
+//- /foo/src/main.rs
 use bar::Bar;
 trait Bar {
   fn bar();
@@ -618,7 +618,7 @@ fn main() {
   Foo::bar();
 }
 
-//- bar/Cargo.toml
+//- /bar/Cargo.toml
 [package]
 name = "bar"
 version = "0.0.0"
@@ -627,7 +627,7 @@ edition = "2018"
 [lib]
 proc-macro = true
 
-//- bar/src/lib.rs
+//- /bar/src/lib.rs
 extern crate proc_macro;
 use proc_macro::{Delimiter, Group, Ident, Span, TokenStream, TokenTree};
 macro_rules! t {

--- a/crates/rust-analyzer/tests/heavy_tests/support.rs
+++ b/crates/rust-analyzer/tests/heavy_tests/support.rs
@@ -69,7 +69,7 @@ impl<'a> Project<'a> {
         let mut paths = vec![];
 
         for entry in parse_fixture(self.fixture) {
-            let path = tmp_dir.path().join(entry.meta.path().as_str());
+            let path = tmp_dir.path().join(&entry.meta.path()['/'.len_utf8()..]);
             fs::create_dir_all(path.parent().unwrap()).unwrap();
             fs::write(path.as_path(), entry.text.as_bytes()).unwrap();
             paths.push((path, entry.text));

--- a/crates/test_utils/src/lib.rs
+++ b/crates/test_utils/src/lib.rs
@@ -168,13 +168,13 @@ pub struct FixtureEntry {
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum FixtureMeta {
-    Root { path: RelativePathBuf },
+    Root { path: String },
     File(FileMeta),
 }
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct FileMeta {
-    pub path: RelativePathBuf,
+    pub path: String,
     pub crate_name: Option<String>,
     pub deps: Vec<String>,
     pub cfg: CfgOptions,
@@ -183,7 +183,7 @@ pub struct FileMeta {
 }
 
 impl FixtureMeta {
-    pub fn path(&self) -> &RelativePath {
+    pub fn path(&self) -> &str {
         match self {
             FixtureMeta::Root { path } => &path,
             FixtureMeta::File(f) => &f.path,
@@ -292,12 +292,12 @@ fn parse_meta(meta: &str) -> FixtureMeta {
     let components = meta.split_ascii_whitespace().collect::<Vec<_>>();
 
     if components[0] == "root" {
-        let path: RelativePathBuf = components[1].into();
+        let path = components[1].to_string();
         assert!(path.starts_with("/") && path.ends_with("/"));
         return FixtureMeta::Root { path };
     }
 
-    let path: RelativePathBuf = components[0].into();
+    let path = components[0].to_string();
     assert!(path.starts_with("/"));
 
     let mut krate = None;


### PR DESCRIPTION
The paths in fixture are not really relative (the default one is
`/main.rs`), so it doesn't make sense to use `RelativePathBuf` here.



bors r+
🤖