### PR TITLE
Micro-optimize lookahead in composite tokens

### DIFF
--- a/crates/ra_parser/src/parser.rs
+++ b/crates/ra_parser/src/parser.rs
@@ -127,17 +127,24 @@ impl<'t> Parser<'t> {
 
     fn at_composite2(&self, n: usize, k1: SyntaxKind, k2: SyntaxKind) -> bool {
         let t1 = self.token_source.lookahead_nth(n);
+        if t1.kind != k1 || !t1.is_jointed_to_next {
+            return false;
+        }
         let t2 = self.token_source.lookahead_nth(n + 1);
-        t1.kind == k1 && t1.is_jointed_to_next && t2.kind == k2
+        t2.kind == k2
     }
 
     fn at_composite3(&self, n: usize, k1: SyntaxKind, k2: SyntaxKind, k3: SyntaxKind) -> bool {
         let t1 = self.token_source.lookahead_nth(n);
+        if t1.kind != k1 || !t1.is_jointed_to_next {
+            return false;
+        }
         let t2 = self.token_source.lookahead_nth(n + 1);
+        if t2.kind != k2 || !t2.is_jointed_to_next {
+            return false;
+        }
         let t3 = self.token_source.lookahead_nth(n + 2);
-        (t1.kind == k1 && t1.is_jointed_to_next)
-            && (t2.kind == k2 && t2.is_jointed_to_next)
-            && t3.kind == k3
+        t3.kind == k3
     }
 
     /// Checks if the current token is in `kinds`.


### PR DESCRIPTION
I'm not sure that this is measurable, but can't hurt, I guess.