### PR TITLE
Try figure out correct workspace in vscode multi root workspace

### DIFF
--- a/editors/code/src/debug.ts
+++ b/editors/code/src/debug.ts
@@ -87,9 +87,18 @@ async function getDebugConfiguration(ctx: Ctx, runnable: ra.Runnable): Promise<v
         debugOutput.show(true);
     }
 
-    const wsFolder = path.normalize(vscode.workspace.workspaceFolders![0].uri.fsPath); // folder exists or RA is not active.
+
+    const isMultiFolderWorkspace = vscode.workspace.workspaceFolders!.length > 1;
+    const firstWorkspace = vscode.workspace.workspaceFolders![0]; // folder exists or RA is not active.
+    const workspace = !isMultiFolderWorkspace || !runnable.args.workspaceRoot ?
+        firstWorkspace :
+        vscode.workspace.workspaceFolders!.find(w => runnable.args.workspaceRoot?.includes(w.uri.fsPath)) || firstWorkspace;
+
+    const wsFolder = path.normalize(workspace.uri.fsPath);
+    const workspaceQualifier = isMultiFolderWorkspace ? `:${workspace.name}` : '';
     function simplifyPath(p: string): string {
-        return path.normalize(p).replace(wsFolder, '${workspaceRoot}');
+        // see https://github.com/rust-analyzer/rust-analyzer/pull/5513#issuecomment-663458818 for why this is needed
+        return path.normalize(p).replace(wsFolder, '${workspaceFolder' + workspaceQualifier + '}');
     }
 
     const executable = await getDebugExecutable(runnable);

--- a/editors/code/src/debug.ts
+++ b/editors/code/src/debug.ts
@@ -87,7 +87,6 @@ async function getDebugConfiguration(ctx: Ctx, runnable: ra.Runnable): Promise<v
         debugOutput.show(true);
     }
 
-
     const isMultiFolderWorkspace = vscode.workspace.workspaceFolders!.length > 1;
     const firstWorkspace = vscode.workspace.workspaceFolders![0]; // folder exists or RA is not active.
     const workspace = !isMultiFolderWorkspace || !runnable.args.workspaceRoot ?


### PR DESCRIPTION
the code to replace the root with the `${workspaceRoot}` arg breaks in multi root workspaces as it needs a qualifier `${workspaceRoot:workspaceName}`

This PR attempts to figure out the root workspace - and if it cant find it falls back to the first workspace