### PR TITLE
SSR internal refactorings

### DIFF
--- a/crates/ra_ssr/src/errors.rs
+++ b/crates/ra_ssr/src/errors.rs
@@ -1,0 +1,29 @@
+//! Code relating to errors produced by SSR.
+
+/// Constructs an SsrError taking arguments like the format macro.
+macro_rules! _error {
+    ($fmt:expr) => {$crate::SsrError::new(format!($fmt))};
+    ($fmt:expr, $($arg:tt)+) => {$crate::SsrError::new(format!($fmt, $($arg)+))}
+}
+pub(crate) use _error as error;
+
+/// Returns from the current function with an error, supplied by arguments as for format!
+macro_rules! _bail {
+    ($($tokens:tt)*) => {return Err(crate::errors::error!($($tokens)*))}
+}
+pub(crate) use _bail as bail;
+
+#[derive(Debug, PartialEq)]
+pub struct SsrError(pub(crate) String);
+
+impl std::fmt::Display for SsrError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "Parse error: {}", self.0)
+    }
+}
+
+impl SsrError {
+    pub(crate) fn new(message: impl Into<String>) -> SsrError {
+        SsrError(message.into())
+    }
+}

--- a/crates/ra_ssr/src/lib.rs
+++ b/crates/ra_ssr/src/lib.rs
@@ -6,9 +6,12 @@
 mod matching;
 mod parsing;
 mod replacing;
+#[macro_use]
+mod errors;
 #[cfg(test)]
 mod tests;
 
+pub use crate::errors::SsrError;
 pub use crate::matching::Match;
 use crate::matching::{record_match_fails_reasons_scope, MatchFailureReason};
 use hir::Semantics;
@@ -40,9 +43,6 @@ pub struct SsrPattern {
     path: Option<SyntaxNode>,
     pattern: Option<SyntaxNode>,
 }
-
-#[derive(Debug, PartialEq)]
-pub struct SsrError(String);
 
 #[derive(Debug, Default)]
 pub struct SsrMatches {
@@ -214,12 +214,6 @@ pub struct MatchDebugInfo {
     /// etc. Will be absent if the pattern can't be parsed as that kind.
     pattern: Result<SyntaxNode, MatchFailureReason>,
     matched: Result<Match, MatchFailureReason>,
-}
-
-impl std::fmt::Display for SsrError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "Parse error: {}", self.0)
-    }
 }
 
 impl std::fmt::Debug for MatchDebugInfo {

--- a/crates/ra_ssr/src/lib.rs
+++ b/crates/ra_ssr/src/lib.rs
@@ -201,9 +201,8 @@ impl<'db> MatchFinder<'db> {
                         );
                     }
                 }
-            } else {
-                self.output_debug_for_nodes_at_range(&node, range, restrict_range, out);
             }
+            self.output_debug_for_nodes_at_range(&node, range, restrict_range, out);
         }
     }
 }
@@ -218,25 +217,26 @@ pub struct MatchDebugInfo {
 
 impl std::fmt::Debug for MatchDebugInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "========= PATTERN ==========\n")?;
-        match &self.pattern {
-            Ok(pattern) => {
-                write!(f, "{:#?}", pattern)?;
-            }
-            Err(err) => {
-                write!(f, "{}", err.reason)?;
-            }
+        match &self.matched {
+            Ok(_) => writeln!(f, "Node matched")?,
+            Err(reason) => writeln!(f, "Node failed to match because: {}", reason.reason)?,
         }
-        write!(
+        writeln!(
             f,
-            "\n============ AST ===========\n\
-            {:#?}\n============================\n",
+            "============ AST ===========\n\
+            {:#?}",
             self.node
         )?;
-        match &self.matched {
-            Ok(_) => write!(f, "Node matched")?,
-            Err(reason) => write!(f, "Node failed to match because: {}", reason.reason)?,
+        writeln!(f, "========= PATTERN ==========")?;
+        match &self.pattern {
+            Ok(pattern) => {
+                writeln!(f, "{:#?}", pattern)?;
+            }
+            Err(err) => {
+                writeln!(f, "{}", err.reason)?;
+            }
         }
+        writeln!(f, "============================")?;
         Ok(())
     }
 }

--- a/crates/ra_ssr/src/parsing.rs
+++ b/crates/ra_ssr/src/parsing.rs
@@ -5,16 +5,11 @@
 //! search patterns, we go further and parse the pattern as each kind of thing that we can match.
 //! e.g. expressions, type references etc.
 
+use crate::errors::bail;
 use crate::{SsrError, SsrPattern, SsrRule};
 use ra_syntax::{ast, AstNode, SmolStr, SyntaxKind, T};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::str::FromStr;
-
-/// Returns from the current function with an error, supplied by arguments as for format!
-macro_rules! bail {
-    ($e:expr) => {return Err($crate::SsrError::new($e))};
-    ($fmt:expr, $($arg:tt)+) => {return Err($crate::SsrError::new(format!($fmt, $($arg)+)))}
-}
 
 #[derive(Clone, Debug)]
 pub(crate) struct SsrTemplate {
@@ -246,7 +241,7 @@ fn parse_placeholder(tokens: &mut std::vec::IntoIter<Token>) -> Result<Placehold
                 }
             }
             _ => {
-                bail!("Placeholders should either be $name or ${name:constraints}");
+                bail!("Placeholders should either be $name or ${{name:constraints}}");
             }
         }
     }
@@ -289,7 +284,7 @@ fn expect_token(tokens: &mut std::vec::IntoIter<Token>, expected: &str) -> Resul
         }
         bail!("Expected {} found {}", expected, t.text);
     }
-    bail!("Expected {} found end of stream");
+    bail!("Expected {} found end of stream", expected);
 }
 
 impl NodeKind {
@@ -304,12 +299,6 @@ impl NodeKind {
 impl Placeholder {
     fn new(name: SmolStr, constraints: Vec<Constraint>) -> Self {
         Self { stand_in_name: format!("__placeholder_{}", name), constraints, ident: name }
-    }
-}
-
-impl SsrError {
-    fn new(message: impl Into<String>) -> SsrError {
-        SsrError(message.into())
     }
 }
 


### PR DESCRIPTION
- Extract error code out to a separate module
- Improve error reporting when a test fails
- Refactor matching code
- Update tests so that all paths in search patterns can be resolved