### PR TITLE
Store macro invocation parameters as text instead of tt

### DIFF
--- a/crates/ra_hir/src/db.rs
+++ b/crates/ra_hir/src/db.rs
@@ -11,7 +11,7 @@ pub use hir_def::db::{
 };
 pub use hir_expand::db::{
     AstDatabase, AstDatabaseStorage, AstIdMapQuery, InternEagerExpansionQuery, InternMacroQuery,
-    MacroArgQuery, MacroDefQuery, MacroExpandQuery, ParseMacroQuery,
+    MacroArgTextQuery, MacroDefQuery, MacroExpandQuery, ParseMacroQuery,
 };
 pub use hir_ty::db::{
     AssociatedTyDataQuery, AssociatedTyValueQuery, CallableItemSignatureQuery, FieldTypesQuery,

--- a/crates/ra_ide_db/src/change.rs
+++ b/crates/ra_ide_db/src/change.rs
@@ -151,7 +151,7 @@ impl RootDatabase {
 
         // Macros do take significant space, but less then the syntax trees
         // self.query(hir::db::MacroDefQuery).sweep(sweep);
-        // self.query(hir::db::MacroArgQuery).sweep(sweep);
+        // self.query(hir::db::MacroArgTextQuery).sweep(sweep);
         // self.query(hir::db::MacroExpandQuery).sweep(sweep);
 
         hir::db::AstIdMapQuery.in_db(self).sweep(sweep);
@@ -199,7 +199,7 @@ impl RootDatabase {
 
             // AstDatabase
             hir::db::AstIdMapQuery
-            hir::db::MacroArgQuery
+            hir::db::MacroArgTextQuery
             hir::db::MacroDefQuery
             hir::db::ParseMacroQuery
             hir::db::MacroExpandQuery

--- a/crates/ra_syntax/src/lib.rs
+++ b/crates/ra_syntax/src/lib.rs
@@ -42,8 +42,6 @@ use std::{marker::PhantomData, sync::Arc};
 use ra_text_edit::Indel;
 use stdx::format_to;
 
-use crate::syntax_node::GreenNode;
-
 pub use crate::{
     algo::InsertPosition,
     ast::{AstNode, AstToken},
@@ -51,7 +49,7 @@ pub use crate::{
     ptr::{AstPtr, SyntaxNodePtr},
     syntax_error::SyntaxError,
     syntax_node::{
-        Direction, NodeOrToken, SyntaxElement, SyntaxElementChildren, SyntaxNode,
+        Direction, GreenNode, NodeOrToken, SyntaxElement, SyntaxElementChildren, SyntaxNode,
         SyntaxNodeChildren, SyntaxToken, SyntaxTreeBuilder,
     },
 };

--- a/crates/ra_syntax/src/syntax_node.rs
+++ b/crates/ra_syntax/src/syntax_node.rs
@@ -10,7 +10,9 @@ use rowan::{GreenNodeBuilder, Language};
 
 use crate::{Parse, SmolStr, SyntaxError, SyntaxKind, TextSize};
 
-pub(crate) use rowan::{GreenNode, GreenToken};
+pub use rowan::GreenNode;
+
+pub(crate) use rowan::GreenToken;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum RustLanguage {}


### PR DESCRIPTION
We don't want to expand macros on every source change because it can be arbitrarily slow, but the token trees can be rather large. So instead we can cache the invocation parameters (as text).