### PR TITLE
Fix remove_dbg

### DIFF
--- a/crates/ra_assists/src/handlers/remove_dbg.rs
+++ b/crates/ra_assists/src/handlers/remove_dbg.rs
@@ -126,4 +126,25 @@ fn foo(n: usize) {
             "dbg!(n.checked_sub(4))",
         );
     }
+
+    #[test]
+    fn remove_dbg_leave_semicolon() {
+        // https://github.com/rust-analyzer/rust-analyzer/issues/5129#issuecomment-651399779
+        // not quite though
+        let code = "
+let res = <|>dbg!(1 * 20); // needless comment
+";
+        let expected = "
+let res = 1 * 20; // needless comment
+";
+        check_assist(remove_dbg, code, expected);
+    }
+
+    #[test]
+    fn remove_dbg_keep_expression() {
+        let code = "
+let res = <|>dbg!(a + b).foo();";
+        let expected = "let res = (a + b).foo();";
+        check_assist(remove_dbg, code, expected);
+    }
 }

--- a/crates/ra_assists/src/handlers/remove_dbg.rs
+++ b/crates/ra_assists/src/handlers/remove_dbg.rs
@@ -99,6 +99,7 @@ fn foo(n: usize) {
 ",
         );
     }
+
     #[test]
     fn test_remove_dbg_with_brackets_and_braces() {
         check_assist(remove_dbg, "dbg![<|>1 + 1]", "1 + 1");
@@ -113,7 +114,7 @@ fn foo(n: usize) {
     }
 
     #[test]
-    fn remove_dbg_target() {
+    fn test_remove_dbg_target() {
         check_assist_target(
             remove_dbg,
             "
@@ -128,7 +129,7 @@ fn foo(n: usize) {
     }
 
     #[test]
-    fn remove_dbg_leave_semicolon() {
+    fn test_remove_dbg_keep_semicolon() {
         // https://github.com/rust-analyzer/rust-analyzer/issues/5129#issuecomment-651399779
         // not quite though
         let code = "
@@ -141,10 +142,35 @@ let res = 1 * 20; // needless comment
     }
 
     #[test]
-    fn remove_dbg_keep_expression() {
+    fn test_remove_dbg_keep_expression() {
         let code = "
 let res = <|>dbg!(a + b).foo();";
         let expected = "let res = (a + b).foo();";
+        check_assist(remove_dbg, code, expected);
+    }
+
+    #[test]
+    fn test_remove_dbg_from_inside_fn() {
+        let code = "
+fn square(x: u32) -> u32 {
+    x * x
+}
+
+fn main() {
+    let x = square(dbg<|>!(5 + 10));
+    println!(\"{}\", x);
+}";
+
+        let expected = "
+fn square(x: u32) -> u32 {
+    x * x
+}
+
+fn main() {
+    let x = square(5 + 10);
+    println!(\"{}\", x);
+}";
+        check_assist_target(remove_dbg, code, "dbg!(5 + 10)");
         check_assist(remove_dbg, code, expected);
     }
 }


### PR DESCRIPTION
Closes #5129 

Addresses two issues:
- keep the parens from dbg!() in case the call is chained or there is
semantic difference if parens are excluded
- Exclude the semicolon after the dbg!(); by checking if it was
accidentally included in the macro_call

investigated, but decided against:
fix ast::MacroCall extraction to never include semicolons at the end -
this logic lives in rowan.

Defensively shorten the macro_range if there is a semicolon token.
Deleted unneccessary temp variable macro_args

Renamed macro_content to "paste_instead_of_dbg", because it isn't a
simple extraction of text inside dbg!() anymore