### PR TITLE
Bump tracing-tree to remove quanta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,16 +993,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quanta"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7a1905379198075914bc93d32a5465c40474f90a078bb13439cb00c547bcc"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1918,14 +1908,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-tree"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a389731c9e6c56fef11e438e5b6afae861d5bc301c8b4bdca8d19f0e830d82"
+checksum = "37ee7f0f53ed2093971a698db799ef56a2dfd89b32e3aeb5165f0e637a02be04"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
  "chrono",
- "quanta",
  "termcolor",
  "tracing",
  "tracing-subscriber",


### PR DESCRIPTION
Hopefully fixes power 32-bit build.
See: https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Fwg-rls-2.2E0/topic/Running.20check.20builds.20on.2032.20bit.20power