### PR TITLE
Add DocumentData to represent in-memory document with LSP info

### DIFF
--- a/crates/rust-analyzer/src/document.rs
+++ b/crates/rust-analyzer/src/document.rs
@@ -1,0 +1,16 @@
+//! In-memory document information.
+
+/// Information about a document that the Language Client
+// knows about.
+// Its lifetime is driven by the textDocument/didOpen and textDocument/didClose
+// client notifications.
+#[derive(Debug, Clone)]
+pub(crate) struct DocumentData {
+    pub version: Option<i64>,
+}
+
+impl DocumentData {
+    pub fn new(version: i64) -> Self {
+        DocumentData { version: Some(version) }
+    }
+}

--- a/crates/rust-analyzer/src/global_state.rs
+++ b/crates/rust-analyzer/src/global_state.rs
@@ -17,6 +17,7 @@ use rustc_hash::FxHashMap;
 use crate::{
     config::Config,
     diagnostics::{CheckFixes, DiagnosticCollection},
+    document::DocumentData,
     from_proto,
     line_endings::LineEndings,
     main_loop::Task,
@@ -69,7 +70,7 @@ pub(crate) struct GlobalState {
     pub(crate) config: Config,
     pub(crate) analysis_host: AnalysisHost,
     pub(crate) diagnostics: DiagnosticCollection,
-    pub(crate) mem_docs: FxHashMap<VfsPath, Option<i64>>,
+    pub(crate) mem_docs: FxHashMap<VfsPath, DocumentData>,
     pub(crate) vfs: Arc<RwLock<(vfs::Vfs, FxHashMap<FileId, LineEndings>)>>,
     pub(crate) status: Status,
     pub(crate) source_root_config: SourceRootConfig,
@@ -84,7 +85,7 @@ pub(crate) struct GlobalStateSnapshot {
     pub(crate) analysis: Analysis,
     pub(crate) check_fixes: CheckFixes,
     pub(crate) latest_requests: Arc<RwLock<LatestRequests>>,
-    mem_docs: FxHashMap<VfsPath, Option<i64>>,
+    mem_docs: FxHashMap<VfsPath, DocumentData>,
     vfs: Arc<RwLock<(vfs::Vfs, FxHashMap<FileId, LineEndings>)>>,
     pub(crate) workspaces: Arc<Vec<ProjectWorkspace>>,
 }
@@ -259,7 +260,7 @@ impl GlobalStateSnapshot {
 
     pub(crate) fn url_file_version(&self, url: &Url) -> Option<i64> {
         let path = from_proto::vfs_path(&url).ok()?;
-        self.mem_docs.get(&path).copied()?
+        self.mem_docs.get(&path)?.version
     }
 
     pub(crate) fn anchored_path(&self, file_id: FileId, path: &str) -> Url {

--- a/crates/rust-analyzer/src/lib.rs
+++ b/crates/rust-analyzer/src/lib.rs
@@ -33,6 +33,7 @@ mod line_endings;
 mod request_metrics;
 mod lsp_utils;
 mod thread_pool;
+mod document;
 pub mod lsp_ext;
 pub mod config;
 


### PR DESCRIPTION
At the moment this only holds document version information but in the near-future it will hold other things like semantic token delta info.