### PR TITLE
Fix classify_name_ref on multi-path macro calls

### DIFF
--- a/crates/ra_ide/src/goto_definition.rs
+++ b/crates/ra_ide/src/goto_definition.rs
@@ -866,4 +866,22 @@ type Alias<T> = T<|>;
 "#,
         )
     }
+
+    #[test]
+    fn goto_def_for_macro_container() {
+        check(
+            r#"
+//- /lib.rs
+foo::module<|>::mac!();
+
+//- /foo/lib.rs
+pub mod module {
+      //^^^^^^
+    #[macro_export]
+    macro_rules! _mac { () => { () } }
+    pub use crate::_mac as mac;
+}
+"#,
+        );
+    }
 }

--- a/crates/ra_ide_db/src/defs.rs
+++ b/crates/ra_ide_db/src/defs.rs
@@ -255,8 +255,14 @@ pub fn classify_name_ref(
     }
 
     if let Some(macro_call) = parent.ancestors().find_map(ast::MacroCall::cast) {
-        if let Some(macro_def) = sema.resolve_macro_call(&macro_call) {
-            return Some(NameRefClass::Definition(Definition::Macro(macro_def)));
+        if let Some(path) = macro_call.path() {
+            if path.qualifier().is_none() {
+                // Only use this to resolve single-segment macro calls like `foo!()`. Multi-segment
+                // paths are handled below (allowing `log<|>::info!` to resolve to the log crate).
+                if let Some(macro_def) = sema.resolve_macro_call(&macro_call) {
+                    return Some(NameRefClass::Definition(Definition::Macro(macro_def)));
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Previously, "go to definition" on `log<|>::info!(...)` would go to the `info!` macro, not to the `log` crate. This fixes that.