### PR TITLE
missing impl members: remove assoc. type bounds

### DIFF
--- a/crates/ra_assists/src/handlers/add_missing_impl_members.rs
+++ b/crates/ra_assists/src/handlers/add_missing_impl_members.rs
@@ -158,6 +158,9 @@ fn add_missing_impl_members_inner(
             .map(|it| ast_transform::apply(&*ast_transform, it))
             .map(|it| match it {
                 ast::AssocItem::FnDef(def) => ast::AssocItem::FnDef(add_body(def)),
+                ast::AssocItem::TypeAliasDef(def) => {
+                    ast::AssocItem::TypeAliasDef(remove_bounds(def))
+                }
                 _ => it,
             })
             .map(|it| edit::remove_attrs_and_docs(&it));
@@ -186,6 +189,14 @@ fn add_missing_impl_members_inner(
             }
         };
     })
+}
+
+fn remove_bounds(ty_def: ast::TypeAliasDef) -> ast::TypeAliasDef {
+    if let Some(name) = ty_def.name() {
+        make::type_alias_def(name, None, ty_def.type_ref())
+    } else {
+        ty_def
+    }
 }
 
 fn add_body(fn_def: ast::FnDef) -> ast::FnDef {
@@ -681,6 +692,28 @@ impl Foo<T> for S<T> {
     fn bar(&self, this: &T, that: &Self) {
         ${0:todo!()}
     }
+}"#,
+        )
+    }
+
+    #[test]
+    fn test_assoc_type_bounds_are_removed() {
+        check_assist(
+            add_missing_impl_members,
+            r#"
+trait Tr {
+    type Ty: Copy + 'static;
+}
+
+impl Tr for ()<|> {
+}"#,
+            r#"
+trait Tr {
+    type Ty: Copy + 'static;
+}
+
+impl Tr for () {
+    $0type Ty;
 }"#,
         )
     }

--- a/crates/ra_assists/src/handlers/add_missing_impl_members.rs
+++ b/crates/ra_assists/src/handlers/add_missing_impl_members.rs
@@ -159,7 +159,7 @@ fn add_missing_impl_members_inner(
             .map(|it| match it {
                 ast::AssocItem::FnDef(def) => ast::AssocItem::FnDef(add_body(def)),
                 ast::AssocItem::TypeAliasDef(def) => {
-                    ast::AssocItem::TypeAliasDef(remove_bounds(def))
+                    ast::AssocItem::TypeAliasDef(def.remove_bounds())
                 }
                 _ => it,
             })
@@ -189,14 +189,6 @@ fn add_missing_impl_members_inner(
             }
         };
     })
-}
-
-fn remove_bounds(ty_def: ast::TypeAliasDef) -> ast::TypeAliasDef {
-    if let Some(name) = ty_def.name() {
-        make::type_alias_def(name, None, ty_def.type_ref())
-    } else {
-        ty_def
-    }
 }
 
 fn add_body(fn_def: ast::FnDef) -> ast::FnDef {

--- a/crates/ra_syntax/src/ast/edit.rs
+++ b/crates/ra_syntax/src/ast/edit.rs
@@ -189,6 +189,21 @@ impl ast::RecordFieldList {
     }
 }
 
+impl ast::TypeAliasDef {
+    #[must_use]
+    pub fn remove_bounds(&self) -> ast::TypeAliasDef {
+        let colon = match self.colon_token() {
+            Some(it) => it,
+            None => return self.clone(),
+        };
+        let end = match self.type_bound_list() {
+            Some(it) => it.syntax().clone().into(),
+            None => colon.clone().into(),
+        };
+        self.replace_children(colon.into()..=end, iter::empty())
+    }
+}
+
 impl ast::TypeParam {
     #[must_use]
     pub fn remove_bounds(&self) -> ast::TypeParam {

--- a/crates/ra_syntax/src/ast/make.rs
+++ b/crates/ra_syntax/src/ast/make.rs
@@ -64,19 +64,6 @@ pub fn use_item(use_tree: ast::UseTree) -> ast::UseItem {
     ast_from_text(&format!("use {};", use_tree))
 }
 
-pub fn type_alias_def(
-    name: ast::Name,
-    bounds: Option<ast::TypeBoundList>,
-    ty: Option<ast::TypeRef>,
-) -> ast::TypeAliasDef {
-    match (bounds, ty) {
-        (None, None) => ast_from_text(&format!("type {};", name)),
-        (None, Some(ty)) => ast_from_text(&format!("type {} = {};", name, ty)),
-        (Some(bounds), None) => ast_from_text(&format!("type {}: {};", name, bounds)),
-        (Some(bounds), Some(ty)) => ast_from_text(&format!("type {}: {} = {};", name, bounds, ty)),
-    }
-}
-
 pub fn record_field(name: ast::NameRef, expr: Option<ast::Expr>) -> ast::RecordField {
     return match expr {
         Some(expr) => from_text(&format!("{}: {}", name, expr)),

--- a/crates/ra_syntax/src/ast/make.rs
+++ b/crates/ra_syntax/src/ast/make.rs
@@ -64,6 +64,19 @@ pub fn use_item(use_tree: ast::UseTree) -> ast::UseItem {
     ast_from_text(&format!("use {};", use_tree))
 }
 
+pub fn type_alias_def(
+    name: ast::Name,
+    bounds: Option<ast::TypeBoundList>,
+    ty: Option<ast::TypeRef>,
+) -> ast::TypeAliasDef {
+    match (bounds, ty) {
+        (None, None) => ast_from_text(&format!("type {};", name)),
+        (None, Some(ty)) => ast_from_text(&format!("type {} = {};", name, ty)),
+        (Some(bounds), None) => ast_from_text(&format!("type {}: {};", name, bounds)),
+        (Some(bounds), Some(ty)) => ast_from_text(&format!("type {}: {} = {};", name, bounds, ty)),
+    }
+}
+
 pub fn record_field(name: ast::NameRef, expr: Option<ast::Expr>) -> ast::RecordField {
     return match expr {
         Some(expr) => from_text(&format!("{}: {}", name, expr)),


### PR DESCRIPTION
Previously "Add missing impl members" would paste bounds on associated types into the impl, which is not allowed. This removes them before pasting the item.