### PR TITLE
Require quotes around key-value cfg flags in rust-project.json

### DIFF
--- a/crates/ra_project_model/src/cfg_flag.rs
+++ b/crates/ra_project_model/src/cfg_flag.rs
@@ -1,0 +1,51 @@
+//! Parsing of CfgFlags as command line arguments, as in
+//!
+//! rustc main.rs --cfg foo --cfg 'feature="bar"'
+use std::str::FromStr;
+
+use ra_cfg::CfgOptions;
+use stdx::split_delim;
+
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub enum CfgFlag {
+    Atom(String),
+    KeyValue { key: String, value: String },
+}
+
+impl FromStr for CfgFlag {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let res = match split_delim(s, '=') {
+            Some((key, value)) => {
+                if !(value.starts_with('"') && value.ends_with('"')) {
+                    return Err(format!("Invalid cfg ({:?}), value should be in quotes", s));
+                }
+                let key = key.to_string();
+                let value = value[1..value.len() - 1].to_string();
+                CfgFlag::KeyValue { key, value }
+            }
+            None => CfgFlag::Atom(s.into()),
+        };
+        Ok(res)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for CfgFlag {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        String::deserialize(deserializer)?.parse().map_err(serde::de::Error::custom)
+    }
+}
+
+impl Extend<CfgFlag> for CfgOptions {
+    fn extend<T: IntoIterator<Item = CfgFlag>>(&mut self, iter: T) {
+        for cfg_flag in iter {
+            match cfg_flag {
+                CfgFlag::Atom(it) => self.insert_atom(it.into()),
+                CfgFlag::KeyValue { key, value } => self.insert_key_value(key.into(), value.into()),
+            }
+        }
+    }
+}

--- a/crates/ra_project_model/src/sysroot.rs
+++ b/crates/ra_project_model/src/sysroot.rs
@@ -6,7 +6,7 @@ use anyhow::{bail, format_err, Result};
 use paths::{AbsPath, AbsPathBuf};
 use ra_arena::{Arena, Idx};
 
-use crate::output;
+use crate::utf8_stdout;
 
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 pub struct Sysroot {
@@ -92,15 +92,14 @@ fn get_or_install_rust_src(cargo_toml: &AbsPath) -> Result<AbsPathBuf> {
     let current_dir = cargo_toml.parent().unwrap();
     let mut rustc = Command::new(ra_toolchain::rustc());
     rustc.current_dir(current_dir).args(&["--print", "sysroot"]);
-    let rustc_output = output(rustc)?;
-    let stdout = String::from_utf8(rustc_output.stdout)?;
+    let stdout = utf8_stdout(rustc)?;
     let sysroot_path = AbsPath::assert(Path::new(stdout.trim()));
     let src_path = sysroot_path.join("lib/rustlib/src/rust/src");
 
     if !src_path.exists() {
         let mut rustup = Command::new(ra_toolchain::rustup());
         rustup.current_dir(current_dir).args(&["component", "add", "rust-src"]);
-        let _output = output(rustup)?;
+        utf8_stdout(rustup)?;
     }
     if !src_path.exists() {
         bail!(

--- a/crates/rust-analyzer/tests/heavy_tests/main.rs
+++ b/crates/rust-analyzer/tests/heavy_tests/main.rs
@@ -318,7 +318,7 @@ fn test_missing_module_code_action_in_json_project() {
             "root_module": path.join("src/lib.rs"),
             "deps": [],
             "edition": "2015",
-            "cfg": [ "cfg_atom_1", "feature=cfg_1"],
+            "cfg": [ "cfg_atom_1", "feature=\"cfg_1\""],
         } ]
     });
 


### PR DESCRIPTION
This matches rustc command-line flags, as well as the build.rs format.



bors r+
🤖