### PR TITLE
Use resolved paths in SSR rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1164,6 +1164,7 @@ dependencies = [
 name = "ra_ssr"
 version = "0.1.0"
 dependencies = [
+ "expect",
  "ra_db",
  "ra_hir",
  "ra_ide_db",

--- a/crates/ra_ide/src/lib.rs
+++ b/crates/ra_ide/src/lib.rs
@@ -505,9 +505,10 @@ impl Analysis {
         &self,
         query: &str,
         parse_only: bool,
+        position: FilePosition,
     ) -> Cancelable<Result<SourceChange, SsrError>> {
         self.with_db(|db| {
-            let edits = ssr::parse_search_replace(query, parse_only, db)?;
+            let edits = ssr::parse_search_replace(query, parse_only, db, position)?;
             Ok(SourceChange::from(edits))
         })
     }

--- a/crates/ra_ide/src/ssr.rs
+++ b/crates/ra_ide/src/ssr.rs
@@ -1,5 +1,4 @@
-use ra_db::SourceDatabaseExt;
-use ra_ide_db::{symbol_index::SymbolsDatabase, RootDatabase};
+use ra_ide_db::RootDatabase;
 
 use crate::SourceFileEdit;
 use ra_ssr::{MatchFinder, SsrError, SsrRule};
@@ -44,20 +43,11 @@ pub fn parse_search_replace(
     parse_only: bool,
     db: &RootDatabase,
 ) -> Result<Vec<SourceFileEdit>, SsrError> {
-    let mut edits = vec![];
     let rule: SsrRule = rule.parse()?;
     if parse_only {
-        return Ok(edits);
+        return Ok(Vec::new());
     }
     let mut match_finder = MatchFinder::new(db);
     match_finder.add_rule(rule);
-    for &root in db.local_roots().iter() {
-        let sr = db.source_root(root);
-        for file_id in sr.iter() {
-            if let Some(edit) = match_finder.edits_for_file(file_id) {
-                edits.push(SourceFileEdit { file_id, edit });
-            }
-        }
-    }
-    Ok(edits)
+    Ok(match_finder.edits())
 }

--- a/crates/ra_ide/src/ssr.rs
+++ b/crates/ra_ide/src/ssr.rs
@@ -1,3 +1,4 @@
+use ra_db::FilePosition;
 use ra_ide_db::RootDatabase;
 
 use crate::SourceFileEdit;
@@ -42,12 +43,13 @@ pub fn parse_search_replace(
     rule: &str,
     parse_only: bool,
     db: &RootDatabase,
+    position: FilePosition,
 ) -> Result<Vec<SourceFileEdit>, SsrError> {
     let rule: SsrRule = rule.parse()?;
+    let mut match_finder = MatchFinder::in_context(db, position);
+    match_finder.add_rule(rule);
     if parse_only {
         return Ok(Vec::new());
     }
-    let mut match_finder = MatchFinder::new(db);
-    match_finder.add_rule(rule);
     Ok(match_finder.edits())
 }

--- a/crates/ra_ide/src/ssr.rs
+++ b/crates/ra_ide/src/ssr.rs
@@ -21,6 +21,9 @@ use ra_ssr::{MatchFinder, SsrError, SsrRule};
 // replacement occurs. For example if our replacement template is `foo::Bar` and we match some
 // code in the `foo` module, we'll insert just `Bar`.
 //
+// Method calls should generally be written in UFCS form. e.g. `foo::Bar::baz($s, $a)` will match
+// `$s.baz($a)`, provided the method call `baz` resolves to the method `foo::Bar::baz`.
+//
 // Placeholders may be given constraints by writing them as `${<name>:<constraint1>:<constraint2>...}`.
 //
 // Supported constraints:

--- a/crates/ra_ide_db/src/search.rs
+++ b/crates/ra_ide_db/src/search.rs
@@ -60,6 +60,10 @@ impl SearchScope {
         SearchScope::new(std::iter::once((file, None)).collect())
     }
 
+    pub fn files(files: &[FileId]) -> SearchScope {
+        SearchScope::new(files.iter().map(|f| (*f, None)).collect())
+    }
+
     pub fn intersection(&self, other: &SearchScope) -> SearchScope {
         let (mut small, mut large) = (&self.entries, &other.entries);
         if small.len() > large.len() {

--- a/crates/ra_ssr/Cargo.toml
+++ b/crates/ra_ssr/Cargo.toml
@@ -18,3 +18,6 @@ ra_ide_db = { path = "../ra_ide_db" }
 hir = { path = "../ra_hir", package = "ra_hir" }
 rustc-hash = "1.1.0"
 test_utils = { path = "../test_utils" }
+
+[dev-dependencies]
+expect = { path = "../expect" }

--- a/crates/ra_ssr/src/lib.rs
+++ b/crates/ra_ssr/src/lib.rs
@@ -151,8 +151,9 @@ impl<'db> MatchFinder<'db> {
     /// Returns matches for all added rules.
     pub fn matches(&self) -> SsrMatches {
         let mut matches = Vec::new();
+        let mut usage_cache = search::UsageCache::default();
         for rule in &self.rules {
-            self.find_matches_for_rule(rule, &mut matches);
+            self.find_matches_for_rule(rule, &mut usage_cache, &mut matches);
         }
         nester::nest_and_remove_collisions(matches, &self.sema)
     }

--- a/crates/ra_ssr/src/lib.rs
+++ b/crates/ra_ssr/src/lib.rs
@@ -4,6 +4,7 @@
 //! based on a template.
 
 mod matching;
+mod nester;
 mod parsing;
 mod replacing;
 mod search;
@@ -90,8 +91,10 @@ impl<'db> MatchFinder<'db> {
     /// Returns matches for all added rules.
     pub fn matches(&self) -> SsrMatches {
         let mut matches = Vec::new();
-        self.find_all_matches(&mut matches);
-        SsrMatches { matches }
+        for rule in &self.rules {
+            self.find_matches_for_rule(rule, &mut matches);
+        }
+        nester::nest_and_remove_collisions(matches, &self.sema)
     }
 
     /// Finds all nodes in `file_id` whose text is exactly equal to `snippet` and attempts to match

--- a/crates/ra_ssr/src/lib.rs
+++ b/crates/ra_ssr/src/lib.rs
@@ -202,8 +202,12 @@ impl<'db> MatchFinder<'db> {
                     // For now we ignore rules that have a different kind than our node, otherwise
                     // we get lots of noise. If at some point we add support for restricting rules
                     // to a particular kind of thing (e.g. only match type references), then we can
-                    // relax this.
-                    if rule.pattern.node.kind() != node.kind() {
+                    // relax this. We special-case expressions, since function calls can match
+                    // method calls.
+                    if rule.pattern.node.kind() != node.kind()
+                        && !(ast::Expr::can_cast(rule.pattern.node.kind())
+                            && ast::Expr::can_cast(node.kind()))
+                    {
                         continue;
                     }
                     out.push(MatchDebugInfo {

--- a/crates/ra_ssr/src/matching.rs
+++ b/crates/ra_ssr/src/matching.rs
@@ -576,8 +576,8 @@ mod tests {
         let rule: SsrRule = "foo($x) ==>> bar($x)".parse().unwrap();
         let input = "fn foo() {} fn bar() {} fn main() { foo(1+2); }";
 
-        let (db, _) = crate::tests::single_file(input);
-        let mut match_finder = MatchFinder::new(&db);
+        let (db, position) = crate::tests::single_file(input);
+        let mut match_finder = MatchFinder::in_context(&db, position);
         match_finder.add_rule(rule);
         let matches = match_finder.matches();
         assert_eq!(matches.matches.len(), 1);

--- a/crates/ra_ssr/src/matching.rs
+++ b/crates/ra_ssr/src/matching.rs
@@ -49,6 +49,8 @@ pub struct Match {
     pub(crate) placeholder_values: FxHashMap<Var, PlaceholderMatch>,
     pub(crate) ignored_comments: Vec<ast::Comment>,
     pub(crate) rule_index: usize,
+    /// The depth of matched_node.
+    pub(crate) depth: usize,
 }
 
 /// Represents a `$var` in an SSR query.
@@ -130,10 +132,12 @@ impl<'db, 'sema> Matcher<'db, 'sema> {
             placeholder_values: FxHashMap::default(),
             ignored_comments: Vec::new(),
             rule_index: rule.index,
+            depth: 0,
         };
         // Second matching pass, where we record placeholder matches, ignored comments and maybe do
         // any other more expensive checks that we didn't want to do on the first pass.
         match_state.attempt_match_node(&mut Phase::Second(&mut the_match), &rule.pattern, code)?;
+        the_match.depth = sema.ancestors_with_macros(the_match.matched_node.clone()).count();
         Ok(the_match)
     }
 

--- a/crates/ra_ssr/src/nester.rs
+++ b/crates/ra_ssr/src/nester.rs
@@ -1,0 +1,98 @@
+//! Converts a flat collection of matches into a nested form suitable for replacement. When there
+//! are multiple matches for a node, or that overlap, priority is given to the earlier rule. Nested
+//! matches are only permitted if the inner match is contained entirely within a placeholder of an
+//! outer match.
+//!
+//! For example, if our search pattern is `foo(foo($a))` and the code had `foo(foo(foo(foo(42))))`,
+//! then we'll get 3 matches, however only the outermost and innermost matches can be accepted. The
+//! middle match would take the second `foo` from the outer match.
+
+use crate::{Match, SsrMatches};
+use ra_syntax::SyntaxNode;
+use rustc_hash::FxHashMap;
+
+pub(crate) fn nest_and_remove_collisions(
+    mut matches: Vec<Match>,
+    sema: &hir::Semantics<ra_ide_db::RootDatabase>,
+) -> SsrMatches {
+    // We sort the matches by depth then by rule index. Sorting by depth means that by the time we
+    // see a match, any parent matches or conflicting matches will have already been seen. Sorting
+    // by rule_index means that if there are two matches for the same node, the rule added first
+    // will take precedence.
+    matches.sort_by(|a, b| a.depth.cmp(&b.depth).then_with(|| a.rule_index.cmp(&b.rule_index)));
+    let mut collector = MatchCollector::default();
+    for m in matches {
+        collector.add_match(m, sema);
+    }
+    collector.into()
+}
+
+#[derive(Default)]
+struct MatchCollector {
+    matches_by_node: FxHashMap<SyntaxNode, Match>,
+}
+
+impl MatchCollector {
+    /// Attempts to add `m` to matches. If it conflicts with an existing match, it is discarded. If
+    /// it is entirely within the a placeholder of an existing match, then it is added as a child
+    /// match of the existing match.
+    fn add_match(&mut self, m: Match, sema: &hir::Semantics<ra_ide_db::RootDatabase>) {
+        let matched_node = m.matched_node.clone();
+        if let Some(existing) = self.matches_by_node.get_mut(&matched_node) {
+            try_add_sub_match(m, existing, sema);
+            return;
+        }
+        for ancestor in sema.ancestors_with_macros(m.matched_node.clone()) {
+            if let Some(existing) = self.matches_by_node.get_mut(&ancestor) {
+                try_add_sub_match(m, existing, sema);
+                return;
+            }
+        }
+        self.matches_by_node.insert(matched_node, m);
+    }
+}
+
+/// Attempts to add `m` as a sub-match of `existing`.
+fn try_add_sub_match(
+    m: Match,
+    existing: &mut Match,
+    sema: &hir::Semantics<ra_ide_db::RootDatabase>,
+) {
+    for p in existing.placeholder_values.values_mut() {
+        // Note, no need to check if p.range.file is equal to m.range.file, since we
+        // already know we're within `existing`.
+        if p.range.range.contains_range(m.range.range) {
+            // Convert the inner matches in `p` into a temporary MatchCollector. When
+            // we're done, we then convert it back into an SsrMatches. If we expected
+            // lots of inner matches, it might be worthwhile keeping a MatchCollector
+            // around for each placeholder match. However we expect most placeholder
+            // will have 0 and a few will have 1. More than that should hopefully be
+            // exceptional.
+            let mut collector = MatchCollector::default();
+            for m in std::mem::replace(&mut p.inner_matches.matches, Vec::new()) {
+                collector.matches_by_node.insert(m.matched_node.clone(), m);
+            }
+            collector.add_match(m, sema);
+            p.inner_matches = collector.into();
+            break;
+        }
+    }
+}
+
+impl From<MatchCollector> for SsrMatches {
+    fn from(mut match_collector: MatchCollector) -> Self {
+        let mut matches = SsrMatches::default();
+        for (_, m) in match_collector.matches_by_node.drain() {
+            matches.matches.push(m);
+        }
+        matches.matches.sort_by(|a, b| {
+            // Order matches by file_id then by start range. This should be sufficient since ranges
+            // shouldn't be overlapping.
+            a.range
+                .file_id
+                .cmp(&b.range.file_id)
+                .then_with(|| a.range.range.start().cmp(&b.range.range.start()))
+        });
+        matches
+    }
+}

--- a/crates/ra_ssr/src/parsing.rs
+++ b/crates/ra_ssr/src/parsing.rs
@@ -7,9 +7,16 @@
 
 use crate::errors::bail;
 use crate::{SsrError, SsrPattern, SsrRule};
-use ra_syntax::{ast, AstNode, SmolStr, SyntaxKind, T};
+use ra_syntax::{ast, AstNode, SmolStr, SyntaxKind, SyntaxNode, SyntaxToken, T};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::str::FromStr;
+
+#[derive(Debug)]
+pub(crate) struct ParsedRule {
+    pub(crate) placeholders_by_stand_in: FxHashMap<SmolStr, Placeholder>,
+    pub(crate) pattern: SyntaxNode,
+    pub(crate) template: Option<SsrTemplate>,
+}
 
 #[derive(Clone, Debug)]
 pub(crate) struct SsrTemplate {
@@ -17,7 +24,7 @@ pub(crate) struct SsrTemplate {
 }
 
 #[derive(Debug)]
-pub(crate) struct RawSearchPattern {
+pub(crate) struct RawPattern {
     tokens: Vec<PatternElement>,
 }
 
@@ -54,6 +61,50 @@ pub(crate) struct Token {
     pub(crate) text: SmolStr,
 }
 
+impl ParsedRule {
+    fn new(
+        pattern: &RawPattern,
+        template: Option<&SsrTemplate>,
+    ) -> Result<Vec<ParsedRule>, SsrError> {
+        let raw_pattern = pattern.as_rust_code();
+        let mut builder = RuleBuilder {
+            placeholders_by_stand_in: pattern.placeholders_by_stand_in(),
+            rules: Vec::new(),
+        };
+        builder.try_add(ast::Expr::parse(&raw_pattern), template);
+        builder.try_add(ast::TypeRef::parse(&raw_pattern), template);
+        builder.try_add(ast::ModuleItem::parse(&raw_pattern), template);
+        builder.try_add(ast::Path::parse(&raw_pattern), template);
+        builder.try_add(ast::Pat::parse(&raw_pattern), template);
+        builder.build()
+    }
+}
+
+struct RuleBuilder {
+    placeholders_by_stand_in: FxHashMap<SmolStr, Placeholder>,
+    rules: Vec<ParsedRule>,
+}
+
+impl RuleBuilder {
+    fn try_add<T: AstNode>(&mut self, pattern: Result<T, ()>, template: Option<&SsrTemplate>) {
+        match pattern {
+            Ok(pattern) => self.rules.push(ParsedRule {
+                placeholders_by_stand_in: self.placeholders_by_stand_in.clone(),
+                pattern: pattern.syntax().clone(),
+                template: template.cloned(),
+            }),
+            _ => {}
+        }
+    }
+
+    fn build(self) -> Result<Vec<ParsedRule>, SsrError> {
+        if self.rules.is_empty() {
+            bail!("Pattern is not a valid Rust expression, type, item, path or pattern");
+        }
+        Ok(self.rules)
+    }
+}
+
 impl FromStr for SsrRule {
     type Err = SsrError;
 
@@ -68,21 +119,24 @@ impl FromStr for SsrRule {
         if it.next().is_some() {
             return Err(SsrError("More than one delimiter found".into()));
         }
-        let rule = SsrRule { pattern: pattern.parse()?, template: template.parse()? };
+        let raw_pattern = pattern.parse()?;
+        let raw_template = template.parse()?;
+        let parsed_rules = ParsedRule::new(&raw_pattern, Some(&raw_template))?;
+        let rule = SsrRule { pattern: raw_pattern, template: raw_template, parsed_rules };
         validate_rule(&rule)?;
         Ok(rule)
     }
 }
 
-impl FromStr for RawSearchPattern {
+impl FromStr for RawPattern {
     type Err = SsrError;
 
-    fn from_str(pattern_str: &str) -> Result<RawSearchPattern, SsrError> {
-        Ok(RawSearchPattern { tokens: parse_pattern(pattern_str)? })
+    fn from_str(pattern_str: &str) -> Result<RawPattern, SsrError> {
+        Ok(RawPattern { tokens: parse_pattern(pattern_str)? })
     }
 }
 
-impl RawSearchPattern {
+impl RawPattern {
     /// Returns this search pattern as Rust source code that we can feed to the Rust parser.
     fn as_rust_code(&self) -> String {
         let mut res = String::new();
@@ -95,7 +149,7 @@ impl RawSearchPattern {
         res
     }
 
-    fn placeholders_by_stand_in(&self) -> FxHashMap<SmolStr, Placeholder> {
+    pub(crate) fn placeholders_by_stand_in(&self) -> FxHashMap<SmolStr, Placeholder> {
         let mut res = FxHashMap::default();
         for t in &self.tokens {
             if let PatternElement::Placeholder(placeholder) = t {
@@ -106,30 +160,22 @@ impl RawSearchPattern {
     }
 }
 
+impl ParsedRule {
+    pub(crate) fn get_placeholder(&self, token: &SyntaxToken) -> Option<&Placeholder> {
+        if token.kind() != SyntaxKind::IDENT {
+            return None;
+        }
+        self.placeholders_by_stand_in.get(token.text())
+    }
+}
+
 impl FromStr for SsrPattern {
     type Err = SsrError;
 
     fn from_str(pattern_str: &str) -> Result<SsrPattern, SsrError> {
-        let raw: RawSearchPattern = pattern_str.parse()?;
-        let raw_str = raw.as_rust_code();
-        let res = SsrPattern {
-            expr: ast::Expr::parse(&raw_str).ok().map(|n| n.syntax().clone()),
-            type_ref: ast::TypeRef::parse(&raw_str).ok().map(|n| n.syntax().clone()),
-            item: ast::ModuleItem::parse(&raw_str).ok().map(|n| n.syntax().clone()),
-            path: ast::Path::parse(&raw_str).ok().map(|n| n.syntax().clone()),
-            pattern: ast::Pat::parse(&raw_str).ok().map(|n| n.syntax().clone()),
-            placeholders_by_stand_in: raw.placeholders_by_stand_in(),
-            raw,
-        };
-        if res.expr.is_none()
-            && res.type_ref.is_none()
-            && res.item.is_none()
-            && res.path.is_none()
-            && res.pattern.is_none()
-        {
-            bail!("Pattern is not a valid Rust expression, type, item, path or pattern");
-        }
-        Ok(res)
+        let raw_pattern = pattern_str.parse()?;
+        let parsed_rules = ParsedRule::new(&raw_pattern, None)?;
+        Ok(SsrPattern { raw: raw_pattern, parsed_rules })
     }
 }
 
@@ -173,7 +219,7 @@ fn parse_pattern(pattern_str: &str) -> Result<Vec<PatternElement>, SsrError> {
 /// pattern didn't define.
 fn validate_rule(rule: &SsrRule) -> Result<(), SsrError> {
     let mut defined_placeholders = FxHashSet::default();
-    for p in &rule.pattern.raw.tokens {
+    for p in &rule.pattern.tokens {
         if let PatternElement::Placeholder(placeholder) = p {
             defined_placeholders.insert(&placeholder.ident);
         }
@@ -316,7 +362,7 @@ mod tests {
         }
         let result: SsrRule = "foo($a, $b) ==>> bar($b, $a)".parse().unwrap();
         assert_eq!(
-            result.pattern.raw.tokens,
+            result.pattern.tokens,
             vec![
                 token(SyntaxKind::IDENT, "foo"),
                 token(T!['('], "("),

--- a/crates/ra_ssr/src/parsing.rs
+++ b/crates/ra_ssr/src/parsing.rs
@@ -7,7 +7,7 @@
 
 use crate::errors::bail;
 use crate::{SsrError, SsrPattern, SsrRule};
-use ra_syntax::{ast, AstNode, SmolStr, SyntaxKind, SyntaxNode, SyntaxToken, T};
+use ra_syntax::{ast, AstNode, SmolStr, SyntaxKind, SyntaxNode, T};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::str::FromStr;
 
@@ -16,7 +16,6 @@ pub(crate) struct ParsedRule {
     pub(crate) placeholders_by_stand_in: FxHashMap<SmolStr, Placeholder>,
     pub(crate) pattern: SyntaxNode,
     pub(crate) template: Option<SyntaxNode>,
-    pub(crate) index: usize,
 }
 
 #[derive(Debug)]
@@ -93,16 +92,11 @@ impl RuleBuilder {
                 placeholders_by_stand_in: self.placeholders_by_stand_in.clone(),
                 pattern: pattern.syntax().clone(),
                 template: Some(template.syntax().clone()),
-                // For now we give the rule an index of 0. It's given a proper index when the rule
-                // is added to the SsrMatcher. Using an Option<usize>, instead would be slightly
-                // more correct, but we delete this field from ParsedRule in a subsequent commit.
-                index: 0,
             }),
             (Ok(pattern), None) => self.rules.push(ParsedRule {
                 placeholders_by_stand_in: self.placeholders_by_stand_in.clone(),
                 pattern: pattern.syntax().clone(),
                 template: None,
-                index: 0,
             }),
             _ => {}
         }
@@ -168,15 +162,6 @@ impl RawPattern {
             }
         }
         res
-    }
-}
-
-impl ParsedRule {
-    pub(crate) fn get_placeholder(&self, token: &SyntaxToken) -> Option<&Placeholder> {
-        if token.kind() != SyntaxKind::IDENT {
-            return None;
-        }
-        self.placeholders_by_stand_in.get(token.text())
     }
 }
 

--- a/crates/ra_ssr/src/replacing.rs
+++ b/crates/ra_ssr/src/replacing.rs
@@ -31,7 +31,11 @@ fn matches_to_edit_at_offset(
 
 fn render_replace(match_info: &Match, file_src: &str) -> String {
     let mut out = String::new();
-    for r in &match_info.template.tokens {
+    let template = match_info
+        .template
+        .as_ref()
+        .expect("You called MatchFinder::edits after calling MatchFinder::add_search_pattern");
+    for r in &template.tokens {
         match r {
             PatternElement::Token(t) => out.push_str(t.text.as_str()),
             PatternElement::Placeholder(p) => {

--- a/crates/ra_ssr/src/replacing.rs
+++ b/crates/ra_ssr/src/replacing.rs
@@ -1,70 +1,104 @@
 //! Code for applying replacement templates for matches that have previously been found.
 
 use crate::matching::Var;
-use crate::parsing::PatternElement;
-use crate::{Match, SsrMatches};
+use crate::{parsing::ParsedRule, Match, SsrMatches};
 use ra_syntax::ast::AstToken;
-use ra_syntax::TextSize;
+use ra_syntax::{SyntaxElement, SyntaxNode, SyntaxToken, TextSize};
 use ra_text_edit::TextEdit;
 
 /// Returns a text edit that will replace each match in `matches` with its corresponding replacement
 /// template. Placeholders in the template will have been substituted with whatever they matched to
 /// in the original code.
-pub(crate) fn matches_to_edit(matches: &SsrMatches, file_src: &str) -> TextEdit {
-    matches_to_edit_at_offset(matches, file_src, 0.into())
+pub(crate) fn matches_to_edit(
+    matches: &SsrMatches,
+    file_src: &str,
+    rules: &[ParsedRule],
+) -> TextEdit {
+    matches_to_edit_at_offset(matches, file_src, 0.into(), rules)
 }
 
 fn matches_to_edit_at_offset(
     matches: &SsrMatches,
     file_src: &str,
     relative_start: TextSize,
+    rules: &[ParsedRule],
 ) -> TextEdit {
     let mut edit_builder = ra_text_edit::TextEditBuilder::default();
     for m in &matches.matches {
         edit_builder.replace(
             m.range.range.checked_sub(relative_start).unwrap(),
-            render_replace(m, file_src),
+            render_replace(m, file_src, rules),
         );
     }
     edit_builder.finish()
 }
 
-fn render_replace(match_info: &Match, file_src: &str) -> String {
+struct ReplacementRenderer<'a> {
+    match_info: &'a Match,
+    file_src: &'a str,
+    rules: &'a [ParsedRule],
+    rule: &'a ParsedRule,
+}
+
+fn render_replace(match_info: &Match, file_src: &str, rules: &[ParsedRule]) -> String {
     let mut out = String::new();
-    let template = match_info
+    let rule = &rules[match_info.rule_index];
+    let template = rule
         .template
         .as_ref()
         .expect("You called MatchFinder::edits after calling MatchFinder::add_search_pattern");
-    for r in &template.tokens {
-        match r {
-            PatternElement::Token(t) => out.push_str(t.text.as_str()),
-            PatternElement::Placeholder(p) => {
-                if let Some(placeholder_value) =
-                    match_info.placeholder_values.get(&Var(p.ident.to_string()))
-                {
-                    let range = &placeholder_value.range.range;
-                    let mut matched_text =
-                        file_src[usize::from(range.start())..usize::from(range.end())].to_owned();
-                    let edit = matches_to_edit_at_offset(
-                        &placeholder_value.inner_matches,
-                        file_src,
-                        range.start(),
-                    );
-                    edit.apply(&mut matched_text);
-                    out.push_str(&matched_text);
-                } else {
-                    // We validated that all placeholder references were valid before we
-                    // started, so this shouldn't happen.
-                    panic!(
-                        "Internal error: replacement referenced unknown placeholder {}",
-                        p.ident
-                    );
-                }
-            }
-        }
-    }
+    let renderer = ReplacementRenderer { match_info, file_src, rules, rule };
+    renderer.render_node_children(&template, &mut out);
     for comment in &match_info.ignored_comments {
         out.push_str(&comment.syntax().to_string());
     }
     out
+}
+
+impl ReplacementRenderer<'_> {
+    fn render_node_children(&self, node: &SyntaxNode, out: &mut String) {
+        for node_or_token in node.children_with_tokens() {
+            self.render_node_or_token(&node_or_token, out);
+        }
+    }
+
+    fn render_node_or_token(&self, node_or_token: &SyntaxElement, out: &mut String) {
+        match node_or_token {
+            SyntaxElement::Token(token) => {
+                self.render_token(&token, out);
+            }
+            SyntaxElement::Node(child_node) => {
+                self.render_node_children(&child_node, out);
+            }
+        }
+    }
+
+    fn render_token(&self, token: &SyntaxToken, out: &mut String) {
+        if let Some(placeholder) = self.rule.get_placeholder(&token) {
+            if let Some(placeholder_value) =
+                self.match_info.placeholder_values.get(&Var(placeholder.ident.to_string()))
+            {
+                let range = &placeholder_value.range.range;
+                let mut matched_text =
+                    self.file_src[usize::from(range.start())..usize::from(range.end())].to_owned();
+                let edit = matches_to_edit_at_offset(
+                    &placeholder_value.inner_matches,
+                    self.file_src,
+                    range.start(),
+                    self.rules,
+                );
+                edit.apply(&mut matched_text);
+                out.push_str(&matched_text);
+            } else {
+                // We validated that all placeholder references were valid before we
+                // started, so this shouldn't happen.
+                panic!(
+                    "Internal error: replacement referenced unknown placeholder {}",
+                    placeholder.ident
+                );
+            }
+        } else {
+            out.push_str(token.text().as_str());
+        }
+    }
 }

--- a/crates/ra_ssr/src/resolving.rs
+++ b/crates/ra_ssr/src/resolving.rs
@@ -1,0 +1,153 @@
+//! This module is responsible for resolving paths within rules.
+
+use crate::errors::error;
+use crate::{parsing, SsrError};
+use parsing::Placeholder;
+use ra_syntax::{ast, SmolStr, SyntaxKind, SyntaxNode, SyntaxToken};
+use rustc_hash::{FxHashMap, FxHashSet};
+use test_utils::mark;
+
+pub(crate) struct ResolvedRule {
+    pub(crate) pattern: ResolvedPattern,
+    pub(crate) template: Option<ResolvedPattern>,
+    pub(crate) index: usize,
+}
+
+pub(crate) struct ResolvedPattern {
+    pub(crate) placeholders_by_stand_in: FxHashMap<SmolStr, parsing::Placeholder>,
+    pub(crate) node: SyntaxNode,
+    // Paths in `node` that we've resolved.
+    pub(crate) resolved_paths: FxHashMap<SyntaxNode, ResolvedPath>,
+}
+
+pub(crate) struct ResolvedPath {
+    pub(crate) resolution: hir::PathResolution,
+}
+
+impl ResolvedRule {
+    pub(crate) fn new(
+        rule: parsing::ParsedRule,
+        scope: &hir::SemanticsScope,
+        hygiene: &hir::Hygiene,
+        index: usize,
+    ) -> Result<ResolvedRule, SsrError> {
+        let resolver =
+            Resolver { scope, hygiene, placeholders_by_stand_in: rule.placeholders_by_stand_in };
+        let resolved_template = if let Some(template) = rule.template {
+            Some(resolver.resolve_pattern_tree(template)?)
+        } else {
+            None
+        };
+        Ok(ResolvedRule {
+            pattern: resolver.resolve_pattern_tree(rule.pattern)?,
+            template: resolved_template,
+            index,
+        })
+    }
+
+    pub(crate) fn get_placeholder(&self, token: &SyntaxToken) -> Option<&Placeholder> {
+        if token.kind() != SyntaxKind::IDENT {
+            return None;
+        }
+        self.pattern.placeholders_by_stand_in.get(token.text())
+    }
+}
+
+struct Resolver<'a, 'db> {
+    scope: &'a hir::SemanticsScope<'db>,
+    hygiene: &'a hir::Hygiene,
+    placeholders_by_stand_in: FxHashMap<SmolStr, parsing::Placeholder>,
+}
+
+impl Resolver<'_, '_> {
+    fn resolve_pattern_tree(&self, pattern: SyntaxNode) -> Result<ResolvedPattern, SsrError> {
+        let mut resolved_paths = FxHashMap::default();
+        self.resolve(pattern.clone(), &mut resolved_paths)?;
+        Ok(ResolvedPattern {
+            node: pattern,
+            resolved_paths,
+            placeholders_by_stand_in: self.placeholders_by_stand_in.clone(),
+        })
+    }
+
+    fn resolve(
+        &self,
+        node: SyntaxNode,
+        resolved_paths: &mut FxHashMap<SyntaxNode, ResolvedPath>,
+    ) -> Result<(), SsrError> {
+        use ra_syntax::ast::AstNode;
+        if let Some(path) = ast::Path::cast(node.clone()) {
+            // Check if this is an appropriate place in the path to resolve. If the path is
+            // something like `a::B::<i32>::c` then we want to resolve `a::B`. If the path contains
+            // a placeholder. e.g. `a::$b::c` then we want to resolve `a`.
+            if !path_contains_type_arguments(path.qualifier())
+                && !self.path_contains_placeholder(&path)
+            {
+                let resolution = self
+                    .resolve_path(&path)
+                    .ok_or_else(|| error!("Failed to resolve path `{}`", node.text()))?;
+                resolved_paths.insert(node, ResolvedPath { resolution });
+                return Ok(());
+            }
+        }
+        for node in node.children() {
+            self.resolve(node, resolved_paths)?;
+        }
+        Ok(())
+    }
+
+    /// Returns whether `path` contains a placeholder, but ignores any placeholders within type
+    /// arguments.
+    fn path_contains_placeholder(&self, path: &ast::Path) -> bool {
+        if let Some(segment) = path.segment() {
+            if let Some(name_ref) = segment.name_ref() {
+                if self.placeholders_by_stand_in.contains_key(name_ref.text()) {
+                    return true;
+                }
+            }
+        }
+        if let Some(qualifier) = path.qualifier() {
+            return self.path_contains_placeholder(&qualifier);
+        }
+        false
+    }
+
+    fn resolve_path(&self, path: &ast::Path) -> Option<hir::PathResolution> {
+        let hir_path = hir::Path::from_src(path.clone(), self.hygiene)?;
+        // First try resolving the whole path. This will work for things like
+        // `std::collections::HashMap`, but will fail for things like
+        // `std::collections::HashMap::new`.
+        if let Some(resolution) = self.scope.resolve_hir_path(&hir_path) {
+            return Some(resolution);
+        }
+        // Resolution failed, try resolving the qualifier (e.g. `std::collections::HashMap` and if
+        // that succeeds, then iterate through the candidates on the resolved type with the provided
+        // name.
+        let resolved_qualifier = self.scope.resolve_hir_path_qualifier(&hir_path.qualifier()?)?;
+        if let hir::PathResolution::Def(hir::ModuleDef::Adt(adt)) = resolved_qualifier {
+            adt.ty(self.scope.db).iterate_path_candidates(
+                self.scope.db,
+                self.scope.module()?.krate(),
+                &FxHashSet::default(),
+                Some(hir_path.segments().last()?.name),
+                |_ty, assoc_item| Some(hir::PathResolution::AssocItem(assoc_item)),
+            )
+        } else {
+            None
+        }
+    }
+}
+
+/// Returns whether `path` or any of its qualifiers contains type arguments.
+fn path_contains_type_arguments(path: Option<ast::Path>) -> bool {
+    if let Some(path) = path {
+        if let Some(segment) = path.segment() {
+            if segment.type_arg_list().is_some() {
+                mark::hit!(type_arguments_within_path);
+                return true;
+            }
+        }
+        return path_contains_type_arguments(path.qualifier());
+    }
+    false
+}

--- a/crates/ra_ssr/src/search.rs
+++ b/crates/ra_ssr/src/search.rs
@@ -1,17 +1,106 @@
 //! Searching for matches.
 
-use crate::{matching, resolving::ResolvedRule, Match, MatchFinder};
+use crate::{
+    matching,
+    resolving::{ResolvedPath, ResolvedPattern, ResolvedRule},
+    Match, MatchFinder,
+};
 use ra_db::FileRange;
+use ra_ide_db::{
+    defs::Definition,
+    search::{Reference, SearchScope},
+};
 use ra_syntax::{ast, AstNode, SyntaxNode};
+
+/// A cache for the results of find_usages. This is for when we have multiple patterns that have the
+/// same path. e.g. if the pattern was `foo::Bar` that can parse as a path, an expression, a type
+/// and as a pattern. In each, the usages of `foo::Bar` are the same and we'd like to avoid finding
+/// them more than once.
+#[derive(Default)]
+pub(crate) struct UsageCache {
+    usages: Vec<(Definition, Vec<Reference>)>,
+}
 
 impl<'db> MatchFinder<'db> {
     /// Adds all matches for `rule` to `matches_out`. Matches may overlap in ways that make
     /// replacement impossible, so further processing is required in order to properly nest matches
     /// and remove overlapping matches. This is done in the `nesting` module.
-    pub(crate) fn find_matches_for_rule(&self, rule: &ResolvedRule, matches_out: &mut Vec<Match>) {
-        // FIXME: Use resolved paths in the pattern to find places to search instead of always
-        // scanning every node.
-        self.slow_scan(rule, matches_out);
+    pub(crate) fn find_matches_for_rule(
+        &self,
+        rule: &ResolvedRule,
+        usage_cache: &mut UsageCache,
+        matches_out: &mut Vec<Match>,
+    ) {
+        if pick_path_for_usages(&rule.pattern).is_none() {
+            self.slow_scan(rule, matches_out);
+            return;
+        }
+        self.find_matches_for_pattern_tree(rule, &rule.pattern, usage_cache, matches_out);
+    }
+
+    fn find_matches_for_pattern_tree(
+        &self,
+        rule: &ResolvedRule,
+        pattern: &ResolvedPattern,
+        usage_cache: &mut UsageCache,
+        matches_out: &mut Vec<Match>,
+    ) {
+        if let Some(first_path) = pick_path_for_usages(pattern) {
+            let definition: Definition = first_path.resolution.clone().into();
+            for reference in self.find_usages(usage_cache, definition) {
+                let file = self.sema.parse(reference.file_range.file_id);
+                if let Some(path) = self.sema.find_node_at_offset_with_descend::<ast::Path>(
+                    file.syntax(),
+                    reference.file_range.range.start(),
+                ) {
+                    if let Some(node_to_match) = self
+                        .sema
+                        .ancestors_with_macros(path.syntax().clone())
+                        .skip(first_path.depth as usize)
+                        .next()
+                    {
+                        if let Ok(m) =
+                            matching::get_match(false, rule, &node_to_match, &None, &self.sema)
+                        {
+                            matches_out.push(m);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn find_usages<'a>(
+        &self,
+        usage_cache: &'a mut UsageCache,
+        definition: Definition,
+    ) -> &'a [Reference] {
+        // Logically if a lookup succeeds we should just return it. Unfortunately returning it would
+        // extend the lifetime of the borrow, then we wouldn't be able to do the insertion on a
+        // cache miss. This is a limitation of NLL and is fixed with Polonius. For now we do two
+        // lookups in the case of a cache hit.
+        if usage_cache.find(&definition).is_none() {
+            let usages = definition.find_usages(&self.sema, Some(self.search_scope()));
+            usage_cache.usages.push((definition, usages));
+            return &usage_cache.usages.last().unwrap().1;
+        }
+        usage_cache.find(&definition).unwrap()
+    }
+
+    /// Returns the scope within which we want to search. We don't want un unrestricted search
+    /// scope, since we don't want to find references in external dependencies.
+    fn search_scope(&self) -> SearchScope {
+        // FIXME: We should ideally have a test that checks that we edit local roots and not library
+        // roots. This probably would require some changes to fixtures, since currently everything
+        // seems to get put into a single source root.
+        use ra_db::SourceDatabaseExt;
+        use ra_ide_db::symbol_index::SymbolsDatabase;
+        let mut files = Vec::new();
+        for &root in self.sema.db.local_roots().iter() {
+            let sr = self.sema.db.source_root(root);
+            files.extend(sr.iter());
+        }
+        SearchScope::files(&files)
     }
 
     fn slow_scan(&self, rule: &ResolvedRule, matches_out: &mut Vec<Match>) {
@@ -58,4 +147,36 @@ impl<'db> MatchFinder<'db> {
             self.slow_scan_node(&child, rule, restrict_range, matches_out);
         }
     }
+}
+
+impl UsageCache {
+    fn find(&mut self, definition: &Definition) -> Option<&[Reference]> {
+        // We expect a very small number of cache entries (generally 1), so a linear scan should be
+        // fast enough and avoids the need to implement Hash for Definition.
+        for (d, refs) in &self.usages {
+            if d == definition {
+                return Some(refs);
+            }
+        }
+        None
+    }
+}
+
+/// Returns a path that's suitable for path resolution. We exclude builtin types, since they aren't
+/// something that we can find references to. We then somewhat arbitrarily pick the path that is the
+/// longest as this is hopefully more likely to be less common, making it faster to find.
+fn pick_path_for_usages(pattern: &ResolvedPattern) -> Option<&ResolvedPath> {
+    // FIXME: Take the scope of the resolved path into account. e.g. if there are any paths that are
+    // private to the current module, then we definitely would want to pick them over say a path
+    // from std. Possibly we should go further than this and intersect the search scopes for all
+    // resolved paths then search only in that scope.
+    pattern
+        .resolved_paths
+        .iter()
+        .filter(|(_, p)| {
+            !matches!(p.resolution, hir::PathResolution::Def(hir::ModuleDef::BuiltinType(_)))
+        })
+        .map(|(node, resolved)| (node.text().len(), resolved))
+        .max_by(|(a, _), (b, _)| a.cmp(b))
+        .map(|(_, resolved)| resolved)
 }

--- a/crates/ra_ssr/src/search.rs
+++ b/crates/ra_ssr/src/search.rs
@@ -1,6 +1,6 @@
 //! Searching for matches.
 
-use crate::{matching, parsing::ParsedRule, Match, MatchFinder};
+use crate::{matching, resolving::ResolvedRule, Match, MatchFinder};
 use ra_db::FileRange;
 use ra_syntax::{ast, AstNode, SyntaxNode};
 
@@ -8,13 +8,13 @@ impl<'db> MatchFinder<'db> {
     /// Adds all matches for `rule` to `matches_out`. Matches may overlap in ways that make
     /// replacement impossible, so further processing is required in order to properly nest matches
     /// and remove overlapping matches. This is done in the `nesting` module.
-    pub(crate) fn find_matches_for_rule(&self, rule: &ParsedRule, matches_out: &mut Vec<Match>) {
+    pub(crate) fn find_matches_for_rule(&self, rule: &ResolvedRule, matches_out: &mut Vec<Match>) {
         // FIXME: Use resolved paths in the pattern to find places to search instead of always
         // scanning every node.
         self.slow_scan(rule, matches_out);
     }
 
-    fn slow_scan(&self, rule: &ParsedRule, matches_out: &mut Vec<Match>) {
+    fn slow_scan(&self, rule: &ResolvedRule, matches_out: &mut Vec<Match>) {
         use ra_db::SourceDatabaseExt;
         use ra_ide_db::symbol_index::SymbolsDatabase;
         for &root in self.sema.db.local_roots().iter() {
@@ -30,7 +30,7 @@ impl<'db> MatchFinder<'db> {
     fn slow_scan_node(
         &self,
         code: &SyntaxNode,
-        rule: &ParsedRule,
+        rule: &ResolvedRule,
         restrict_range: &Option<FileRange>,
         matches_out: &mut Vec<Match>,
     ) {

--- a/crates/ra_ssr/src/search.rs
+++ b/crates/ra_ssr/src/search.rs
@@ -1,0 +1,54 @@
+//! Searching for matches.
+
+use crate::{matching, Match, MatchFinder};
+use ra_db::FileRange;
+use ra_syntax::{ast, AstNode, SyntaxNode};
+
+impl<'db> MatchFinder<'db> {
+    pub(crate) fn slow_scan_node(
+        &self,
+        code: &SyntaxNode,
+        restrict_range: &Option<FileRange>,
+        matches_out: &mut Vec<Match>,
+    ) {
+        for rule in &self.rules {
+            if let Ok(mut m) = matching::get_match(false, rule, &code, restrict_range, &self.sema) {
+                // Continue searching in each of our placeholders.
+                for placeholder_value in m.placeholder_values.values_mut() {
+                    if let Some(placeholder_node) = &placeholder_value.node {
+                        // Don't search our placeholder if it's the entire matched node, otherwise we'd
+                        // find the same match over and over until we got a stack overflow.
+                        if placeholder_node != code {
+                            self.slow_scan_node(
+                                placeholder_node,
+                                restrict_range,
+                                &mut placeholder_value.inner_matches.matches,
+                            );
+                        }
+                    }
+                }
+                matches_out.push(m);
+                return;
+            }
+        }
+        // If we've got a macro call, we already tried matching it pre-expansion, which is the only
+        // way to match the whole macro, now try expanding it and matching the expansion.
+        if let Some(macro_call) = ast::MacroCall::cast(code.clone()) {
+            if let Some(expanded) = self.sema.expand(&macro_call) {
+                if let Some(tt) = macro_call.token_tree() {
+                    // When matching within a macro expansion, we only want to allow matches of
+                    // nodes that originated entirely from within the token tree of the macro call.
+                    // i.e. we don't want to match something that came from the macro itself.
+                    self.slow_scan_node(
+                        &expanded,
+                        &Some(self.sema.original_range(tt.syntax())),
+                        matches_out,
+                    );
+                }
+            }
+        }
+        for child in code.children() {
+            self.slow_scan_node(&child, restrict_range, matches_out);
+        }
+    }
+}

--- a/crates/ra_ssr/src/tests.rs
+++ b/crates/ra_ssr/src/tests.rs
@@ -37,7 +37,7 @@ fn parser_repeated_name() {
 fn parser_invalid_pattern() {
     assert_eq!(
         parse_error_text(" ==>> ()"),
-        "Parse error: Pattern is not a valid Rust expression, type, item, path or pattern"
+        "Parse error: Not a valid Rust expression, type, item, path or pattern"
     );
 }
 
@@ -45,7 +45,7 @@ fn parser_invalid_pattern() {
 fn parser_invalid_template() {
     assert_eq!(
         parse_error_text("() ==>> )"),
-        "Parse error: Replacement is not a valid Rust expression, type, item, path or pattern"
+        "Parse error: Not a valid Rust expression, type, item, path or pattern"
     );
 }
 

--- a/crates/rust-analyzer/src/cli/ssr.rs
+++ b/crates/rust-analyzer/src/cli/ssr.rs
@@ -9,7 +9,7 @@ pub fn apply_ssr_rules(rules: Vec<SsrRule>) -> Result<()> {
     let db = host.raw_database();
     let mut match_finder = MatchFinder::at_first_file(db)?;
     for rule in rules {
-        match_finder.add_rule(rule);
+        match_finder.add_rule(rule)?;
     }
     let edits = match_finder.edits();
     for edit in edits {
@@ -32,7 +32,7 @@ pub fn search_for_patterns(patterns: Vec<SsrPattern>, debug_snippet: Option<Stri
     let db = host.raw_database();
     let mut match_finder = MatchFinder::at_first_file(db)?;
     for pattern in patterns {
-        match_finder.add_search_pattern(pattern);
+        match_finder.add_search_pattern(pattern)?;
     }
     if let Some(debug_snippet) = &debug_snippet {
         for &root in db.local_roots().iter() {

--- a/crates/rust-analyzer/src/cli/ssr.rs
+++ b/crates/rust-analyzer/src/cli/ssr.rs
@@ -1,27 +1,17 @@
 //! Applies structured search replace rules from the command line.
 
 use crate::cli::{load_cargo::load_cargo, Result};
-use ra_ide::SourceFileEdit;
 use ra_ssr::{MatchFinder, SsrPattern, SsrRule};
 
 pub fn apply_ssr_rules(rules: Vec<SsrRule>) -> Result<()> {
     use ra_db::SourceDatabaseExt;
-    use ra_ide_db::symbol_index::SymbolsDatabase;
     let (host, vfs) = load_cargo(&std::env::current_dir()?, true, true)?;
     let db = host.raw_database();
     let mut match_finder = MatchFinder::new(db);
     for rule in rules {
         match_finder.add_rule(rule);
     }
-    let mut edits = Vec::new();
-    for &root in db.local_roots().iter() {
-        let sr = db.source_root(root);
-        for file_id in sr.iter() {
-            if let Some(edit) = match_finder.edits_for_file(file_id) {
-                edits.push(SourceFileEdit { file_id, edit });
-            }
-        }
-    }
+    let edits = match_finder.edits();
     for edit in edits {
         if let Some(path) = vfs.file_path(edit.file_id).as_path() {
             let mut contents = db.file_text(edit.file_id).to_string();
@@ -38,33 +28,26 @@ pub fn apply_ssr_rules(rules: Vec<SsrRule>) -> Result<()> {
 pub fn search_for_patterns(patterns: Vec<SsrPattern>, debug_snippet: Option<String>) -> Result<()> {
     use ra_db::SourceDatabaseExt;
     use ra_ide_db::symbol_index::SymbolsDatabase;
-    let (host, vfs) = load_cargo(&std::env::current_dir()?, true, true)?;
+    let (host, _vfs) = load_cargo(&std::env::current_dir()?, true, true)?;
     let db = host.raw_database();
     let mut match_finder = MatchFinder::new(db);
     for pattern in patterns {
         match_finder.add_search_pattern(pattern);
     }
-    for &root in db.local_roots().iter() {
-        let sr = db.source_root(root);
-        for file_id in sr.iter() {
-            if let Some(debug_snippet) = &debug_snippet {
+    if let Some(debug_snippet) = &debug_snippet {
+        for &root in db.local_roots().iter() {
+            let sr = db.source_root(root);
+            for file_id in sr.iter() {
                 for debug_info in match_finder.debug_where_text_equal(file_id, debug_snippet) {
                     println!("{:#?}", debug_info);
                 }
-            } else {
-                let matches = match_finder.find_matches_in_file(file_id);
-                if !matches.matches.is_empty() {
-                    let matches = matches.flattened().matches;
-                    if let Some(path) = vfs.file_path(file_id).as_path() {
-                        println!("{} matches in '{}'", matches.len(), path.to_string_lossy());
-                    }
-                    // We could possibly at some point do something more useful than just printing
-                    // the matched text. For now though, that's the easiest thing to do.
-                    for m in matches {
-                        println!("{}", m.matched_text());
-                    }
-                }
             }
+        }
+    } else {
+        for m in match_finder.matches().flattened().matches {
+            // We could possibly at some point do something more useful than just printing
+            // the matched text. For now though, that's the easiest thing to do.
+            println!("{}", m.matched_text());
         }
     }
     Ok(())

--- a/crates/rust-analyzer/src/cli/ssr.rs
+++ b/crates/rust-analyzer/src/cli/ssr.rs
@@ -7,7 +7,7 @@ pub fn apply_ssr_rules(rules: Vec<SsrRule>) -> Result<()> {
     use ra_db::SourceDatabaseExt;
     let (host, vfs) = load_cargo(&std::env::current_dir()?, true, true)?;
     let db = host.raw_database();
-    let mut match_finder = MatchFinder::new(db);
+    let mut match_finder = MatchFinder::at_first_file(db)?;
     for rule in rules {
         match_finder.add_rule(rule);
     }
@@ -30,7 +30,7 @@ pub fn search_for_patterns(patterns: Vec<SsrPattern>, debug_snippet: Option<Stri
     use ra_ide_db::symbol_index::SymbolsDatabase;
     let (host, _vfs) = load_cargo(&std::env::current_dir()?, true, true)?;
     let db = host.raw_database();
-    let mut match_finder = MatchFinder::new(db);
+    let mut match_finder = MatchFinder::at_first_file(db)?;
     for pattern in patterns {
         match_finder.add_search_pattern(pattern);
     }

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -1026,8 +1026,9 @@ pub(crate) fn handle_ssr(
     params: lsp_ext::SsrParams,
 ) -> Result<lsp_types::WorkspaceEdit> {
     let _p = profile("handle_ssr");
+    let position = from_proto::file_position(&snap, params.position)?;
     let source_change =
-        snap.analysis.structural_search_replace(&params.query, params.parse_only)??;
+        snap.analysis.structural_search_replace(&params.query, params.parse_only, position)??;
     to_proto::workspace_edit(&snap, source_change)
 }
 

--- a/crates/rust-analyzer/src/lsp_ext.rs
+++ b/crates/rust-analyzer/src/lsp_ext.rs
@@ -216,6 +216,11 @@ impl Request for Ssr {
 pub struct SsrParams {
     pub query: String,
     pub parse_only: bool,
+
+    /// File position where SSR was invoked. Paths in `query` will be resolved relative to this
+    /// position.
+    #[serde(flatten)]
+    pub position: lsp_types::TextDocumentPositionParams,
 }
 
 pub enum StatusNotification {}

--- a/docs/dev/lsp-extensions.md
+++ b/docs/dev/lsp-extensions.md
@@ -274,6 +274,11 @@ interface SsrParams {
     query: string,
     /// If true, only check the syntax of the query and don't compute the actual edit.
     parseOnly: bool,
+    /// The current text document. This and `position` will be used to determine in what scope
+    /// paths in `query` should be resolved.
+    textDocument: lc.TextDocumentIdentifier;
+    /// Position where SSR was invoked.
+    position: lc.Position;
 }
 ```
 
@@ -285,7 +290,7 @@ WorkspaceEdit
 
 ### Example
 
-SSR with query `foo($a:expr, $b:expr) ==>> ($a).foo($b)` will transform, eg `foo(y + 5, z)` into `(y + 5).foo(z)`.
+SSR with query `foo($a, $b) ==>> ($a).foo($b)` will transform, eg `foo(y + 5, z)` into `(y + 5).foo(z)`.
 
 ### Unresolved Question
 

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -190,7 +190,7 @@ export function ssr(ctx: Ctx): Cmd {
         if (!editor || !client) return;
 
         const position = editor.selection.active;
-        let textDocument = { uri: editor.document.uri.toString() };
+        const textDocument = { uri: editor.document.uri.toString() };
 
         const options: vscode.InputBoxOptions = {
             value: "() ==>> ()",

--- a/editors/code/src/lsp_ext.ts
+++ b/editors/code/src/lsp_ext.ts
@@ -93,6 +93,8 @@ export const inlayHints = new lc.RequestType<InlayHintsParams, InlayHint[], void
 export interface SsrParams {
     query: string;
     parseOnly: boolean;
+    textDocument: lc.TextDocumentIdentifier;
+    position: lc.Position;
 }
 export const ssr = new lc.RequestType<SsrParams, lc.WorkspaceEdit, void>('experimental/ssr');
 


### PR DESCRIPTION
The main user-visible changes are:
* SSR now matches paths based on whether they resolve to the same thing instead of whether they're written the same.
  * So `foo()` won't match `foo()` if it's a different function `foo()`, but will match `bar::foo()` if it's the same `foo`.
* Paths in the replacement will now be rendered with appropriate qualification for their context.
  * For example `foo::Bar` will render as just `Bar` inside the module `foo`, but might render as `baz::foo::Bar` from elsewhere.
* This means that all paths in the search pattern and replacement template must be able to be resolved.
* It now also matters where you invoke SSR from, since paths are resolved relative to wherever that is.
* Search now uses find-uses on paths to locate places to try matching. This means that when a path is present in the pattern, search will generally be pretty fast.
* Function calls can now match method calls again, but this time only if they resolve to the same function.