### PR TITLE
Only take first 500 syntax errors

### DIFF
--- a/crates/ra_ide/src/diagnostics.rs
+++ b/crates/ra_ide/src/diagnostics.rs
@@ -35,7 +35,8 @@ pub(crate) fn diagnostics(db: &RootDatabase, file_id: FileId) -> Vec<Diagnostic>
     let parse = db.parse(file_id);
     let mut res = Vec::new();
 
-    res.extend(parse.errors().iter().map(|err| Diagnostic {
+    // [#34344] Only take first 500 errors to prevent slowing down editor/ide, the number 500 is chosen arbitrarily.
+    res.extend(parse.errors().iter().take(500).map(|err| Diagnostic {
         range: err.range(),
         message: format!("Syntax Error: {}", err),
         severity: Severity::Error,


### PR DESCRIPTION
Too many syntax errors make some editor/ide slow, fix #3434.