### PR TITLE
Add custom cargo runners support.

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -336,6 +336,14 @@
                     "default": null,
                     "description": "List of features to activate. Defaults to `rust-analyzer.cargo.features`."
                 },
+                "rust-analyzer.cargoRunner": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "default": null,
+                    "description": "Custom cargo runner extension ID."
+                },
                 "rust-analyzer.inlayHints.enable": {
                     "type": "boolean",
                     "default": true,

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -394,7 +394,7 @@ export function run(ctx: Ctx): Cmd {
 
         item.detail = 'rerun';
         prevRunnable = item;
-        const task = createTask(item.runnable);
+        const task = await createTask(item.runnable, ctx.config);
         return await vscode.tasks.executeTask(task);
     };
 }
@@ -404,7 +404,7 @@ export function runSingle(ctx: Ctx): Cmd {
         const editor = ctx.activeRustEditor;
         if (!editor) return;
 
-        const task = createTask(runnable);
+        const task = await createTask(runnable, ctx.config);
         task.group = vscode.TaskGroup.Build;
         task.presentationOptions = {
             reveal: vscode.TaskRevealKind.Always,

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -110,6 +110,10 @@ export class Config {
         };
     }
 
+    get cargoRunner() {
+        return this.get<string | undefined>("cargoRunner");
+    }
+
     get debug() {
         // "/rustc/<id>" used by suggestions only.
         const { ["/rustc/<id>"]: _, ...sourceFileMap } = this.get<Record<string, string>>("debug.sourceFileMap");

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -115,7 +115,7 @@ export async function activate(context: vscode.ExtensionContext) {
     ctx.registerCommand('applyActionGroup', commands.applyActionGroup);
     ctx.registerCommand('gotoLocation', commands.gotoLocation);
 
-    ctx.pushCleanup(activateTaskProvider(workspaceFolder));
+    ctx.pushCleanup(activateTaskProvider(workspaceFolder, ctx.config));
 
     activateStatusDisplay(ctx);
 

--- a/editors/code/src/run.ts
+++ b/editors/code/src/run.ts
@@ -1,10 +1,11 @@
 import * as vscode from 'vscode';
 import * as lc from 'vscode-languageclient';
 import * as ra from './lsp_ext';
-import * as toolchain from "./toolchain";
+import * as tasks from './tasks';
 
 import { Ctx } from './ctx';
 import { makeDebugConfig } from './debug';
+import { Config } from './config';
 
 const quickPickButtons = [{ iconPath: new vscode.ThemeIcon("save"), tooltip: "Save as a launch.json configurtation." }];
 
@@ -95,52 +96,28 @@ export class RunnableQuickPick implements vscode.QuickPickItem {
     }
 }
 
-interface CargoTaskDefinition extends vscode.TaskDefinition {
-    type: 'cargo';
-    label: string;
-    command: string;
-    args: string[];
-    env?: { [key: string]: string };
-}
+export async function createTask(runnable: ra.Runnable, config: Config): Promise<vscode.Task> {
+    if (runnable.kind !== "cargo") {
+        // rust-analyzer supports only one kind, "cargo"
+        // do not use tasks.TASK_TYPE here, these are completely different meanings.
 
-export function createTask(runnable: ra.Runnable): vscode.Task {
-    const TASK_SOURCE = 'Rust';
-
-    let command;
-    switch (runnable.kind) {
-        case "cargo": command = toolchain.getPathForExecutable("cargo");
+        throw `Unexpected runnable kind: ${runnable.kind}`;
     }
+
     const args = [...runnable.args.cargoArgs]; // should be a copy!
     if (runnable.args.executableArgs.length > 0) {
         args.push('--', ...runnable.args.executableArgs);
     }
-    const definition: CargoTaskDefinition = {
-        type: 'cargo',
-        label: runnable.label,
-        command,
-        args,
+    const definition: tasks.CargoTaskDefinition = {
+        type: tasks.TASK_TYPE,
+        command: args[0], // run, test, etc...
+        args: args.slice(1),
+        cwd: runnable.args.workspaceRoot,
         env: Object.assign({}, process.env as { [key: string]: string }, { "RUST_BACKTRACE": "short" }),
     };
 
-    const execOption: vscode.ShellExecutionOptions = {
-        cwd: runnable.args.workspaceRoot || '.',
-        env: definition.env,
-    };
-    const exec = new vscode.ShellExecution(
-        definition.command,
-        definition.args,
-        execOption,
-    );
+    const cargoTask = await tasks.buildCargoTask(definition, runnable.label, args, config.cargoRunner);
+    cargoTask.presentationOptions.clear = true;
 
-    const f = vscode.workspace.workspaceFolders![0];
-    const t = new vscode.Task(
-        definition,
-        f,
-        definition.label,
-        TASK_SOURCE,
-        exec,
-        ['$rustc'],
-    );
-    t.presentationOptions.clear = true;
-    return t;
+    return cargoTask;
 }

--- a/editors/code/src/run.ts
+++ b/editors/code/src/run.ts
@@ -116,7 +116,8 @@ export async function createTask(runnable: ra.Runnable, config: Config): Promise
         env: Object.assign({}, process.env as { [key: string]: string }, { "RUST_BACKTRACE": "short" }),
     };
 
-    const cargoTask = await tasks.buildCargoTask(definition, runnable.label, args, config.cargoRunner);
+    const target = vscode.workspace.workspaceFolders![0]; // safe, see main activate()
+    const cargoTask = await tasks.buildCargoTask(target, definition, runnable.label, args, config.cargoRunner, true);
     cargoTask.presentationOptions.clear = true;
 
     return cargoTask;

--- a/editors/code/src/tasks.ts
+++ b/editors/code/src/tasks.ts
@@ -83,7 +83,7 @@ export async function buildCargoTask(
             const customExec = await vscode.commands.executeCommand(runnerCommand, runnerArgs);
             if (customExec) {
                 if (customExec instanceof vscode.ShellExecution) {
-                    exec = customExec as vscode.ShellExecution;
+                    exec = customExec;
                 } else {
                     log.debug("Invalid cargo ShellExecution", customExec);
                     throw "Invalid cargo ShellExecution.";
@@ -98,7 +98,7 @@ export async function buildCargoTask(
     }
 
     if (!exec) {
-        exec = new vscode.ShellExecution(toolchain.cargoPath(), args, definition)
+        exec = new vscode.ShellExecution(toolchain.cargoPath(), args, definition);
     }
 
     return new vscode.Task(

--- a/editors/code/src/tasks.ts
+++ b/editors/code/src/tasks.ts
@@ -1,11 +1,14 @@
 import * as vscode from 'vscode';
 import * as toolchain from "./toolchain";
+import { Config } from './config';
+import { log } from './util';
 
 // This ends up as the `type` key in tasks.json. RLS also uses `cargo` and
 // our configuration should be compatible with it so use the same key.
-const TASK_TYPE = 'cargo';
+export const TASK_TYPE = 'cargo';
+export const TASK_SOURCE = 'rust';
 
-interface CargoTaskDefinition extends vscode.TaskDefinition {
+export interface CargoTaskDefinition extends vscode.TaskDefinition {
     command?: string;
     args?: string[];
     cwd?: string;
@@ -14,9 +17,11 @@ interface CargoTaskDefinition extends vscode.TaskDefinition {
 
 class CargoTaskProvider implements vscode.TaskProvider {
     private readonly target: vscode.WorkspaceFolder;
+    private readonly config: Config;
 
-    constructor(target: vscode.WorkspaceFolder) {
+    constructor(target: vscode.WorkspaceFolder, config: Config) {
         this.target = target;
+        this.config = config;
     }
 
     provideTasks(): vscode.Task[] {
@@ -58,29 +63,52 @@ class CargoTaskProvider implements vscode.TaskProvider {
             });
     }
 
-    resolveTask(task: vscode.Task): vscode.Task | undefined {
+    async resolveTask(task: vscode.Task): Promise<vscode.Task | undefined> {
         // VSCode calls this for every cargo task in the user's tasks.json,
         // we need to inform VSCode how to execute that command by creating
         // a ShellExecution for it.
 
         const definition = task.definition as CargoTaskDefinition;
 
-        if (definition.type === 'cargo' && definition.command) {
+        if (definition.type === TASK_TYPE && definition.command) {
             const args = [definition.command].concat(definition.args ?? []);
 
-            return new vscode.Task(
-                definition,
-                task.name,
-                'rust',
-                new vscode.ShellExecution('cargo', args, definition),
-            );
+            return await buildCargoTask(definition, task.name, args, this.config.cargoRunner);
         }
 
         return undefined;
     }
 }
 
-export function activateTaskProvider(target: vscode.WorkspaceFolder): vscode.Disposable {
-    const provider = new CargoTaskProvider(target);
+export async function buildCargoTask(definition: CargoTaskDefinition, name: string, args: string[], customRunner?: string): Promise<vscode.Task> {
+    if (customRunner) {
+        const runnerCommand = `${customRunner}.createCargoTask`;
+        try {
+            const runnerArgs = { name, args, cwd: definition.cwd, env: definition.env, source: TASK_SOURCE };
+            const task = await vscode.commands.executeCommand(runnerCommand, runnerArgs);
+
+            if (task instanceof vscode.Task) {
+                return task;
+            } else if (task) {
+                log.debug("Invalid cargo task", task);
+                throw `Invalid task!`;
+            }
+            // fallback to default processing
+
+        } catch (e) {
+            throw `Cargo runner '${customRunner}' failed! ${e}`;
+        }
+    }
+
+    return new vscode.Task(
+        definition,
+        name,
+        TASK_SOURCE,
+        new vscode.ShellExecution(toolchain.cargoPath(), args, definition),
+    );
+}
+
+export function activateTaskProvider(target: vscode.WorkspaceFolder, config: Config): vscode.Disposable {
+    const provider = new CargoTaskProvider(target, config);
     return vscode.tasks.registerTaskProvider(TASK_TYPE, provider);
 }


### PR DESCRIPTION
This PR adds an option to delegate actual cargo commands building to another extension. For example, to use a different manager like [cross](https://github.com/rust-embedded/cross).

https://github.com/vsrs/cross-rust-analyzer is an example of such extension. I'll publish it after the rust-analyzer release with this functionality.

Fixes https://github.com/rust-analyzer/rust-analyzer/issues/4902