### PR TITLE
Use SVG logo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://user-images.githubusercontent.com/1711539/72443316-5a79f280-37ae-11ea-858f-035209ece2dd.png" alt="rust-analyzer logo">
+  <img src="http://aloso.bplaced.net/ra/rust%20analyzer.svg" alt="rust-analyzer logo">
 </p>
 
 rust-analyzer is an **experimental** modular compiler frontend for the Rust


### PR DESCRIPTION
I saw that the logo in the readme looked quite blurry, so I managed to find an [SVG from the creator of the logo](http://aloso.bplaced.net/ra/rust%20analyzer.svg). This works, but I also managed to find an SVG of the logo uploaded by @matklad [here](https://gist.githubusercontent.com/matklad/49c01e8f48a984f3f3be4f525267892d/raw/b74cafe393cff62599c3791c055870bee06f7bbc/logo.svg). However, the font doesn’t seem to load, substituting it with Times New Roman.