### PR TITLE
Simplify lexer::Token to contain offset instead of len.

### DIFF
--- a/crates/ra_syntax/src/lib.rs
+++ b/crates/ra_syntax/src/lib.rs
@@ -47,7 +47,9 @@ use crate::syntax_node::GreenNode;
 pub use crate::{
     algo::InsertPosition,
     ast::{AstNode, AstToken},
-    parsing::{lex_single_syntax_kind, lex_single_valid_syntax_kind, tokenize, Token},
+    parsing::{
+        kinds_with_ranges, lex_single_syntax_kind, lex_single_valid_syntax_kind, tokenize, Token,
+    },
     ptr::{AstPtr, SyntaxNodePtr},
     syntax_error::SyntaxError,
     syntax_node::{

--- a/crates/ra_syntax/src/tests.rs
+++ b/crates/ra_syntax/src/tests.rs
@@ -5,7 +5,7 @@ use std::{
 
 use test_utils::{collect_rust_files, dir_tests, project_dir, read_text};
 
-use crate::{fuzz, tokenize, SourceFile, SyntaxError, TextRange, TextSize, Token};
+use crate::{fuzz, parsing::kinds_with_ranges, tokenize, SourceFile, SyntaxError, Token};
 
 #[test]
 fn lexer_tests() {
@@ -166,12 +166,9 @@ fn assert_errors_are_absent(errors: &[SyntaxError], path: &Path) {
 
 fn dump_tokens_and_errors(tokens: &[Token], errors: &[SyntaxError], text: &str) -> String {
     let mut acc = String::new();
-    let mut offset: TextSize = 0.into();
-    for token in tokens {
-        let token_len = token.len;
-        let token_text = &text[TextRange::at(offset, token.len)];
-        offset += token.len;
-        writeln!(acc, "{:?} {:?} {:?}", token.kind, token_len, token_text).unwrap();
+    for (kind, range) in kinds_with_ranges(text, tokens) {
+        let token_text = &text[range];
+        writeln!(acc, "{:?} {:?} {:?}", kind, range.len(), token_text).unwrap();
     }
     for err in errors {
         writeln!(acc, "> error{:?} token({:?}) msg({})", err.range(), &text[err.range()], err)


### PR DESCRIPTION
By storing the token offset we kinda add identity for the token which simplifies things.
Before this PR:
We are storing the length of the tokens. so:
- To get the offset of a random token we need to do a linear sum of the length of prev tokens
    - In turn, this means we store some additional state in local mutable variables or in a struct when iterating over tokens
- To get the length of a random token we need a constant lookup
- Tokens don't have an identity, you may intern them (which is what we don't do :D )

After this PR:
We are storing the offsets of the tokens, so:
- To get the offset of a token we need a constant lookup
- To get the length of a token we need a constant lookup +
 the info about the last token length (i.e. input length)
 - Tokens have an identity, it is not possible to intern them (bruh, we don't do this).

One more appealing simplification would be storing `(EOF, text_len)` token right at the end of `Vec<Token>` which will quite reduce the handling of the last-token-length special case. I haven't gone this route because in our code we have access to this information everywhere (but anyway, I think this will further simplify `kinds_with_ranges()` function as well as increase performance?)