### PR TITLE
Improve client logging (use output channel and more log levels)

### DIFF
--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -39,10 +39,10 @@ export class Config {
 
     private refreshLogging() {
         log.setEnabled(this.traceExtension);
-        log.debug(
-            "Extension version:", this.package.version,
-            "using configuration:", this.cfg
-        );
+        log.info("Extension version:", this.package.version);
+
+        const cfg = Object.entries(this.cfg).filter(([_, val]) => !(val instanceof Function));
+        log.info("Using configuration", Object.fromEntries(cfg));
     }
 
     private async onDidChangeConfiguration(event: vscode.ConfigurationChangeEvent) {

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -59,8 +59,8 @@ async function tryActivate(context: vscode.ExtensionContext) {
             message += "you should close them and reload this window to retry. ";
         }
 
-        message += 'Open "Help > Toggle Developer Tools > Console" to see the logs ';
-        message += '(enable verbose logs with "rust-analyzer.trace.extension")';
+        message += 'See the logs in "OUTPUT > Rust Analyzer Client" (should open automatically). ';
+        message += 'To enable verbose logs use { "rust-analyzer.trace.extension": true }';
 
         log.error("Bootstrap error", err);
         throw new Error(message);
@@ -214,7 +214,7 @@ async function bootstrapServer(config: Config, state: PersistentState): Promise<
         );
     }
 
-    log.debug("Using server binary at", path);
+    log.info("Using server binary at", path);
 
     if (!isValidExecutable(path)) {
         throw new Error(`Failed to execute ${path} --version`);

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -49,8 +49,6 @@ async function tryActivate(context: vscode.ExtensionContext) {
     );
     context.subscriptions.push(defaultOnEnter);
 
-    context.subscriptions.push(log);
-
     const config = new Config(context);
     const state = new PersistentState(context.globalState);
     const serverPath = await bootstrap(config, state).catch(err => {

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -49,6 +49,8 @@ async function tryActivate(context: vscode.ExtensionContext) {
     );
     context.subscriptions.push(defaultOnEnter);
 
+    context.subscriptions.push(log);
+
     const config = new Config(context);
     const state = new PersistentState(context.globalState);
     const serverPath = await bootstrap(config, state).catch(err => {

--- a/editors/code/src/persistent_state.ts
+++ b/editors/code/src/persistent_state.ts
@@ -4,7 +4,7 @@ import { log } from './util';
 export class PersistentState {
     constructor(private readonly globalState: vscode.Memento) {
         const { lastCheck, releaseId, serverVersion } = this;
-        log.debug("PersistentState: ", { lastCheck, releaseId, serverVersion });
+        log.info("PersistentState:", { lastCheck, releaseId, serverVersion });
     }
 
     /**

--- a/editors/code/src/util.ts
+++ b/editors/code/src/util.ts
@@ -18,10 +18,6 @@ export const log = new class {
     private enabled = true;
     private readonly output = vscode.window.createOutputChannel("Rust Analyzer Client");
 
-    dispose() {
-        log.output.dispose();
-    }
-
     setEnabled(yes: boolean): void {
         log.enabled = yes;
     }

--- a/editors/code/src/util.ts
+++ b/editors/code/src/util.ts
@@ -18,6 +18,10 @@ export const log = new class {
     private enabled = true;
     private readonly output = vscode.window.createOutputChannel("Rust Analyzer Client");
 
+    dispose() {
+        log.output.dispose();
+    }
+
     setEnabled(yes: boolean): void {
         log.enabled = yes;
     }


### PR DESCRIPTION
The improvements:
* Separate output channel allows viewing the logs belonging to only our extension (without the intervention of other vscode extensions)
* All the objects in the output channel are always expanded so users only need to `Ctrl + A and Ctrl + C` to copy the entire output to send us and nothing more (e.g. currently users need to expand the object which is not obvious for them and we may lose the logs this way, see two comments: https://github.com/rust-analyzer/rust-analyzer/issues/5009#issuecomment-651361137
* More log levels allows us to be more granular in disabling only optional verbose debug-level output and leave the logs for us as developers to understand the context of user issues.
* For `log.error(...)` invocations we reveal `Rust Analyzer Client` channel automatically so that users don't have to do any additional actions to get the logs output window visible

Demo:
![image](https://user-images.githubusercontent.com/36276403/86535275-d7795f80-bee7-11ea-8c30-135c83c1bc7d.png)

