### PR TITLE
Escape space in path for MacOS binary location

### DIFF
--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -57,7 +57,7 @@ To disable this notification put the following to `settings.json`
 The server binary is stored in:
 
 * Linux: `~/.config/Code/User/globalStorage/matklad.rust-analyzer`
-* macOS: `~/Library/Application Support/Code/User/globalStorage/matklad.rust-analyzer`
+* macOS: `~/Library/Application\ Support/Code/User/globalStorage/matklad.rust-analyzer`
 * Windows: `%APPDATA%\Code\User\globalStorage\matklad.rust-analyzer`
 
 Note that we only support two most recent versions of VS Code.


### PR DESCRIPTION
This makes it possible and easier to copy paste the path to the binary server, without needing to add quotes.