### PR TITLE
Mark fixes from check as preferred

### DIFF
--- a/crates/rust-analyzer/src/diagnostics/to_proto.rs
+++ b/crates/rust-analyzer/src/diagnostics/to_proto.rs
@@ -118,6 +118,7 @@ fn map_rust_child_diagnostic(
                 changes: Some(edit_map),
                 document_changes: None,
             }),
+            is_preferred: Some(true),
         })
     }
 }

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -775,6 +775,7 @@ fn handle_fixes(
             group: None,
             kind: Some(CodeActionKind::QUICKFIX),
             edit: Some(edit),
+            is_preferred: Some(false),
         };
         res.push(action);
     }

--- a/crates/rust-analyzer/src/lsp_ext.rs
+++ b/crates/rust-analyzer/src/lsp_ext.rs
@@ -243,6 +243,7 @@ impl Request for CodeActionRequest {
 }
 
 #[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodeAction {
     pub title: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -256,6 +257,8 @@ pub struct CodeAction {
     // pub command: Option<lsp_types::Command>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub edit: Option<SnippetWorkspaceEdit>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_preferred: Option<bool>,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -652,6 +652,7 @@ pub(crate) fn unresolved_code_action(
         group: assist.group.filter(|_| snap.config.client_caps.code_action_group).map(|gr| gr.0),
         kind: Some(code_action_kind(assist.id.1)),
         edit: None,
+        is_preferred: None,
     };
     Ok(res)
 }

--- a/crates/rust-analyzer/test_data/rustc_unused_variable.txt
+++ b/crates/rust-analyzer/test_data/rustc_unused_variable.txt
@@ -65,6 +65,9 @@
                         document_changes: None,
                     },
                 ),
+                is_preferred: Some(
+                    true,
+                ),
             },
         ],
     },

--- a/crates/rust-analyzer/test_data/rustc_unused_variable_as_hint.txt
+++ b/crates/rust-analyzer/test_data/rustc_unused_variable_as_hint.txt
@@ -65,6 +65,9 @@
                         document_changes: None,
                     },
                 ),
+                is_preferred: Some(
+                    true,
+                ),
             },
         ],
     },

--- a/crates/rust-analyzer/test_data/rustc_unused_variable_as_info.txt
+++ b/crates/rust-analyzer/test_data/rustc_unused_variable_as_info.txt
@@ -65,6 +65,9 @@
                         document_changes: None,
                     },
                 ),
+                is_preferred: Some(
+                    true,
+                ),
             },
         ],
     },

--- a/crates/rust-analyzer/test_data/snap_multi_line_fix.txt
+++ b/crates/rust-analyzer/test_data/snap_multi_line_fix.txt
@@ -93,6 +93,9 @@
                         document_changes: None,
                     },
                 ),
+                is_preferred: Some(
+                    true,
+                ),
             },
         ],
     },

--- a/crates/rust-analyzer/tests/heavy_tests/main.rs
+++ b/crates/rust-analyzer/tests/heavy_tests/main.rs
@@ -284,6 +284,7 @@ fn main() {}
                 }
               ]
             },
+            "isPreferred": false,
             "kind": "quickfix",
             "title": "Create module"
         }]),
@@ -355,6 +356,7 @@ fn main() {{}}
                 }
               ]
             },
+            "isPreferred": false,
             "kind": "quickfix",
             "title": "Create module"
         }]),


### PR DESCRIPTION
This allows us to run the auto fix command from vscode to automatically fix diagnostics in the file.

They are also distinguished in the UI.