### PR TITLE
Fix panic in split/merge import assists

### DIFF
--- a/crates/ra_assists/src/handlers/merge_imports.rs
+++ b/crates/ra_assists/src/handlers/merge_imports.rs
@@ -127,7 +127,7 @@ fn first_path(path: &ast::Path) -> ast::Path {
 
 #[cfg(test)]
 mod tests {
-    use crate::tests::check_assist;
+    use crate::tests::{check_assist, check_assist_not_applicable};
 
     use super::*;
 
@@ -275,5 +275,15 @@ use foo::{
 bar::baz};
 ",
         )
+    }
+
+    #[test]
+    fn test_empty_use() {
+        check_assist_not_applicable(
+            merge_imports,
+            r"
+use std::<|>
+fn main() {}",
+        );
     }
 }

--- a/crates/ra_assists/src/handlers/split_import.rs
+++ b/crates/ra_assists/src/handlers/split_import.rs
@@ -66,4 +66,14 @@ mod tests {
     fn issue4044() {
         check_assist_not_applicable(split_import, "use crate::<|>:::self;")
     }
+
+    #[test]
+    fn test_empty_use() {
+        check_assist_not_applicable(
+            split_import,
+            r"
+use std::<|>
+fn main() {}",
+        );
+    }
 }

--- a/crates/ra_parser/src/grammar/paths.rs
+++ b/crates/ra_parser/src/grammar/paths.rs
@@ -73,8 +73,10 @@ fn path_segment(p: &mut Parser, mode: Mode, first: bool) {
         }
         p.expect(T![>]);
     } else {
+        let mut empty = true;
         if first {
             p.eat(T![::]);
+            empty = false;
         }
         match p.current() {
             IDENT => {
@@ -86,6 +88,12 @@ fn path_segment(p: &mut Parser, mode: Mode, first: bool) {
             T![self] | T![super] | T![crate] => p.bump_any(),
             _ => {
                 p.err_recover("expected identifier", items::ITEM_RECOVERY_SET);
+                if empty {
+                    // test_err empty_segment
+                    // use crate::;
+                    m.abandon(p);
+                    return;
+                }
             }
         };
     }

--- a/crates/ra_syntax/test_data/parser/err/0004_use_path_bad_segment.rast
+++ b/crates/ra_syntax/test_data/parser/err/0004_use_path_bad_segment.rast
@@ -9,8 +9,7 @@ SOURCE_FILE@0..12
             NAME_REF@4..7
               IDENT@4..7 "foo"
         COLON2@7..9 "::"
-        PATH_SEGMENT@9..11
-          ERROR@9..11
-            INT_NUMBER@9..11 "92"
+        ERROR@9..11
+          INT_NUMBER@9..11 "92"
     SEMICOLON@11..12 ";"
 error 9..9: expected identifier

--- a/crates/ra_syntax/test_data/parser/inline/err/0015_empty_segment.rast
+++ b/crates/ra_syntax/test_data/parser/inline/err/0015_empty_segment.rast
@@ -1,0 +1,15 @@
+SOURCE_FILE@0..13
+  USE_ITEM@0..12
+    USE_KW@0..3 "use"
+    WHITESPACE@3..4 " "
+    USE_TREE@4..12
+      PATH@4..12
+        PATH@4..9
+          PATH_SEGMENT@4..9
+            CRATE_KW@4..9 "crate"
+        COLON2@9..11 "::"
+        ERROR@11..12
+          SEMICOLON@11..12 ";"
+  WHITESPACE@12..13 "\n"
+error 11..11: expected identifier
+error 12..12: expected SEMICOLON

--- a/crates/ra_syntax/test_data/parser/inline/err/0015_empty_segment.rs
+++ b/crates/ra_syntax/test_data/parser/inline/err/0015_empty_segment.rs
@@ -1,0 +1,1 @@
+use crate::;

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -348,6 +348,8 @@ To update test data, run with `UPDATE_EXPECTATIONS` variable:
 env UPDATE_EXPECTATIONS=1 cargo qt
 ```
 
+After adding a new inline test you need to run `cargo xtest codegen` and also update the test data as described above.
+
 # Logging
 
 Logging is done by both rust-analyzer and VS Code, so it might be tricky to


### PR DESCRIPTION
Fixes #4368 #4905

Not sure if this is the best solution here. Maybe the `make` functions should be fallible? We generally seem to be playing whack-a-mole with panics in assists, although most of them are `unwrap`s in the assist code.