### PR TITLE
Remove namedExports config

### DIFF
--- a/editors/code/rollup.config.js
+++ b/editors/code/rollup.config.js
@@ -11,12 +11,7 @@ export default {
         resolve({
             preferBuiltins: true
         }),
-        commonjs({
-            namedExports: {
-                // squelch missing import warnings
-                'vscode-languageclient': ['CreateFile', 'RenameFile', 'ErrorCodes', 'WorkDoneProgress', 'WorkDoneProgressBegin', 'WorkDoneProgressReport', 'WorkDoneProgressEnd']
-            }
-        })
+        commonjs()
     ],
     external: [...nodeBuiltins, 'vscode'],
     output: {


### PR DESCRIPTION
Fixes a warning:

```
(!) Plugin commonjs: The namedExports option from "@rollup/plugin-commonjs" is deprecated. Named exports are now handled automatically.
```