### PR TITLE
Chalk writer integration

### DIFF
--- a/crates/hir_ty/src/traits/chalk.rs
+++ b/crates/hir_ty/src/traits/chalk.rs
@@ -240,20 +240,22 @@ impl<'a> chalk_solve::RustIrDatabase<Interner> for ChalkContext<'a> {
         Substs::empty().to_chalk(self.db)
     }
 
-    fn trait_name(&self, _trait_id: chalk_ir::TraitId<Interner>) -> String {
-        unimplemented!()
+    fn trait_name(&self, trait_id: chalk_ir::TraitId<Interner>) -> String {
+        let id = from_chalk(self.db, trait_id);
+        self.db.trait_data(id).name.to_string()
     }
-    fn adt_name(&self, _struct_id: chalk_ir::AdtId<Interner>) -> String {
-        unimplemented!()
+    // FIXME: lookup names
+    fn adt_name(&self, struct_id: chalk_ir::AdtId<Interner>) -> String {
+        format!("Adt_{:?}", struct_id.0).replace("TypeCtorId(", "").replace(")", "")
     }
-    fn assoc_type_name(&self, _assoc_ty_id: chalk_ir::AssocTypeId<Interner>) -> String {
-        unimplemented!()
+    fn assoc_type_name(&self, assoc_ty_id: chalk_ir::AssocTypeId<Interner>) -> String {
+        format!("Assoc_{}", assoc_ty_id.0)
     }
-    fn opaque_type_name(&self, _opaque_ty_id: chalk_ir::OpaqueTyId<Interner>) -> String {
-        unimplemented!()
+    fn opaque_type_name(&self, opaque_ty_id: chalk_ir::OpaqueTyId<Interner>) -> String {
+        format!("Opaque_{}", opaque_ty_id.0)
     }
-    fn fn_def_name(&self, _fn_def_id: chalk_ir::FnDefId<Interner>) -> String {
-        unimplemented!()
+    fn fn_def_name(&self, fn_def_id: chalk_ir::FnDefId<Interner>) -> String {
+        format!("fn_{}", fn_def_id.0)
     }
 }
 

--- a/crates/hir_ty/src/traits/chalk.rs
+++ b/crates/hir_ty/src/traits/chalk.rs
@@ -246,7 +246,8 @@ impl<'a> chalk_solve::RustIrDatabase<Interner> for ChalkContext<'a> {
     }
     // FIXME: lookup names
     fn adt_name(&self, struct_id: chalk_ir::AdtId<Interner>) -> String {
-        format!("Adt_{:?}", struct_id.0).replace("TypeCtorId(", "").replace(")", "")
+        let datum = self.db.struct_datum(self.krate, struct_id);
+        format!("{:?}", datum.name(&Interner))
     }
     fn assoc_type_name(&self, assoc_ty_id: chalk_ir::AssocTypeId<Interner>) -> String {
         format!("Assoc_{}", assoc_ty_id.0)


### PR DESCRIPTION
~~This adds a `rust-analyzer dump-chalk` command, similar to analysis-stats, which writes out the whole chalk progam (see [chalk#365](https://github.com/rust-lang/chalk/issues/365) for more info about the .chalk writer)~~

Write out chalk programs in debug output if chalk debugging is active (using `CHALK_DEBUG`).

Example output:
```
[DEBUG ra_hir_ty::traits] solve(UCanonical { canonical: Canonical { value: InEnvironment { environment: Env([]), goal: Implemented(SeparatorTraitRef(?)) }, binders: [] }, universes: 1 }) => None
[INFO  ra_hir_ty::traits] trait_solve_query(Implements(fn min<?0.0>(?0.0, ?0.0) -> ?0.0: Deref))
[DEBUG ra_hir_ty::traits] solve goal: UCanonical { canonical: Canonical { value: InEnvironment { environment: Env([]), goal: Implemented(SeparatorTraitRef(?)) }, binders: [U0 with kind type] }, universes: 1 }
[DEBUG ra_hir_ty::traits::chalk] impls_for_trait Deref
[DEBUG ra_hir_ty::traits::chalk] impls_for_trait returned 0 impls
[DEBUG ra_hir_ty::traits::chalk] trait_datum Ord
[DEBUG ra_hir_ty::traits::chalk] trait Ord = Name(Text("Ord"))
[DEBUG ra_hir_ty::traits] chalk program:
    #[upstream]
    #[non_enumerable]
    #[object_safe]
    trait Ord {}
    #[upstream]
    #[non_enumerable]
    #[object_safe]
    #[lang(sized)]
    trait Sized {}
    fn fn_0<_1_0>(arg_0: _1_0, arg_1: _1_0) -> _1_0
    where
      _1_0: Ord;
    #[upstream]
    #[non_enumerable]
    #[object_safe]
    trait Deref {
      type Assoc_1829: Sized;
    }
    
[DEBUG ra_hir_ty::traits] solve(UCanonical { canonical: Canonical { value: InEnvironment { environment: Env([]), goal: Implemented(SeparatorTraitRef(?)) }, binders: [U0 with kind type] }, universes: 1 }) => None
[INFO  ra_hir_ty::traits] trait_solve_query(Implements(?0.0: Ord))
```