### PR TITLE
Demonstrate excessive stack usage

### DIFF
--- a/crates/ra_hir_ty/src/tests/regression.rs
+++ b/crates/ra_hir_ty/src/tests/regression.rs
@@ -779,3 +779,21 @@ pub trait Service<Request> {
     "###
     );
 }
+
+#[test]
+fn your_stack_belongs_to_me() {
+    check_types(
+        "
+    macro_rules! n_nuple {
+        ($e:tt) => ();
+        ($($rest:tt)*) => {{
+            (n_nuple!($($rest)*)None,)
+        }};
+    }
+    fn main() {
+        let t = n_nuple!(1,2,3);
+        t;
+    } //^ ()
+",
+    )
+}


### PR DESCRIPTION
Use this to run the test:

  cargo test --package ra_hir_ty --lib --release -- \
      tests::regression::your_stack_belongs_to_me --exact --nocapture

You can uncomment more branches to see the effect on stack usage.

It seems that we use Sum(branches) in debug, and Max(branches) in
release (as measured by the final depth before SO).