### PR TITLE
Allow null or empty values for configuration

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -177,6 +177,11 @@ impl Config {
 
     pub fn update(&mut self, json: serde_json::Value) {
         log::info!("Config::update({:#})", json);
+
+        if json.is_null() {
+            return;
+        }
+
         let data = ConfigData::from_json(json);
 
         self.with_sysroot = data.withSysroot;

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -178,7 +178,7 @@ impl Config {
     pub fn update(&mut self, json: serde_json::Value) {
         log::info!("Config::update({:#})", json);
 
-        if json.is_null() {
+        if json.is_null() || json.as_object().map_or(false, |it| it.is_empty()) {
             return;
         }
 

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -468,6 +468,8 @@ impl GlobalState {
                             }
                             (None, Some(mut configs)) => {
                                 if let Some(json) = configs.get_mut(0) {
+                                    // Note that json can be null according to the spec if the client can't
+                                    // provide a configuration. This is handled in Config::update below.
                                     let mut config = this.config.clone();
                                     config.update(json.take());
                                     this.update_configuration(config);


### PR DESCRIPTION
Allow the client to respond to `workspace/configuration` with `null` values. This is allowed per the spec if the client doesn't know about the configuration we've requested.

This also protects against `null` or `{}` during initialize. I'm not sure if we want to interpret `{}` as "don't change anything" but I think that's a reasonable approach to take.

This should help with LSP clients working out of the box.

Fixes #5464 