### PR TITLE
[WIP] Don't record private impls in `CrateImplDefs`

### DIFF
--- a/crates/ra_hir_def/src/data.rs
+++ b/crates/ra_hir_def/src/data.rs
@@ -78,6 +78,7 @@ impl TypeAliasData {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TraitData {
     pub name: Name,
+    pub is_public: bool,
     pub items: Vec<(Name, AssocItemId)>,
     pub auto: bool,
 }
@@ -87,6 +88,7 @@ impl TraitData {
         let tr_loc = tr.lookup(db);
         let item_tree = db.item_tree(tr_loc.id.file_id);
         let tr_def = &item_tree[tr_loc.id.value];
+        let vis = &item_tree[tr_def.visibility];
         let name = tr_def.name.clone();
         let auto = tr_def.auto;
         let module_id = tr_loc.container.module(db);
@@ -103,7 +105,7 @@ impl TraitData {
             100,
         );
 
-        Arc::new(TraitData { name, items, auto })
+        Arc::new(TraitData { name, is_public: vis.is_public(), items, auto })
     }
 
     pub fn associated_types(&self) -> impl Iterator<Item = TypeAliasId> + '_ {

--- a/crates/ra_hir_def/src/visibility.rs
+++ b/crates/ra_hir_def/src/visibility.rs
@@ -73,6 +73,10 @@ impl RawVisibility {
         }
     }
 
+    pub(crate) fn is_public(&self) -> bool {
+        matches!(self, RawVisibility::Public)
+    }
+
     pub fn resolve(
         &self,
         db: &dyn DefDatabase,

--- a/crates/ra_hir_ty/src/db.rs
+++ b/crates/ra_hir_ty/src/db.rs
@@ -70,6 +70,9 @@ pub trait HirDatabase: DefDatabase + Upcast<dyn DefDatabase> {
     #[salsa::invoke(crate::method_resolution::CrateImplDefs::impls_in_crate_query)]
     fn impls_in_crate(&self, krate: CrateId) -> Arc<CrateImplDefs>;
 
+    #[salsa::invoke(crate::method_resolution::CrateImplDefs::public_impls_in_crate_query)]
+    fn public_impls_in_crate(&self, krate: CrateId) -> Arc<CrateImplDefs>;
+
     #[salsa::invoke(crate::method_resolution::CrateImplDefs::impls_from_deps_query)]
     fn impls_from_deps(&self, krate: CrateId) -> Arc<CrateImplDefs>;
 

--- a/crates/ra_hir_ty/src/tests/macros.rs
+++ b/crates/ra_hir_ty/src/tests/macros.rs
@@ -700,7 +700,7 @@ fn infer_derive_clone_in_core() {
 #[prelude_import]
 use clone::*;
 mod clone {
-    trait Clone {
+    pub trait Clone {
         fn clone(&self) -> Self;
     }
 }

--- a/crates/ra_hir_ty/src/tests/traits.rs
+++ b/crates/ra_hir_ty/src/tests/traits.rs
@@ -99,7 +99,7 @@ fn test() {
 //- /core.rs crate:core
 #[prelude_import] use ops::*;
 mod ops {
-    trait Try {
+    pub trait Try {
         type Ok;
         type Error;
     }
@@ -139,7 +139,7 @@ fn test() {
 //- /core.rs crate:core
 #[prelude_import] use iter::*;
 mod iter {
-    trait IntoIterator {
+    pub trait IntoIterator {
         type Item;
     }
 }


### PR DESCRIPTION
This was intended to reduce memory usage of the `impls_from_deps` query, but it hasn't changed at all:

```
master:
Total: 43.797159755s, 1718mb allocated 1776mb resident
   174mb TraitSolveQuery (deps)
   157mb MacroArgQuery
   156mb ItemTreeQuery
   130mb CrateDefMapQueryQuery
   129mb ImplsFromDepsQuery
    75mb InferQueryQuery (deps)
    69mb ImplDatumQuery (deps)
    55mb ImplDatumQuery

omit-priv-impls:
Total: 42.122860744s, 1722mb allocated 1780mb resident
   173mb TraitSolveQuery (deps)
   157mb MacroArgQuery
   156mb ItemTreeQuery
   130mb CrateDefMapQueryQuery
   124mb ImplsFromDepsQuery
    74mb InferQueryQuery (deps)
    69mb ImplDatumQuery (deps)
    55mb ImplDatumQuery
```

Not sure why, or where all this memory is getting used...