### PR TITLE
Add opt-in mimalloc feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56268c17a6248366d66d4a47a3381369d068cce8409bb1716ed77ea32163bb"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "console"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,6 +684,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a27252ec1d0c4e0dd6142cbc572da50b363ab56fc334f7aa8fadf295b2e24e74"
+dependencies = [
+ "cmake",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +786,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c52de2069999f01bd26436564dbe7de3a87898feeb7a0d0ff9eb20a05bb7ca0"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -1248,6 +1275,7 @@ dependencies = [
  "backtrace",
  "jemalloc-ctl",
  "jemallocator",
+ "mimalloc",
  "once_cell",
  "ra_arena",
 ]

--- a/crates/ra_prof/Cargo.toml
+++ b/crates/ra_prof/Cargo.toml
@@ -12,6 +12,7 @@ doctest = false
 ra_arena = { path = "../ra_arena" }
 once_cell = "1.3.1"
 backtrace = { version = "0.3.44", optional = true }
+mimalloc = { version = "0.1.19", default-features = false, optional = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemallocator = { version = "0.3.2", optional = true }
@@ -24,4 +25,5 @@ cpu_profiler = []
 # Uncomment to enable for the whole crate graph
 # default = [ "backtrace" ]
 # default = [ "jemalloc" ]
+# default = [ "mimalloc" ]
 # default = [ "cpu_profiler" ]

--- a/crates/ra_prof/src/lib.rs
+++ b/crates/ra_prof/src/lib.rs
@@ -19,6 +19,10 @@ pub use crate::{
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
+#[cfg(all(feature = "mimalloc"))]
+#[global_allocator]
+static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// Prints backtrace to stderr, useful for debugging.
 #[cfg(feature = "backtrace")]
 pub fn print_backtrace() {

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -65,3 +65,4 @@ tt = { path = "../ra_tt", package = "ra_tt" }
 
 [features]
 jemalloc = [ "ra_prof/jemalloc" ]
+mimalloc = [ "ra_prof/mimalloc" ]

--- a/xtask/src/install.rs
+++ b/xtask/src/install.rs
@@ -19,7 +19,13 @@ pub enum ClientOpt {
 }
 
 pub struct ServerOpt {
-    pub jemalloc: bool,
+    pub malloc: Malloc,
+}
+
+pub enum Malloc {
+    System,
+    Jemalloc,
+    Mimalloc,
 }
 
 impl InstallCmd {
@@ -130,8 +136,12 @@ fn install_server(opts: ServerOpt) -> Result<()> {
         )
     }
 
-    let jemalloc = if opts.jemalloc { "--features jemalloc" } else { "" };
-    let res = run!("cargo install --path crates/rust-analyzer --locked --force {}", jemalloc);
+    let malloc_feature = match opts.malloc {
+        Malloc::System => "",
+        Malloc::Jemalloc => "--features jemalloc",
+        Malloc::Mimalloc => "--features mimalloc",
+    };
+    let res = run!("cargo install --path crates/rust-analyzer --locked --force {}", malloc_feature);
 
     if res.is_err() && old_rust {
         eprintln!(


### PR DESCRIPTION
This adds a `mimalloc` feature to use [mimalloc](https://github.com/microsoft/mimalloc) via [mimalloc_rust](https://github.com/purpleprotocol/mimalloc_rust), and a corresponding `cargo xtask install --server --mimalloc`.

In my tests on Linux, mimalloc seems to run consistently faster than jemalloc and uses only slightly more memory in `analysis-stats` on chalk. Also, builds with mimalloc produce a binary 3MB smaller than builds with jemalloc.

A summary of `env time -v cargo run --release -p rust-analyzer -- analysis-stats ../chalk/` runs on NixOS master on an Intel 4790K in VMware Workstation:

<table>
<tr>
<td></td><td>self-reported time</td><td>elapsed time</td><td>max RSS</td>
</tr>
<tr><td>glibc 2.30 run 1</td><td>225.1 sec</td><td>3:46.91</td><td>1075208</td></tr>
<tr><td>glibc 2.30 run 2</td><td>228.4 sec</td><td>3:50.13</td><td>1074996</td></tr>
<tr><td>jemalloc run 1</td><td>201.8 sec</td><td>3:23.03</td><td>1055960</td></tr>
<tr><td>jemalloc run 2</td><td>199.2 sec</td><td>3:20.41</td><td>1065040</td></tr>
<tr><td>mimalloc run 1</td><td>188.6 sec</td><td>3:09.77</td><td>1105584</td></tr>
<tr><td>mimalloc run 2</td><td>185.0 sec</td><td>3:06.23</td><td>1108132</td></tr>
<tr><td>mimalloc + lto run 1</td><td>160.7 sec</td><td>2:41.80</td><td>1106076</td></tr>
<tr><td>mimalloc + lto run 2</td><td>162.2 sec</td><td>2:43.31</td><td>1104268</td></tr>
</tr>
</table>

I included an `lto = true; codegen-units = 1` run out of curiosity, this PR doesn't enable it.

<details>
<summary>analysis-stats benchmark runs</summary>

## default

```
# env time -v cargo run --release -p rust-analyzer -- analysis-stats ../chalk/
    Finished release [optimized] target(s) in 0.10s
     Running `target/release/rust-analyzer analysis-stats ../chalk/`
[ERROR ra_project_model] cyclic dependency chalk-integration -> chalk-engine
[ERROR ra_project_model] cyclic dependency chalk-recursive -> chalk-integration
[ERROR ra_project_model] cyclic dependency chalk-solve -> chalk-integration
Database loaded 333.880345ms
Crates in this dir: 11
Total modules found: 159
Total declarations: 2631
Total functions: 1947
Item Collection: 10.176299461s, 0b allocated 0b resident
Total expressions: 57094
Expressions of unknown type: 2938 (5%)
Expressions of partially unknown type: 2427 (4%)
Type mismatches: 232
Inference: 214.968806927s, 0b allocated 0b resident
Total: 225.145114417s, 0b allocated 0b resident
        Command being timed: "cargo run --release -p rust-analyzer -- analysis-stats ../chalk/"
        User time (seconds): 225.34
        System time (seconds): 1.49
        Percent of CPU this job got: 99%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 3:46.91
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 1075208
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 6
        Minor (reclaiming a frame) page faults: 294711
        Voluntary context switches: 365
        Involuntary context switches: 3273
        Swaps: 0
        File system inputs: 2904
        File system outputs: 0
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
# env time -v cargo run --release -p rust-analyzer -- analysis-stats ../chalk/
    Finished release [optimized] target(s) in 0.10s
     Running `target/release/rust-analyzer analysis-stats ../chalk/`
[ERROR ra_project_model] cyclic dependency chalk-integration -> chalk-engine
[ERROR ra_project_model] cyclic dependency chalk-recursive -> chalk-integration
[ERROR ra_project_model] cyclic dependency chalk-solve -> chalk-integration
Database loaded 332.711598ms
Crates in this dir: 11
Total modules found: 159
Total declarations: 2631
Total functions: 1947
Item Collection: 9.895020518s, 0b allocated 0b resident
Total expressions: 57094
Expressions of unknown type: 2938 (5%)
Expressions of partially unknown type: 2427 (4%)
Type mismatches: 232
Inference: 218.5001697s, 0b allocated 0b resident
Total: 228.39519833s, 0b allocated 0b resident
        Command being timed: "cargo run --release -p rust-analyzer -- analysis-stats ../chalk/"
        User time (seconds): 228.26
        System time (seconds): 1.75
        Percent of CPU this job got: 99%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 3:50.13
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 1074996
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 9
        Minor (reclaiming a frame) page faults: 294748
        Voluntary context switches: 330
        Involuntary context switches: 1561
        Swaps: 0
        File system inputs: 12608
        File system outputs: 0
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

## jemalloc
```
# env time -v cargo run --release -p rust-analyzer -- analysis-stats ../chalk/
    Finished release [optimized] target(s) in 0.11s
     Running `target/release/rust-analyzer analysis-stats ../chalk/`
[ERROR ra_project_model] cyclic dependency chalk-integration -> chalk-engine
[ERROR ra_project_model] cyclic dependency chalk-recursive -> chalk-integration
[ERROR ra_project_model] cyclic dependency chalk-solve -> chalk-integration
Database loaded 356.090374ms
Crates in this dir: 11
Total modules found: 159
Total declarations: 2631
Total functions: 1947
Item Collection: 10.176550183s, 439mb allocated 465mb resident
Total expressions: 57094
Expressions of unknown type: 2938 (5%)
Expressions of partially unknown type: 2427 (4%)
Type mismatches: 232
Inference: 191.607201827s, 993mb allocated 1036mb resident
Total: 201.783937913s, 993mb allocated 1036mb resident
        Command being timed: "cargo run --release -p rust-analyzer -- analysis-stats ../chalk/"
        User time (seconds): 201.07
        System time (seconds): 1.89
        Percent of CPU this job got: 99%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 3:23.03
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 1055960
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 357755
        Voluntary context switches: 240
        Involuntary context switches: 1889
        Swaps: 0
        File system inputs: 256
        File system outputs: 0
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
# env time -v cargo run --release -p rust-analyzer -- analysis-stats ../chalk/
    Finished release [optimized] target(s) in 0.10s
     Running `target/release/rust-analyzer analysis-stats ../chalk/`
[ERROR ra_project_model] cyclic dependency chalk-integration -> chalk-engine
[ERROR ra_project_model] cyclic dependency chalk-recursive -> chalk-integration
[ERROR ra_project_model] cyclic dependency chalk-solve -> chalk-integration
Database loaded 317.917622ms
Crates in this dir: 11
Total modules found: 159
Total declarations: 2631
Total functions: 1947
Item Collection: 9.902142185s, 439mb allocated 463mb resident
Total expressions: 57094
Expressions of unknown type: 2938 (5%)
Expressions of partially unknown type: 2427 (4%)
Type mismatches: 232
Inference: 189.295317017s, 993mb allocated 1046mb resident
Total: 199.197555943s, 993mb allocated 1046mb resident
        Command being timed: "cargo run --release -p rust-analyzer -- analysis-stats ../chalk/"
        User time (seconds): 198.64
        System time (seconds): 1.67
        Percent of CPU this job got: 99%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 3:20.41
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 1065040
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 369013
        Voluntary context switches: 243
        Involuntary context switches: 2835
        Swaps: 0
        File system inputs: 0
        File system outputs: 0
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

## mimalloc
```
# env time -v cargo run --release -p rust-analyzer -- analysis-stats ../chalk/
    Finished release [optimized] target(s) in 0.12s
     Running `target/release/rust-analyzer analysis-stats ../chalk/`
[ERROR ra_project_model] cyclic dependency chalk-integration -> chalk-engine
[ERROR ra_project_model] cyclic dependency chalk-recursive -> chalk-integration
[ERROR ra_project_model] cyclic dependency chalk-solve -> chalk-integration
Database loaded 332.116806ms
Crates in this dir: 11
Total modules found: 159
Total declarations: 2631
Total functions: 1947
Item Collection: 9.796643695s, 0b allocated 0b resident
Total expressions: 57094
Expressions of unknown type: 2938 (5%)
Expressions of partially unknown type: 2427 (4%)
Type mismatches: 232
Inference: 178.82132362s, 0b allocated 0b resident
Total: 188.617975605s, 0b allocated 0b resident
        Command being timed: "cargo run --release -p rust-analyzer -- analysis-stats ../chalk/"
        User time (seconds): 187.70
        System time (seconds): 1.97
        Percent of CPU this job got: 99%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 3:09.77
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 1105584
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 296481
        Voluntary context switches: 222
        Involuntary context switches: 1868
        Swaps: 0
        File system inputs: 256
        File system outputs: 0
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
# env time -v cargo run --release -p rust-analyzer -- analysis-stats ../chalk/
    Finished release [optimized] target(s) in 0.13s
     Running `target/release/rust-analyzer analysis-stats ../chalk/`
[ERROR ra_project_model] cyclic dependency chalk-integration -> chalk-engine
[ERROR ra_project_model] cyclic dependency chalk-recursive -> chalk-integration
[ERROR ra_project_model] cyclic dependency chalk-solve -> chalk-integration
Database loaded 320.046776ms
Crates in this dir: 11
Total modules found: 159
Total declarations: 2631
Total functions: 1947
Item Collection: 9.287690124s, 0b allocated 0b resident
Total expressions: 57094
Expressions of unknown type: 2938 (5%)
Expressions of partially unknown type: 2427 (4%)
Type mismatches: 232
Inference: 175.710939697s, 0b allocated 0b resident
Total: 184.998640033s, 0b allocated 0b resident
        Command being timed: "cargo run --release -p rust-analyzer -- analysis-stats ../chalk/"
        User time (seconds): 184.38
        System time (seconds): 1.81
        Percent of CPU this job got: 99%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 3:06.23
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 1108132
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 297055
        Voluntary context switches: 374
        Involuntary context switches: 2374
        Swaps: 0
        File system inputs: 0
        File system outputs: 0
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

## mimalloc + lto
```
# env time -v cargo run --release -p rust-analyzer -- analysis-stats ../chalk/
    Finished release [optimized] target(s) in 0.11s
     Running `target/release/rust-analyzer analysis-stats ../chalk/`
[ERROR ra_project_model] cyclic dependency chalk-integration -> chalk-engine
[ERROR ra_project_model] cyclic dependency chalk-recursive -> chalk-integration
[ERROR ra_project_model] cyclic dependency chalk-solve -> chalk-integration
Database loaded 369.600196ms
Crates in this dir: 11
Total modules found: 159
Total declarations: 2631
Total functions: 1947
Item Collection: 7.572726834s, 0b allocated 0b resident
Total expressions: 57094
Expressions of unknown type: 2938 (5%)
Expressions of partially unknown type: 2427 (4%)
Type mismatches: 232
Inference: 153.090899101s, 0b allocated 0b resident
Total: 160.663635235s, 0b allocated 0b resident
        Command being timed: "cargo run --release -p rust-analyzer -- analysis-stats ../chalk/"
        User time (seconds): 160.01
        System time (seconds): 1.70
        Percent of CPU this job got: 99%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 2:41.80
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 1106076
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 1
        Minor (reclaiming a frame) page faults: 296610
        Voluntary context switches: 209
        Involuntary context switches: 2798
        Swaps: 0
        File system inputs: 8
        File system outputs: 0
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
# env time -v cargo run --release -p rust-analyzer -- analysis-stats ../chalk/
    Finished release [optimized] target(s) in 0.10s
     Running `target/release/rust-analyzer analysis-stats ../chalk/`
[ERROR ra_project_model] cyclic dependency chalk-integration -> chalk-engine
[ERROR ra_project_model] cyclic dependency chalk-recursive -> chalk-integration
[ERROR ra_project_model] cyclic dependency chalk-solve -> chalk-integration
Database loaded 334.630658ms
Crates in this dir: 11
Total modules found: 159
Total declarations: 2631
Total functions: 1947
Item Collection: 7.71699197s, 0b allocated 0b resident
Total expressions: 57094
Expressions of unknown type: 2938 (5%)
Expressions of partially unknown type: 2427 (4%)
Type mismatches: 232
Inference: 154.50351318s, 0b allocated 0b resident
Total: 162.220513775s, 0b allocated 0b resident
        Command being timed: "cargo run --release -p rust-analyzer -- analysis-stats ../chalk/"
        User time (seconds): 161.52
        System time (seconds): 1.74
        Percent of CPU this job got: 99%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 2:43.31
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 1104268
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 296183
        Voluntary context switches: 200
        Involuntary context switches: 1666
        Swaps: 0
        File system inputs: 0
        File system outputs: 0
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```
</details>