### PR TITLE
Use the selection range when resolving call hierarchy items

### DIFF
--- a/crates/ra_ide/src/call_hierarchy.rs
+++ b/crates/ra_ide/src/call_hierarchy.rs
@@ -355,4 +355,41 @@ fn caller3() {
             &["caller3 FN_DEF FileId(1) 66..83 69..76 : [52..59]"],
         );
     }
+
+    #[test]
+    fn test_call_hierarchy_issue_5103() {
+        check_hierarchy(
+            r#"
+fn a() {
+    b()
+}
+
+fn b() {}
+
+fn main() {
+    a<|>()
+}
+"#,
+            "a FN_DEF FileId(1) 0..18 3..4",
+            &["main FN_DEF FileId(1) 31..52 34..38 : [47..48]"],
+            &["b FN_DEF FileId(1) 20..29 23..24 : [13..14]"],
+        );
+
+        check_hierarchy(
+            r#"
+fn a() {
+    b<|>()
+}
+
+fn b() {}
+
+fn main() {
+    a()
+}
+"#,
+            "b FN_DEF FileId(1) 20..29 23..24",
+            &["a FN_DEF FileId(1) 0..18 3..4 : [13..14]"],
+            &[],
+        );
+    }
 }

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -1045,7 +1045,7 @@ pub(crate) fn handle_call_hierarchy_incoming(
     let item = params.item;
 
     let doc = TextDocumentIdentifier::new(item.uri);
-    let frange = from_proto::file_range(&snap, doc, item.range)?;
+    let frange = from_proto::file_range(&snap, doc, item.selection_range)?;
     let fpos = FilePosition { file_id: frange.file_id, offset: frange.range.start() };
 
     let call_items = match snap.analysis.incoming_calls(fpos)? {
@@ -1080,7 +1080,7 @@ pub(crate) fn handle_call_hierarchy_outgoing(
     let item = params.item;
 
     let doc = TextDocumentIdentifier::new(item.uri);
-    let frange = from_proto::file_range(&snap, doc, item.range)?;
+    let frange = from_proto::file_range(&snap, doc, item.selection_range)?;
     let fpos = FilePosition { file_id: frange.file_id, offset: frange.range.start() };
 
     let call_items = match snap.analysis.outgoing_calls(fpos)? {


### PR DESCRIPTION
Add a test in call_hierarchy that already passed and a corresponding
heavy test to test the LSP requests which exposed the issue.

Fixes #5103