### PR TITLE
ItemTree: Lower fields despite invalid type

### DIFF
--- a/crates/ra_hir_def/src/item_tree/lower.rs
+++ b/crates/ra_hir_def/src/item_tree/lower.rs
@@ -211,7 +211,7 @@ impl Ctx {
     fn lower_record_field(&mut self, field: &ast::RecordFieldDef) -> Option<Field> {
         let name = field.name()?.as_name();
         let visibility = self.lower_visibility(field);
-        let type_ref = self.lower_type_ref(&field.ascribed_type()?);
+        let type_ref = self.lower_type_ref_opt(field.ascribed_type());
         let res = Field { name, type_ref, visibility };
         Some(res)
     }

--- a/crates/ra_hir_ty/src/tests.rs
+++ b/crates/ra_hir_ty/src/tests.rs
@@ -508,6 +508,30 @@ fn no_such_field_with_feature_flag_diagnostics_on_struct_fields() {
 }
 
 #[test]
+fn no_such_field_with_type_macro() {
+    let diagnostics = TestDB::with_files(
+        r"
+        macro_rules! Type {
+            () => { u32 };
+        }
+
+        struct Foo {
+            bar: Type![],
+        }
+        impl Foo {
+            fn new() -> Self {
+                Foo { bar: 0 }
+            }
+        }
+        ",
+    )
+    .diagnostics()
+    .0;
+
+    assert_snapshot!(diagnostics, @r###""###);
+}
+
+#[test]
 fn missing_record_pat_field_diagnostic() {
     let diagnostics = TestDB::with_files(
         r"


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/5147

bors r+