### PR TITLE
Add checkOnSave.noDefaultFeatures and correct, how we handle some cargo flags.

### DIFF
--- a/crates/flycheck/src/lib.rs
+++ b/crates/flycheck/src/lib.rs
@@ -24,6 +24,7 @@ pub enum FlycheckConfig {
         command: String,
         target_triple: Option<String>,
         all_targets: bool,
+        no_default_features: bool,
         all_features: bool,
         features: Vec<String>,
         extra_args: Vec<String>,
@@ -180,6 +181,7 @@ impl FlycheckActor {
             FlycheckConfig::CargoCommand {
                 command,
                 target_triple,
+                no_default_features,
                 all_targets,
                 all_features,
                 extra_args,
@@ -198,9 +200,14 @@ impl FlycheckActor {
                 }
                 if *all_features {
                     cmd.arg("--all-features");
-                } else if !features.is_empty() {
-                    cmd.arg("--features");
-                    cmd.arg(features.join(" "));
+                } else {
+                    if *no_default_features {
+                        cmd.arg("--no-default-features");
+                    }
+                    if !features.is_empty() {
+                        cmd.arg("--features");
+                        cmd.arg(features.join(" "));
+                    }
                 }
                 cmd.args(extra_args);
                 cmd

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -151,6 +151,7 @@ impl Config {
             flycheck: Some(FlycheckConfig::CargoCommand {
                 command: "check".to_string(),
                 target_triple: None,
+                no_default_features: false,
                 all_targets: true,
                 all_features: false,
                 extra_args: Vec::new(),
@@ -234,6 +235,9 @@ impl Config {
                     command: data.checkOnSave_command,
                     target_triple: data.checkOnSave_target.or(data.cargo_target),
                     all_targets: data.checkOnSave_allTargets,
+                    no_default_features: data
+                        .checkOnSave_noDefaultFeatures
+                        .unwrap_or(data.cargo_noDefaultFeatures),
                     all_features: data.checkOnSave_allFeatures.unwrap_or(data.cargo_allFeatures),
                     features: data.checkOnSave_features.unwrap_or(data.cargo_features),
                     extra_args: data.checkOnSave_extraArgs,
@@ -398,6 +402,7 @@ config_data! {
         checkOnSave_allFeatures: Option<bool>            = None,
         checkOnSave_allTargets: bool                     = true,
         checkOnSave_command: String                      = "check".into(),
+        checkOnSave_noDefaultFeatures: Option<bool>      = None,
         checkOnSave_target: Option<String>               = None,
         checkOnSave_extraArgs: Vec<String>               = Vec::new(),
         checkOnSave_features: Option<Vec<String>>        = None,

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -323,6 +323,14 @@
                     "default": true,
                     "markdownDescription": "Check all targets and tests (will be passed as `--all-targets`)"
                 },
+                "rust-analyzer.checkOnSave.noDefaultFeatures": {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "default": null,
+                    "markdownDescription": "Do not activate the `default` feature"
+                },
                 "rust-analyzer.checkOnSave.allFeatures": {
                     "type": [
                         "null",


### PR DESCRIPTION
This PR adds the `rust-analyzer.checkOnSave.noDefaultFeatures` option
and fixes the handling of `cargo.allFeatures`, `cargo.noDefaultFeatures` and `cargo.features`.
Fixes: #5550 