### PR TITLE
Make SemanticsScope non-generic

### DIFF
--- a/crates/ra_ide/src/completion/completion_context.rs
+++ b/crates/ra_ide/src/completion/completion_context.rs
@@ -213,7 +213,7 @@ impl<'a> CompletionContext<'a> {
         }
     }
 
-    pub(crate) fn scope(&self) -> SemanticsScope<'_, RootDatabase> {
+    pub(crate) fn scope(&self) -> SemanticsScope<'_> {
         self.sema.scope_at_offset(&self.token.parent(), self.offset)
     }
 


### PR DESCRIPTION
This slightly reduces the build times:

![image](https://user-images.githubusercontent.com/308347/86210975-3a809480-bb7e-11ea-8975-788457f6b353.png)

(compare to https://github.com/rust-analyzer/rust-analyzer/issues/1987#issuecomment-652202248)