### PR TITLE
Disable auto-complete on comments

### DIFF
--- a/crates/ra_ide/src/completion/complete_keyword.rs
+++ b/crates/ra_ide/src/completion/complete_keyword.rs
@@ -1,6 +1,6 @@
 //! FIXME: write short doc here
 
-use ra_syntax::ast;
+use ra_syntax::{ast, SyntaxKind};
 
 use crate::completion::{
     CompletionContext, CompletionItem, CompletionItemKind, CompletionKind, Completions,
@@ -37,6 +37,10 @@ pub(super) fn complete_use_tree_keyword(acc: &mut Completions, ctx: &CompletionC
 }
 
 pub(super) fn complete_expr_keyword(acc: &mut Completions, ctx: &CompletionContext) {
+    if ctx.token.kind() == SyntaxKind::COMMENT {
+        return;
+    }
+
     let has_trait_or_impl_parent = ctx.has_impl_parent || ctx.has_trait_parent;
     if ctx.trait_as_prev_sibling || ctx.impl_as_prev_sibling {
         add_keyword(ctx, acc, "where", "where ");

--- a/crates/ra_ide/src/completion/presentation.rs
+++ b/crates/ra_ide/src/completion/presentation.rs
@@ -1516,4 +1516,54 @@ mod tests {
         "###
         );
     }
+
+    #[test]
+    fn no_keyword_autocompletion_on_line_comments() {
+        assert_debug_snapshot!(
+        do_completion(
+                r"
+                    fn test() {
+                        let x = 2; // A comment<|>
+                    }
+                    ",
+                CompletionKind::Keyword
+        ),
+            @r###"
+            []
+            "###
+        );
+    }
+
+    #[test]
+    fn no_keyword_autocompletion_on_multi_line_comments() {
+        assert_debug_snapshot!(
+        do_completion(
+                r"
+                    /*
+                    Some multi-line comment<|>
+                    */
+                    ",
+                CompletionKind::Keyword
+        ),
+            @r###"
+            []
+            "###
+        );
+    }
+
+    #[test]
+    fn no_keyword_autocompletion_on_doc_comments() {
+        assert_debug_snapshot!(
+        do_completion(
+                r"
+                    /// Some doc comment
+                    /// let test<|> = 1
+                    ",
+                CompletionKind::Keyword
+        ),
+            @r###"
+            []
+            "###
+        );
+    }
 }


### PR DESCRIPTION
Resolves #4907 by disabling any auto-completion on comments.

As flodiebold [pointed out](https://github.com/rust-analyzer/rust-analyzer/issues/4907#issuecomment-648439979), in the future we may want to support some form of auto-completion within doc comments, but for now it was suggested to just disable auto-completion on them entirely.

The implementation involves adding a new field `is_comment` to `CompletionContext` and checking if the immediate token we auto-completed on is a comment. I couldn't see a case where we need to check any of the ancestors, but let me know if this is not sufficient. I also wasn't sure if it was necessary to add a new field to this struct, but I decided it's probably the best option if we want to potentially do auto-completion on doc comments in the future.

Finally, the three tests I added should I think ideally not filter results by `CompletionKind::Keyword`, but if I want to get unfiltered results, I need access to a non-public function [get_all_completion_items](https://github.com/rust-analyzer/rust-analyzer/blob/9a4d02faf9c47f401b8756c3f7fcab2198f5f9cd/crates/ra_ide/src/completion/test_utils.rs#L32-L39) which I don't know if I should make public just for this.

