### PR TITLE
Add argument count mismatch diagnostic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,6 +1104,7 @@ dependencies = [
  "chalk-ir",
  "chalk-solve",
  "ena",
+ "expect",
  "insta",
  "itertools",
  "log",

--- a/crates/ra_hir/src/diagnostics.rs
+++ b/crates/ra_hir/src/diagnostics.rs
@@ -1,4 +1,6 @@
 //! FIXME: write short doc here
 pub use hir_def::diagnostics::UnresolvedModule;
 pub use hir_expand::diagnostics::{AstDiagnostic, Diagnostic, DiagnosticSink};
-pub use hir_ty::diagnostics::{MissingFields, MissingMatchArms, MissingOkInTailExpr, NoSuchField};
+pub use hir_ty::diagnostics::{
+    MismatchedArgCount, MissingFields, MissingMatchArms, MissingOkInTailExpr, NoSuchField,
+};

--- a/crates/ra_hir_ty/Cargo.toml
+++ b/crates/ra_hir_ty/Cargo.toml
@@ -32,3 +32,4 @@ chalk-ir = { version = "0.15.0" }
 
 [dev-dependencies]
 insta = "0.16.0"
+expect = { path = "../expect" }

--- a/crates/ra_hir_ty/src/diagnostics.rs
+++ b/crates/ra_hir_ty/src/diagnostics.rs
@@ -208,7 +208,8 @@ pub struct MismatchedArgCount {
 
 impl Diagnostic for MismatchedArgCount {
     fn message(&self) -> String {
-        format!("Expected {} arguments, found {}", self.expected, self.found)
+        let s = if self.expected == 1 { "" } else { "s" };
+        format!("Expected {} argument{}, found {}", self.expected, s, self.found)
     }
     fn source(&self) -> InFile<SyntaxNodePtr> {
         InFile { file_id: self.file, value: self.call_expr.clone().into() }

--- a/crates/ra_hir_ty/src/diagnostics.rs
+++ b/crates/ra_hir_ty/src/diagnostics.rs
@@ -197,3 +197,32 @@ impl AstDiagnostic for MissingUnsafe {
         ast::Expr::cast(node).unwrap()
     }
 }
+
+#[derive(Debug)]
+pub struct MismatchedArgCount {
+    pub file: HirFileId,
+    pub call_expr: AstPtr<ast::Expr>,
+    pub expected: usize,
+    pub found: usize,
+}
+
+impl Diagnostic for MismatchedArgCount {
+    fn message(&self) -> String {
+        format!("Expected {} arguments, found {}", self.expected, self.found)
+    }
+    fn source(&self) -> InFile<SyntaxNodePtr> {
+        InFile { file_id: self.file, value: self.call_expr.clone().into() }
+    }
+    fn as_any(&self) -> &(dyn Any + Send + 'static) {
+        self
+    }
+}
+
+impl AstDiagnostic for MismatchedArgCount {
+    type AST = ast::CallExpr;
+    fn ast(&self, db: &dyn AstDatabase) -> Self::AST {
+        let root = db.parse_or_expand(self.source().file_id).unwrap();
+        let node = self.source().value.to_node(&root);
+        ast::CallExpr::cast(node).unwrap()
+    }
+}

--- a/crates/ra_hir_ty/src/expr.rs
+++ b/crates/ra_hir_ty/src/expr.rs
@@ -150,6 +150,13 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
 
     fn validate_call(&mut self, db: &dyn HirDatabase, call_id: ExprId, expr: &Expr) -> Option<()> {
         // Check that the number of arguments matches the number of parameters.
+
+        // Due to shortcomings in the current type system implementation, only emit this diagnostic
+        // if there are no type mismatches in the containing function.
+        if self.infer.type_mismatches.iter().next().is_some() {
+            return Some(());
+        }
+
         let (callee, args) = match expr {
             Expr::Call { callee, args } => {
                 let callee = &self.infer.type_of_expr[*callee];

--- a/crates/ra_ide/src/diagnostics.rs
+++ b/crates/ra_ide/src/diagnostics.rs
@@ -127,6 +127,14 @@ pub(crate) fn diagnostics(db: &RootDatabase, file_id: FileId) -> Vec<Diagnostic>
             severity: Severity::Error,
             fix: missing_struct_field_fix(&sema, file_id, d),
         })
+    })
+    .on::<hir::diagnostics::MismatchedArgCount, _>(|d| {
+        res.borrow_mut().push(Diagnostic {
+            range: sema.diagnostics_range(d).range,
+            message: d.message(),
+            severity: Severity::Error,
+            fix: None,
+        })
     });
 
     if let Some(m) = sema.to_module_def(file_id) {

--- a/crates/ra_ide/src/diagnostics.rs
+++ b/crates/ra_ide/src/diagnostics.rs
@@ -99,14 +99,6 @@ pub(crate) fn diagnostics(db: &RootDatabase, file_id: FileId) -> Vec<Diagnostic>
             fix,
         })
     })
-    .on::<hir::diagnostics::MissingMatchArms, _>(|d| {
-        res.borrow_mut().push(Diagnostic {
-            range: sema.diagnostics_range(d).range,
-            message: d.message(),
-            severity: Severity::Error,
-            fix: None,
-        })
-    })
     .on::<hir::diagnostics::MissingOkInTailExpr, _>(|d| {
         let node = d.ast(db);
         let replacement = format!("Ok({})", node.syntax());
@@ -126,14 +118,6 @@ pub(crate) fn diagnostics(db: &RootDatabase, file_id: FileId) -> Vec<Diagnostic>
             message: d.message(),
             severity: Severity::Error,
             fix: missing_struct_field_fix(&sema, file_id, d),
-        })
-    })
-    .on::<hir::diagnostics::MismatchedArgCount, _>(|d| {
-        res.borrow_mut().push(Diagnostic {
-            range: sema.diagnostics_range(d).range,
-            message: d.message(),
-            severity: Severity::Error,
-            fix: None,
         })
     });
 


### PR DESCRIPTION
Closes https://github.com/rust-analyzer/rust-analyzer/issues/4025.

This currently has one false positive on this line, where `max` is resolved to `Iterator::max` instead of `Ord::max`:

https://github.com/rust-analyzer/rust-analyzer/blob/8aa10c00a4c5b957d459fac5a103cd9688e8dcdd/crates/expect/src/lib.rs#L263

(I have no idea why it thinks that `usize` is an `Iterator`)

TODO:
* [x] Tests
* [x] Improve diagnostic text for method calls