### PR TITLE
Do not show default types in function and closure return values

### DIFF
--- a/crates/ra_hir_ty/src/display.rs
+++ b/crates/ra_hir_ty/src/display.rs
@@ -257,7 +257,12 @@ impl HirDisplay for ApplicationTy {
                 write!(f, ")")?;
                 let ret = sig.ret();
                 if *ret != Ty::unit() {
-                    write!(f, " -> {}", ret.display(f.db))?;
+                    let ret_display = if f.omit_verbose_types() {
+                        ret.display_truncated(f.db, f.max_size)
+                    } else {
+                        ret.display(f.db)
+                    };
+                    write!(f, " -> {}", ret_display)?;
                 }
             }
             TypeCtor::FnDef(def) => {
@@ -288,7 +293,12 @@ impl HirDisplay for ApplicationTy {
                 write!(f, ")")?;
                 let ret = sig.ret();
                 if *ret != Ty::unit() {
-                    write!(f, " -> {}", ret.display(f.db))?;
+                    let ret_display = if f.omit_verbose_types() {
+                        ret.display_truncated(f.db, f.max_size)
+                    } else {
+                        ret.display(f.db)
+                    };
+                    write!(f, " -> {}", ret_display)?;
                 }
             }
             TypeCtor::Adt(def_id) => {
@@ -397,7 +407,13 @@ impl HirDisplay for ApplicationTy {
                         f.write_joined(sig.params(), ", ")?;
                         write!(f, "|")?;
                     };
-                    write!(f, " -> {}", sig.ret().display(f.db))?;
+
+                    let ret_display = if f.omit_verbose_types() {
+                        sig.ret().display_truncated(f.db, f.max_size)
+                    } else {
+                        sig.ret().display(f.db)
+                    };
+                    write!(f, " -> {}", ret_display)?;
                 } else {
                     write!(f, "{{closure}}")?;
                 }

--- a/crates/ra_ide/src/inlay_hints.rs
+++ b/crates/ra_ide/src/inlay_hints.rs
@@ -425,6 +425,8 @@ fn main() {
       //^^ Test<i32>
     let zz_ref = &zz;
       //^^^^^^ &Test<i32>
+    let test = || zz;
+      //^^^^ || -> Test<i32>
 }"#,
         );
     }


### PR DESCRIPTION
Avoid things like 
<img width="522" alt="image" src="https://user-images.githubusercontent.com/2690773/87985936-1bbe4f80-cae5-11ea-9b8a-5383d896c296.png">
