### PR TITLE
Introduce VSCode `rust` debug type.

### DIFF
--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -143,9 +143,9 @@
             }
         },
         "@types/vscode": {
-            "version": "1.45.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.45.0.tgz",
-            "integrity": "sha512-b0Gyir7sPBCqiKLygAhn/AYVfzWD+SMPkWltBrIuPEyTOxSU1wVApWY/FcxYO2EWTRacoubTl4+gvZf86RkecA==",
+            "version": "1.47.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.47.0.tgz",
+            "integrity": "sha512-nJA37ykkz9FYA0ZOQUSc3OZnhuzEW2vUhUEo4MiduUo82jGwwcLfyvmgd/Q7b0WrZAAceojGhZybg319L24bTA==",
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -21,7 +21,7 @@
         "Programming Languages"
     ],
     "engines": {
-        "vscode": "^1.46"
+        "vscode": "^1.46.0"
     },
     "enableProposedApi": true,
     "scripts": {
@@ -98,6 +98,7 @@
                                 }
                             ],
                             "cargo": {
+                                "description": "Cargo options.",
                                 "command": {
                                     "enum": [
                                         "run",
@@ -166,7 +167,127 @@
                             }
                         }
                     }
-                }
+                },
+                "configurationSnippets": [
+                    {
+                        "label": "Rust: Main binary",
+                        "body": {
+                            "type": "rust",
+                            "request": "launch",
+                            "name": "${1:Run main binary}",
+                            "cargo": {
+                                "command": "run"
+                            }
+                        }
+                    },
+                    {
+                        "label": "Rust: All tests",
+                        "body": {
+                            "type": "rust",
+                            "request": "launch",
+                            "name": "${1:Run all tests}",
+                            "cargo": {
+                                "command": "test"
+                            }
+                        }
+                    },
+                    {
+                        "label": "Rust: Example",
+                        "body": {
+                            "type": "rust",
+                            "request": "launch",
+                            "name": "${2:Run example}",
+                            "cargo": {
+                                "command": "run",
+                                "args": [
+                                    "--example",
+                                    "${1:Example name}"
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "label": "Rust: Specified binary",
+                        "body": {
+                            "type": "rust",
+                            "request": "launch",
+                            "name": "${2:Run binary}",
+                            "cargo": {
+                                "command": "run",
+                                "args": [
+                                    "--bin",
+                                    "${1:Binary name}"
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "label": "Rust: Library unit tests",
+                        "body": {
+                            "type": "rust",
+                            "request": "launch",
+                            "name": "${1:Run unit tests}",
+                            "cargo": {
+                                "command": "test",
+                                "args": [
+                                    "--lib"
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "label": "Rust: Specified binary tests",
+                        "body": {
+                            "type": "rust",
+                            "request": "launch",
+                            "name": "${2:Run binary tests}",
+                            "cargo": {
+                                "command": "test",
+                                "args": [
+                                    "--bin",
+                                    "${1:Binary name}"
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "label": "Rust: Specified library unit test",
+                        "body": {
+                            "type": "rust",
+                            "request": "launch",
+                            "name": "${2:Run unit test}",
+                            "cargo": {
+                                "command": "test",
+                                "args": [
+                                    "--lib"
+                                ]
+                            },
+                            "args": [
+                                "${1:Test name}",
+                                "--nocapture"
+                            ]
+                        }
+                    },
+                    {
+                        "label": "Rust: Specified integration test",
+                        "body": {
+                            "type": "rust",
+                            "request": "launch",
+                            "name": "${3:Run integration test}",
+                            "cargo": {
+                                "command": "test",
+                                "args": [
+                                    "--bin",
+                                    "${1:Binary name}"
+                                ]
+                            },
+                            "args": [
+                                "${2:Test name}",
+                                "--nocapture"
+                            ]
+                        }
+                    }
+                ]
             }
         ],
         "taskDefinitions": [

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -21,7 +21,7 @@
         "Programming Languages"
     ],
     "engines": {
-        "vscode": "^1.44.1"
+        "vscode": "^1.46"
     },
     "enableProposedApi": true,
     "scripts": {
@@ -45,7 +45,7 @@
         "@types/mocha": "^7.0.2",
         "@types/node": "~12.7.0",
         "@types/node-fetch": "^2.5.7",
-        "@types/vscode": "^1.44.1",
+        "@types/vscode": "^1.46",
         "@typescript-eslint/eslint-plugin": "^3.4.0",
         "@typescript-eslint/parser": "^3.4.0",
         "eslint": "^7.3.1",
@@ -63,10 +63,112 @@
         "onCommand:rust-analyzer.analyzerStatus",
         "onCommand:rust-analyzer.memoryUsage",
         "onCommand:rust-analyzer.reloadWorkspace",
+        "onDebugInitialConfigurations",
+        "onDebugDynamicConfigurations:rust",
+        "onDebugResolve:rust",
         "workspaceContains:**/Cargo.toml"
     ],
     "main": "./out/src/main",
     "contributes": {
+        "breakpoints": [
+            {
+                "language": "rust"
+            }
+        ],
+        "debuggers": [
+            {
+                "type": "rust",
+                "label": "Rust (preview)",
+                "languages": [
+                    "rust"
+                ],
+                "configurationAttributes": {
+                    "launch": {
+                        "properties": {
+                            "oneOf": [
+                                {
+                                    "required": [
+                                        "program"
+                                    ]
+                                },
+                                {
+                                    "required": [
+                                        "cargo"
+                                    ]
+                                }
+                            ],
+                            "cargo": {
+                                "command": {
+                                    "enum": [
+                                        "run",
+                                        "test",
+                                        "bench"
+                                    ],
+                                    "default": "run"
+                                },
+                                "args": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "default": []
+                                },
+                                "env": {
+                                    "description": "Environment variables to add to the environment for the cargo only. Example: { \"VAR\": \"VALUE\" }.",
+                                    "type": "object",
+                                    "patternProperties": {
+                                        ".*": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "default": {}
+                                },
+                                "required": [
+                                    "command"
+                                ]
+                            },
+                            "program": {
+                                "type": "string",
+                                "description": "Full path to program executable."
+                            },
+                            "args": {
+                                "type": "array",
+                                "description": "Command line arguments passed to the program. In case of `cargo` launch this is the arguments after `--`.",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "default": []
+                            },
+                            "cwd": {
+                                "type": "string",
+                                "description": "The working directory of the target.",
+                                "default": "${workspaceFolder}"
+                            },
+                            "env": {
+                                "description": "Environment variables to add to the environment for the program. Example: { \"VAR\": \"VALUE\" }.",
+                                "type": "object",
+                                "patternProperties": {
+                                    ".*": {
+                                        "type": "string"
+                                    }
+                                },
+                                "default": {}
+                            },
+                            "envFile": {
+                                "type": "string",
+                                "description": "Absolute path to a file containing environment variable definitions. This file has JSON with key value pairs and optional mask.",
+                                "default": "${workspaceFolder}/.vscode/env.json"
+                            },
+                            "debugEngineSettings": {
+                                "type": "object",
+                                "default": {},
+                                "description": "Optional settings passed to the underlying debug engine. E.g. { \"cppvsdbg\": { \"logging\":{ \"moduleLoad\": false } } } }"
+                            }
+                        }
+                    }
+                }
+            }
+        ],
         "taskDefinitions": [
             {
                 "type": "cargo",

--- a/editors/code/src/debug.ts
+++ b/editors/code/src/debug.ts
@@ -65,7 +65,9 @@ function workspaceRoot() : string {
     return path.normalize(vscode.workspace.workspaceFolders![0].uri.fsPath); // folder exists or RA is not active.
 }
 
-function simplifyPath(p: string): string {
+function simplifyPath(p?: string): string | undefined {
+    if (!p) return undefined;
+
     return path.normalize(p).replace(workspaceRoot(), '${workspaceRoot}');
 }
 
@@ -132,7 +134,7 @@ function proxyFromRunnable(runnable: ra.Runnable): ProxyDebugConfiguration | und
             args: runnable.args.cargoArgs.slice(1),
         },
         args: runnable.args.executableArgs,
-        cwd: runnable.args.workspaceRoot,
+        cwd: simplifyPath(runnable.args.workspaceRoot),
     };
 
     return proxyConfig;
@@ -189,7 +191,7 @@ class ProxyConfigurationProvider implements vscode.DebugConfigurationProvider {
         const executable = await this.getExecutable(proxyCfg, cwd);
         const env = prepareEnv(proxyCfg.name, proxyCfg.env, this.context.config.runnableEnv);
         const debugOptions = this.context.config.debug;
-        const debugConfig = configProvider(proxyCfg, simplifyPath(executable), env, debugOptions.sourceFileMap);
+        const debugConfig = configProvider(proxyCfg, simplifyPath(executable)!, env, debugOptions.sourceFileMap);
 
         const customEngineSettings = proxyCfg.debugEngineSettings ?? debugOptions.engineSettings;
         if (debugConfig.type in customEngineSettings) {

--- a/editors/code/src/debug.ts
+++ b/editors/code/src/debug.ts
@@ -61,7 +61,7 @@ export async function startDebugSession(_ctx: Ctx, runnable: ra.Runnable): Promi
     return vscode.debug.startDebugging(undefined, debugConfig);
 }
 
-function workspaceRoot() : string {
+function workspaceRoot(): string {
     return path.normalize(vscode.workspace.workspaceFolders![0].uri.fsPath); // folder exists or RA is not active.
 }
 
@@ -107,19 +107,19 @@ function getCppvsDebugConfig(proxyCfg: ProxyDebugConfiguration, executable: stri
 // These interfaces should be in sync with pacakge.json debuggers : rust : configurationAttributes
 type CargoCommand = "run" | "test" | "bench";
 interface CargoDebugConfiguration {
-    command: CargoCommand,
-    args?: string[],
-    env?: Record<string, string>,
-    cwd?: string,
+    command: CargoCommand;
+    args?: string[];
+    env?: Record<string, string>;
+    cwd?: string;
 }
 interface ProxyDebugConfiguration extends vscode.DebugConfiguration {
-    program?: string,
-    cargo?: CargoDebugConfiguration,
-    args?: string[],
-    cwd?: string,
-    env?: Record<string, string>,
-    envFile?: string,
-    debugEngineSettings?: Record<string, object>,
+    program?: string;
+    cargo?: CargoDebugConfiguration;
+    args?: string[];
+    cwd?: string;
+    env?: Record<string, string>;
+    envFile?: string;
+    debugEngineSettings?: Record<string, object>;
 }
 
 function proxyFromRunnable(runnable: ra.Runnable): ProxyDebugConfiguration | undefined {
@@ -179,7 +179,7 @@ class ProxyConfigurationProvider implements vscode.DebugConfigurationProvider {
 
     async resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefined, debugConfiguration: vscode.DebugConfiguration, _token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration> {
         // debugConfiguration is {} if the user clicks Run\Debug button on the Run panel and there is no launch.json.
-        const proxyCfg = Object.keys(debugConfiguration).length == 0 ? DEFAULT_TARGETS[0] : debugConfiguration as ProxyDebugConfiguration;
+        const proxyCfg = Object.keys(debugConfiguration).length === 0 ? DEFAULT_TARGETS[0] : debugConfiguration as ProxyDebugConfiguration;
         const configProvider = this.selectDebugConfigProvider();
 
         debugOutput.clear();

--- a/editors/code/src/debug.ts
+++ b/editors/code/src/debug.ts
@@ -5,16 +5,17 @@ import * as ra from './lsp_ext';
 
 import { Cargo } from './toolchain';
 import { Ctx } from "./ctx";
-import { prepareEnv } from "./run";
+import { currentRunnables, isDebuggable } from "./run";
+import { RunnableEnvCfg } from "./config";
 
 const debugOutput = vscode.window.createOutputChannel("Debug");
-type DebugConfigProvider = (config: ra.Runnable, executable: string, env: Record<string, string>, sourceFileMap?: Record<string, string>) => vscode.DebugConfiguration;
+type DebugConfigProvider = (config: ProxyDebugConfiguration, executable: string, env: Record<string, string>, sourceFileMap?: Record<string, string>) => vscode.DebugConfiguration;
 
 export async function makeDebugConfig(ctx: Ctx, runnable: ra.Runnable): Promise<void> {
     const scope = ctx.activeRustEditor?.document.uri;
     if (!scope) return;
 
-    const debugConfig = await getDebugConfiguration(ctx, runnable);
+    const debugConfig = proxyFromRunnable(runnable);
     if (!debugConfig) return;
 
     const wsLaunchSection = vscode.workspace.getConfiguration("launch", scope);
@@ -33,7 +34,7 @@ export async function makeDebugConfig(ctx: Ctx, runnable: ra.Runnable): Promise<
     await wsLaunchSection.update("configurations", configurations);
 }
 
-export async function startDebugSession(ctx: Ctx, runnable: ra.Runnable): Promise<boolean> {
+export async function startDebugSession(_ctx: Ctx, runnable: ra.Runnable): Promise<boolean> {
     let debugConfig: vscode.DebugConfiguration | undefined = undefined;
     let message = "";
 
@@ -46,7 +47,11 @@ export async function startDebugSession(ctx: Ctx, runnable: ra.Runnable): Promis
         message = " (from launch.json)";
         debugOutput.clear();
     } else {
-        debugConfig = await getDebugConfiguration(ctx, runnable);
+        try {
+            debugConfig = proxyFromRunnable(runnable);
+        } catch (err) {
+            vscode.window.showErrorMessage(err);
+        }
     }
 
     if (!debugConfig) return false;
@@ -56,96 +61,265 @@ export async function startDebugSession(ctx: Ctx, runnable: ra.Runnable): Promis
     return vscode.debug.startDebugging(undefined, debugConfig);
 }
 
-async function getDebugConfiguration(ctx: Ctx, runnable: ra.Runnable): Promise<vscode.DebugConfiguration | undefined> {
-    const editor = ctx.activeRustEditor;
-    if (!editor) return;
-
-    const knownEngines: Record<string, DebugConfigProvider> = {
-        "vadimcn.vscode-lldb": getLldbDebugConfig,
-        "ms-vscode.cpptools": getCppvsDebugConfig
-    };
-    const debugOptions = ctx.config.debug;
-
-    let debugEngine = null;
-    if (debugOptions.engine === "auto") {
-        for (var engineId in knownEngines) {
-            debugEngine = vscode.extensions.getExtension(engineId);
-            if (debugEngine) break;
-        }
-    } else {
-        debugEngine = vscode.extensions.getExtension(debugOptions.engine);
-    }
-
-    if (!debugEngine) {
-        vscode.window.showErrorMessage(`Install [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb)`
-            + ` or [MS C++ tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) extension for debugging.`);
-        return;
-    }
-
-    debugOutput.clear();
-    if (ctx.config.debug.openDebugPane) {
-        debugOutput.show(true);
-    }
-
+function simplifyPath(p: string): string {
     const wsFolder = path.normalize(vscode.workspace.workspaceFolders![0].uri.fsPath); // folder exists or RA is not active.
-    function simplifyPath(p: string): string {
-        return path.normalize(p).replace(wsFolder, '${workspaceRoot}');
-    }
-
-    const executable = await getDebugExecutable(runnable);
-    const env = prepareEnv(runnable, ctx.config.runnableEnv);
-    const debugConfig = knownEngines[debugEngine.id](runnable, simplifyPath(executable), env, debugOptions.sourceFileMap);
-    if (debugConfig.type in debugOptions.engineSettings) {
-        const settingsMap = (debugOptions.engineSettings as any)[debugConfig.type];
-        for (var key in settingsMap) {
-            debugConfig[key] = settingsMap[key];
-        }
-    }
-
-    if (debugConfig.name === "run binary") {
-        // The LSP side: crates\rust-analyzer\src\main_loop\handlers.rs,
-        // fn to_lsp_runnable(...) with RunnableKind::Bin
-        debugConfig.name = `run ${path.basename(executable)}`;
-    }
-
-    if (debugConfig.cwd) {
-        debugConfig.cwd = simplifyPath(debugConfig.cwd);
-    }
-
-    return debugConfig;
+    return path.normalize(p).replace(wsFolder, '${workspaceRoot}');
 }
 
-async function getDebugExecutable(runnable: ra.Runnable): Promise<string> {
-    const cargo = new Cargo(runnable.args.workspaceRoot || '.', debugOutput);
-    const executable = await cargo.executableFromArgs(runnable.args.cargoArgs);
-
-    // if we are here, there were no compilation errors.
-    return executable;
+function expandPath(p: string): string {
+    const wsFolder = path.normalize(vscode.workspace.workspaceFolders![0].uri.fsPath); // folder exists or RA is not active.
+    return p.replace('${workspaceRoot}', wsFolder);
 }
 
-function getLldbDebugConfig(runnable: ra.Runnable, executable: string, env: Record<string, string>, sourceFileMap?: Record<string, string>): vscode.DebugConfiguration {
+
+// async function getDebugConfiguration(ctx: Ctx, proxyCfg: ProxyDebugConfiguration): Promise<vscode.DebugConfiguration> {
+//     const knownEngines: Record<string, DebugConfigProvider> = {
+//         "vadimcn.vscode-lldb": getLldbDebugConfig,
+//         "ms-vscode.cpptools": getCppvsDebugConfig
+//     };
+//     const debugOptions = ctx.config.debug;
+
+//     let debugEngine = null;
+//     if (debugOptions.engine === "auto") {
+//         for (var engineId in knownEngines) {
+//             debugEngine = vscode.extensions.getExtension(engineId);
+//             if (debugEngine) break;
+//         }
+//     } else {
+//         debugEngine = vscode.extensions.getExtension(debugOptions.engine);
+//     }
+
+//     if (!debugEngine) {
+//         throw `Install [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb)`
+//             + ` or [MS C++ tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) extension for debugging.`;
+//     }
+
+//     debugOutput.clear();
+//     if (ctx.config.debug.openDebugPane) {
+//         debugOutput.show(true);
+//     }
+
+//     const executable = await getDebugExecutable(runnable);
+//     const env = prepareEnv(runnable, ctx.config.runnableEnv);
+//     const debugConfig = knownEngines[debugEngine.id](runnable, simplifyPath(executable), env, debugOptions.sourceFileMap);
+//     if (debugConfig.type in debugOptions.engineSettings) {
+//         const settingsMap = (debugOptions.engineSettings as any)[debugConfig.type];
+//         for (var key in settingsMap) {
+//             debugConfig[key] = settingsMap[key];
+//         }
+//     }
+
+//     if (debugConfig.name === "run binary") {
+//         // The LSP side: crates\rust-analyzer\src\main_loop\handlers.rs,
+//         // fn to_lsp_runnable(...) with RunnableKind::Bin
+//         debugConfig.name = `run ${path.basename(executable)}`;
+//     }
+
+//     if (debugConfig.cwd) {
+//         debugConfig.cwd = simplifyPath(debugConfig.cwd);
+//     }
+
+//     return debugConfig;
+// }
+
+// async function getDebugExecutable(runnable: ra.Runnable): Promise<string> {
+//     const cargo = new Cargo(runnable.args.workspaceRoot || '.', debugOutput);
+//     const executable = await cargo.executableFromArgs(runnable.args.cargoArgs);
+
+//     // if we are here, there were no compilation errors.
+//     return executable;
+// }
+
+function getLldbDebugConfig(proxyCfg: ProxyDebugConfiguration, executable: string, env: Record<string, string>, sourceFileMap?: Record<string, string>): vscode.DebugConfiguration {
     return {
         type: "lldb",
         request: "launch",
-        name: runnable.label,
+        name: proxyCfg.name,
         program: executable,
-        args: runnable.args.executableArgs,
-        cwd: runnable.args.workspaceRoot,
+        args: proxyCfg.args,
+        cwd: proxyCfg.cwd,
         sourceMap: sourceFileMap,
         sourceLanguages: ["rust"],
         env
     };
 }
 
-function getCppvsDebugConfig(runnable: ra.Runnable, executable: string, env: Record<string, string>, sourceFileMap?: Record<string, string>): vscode.DebugConfiguration {
+function getCppvsDebugConfig(proxyCfg: ProxyDebugConfiguration, executable: string, env: Record<string, string>, sourceFileMap?: Record<string, string>): vscode.DebugConfiguration {
     return {
         type: (os.platform() === "win32") ? "cppvsdbg" : "cppdbg",
         request: "launch",
-        name: runnable.label,
+        name: proxyCfg.label,
         program: executable,
-        args: runnable.args.executableArgs,
-        cwd: runnable.args.workspaceRoot,
+        args: proxyCfg.args,
+        cwd: proxyCfg.cwd,
         sourceFileMap,
         env,
     };
+}
+
+// These interfaces should be in sync with pacakge.json debuggers : rust : configurationAttributes
+type CargoCommand = "run" | "test" | "bench";
+interface CargoDebugConfiguration {
+    command: CargoCommand,
+    args?: string[],
+    env?: Record<string, string>,
+    cwd?: string,
+}
+interface ProxyDebugConfiguration extends vscode.DebugConfiguration {
+    program?: string,
+    cargo?: CargoDebugConfiguration,
+    args?: string[],
+    cwd?: string,
+    env?: Record<string, string>,
+    envFile?: string,
+    debugEngineSettings?: Record<string, object>,
+}
+
+function proxyFromRunnable(runnable: ra.Runnable): ProxyDebugConfiguration | undefined {
+    if (!isDebuggable(runnable)) return undefined;
+
+    const proxyConfig: ProxyDebugConfiguration = {
+        type: "rust",
+        request: "launch",
+        name: runnable.label,
+        cargo: {
+            command: runnable.args.cargoArgs[0] as CargoCommand,
+            args: runnable.args.cargoArgs.slice(1),
+        },
+        args: runnable.args.executableArgs,
+        cwd: runnable.args.workspaceRoot ? simplifyPath(runnable.args.workspaceRoot) : undefined,
+    };
+
+    return proxyConfig;
+}
+
+class ProxyConfigurationProvider implements vscode.DebugConfigurationProvider {
+    constructor(readonly workspaceRoot: vscode.WorkspaceFolder, readonly context: Ctx) { }
+
+    async provideDebugConfigurations?(_folder: vscode.WorkspaceFolder | undefined, _token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration[]> {
+        const defaultTargets: ProxyDebugConfiguration[] =
+            [
+                {
+                    type: "rust",
+                    request: "launch",
+                    name: "Main binary",
+                    cargo: {
+                        command: "run"
+                    }
+                },
+                {
+                    type: "rust",
+                    request: "launch",
+                    name: "Tests",
+                    cargo: {
+                        command: "test"
+                    }
+                },
+            ];
+
+        const runnables = await currentRunnables(this.context);
+        const targets = [...defaultTargets];
+        runnables.forEach(it => {
+            const proxyConfig = proxyFromRunnable(it);
+            if (proxyConfig) {
+                targets.push(proxyConfig);
+            }
+        });
+
+        return targets;
+    }
+
+    async resolveDebugConfiguration?(folder: vscode.WorkspaceFolder | undefined, debugConfiguration: vscode.DebugConfiguration, _token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration> {
+        const proxyCfg = debugConfiguration as ProxyDebugConfiguration;
+        const cwd = expandPath(proxyCfg.cwd || folder?.uri.fsPath || vscode.workspace.workspaceFolders![0].uri.fsPath);
+
+        const knownEngines: Record<string, DebugConfigProvider> = {
+            "vadimcn.vscode-lldb": getLldbDebugConfig,
+            "ms-vscode.cpptools": getCppvsDebugConfig
+        };
+        const debugOptions = this.context.config.debug;
+
+        let debugEngine = null;
+        if (debugOptions.engine === "auto") {
+            for (var engineId in knownEngines) {
+                debugEngine = vscode.extensions.getExtension(engineId);
+                if (debugEngine) break;
+            }
+        } else {
+            debugEngine = vscode.extensions.getExtension(debugOptions.engine);
+        }
+
+        if (!debugEngine) {
+            throw `Install [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb)`
+            + ` or [MS C++ tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) extension for debugging.`;
+        }
+
+        debugOutput.clear();
+        if (this.context.config.debug.openDebugPane) {
+            debugOutput.show(true);
+        }
+
+        let executable: string;
+        if (proxyCfg.cargo) {
+            const cargoCwd = proxyCfg.cargo.cwd ? expandPath(proxyCfg.cargo.cwd) : cwd;
+            const cargo = new Cargo(cargoCwd, debugOutput);
+            const cargoArgs: string[] = [proxyCfg.cargo.command];
+            if (proxyCfg.cargo.args) {
+                cargoArgs.push(...proxyCfg.cargo.args);
+            }
+            executable = await cargo.executableFromArgs(cargoArgs);
+        } else if (proxyCfg.program) {
+            executable = proxyCfg.program;
+        } else {
+            throw `Invalid rust debug configuration: ${proxyCfg.name}`;
+        }
+
+        const env = prepareEnv(proxyCfg.name, proxyCfg.env, this.context.config.runnableEnv);
+        const debugConfig = knownEngines[debugEngine.id](proxyCfg, simplifyPath(executable), env, debugOptions.sourceFileMap);
+        if (debugConfig.type in debugOptions.engineSettings) {
+            const settingsMap = (debugOptions.engineSettings as any)[debugConfig.type];
+            for (var key in settingsMap) {
+                debugConfig[key] = settingsMap[key];
+            }
+        }
+
+        if (debugConfig.name === "run binary") {
+            // The LSP side: crates\rust-analyzer\src\main_loop\handlers.rs,
+            // fn to_lsp_runnable(...) with RunnableKind::Bin
+            debugConfig.name = `run ${path.basename(executable)}`;
+        }
+
+        return debugConfig;
+    }
+
+    async resolveDebugConfigurationWithSubstitutedVariables?(_folder: vscode.WorkspaceFolder | undefined, debugConfiguration: vscode.DebugConfiguration, _token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration> {
+        return debugConfiguration;
+    }
+}
+
+export function prepareEnv(name: string, explicitEnv: Record<string, string> | undefined, runnableEnvCfg: RunnableEnvCfg): Record<string, string> {
+    const env = Object.assign({}, process.env as { [key: string]: string });
+
+    if (runnableEnvCfg) {
+        if (Array.isArray(runnableEnvCfg)) {
+            for (const it of runnableEnvCfg) {
+                if (!it.mask || new RegExp(it.mask).test(name)) {
+                    Object.assign(env, it.env);
+                }
+            }
+        } else {
+            Object.assign(env, runnableEnvCfg);
+        }
+    }
+
+    if (explicitEnv) Object.assign(env, explicitEnv);
+
+    return env;
+}
+
+
+export function activateDebugConfigurationProvider(workspaceRoot: vscode.WorkspaceFolder, context: Ctx) {
+    const provider = new ProxyConfigurationProvider(workspaceRoot, context);
+
+    context.pushCleanup(vscode.debug.registerDebugConfigurationProvider("rust", provider, vscode.DebugConfigurationProviderTriggerKind.Dynamic));
 }

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -13,6 +13,7 @@ import { fetchRelease, download } from './net';
 import { activateTaskProvider } from './tasks';
 import { setContextValue } from './util';
 import { exec } from 'child_process';
+import { activateDebugConfigurationProvider } from './debug';
 
 let ctx: Ctx | undefined;
 
@@ -125,6 +126,7 @@ async function tryActivate(context: vscode.ExtensionContext) {
 
     ctx.pushCleanup(activateTaskProvider(workspaceFolder, ctx.config));
 
+    activateDebugConfigurationProvider(workspaceFolder, ctx);
     activateInlayHints(ctx);
 
     vscode.workspace.onDidChangeConfiguration(

--- a/editors/code/src/run.ts
+++ b/editors/code/src/run.ts
@@ -34,7 +34,7 @@ export function isDebuggable(runnable: ra.Runnable): boolean {
 
 export async function selectRunnable(ctx: Ctx, prevRunnable?: RunnableQuickPick, debuggeeOnly = false, showButtons: boolean = true): Promise<RunnableQuickPick | undefined> {
     const runnables = await currentRunnables(ctx);
-    if (runnables.length == 0) return;
+    if (runnables.length === 0) return;
 
     const items: RunnableQuickPick[] = [];
     if (prevRunnable) {
@@ -48,7 +48,7 @@ export async function selectRunnable(ctx: Ctx, prevRunnable?: RunnableQuickPick,
             continue;
         }
 
-        if (debuggeeOnly && !isDebuggable(r) ) {
+        if (debuggeeOnly && !isDebuggable(r)) {
             continue;
         }
         items.push(new RunnableQuickPick(r));

--- a/editors/code/src/toolchain.ts
+++ b/editors/code/src/toolchain.ts
@@ -19,7 +19,7 @@ export interface ArtifactSpec {
 }
 
 export class Cargo {
-    constructor(readonly rootFolder: string, readonly env: Record<string,string> | undefined, readonly output: OutputChannel) { }
+    constructor(readonly rootFolder: string, readonly env: Record<string, string> | undefined, readonly output: OutputChannel) { }
 
     // Made public for testing purposes
     static artifactSpec(args: readonly string[]): ArtifactSpec {
@@ -85,7 +85,7 @@ export class Cargo {
             throw new Error('No compilation artifacts');
         } else if (artifacts.length > 1) {
             if (artifacts[0].isTest) {
-                const binaries = artifacts.filter(it => it.kind == "bin").map(it => it.name).join(', ');
+                const binaries = artifacts.filter(it => it.kind === "bin").map(it => it.name).join(', ');
                 throw new Error('Could not determine which test suite to run.\n' +
                     'Use the `--bin` option to test the specified binary, or the `--lib` option to test the library.\n\n' +
                     `Available binaries: ${binaries}`);

--- a/editors/code/src/toolchain.ts
+++ b/editors/code/src/toolchain.ts
@@ -19,7 +19,7 @@ export interface ArtifactSpec {
 }
 
 export class Cargo {
-    constructor(readonly rootFolder: string, readonly output: OutputChannel) { }
+    constructor(readonly rootFolder: string, readonly env: Record<string,string> | undefined, readonly output: OutputChannel) { }
 
     // Made public for testing purposes
     static artifactSpec(args: readonly string[]): ArtifactSpec {
@@ -109,7 +109,8 @@ export class Cargo {
         return new Promise((resolve, reject) => {
             const cargo = cp.spawn(cargoPath(), cargoArgs, {
                 stdio: ['ignore', 'pipe', 'pipe'],
-                cwd: this.rootFolder
+                cwd: this.rootFolder,
+                env: this.env
             });
 
             cargo.on('error', err => reject(new Error(`could not launch cargo: ${err}`)));

--- a/editors/code/src/toolchain.ts
+++ b/editors/code/src/toolchain.ts
@@ -84,7 +84,18 @@ export class Cargo {
         if (artifacts.length === 0) {
             throw new Error('No compilation artifacts');
         } else if (artifacts.length > 1) {
-            throw new Error('Multiple compilation artifacts are not supported.');
+            if (artifacts[0].isTest) {
+                const binaries = artifacts.filter(it => it.kind == "bin").map(it => it.name).join(', ');
+                throw new Error('Could not determine which test suite to run.\n' +
+                    'Use the `--bin` option to test the specified binary, or the `--lib` option to test the library.\n\n' +
+                    `Available binaries: ${binaries}`);
+
+            } else {
+                const binaries = artifacts.map(it => it.name).join(', ');
+                throw new Error('Could not determine which binary to run.\n' +
+                    'Use the `--bin` option to specify a binary, or the `default-run` manifest key.\n\n' +
+                    `Available binaries: ${binaries}`);
+            }
         }
 
         return artifacts[0].fileName;

--- a/editors/code/tests/unit/runnable_env.test.ts
+++ b/editors/code/tests/unit/runnable_env.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { prepareEnv } from '../../src/run';
+import { prepareRunnableEnv } from '../../src/run';
 import { RunnableEnvCfg } from '../../src/config';
 import * as ra from '../../src/lsp_ext';
 
@@ -16,7 +16,7 @@ function makeRunnable(label: string): ra.Runnable {
 
 function fakePrepareEnv(runnableName: string, config: RunnableEnvCfg): Record<string, string> {
     const runnable = makeRunnable(runnableName);
-    return prepareEnv(runnable, config);
+    return prepareRunnableEnv(runnable, config);
 }
 
 suite('Runnable env', () => {


### PR DESCRIPTION
This PR adds a VSCode-native debug engine integration for rust code.

Well, it's not a real rust debug engine, and internally reuses lldb or ms cpptools as before. But in VSCode UI it looks like a special rust debugger :)

**Important note:** The PR requires at least 1.46 VSCode engine, so maybe we shouldn't merge it until July VSCode release (1.48 https://github.com/microsoft/vscode/milestone/124).
On the other hand, it might be a good idea to test the code on the nightly version.

**Introduced features:**
Now it is possible to use special "rust" debugger in the launch.json:
```jsonc
{
    "configurations": [
        {
            // uses cargo to build the executable
            "type": "rust",
            "request": "launch",
            "name": "Main binary (cargo)",
            "cargo": {
                "command": "run",
            }
        },
        {
            // generated from a runnable
            "type": "rust",
            "request": "launch",
            "name": "run bin2",
            "cargo": {
                "command": "run",
                "args": [
                    "--package",
                    "multiple_binaries",
                    "--bin",
                    "bin2",
                    "--all-features"
                ]
            },
            "args": [],
            "cwd": "${workspaceRoot}"
        },
	{
             // does not use cargo
            "type": "rust",
            "request": "launch",
            "name": "Main binary",
            "program": "${workspaceRoot}/target/debug/bin1"
        }
    ]
}
```

You can use launch.json snippets for rust:
![Snippets](https://user-images.githubusercontent.com/62505555/87419859-e42f3f00-c5dc-11ea-8420-180f61207052.png)

Or generate configuration directly from VSCode `Select and start debugging` peeker (it looks for runnables in the current file).
![generate_cfg](https://user-images.githubusercontent.com/62505555/87419874-ebeee380-c5dc-11ea-9eb0-147cf77bb875.gif)

Of course, you don't have to create debug configurations and can just use this peeker to start debugging without bothering with launch.json.

P.S. I did not delete existing "rust-analyser.debug" and "rust-analyzer.newDebugConfig" commands but I think that in long term we should remove at least the latter. The former might still be useful for keybindings.