### PR TITLE
Check all targets for package-level tasks

### DIFF
--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -469,12 +469,12 @@ pub(crate) fn handle_runnables(
         res.push(runnable);
     }
 
-    // Add `cargo check` and `cargo test` for the whole package
+    // Add `cargo check` and `cargo test` for all targets of the whole package
     match cargo_spec {
         Some(spec) => {
             for &cmd in ["check", "test"].iter() {
                 res.push(lsp_ext::Runnable {
-                    label: format!("cargo {} -p {}", cmd, spec.package),
+                    label: format!("cargo {} -p {} --all-targets", cmd, spec.package),
                     location: None,
                     kind: lsp_ext::RunnableKind::Cargo,
                     args: lsp_ext::CargoRunnable {
@@ -483,6 +483,7 @@ pub(crate) fn handle_runnables(
                             cmd.to_string(),
                             "--package".to_string(),
                             spec.package.clone(),
+                            "--all-targets".to_string(),
                         ],
                         executable_args: Vec::new(),
                         expect_test: None,

--- a/crates/rust-analyzer/tests/heavy_tests/main.rs
+++ b/crates/rust-analyzer/tests/heavy_tests/main.rs
@@ -115,21 +115,21 @@ fn main() {}
           },
           {
             "args": {
-              "cargoArgs": ["check", "--package", "foo"],
+              "cargoArgs": ["check", "--package", "foo", "--all-targets"],
               "executableArgs": [],
               "workspaceRoot": server.path().join("foo")
             },
             "kind": "cargo",
-            "label": "cargo check -p foo"
+            "label": "cargo check -p foo --all-targets"
           },
           {
             "args": {
-              "cargoArgs": ["test", "--package", "foo"],
+              "cargoArgs": ["test", "--package", "foo", "--all-targets"],
               "executableArgs": [],
               "workspaceRoot": server.path().join("foo")
             },
             "kind": "cargo",
-            "label": "cargo test -p foo"
+            "label": "cargo test -p foo --all-targets"
           }
         ]),
     );


### PR DESCRIPTION
When invoking "Select Runnable" with the caret on a runnable with a specific target (test, bench, binary), append the corresponding argument for the `cargo check -p` module runnable.