### PR TITLE
Move cfg parsing into CfgOptions

### DIFF
--- a/crates/ra_cfg/src/lib.rs
+++ b/crates/ra_cfg/src/lib.rs
@@ -35,11 +35,20 @@ impl CfgOptions {
         self.check(&parse_cfg(attr))
     }
 
-    pub fn insert_atom(&mut self, key: SmolStr) {
-        self.atoms.insert(key);
+    pub fn insert(&mut self, raw_string: &str) {
+        match raw_string.find('=') {
+            None => {
+                self.atoms.insert(raw_string.into());
+            }
+            Some(pos) => {
+                let key = &raw_string[..pos];
+                let value = raw_string[pos + 1..].trim_matches('"');
+                self.key_values.insert((key.into(), value.into()));
+            }
+        }
     }
 
-    pub fn remove_atom(&mut self, name: &str) {
+    pub fn remove(&mut self, name: &str) {
         self.atoms.remove(name);
     }
 
@@ -55,5 +64,54 @@ impl CfgOptions {
         for (key, value) in &other.key_values {
             self.key_values.insert((key.clone(), value.clone()));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cfg_options_atom_from_raw() {
+        let mut cfg_options = CfgOptions::default();
+
+        cfg_options.insert("debug_assertions");
+        cfg_options.insert("unix");
+
+        assert_eq!(Some(true), cfg_options.check(&CfgExpr::Atom("unix".into())));
+        assert_eq!(Some(true), cfg_options.check(&CfgExpr::Atom("debug_assertions".into())));
+
+        assert_eq!(Some(false), cfg_options.check(&CfgExpr::Atom("missing_atom".into())));
+        assert_eq!(
+            Some(false),
+            cfg_options
+                .check(&CfgExpr::KeyValue { key: "target_family".into(), value: "unix".into() })
+        );
+    }
+
+    #[test]
+    fn test_cfg_options_key_value_from_raw() {
+        let mut cfg_options = CfgOptions::default();
+
+        cfg_options.insert(r#"target_arch="x86_64""#);
+        cfg_options.insert("target_endian=little");
+
+        assert_eq!(
+            Some(true),
+            cfg_options
+                .check(&CfgExpr::KeyValue { key: "target_arch".into(), value: "x86_64".into() })
+        );
+        assert_eq!(
+            Some(true),
+            cfg_options
+                .check(&CfgExpr::KeyValue { key: "target_endian".into(), value: "little".into() })
+        );
+
+        assert_eq!(
+            Some(false),
+            cfg_options
+                .check(&CfgExpr::KeyValue { key: "target_family".into(), value: "unix".into() })
+        );
+        assert_eq!(Some(false), cfg_options.check(&CfgExpr::Atom("missing_atom".into())));
     }
 }

--- a/crates/ra_db/src/fixture.rs
+++ b/crates/ra_db/src/fixture.rs
@@ -210,8 +210,7 @@ struct FileMeta {
 impl From<Fixture> for FileMeta {
     fn from(f: Fixture) -> FileMeta {
         let mut cfg = CfgOptions::default();
-        f.cfg_atoms.iter().for_each(|it| cfg.insert_atom(it.into()));
-        f.cfg_key_values.iter().for_each(|(k, v)| cfg.insert_key_value(k.into(), v.into()));
+        f.cfg.iter().for_each(|it| cfg.insert(it));
 
         FileMeta {
             path: f.path,

--- a/crates/ra_ide/src/lib.rs
+++ b/crates/ra_ide/src/lib.rs
@@ -222,7 +222,7 @@ impl Analysis {
         // FIXME: cfg options
         // Default to enable test for single file.
         let mut cfg_options = CfgOptions::default();
-        cfg_options.insert_atom("test".into());
+        cfg_options.insert("test");
         crate_graph.add_crate_root(
             file_id,
             Edition::Edition2018,

--- a/crates/ra_ide/src/mock_analysis.rs
+++ b/crates/ra_ide/src/mock_analysis.rs
@@ -104,8 +104,7 @@ impl MockAnalysis {
             assert!(path.starts_with('/'));
 
             let mut cfg = CfgOptions::default();
-            data.cfg_atoms.iter().for_each(|it| cfg.insert_atom(it.into()));
-            data.cfg_key_values.iter().for_each(|(k, v)| cfg.insert_key_value(k.into(), v.into()));
+            data.cfg.iter().for_each(|it| cfg.insert(it));
             let edition: Edition =
                 data.edition.and_then(|it| it.parse().ok()).unwrap_or(Edition::Edition2018);
 

--- a/crates/ra_project_model/src/project_json.rs
+++ b/crates/ra_project_model/src/project_json.rs
@@ -7,7 +7,6 @@ use ra_cfg::CfgOptions;
 use ra_db::{CrateId, CrateName, Dependency, Edition};
 use rustc_hash::FxHashSet;
 use serde::{de, Deserialize};
-use stdx::split_delim;
 
 /// Roots and crates that compose this Rust project.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -64,12 +63,7 @@ impl ProjectJson {
                         cfg: {
                             let mut cfg = CfgOptions::default();
                             for entry in &crate_data.cfg {
-                                match split_delim(entry, '=') {
-                                    Some((key, value)) => {
-                                        cfg.insert_key_value(key.into(), value.into());
-                                    }
-                                    None => cfg.insert_atom(entry.into()),
-                                }
+                                cfg.insert(entry);
                             }
                             cfg
                         },


### PR DESCRIPTION
Move the parsing of atoms as distinct from key=value pairs into
CfgOptions itself so that sources of cfg strings don't have to
be aware of the distinction, or worry about whether or not to put
quotes around the value in strings for key=value pairs.

Added unit-tests for CfgOptions to test this specific behavior,
with both `key=value` and `key="value"` strings, as well as atoms.