### PR TITLE
Structured search debugging

### DIFF
--- a/crates/ra_ssr/src/matching.rs
+++ b/crates/ra_ssr/src/matching.rs
@@ -8,9 +8,7 @@ use crate::{
 use hir::Semantics;
 use ra_db::FileRange;
 use ra_syntax::ast::{AstNode, AstToken};
-use ra_syntax::{
-    ast, SyntaxElement, SyntaxElementChildren, SyntaxKind, SyntaxNode, SyntaxToken, TextRange,
-};
+use ra_syntax::{ast, SyntaxElement, SyntaxElementChildren, SyntaxKind, SyntaxNode, SyntaxToken};
 use rustc_hash::FxHashMap;
 use std::{cell::Cell, iter::Peekable};
 
@@ -44,8 +42,8 @@ macro_rules! fail_match {
 
 /// Information about a match that was found.
 #[derive(Debug)]
-pub(crate) struct Match {
-    pub(crate) range: TextRange,
+pub struct Match {
+    pub(crate) range: FileRange,
     pub(crate) matched_node: SyntaxNode,
     pub(crate) placeholder_values: FxHashMap<Var, PlaceholderMatch>,
     pub(crate) ignored_comments: Vec<ast::Comment>,
@@ -135,7 +133,7 @@ impl<'db, 'sema> MatchState<'db, 'sema> {
         match_state.attempt_match_node(&match_inputs, &pattern_tree, code)?;
         match_state.validate_range(&sema.original_range(code))?;
         match_state.match_out = Some(Match {
-            range: sema.original_range(code).range,
+            range: sema.original_range(code),
             matched_node: code.clone(),
             placeholder_values: FxHashMap::default(),
             ignored_comments: Vec::new(),

--- a/crates/ra_ssr/src/replacing.rs
+++ b/crates/ra_ssr/src/replacing.rs
@@ -21,8 +21,10 @@ fn matches_to_edit_at_offset(
 ) -> TextEdit {
     let mut edit_builder = ra_text_edit::TextEditBuilder::default();
     for m in &matches.matches {
-        edit_builder
-            .replace(m.range.checked_sub(relative_start).unwrap(), render_replace(m, file_src));
+        edit_builder.replace(
+            m.range.range.checked_sub(relative_start).unwrap(),
+            render_replace(m, file_src),
+        );
     }
     edit_builder.finish()
 }

--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -65,6 +65,9 @@ fn main() -> Result<()> {
         args::Command::Ssr { rules } => {
             cli::apply_ssr_rules(rules)?;
         }
+        args::Command::StructuredSearch { patterns, debug_snippet } => {
+            cli::search_for_patterns(patterns, debug_snippet)?;
+        }
         args::Command::Version => println!("rust-analyzer {}", env!("REV")),
     }
     Ok(())

--- a/crates/rust-analyzer/src/cli.rs
+++ b/crates/rust-analyzer/src/cli.rs
@@ -18,7 +18,7 @@ pub use analysis_bench::{analysis_bench, BenchWhat, Position};
 pub use analysis_stats::analysis_stats;
 pub use diagnostics::diagnostics;
 pub use load_cargo::load_cargo;
-pub use ssr::apply_ssr_rules;
+pub use ssr::{apply_ssr_rules, search_for_patterns};
 
 #[derive(Clone, Copy)]
 pub enum Verbosity {

--- a/crates/rust-analyzer/src/cli/ssr.rs
+++ b/crates/rust-analyzer/src/cli/ssr.rs
@@ -2,7 +2,7 @@
 
 use crate::cli::{load_cargo::load_cargo, Result};
 use ra_ide::SourceFileEdit;
-use ra_ssr::{MatchFinder, SsrRule};
+use ra_ssr::{MatchFinder, SsrPattern, SsrRule};
 
 pub fn apply_ssr_rules(rules: Vec<SsrRule>) -> Result<()> {
     use ra_db::SourceDatabaseExt;
@@ -27,6 +27,44 @@ pub fn apply_ssr_rules(rules: Vec<SsrRule>) -> Result<()> {
             let mut contents = db.file_text(edit.file_id).to_string();
             edit.edit.apply(&mut contents);
             std::fs::write(path, contents)?;
+        }
+    }
+    Ok(())
+}
+
+/// Searches for `patterns`, printing debug information for any nodes whose text exactly matches
+/// `debug_snippet`. This is intended for debugging and probably isn't in it's current form useful
+/// for much else.
+pub fn search_for_patterns(patterns: Vec<SsrPattern>, debug_snippet: Option<String>) -> Result<()> {
+    use ra_db::SourceDatabaseExt;
+    use ra_ide_db::symbol_index::SymbolsDatabase;
+    let (host, vfs) = load_cargo(&std::env::current_dir()?, true, true)?;
+    let db = host.raw_database();
+    let mut match_finder = MatchFinder::new(db);
+    for pattern in patterns {
+        match_finder.add_search_pattern(pattern);
+    }
+    for &root in db.local_roots().iter() {
+        let sr = db.source_root(root);
+        for file_id in sr.iter() {
+            if let Some(debug_snippet) = &debug_snippet {
+                for debug_info in match_finder.debug_where_text_equal(file_id, debug_snippet) {
+                    println!("{:#?}", debug_info);
+                }
+            } else {
+                let matches = match_finder.find_matches_in_file(file_id);
+                if !matches.matches.is_empty() {
+                    let matches = matches.flattened().matches;
+                    if let Some(path) = vfs.file_path(file_id).as_path() {
+                        println!("{} matches in '{}'", matches.len(), path.to_string_lossy());
+                    }
+                    // We could possibly at some point do something more useful than just printing
+                    // the matched text. For now though, that's the easiest thing to do.
+                    for m in matches {
+                        println!("{}", m.matched_text());
+                    }
+                }
+            }
         }
     }
     Ok(())


### PR DESCRIPTION
Adds a "search" mode to the rust-analyzer binary that does structured search (SSR without the replace part). This is intended primarily for debugging why a bit of code isn't matching a pattern.