### PR TITLE
Add fix ranges for diagnostics

### DIFF
--- a/crates/ra_assists/src/handlers/fix_visibility.rs
+++ b/crates/ra_assists/src/handlers/fix_visibility.rs
@@ -121,7 +121,7 @@ fn add_vis_to_referenced_record_field(acc: &mut Assists, ctx: &AssistContext) ->
             Some(cap) => match current_visibility {
                 Some(current_visibility) => builder.replace_snippet(
                     cap,
-                    dbg!(current_visibility.syntax()).text_range(),
+                    current_visibility.syntax().text_range(),
                     format!("$0{}", missing_visibility),
                 ),
                 None => builder.insert_snippet(cap, offset, format!("$0{} ", missing_visibility)),

--- a/crates/ra_hir/src/diagnostics.rs
+++ b/crates/ra_hir/src/diagnostics.rs
@@ -1,7 +1,7 @@
 //! FIXME: write short doc here
 pub use hir_def::diagnostics::UnresolvedModule;
 pub use hir_expand::diagnostics::{
-    AstDiagnostic, Diagnostic, DiagnosticSink, DiagnosticSinkBuilder,
+    Diagnostic, DiagnosticSink, DiagnosticSinkBuilder, DiagnosticWithFix,
 };
 pub use hir_ty::diagnostics::{
     MismatchedArgCount, MissingFields, MissingMatchArms, MissingOkInTailExpr, NoSuchField,

--- a/crates/ra_hir/src/diagnostics.rs
+++ b/crates/ra_hir/src/diagnostics.rs
@@ -1,8 +1,6 @@
 //! FIXME: write short doc here
 pub use hir_def::diagnostics::UnresolvedModule;
-pub use hir_expand::diagnostics::{
-    Diagnostic, DiagnosticSink, DiagnosticSinkBuilder, DiagnosticWithFix,
-};
+pub use hir_expand::diagnostics::{Diagnostic, DiagnosticSink, DiagnosticSinkBuilder};
 pub use hir_ty::diagnostics::{
     MismatchedArgCount, MissingFields, MissingMatchArms, MissingOkInTailExpr, NoSuchField,
 };

--- a/crates/ra_hir/src/semantics.rs
+++ b/crates/ra_hir/src/semantics.rs
@@ -8,7 +8,7 @@ use hir_def::{
     resolver::{self, HasResolver, Resolver},
     AsMacroCall, FunctionId, TraitId, VariantId,
 };
-use hir_expand::{diagnostics::AstDiagnostic, hygiene::Hygiene, name::AsName, ExpansionInfo};
+use hir_expand::{diagnostics::DiagnosticWithFix, hygiene::Hygiene, name::AsName, ExpansionInfo};
 use hir_ty::associated_type_shorthand_candidates;
 use itertools::Itertools;
 use ra_db::{FileId, FileRange};
@@ -109,12 +109,12 @@ impl<'db, DB: HirDatabase> Semantics<'db, DB> {
         self.imp.parse(file_id)
     }
 
-    pub fn diagnostic_fix_source<T: AstDiagnostic + Diagnostic>(
+    pub fn diagnostic_fix_source<T: DiagnosticWithFix + Diagnostic>(
         &self,
         d: &T,
-    ) -> <T as AstDiagnostic>::AST {
+    ) -> Option<<T as DiagnosticWithFix>::AST> {
         let file_id = d.presentation().file_id;
-        let root = self.db.parse_or_expand(file_id).unwrap();
+        let root = self.db.parse_or_expand(file_id)?;
         self.imp.cache(root, file_id);
         d.fix_source(self.db.upcast())
     }

--- a/crates/ra_hir/src/semantics.rs
+++ b/crates/ra_hir/src/semantics.rs
@@ -138,8 +138,8 @@ impl<'db, DB: HirDatabase> Semantics<'db, DB> {
         self.imp.original_range(node)
     }
 
-    pub fn diagnostics_presentation_range(&self, diagnostics: &dyn Diagnostic) -> FileRange {
-        self.imp.diagnostics_presentation_range(diagnostics)
+    pub fn diagnostics_display_range(&self, diagnostics: &dyn Diagnostic) -> FileRange {
+        self.imp.diagnostics_display_range(diagnostics)
     }
 
     pub fn ancestors_with_macros(&self, node: SyntaxNode) -> impl Iterator<Item = SyntaxNode> + '_ {
@@ -369,8 +369,8 @@ impl<'db> SemanticsImpl<'db> {
         original_range(self.db, node.as_ref())
     }
 
-    fn diagnostics_presentation_range(&self, diagnostics: &dyn Diagnostic) -> FileRange {
-        let src = diagnostics.presentation();
+    fn diagnostics_display_range(&self, diagnostics: &dyn Diagnostic) -> FileRange {
+        let src = diagnostics.display_source();
         let root = self.db.parse_or_expand(src.file_id).unwrap();
         let node = src.value.to_node(&root);
         self.cache(root, src.file_id);

--- a/crates/ra_hir/src/semantics.rs
+++ b/crates/ra_hir/src/semantics.rs
@@ -145,6 +145,10 @@ impl<'db, DB: HirDatabase> Semantics<'db, DB> {
         self.imp.original_range(node)
     }
 
+    pub fn diagnostics_fix_range(&self, diagnostics: &dyn Diagnostic) -> FileRange {
+        self.imp.diagnostics_fix_range(diagnostics)
+    }
+
     pub fn diagnostics_range(&self, diagnostics: &dyn Diagnostic) -> FileRange {
         self.imp.diagnostics_range(diagnostics)
     }
@@ -374,6 +378,13 @@ impl<'db> SemanticsImpl<'db> {
     fn original_range(&self, node: &SyntaxNode) -> FileRange {
         let node = self.find_file(node.clone());
         original_range(self.db, node.as_ref())
+    }
+
+    fn diagnostics_fix_range(&self, diagnostics: &dyn Diagnostic) -> FileRange {
+        let src = diagnostics.fix_source();
+        let root = self.db.parse_or_expand(src.file_id).unwrap();
+        let node = src.value.to_node(&root);
+        original_range(self.db, src.with_value(&node))
     }
 
     fn diagnostics_range(&self, diagnostics: &dyn Diagnostic) -> FileRange {

--- a/crates/ra_hir/src/semantics.rs
+++ b/crates/ra_hir/src/semantics.rs
@@ -8,7 +8,7 @@ use hir_def::{
     resolver::{self, HasResolver, Resolver},
     AsMacroCall, FunctionId, TraitId, VariantId,
 };
-use hir_expand::{diagnostics::DiagnosticWithFix, hygiene::Hygiene, name::AsName, ExpansionInfo};
+use hir_expand::{hygiene::Hygiene, name::AsName, ExpansionInfo};
 use hir_ty::associated_type_shorthand_candidates;
 use itertools::Itertools;
 use ra_db::{FileId, FileRange};
@@ -109,14 +109,8 @@ impl<'db, DB: HirDatabase> Semantics<'db, DB> {
         self.imp.parse(file_id)
     }
 
-    pub fn diagnostic_fix_source<T: DiagnosticWithFix + Diagnostic>(
-        &self,
-        d: &T,
-    ) -> Option<<T as DiagnosticWithFix>::AST> {
-        let file_id = d.presentation().file_id;
-        let root = self.db.parse_or_expand(file_id)?;
-        self.imp.cache(root, file_id);
-        d.fix_source(self.db.upcast())
+    pub fn cache(&self, root_node: SyntaxNode, file_id: HirFileId) {
+        self.imp.cache(root_node, file_id)
     }
 
     pub fn expand(&self, macro_call: &ast::MacroCall) -> Option<SyntaxNode> {

--- a/crates/ra_hir/src/semantics.rs
+++ b/crates/ra_hir/src/semantics.rs
@@ -109,10 +109,6 @@ impl<'db, DB: HirDatabase> Semantics<'db, DB> {
         self.imp.parse(file_id)
     }
 
-    pub fn cache(&self, root_node: SyntaxNode, file_id: HirFileId) {
-        self.imp.cache(root_node, file_id)
-    }
-
     pub fn expand(&self, macro_call: &ast::MacroCall) -> Option<SyntaxNode> {
         self.imp.expand(macro_call)
     }
@@ -377,6 +373,7 @@ impl<'db> SemanticsImpl<'db> {
         let src = diagnostics.presentation();
         let root = self.db.parse_or_expand(src.file_id).unwrap();
         let node = src.value.to_node(&root);
+        self.cache(root, src.file_id);
         original_range(self.db, src.with_value(&node))
     }
 

--- a/crates/ra_hir_def/src/diagnostics.rs
+++ b/crates/ra_hir_def/src/diagnostics.rs
@@ -18,7 +18,7 @@ impl Diagnostic for UnresolvedModule {
     fn message(&self) -> String {
         "unresolved module".to_string()
     }
-    fn fix_source(&self) -> InFile<SyntaxNodePtr> {
+    fn source(&self) -> InFile<SyntaxNodePtr> {
         InFile::new(self.file, self.decl.clone().into())
     }
     fn as_any(&self) -> &(dyn Any + Send + 'static) {

--- a/crates/ra_hir_def/src/diagnostics.rs
+++ b/crates/ra_hir_def/src/diagnostics.rs
@@ -18,7 +18,7 @@ impl Diagnostic for UnresolvedModule {
     fn message(&self) -> String {
         "unresolved module".to_string()
     }
-    fn source(&self) -> InFile<SyntaxNodePtr> {
+    fn fix_source(&self) -> InFile<SyntaxNodePtr> {
         InFile::new(self.file, self.decl.clone().into())
     }
     fn as_any(&self) -> &(dyn Any + Send + 'static) {

--- a/crates/ra_hir_def/src/diagnostics.rs
+++ b/crates/ra_hir_def/src/diagnostics.rs
@@ -2,7 +2,7 @@
 
 use std::any::Any;
 
-use hir_expand::diagnostics::{AstDiagnostic, Diagnostic};
+use hir_expand::diagnostics::{Diagnostic, DiagnosticWithFix};
 use ra_syntax::{ast, AstPtr, SyntaxNodePtr};
 
 use hir_expand::{HirFileId, InFile};
@@ -26,10 +26,10 @@ impl Diagnostic for UnresolvedModule {
     }
 }
 
-impl AstDiagnostic for UnresolvedModule {
+impl DiagnosticWithFix for UnresolvedModule {
     type AST = ast::Module;
-    fn fix_source(&self, db: &dyn hir_expand::db::AstDatabase) -> Self::AST {
-        let root = db.parse_or_expand(self.file).unwrap();
-        self.decl.to_node(&root)
+    fn fix_source(&self, db: &dyn hir_expand::db::AstDatabase) -> Option<Self::AST> {
+        let root = db.parse_or_expand(self.file)?;
+        Some(self.decl.to_node(&root))
     }
 }

--- a/crates/ra_hir_def/src/diagnostics.rs
+++ b/crates/ra_hir_def/src/diagnostics.rs
@@ -2,7 +2,7 @@
 
 use std::any::Any;
 
-use hir_expand::diagnostics::{Diagnostic, DiagnosticWithFix};
+use hir_expand::diagnostics::Diagnostic;
 use ra_syntax::{ast, AstPtr, SyntaxNodePtr};
 
 use hir_expand::{HirFileId, InFile};
@@ -23,13 +23,5 @@ impl Diagnostic for UnresolvedModule {
     }
     fn as_any(&self) -> &(dyn Any + Send + 'static) {
         self
-    }
-}
-
-impl DiagnosticWithFix for UnresolvedModule {
-    type AST = ast::Module;
-    fn fix_source(&self, db: &dyn hir_expand::db::AstDatabase) -> Option<Self::AST> {
-        let root = db.parse_or_expand(self.file)?;
-        Some(self.decl.to_node(&root))
     }
 }

--- a/crates/ra_hir_def/src/diagnostics.rs
+++ b/crates/ra_hir_def/src/diagnostics.rs
@@ -2,7 +2,7 @@
 
 use std::any::Any;
 
-use hir_expand::diagnostics::Diagnostic;
+use hir_expand::diagnostics::{AstDiagnostic, Diagnostic};
 use ra_syntax::{ast, AstPtr, SyntaxNodePtr};
 
 use hir_expand::{HirFileId, InFile};
@@ -18,10 +18,18 @@ impl Diagnostic for UnresolvedModule {
     fn message(&self) -> String {
         "unresolved module".to_string()
     }
-    fn source(&self) -> InFile<SyntaxNodePtr> {
+    fn presentation(&self) -> InFile<SyntaxNodePtr> {
         InFile::new(self.file, self.decl.clone().into())
     }
     fn as_any(&self) -> &(dyn Any + Send + 'static) {
         self
+    }
+}
+
+impl AstDiagnostic for UnresolvedModule {
+    type AST = ast::Module;
+    fn fix_source(&self, db: &dyn hir_expand::db::AstDatabase) -> Self::AST {
+        let root = db.parse_or_expand(self.file).unwrap();
+        self.decl.to_node(&root)
     }
 }

--- a/crates/ra_hir_def/src/diagnostics.rs
+++ b/crates/ra_hir_def/src/diagnostics.rs
@@ -18,7 +18,7 @@ impl Diagnostic for UnresolvedModule {
     fn message(&self) -> String {
         "unresolved module".to_string()
     }
-    fn presentation(&self) -> InFile<SyntaxNodePtr> {
+    fn display_source(&self) -> InFile<SyntaxNodePtr> {
         InFile::new(self.file, self.decl.clone().into())
     }
     fn as_any(&self) -> &(dyn Any + Send + 'static) {

--- a/crates/ra_hir_expand/src/diagnostics.rs
+++ b/crates/ra_hir_expand/src/diagnostics.rs
@@ -18,7 +18,7 @@ use std::{any::Any, fmt};
 
 use ra_syntax::SyntaxNodePtr;
 
-use crate::{db::AstDatabase, InFile};
+use crate::InFile;
 
 pub trait Diagnostic: Any + Send + Sync + fmt::Debug + 'static {
     fn message(&self) -> String;
@@ -27,11 +27,6 @@ pub trait Diagnostic: Any + Send + Sync + fmt::Debug + 'static {
     fn is_experimental(&self) -> bool {
         false
     }
-}
-
-pub trait DiagnosticWithFix {
-    type AST;
-    fn fix_source(&self, db: &dyn AstDatabase) -> Option<Self::AST>;
 }
 
 pub struct DiagnosticSink<'a> {

--- a/crates/ra_hir_expand/src/diagnostics.rs
+++ b/crates/ra_hir_expand/src/diagnostics.rs
@@ -22,8 +22,8 @@ use crate::InFile;
 
 pub trait Diagnostic: Any + Send + Sync + fmt::Debug + 'static {
     fn message(&self) -> String;
-    /// A presentation source of the diagnostics, to use in highlighting and similar actions
-    fn presentation(&self) -> InFile<SyntaxNodePtr>;
+    /// Used in highlighting and related purposes
+    fn display_source(&self) -> InFile<SyntaxNodePtr>;
     fn as_any(&self) -> &(dyn Any + Send + 'static);
     fn is_experimental(&self) -> bool {
         false

--- a/crates/ra_hir_expand/src/diagnostics.rs
+++ b/crates/ra_hir_expand/src/diagnostics.rs
@@ -16,7 +16,7 @@
 
 use std::{any::Any, fmt};
 
-use ra_syntax::SyntaxNodePtr;
+use ra_syntax::{SyntaxNode, SyntaxNodePtr};
 
 use crate::{db::AstDatabase, InFile};
 
@@ -38,6 +38,11 @@ pub trait AstDiagnostic {
 }
 
 impl dyn Diagnostic {
+    pub fn syntax_node(&self, db: &impl AstDatabase) -> SyntaxNode {
+        let node = db.parse_or_expand(self.source().file_id).unwrap();
+        self.source().value.to_node(&node)
+    }
+
     pub fn downcast_ref<D: Diagnostic>(&self) -> Option<&D> {
         self.as_any().downcast_ref()
     }

--- a/crates/ra_hir_expand/src/diagnostics.rs
+++ b/crates/ra_hir_expand/src/diagnostics.rs
@@ -22,9 +22,9 @@ use crate::{db::AstDatabase, InFile};
 
 pub trait Diagnostic: Any + Send + Sync + fmt::Debug + 'static {
     fn message(&self) -> String;
-    fn source(&self) -> InFile<SyntaxNodePtr>;
-    fn highlighting_source(&self) -> InFile<SyntaxNodePtr> {
-        self.source()
+    fn fix_source(&self) -> InFile<SyntaxNodePtr>;
+    fn source(&self) -> InFile<SyntaxNodePtr> {
+        self.fix_source()
     }
     fn as_any(&self) -> &(dyn Any + Send + 'static);
     fn is_experimental(&self) -> bool {

--- a/crates/ra_hir_expand/src/diagnostics.rs
+++ b/crates/ra_hir_expand/src/diagnostics.rs
@@ -22,6 +22,7 @@ use crate::InFile;
 
 pub trait Diagnostic: Any + Send + Sync + fmt::Debug + 'static {
     fn message(&self) -> String;
+    /// A presentation source of the diagnostics, to use in highlighting and similar actions
     fn presentation(&self) -> InFile<SyntaxNodePtr>;
     fn as_any(&self) -> &(dyn Any + Send + 'static);
     fn is_experimental(&self) -> bool {

--- a/crates/ra_hir_expand/src/diagnostics.rs
+++ b/crates/ra_hir_expand/src/diagnostics.rs
@@ -72,9 +72,12 @@ impl<'a> DiagnosticSinkBuilder<'a> {
         self
     }
 
-    pub fn on<D: Diagnostic, F: FnMut(&D) -> Option<()> + 'a>(mut self, mut cb: F) -> Self {
+    pub fn on<D: Diagnostic, F: FnMut(&D) + 'a>(mut self, mut cb: F) -> Self {
         let cb = move |diag: &dyn Diagnostic| match diag.as_any().downcast_ref::<D>() {
-            Some(d) => cb(d).ok_or(()),
+            Some(d) => {
+                cb(d);
+                Ok(())
+            }
             None => Err(()),
         };
         self.callbacks.push(Box::new(cb));

--- a/crates/ra_hir_expand/src/diagnostics.rs
+++ b/crates/ra_hir_expand/src/diagnostics.rs
@@ -16,13 +16,16 @@
 
 use std::{any::Any, fmt};
 
-use ra_syntax::{SyntaxNode, SyntaxNodePtr};
+use ra_syntax::SyntaxNodePtr;
 
 use crate::{db::AstDatabase, InFile};
 
 pub trait Diagnostic: Any + Send + Sync + fmt::Debug + 'static {
     fn message(&self) -> String;
     fn source(&self) -> InFile<SyntaxNodePtr>;
+    fn highlighting_source(&self) -> InFile<SyntaxNodePtr> {
+        self.source()
+    }
     fn as_any(&self) -> &(dyn Any + Send + 'static);
     fn is_experimental(&self) -> bool {
         false
@@ -35,12 +38,6 @@ pub trait AstDiagnostic {
 }
 
 impl dyn Diagnostic {
-    pub fn syntax_node(&self, db: &impl AstDatabase) -> SyntaxNode {
-        let source = self.source();
-        let node = db.parse_or_expand(source.file_id).unwrap();
-        source.value.to_node(&node)
-    }
-
     pub fn downcast_ref<D: Diagnostic>(&self) -> Option<&D> {
         self.as_any().downcast_ref()
     }

--- a/crates/ra_hir_expand/src/diagnostics.rs
+++ b/crates/ra_hir_expand/src/diagnostics.rs
@@ -36,8 +36,9 @@ pub trait AstDiagnostic {
 
 impl dyn Diagnostic {
     pub fn syntax_node(&self, db: &impl AstDatabase) -> SyntaxNode {
-        let node = db.parse_or_expand(self.source().file_id).unwrap();
-        self.source().value.to_node(&node)
+        let source = self.source();
+        let node = db.parse_or_expand(source.file_id).unwrap();
+        source.value.to_node(&node)
     }
 
     pub fn downcast_ref<D: Diagnostic>(&self) -> Option<&D> {

--- a/crates/ra_hir_ty/src/diagnostics.rs
+++ b/crates/ra_hir_ty/src/diagnostics.rs
@@ -37,7 +37,7 @@ impl Diagnostic for NoSuchField {
         "no such field".to_string()
     }
 
-    fn fix_source(&self) -> InFile<SyntaxNodePtr> {
+    fn source(&self) -> InFile<SyntaxNodePtr> {
         InFile::new(self.file, self.field.clone().into())
     }
 
@@ -137,7 +137,7 @@ impl Diagnostic for MissingMatchArms {
     fn message(&self) -> String {
         String::from("Missing match arm")
     }
-    fn fix_source(&self) -> InFile<SyntaxNodePtr> {
+    fn source(&self) -> InFile<SyntaxNodePtr> {
         InFile { file_id: self.file, value: self.match_expr.clone().into() }
     }
     fn as_any(&self) -> &(dyn Any + Send + 'static) {
@@ -155,7 +155,7 @@ impl Diagnostic for MissingOkInTailExpr {
     fn message(&self) -> String {
         "wrap return expression in Ok".to_string()
     }
-    fn fix_source(&self) -> InFile<SyntaxNodePtr> {
+    fn source(&self) -> InFile<SyntaxNodePtr> {
         InFile { file_id: self.file, value: self.expr.clone().into() }
     }
     fn as_any(&self) -> &(dyn Any + Send + 'static) {
@@ -182,7 +182,7 @@ impl Diagnostic for BreakOutsideOfLoop {
     fn message(&self) -> String {
         "break outside of loop".to_string()
     }
-    fn fix_source(&self) -> InFile<SyntaxNodePtr> {
+    fn source(&self) -> InFile<SyntaxNodePtr> {
         InFile { file_id: self.file, value: self.expr.clone().into() }
     }
     fn as_any(&self) -> &(dyn Any + Send + 'static) {
@@ -209,7 +209,7 @@ impl Diagnostic for MissingUnsafe {
     fn message(&self) -> String {
         format!("This operation is unsafe and requires an unsafe function or block")
     }
-    fn fix_source(&self) -> InFile<SyntaxNodePtr> {
+    fn source(&self) -> InFile<SyntaxNodePtr> {
         InFile { file_id: self.file, value: self.expr.clone().into() }
     }
     fn as_any(&self) -> &(dyn Any + Send + 'static) {
@@ -239,7 +239,7 @@ impl Diagnostic for MismatchedArgCount {
         let s = if self.expected == 1 { "" } else { "s" };
         format!("Expected {} argument{}, found {}", self.expected, s, self.found)
     }
-    fn fix_source(&self) -> InFile<SyntaxNodePtr> {
+    fn source(&self) -> InFile<SyntaxNodePtr> {
         InFile { file_id: self.file, value: self.call_expr.clone().into() }
     }
     fn as_any(&self) -> &(dyn Any + Send + 'static) {

--- a/crates/ra_hir_ty/src/diagnostics.rs
+++ b/crates/ra_hir_ty/src/diagnostics.rs
@@ -6,8 +6,8 @@ mod unsafe_check;
 use std::any::Any;
 
 use hir_def::DefWithBodyId;
-use hir_expand::diagnostics::{Diagnostic, DiagnosticSink, DiagnosticWithFix};
-use hir_expand::{db::AstDatabase, name::Name, HirFileId, InFile};
+use hir_expand::diagnostics::{Diagnostic, DiagnosticSink};
+use hir_expand::{name::Name, HirFileId, InFile};
 use ra_prof::profile;
 use ra_syntax::{ast, AstPtr, SyntaxNodePtr};
 use stdx::format_to;
@@ -46,15 +46,6 @@ impl Diagnostic for NoSuchField {
     }
 }
 
-impl DiagnosticWithFix for NoSuchField {
-    type AST = ast::RecordExprField;
-
-    fn fix_source(&self, db: &dyn AstDatabase) -> Option<Self::AST> {
-        let root = db.parse_or_expand(self.file)?;
-        Some(self.field.to_node(&root))
-    }
-}
-
 #[derive(Debug)]
 pub struct MissingFields {
     pub file: HirFileId,
@@ -85,15 +76,6 @@ impl Diagnostic for MissingFields {
 
     fn as_any(&self) -> &(dyn Any + Send + 'static) {
         self
-    }
-}
-
-impl DiagnosticWithFix for MissingFields {
-    type AST = ast::RecordExpr;
-
-    fn fix_source(&self, db: &dyn AstDatabase) -> Option<Self::AST> {
-        let root = db.parse_or_expand(self.file)?;
-        Some(self.field_list_parent.to_node(&root))
     }
 }
 
@@ -160,15 +142,6 @@ impl Diagnostic for MissingOkInTailExpr {
     }
     fn as_any(&self) -> &(dyn Any + Send + 'static) {
         self
-    }
-}
-
-impl DiagnosticWithFix for MissingOkInTailExpr {
-    type AST = ast::Expr;
-
-    fn fix_source(&self, db: &dyn AstDatabase) -> Option<Self::AST> {
-        let root = db.parse_or_expand(self.file)?;
-        Some(self.expr.to_node(&root))
     }
 }
 

--- a/crates/ra_hir_ty/src/diagnostics.rs
+++ b/crates/ra_hir_ty/src/diagnostics.rs
@@ -6,7 +6,7 @@ mod unsafe_check;
 use std::any::Any;
 
 use hir_def::DefWithBodyId;
-use hir_expand::diagnostics::{AstDiagnostic, Diagnostic, DiagnosticSink};
+use hir_expand::diagnostics::{Diagnostic, DiagnosticSink, DiagnosticWithFix};
 use hir_expand::{db::AstDatabase, name::Name, HirFileId, InFile};
 use ra_prof::profile;
 use ra_syntax::{ast, AstPtr, SyntaxNodePtr};
@@ -46,12 +46,12 @@ impl Diagnostic for NoSuchField {
     }
 }
 
-impl AstDiagnostic for NoSuchField {
+impl DiagnosticWithFix for NoSuchField {
     type AST = ast::RecordExprField;
 
-    fn fix_source(&self, db: &dyn AstDatabase) -> Self::AST {
-        let root = db.parse_or_expand(self.file).unwrap();
-        self.field.to_node(&root)
+    fn fix_source(&self, db: &dyn AstDatabase) -> Option<Self::AST> {
+        let root = db.parse_or_expand(self.file)?;
+        Some(self.field.to_node(&root))
     }
 }
 
@@ -88,12 +88,12 @@ impl Diagnostic for MissingFields {
     }
 }
 
-impl AstDiagnostic for MissingFields {
+impl DiagnosticWithFix for MissingFields {
     type AST = ast::RecordExpr;
 
-    fn fix_source(&self, db: &dyn AstDatabase) -> Self::AST {
-        let root = db.parse_or_expand(self.file).unwrap();
-        self.field_list_parent.to_node(&root)
+    fn fix_source(&self, db: &dyn AstDatabase) -> Option<Self::AST> {
+        let root = db.parse_or_expand(self.file)?;
+        Some(self.field_list_parent.to_node(&root))
     }
 }
 
@@ -163,12 +163,12 @@ impl Diagnostic for MissingOkInTailExpr {
     }
 }
 
-impl AstDiagnostic for MissingOkInTailExpr {
+impl DiagnosticWithFix for MissingOkInTailExpr {
     type AST = ast::Expr;
 
-    fn fix_source(&self, db: &dyn AstDatabase) -> Self::AST {
-        let root = db.parse_or_expand(self.file).unwrap();
-        self.expr.to_node(&root)
+    fn fix_source(&self, db: &dyn AstDatabase) -> Option<Self::AST> {
+        let root = db.parse_or_expand(self.file)?;
+        Some(self.expr.to_node(&root))
     }
 }
 

--- a/crates/ra_hir_ty/src/diagnostics.rs
+++ b/crates/ra_hir_ty/src/diagnostics.rs
@@ -262,10 +262,7 @@ impl AstDiagnostic for MismatchedArgCount {
 #[cfg(test)]
 mod tests {
     use hir_def::{db::DefDatabase, AssocItemId, ModuleDefId};
-    use hir_expand::{
-        db::AstDatabase,
-        diagnostics::{Diagnostic, DiagnosticSinkBuilder},
-    };
+    use hir_expand::diagnostics::{Diagnostic, DiagnosticSinkBuilder};
     use ra_db::{fixture::WithFixture, FileId, SourceDatabase, SourceDatabaseExt};
     use ra_syntax::{TextRange, TextSize};
     use rustc_hash::FxHashMap;
@@ -310,12 +307,11 @@ mod tests {
 
         let mut actual: FxHashMap<FileId, Vec<(TextRange, String)>> = FxHashMap::default();
         db.diagnostics(|d| {
-            // FXIME: macros...
-            let source = d.source();
-            let root = db.parse_or_expand(source.file_id).unwrap();
-            let range = source.value.to_node(&root).text_range();
+            // FIXME: macros...
+            let file_id = d.source().file_id.original_file(&db);
+            let range = d.syntax_node(&db).text_range();
             let message = d.message().to_owned();
-            actual.entry(source.file_id.original_file(&db)).or_default().push((range, message));
+            actual.entry(file_id).or_default().push((range, message));
         });
 
         for (file_id, diags) in actual.iter_mut() {

--- a/crates/ra_hir_ty/src/diagnostics/expr.rs
+++ b/crates/ra_hir_ty/src/diagnostics/expr.rs
@@ -111,6 +111,7 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
                         file: source_ptr.file_id,
                         field_list: AstPtr::new(&field_list),
                         missed_fields,
+                        list_parent_path: record_lit.path().map(|path| AstPtr::new(&path)),
                     })
                 }
             }

--- a/crates/ra_hir_ty/src/diagnostics/expr.rs
+++ b/crates/ra_hir_ty/src/diagnostics/expr.rs
@@ -110,8 +110,8 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
                     self.sink.push(MissingFields {
                         file: source_ptr.file_id,
                         field_list: AstPtr::new(&field_list),
+                        field_list_parent_path: record_lit.path().map(|path| AstPtr::new(&path)),
                         missed_fields,
-                        list_parent_path: record_lit.path().map(|path| AstPtr::new(&path)),
                     })
                 }
             }
@@ -141,6 +141,9 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
                         self.sink.push(MissingPatFields {
                             file: source_ptr.file_id,
                             field_list: AstPtr::new(&field_list),
+                            field_list_parent_path: record_pat
+                                .path()
+                                .map(|path| AstPtr::new(&path)),
                             missed_fields,
                         })
                     }

--- a/crates/ra_hir_ty/src/diagnostics/expr.rs
+++ b/crates/ra_hir_ty/src/diagnostics/expr.rs
@@ -100,8 +100,8 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
 
         if let Ok(source_ptr) = source_map.expr_syntax(id) {
             let root = source_ptr.file_syntax(db.upcast());
-            if let ast::Expr::RecordExpr(record_lit) = &source_ptr.value.to_node(&root) {
-                if let Some(field_list) = record_lit.record_expr_field_list() {
+            if let ast::Expr::RecordExpr(record_expr) = &source_ptr.value.to_node(&root) {
+                if let Some(_) = record_expr.record_expr_field_list() {
                     let variant_data = variant_data(db.upcast(), variant_def);
                     let missed_fields = missed_fields
                         .into_iter()
@@ -109,8 +109,8 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
                         .collect();
                     self.sink.push(MissingFields {
                         file: source_ptr.file_id,
-                        field_list: AstPtr::new(&field_list),
-                        field_list_parent_path: record_lit.path().map(|path| AstPtr::new(&path)),
+                        field_list_parent: AstPtr::new(&record_expr),
+                        field_list_parent_path: record_expr.path().map(|path| AstPtr::new(&path)),
                         missed_fields,
                     })
                 }
@@ -132,7 +132,7 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
             if let Some(expr) = source_ptr.value.as_ref().left() {
                 let root = source_ptr.file_syntax(db.upcast());
                 if let ast::Pat::RecordPat(record_pat) = expr.to_node(&root) {
-                    if let Some(field_list) = record_pat.record_pat_field_list() {
+                    if let Some(_) = record_pat.record_pat_field_list() {
                         let variant_data = variant_data(db.upcast(), variant_def);
                         let missed_fields = missed_fields
                             .into_iter()
@@ -140,7 +140,7 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
                             .collect();
                         self.sink.push(MissingPatFields {
                             file: source_ptr.file_id,
-                            field_list: AstPtr::new(&field_list),
+                            field_list_parent: AstPtr::new(&record_pat),
                             field_list_parent_path: record_pat
                                 .path()
                                 .map(|path| AstPtr::new(&path)),

--- a/crates/ra_hir_ty/src/diagnostics/match_check.rs
+++ b/crates/ra_hir_ty/src/diagnostics/match_check.rs
@@ -1161,15 +1161,15 @@ fn main() {
         //^ Missing match arm
     match a {
         Either::A { } => (),
-                //^^^ Missing structure fields:
-                //  | - foo
+      //^^^^^^^^^ Missing structure fields:
+      //        | - foo
         Either::B => (),
     }
     match a {
         //^ Missing match arm
         Either::A { } => (),
-    }           //^^^ Missing structure fields:
-                //  | - foo
+    } //^^^^^^^^^ Missing structure fields:
+      //        | - foo
 
     match a {
         Either::A { foo: true } => (),

--- a/crates/ra_ide/src/diagnostics.rs
+++ b/crates/ra_ide/src/diagnostics.rs
@@ -183,7 +183,7 @@ mod tests {
     /// Takes a multi-file input fixture with annotated cursor positions,
     /// and checks that:
     ///  * a diagnostic is produced
-    ///  * this diagnostic fix touches the input cursor position
+    ///  * this diagnostic fix trigger range touches the input cursor position
     ///  * that the contents of the file containing the cursor match `after` after the diagnostic fix is applied
     fn check_fix(ra_fixture_before: &str, ra_fixture_after: &str) {
         let after = trim_indent(ra_fixture_after);

--- a/crates/ra_ide/src/diagnostics.rs
+++ b/crates/ra_ide/src/diagnostics.rs
@@ -100,8 +100,10 @@ pub(crate) fn diagnostics(
             };
 
             res.borrow_mut().push(Diagnostic {
-                // TODO kb use a smaller range here
-                range,
+                range: d
+                    .list_parent_ast(db)
+                    .map(|path| path.syntax().text_range())
+                    .unwrap_or(range),
                 message: d.message(),
                 severity: Severity::Error,
                 fix,

--- a/crates/ra_ide/src/diagnostics.rs
+++ b/crates/ra_ide/src/diagnostics.rs
@@ -7,7 +7,7 @@
 use std::cell::RefCell;
 
 use hir::{
-    diagnostics::{AstDiagnostic, Diagnostic as _, DiagnosticSinkBuilder},
+    diagnostics::{Diagnostic as _, DiagnosticSinkBuilder},
     HasSource, HirDisplay, Semantics, VariantDef,
 };
 use itertools::Itertools;
@@ -63,10 +63,10 @@ pub(crate) fn diagnostics(
                 .into(),
             );
             res.borrow_mut().push(Diagnostic {
-                range: sema.diagnostics_range(d).range,
+                range: sema.diagnostics_presentation_range(d).range,
                 message: d.message(),
                 severity: Severity::Error,
-                fix: Some((fix, sema.diagnostics_fix_range(d).range)),
+                fix: Some((fix, sema.diagnostic_fix_source(d).syntax().text_range())),
             })
         })
         .on::<hir::diagnostics::MissingFields, _>(|d| {
@@ -78,56 +78,58 @@ pub(crate) fn diagnostics(
             let fix = if d.missed_fields.iter().any(|it| it.as_tuple_index().is_some()) {
                 None
             } else {
-                let mut field_list = d.ast(db);
-                for f in d.missed_fields.iter() {
-                    let field = make::record_expr_field(
-                        make::name_ref(&f.to_string()),
-                        Some(make::expr_unit()),
-                    );
-                    field_list = field_list.append_field(&field);
-                }
+                let record_expr = sema.diagnostic_fix_source(d);
+                if let Some(old_field_list) = record_expr.record_expr_field_list() {
+                    let mut new_field_list = old_field_list.clone();
+                    for f in d.missed_fields.iter() {
+                        let field = make::record_expr_field(
+                            make::name_ref(&f.to_string()),
+                            Some(make::expr_unit()),
+                        );
+                        new_field_list = new_field_list.append_field(&field);
+                    }
 
-                let edit = {
-                    let mut builder = TextEditBuilder::default();
-                    algo::diff(&d.ast(db).syntax(), &field_list.syntax())
-                        .into_text_edit(&mut builder);
-                    builder.finish()
-                };
-                Some((
-                    Fix::new("Fill struct fields", SourceFileEdit { file_id, edit }.into()),
-                    sema.diagnostics_fix_range(d).range,
-                ))
+                    let edit = {
+                        let mut builder = TextEditBuilder::default();
+                        algo::diff(&old_field_list.syntax(), &new_field_list.syntax())
+                            .into_text_edit(&mut builder);
+                        builder.finish()
+                    };
+                    Some((
+                        Fix::new("Fill struct fields", SourceFileEdit { file_id, edit }.into()),
+                        sema.original_range(&old_field_list.syntax()).range,
+                    ))
+                } else {
+                    None
+                }
             };
 
             res.borrow_mut().push(Diagnostic {
-                range: sema.diagnostics_range(d).range,
+                range: sema.diagnostics_presentation_range(d).range,
                 message: d.message(),
                 severity: Severity::Error,
                 fix,
             })
         })
         .on::<hir::diagnostics::MissingOkInTailExpr, _>(|d| {
-            let node = d.ast(db);
-            let replacement = format!("Ok({})", node.syntax());
-            let edit = TextEdit::replace(node.syntax().text_range(), replacement);
+            let tail_expr = sema.diagnostic_fix_source(d);
+            let tail_expr_range = tail_expr.syntax().text_range();
+            let edit = TextEdit::replace(tail_expr_range, format!("Ok({})", tail_expr.syntax()));
             let source_change = SourceFileEdit { file_id, edit }.into();
             res.borrow_mut().push(Diagnostic {
-                range: sema.diagnostics_range(d).range,
+                range: sema.diagnostics_presentation_range(d).range,
                 message: d.message(),
                 severity: Severity::Error,
-                fix: Some((
-                    Fix::new("Wrap with ok", source_change),
-                    sema.diagnostics_fix_range(d).range,
-                )),
+                fix: Some((Fix::new("Wrap with ok", source_change), tail_expr_range)),
             })
         })
         .on::<hir::diagnostics::NoSuchField, _>(|d| {
             res.borrow_mut().push(Diagnostic {
-                range: sema.diagnostics_range(d).range,
+                range: sema.diagnostics_presentation_range(d).range,
                 message: d.message(),
                 severity: Severity::Error,
                 fix: missing_struct_field_fix(&sema, file_id, d)
-                    .map(|fix| (fix, sema.diagnostics_fix_range(d).range)),
+                    .map(|fix| (fix, sema.diagnostic_fix_source(d).syntax().text_range())),
             })
         })
         // Only collect experimental diagnostics when they're enabled.
@@ -136,7 +138,7 @@ pub(crate) fn diagnostics(
         .build(|d| {
             res.borrow_mut().push(Diagnostic {
                 message: d.message(),
-                range: sema.diagnostics_range(d).range,
+                range: sema.diagnostics_presentation_range(d).range,
                 severity: Severity::Error,
                 fix: None,
             })
@@ -154,9 +156,9 @@ fn missing_struct_field_fix(
     usage_file_id: FileId,
     d: &hir::diagnostics::NoSuchField,
 ) -> Option<Fix> {
-    let record_expr = sema.ast(d);
+    let record_expr_field = sema.diagnostic_fix_source(d);
 
-    let record_lit = ast::RecordExpr::cast(record_expr.syntax().parent()?.parent()?)?;
+    let record_lit = ast::RecordExpr::cast(record_expr_field.syntax().parent()?.parent()?)?;
     let def_id = sema.resolve_variant(record_lit)?;
     let module;
     let def_file_id;
@@ -184,12 +186,12 @@ fn missing_struct_field_fix(
     };
     let def_file_id = def_file_id.original_file(sema.db);
 
-    let new_field_type = sema.type_of_expr(&record_expr.expr()?)?;
+    let new_field_type = sema.type_of_expr(&record_expr_field.expr()?)?;
     if new_field_type.is_unknown() {
         return None;
     }
     let new_field = make::record_field(
-        record_expr.field_name()?,
+        record_expr_field.field_name()?,
         make::ty(&new_field_type.display_source_code(sema.db, module.into()).ok()?),
     );
 

--- a/crates/ra_ide/src/diagnostics.rs
+++ b/crates/ra_ide/src/diagnostics.rs
@@ -69,7 +69,6 @@ pub(crate) fn diagnostics(
             })
         })
         .on::<hir::diagnostics::MissingFields, _>(|d| {
-            let range = sema.diagnostics_range(d).range;
             // Note that although we could add a diagnostics to
             // fill the missing tuple field, e.g :
             // `struct A(usize);`
@@ -95,15 +94,12 @@ pub(crate) fn diagnostics(
                 };
                 Some((
                     Fix::new("Fill struct fields", SourceFileEdit { file_id, edit }.into()),
-                    range,
+                    sema.diagnostics_range(d).range,
                 ))
             };
 
             res.borrow_mut().push(Diagnostic {
-                range: d
-                    .list_parent_ast(db)
-                    .map(|path| path.syntax().text_range())
-                    .unwrap_or(range),
+                range: d.highlighting_source().file_syntax(db).text_range(),
                 message: d.message(),
                 severity: Severity::Error,
                 fix,

--- a/crates/ra_ide/src/diagnostics/diagnostics_with_fix.rs
+++ b/crates/ra_ide/src/diagnostics/diagnostics_with_fix.rs
@@ -1,46 +1,169 @@
+use crate::Fix;
+use ast::{edit::IndentLevel, make};
 use hir::{
     db::AstDatabase,
     diagnostics::{MissingFields, MissingOkInTailExpr, NoSuchField, UnresolvedModule},
+    HasSource, HirDisplay, Semantics, VariantDef,
 };
-use ra_syntax::ast;
+use ra_db::FileId;
+use ra_ide_db::{
+    source_change::{FileSystemEdit, SourceFileEdit},
+    RootDatabase,
+};
+use ra_syntax::{algo, ast, AstNode, TextRange};
+use ra_text_edit::{TextEdit, TextEditBuilder};
 
 // TODO kb
 pub trait DiagnosticWithFix {
-    type AST;
-    fn fix_source(&self, db: &dyn AstDatabase) -> Option<Self::AST>;
+    fn fix(&self, sema: &Semantics<RootDatabase>) -> Option<(Fix, TextRange)>;
 }
 
 impl DiagnosticWithFix for UnresolvedModule {
-    type AST = ast::Module;
-    fn fix_source(&self, db: &dyn AstDatabase) -> Option<Self::AST> {
-        let root = db.parse_or_expand(self.file)?;
-        Some(self.decl.to_node(&root))
+    fn fix(&self, sema: &Semantics<RootDatabase>) -> Option<(Fix, TextRange)> {
+        let fix = Fix::new(
+            "Create module",
+            FileSystemEdit::CreateFile {
+                anchor: self.file.original_file(sema.db),
+                dst: self.candidate.clone(),
+            }
+            .into(),
+        );
+
+        let root = sema.db.parse_or_expand(self.file)?;
+        let unresolved_module = self.decl.to_node(&root);
+        Some((fix, unresolved_module.syntax().text_range()))
     }
 }
 
 impl DiagnosticWithFix for NoSuchField {
-    type AST = ast::RecordExprField;
-
-    fn fix_source(&self, db: &dyn AstDatabase) -> Option<Self::AST> {
-        let root = db.parse_or_expand(self.file)?;
-        Some(self.field.to_node(&root))
+    fn fix(&self, sema: &Semantics<RootDatabase>) -> Option<(Fix, TextRange)> {
+        let root = sema.db.parse_or_expand(self.file)?;
+        let record_expr_field = self.field.to_node(&root);
+        let fix =
+            missing_struct_field_fix(&sema, self.file.original_file(sema.db), &record_expr_field)?;
+        Some((fix, record_expr_field.syntax().text_range()))
     }
 }
 
 impl DiagnosticWithFix for MissingFields {
-    type AST = ast::RecordExpr;
+    fn fix(&self, sema: &Semantics<RootDatabase>) -> Option<(Fix, TextRange)> {
+        // Note that although we could add a diagnostics to
+        // fill the missing tuple field, e.g :
+        // `struct A(usize);`
+        // `let a = A { 0: () }`
+        // but it is uncommon usage and it should not be encouraged.
+        if self.missed_fields.iter().any(|it| it.as_tuple_index().is_some()) {
+            None
+        } else {
+            let root = sema.db.parse_or_expand(self.file)?;
+            let old_field_list = self.field_list_parent.to_node(&root).record_expr_field_list()?;
+            let mut new_field_list = old_field_list.clone();
+            for f in self.missed_fields.iter() {
+                let field = make::record_expr_field(
+                    make::name_ref(&f.to_string()),
+                    Some(make::expr_unit()),
+                );
+                new_field_list = new_field_list.append_field(&field);
+            }
 
-    fn fix_source(&self, db: &dyn AstDatabase) -> Option<Self::AST> {
-        let root = db.parse_or_expand(self.file)?;
-        Some(self.field_list_parent.to_node(&root))
+            let edit = {
+                let mut builder = TextEditBuilder::default();
+                algo::diff(&old_field_list.syntax(), &new_field_list.syntax())
+                    .into_text_edit(&mut builder);
+                builder.finish()
+            };
+            Some((
+                Fix::new(
+                    "Fill struct fields",
+                    SourceFileEdit { file_id: self.file.original_file(sema.db), edit }.into(),
+                ),
+                sema.original_range(&old_field_list.syntax()).range,
+                // old_field_list.syntax().text_range(),
+            ))
+        }
     }
 }
 
 impl DiagnosticWithFix for MissingOkInTailExpr {
-    type AST = ast::Expr;
+    fn fix(&self, sema: &Semantics<RootDatabase>) -> Option<(Fix, TextRange)> {
+        let root = sema.db.parse_or_expand(self.file)?;
+        let tail_expr = self.expr.to_node(&root);
+        let tail_expr_range = tail_expr.syntax().text_range();
+        let edit = TextEdit::replace(tail_expr_range, format!("Ok({})", tail_expr.syntax()));
+        let source_change =
+            SourceFileEdit { file_id: self.file.original_file(sema.db), edit }.into();
+        Some((Fix::new("Wrap with ok", source_change), tail_expr_range))
+    }
+}
 
-    fn fix_source(&self, db: &dyn AstDatabase) -> Option<Self::AST> {
-        let root = db.parse_or_expand(self.file)?;
-        Some(self.expr.to_node(&root))
+fn missing_struct_field_fix(
+    sema: &Semantics<RootDatabase>,
+    usage_file_id: FileId,
+    record_expr_field: &ast::RecordExprField,
+) -> Option<Fix> {
+    let record_lit = ast::RecordExpr::cast(record_expr_field.syntax().parent()?.parent()?)?;
+    let def_id = sema.resolve_variant(record_lit)?;
+    let module;
+    let def_file_id;
+    let record_fields = match VariantDef::from(def_id) {
+        VariantDef::Struct(s) => {
+            module = s.module(sema.db);
+            let source = s.source(sema.db);
+            def_file_id = source.file_id;
+            let fields = source.value.field_list()?;
+            record_field_list(fields)?
+        }
+        VariantDef::Union(u) => {
+            module = u.module(sema.db);
+            let source = u.source(sema.db);
+            def_file_id = source.file_id;
+            source.value.record_field_list()?
+        }
+        VariantDef::EnumVariant(e) => {
+            module = e.module(sema.db);
+            let source = e.source(sema.db);
+            def_file_id = source.file_id;
+            let fields = source.value.field_list()?;
+            record_field_list(fields)?
+        }
+    };
+    let def_file_id = def_file_id.original_file(sema.db);
+
+    let new_field_type = sema.type_of_expr(&record_expr_field.expr()?)?;
+    if new_field_type.is_unknown() {
+        return None;
+    }
+    let new_field = make::record_field(
+        record_expr_field.field_name()?,
+        make::ty(&new_field_type.display_source_code(sema.db, module.into()).ok()?),
+    );
+
+    let last_field = record_fields.fields().last()?;
+    let last_field_syntax = last_field.syntax();
+    let indent = IndentLevel::from_node(last_field_syntax);
+
+    let mut new_field = new_field.to_string();
+    if usage_file_id != def_file_id {
+        new_field = format!("pub(crate) {}", new_field);
+    }
+    new_field = format!("\n{}{}", indent, new_field);
+
+    let needs_comma = !last_field_syntax.to_string().ends_with(',');
+    if needs_comma {
+        new_field = format!(",{}", new_field);
+    }
+
+    let source_change = SourceFileEdit {
+        file_id: def_file_id,
+        edit: TextEdit::insert(last_field_syntax.text_range().end(), new_field),
+    };
+    let fix = Fix::new("Create field", source_change.into());
+    return Some(fix);
+
+    fn record_field_list(field_def_list: ast::FieldList) -> Option<ast::RecordFieldList> {
+        match field_def_list {
+            ast::FieldList::RecordFieldList(it) => Some(it),
+            ast::FieldList::TupleFieldList(_) => None,
+        }
     }
 }

--- a/crates/ra_ide/src/diagnostics/diagnostics_with_fix.rs
+++ b/crates/ra_ide/src/diagnostics/diagnostics_with_fix.rs
@@ -1,0 +1,46 @@
+use hir::{
+    db::AstDatabase,
+    diagnostics::{MissingFields, MissingOkInTailExpr, NoSuchField, UnresolvedModule},
+};
+use ra_syntax::ast;
+
+// TODO kb
+pub trait DiagnosticWithFix {
+    type AST;
+    fn fix_source(&self, db: &dyn AstDatabase) -> Option<Self::AST>;
+}
+
+impl DiagnosticWithFix for UnresolvedModule {
+    type AST = ast::Module;
+    fn fix_source(&self, db: &dyn AstDatabase) -> Option<Self::AST> {
+        let root = db.parse_or_expand(self.file)?;
+        Some(self.decl.to_node(&root))
+    }
+}
+
+impl DiagnosticWithFix for NoSuchField {
+    type AST = ast::RecordExprField;
+
+    fn fix_source(&self, db: &dyn AstDatabase) -> Option<Self::AST> {
+        let root = db.parse_or_expand(self.file)?;
+        Some(self.field.to_node(&root))
+    }
+}
+
+impl DiagnosticWithFix for MissingFields {
+    type AST = ast::RecordExpr;
+
+    fn fix_source(&self, db: &dyn AstDatabase) -> Option<Self::AST> {
+        let root = db.parse_or_expand(self.file)?;
+        Some(self.field_list_parent.to_node(&root))
+    }
+}
+
+impl DiagnosticWithFix for MissingOkInTailExpr {
+    type AST = ast::Expr;
+
+    fn fix_source(&self, db: &dyn AstDatabase) -> Option<Self::AST> {
+        let root = db.parse_or_expand(self.file)?;
+        Some(self.expr.to_node(&root))
+    }
+}

--- a/crates/ra_ide/src/diagnostics/diagnostics_with_fix.rs
+++ b/crates/ra_ide/src/diagnostics/diagnostics_with_fix.rs
@@ -1,3 +1,4 @@
+//! Provides a way to derive fixes based on the diagnostic data.
 use crate::Fix;
 use ast::{edit::IndentLevel, make};
 use hir::{
@@ -13,8 +14,9 @@ use ra_ide_db::{
 use ra_syntax::{algo, ast, AstNode, TextRange};
 use ra_text_edit::{TextEdit, TextEditBuilder};
 
-// TODO kb
+/// A trait to implement fot the Diagnostic that has a fix available.
 pub trait DiagnosticWithFix {
+    /// Provides a fix with the fix range, if applicable in the current semantics.
     fn fix(&self, sema: &Semantics<RootDatabase>) -> Option<(Fix, TextRange)>;
 }
 

--- a/crates/ra_ide/src/diagnostics/diagnostics_with_fix.rs
+++ b/crates/ra_ide/src/diagnostics/diagnostics_with_fix.rs
@@ -1,4 +1,5 @@
-//! Provides a way to attach fix actions to the
+//! Provides a way to attach fixes to the diagnostics.
+//! The same module also has all curret custom fixes for the diagnostics implemented.
 use crate::Fix;
 use ast::{edit::IndentLevel, make};
 use hir::{

--- a/crates/ra_ide/src/lib.rs
+++ b/crates/ra_ide/src/lib.rs
@@ -105,20 +105,26 @@ pub struct Diagnostic {
     pub message: String,
     pub range: TextRange,
     pub severity: Severity,
-    pub fix: Option<(Fix, TextRange)>,
+    pub fix: Option<Fix>,
 }
 
 #[derive(Debug)]
 pub struct Fix {
     pub label: String,
     pub source_change: SourceChange,
+    /// Allows to trigger the fix only when the caret is in the range given
+    pub fix_trigger_range: TextRange,
 }
 
 impl Fix {
-    pub fn new(label: impl Into<String>, source_change: SourceChange) -> Self {
+    pub fn new(
+        label: impl Into<String>,
+        source_change: SourceChange,
+        fix_trigger_range: TextRange,
+    ) -> Self {
         let label = label.into();
         assert!(label.starts_with(char::is_uppercase) && !label.ends_with('.'));
-        Self { label, source_change }
+        Self { label, source_change, fix_trigger_range }
     }
 }
 

--- a/crates/ra_ide/src/lib.rs
+++ b/crates/ra_ide/src/lib.rs
@@ -105,7 +105,7 @@ pub struct Diagnostic {
     pub message: String,
     pub range: TextRange,
     pub severity: Severity,
-    pub fix: Option<Fix>,
+    pub fix: Option<(Fix, TextRange)>,
 }
 
 #[derive(Debug)]

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -775,9 +775,9 @@ fn handle_fixes(
 
     let fixes_from_diagnostics = diagnostics
         .into_iter()
-        .filter_map(|d| Some((d.range, d.fix?)))
-        .filter(|(diag_range, _fix)| diag_range.intersect(range).is_some())
-        .map(|(_range, fix)| fix);
+        .filter_map(|d| d.fix)
+        .filter(|(_fix, fix_range)| fix_range.intersect(range).is_some())
+        .map(|(fix, _range)| fix);
     for fix in fixes_from_diagnostics {
         let title = fix.label;
         let edit = to_proto::snippet_workspace_edit(&snap, fix.source_change)?;

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -773,12 +773,11 @@ fn handle_fixes(
 
     let diagnostics = snap.analysis.diagnostics(file_id, snap.config.experimental_diagnostics)?;
 
-    let fixes_from_diagnostics = diagnostics
+    for fix in diagnostics
         .into_iter()
         .filter_map(|d| d.fix)
-        .filter(|(_fix, fix_range)| fix_range.intersect(range).is_some())
-        .map(|(fix, _range)| fix);
-    for fix in fixes_from_diagnostics {
+        .filter(|fix| fix.fix_trigger_range.intersect(range).is_some())
+    {
         let title = fix.label;
         let edit = to_proto::snippet_workspace_edit(&snap, fix.source_change)?;
         let action = lsp_ext::CodeAction {


### PR DESCRIPTION
A follow-up of https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Fwg-rls-2.2E0/topic/Less.20red.20in.20the.20code

Now diagnostics can apply fixes in a range that's different from the range used to highlight the diagnostics.
Previous logic did not consider the fix range, having both ranges equal, which could cause a lot of red noise in the editor.
Now, the fix range gets used with the fix, the diagnostics range is used for everything else which allows to improve the error highlighting.

before:
<img width="191" alt="image" src="https://user-images.githubusercontent.com/2690773/88590727-df9a6a00-d063-11ea-97ed-9809c1c5e6e6.png">
after:
<img width="222" alt="image" src="https://user-images.githubusercontent.com/2690773/88590734-e1fcc400-d063-11ea-9b7c-25701cbd5352.png">

`MissingFields` and `MissingPatFields` diagnostics now have the fix range as `ast::RecordFieldList` of the expression with an error (as it was before this PR), and the diagnostics range as a `ast::Path` of the expression, if it's present (do you have any example of `ast::Expr::RecordLit` that has no path btw?).
The rest of the diagnostics have both ranges equal, same as it was before this PR.