### PR TITLE
Refactor AssistBuilder to manage a SourceChange

### DIFF
--- a/crates/ra_assists/src/assist_context.rs
+++ b/crates/ra_assists/src/assist_context.rs
@@ -176,7 +176,7 @@ pub(crate) struct AssistBuilder {
     edit: TextEditBuilder,
     file_id: FileId,
     is_snippet: bool,
-    edits: Vec<SourceFileEdit>,
+    change: SourceChange,
 }
 
 impl AssistBuilder {
@@ -185,7 +185,7 @@ impl AssistBuilder {
             edit: TextEditBuilder::default(),
             file_id,
             is_snippet: false,
-            edits: Vec::new(),
+            change: SourceChange::default(),
         }
     }
 
@@ -197,8 +197,8 @@ impl AssistBuilder {
         let edit = mem::take(&mut self.edit).finish();
         if !edit.is_empty() {
             let new_edit = SourceFileEdit { file_id: self.file_id, edit };
-            assert!(!self.edits.iter().any(|it| it.file_id == new_edit.file_id));
-            self.edits.push(new_edit);
+            assert!(!self.change.source_file_edits.iter().any(|it| it.file_id == new_edit.file_id));
+            self.change.source_file_edits.push(new_edit);
         }
     }
 
@@ -265,10 +265,10 @@ impl AssistBuilder {
 
     fn finish(mut self) -> SourceChange {
         self.commit();
-        let mut res: SourceChange = mem::take(&mut self.edits).into();
+        let mut change = mem::take(&mut self.change);
         if self.is_snippet {
-            res.is_snippet = true;
+            change.is_snippet = true;
         }
-        res
+        change
     }
 }

--- a/crates/ra_ide_db/src/source_change.rs
+++ b/crates/ra_ide_db/src/source_change.rs
@@ -6,7 +6,7 @@
 use ra_db::FileId;
 use ra_text_edit::TextEdit;
 
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct SourceChange {
     pub source_file_edits: Vec<SourceFileEdit>,
     pub file_system_edits: Vec<FileSystemEdit>,


### PR DESCRIPTION
`AssistBuilder` now managaes a full `SourceChange` instead of a
`Vec<SourceFileEdit>`.

This prepares AssistBuilder to handle creation of new files.
