### PR TITLE
assists: change_return_type_to_result: clarify assist description

### DIFF
--- a/crates/ra_assists/src/handlers/change_return_type_to_result.rs
+++ b/crates/ra_assists/src/handlers/change_return_type_to_result.rs
@@ -36,7 +36,7 @@ pub(crate) fn change_return_type_to_result(acc: &mut Assists, ctx: &AssistContex
 
     acc.add(
         AssistId("change_return_type_to_result", AssistKind::RefactorRewrite),
-        "Change return type to Result",
+        "Wrap return type in Result",
         type_ref.syntax().text_range(),
         |builder| {
             let mut tail_return_expr_collector = TailReturnCollector::new();


### PR DESCRIPTION
I had a -> Option<PathBuf> fn, which I wanted to change to Result<PathBuf, _>, but despite advertising to do so, the assist did not change the result type to Result<PathBuf, _> but instead just wrapped it in a Result: <Result<Option<PathBuf>, _>.

I changed the assist description to "Wrap return type in Result" to clarify that the assist only wraps the preexisting type and does not do any actual Option-to-Result refactoring.