### PR TITLE
ProblemMatcher fixes/improvements.

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -655,24 +655,30 @@
         "problemMatchers": [
             {
                 "name": "rustc",
+                "owner": "rustc",
+                "source": "rustc",
                 "fileLocation": [
-                    "relative",
+                    "autoDetect",
                     "${workspaceRoot}"
                 ],
                 "pattern": "$rustc"
             },
             {
                 "name": "rustc-json",
+                "owner": "rustc",
+                "source": "rustc",
                 "fileLocation": [
-                    "relative",
+                    "autoDetect",
                     "${workspaceRoot}"
                 ],
                 "pattern": "$rustc-json"
             },
             {
                 "name": "rustc-watch",
+                "owner": "rustc",
+                "source": "rustc",
                 "fileLocation": [
-                    "relative",
+                    "autoDetect",
                     "${workspaceRoot}"
                 ],
                 "background": {

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -41,6 +41,7 @@ export function createClient(serverPath: string, cwd: string): lc.LanguageClient
     const clientOptions: lc.LanguageClientOptions = {
         documentSelector: [{ scheme: 'file', language: 'rust' }],
         initializationOptions: vscode.workspace.getConfiguration("rust-analyzer"),
+        diagnosticCollectionName: "rustc",
         traceOutputChannel,
         middleware: {
             // Workaround for https://github.com/microsoft/vscode-languageserver-node/issues/576


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/5482.

ProblemMatcher auto detects relative/absolute paths and matches VSCode LSP's owner and source.  VSCode LSP updated to specify owner.