### PR TITLE
Chalk upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,9 +144,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chalk-derive"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7379caa72d04103fcfd9bde5642b816f58e3ffd6a0d39347e9e35a066648226"
+checksum = "9396f12a23b1a40d5019aa81bc0cbd7ccd2c9736d6bc4afc95868533c2346dcb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -155,35 +155,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "chalk-engine"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8afe48b5663504b485791ab4fae69cf4864869a71ceec9c758fd4d03423722"
-dependencies = [
- "chalk-derive",
- "chalk-ir",
- "rustc-hash",
- "tracing",
-]
-
-[[package]]
 name = "chalk-ir"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231e391a03c1fc45874171d92be9542efedc939bac59d9501ee28b9521feb406"
+checksum = "87e9c67d500717d65ede27affb7ae40efe240d86fbefff1006fe0ffb62d4caf9"
 dependencies = [
  "chalk-derive",
  "lazy_static",
 ]
 
 [[package]]
-name = "chalk-solve"
-version = "0.15.0"
+name = "chalk-recursive"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c969c0fd06ad50538253327ca3445ff02cc9d0209f94c3cbf198ad9d365b48"
+checksum = "a8fd2ac0fc06c857b95614d229bbe8ea317d1d94a7e8b9442a3f05c9a2c2d5f4"
 dependencies = [
  "chalk-derive",
- "chalk-engine",
+ "chalk-ir",
+ "chalk-solve",
+ "rustc-hash",
+ "tracing",
+]
+
+[[package]]
+name = "chalk-solve"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a79166f2405c1e51eadcc1344f5ee833c7b391532dd78f64a0731a9a123cc58"
+dependencies = [
+ "chalk-derive",
  "chalk-ir",
  "ena",
  "itertools",
@@ -191,6 +191,7 @@ dependencies = [
  "rustc-hash",
  "tracing",
  "tracing-subscriber",
+ "tracing-tree",
 ]
 
 [[package]]
@@ -1133,6 +1134,7 @@ version = "0.1.0"
 dependencies = [
  "arrayvec",
  "chalk-ir",
+ "chalk-recursive",
  "chalk-solve",
  "ena",
  "expect",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,6 +59,17 @@ name = "arrayvec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "autocfg"
@@ -972,6 +992,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7a1905379198075914bc93d32a5465c40474f90a078bb13439cb00c547bcc"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,6 +1150,9 @@ dependencies = [
  "smallvec",
  "stdx",
  "test_utils",
+ "tracing",
+ "tracing-subscriber",
+ "tracing-tree",
 ]
 
 [[package]]
@@ -1723,6 +1756,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1856,7 +1898,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c72c8cf3ec4ed69fef614d011a5ae4274537a8a8c59133558029bd731eb71659"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "chrono",
  "lazy_static",
  "matchers",
@@ -1868,6 +1910,21 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-tree"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a389731c9e6c56fef11e438e5b6afae861d5bc301c8b4bdca8d19f0e830d82"
+dependencies = [
+ "ansi_term 0.12.1",
+ "atty",
+ "chrono",
+ "quanta",
+ "termcolor",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/ra_hir_ty/Cargo.toml
+++ b/crates/ra_hir_ty/Cargo.toml
@@ -33,3 +33,7 @@ chalk-ir = { version = "0.15.0" }
 [dev-dependencies]
 insta = "0.16.0"
 expect = { path = "../expect" }
+
+tracing = "0.1"
+tracing-subscriber = { version = "0.2", default-features = false, features = ["env-filter", "registry"] }
+tracing-tree = { version = "0.1.3" }

--- a/crates/ra_hir_ty/Cargo.toml
+++ b/crates/ra_hir_ty/Cargo.toml
@@ -27,8 +27,9 @@ test_utils = { path = "../test_utils" }
 
 scoped-tls = "1"
 
-chalk-solve = { version = "0.15.0" }
-chalk-ir = { version = "0.15.0" }
+chalk-solve = { version = "0.17.0" }
+chalk-ir = { version = "0.17.0" }
+chalk-recursive = { version = "0.17.0" }
 
 [dev-dependencies]
 insta = "0.16.0"

--- a/crates/ra_hir_ty/src/method_resolution.rs
+++ b/crates/ra_hir_ty/src/method_resolution.rs
@@ -6,8 +6,10 @@ use std::{iter, sync::Arc};
 
 use arrayvec::ArrayVec;
 use hir_def::{
-    lang_item::LangItemTarget, type_ref::Mutability, AssocContainerId, AssocItemId, FunctionId,
-    HasModule, ImplId, Lookup, TraitId,
+    builtin_type::{IntBitness, Signedness},
+    lang_item::LangItemTarget,
+    type_ref::Mutability,
+    AssocContainerId, AssocItemId, FunctionId, HasModule, ImplId, Lookup, TraitId,
 };
 use hir_expand::name::Name;
 use ra_db::CrateId;
@@ -16,9 +18,12 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::Substs;
 use crate::{
-    autoderef, db::HirDatabase, primitive::FloatBitness, utils::all_super_traits, ApplicationTy,
-    Canonical, DebruijnIndex, InEnvironment, TraitEnvironment, TraitRef, Ty, TyKind, TypeCtor,
-    TypeWalk,
+    autoderef,
+    db::HirDatabase,
+    primitive::{FloatBitness, FloatTy, IntTy},
+    utils::all_super_traits,
+    ApplicationTy, Canonical, DebruijnIndex, InEnvironment, TraitEnvironment, TraitRef, Ty, TyKind,
+    TypeCtor, TypeWalk,
 };
 
 /// This is used as a key for indexing impls.
@@ -38,6 +43,62 @@ impl TyFingerprint {
         }
     }
 }
+
+pub(crate) const ALL_INT_FPS: [TyFingerprint; 12] = [
+    TyFingerprint::Apply(TypeCtor::Int(IntTy {
+        signedness: Signedness::Unsigned,
+        bitness: IntBitness::X8,
+    })),
+    TyFingerprint::Apply(TypeCtor::Int(IntTy {
+        signedness: Signedness::Unsigned,
+        bitness: IntBitness::X16,
+    })),
+    TyFingerprint::Apply(TypeCtor::Int(IntTy {
+        signedness: Signedness::Unsigned,
+        bitness: IntBitness::X32,
+    })),
+    TyFingerprint::Apply(TypeCtor::Int(IntTy {
+        signedness: Signedness::Unsigned,
+        bitness: IntBitness::X64,
+    })),
+    TyFingerprint::Apply(TypeCtor::Int(IntTy {
+        signedness: Signedness::Unsigned,
+        bitness: IntBitness::X128,
+    })),
+    TyFingerprint::Apply(TypeCtor::Int(IntTy {
+        signedness: Signedness::Unsigned,
+        bitness: IntBitness::Xsize,
+    })),
+    TyFingerprint::Apply(TypeCtor::Int(IntTy {
+        signedness: Signedness::Signed,
+        bitness: IntBitness::X8,
+    })),
+    TyFingerprint::Apply(TypeCtor::Int(IntTy {
+        signedness: Signedness::Signed,
+        bitness: IntBitness::X16,
+    })),
+    TyFingerprint::Apply(TypeCtor::Int(IntTy {
+        signedness: Signedness::Signed,
+        bitness: IntBitness::X32,
+    })),
+    TyFingerprint::Apply(TypeCtor::Int(IntTy {
+        signedness: Signedness::Signed,
+        bitness: IntBitness::X64,
+    })),
+    TyFingerprint::Apply(TypeCtor::Int(IntTy {
+        signedness: Signedness::Signed,
+        bitness: IntBitness::X128,
+    })),
+    TyFingerprint::Apply(TypeCtor::Int(IntTy {
+        signedness: Signedness::Signed,
+        bitness: IntBitness::Xsize,
+    })),
+];
+
+pub(crate) const ALL_FLOAT_FPS: [TyFingerprint; 2] = [
+    TyFingerprint::Apply(TypeCtor::Float(FloatTy { bitness: FloatBitness::X32 })),
+    TyFingerprint::Apply(TypeCtor::Float(FloatTy { bitness: FloatBitness::X64 })),
+];
 
 /// Trait impls defined or available in some crate.
 #[derive(Debug, Eq, PartialEq)]

--- a/crates/ra_hir_ty/src/tests.rs
+++ b/crates/ra_hir_ty/src/tests.rs
@@ -37,6 +37,15 @@ use crate::{
 // against snapshots of the expected results using insta. Use cargo-insta to
 // update the snapshots.
 
+fn setup_tracing() -> tracing::subscriber::DefaultGuard {
+    use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Registry};
+    use tracing_tree::HierarchicalLayer;
+    let filter = EnvFilter::from_env("CHALK_DEBUG");
+    let layer = HierarchicalLayer::default().with_indent_amount(2).with_writer(std::io::stderr);
+    let subscriber = Registry::default().with(filter).with(layer);
+    tracing::subscriber::set_default(subscriber)
+}
+
 fn check_types(ra_fixture: &str) {
     check_types_impl(ra_fixture, false)
 }
@@ -46,6 +55,7 @@ fn check_types_source_code(ra_fixture: &str) {
 }
 
 fn check_types_impl(ra_fixture: &str, display_source: bool) {
+    let _tracing = setup_tracing();
     let db = TestDB::with_files(ra_fixture);
     let mut checked_one = false;
     for (file_id, annotations) in db.extract_annotations() {
@@ -86,6 +96,7 @@ fn infer(ra_fixture: &str) -> String {
 }
 
 fn infer_with_mismatches(content: &str, include_mismatches: bool) -> String {
+    let _tracing = setup_tracing();
     let (db, file_id) = TestDB::with_single_file(content);
 
     let mut buf = String::new();

--- a/crates/ra_hir_ty/src/tests/traits.rs
+++ b/crates/ra_hir_ty/src/tests/traits.rs
@@ -1992,6 +1992,29 @@ fn test() {
 }
 
 #[test]
+fn fn_item_fn_trait() {
+    check_types(
+        r#"
+//- /main.rs
+#[lang = "fn_once"]
+trait FnOnce<Args> {
+    type Output;
+}
+
+struct S;
+
+fn foo() -> S {}
+
+fn takes_closure<U, F: FnOnce() -> U>(f: F) -> U { f() }
+
+fn test() {
+    takes_closure(foo);
+} //^^^^^^^^^^^^^^^^^^ S
+"#,
+    );
+}
+
+#[test]
 fn unselected_projection_in_trait_env_1() {
     check_types(
         r#"

--- a/crates/ra_hir_ty/src/tests/traits.rs
+++ b/crates/ra_hir_ty/src/tests/traits.rs
@@ -1995,7 +1995,6 @@ fn test() {
 fn fn_item_fn_trait() {
     check_types(
         r#"
-//- /main.rs
 #[lang = "fn_once"]
 trait FnOnce<Args> {
     type Output;
@@ -3025,7 +3024,6 @@ fn infer_box_fn_arg() {
 fn infer_dyn_fn_output() {
     check_types(
         r#"
-//- /lib.rs
 #[lang = "fn_once"]
 pub trait FnOnce<Args> {
     type Output;
@@ -3049,7 +3047,6 @@ fn foo() {
 fn infer_dyn_fn_once_output() {
     check_types(
         r#"
-//- /lib.rs
 #[lang = "fn_once"]
 pub trait FnOnce<Args> {
     type Output;

--- a/crates/ra_hir_ty/src/tests/traits.rs
+++ b/crates/ra_hir_ty/src/tests/traits.rs
@@ -3042,7 +3042,7 @@ fn foo() {
 }
 
 #[test]
-fn variable_kinds() {
+fn variable_kinds_1() {
     check_types(
         r#"
 trait Trait<T> { fn get(self, t: T) -> T; }
@@ -3054,6 +3054,23 @@ fn test() {
   //^^^^^^^^ u128
     S.get(1.);
   //^^^^^^^^ f32
+}
+        "#,
+    );
+}
+
+#[test]
+fn variable_kinds_2() {
+    check_types(
+        r#"
+trait Trait { fn get(self) -> Self; }
+impl Trait for u128 {}
+impl Trait for f32 {}
+fn test() {
+    1.get();
+  //^^^^^^^ u128
+    (1.).get();
+  //^^^^^^^^^^ f32
 }
         "#,
     );

--- a/crates/ra_hir_ty/src/traits.rs
+++ b/crates/ra_hir_ty/src/traits.rs
@@ -295,13 +295,8 @@ pub enum Impl {
     /// A normal impl from an impl block.
     ImplDef(ImplId),
     /// Closure types implement the Fn traits synthetically.
+    // FIXME: implement closure support from Chalk, remove this
     ClosureFnTraitImpl(ClosureFnTraitImplData),
-    /// [T; n]: Unsize<[T]>
-    UnsizeArray,
-    /// T: Unsize<dyn Trait> where T: Trait
-    UnsizeToTraitObject(TraitId),
-    /// dyn Trait: Unsize<dyn SuperTrait> if Trait: SuperTrait
-    UnsizeToSuperTraitObject(UnsizeToSuperTraitObjectData),
 }
 /// This exists just for Chalk, because our ImplIds are only unique per module.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/ra_hir_ty/src/traits.rs
+++ b/crates/ra_hir_ty/src/traits.rs
@@ -2,6 +2,7 @@
 use std::sync::Arc;
 
 use chalk_ir::cast::Cast;
+use chalk_solve::Solver;
 use hir_def::{
     expr::ExprId, lang_item::LangItemTarget, DefWithBodyId, ImplId, TraitId, TypeAliasId,
 };
@@ -32,9 +33,10 @@ struct ChalkContext<'a> {
     krate: CrateId,
 }
 
-fn create_chalk_solver() -> chalk_solve::Solver<Interner> {
-    let solver_choice = chalk_solve::SolverChoice::recursive();
-    solver_choice.into_solver()
+fn create_chalk_solver() -> chalk_recursive::RecursiveSolver<Interner> {
+    let overflow_depth = 100;
+    let caching_enabled = true;
+    chalk_recursive::RecursiveSolver::new(overflow_depth, caching_enabled)
 }
 
 /// A set of clauses that we assume to be true. E.g. if we are inside this function:

--- a/crates/ra_hir_ty/src/traits/builtin.rs
+++ b/crates/ra_hir_ty/src/traits/builtin.rs
@@ -1,15 +1,12 @@
 //! This module provides the built-in trait implementations, e.g. to make
 //! closures implement `Fn`.
-use hir_def::{expr::Expr, lang_item::LangItemTarget, TraitId, TypeAliasId};
+use hir_def::{expr::Expr, TraitId, TypeAliasId};
 use hir_expand::name::name;
 use ra_db::CrateId;
 
-use super::{AssocTyValue, Impl, UnsizeToSuperTraitObjectData};
+use super::{AssocTyValue, Impl};
 use crate::{
-    db::HirDatabase,
-    utils::{all_super_traits, generics},
-    ApplicationTy, Binders, BoundVar, DebruijnIndex, GenericPredicate, Substs, TraitRef, Ty,
-    TypeCtor, TypeWalk,
+    db::HirDatabase, ApplicationTy, BoundVar, DebruijnIndex, Substs, TraitRef, Ty, TypeCtor,
 };
 
 pub(super) struct BuiltinImplData {
@@ -31,7 +28,7 @@ pub(super) fn get_builtin_impls(
     krate: CrateId,
     ty: &Ty,
     // The first argument for the trait, if present
-    arg: &Option<Ty>,
+    _arg: &Option<Ty>,
     trait_: TraitId,
     mut callback: impl FnMut(Impl),
 ) {
@@ -50,60 +47,12 @@ pub(super) fn get_builtin_impls(
             }
         }
     }
-
-    let unsize_trait = get_unsize_trait(db, krate);
-    if let Some(actual_trait) = unsize_trait {
-        if trait_ == actual_trait {
-            get_builtin_unsize_impls(db, krate, ty, arg, callback);
-        }
-    }
-}
-
-fn get_builtin_unsize_impls(
-    db: &dyn HirDatabase,
-    krate: CrateId,
-    ty: &Ty,
-    // The first argument for the trait, if present
-    arg: &Option<Ty>,
-    mut callback: impl FnMut(Impl),
-) {
-    if !check_unsize_impl_prerequisites(db, krate) {
-        return;
-    }
-
-    if let Ty::Apply(ApplicationTy { ctor: TypeCtor::Array, .. }) = ty {
-        callback(Impl::UnsizeArray);
-        return; // array is unsized, the rest of the impls shouldn't apply
-    }
-
-    if let Some(target_trait) = arg.as_ref().and_then(|t| t.dyn_trait_ref()) {
-        // FIXME what about more complicated dyn tys with marker traits?
-        if let Some(trait_ref) = ty.dyn_trait_ref() {
-            if trait_ref.trait_ != target_trait.trait_ {
-                let super_traits = all_super_traits(db.upcast(), trait_ref.trait_);
-                if super_traits.contains(&target_trait.trait_) {
-                    callback(Impl::UnsizeToSuperTraitObject(UnsizeToSuperTraitObjectData {
-                        trait_: trait_ref.trait_,
-                        super_trait: target_trait.trait_,
-                    }));
-                }
-            }
-        } else {
-            // FIXME only for sized types
-            callback(Impl::UnsizeToTraitObject(target_trait.trait_));
-        }
-    }
 }
 
 pub(super) fn impl_datum(db: &dyn HirDatabase, krate: CrateId, impl_: Impl) -> BuiltinImplData {
     match impl_ {
         Impl::ImplDef(_) => unreachable!(),
         Impl::ClosureFnTraitImpl(data) => closure_fn_trait_impl_datum(db, krate, data),
-        Impl::UnsizeArray => array_unsize_impl_datum(db, krate),
-        Impl::UnsizeToTraitObject(trait_) => trait_object_unsize_impl_datum(db, krate, trait_),
-        Impl::UnsizeToSuperTraitObject(data) => {
-            super_trait_object_unsize_impl_datum(db, krate, data)
-        }
     }
 }
 
@@ -225,147 +174,5 @@ fn closure_fn_trait_output_assoc_ty_value(
         assoc_ty_id: output_ty_id,
         num_vars: num_args as usize + 1,
         value: output_ty,
-    }
-}
-
-// Array unsizing
-
-fn check_unsize_impl_prerequisites(db: &dyn HirDatabase, krate: CrateId) -> bool {
-    // the Unsize trait needs to exist and have two type parameters (Self and T)
-    let unsize_trait = match get_unsize_trait(db, krate) {
-        Some(t) => t,
-        None => return false,
-    };
-    let generic_params = generics(db.upcast(), unsize_trait.into());
-    generic_params.len() == 2
-}
-
-fn array_unsize_impl_datum(db: &dyn HirDatabase, krate: CrateId) -> BuiltinImplData {
-    // impl<T> Unsize<[T]> for [T; _]
-    // (this can be a single impl because we don't distinguish array sizes currently)
-
-    let trait_ = get_unsize_trait(db, krate) // get unsize trait
-        // the existence of the Unsize trait has been checked before
-        .expect("Unsize trait missing");
-
-    let var = Ty::Bound(BoundVar::new(DebruijnIndex::INNERMOST, 0));
-    let substs = Substs::builder(2)
-        .push(Ty::apply_one(TypeCtor::Array, var.clone()))
-        .push(Ty::apply_one(TypeCtor::Slice, var))
-        .build();
-
-    let trait_ref = TraitRef { trait_, substs };
-
-    BuiltinImplData {
-        num_vars: 1,
-        trait_ref,
-        where_clauses: Vec::new(),
-        assoc_ty_values: Vec::new(),
-    }
-}
-
-// Trait object unsizing
-
-fn trait_object_unsize_impl_datum(
-    db: &dyn HirDatabase,
-    krate: CrateId,
-    trait_: TraitId,
-) -> BuiltinImplData {
-    // impl<T, T1, ...> Unsize<dyn Trait<T1, ...>> for T where T: Trait<T1, ...>
-
-    let unsize_trait = get_unsize_trait(db, krate) // get unsize trait
-        // the existence of the Unsize trait has been checked before
-        .expect("Unsize trait missing");
-
-    let self_ty = Ty::Bound(BoundVar::new(DebruijnIndex::INNERMOST, 0));
-
-    let target_substs = Substs::build_for_def(db, trait_)
-        .push(Ty::Bound(BoundVar::new(DebruijnIndex::INNERMOST, 0)))
-        .fill_with_bound_vars(DebruijnIndex::ONE, 1)
-        .build();
-    let num_vars = target_substs.len();
-    let target_trait_ref = TraitRef { trait_, substs: target_substs };
-    let target_bounds = vec![GenericPredicate::Implemented(target_trait_ref)];
-
-    let self_substs =
-        Substs::build_for_def(db, trait_).fill_with_bound_vars(DebruijnIndex::INNERMOST, 0).build();
-    let self_trait_ref = TraitRef { trait_, substs: self_substs };
-    let where_clauses = vec![GenericPredicate::Implemented(self_trait_ref)];
-
-    let impl_substs = Substs::builder(2).push(self_ty).push(Ty::Dyn(target_bounds.into())).build();
-
-    let trait_ref = TraitRef { trait_: unsize_trait, substs: impl_substs };
-
-    BuiltinImplData { num_vars, trait_ref, where_clauses, assoc_ty_values: Vec::new() }
-}
-
-fn super_trait_object_unsize_impl_datum(
-    db: &dyn HirDatabase,
-    krate: CrateId,
-    data: UnsizeToSuperTraitObjectData,
-) -> BuiltinImplData {
-    // impl<T1, ...> Unsize<dyn SuperTrait> for dyn Trait<T1, ...>
-
-    let unsize_trait = get_unsize_trait(db, krate) // get unsize trait
-        // the existence of the Unsize trait has been checked before
-        .expect("Unsize trait missing");
-
-    let self_substs = Substs::build_for_def(db, data.trait_)
-        .fill_with_bound_vars(DebruijnIndex::INNERMOST, 0)
-        .build();
-    let self_trait_ref = TraitRef { trait_: data.trait_, substs: self_substs.clone() };
-
-    let num_vars = self_substs.len() - 1;
-
-    // we need to go from our trait to the super trait, substituting type parameters
-    let path = crate::utils::find_super_trait_path(db.upcast(), data.trait_, data.super_trait);
-
-    let mut current_trait_ref = self_trait_ref.clone();
-    for t in path.into_iter().skip(1) {
-        let bounds = db.generic_predicates(current_trait_ref.trait_.into());
-        let super_trait_ref = bounds
-            .iter()
-            .find_map(|b| match &b.value {
-                GenericPredicate::Implemented(tr)
-                    if tr.trait_ == t
-                        && tr.substs[0]
-                            == Ty::Bound(BoundVar::new(DebruijnIndex::INNERMOST, 0)) =>
-                {
-                    Some(Binders { value: tr, num_binders: b.num_binders })
-                }
-                _ => None,
-            })
-            .expect("trait bound for known super trait not found");
-        current_trait_ref = super_trait_ref.cloned().subst(&current_trait_ref.substs);
-    }
-
-    // We need to renumber the variables a bit now: from ^0.0, ^0.1, ^0.2, ...
-    // to ^0.0, ^1.0, ^1.1. The reason for this is that the first variable comes
-    // from the dyn Trait binder, while the other variables come from the impl.
-    let new_substs = Substs::builder(num_vars + 1)
-        .push(Ty::Bound(BoundVar::new(DebruijnIndex::INNERMOST, 0)))
-        .fill_with_bound_vars(DebruijnIndex::ONE, 0)
-        .build();
-
-    let self_bounds =
-        vec![GenericPredicate::Implemented(self_trait_ref.subst_bound_vars(&new_substs))];
-    let super_bounds =
-        vec![GenericPredicate::Implemented(current_trait_ref.subst_bound_vars(&new_substs))];
-
-    let substs = Substs::builder(2)
-        .push(Ty::Dyn(self_bounds.into()))
-        .push(Ty::Dyn(super_bounds.into()))
-        .build();
-
-    let trait_ref = TraitRef { trait_: unsize_trait, substs };
-
-    BuiltinImplData { num_vars, trait_ref, where_clauses: Vec::new(), assoc_ty_values: Vec::new() }
-}
-
-fn get_unsize_trait(db: &dyn HirDatabase, krate: CrateId) -> Option<TraitId> {
-    let target = db.lang_item(krate, "unsize".into())?;
-    match target {
-        LangItemTarget::TraitId(t) => Some(t),
-        _ => None,
     }
 }

--- a/crates/ra_hir_ty/src/traits/chalk.rs
+++ b/crates/ra_hir_ty/src/traits/chalk.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use log::debug;
 
-use chalk_ir::{fold::shift::Shift, GenericArg, TypeName, CanonicalVarKinds};
+use chalk_ir::{fold::shift::Shift, CanonicalVarKinds, GenericArg, TypeName};
 use chalk_solve::rust_ir::{self, OpaqueTyDatumBound, WellKnownTrait};
 
 use hir_def::{
@@ -377,16 +377,13 @@ pub(crate) fn struct_datum_query(
     let variant = rust_ir::AdtVariantDatum {
         fields: Vec::new(), // FIXME add fields (only relevant for auto traits),
     };
-    let struct_datum_bound = rust_ir::AdtDatumBound {
-        variants: vec![variant],
-        where_clauses,
-    };
+    let struct_datum_bound = rust_ir::AdtDatumBound { variants: vec![variant], where_clauses };
     let struct_datum = StructDatum {
         // FIXME set ADT kind
         kind: rust_ir::AdtKind::Struct,
         id: struct_id,
         binders: make_binders(struct_datum_bound, num_params),
-        flags
+        flags,
     };
     Arc::new(struct_datum)
 }

--- a/crates/ra_hir_ty/src/traits/chalk/interner.rs
+++ b/crates/ra_hir_ty/src/traits/chalk/interner.rs
@@ -39,6 +39,7 @@ impl chalk_ir::interner::Interner for Interner {
     type InternedQuantifiedWhereClauses = Vec<chalk_ir::QuantifiedWhereClause<Self>>;
     type InternedVariableKinds = Vec<chalk_ir::VariableKind<Self>>;
     type InternedCanonicalVarKinds = Vec<chalk_ir::CanonicalVarKind<Self>>;
+    type InternedConstraints = Vec<chalk_ir::InEnvironment<chalk_ir::Constraint<Self>>>;
     type DefId = InternId;
     type InternedAdtId = crate::TypeCtorId;
     type Identifier = TypeAliasId;
@@ -348,6 +349,20 @@ impl chalk_ir::interner::Interner for Interner {
         canonical_var_kinds: &'a Self::InternedCanonicalVarKinds,
     ) -> &'a [chalk_ir::CanonicalVarKind<Self>] {
         &canonical_var_kinds
+    }
+
+    fn intern_constraints<E>(
+        &self,
+        data: impl IntoIterator<Item = Result<chalk_ir::InEnvironment<chalk_ir::Constraint<Self>>, E>>,
+    ) -> Result<Self::InternedConstraints, E> {
+        data.into_iter().collect()
+    }
+
+    fn constraints_data<'a>(
+        &self,
+        constraints: &'a Self::InternedConstraints,
+    ) -> &'a [chalk_ir::InEnvironment<chalk_ir::Constraint<Self>>] {
+        constraints
     }
 }
 

--- a/crates/ra_hir_ty/src/traits/chalk/mapping.rs
+++ b/crates/ra_hir_ty/src/traits/chalk/mapping.rs
@@ -271,6 +271,7 @@ impl ToChalk for TypeCtor {
             }
             TypeCtor::Never => TypeName::Never,
 
+            // FIXME convert these
             TypeCtor::Adt(_)
             | TypeCtor::Array
             | TypeCtor::FnPtr { .. }

--- a/crates/ra_hir_ty/src/traits/chalk/mapping.rs
+++ b/crates/ra_hir_ty/src/traits/chalk/mapping.rs
@@ -575,7 +575,10 @@ where
                 )
             });
         let value = self.value.to_chalk(db);
-        chalk_ir::Canonical { value, binders: chalk_ir::CanonicalVarKinds::from_iter(&Interner, kinds) }
+        chalk_ir::Canonical {
+            value,
+            binders: chalk_ir::CanonicalVarKinds::from_iter(&Interner, kinds),
+        }
     }
 
     fn from_chalk(db: &dyn HirDatabase, canonical: chalk_ir::Canonical<T::Chalk>) -> Canonical<T> {

--- a/crates/ra_hir_ty/src/traits/chalk/tls.rs
+++ b/crates/ra_hir_ty/src/traits/chalk/tls.rs
@@ -157,7 +157,7 @@ impl DebugContext<'_> {
             _ => panic!("associated type not in trait"),
         };
         let trait_data = self.0.trait_data(trait_);
-        let params = projection_ty.substitution.parameters(&Interner);
+        let params = projection_ty.substitution.as_slice(&Interner);
         write!(fmt, "<{:?} as {}", &params[0], trait_data.name,)?;
         if params.len() > 1 {
             write!(

--- a/crates/ra_hir_ty/src/utils.rs
+++ b/crates/ra_hir_ty/src/utils.rs
@@ -110,38 +110,6 @@ pub(super) fn all_super_trait_refs(db: &dyn HirDatabase, trait_ref: TraitRef) ->
     result
 }
 
-/// Finds a path from a trait to one of its super traits. Returns an empty
-/// vector if there is no path.
-pub(super) fn find_super_trait_path(
-    db: &dyn DefDatabase,
-    trait_: TraitId,
-    super_trait: TraitId,
-) -> Vec<TraitId> {
-    let mut result = Vec::with_capacity(2);
-    result.push(trait_);
-    return if go(db, super_trait, &mut result) { result } else { Vec::new() };
-
-    fn go(db: &dyn DefDatabase, super_trait: TraitId, path: &mut Vec<TraitId>) -> bool {
-        let trait_ = *path.last().unwrap();
-        if trait_ == super_trait {
-            return true;
-        }
-
-        for tt in direct_super_traits(db, trait_) {
-            if path.contains(&tt) {
-                continue;
-            }
-            path.push(tt);
-            if go(db, super_trait, path) {
-                return true;
-            } else {
-                path.pop();
-            }
-        }
-        false
-    }
-}
-
 pub(super) fn associated_type_by_name_including_super_traits(
     db: &dyn HirDatabase,
     trait_ref: TraitRef,


### PR DESCRIPTION
 - upgrade Chalk
 - make use of Chalk's `Unsize` impls, remove ours
 - use Chalk's built-in array type
 - search efficiently for impls for an int/float variable
 - output Chalk tracing logs in hir_ty tests

Fixes #2534.
Fixes #5057.
Fixes #4374.
Fixes #4281.