### PR TITLE
Filter assists

### DIFF
--- a/crates/ra_assists/src/assist_config.rs
+++ b/crates/ra_assists/src/assist_config.rs
@@ -4,9 +4,12 @@
 //! module, and we use to statically check that we only produce snippet
 //! assists if we are allowed to.
 
+use crate::AssistKind;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AssistConfig {
     pub snippet_cap: Option<SnippetCap>,
+    pub allowed: Option<Vec<AssistKind>>,
 }
 
 impl AssistConfig {
@@ -22,6 +25,6 @@ pub struct SnippetCap {
 
 impl Default for AssistConfig {
     fn default() -> Self {
-        AssistConfig { snippet_cap: Some(SnippetCap { _private: () }) }
+        AssistConfig { snippet_cap: Some(SnippetCap { _private: () }), allowed: None }
     }
 }

--- a/crates/ra_assists/src/assist_context.rs
+++ b/crates/ra_assists/src/assist_context.rs
@@ -57,7 +57,6 @@ pub(crate) struct AssistContext<'a> {
     pub(crate) sema: Semantics<'a, RootDatabase>,
     pub(crate) frange: FileRange,
     source_file: SourceFile,
-    allowed: Option<Vec<AssistKind>>,
 }
 
 impl<'a> AssistContext<'a> {
@@ -65,10 +64,9 @@ impl<'a> AssistContext<'a> {
         sema: Semantics<'a, RootDatabase>,
         config: &'a AssistConfig,
         frange: FileRange,
-        allowed: Option<Vec<AssistKind>>,
     ) -> AssistContext<'a> {
         let source_file = sema.parse(frange.file_id);
-        AssistContext { config, sema, frange, source_file, allowed }
+        AssistContext { config, sema, frange, source_file }
     }
 
     pub(crate) fn db(&self) -> &RootDatabase {
@@ -114,7 +112,7 @@ impl Assists {
             resolve: true,
             file: ctx.frange.file_id,
             buf: Vec::new(),
-            allowed: ctx.allowed.clone(),
+            allowed: ctx.config.allowed.clone(),
         }
     }
 
@@ -123,7 +121,7 @@ impl Assists {
             resolve: false,
             file: ctx.frange.file_id,
             buf: Vec::new(),
-            allowed: ctx.allowed.clone(),
+            allowed: ctx.config.allowed.clone(),
         }
     }
 

--- a/crates/ra_assists/src/lib.rs
+++ b/crates/ra_assists/src/lib.rs
@@ -86,14 +86,9 @@ impl Assist {
     ///
     /// Assists are returned in the "unresolved" state, that is only labels are
     /// returned, without actual edits.
-    pub fn unresolved(
-        db: &RootDatabase,
-        config: &AssistConfig,
-        range: FileRange,
-        allowed: Option<Vec<AssistKind>>,
-    ) -> Vec<Assist> {
+    pub fn unresolved(db: &RootDatabase, config: &AssistConfig, range: FileRange) -> Vec<Assist> {
         let sema = Semantics::new(db);
-        let ctx = AssistContext::new(sema, config, range, allowed);
+        let ctx = AssistContext::new(sema, config, range);
         let mut acc = Assists::new_unresolved(&ctx);
         handlers::all().iter().for_each(|handler| {
             handler(&mut acc, &ctx);
@@ -109,10 +104,9 @@ impl Assist {
         db: &RootDatabase,
         config: &AssistConfig,
         range: FileRange,
-        allowed: Option<Vec<AssistKind>>,
     ) -> Vec<ResolvedAssist> {
         let sema = Semantics::new(db);
-        let ctx = AssistContext::new(sema, config, range, allowed);
+        let ctx = AssistContext::new(sema, config, range);
         let mut acc = Assists::new_resolved(&ctx);
         handlers::all().iter().for_each(|handler| {
             handler(&mut acc, &ctx);

--- a/crates/ra_assists/src/tests.rs
+++ b/crates/ra_assists/src/tests.rs
@@ -35,14 +35,14 @@ fn check_doc_test(assist_id: &str, before: &str, after: &str) {
     let before = db.file_text(file_id).to_string();
     let frange = FileRange { file_id, range: selection.into() };
 
-    let mut assist = Assist::resolved(&db, &AssistConfig::default(), frange, None)
+    let mut assist = Assist::resolved(&db, &AssistConfig::default(), frange)
         .into_iter()
         .find(|assist| assist.assist.id.0 == assist_id)
         .unwrap_or_else(|| {
             panic!(
                 "\n\nAssist is not applicable: {}\nAvailable assists: {}",
                 assist_id,
-                Assist::resolved(&db, &AssistConfig::default(), frange, None)
+                Assist::resolved(&db, &AssistConfig::default(), frange)
                     .into_iter()
                     .map(|assist| assist.assist.id.0)
                     .collect::<Vec<_>>()
@@ -73,7 +73,7 @@ fn check(handler: Handler, before: &str, expected: ExpectedResult) {
 
     let sema = Semantics::new(&db);
     let config = AssistConfig::default();
-    let ctx = AssistContext::new(sema, &config, frange, None);
+    let ctx = AssistContext::new(sema, &config, frange);
     let mut acc = Assists::new_resolved(&ctx);
     handler(&mut acc, &ctx);
     let mut res = acc.finish_resolved();
@@ -105,7 +105,7 @@ fn assist_order_field_struct() {
     let (before_cursor_pos, before) = extract_offset(before);
     let (db, file_id) = with_single_file(&before);
     let frange = FileRange { file_id, range: TextRange::empty(before_cursor_pos) };
-    let assists = Assist::resolved(&db, &AssistConfig::default(), frange, None);
+    let assists = Assist::resolved(&db, &AssistConfig::default(), frange);
     let mut assists = assists.iter();
 
     assert_eq!(
@@ -128,7 +128,7 @@ fn assist_order_if_expr() {
     let (range, before) = extract_range(before);
     let (db, file_id) = with_single_file(&before);
     let frange = FileRange { file_id, range };
-    let assists = Assist::resolved(&db, &AssistConfig::default(), frange, None);
+    let assists = Assist::resolved(&db, &AssistConfig::default(), frange);
     let mut assists = assists.iter();
 
     assert_eq!(assists.next().expect("expected assist").assist.label, "Extract into variable");
@@ -150,9 +150,10 @@ fn assist_filter_works() {
     let frange = FileRange { file_id, range };
 
     {
-        let allowed = Some(vec![AssistKind::Refactor]);
+        let mut cfg = AssistConfig::default();
+        cfg.allowed = Some(vec![AssistKind::Refactor]);
 
-        let assists = Assist::resolved(&db, &AssistConfig::default(), frange, allowed);
+        let assists = Assist::resolved(&db, &cfg, frange);
         let mut assists = assists.iter();
 
         assert_eq!(assists.next().expect("expected assist").assist.label, "Extract into variable");
@@ -160,8 +161,9 @@ fn assist_filter_works() {
     }
 
     {
-        let allowed = Some(vec![AssistKind::RefactorExtract]);
-        let assists = Assist::resolved(&db, &AssistConfig::default(), frange, allowed);
+        let mut cfg = AssistConfig::default();
+        cfg.allowed = Some(vec![AssistKind::RefactorExtract]);
+        let assists = Assist::resolved(&db, &cfg, frange);
         assert_eq!(assists.len(), 1);
 
         let mut assists = assists.iter();
@@ -169,8 +171,9 @@ fn assist_filter_works() {
     }
 
     {
-        let allowed = Some(vec![AssistKind::QuickFix]);
-        let assists = Assist::resolved(&db, &AssistConfig::default(), frange, allowed);
+        let mut cfg = AssistConfig::default();
+        cfg.allowed = Some(vec![AssistKind::QuickFix]);
+        let assists = Assist::resolved(&db, &cfg, frange);
         assert!(assists.is_empty(), "All asserts but quickfixes should be filtered out");
     }
 }

--- a/crates/ra_ide/src/lib.rs
+++ b/crates/ra_ide/src/lib.rs
@@ -476,8 +476,9 @@ impl Analysis {
         &self,
         config: &AssistConfig,
         frange: FileRange,
+        allowed: Option<Vec<AssistKind>>,
     ) -> Cancelable<Vec<ResolvedAssist>> {
-        self.with_db(|db| ra_assists::Assist::resolved(db, config, frange))
+        self.with_db(|db| ra_assists::Assist::resolved(db, config, frange, allowed))
     }
 
     /// Computes unresolved assists (aka code actions aka intentions) for the given
@@ -486,8 +487,9 @@ impl Analysis {
         &self,
         config: &AssistConfig,
         frange: FileRange,
+        allowed: Option<Vec<AssistKind>>,
     ) -> Cancelable<Vec<Assist>> {
-        self.with_db(|db| Assist::unresolved(db, config, frange))
+        self.with_db(|db| Assist::unresolved(db, config, frange, allowed))
     }
 
     /// Computes the set of diagnostics for the given file.

--- a/crates/ra_ide/src/lib.rs
+++ b/crates/ra_ide/src/lib.rs
@@ -476,9 +476,8 @@ impl Analysis {
         &self,
         config: &AssistConfig,
         frange: FileRange,
-        allowed: Option<Vec<AssistKind>>,
     ) -> Cancelable<Vec<ResolvedAssist>> {
-        self.with_db(|db| ra_assists::Assist::resolved(db, config, frange, allowed))
+        self.with_db(|db| ra_assists::Assist::resolved(db, config, frange))
     }
 
     /// Computes unresolved assists (aka code actions aka intentions) for the given
@@ -487,9 +486,8 @@ impl Analysis {
         &self,
         config: &AssistConfig,
         frange: FileRange,
-        allowed: Option<Vec<AssistKind>>,
     ) -> Cancelable<Vec<Assist>> {
-        self.with_db(|db| Assist::unresolved(db, config, frange, allowed))
+        self.with_db(|db| Assist::unresolved(db, config, frange))
     }
 
     /// Computes the set of diagnostics for the given file.

--- a/crates/rust-analyzer/src/from_proto.rs
+++ b/crates/rust-analyzer/src/from_proto.rs
@@ -58,9 +58,9 @@ pub(crate) fn assist_kind(kind: lsp_types::CodeActionKind) -> Option<AssistKind>
         k if k == &lsp_types::CodeActionKind::EMPTY => AssistKind::None,
         k if k == &lsp_types::CodeActionKind::QUICKFIX => AssistKind::QuickFix,
         k if k == &lsp_types::CodeActionKind::REFACTOR => AssistKind::Refactor,
-        k if k == &lsp_types::CodeActionKind::REFACTOR => AssistKind::RefactorExtract,
-        k if k == &lsp_types::CodeActionKind::REFACTOR => AssistKind::RefactorInline,
-        k if k == &lsp_types::CodeActionKind::REFACTOR => AssistKind::RefactorRewrite,
+        k if k == &lsp_types::CodeActionKind::REFACTOR_EXTRACT => AssistKind::RefactorExtract,
+        k if k == &lsp_types::CodeActionKind::REFACTOR_INLINE => AssistKind::RefactorInline,
+        k if k == &lsp_types::CodeActionKind::REFACTOR_REWRITE => AssistKind::RefactorRewrite,
         _ => return None,
     };
 

--- a/crates/rust-analyzer/src/from_proto.rs
+++ b/crates/rust-analyzer/src/from_proto.rs
@@ -2,7 +2,7 @@
 use std::convert::TryFrom;
 
 use ra_db::{FileId, FilePosition, FileRange};
-use ra_ide::{LineCol, LineIndex};
+use ra_ide::{AssistKind, LineCol, LineIndex};
 use ra_syntax::{TextRange, TextSize};
 use vfs::AbsPathBuf;
 
@@ -51,4 +51,18 @@ pub(crate) fn file_range(
     let line_index = world.analysis.file_line_index(file_id)?;
     let range = text_range(&line_index, range);
     Ok(FileRange { file_id, range })
+}
+
+pub(crate) fn assist_kind(kind: lsp_types::CodeActionKind) -> Option<AssistKind> {
+    let assist_kind = match &kind {
+        k if k == &lsp_types::CodeActionKind::EMPTY => AssistKind::None,
+        k if k == &lsp_types::CodeActionKind::QUICKFIX => AssistKind::QuickFix,
+        k if k == &lsp_types::CodeActionKind::REFACTOR => AssistKind::Refactor,
+        k if k == &lsp_types::CodeActionKind::REFACTOR => AssistKind::RefactorExtract,
+        k if k == &lsp_types::CodeActionKind::REFACTOR => AssistKind::RefactorInline,
+        k if k == &lsp_types::CodeActionKind::REFACTOR => AssistKind::RefactorRewrite,
+        _ => return None,
+    };
+
+    Some(assist_kind)
 }

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -749,7 +749,7 @@ fn handle_fixes(
 
     match &params.context.only {
         Some(v) => {
-            if v.iter().any(|it| {
+            if !v.iter().any(|it| {
                 it == &lsp_types::CodeActionKind::EMPTY
                     || it == &lsp_types::CodeActionKind::QUICKFIX
             }) {


### PR DESCRIPTION
Uses the `CodeActionContext::only` field to compute only those assists the client cares about.

It works but I don't really like the implementation.