### PR TITLE
ItemTree: Lower tuple types despite invalid type

### DIFF
--- a/crates/ra_hir_def/src/item_tree/lower.rs
+++ b/crates/ra_hir_def/src/item_tree/lower.rs
@@ -219,21 +219,20 @@ impl Ctx {
     fn lower_tuple_fields(&mut self, fields: &ast::TupleFieldDefList) -> IdRange<Field> {
         let start = self.next_field_idx();
         for (i, field) in fields.fields().enumerate() {
-            if let Some(data) = self.lower_tuple_field(i, &field) {
-                let idx = self.data().fields.alloc(data);
-                self.add_attrs(idx.into(), Attrs::new(&field, &self.hygiene));
-            }
+            let data = self.lower_tuple_field(i, &field);
+            let idx = self.data().fields.alloc(data);
+            self.add_attrs(idx.into(), Attrs::new(&field, &self.hygiene));
         }
         let end = self.next_field_idx();
         IdRange::new(start..end)
     }
 
-    fn lower_tuple_field(&mut self, idx: usize, field: &ast::TupleFieldDef) -> Option<Field> {
+    fn lower_tuple_field(&mut self, idx: usize, field: &ast::TupleFieldDef) -> Field {
         let name = Name::new_tuple_field(idx);
         let visibility = self.lower_visibility(field);
-        let type_ref = self.lower_type_ref(&field.type_ref()?);
+        let type_ref = self.lower_type_ref_opt(field.type_ref());
         let res = Field { name, type_ref, visibility };
-        Some(res)
+        res
     }
 
     fn lower_union(&mut self, union: &ast::UnionDef) -> Option<FileItemTreeId<Union>> {

--- a/crates/ra_hir_ty/src/diagnostics/expr.rs
+++ b/crates/ra_hir_ty/src/diagnostics/expr.rs
@@ -489,4 +489,27 @@ fn f() {
 "#,
         )
     }
+
+    #[test]
+    fn enum_variant_type_macro() {
+        check_diagnostics(
+            r#"
+macro_rules! Type {
+    () => { u32 };
+}
+enum Foo {
+    Bar(Type![])
+}
+impl Foo {
+    fn new() {
+        Foo::Bar(0);
+        Foo::Bar(0, 1);
+      //^^^^^^^^^^^^^^ Expected 1 argument, found 2
+        Foo::Bar();
+      //^^^^^^^^^^ Expected 1 argument, found 0
+    }
+}
+        "#,
+        );
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/5380