### PR TITLE
Semantic Highlighting: Emit mutable modifier for 'self' when applicable

### DIFF
--- a/crates/ra_ide/src/syntax_highlighting/tests.rs
+++ b/crates/ra_ide/src/syntax_highlighting/tests.rs
@@ -25,6 +25,16 @@ impl Bar for Foo {
     }
 }
 
+impl Foo {
+    fn baz(mut self) -> i32 {
+        self.x
+    }
+
+    fn qux(&mut self) {
+        self.x = 0;
+    }
+}
+
 static mut STATIC_MUT: i32 = 0;
 
 fn foo<'a, T>() -> T {

--- a/crates/ra_ide/test_data/highlighting.html
+++ b/crates/ra_ide/test_data/highlighting.html
@@ -51,6 +51,16 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
     }
 }
 
+<span class="keyword">impl</span> <span class="struct">Foo</span> {
+    <span class="keyword">fn</span> <span class="function declaration">baz</span>(<span class="keyword">mut</span> <span class="self_keyword mutable">self</span>) -&gt; <span class="builtin_type">i32</span> {
+        <span class="self_keyword">self</span>.<span class="field">x</span>
+    }
+
+    <span class="keyword">fn</span> <span class="function declaration">qux</span>(&<span class="keyword">mut</span> <span class="self_keyword mutable">self</span>) {
+        <span class="self_keyword mutable">self</span>.<span class="field">x</span> = <span class="numeric_literal">0</span>;
+    }
+}
+
 <span class="keyword">static</span> <span class="keyword">mut</span> <span class="static declaration mutable">STATIC_MUT</span>: <span class="builtin_type">i32</span> = <span class="numeric_literal">0</span>;
 
 <span class="keyword">fn</span> <span class="function declaration">foo</span>&lt;<span class="lifetime declaration">'a</span>, <span class="type_param declaration">T</span>&gt;() -&gt; <span class="type_param">T</span> {


### PR DESCRIPTION
This PR implements emitting the mutable modifier for the self keyword when applicable for semantic highlighting as mentioned in #5041. The rendered highlighting test html file:
![firefox_5lbsFNBqsT](https://user-images.githubusercontent.com/3757771/87346245-a5a07280-c551-11ea-9051-e5901255f8c9.png)
As you can see it does not emit the modifier when `self` is not used in a mutable context even if it is declared mutably in the enclosing function. I'm not sure if this is actually something wanted or not.