### PR TITLE
Workaround rollup messing up default imports

### DIFF
--- a/editors/code/src/net.ts
+++ b/editors/code/src/net.ts
@@ -1,4 +1,7 @@
-import fetch from "node-fetch";
+// Replace with `import fetch from "node-fetch"` once this is fixed in rollup:
+// https://github.com/rollup/plugins/issues/491
+const fetch = require("node-fetch") as typeof import("node-fetch")["default"];
+
 import * as vscode from "vscode";
 import * as stream from "stream";
 import * as crypto from "crypto";


### PR DESCRIPTION
Tackles https://github.com/rust-analyzer/rust-analyzer/issues/5257#issuecomment-655435271
Related: https://github.com/rollup/plugins/issues/491