### PR TITLE
Allow gathering memory stats on non-jemalloc Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,8 +1198,10 @@ name = "ra_prof"
 version = "0.1.0"
 dependencies = [
  "backtrace",
+ "cfg-if",
  "jemalloc-ctl",
  "jemallocator",
+ "libc",
  "mimalloc",
  "once_cell",
  "ra_arena",

--- a/crates/ra_prof/Cargo.toml
+++ b/crates/ra_prof/Cargo.toml
@@ -14,6 +14,8 @@ ra_arena = { path = "../ra_arena" }
 once_cell = "1.3.1"
 backtrace = { version = "0.3.44", optional = true }
 mimalloc = { version = "0.1.19", default-features = false, optional = true }
+cfg-if = "0.1.10"
+libc = "0.2.73"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemallocator = { version = "0.3.2", optional = true }


### PR DESCRIPTION
I could also parse `/proc/$PID/statm` to get the resident set size, but decided against that for now as it isn't terribly useful.

Note that `mallinfo()` is incredibly slow for some reason, and unfortunately this will be exposed to users via the "Memory Usage" command (even worse, the opened document will show the outdated values while the server is processing). So, not very ideal, but it keeps me from recompiling r-a with different feature sets all the time.