### PR TITLE
Fix snippetTextEdits applying to other files

### DIFF
--- a/editors/code/src/snippets.ts
+++ b/editors/code/src/snippets.ts
@@ -6,6 +6,10 @@ export async function applySnippetWorkspaceEdit(edit: vscode.WorkspaceEdit) {
     assert(edit.entries().length === 1, `bad ws edit: ${JSON.stringify(edit)}`);
     const [uri, edits] = edit.entries()[0];
 
+    if (vscode.window.activeTextEditor?.document.uri !== uri) {
+        // `vscode.window.visibleTextEditors` only contains editors whose contents are being displayed
+        await vscode.window.showTextDocument(uri, {});
+    }
     const editor = vscode.window.visibleTextEditors.find((it) => it.document.uri.toString() === uri.toString());
     if (!editor) return;
     await applySnippetTextEdits(editor, edits);


### PR DESCRIPTION
Fixes #4551
`vscode.window.visibleTextEditors` only contains editors whose contents are being displayed at the moment, so the previous logic only worked if the other file for which a snippetTextEdit is being received was visible in a separate split.

I feel that this is a hacky approach, so feel free to reject it for something nicer :)