### PR TITLE
Implement Chalk variable kinds

### DIFF
--- a/crates/ra_hir/src/code_model.rs
+++ b/crates/ra_hir/src/code_model.rs
@@ -1187,7 +1187,7 @@ impl Type {
             None => return false,
         };
 
-        let canonical_ty = Canonical { value: self.ty.value.clone(), num_vars: 0 };
+        let canonical_ty = Canonical { value: self.ty.value.clone(), kinds: Arc::new([]) };
         method_resolution::implements_trait(
             &canonical_ty,
             db,
@@ -1211,7 +1211,7 @@ impl Type {
                 self.ty.environment.clone(),
                 hir_ty::Obligation::Trait(trait_ref),
             ),
-            num_vars: 0,
+            kinds: Arc::new([]),
         };
 
         db.trait_solve(self.krate, goal).is_some()
@@ -1286,7 +1286,7 @@ impl Type {
     pub fn autoderef<'a>(&'a self, db: &'a dyn HirDatabase) -> impl Iterator<Item = Type> + 'a {
         // There should be no inference vars in types passed here
         // FIXME check that?
-        let canonical = Canonical { value: self.ty.value.clone(), num_vars: 0 };
+        let canonical = Canonical { value: self.ty.value.clone(), kinds: Arc::new([]) };
         let environment = self.ty.environment.clone();
         let ty = InEnvironment { value: canonical, environment };
         autoderef(db, Some(self.krate), ty)
@@ -1327,7 +1327,7 @@ impl Type {
         // There should be no inference vars in types passed here
         // FIXME check that?
         // FIXME replace Unknown by bound vars here
-        let canonical = Canonical { value: self.ty.value.clone(), num_vars: 0 };
+        let canonical = Canonical { value: self.ty.value.clone(), kinds: Arc::new([]) };
 
         let env = self.ty.environment.clone();
         let krate = krate.id;
@@ -1358,7 +1358,7 @@ impl Type {
         // There should be no inference vars in types passed here
         // FIXME check that?
         // FIXME replace Unknown by bound vars here
-        let canonical = Canonical { value: self.ty.value.clone(), num_vars: 0 };
+        let canonical = Canonical { value: self.ty.value.clone(), kinds: Arc::new([]) };
 
         let env = self.ty.environment.clone();
         let krate = krate.id;

--- a/crates/ra_hir_ty/src/lib.rs
+++ b/crates/ra_hir_ty/src/lib.rs
@@ -662,13 +662,27 @@ impl TypeWalk for GenericPredicate {
 
 /// Basically a claim (currently not validated / checked) that the contained
 /// type / trait ref contains no inference variables; any inference variables it
-/// contained have been replaced by bound variables, and `num_vars` tells us how
-/// many there are. This is used to erase irrelevant differences between types
-/// before using them in queries.
+/// contained have been replaced by bound variables, and `kinds` tells us how
+/// many there are and whether they were normal or float/int variables. This is
+/// used to erase irrelevant differences between types before using them in
+/// queries.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Canonical<T> {
     pub value: T,
-    pub num_vars: usize,
+    pub kinds: Arc<[TyKind]>,
+}
+
+impl<T> Canonical<T> {
+    pub fn new(value: T, kinds: impl IntoIterator<Item = TyKind>) -> Self {
+        Self { value, kinds: kinds.into_iter().collect() }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum TyKind {
+    General,
+    Integer,
+    Float,
 }
 
 /// A function signature as seen by type inference: Several parameter types and

--- a/crates/ra_hir_ty/src/tests/traits.rs
+++ b/crates/ra_hir_ty/src/tests/traits.rs
@@ -3029,3 +3029,21 @@ fn infer_dyn_fn_output() {
     "###
     );
 }
+
+#[test]
+fn variable_kinds() {
+    check_types(
+        r#"
+trait Trait<T> { fn get(self, t: T) -> T; }
+struct S;
+impl Trait<u128> for S {}
+impl Trait<f32> for S {}
+fn test() {
+    S.get(1);
+  //^^^^^^^^ u128
+    S.get(1.);
+  //^^^^^^^^ f32
+}
+        "#,
+    );
+}


### PR DESCRIPTION
This means we need to keep track of the kinds (general/int/float) of variables in `Canonical`, which requires some more ceremony. (It also exposes some places where we're not really dealing with canonicalization correctly -- another thing to be cleaned up when we switch to using Chalk's types directly.)

Should fix the last remaining issue of #2534.