### PR TITLE
Add Rust ungrammar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,6 +1750,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "ungram"
+version = "0.1.0"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/ungram/Cargo.toml
+++ b/crates/ungram/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "ungram"
+version = "0.1.0"
+authors = ["rust-analyzer developers"]
+edition = "2018"
+license = "MIT OR Apache-2.0"
+
+[lib]
+doctest = false

--- a/crates/ungram/rust.ungram
+++ b/crates/ungram/rust.ungram
@@ -1,0 +1,21 @@
+Enum =
+ 'enum' Name Generics? WhereClause? '{' variants:EnumItems? '}'
+
+EnumItems =
+ EnumItem ( ',' EnumItem )* ','?
+
+EnumItem =
+ OuterAttribute* Visibility?
+ Name ( EnumItemTuple | EnumItemStruct | EnumItemDiscriminant )?
+
+EnumItemTuple =
+ '(' TupleFields? ')'
+
+EnumItemStruct =
+ '{' StructFields? '}'
+
+EnumItemDiscriminant =
+ '=' Expression
+
+MethodCallExpression =
+   receiver:Expression '.' PathExprSegment '(' CallParams? ')'

--- a/crates/ungram/src/error.rs
+++ b/crates/ungram/src/error.rs
@@ -1,0 +1,42 @@
+//! Boilerplate error definitions.
+use std::fmt;
+
+use crate::lexer::Location;
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Debug)]
+pub struct Error {
+    pub(crate) message: String,
+    pub(crate) location: Option<Location>,
+}
+
+impl Error {
+    pub(crate) fn with_location(self, location: Location) -> Error {
+        Error {
+            location: Some(location),
+            ..self
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+macro_rules! _format_err {
+    ($($tt:tt)*) => {
+        $crate::error::Error {
+            message: format!($($tt)*),
+            location: None,
+        }
+    };
+}
+pub(crate) use _format_err as format_err;
+
+macro_rules! _bail {
+    ($($tt:tt)*) => { return Err($crate::error::format_err!($($tt)*)) };
+}
+pub(crate) use _bail as bail;

--- a/crates/ungram/src/lexer.rs
+++ b/crates/ungram/src/lexer.rs
@@ -1,0 +1,96 @@
+//! Simple hand-written ungrammar lexer
+use crate::error::{bail, Result};
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum TokenKind {
+    Node(String),
+    Token(String),
+    Eq,
+    Star,
+    Pipe,
+    QMark,
+    Colon,
+    LParen,
+    RParen,
+}
+
+#[derive(Debug)]
+pub(crate) struct Token {
+    pub(crate) kind: TokenKind,
+    pub(crate) loc: Location,
+}
+
+#[derive(Copy, Clone, Default, Debug)]
+pub(crate) struct Location {
+    offset: usize,
+}
+
+pub(crate) fn tokenize(mut input: &str) -> Result<Vec<Token>> {
+    let mut res = Vec::new();
+    let mut loc = Location::default();
+    while !input.is_empty() {
+        let old_len = input.len();
+        skip_ws(&mut input);
+        if old_len == input.len() {
+            match advance(&mut input) {
+                Ok(kind) => {
+                    res.push(Token { kind, loc });
+                }
+                Err(err) => return Err(err.with_location(loc)),
+            }
+        }
+        loc.offset += old_len - input.len();
+    }
+
+    Ok(res)
+}
+
+fn skip_ws(input: &mut &str) {
+    *input = input.trim_start_matches(|c: char| c.is_ascii_whitespace())
+}
+fn advance(input: &mut &str) -> Result<TokenKind> {
+    let mut chars = input.chars();
+    let c = chars.next().unwrap();
+    let res = match c {
+        '=' => TokenKind::Eq,
+        '*' => TokenKind::Star,
+        '?' => TokenKind::QMark,
+        '(' => TokenKind::LParen,
+        ')' => TokenKind::RParen,
+        '|' => TokenKind::Pipe,
+        ':' => TokenKind::Colon,
+        '\'' => {
+            let mut buf = String::new();
+            loop {
+                match chars.next() {
+                    None => bail!("unclosed token literal"),
+                    Some('\'') => break,
+                    Some(c) => buf.push(c),
+                }
+            }
+            TokenKind::Token(buf)
+        }
+        c if is_ident_char(c) => {
+            let mut buf = String::new();
+            buf.push(c);
+            loop {
+                match chars.clone().next() {
+                    Some(c) if is_ident_char(c) => {
+                        chars.next();
+                        buf.push(c);
+                    }
+                    _ => break,
+                }
+            }
+            TokenKind::Node(buf)
+        }
+        c => bail!("unexpected character: `{}`", c),
+    };
+
+    *input = chars.as_str();
+    Ok(res)
+}
+
+fn is_ident_char(c: char) -> bool {
+    matches!(c, 'a'..='z' | 'A'..='Z' | '_')
+}

--- a/crates/ungram/src/lib.rs
+++ b/crates/ungram/src/lib.rs
@@ -1,0 +1,77 @@
+//! Ungrammar -- a DSL for specifying concrete syntax tree grammar.
+//!
+//! Producing a parser is an explicit non-goal -- it's ok for this grammar to be
+//! ambiguous, non LL, non LR, etc.
+mod error;
+mod lexer;
+mod parser;
+
+use std::{collections::HashMap, ops, str::FromStr};
+
+pub use error::{Error, Result};
+
+#[derive(Eq, PartialEq, Debug, Copy, Clone)]
+pub struct Node(usize);
+#[derive(Eq, PartialEq, Debug, Copy, Clone)]
+pub struct Token(usize);
+
+#[derive(Default, Debug)]
+pub struct Grammar {
+    nodes: Vec<NodeData>,
+    tokens: Vec<TokenData>,
+}
+
+impl FromStr for Grammar {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self> {
+        let tokens = lexer::tokenize(s)?;
+        parser::parse(tokens)
+    }
+}
+
+impl ops::Index<Node> for Grammar {
+    type Output = NodeData;
+    fn index(&self, Node(index): Node) -> &NodeData {
+        &self.nodes[index]
+    }
+}
+
+impl ops::Index<Token> for Grammar {
+    type Output = TokenData;
+    fn index(&self, Token(index): Token) -> &TokenData {
+        &self.tokens[index]
+    }
+}
+
+#[derive(Debug)]
+pub struct NodeData {
+    pub name: String,
+    pub rule: Rule,
+}
+
+#[derive(Debug)]
+pub struct TokenData {
+    name: String,
+}
+
+#[derive(Debug)]
+pub enum Rule {
+    Labeled { label: String, rule: Box<Rule> },
+    Node(Node),
+    Token(Token),
+    Seq(Vec<Rule>),
+    Alt(Vec<Rule>),
+    Opt(Box<Rule>),
+    Rep(Box<Rule>),
+}
+
+fn main() {
+    println!("Hello, world!");
+}
+
+#[test]
+fn smoke() {
+    let grammar = include_str!("../ungrammar.ungram");
+    let grammar = grammar.parse::<Grammar>().unwrap();
+    eprintln!("grammar = {:#?}", grammar);
+}

--- a/crates/ungram/src/parser.rs
+++ b/crates/ungram/src/parser.rs
@@ -1,0 +1,194 @@
+//! Simple hand-written ungrammar parser.
+use std::collections::HashMap;
+
+use crate::{
+    error::{bail, format_err, Result},
+    lexer::{self, TokenKind},
+    Grammar, Node, NodeData, Rule, Token, TokenData,
+};
+
+macro_rules! bail {
+    ($loc:expr, $($tt:tt)*) => {{
+        let err = $crate::error::format_err!($($tt)*)
+            .with_location($loc);
+        return Err(err);
+    }};
+}
+
+pub(crate) fn parse(tokens: Vec<lexer::Token>) -> Result<Grammar> {
+    let mut p = Parser::new(tokens);
+    while !p.is_eof() {
+        node(&mut p)?;
+    }
+    p.finish()
+}
+
+#[derive(Default)]
+struct Parser {
+    grammar: Grammar,
+    tokens: Vec<lexer::Token>,
+    node_table: HashMap<String, Node>,
+    token_table: HashMap<String, Token>,
+}
+
+const DUMMY: Node = Node(!0);
+
+impl Parser {
+    fn new(mut tokens: Vec<lexer::Token>) -> Parser {
+        tokens.reverse();
+        Parser { tokens, ..Parser::default() }
+    }
+
+    fn peek(&self) -> Option<&lexer::Token> {
+        self.peek_n(0)
+    }
+    fn peek_n(&self, n: usize) -> Option<&lexer::Token> {
+        self.tokens.get(self.tokens.len().saturating_sub(n + 1))
+    }
+    fn bump(&mut self) -> Result<lexer::Token> {
+        self.tokens.pop().ok_or_else(|| format_err!("unexpected EOF"))
+    }
+    fn expect(&mut self, kind: TokenKind, what: &str) -> Result<()> {
+        let token = self.bump()?;
+        if token.kind != kind {
+            bail!(token.loc, "unexpected token, expected `{}`", what);
+        }
+        Ok(())
+    }
+    fn is_eof(&self) -> bool {
+        self.tokens.is_empty()
+    }
+    fn finish(self) -> Result<Grammar> {
+        for node_data in &self.grammar.nodes {
+            if matches!(node_data.rule, Rule::Node(DUMMY)) {
+                crate::error::bail!("Undefined node: {}", node_data.name)
+            }
+        }
+        Ok(self.grammar)
+    }
+    fn intern_node(&mut self, name: String) -> Node {
+        let len = self.node_table.len();
+        let grammar = &mut self.grammar;
+        *self.node_table.entry(name.clone()).or_insert_with(|| {
+            grammar.nodes.push(NodeData { name, rule: Rule::Node(DUMMY) });
+            Node(len)
+        })
+    }
+    fn intern_token(&mut self, name: String) -> Token {
+        let len = self.tokens.len();
+        let grammar = &mut self.grammar;
+        *self.token_table.entry(name.clone()).or_insert_with(|| {
+            grammar.tokens.push(TokenData { name });
+            Token(len)
+        })
+    }
+}
+
+fn node(p: &mut Parser) -> Result<()> {
+    let token = p.bump()?;
+    let Node(node_index) = match token.kind {
+        TokenKind::Node(it) => p.intern_node(it),
+        _ => bail!(token.loc, "expected ident"),
+    };
+    p.expect(TokenKind::Eq, "=")?;
+    let rule = rule(p)?;
+    p.grammar.nodes[node_index].rule = rule;
+    Ok(())
+}
+
+fn rule(p: &mut Parser) -> Result<Rule> {
+    let lhs = seq_rule(p)?;
+    let mut alt = vec![lhs];
+    while let Some(token) = p.peek() {
+        if token.kind != TokenKind::Pipe {
+            break;
+        }
+        p.bump()?;
+        let rule = seq_rule(p)?;
+        alt.push(rule)
+    }
+    let res = if alt.len() == 1 { alt.pop().unwrap() } else { Rule::Alt(alt) };
+    Ok(res)
+}
+
+fn seq_rule(p: &mut Parser) -> Result<Rule> {
+    let lhs = atom_rule(p)?;
+
+    let mut seq = vec![lhs];
+    while let Some(rule) = opt_atom_rule(p)? {
+        seq.push(rule)
+    }
+    let res = if seq.len() == 1 { seq.pop().unwrap() } else { Rule::Seq(seq) };
+    Ok(res)
+}
+
+fn atom_rule(p: &mut Parser) -> Result<Rule> {
+    match opt_atom_rule(p)? {
+        Some(it) => Ok(it),
+        None => {
+            let token = p.bump()?;
+            bail!(token.loc, "unexpected token")
+        }
+    }
+}
+
+fn opt_atom_rule(p: &mut Parser) -> Result<Option<Rule>> {
+    let token = match p.peek() {
+        Some(it) => it,
+        None => return Ok(None),
+    };
+    let mut res = match &token.kind {
+        TokenKind::Node(name) => {
+            if let Some(lookahead) = p.peek_n(1) {
+                match lookahead.kind {
+                    TokenKind::Eq => return Ok(None),
+                    TokenKind::Colon => {
+                        let label = name.clone();
+                        p.bump()?;
+                        p.bump()?;
+                        let rule = atom_rule(p)?;
+                        let res = Rule::Labeled { label, rule: Box::new(rule) };
+                        return Ok(Some(res));
+                    }
+                    _ => (),
+                }
+            }
+            match p.peek_n(1) {
+                Some(token) if token.kind == TokenKind::Eq => return Ok(None),
+                _ => (),
+            }
+            let name = name.clone();
+            p.bump()?;
+            let node = p.intern_node(name);
+            Rule::Node(node)
+        }
+        TokenKind::Token(name) => {
+            let name = name.clone();
+            p.bump()?;
+            let token = p.intern_token(name);
+            Rule::Token(token)
+        }
+        TokenKind::LParen => {
+            p.bump()?;
+            let rule = rule(p)?;
+            p.expect(TokenKind::RParen, ")")?;
+            rule
+        }
+        _ => return Ok(None),
+    };
+
+    if let Some(token) = p.peek() {
+        match &token.kind {
+            TokenKind::QMark => {
+                p.bump()?;
+                res = Rule::Opt(Box::new(res));
+            }
+            TokenKind::Star => {
+                p.bump()?;
+                res = Rule::Rep(Box::new(res));
+            }
+            _ => (),
+        }
+    }
+    Ok(Some(res))
+}

--- a/crates/ungram/ungrammar.ungram
+++ b/crates/ungram/ungrammar.ungram
@@ -1,0 +1,15 @@
+Grammar =
+  Node *
+
+Node =
+  name:'ident' '=' Rule
+
+Rule =
+  'ident'
+| 'token_ident'
+| Rule *
+| Rule ( '|' Rule) *
+| Rule '?'
+| Rule '*'
+| '(' Rule ')'
+| label:'ident' ':'


### PR DESCRIPTION
As a first step towards parser library-ification, I want to make sure that we can generate both rust-analyzer CST and Rust AST from the same "ungrammar" file.

"Ungrammar" is a made-up file format to specify *concrete*  syntax tree. It is explicitly **not** aimed at producing a parser. (so, the if-expression would look like `'if' Expr BlockExp`, without mentioning that struct literals are forbidden).