### PR TITLE
Fix underflow panic when doctests are at top of file

### DIFF
--- a/crates/ra_ide/src/snapshots/highlight_doctest.html
+++ b/crates/ra_ide/src/snapshots/highlight_doctest.html
@@ -32,7 +32,10 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .keyword.unsafe     { color: #BC8383; font-weight: bold; }
 .control            { font-style: italic; }
 </style>
-<pre><code><span class="keyword">struct</span> <span class="struct declaration">Foo</span> {
+<pre><code><span class="comment documentation">/// ```</span>
+<span class="comment documentation">/// </span><span class="keyword">let</span> _ = <span class="string_literal">"early doctests should not go boom"</span>;
+<span class="comment documentation">/// ```</span>
+<span class="keyword">struct</span> <span class="struct declaration">Foo</span> {
     <span class="field declaration">bar</span>: <span class="builtin_type">bool</span>,
 }
 

--- a/crates/ra_ide/src/syntax_highlighting/injection.rs
+++ b/crates/ra_ide/src/syntax_highlighting/injection.rs
@@ -155,17 +155,21 @@ pub(super) fn highlight_doc_comment(
         let mut start_offset = None;
         let mut end_offset = None;
         for (line_start, orig_line_start) in range_mapping.range(..h.range.end()).rev() {
+            // It's possible for orig_line_start - line_start to be negative. Add h.range.start()
+            // here and remove it from the end range after the loop below so that the values are
+            // always non-negative.
+            let offset = h.range.start() + orig_line_start - line_start;
             if line_start <= &h.range.start() {
-                start_offset.get_or_insert(orig_line_start - line_start);
+                start_offset.get_or_insert(offset);
                 break;
             } else {
-                end_offset.get_or_insert(orig_line_start - line_start);
+                end_offset.get_or_insert(offset);
             }
         }
         if let Some(start_offset) = start_offset {
             h.range = TextRange::new(
-                h.range.start() + start_offset,
-                h.range.end() + end_offset.unwrap_or(start_offset),
+                start_offset,
+                h.range.end() + end_offset.unwrap_or(start_offset) - h.range.start(),
             );
 
             stack.add(h);

--- a/crates/ra_ide/src/syntax_highlighting/tests.rs
+++ b/crates/ra_ide/src/syntax_highlighting/tests.rs
@@ -291,6 +291,9 @@ fn main() {
 fn test_highlight_doctest() {
     check_highlighting(
         r#"
+/// ```
+/// let _ = "early doctests should not go boom";
+/// ```
 struct Foo {
     bar: bool,
 }


### PR DESCRIPTION
While debugging a comment at the top of a test string, I discovered that the offset calculations could underflow and panic. This only seemed to occur in tests, I assume because it's running a debug mode. The wrapping is quickly fixed later on in release mode, which is why this seems to have gone unnoticed. The new checks ensure the value is always positive or zero.