### PR TITLE
Add a command to compute memory usage statistics

### DIFF
--- a/crates/ra_ide_db/src/change.rs
+++ b/crates/ra_ide_db/src/change.rs
@@ -164,6 +164,15 @@ impl RootDatabase {
         hir::db::BodyQuery.in_db(self).sweep(sweep);
     }
 
+    // Feature: Memory Usage
+    //
+    // Clears rust-analyzer's internal database and prints memory usage statistics.
+    //
+    // |===
+    // | Editor  | Action Name
+    //
+    // | VS Code | **Rust Analyzer: Memory Usage (Clears Database)**
+    // |===
     pub fn per_query_memory_usage(&mut self) -> Vec<(String, Bytes)> {
         let mut acc: Vec<(String, Bytes)> = vec![];
         let sweep = SweepStrategy::default().discard_values().sweep_all_revisions();

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -32,7 +32,7 @@ use crate::{
     cargo_target_spec::CargoTargetSpec,
     config::RustfmtConfig,
     from_json, from_proto,
-    global_state::GlobalStateSnapshot,
+    global_state::{GlobalState, GlobalStateSnapshot},
     lsp_ext::{self, InlayHint, InlayHintsParams},
     to_proto, LspError, Result,
 };
@@ -60,6 +60,17 @@ pub(crate) fn handle_analyzer_status(snap: GlobalStateSnapshot, _: ()) -> Result
         format_to!(buf, "{}{:4} {:<36}{}ms\n", mark, r.id, r.method, r.duration.as_millis());
     }
     Ok(buf)
+}
+
+pub(crate) fn handle_memory_usage(state: &mut GlobalState, _: ()) -> Result<String> {
+    let _p = profile("handle_memory_usage");
+    let mem = state.analysis_host.per_query_memory_usage();
+
+    let mut out = String::new();
+    for (name, bytes) in mem {
+        format_to!(out, "{:>8} {}\n", bytes, name);
+    }
+    Ok(out)
 }
 
 pub(crate) fn handle_syntax_tree(

--- a/crates/rust-analyzer/src/lsp_ext.rs
+++ b/crates/rust-analyzer/src/lsp_ext.rs
@@ -14,6 +14,14 @@ impl Request for AnalyzerStatus {
     const METHOD: &'static str = "rust-analyzer/analyzerStatus";
 }
 
+pub enum MemoryUsage {}
+
+impl Request for MemoryUsage {
+    type Params = ();
+    type Result = String;
+    const METHOD: &'static str = "rust-analyzer/memoryUsage";
+}
+
 pub enum ReloadWorkspace {}
 
 impl Request for ReloadWorkspace {

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -341,6 +341,7 @@ impl GlobalState {
             .on_sync::<lsp_ext::MatchingBrace>(|s, p| {
                 handlers::handle_matching_brace(s.snapshot(), p)
             })?
+            .on_sync::<lsp_ext::MemoryUsage>(|s, p| handlers::handle_memory_usage(s, p))?
             .on::<lsp_ext::AnalyzerStatus>(handlers::handle_analyzer_status)?
             .on::<lsp_ext::SyntaxTree>(handlers::handle_syntax_tree)?
             .on::<lsp_ext::ExpandMacro>(handlers::handle_expand_macro)?

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -61,6 +61,7 @@
     "activationEvents": [
         "onLanguage:rust",
         "onCommand:rust-analyzer.analyzerStatus",
+        "onCommand:rust-analyzer.memoryUsage",
         "onCommand:rust-analyzer.reloadWorkspace",
         "workspaceContains:**/Cargo.toml"
     ],
@@ -140,6 +141,11 @@
             {
                 "command": "rust-analyzer.analyzerStatus",
                 "title": "Status",
+                "category": "Rust Analyzer"
+            },
+            {
+                "command": "rust-analyzer.memoryUsage",
+                "title": "Memory Usage (Clears Database)",
                 "category": "Rust Analyzer"
             },
             {
@@ -841,6 +847,10 @@
                 },
                 {
                     "command": "rust-analyzer.analyzerStatus",
+                    "when": "inRustProject"
+                },
+                {
+                    "command": "rust-analyzer.memoryUsage",
                     "when": "inRustProject"
                 },
                 {

--- a/editors/code/src/lsp_ext.ts
+++ b/editors/code/src/lsp_ext.ts
@@ -5,6 +5,7 @@
 import * as lc from "vscode-languageclient";
 
 export const analyzerStatus = new lc.RequestType<null, string, void>("rust-analyzer/analyzerStatus");
+export const memoryUsage = new lc.RequestType<null, string, void>("rust-analyzer/memoryUsage");
 
 export type Status = "loading" | "ready" | "invalid" | "needsReload";
 export const status = new lc.NotificationType<Status>("rust-analyzer/status");

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -96,6 +96,7 @@ async function tryActivate(context: vscode.ExtensionContext) {
     });
 
     ctx.registerCommand('analyzerStatus', commands.analyzerStatus);
+    ctx.registerCommand('memoryUsage', commands.memoryUsage);
     ctx.registerCommand('reloadWorkspace', commands.reloadWorkspace);
     ctx.registerCommand('matchingBrace', commands.matchingBrace);
     ctx.registerCommand('joinLines', commands.joinLines);


### PR DESCRIPTION
This allows inspecting memory usage on a live rust-analyzer instance after it has been used interactively.

This will only work with `--features jemalloc`, so maybe it should print something more useful when that's not available? Right now it will just print 0 Bytes for every query.