### PR TITLE
Rename TypeRef -> Type

### DIFF
--- a/crates/ra_assists/src/ast_transform.rs
+++ b/crates/ra_assists/src/ast_transform.rs
@@ -32,7 +32,7 @@ impl<'a> AstTransform<'a> for NullTransformer {
 
 pub struct SubstituteTypeParams<'a> {
     source_scope: &'a SemanticsScope<'a>,
-    substs: FxHashMap<hir::TypeParam, ast::TypeRef>,
+    substs: FxHashMap<hir::TypeParam, ast::Type>,
     previous: Box<dyn AstTransform<'a> + 'a>,
 }
 
@@ -80,17 +80,17 @@ impl<'a> SubstituteTypeParams<'a> {
 
         // FIXME: It would probably be nicer if we could get this via HIR (i.e. get the
         // trait ref, and then go from the types in the substs back to the syntax)
-        fn get_syntactic_substs(impl_def: ast::Impl) -> Option<Vec<ast::TypeRef>> {
+        fn get_syntactic_substs(impl_def: ast::Impl) -> Option<Vec<ast::Type>> {
             let target_trait = impl_def.target_trait()?;
             let path_type = match target_trait {
-                ast::TypeRef::PathType(path) => path,
+                ast::Type::PathType(path) => path,
                 _ => return None,
             };
             let type_arg_list = path_type.path()?.segment()?.type_arg_list()?;
             let mut result = Vec::new();
             for type_arg in type_arg_list.type_args() {
                 let type_arg: ast::TypeArg = type_arg;
-                result.push(type_arg.type_ref()?);
+                result.push(type_arg.ty()?);
             }
             Some(result)
         }
@@ -99,9 +99,9 @@ impl<'a> SubstituteTypeParams<'a> {
         &self,
         node: &ra_syntax::SyntaxNode,
     ) -> Option<ra_syntax::SyntaxNode> {
-        let type_ref = ast::TypeRef::cast(node.clone())?;
+        let type_ref = ast::Type::cast(node.clone())?;
         let path = match &type_ref {
-            ast::TypeRef::PathType(path_type) => path_type.path()?,
+            ast::Type::PathType(path_type) => path_type.path()?,
             _ => return None,
         };
         // FIXME: use `hir::Path::from_src` instead.

--- a/crates/ra_assists/src/handlers/generate_from_impl_for_enum.rs
+++ b/crates/ra_assists/src/handlers/generate_from_impl_for_enum.rs
@@ -34,7 +34,7 @@ pub(crate) fn generate_from_impl_for_enum(acc: &mut Assists, ctx: &AssistContext
     }
     let field_type = field_list.fields().next()?.ty()?;
     let path = match field_type {
-        ast::TypeRef::PathType(it) => it,
+        ast::Type::PathType(it) => it,
         _ => return None,
     };
 

--- a/crates/ra_assists/src/handlers/introduce_named_lifetime.rs
+++ b/crates/ra_assists/src/handlers/introduce_named_lifetime.rs
@@ -68,7 +68,7 @@ fn generate_fn_def_assist(
         let fn_params_without_lifetime: Vec<_> = param_list
             .params()
             .filter_map(|param| match param.ty() {
-                Some(ast::TypeRef::ReferenceType(ascribed_type))
+                Some(ast::Type::ReferenceType(ascribed_type))
                     if ascribed_type.lifetime_token() == None =>
                 {
                     Some(ascribed_type.amp_token()?.text_range().end())

--- a/crates/ra_hir_def/src/generics.rs
+++ b/crates/ra_hir_def/src/generics.rs
@@ -253,7 +253,7 @@ impl GenericParams {
 
     fn fill_where_predicates(&mut self, lower_ctx: &LowerCtx, where_clause: ast::WhereClause) {
         for pred in where_clause.predicates() {
-            let type_ref = match pred.type_ref() {
+            let type_ref = match pred.ty() {
                 Some(type_ref) => type_ref,
                 None => continue,
             };

--- a/crates/ra_hir_def/src/item_tree/lower.rs
+++ b/crates/ra_hir_def/src/item_tree/lower.rs
@@ -648,10 +648,10 @@ impl Ctx {
         self.data().vis.alloc(vis)
     }
 
-    fn lower_type_ref(&self, type_ref: &ast::TypeRef) -> TypeRef {
+    fn lower_type_ref(&self, type_ref: &ast::Type) -> TypeRef {
         TypeRef::from_ast(&self.body_ctx, type_ref.clone())
     }
-    fn lower_type_ref_opt(&self, type_ref: Option<ast::TypeRef>) -> TypeRef {
+    fn lower_type_ref_opt(&self, type_ref: Option<ast::Type>) -> TypeRef {
         type_ref.map(|ty| self.lower_type_ref(&ty)).unwrap_or(TypeRef::Error)
     }
 

--- a/crates/ra_hir_def/src/path/lower.rs
+++ b/crates/ra_hir_def/src/path/lower.rs
@@ -152,7 +152,7 @@ pub(super) fn lower_generic_args(
 ) -> Option<GenericArgs> {
     let mut args = Vec::new();
     for type_arg in node.type_args() {
-        let type_ref = TypeRef::from_ast_opt(lower_ctx, type_arg.type_ref());
+        let type_ref = TypeRef::from_ast_opt(lower_ctx, type_arg.ty());
         args.push(GenericArg::Type(type_ref));
     }
     // lifetimes ignored for now
@@ -161,7 +161,7 @@ pub(super) fn lower_generic_args(
         let assoc_type_arg: ast::AssocTypeArg = assoc_type_arg;
         if let Some(name_ref) = assoc_type_arg.name_ref() {
             let name = name_ref.as_name();
-            let type_ref = assoc_type_arg.type_ref().map(|it| TypeRef::from_ast(lower_ctx, it));
+            let type_ref = assoc_type_arg.ty().map(|it| TypeRef::from_ast(lower_ctx, it));
             let bounds = if let Some(l) = assoc_type_arg.type_bound_list() {
                 l.bounds().map(|it| TypeBound::from_ast(lower_ctx, it)).collect()
             } else {

--- a/crates/ra_ide/src/display/short_label.rs
+++ b/crates/ra_ide/src/display/short_label.rs
@@ -77,7 +77,7 @@ impl ShortLabel for ast::Variant {
     }
 }
 
-fn short_label_from_ty<T>(node: &T, ty: Option<ast::TypeRef>, prefix: &str) -> Option<String>
+fn short_label_from_ty<T>(node: &T, ty: Option<ast::Type>, prefix: &str) -> Option<String>
 where
     T: NameOwner + VisibilityOwner,
 {

--- a/crates/ra_ide/src/file_structure.rs
+++ b/crates/ra_ide/src/file_structure.rs
@@ -57,7 +57,7 @@ fn structure_node(node: &SyntaxNode) -> Option<StructureNode> {
 
     fn decl_with_type_ref<N: NameOwner + AttrsOwner>(
         node: &N,
-        type_ref: Option<ast::TypeRef>,
+        type_ref: Option<ast::Type>,
     ) -> Option<StructureNode> {
         let detail = type_ref.map(|type_ref| {
             let mut detail = String::new();

--- a/crates/ra_ide/src/references/rename.rs
+++ b/crates/ra_ide/src/references/rename.rs
@@ -157,7 +157,7 @@ fn rename_to_self(
     }
     let first_param = params.params().next()?;
     let mutable = match first_param.ty() {
-        Some(ast::TypeRef::ReferenceType(rt)) => rt.mut_token().is_some(),
+        Some(ast::Type::ReferenceType(rt)) => rt.mut_token().is_some(),
         _ => return None, // not renaming other types
     };
 
@@ -194,7 +194,7 @@ fn text_edit_from_self_param(
     new_name: &str,
 ) -> Option<TextEdit> {
     fn target_type_name(impl_def: &ast::Impl) -> Option<String> {
-        if let Some(ast::TypeRef::PathType(p)) = impl_def.target_type() {
+        if let Some(ast::Type::PathType(p)) = impl_def.target_type() {
             return Some(p.path()?.segment()?.name_ref()?.text().to_string());
         }
         None

--- a/crates/ra_ssr/src/parsing.rs
+++ b/crates/ra_ssr/src/parsing.rs
@@ -70,7 +70,7 @@ impl ParsedRule {
             rules: Vec::new(),
         };
         builder.try_add(ast::Expr::parse(&raw_pattern), raw_template.map(ast::Expr::parse));
-        builder.try_add(ast::TypeRef::parse(&raw_pattern), raw_template.map(ast::TypeRef::parse));
+        builder.try_add(ast::Type::parse(&raw_pattern), raw_template.map(ast::Type::parse));
         builder.try_add(ast::Item::parse(&raw_pattern), raw_template.map(ast::Item::parse));
         builder.try_add(ast::Path::parse(&raw_pattern), raw_template.map(ast::Path::parse));
         builder.try_add(ast::Pat::parse(&raw_pattern), raw_template.map(ast::Pat::parse));

--- a/crates/ra_syntax/src/ast.rs
+++ b/crates/ra_syntax/src/ast.rs
@@ -287,7 +287,7 @@ where
 
     assert!(pred.for_token().is_none());
     assert!(pred.generic_param_list().is_none());
-    assert_eq!("T", pred.type_ref().unwrap().syntax().text().to_string());
+    assert_eq!("T", pred.ty().unwrap().syntax().text().to_string());
     assert_bound("Clone", bounds.next());
     assert_bound("Copy", bounds.next());
     assert_bound("Debug", bounds.next());
@@ -304,20 +304,20 @@ where
     let pred = predicates.next().unwrap();
     let mut bounds = pred.type_bound_list().unwrap().bounds();
 
-    assert_eq!("Iterator::Item", pred.type_ref().unwrap().syntax().text().to_string());
+    assert_eq!("Iterator::Item", pred.ty().unwrap().syntax().text().to_string());
     assert_bound("'a", bounds.next());
 
     let pred = predicates.next().unwrap();
     let mut bounds = pred.type_bound_list().unwrap().bounds();
 
-    assert_eq!("Iterator::Item", pred.type_ref().unwrap().syntax().text().to_string());
+    assert_eq!("Iterator::Item", pred.ty().unwrap().syntax().text().to_string());
     assert_bound("Debug", bounds.next());
     assert_bound("'a", bounds.next());
 
     let pred = predicates.next().unwrap();
     let mut bounds = pred.type_bound_list().unwrap().bounds();
 
-    assert_eq!("<T as Iterator>::Item", pred.type_ref().unwrap().syntax().text().to_string());
+    assert_eq!("<T as Iterator>::Item", pred.ty().unwrap().syntax().text().to_string());
     assert_bound("Debug", bounds.next());
     assert_bound("'a", bounds.next());
 
@@ -326,6 +326,6 @@ where
 
     assert!(pred.for_token().is_some());
     assert_eq!("<'a>", pred.generic_param_list().unwrap().syntax().text().to_string());
-    assert_eq!("F", pred.type_ref().unwrap().syntax().text().to_string());
+    assert_eq!("F", pred.ty().unwrap().syntax().text().to_string());
     assert_bound("Fn(&'a str)", bounds.next());
 }

--- a/crates/ra_syntax/src/ast/generated/nodes.rs
+++ b/crates/ra_syntax/src/ast/generated/nodes.rs
@@ -40,7 +40,7 @@ impl Const {
     pub fn const_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![const]) }
     pub fn underscore_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![_]) }
     pub fn colon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![:]) }
-    pub fn ty(&self) -> Option<TypeRef> { support::child(&self.syntax) }
+    pub fn ty(&self) -> Option<Type> { support::child(&self.syntax) }
     pub fn eq_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![=]) }
     pub fn body(&self) -> Option<Expr> { support::child(&self.syntax) }
     pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![;]) }
@@ -112,7 +112,7 @@ impl Impl {
     pub fn unsafe_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![unsafe]) }
     pub fn impl_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![impl]) }
     pub fn const_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![const]) }
-    pub fn type_ref(&self) -> Option<TypeRef> { support::child(&self.syntax) }
+    pub fn ty(&self) -> Option<Type> { support::child(&self.syntax) }
     pub fn excl_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![!]) }
     pub fn for_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![for]) }
     pub fn assoc_item_list(&self) -> Option<AssocItemList> { support::child(&self.syntax) }
@@ -152,7 +152,7 @@ impl Static {
     pub fn static_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![static]) }
     pub fn mut_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![mut]) }
     pub fn colon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![:]) }
-    pub fn ty(&self) -> Option<TypeRef> { support::child(&self.syntax) }
+    pub fn ty(&self) -> Option<Type> { support::child(&self.syntax) }
     pub fn eq_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![=]) }
     pub fn body(&self) -> Option<Expr> { support::child(&self.syntax) }
     pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![;]) }
@@ -198,7 +198,7 @@ impl TypeAlias {
     pub fn default_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![default]) }
     pub fn type_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![type]) }
     pub fn eq_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![=]) }
-    pub fn ty(&self) -> Option<TypeRef> { support::child(&self.syntax) }
+    pub fn ty(&self) -> Option<Type> { support::child(&self.syntax) }
     pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![;]) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -333,7 +333,7 @@ pub struct RetType {
 }
 impl RetType {
     pub fn thin_arrow_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![->]) }
-    pub fn ty(&self) -> Option<TypeRef> { support::child(&self.syntax) }
+    pub fn ty(&self) -> Option<Type> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct WhereClause {
@@ -369,7 +369,7 @@ impl SelfParam {
     pub fn mut_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![mut]) }
     pub fn self_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![self]) }
     pub fn colon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![:]) }
-    pub fn ty(&self) -> Option<TypeRef> { support::child(&self.syntax) }
+    pub fn ty(&self) -> Option<Type> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Param {
@@ -379,7 +379,7 @@ impl ast::AttrsOwner for Param {}
 impl Param {
     pub fn pat(&self) -> Option<Pat> { support::child(&self.syntax) }
     pub fn colon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![:]) }
-    pub fn ty(&self) -> Option<TypeRef> { support::child(&self.syntax) }
+    pub fn ty(&self) -> Option<Type> { support::child(&self.syntax) }
     pub fn dotdotdot_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![...]) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -416,7 +416,7 @@ impl ast::NameOwner for RecordField {}
 impl ast::VisibilityOwner for RecordField {}
 impl RecordField {
     pub fn colon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![:]) }
-    pub fn ty(&self) -> Option<TypeRef> { support::child(&self.syntax) }
+    pub fn ty(&self) -> Option<Type> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TupleField {
@@ -425,7 +425,7 @@ pub struct TupleField {
 impl ast::AttrsOwner for TupleField {}
 impl ast::VisibilityOwner for TupleField {}
 impl TupleField {
-    pub fn ty(&self) -> Option<TypeRef> { support::child(&self.syntax) }
+    pub fn ty(&self) -> Option<Type> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct VariantList {
@@ -487,7 +487,7 @@ impl ast::NameOwner for TypeParam {}
 impl ast::TypeBoundsOwner for TypeParam {}
 impl TypeParam {
     pub fn eq_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![=]) }
-    pub fn default_type(&self) -> Option<TypeRef> { support::child(&self.syntax) }
+    pub fn default_type(&self) -> Option<Type> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ConstParam {
@@ -498,7 +498,7 @@ impl ast::NameOwner for ConstParam {}
 impl ConstParam {
     pub fn const_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![const]) }
     pub fn colon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![:]) }
-    pub fn ty(&self) -> Option<TypeRef> { support::child(&self.syntax) }
+    pub fn ty(&self) -> Option<Type> { support::child(&self.syntax) }
     pub fn eq_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![=]) }
     pub fn default_val(&self) -> Option<Expr> { support::child(&self.syntax) }
 }
@@ -525,7 +525,7 @@ pub struct ParenType {
 }
 impl ParenType {
     pub fn l_paren_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T!['(']) }
-    pub fn ty(&self) -> Option<TypeRef> { support::child(&self.syntax) }
+    pub fn ty(&self) -> Option<Type> { support::child(&self.syntax) }
     pub fn r_paren_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![')']) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -534,7 +534,7 @@ pub struct TupleType {
 }
 impl TupleType {
     pub fn l_paren_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T!['(']) }
-    pub fn fields(&self) -> AstChildren<TypeRef> { support::children(&self.syntax) }
+    pub fn fields(&self) -> AstChildren<Type> { support::children(&self.syntax) }
     pub fn r_paren_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![')']) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -559,7 +559,7 @@ impl PointerType {
     pub fn star_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![*]) }
     pub fn const_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![const]) }
     pub fn mut_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![mut]) }
-    pub fn ty(&self) -> Option<TypeRef> { support::child(&self.syntax) }
+    pub fn ty(&self) -> Option<Type> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ArrayType {
@@ -567,7 +567,7 @@ pub struct ArrayType {
 }
 impl ArrayType {
     pub fn l_brack_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T!['[']) }
-    pub fn ty(&self) -> Option<TypeRef> { support::child(&self.syntax) }
+    pub fn ty(&self) -> Option<Type> { support::child(&self.syntax) }
     pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![;]) }
     pub fn expr(&self) -> Option<Expr> { support::child(&self.syntax) }
     pub fn r_brack_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![']']) }
@@ -578,7 +578,7 @@ pub struct SliceType {
 }
 impl SliceType {
     pub fn l_brack_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T!['[']) }
-    pub fn ty(&self) -> Option<TypeRef> { support::child(&self.syntax) }
+    pub fn ty(&self) -> Option<Type> { support::child(&self.syntax) }
     pub fn r_brack_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![']']) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -591,7 +591,7 @@ impl ReferenceType {
         support::token(&self.syntax, T![lifetime])
     }
     pub fn mut_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![mut]) }
-    pub fn ty(&self) -> Option<TypeRef> { support::child(&self.syntax) }
+    pub fn ty(&self) -> Option<Type> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PlaceholderType {
@@ -618,7 +618,7 @@ pub struct ForType {
 impl ForType {
     pub fn for_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![for]) }
     pub fn generic_param_list(&self) -> Option<GenericParamList> { support::child(&self.syntax) }
-    pub fn ty(&self) -> Option<TypeRef> { support::child(&self.syntax) }
+    pub fn ty(&self) -> Option<Type> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ImplTraitType {
@@ -882,7 +882,7 @@ impl ast::AttrsOwner for CastExpr {}
 impl CastExpr {
     pub fn expr(&self) -> Option<Expr> { support::child(&self.syntax) }
     pub fn as_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![as]) }
-    pub fn ty(&self) -> Option<TypeRef> { support::child(&self.syntax) }
+    pub fn ty(&self) -> Option<Type> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RefExpr {
@@ -1174,7 +1174,7 @@ impl TypeBound {
         support::token(&self.syntax, T![lifetime])
     }
     pub fn const_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![const]) }
-    pub fn type_ref(&self) -> Option<TypeRef> { support::child(&self.syntax) }
+    pub fn ty(&self) -> Option<Type> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct WherePred {
@@ -1187,7 +1187,7 @@ impl WherePred {
     pub fn lifetime_token(&self) -> Option<SyntaxToken> {
         support::token(&self.syntax, T![lifetime])
     }
-    pub fn type_ref(&self) -> Option<TypeRef> { support::child(&self.syntax) }
+    pub fn ty(&self) -> Option<Type> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ExprStmt {
@@ -1207,7 +1207,7 @@ impl LetStmt {
     pub fn let_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![let]) }
     pub fn pat(&self) -> Option<Pat> { support::child(&self.syntax) }
     pub fn colon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![:]) }
-    pub fn ty(&self) -> Option<TypeRef> { support::child(&self.syntax) }
+    pub fn ty(&self) -> Option<Type> { support::child(&self.syntax) }
     pub fn eq_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![=]) }
     pub fn initializer(&self) -> Option<Expr> { support::child(&self.syntax) }
     pub fn semicolon_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![;]) }
@@ -1234,7 +1234,7 @@ pub struct TypeArg {
     pub(crate) syntax: SyntaxNode,
 }
 impl TypeArg {
-    pub fn type_ref(&self) -> Option<TypeRef> { support::child(&self.syntax) }
+    pub fn ty(&self) -> Option<Type> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct LifetimeArg {
@@ -1253,7 +1253,7 @@ impl ast::TypeBoundsOwner for AssocTypeArg {}
 impl AssocTypeArg {
     pub fn name_ref(&self) -> Option<NameRef> { support::child(&self.syntax) }
     pub fn eq_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![=]) }
-    pub fn type_ref(&self) -> Option<TypeRef> { support::child(&self.syntax) }
+    pub fn ty(&self) -> Option<Type> { support::child(&self.syntax) }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ConstArg {
@@ -1282,7 +1282,7 @@ pub enum Item {
 }
 impl ast::AttrsOwner for Item {}
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum TypeRef {
+pub enum Type {
     ParenType(ParenType),
     TupleType(TupleType),
     NeverType(NeverType),
@@ -1355,6 +1355,16 @@ pub enum Expr {
     BoxExpr(BoxExpr),
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum AdtDef {
+    Struct(Struct),
+    Enum(Enum),
+    Union(Union),
+}
+impl ast::AttrsOwner for AdtDef {}
+impl ast::GenericParamsOwner for AdtDef {}
+impl ast::NameOwner for AdtDef {}
+impl ast::VisibilityOwner for AdtDef {}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AssocItem {
     Fn(Fn),
     TypeAlias(TypeAlias),
@@ -1384,16 +1394,6 @@ pub enum Stmt {
     ExprStmt(ExprStmt),
 }
 impl ast::AttrsOwner for Stmt {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum AdtDef {
-    Struct(Struct),
-    Enum(Enum),
-    Union(Union),
-}
-impl ast::AttrsOwner for AdtDef {}
-impl ast::GenericParamsOwner for AdtDef {}
-impl ast::NameOwner for AdtDef {}
-impl ast::VisibilityOwner for AdtDef {}
 impl AstNode for SourceFile {
     fn can_cast(kind: SyntaxKind) -> bool { kind == SOURCE_FILE }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
@@ -2847,46 +2847,46 @@ impl AstNode for Item {
         }
     }
 }
-impl From<ParenType> for TypeRef {
-    fn from(node: ParenType) -> TypeRef { TypeRef::ParenType(node) }
+impl From<ParenType> for Type {
+    fn from(node: ParenType) -> Type { Type::ParenType(node) }
 }
-impl From<TupleType> for TypeRef {
-    fn from(node: TupleType) -> TypeRef { TypeRef::TupleType(node) }
+impl From<TupleType> for Type {
+    fn from(node: TupleType) -> Type { Type::TupleType(node) }
 }
-impl From<NeverType> for TypeRef {
-    fn from(node: NeverType) -> TypeRef { TypeRef::NeverType(node) }
+impl From<NeverType> for Type {
+    fn from(node: NeverType) -> Type { Type::NeverType(node) }
 }
-impl From<PathType> for TypeRef {
-    fn from(node: PathType) -> TypeRef { TypeRef::PathType(node) }
+impl From<PathType> for Type {
+    fn from(node: PathType) -> Type { Type::PathType(node) }
 }
-impl From<PointerType> for TypeRef {
-    fn from(node: PointerType) -> TypeRef { TypeRef::PointerType(node) }
+impl From<PointerType> for Type {
+    fn from(node: PointerType) -> Type { Type::PointerType(node) }
 }
-impl From<ArrayType> for TypeRef {
-    fn from(node: ArrayType) -> TypeRef { TypeRef::ArrayType(node) }
+impl From<ArrayType> for Type {
+    fn from(node: ArrayType) -> Type { Type::ArrayType(node) }
 }
-impl From<SliceType> for TypeRef {
-    fn from(node: SliceType) -> TypeRef { TypeRef::SliceType(node) }
+impl From<SliceType> for Type {
+    fn from(node: SliceType) -> Type { Type::SliceType(node) }
 }
-impl From<ReferenceType> for TypeRef {
-    fn from(node: ReferenceType) -> TypeRef { TypeRef::ReferenceType(node) }
+impl From<ReferenceType> for Type {
+    fn from(node: ReferenceType) -> Type { Type::ReferenceType(node) }
 }
-impl From<PlaceholderType> for TypeRef {
-    fn from(node: PlaceholderType) -> TypeRef { TypeRef::PlaceholderType(node) }
+impl From<PlaceholderType> for Type {
+    fn from(node: PlaceholderType) -> Type { Type::PlaceholderType(node) }
 }
-impl From<FnPointerType> for TypeRef {
-    fn from(node: FnPointerType) -> TypeRef { TypeRef::FnPointerType(node) }
+impl From<FnPointerType> for Type {
+    fn from(node: FnPointerType) -> Type { Type::FnPointerType(node) }
 }
-impl From<ForType> for TypeRef {
-    fn from(node: ForType) -> TypeRef { TypeRef::ForType(node) }
+impl From<ForType> for Type {
+    fn from(node: ForType) -> Type { Type::ForType(node) }
 }
-impl From<ImplTraitType> for TypeRef {
-    fn from(node: ImplTraitType) -> TypeRef { TypeRef::ImplTraitType(node) }
+impl From<ImplTraitType> for Type {
+    fn from(node: ImplTraitType) -> Type { Type::ImplTraitType(node) }
 }
-impl From<DynTraitType> for TypeRef {
-    fn from(node: DynTraitType) -> TypeRef { TypeRef::DynTraitType(node) }
+impl From<DynTraitType> for Type {
+    fn from(node: DynTraitType) -> Type { Type::DynTraitType(node) }
 }
-impl AstNode for TypeRef {
+impl AstNode for Type {
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
             PAREN_TYPE | TUPLE_TYPE | NEVER_TYPE | PATH_TYPE | POINTER_TYPE | ARRAY_TYPE
@@ -2897,38 +2897,38 @@ impl AstNode for TypeRef {
     }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         let res = match syntax.kind() {
-            PAREN_TYPE => TypeRef::ParenType(ParenType { syntax }),
-            TUPLE_TYPE => TypeRef::TupleType(TupleType { syntax }),
-            NEVER_TYPE => TypeRef::NeverType(NeverType { syntax }),
-            PATH_TYPE => TypeRef::PathType(PathType { syntax }),
-            POINTER_TYPE => TypeRef::PointerType(PointerType { syntax }),
-            ARRAY_TYPE => TypeRef::ArrayType(ArrayType { syntax }),
-            SLICE_TYPE => TypeRef::SliceType(SliceType { syntax }),
-            REFERENCE_TYPE => TypeRef::ReferenceType(ReferenceType { syntax }),
-            PLACEHOLDER_TYPE => TypeRef::PlaceholderType(PlaceholderType { syntax }),
-            FN_POINTER_TYPE => TypeRef::FnPointerType(FnPointerType { syntax }),
-            FOR_TYPE => TypeRef::ForType(ForType { syntax }),
-            IMPL_TRAIT_TYPE => TypeRef::ImplTraitType(ImplTraitType { syntax }),
-            DYN_TRAIT_TYPE => TypeRef::DynTraitType(DynTraitType { syntax }),
+            PAREN_TYPE => Type::ParenType(ParenType { syntax }),
+            TUPLE_TYPE => Type::TupleType(TupleType { syntax }),
+            NEVER_TYPE => Type::NeverType(NeverType { syntax }),
+            PATH_TYPE => Type::PathType(PathType { syntax }),
+            POINTER_TYPE => Type::PointerType(PointerType { syntax }),
+            ARRAY_TYPE => Type::ArrayType(ArrayType { syntax }),
+            SLICE_TYPE => Type::SliceType(SliceType { syntax }),
+            REFERENCE_TYPE => Type::ReferenceType(ReferenceType { syntax }),
+            PLACEHOLDER_TYPE => Type::PlaceholderType(PlaceholderType { syntax }),
+            FN_POINTER_TYPE => Type::FnPointerType(FnPointerType { syntax }),
+            FOR_TYPE => Type::ForType(ForType { syntax }),
+            IMPL_TRAIT_TYPE => Type::ImplTraitType(ImplTraitType { syntax }),
+            DYN_TRAIT_TYPE => Type::DynTraitType(DynTraitType { syntax }),
             _ => return None,
         };
         Some(res)
     }
     fn syntax(&self) -> &SyntaxNode {
         match self {
-            TypeRef::ParenType(it) => &it.syntax,
-            TypeRef::TupleType(it) => &it.syntax,
-            TypeRef::NeverType(it) => &it.syntax,
-            TypeRef::PathType(it) => &it.syntax,
-            TypeRef::PointerType(it) => &it.syntax,
-            TypeRef::ArrayType(it) => &it.syntax,
-            TypeRef::SliceType(it) => &it.syntax,
-            TypeRef::ReferenceType(it) => &it.syntax,
-            TypeRef::PlaceholderType(it) => &it.syntax,
-            TypeRef::FnPointerType(it) => &it.syntax,
-            TypeRef::ForType(it) => &it.syntax,
-            TypeRef::ImplTraitType(it) => &it.syntax,
-            TypeRef::DynTraitType(it) => &it.syntax,
+            Type::ParenType(it) => &it.syntax,
+            Type::TupleType(it) => &it.syntax,
+            Type::NeverType(it) => &it.syntax,
+            Type::PathType(it) => &it.syntax,
+            Type::PointerType(it) => &it.syntax,
+            Type::ArrayType(it) => &it.syntax,
+            Type::SliceType(it) => &it.syntax,
+            Type::ReferenceType(it) => &it.syntax,
+            Type::PlaceholderType(it) => &it.syntax,
+            Type::FnPointerType(it) => &it.syntax,
+            Type::ForType(it) => &it.syntax,
+            Type::ImplTraitType(it) => &it.syntax,
+            Type::DynTraitType(it) => &it.syntax,
         }
     }
 }
@@ -3234,6 +3234,39 @@ impl AstNode for Expr {
         }
     }
 }
+impl From<Struct> for AdtDef {
+    fn from(node: Struct) -> AdtDef { AdtDef::Struct(node) }
+}
+impl From<Enum> for AdtDef {
+    fn from(node: Enum) -> AdtDef { AdtDef::Enum(node) }
+}
+impl From<Union> for AdtDef {
+    fn from(node: Union) -> AdtDef { AdtDef::Union(node) }
+}
+impl AstNode for AdtDef {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        match kind {
+            STRUCT | ENUM | UNION => true,
+            _ => false,
+        }
+    }
+    fn cast(syntax: SyntaxNode) -> Option<Self> {
+        let res = match syntax.kind() {
+            STRUCT => AdtDef::Struct(Struct { syntax }),
+            ENUM => AdtDef::Enum(Enum { syntax }),
+            UNION => AdtDef::Union(Union { syntax }),
+            _ => return None,
+        };
+        Some(res)
+    }
+    fn syntax(&self) -> &SyntaxNode {
+        match self {
+            AdtDef::Struct(it) => &it.syntax,
+            AdtDef::Enum(it) => &it.syntax,
+            AdtDef::Union(it) => &it.syntax,
+        }
+    }
+}
 impl From<Fn> for AssocItem {
     fn from(node: Fn) -> AssocItem { AssocItem::Fn(node) }
 }
@@ -3366,45 +3399,12 @@ impl AstNode for Stmt {
         }
     }
 }
-impl From<Struct> for AdtDef {
-    fn from(node: Struct) -> AdtDef { AdtDef::Struct(node) }
-}
-impl From<Enum> for AdtDef {
-    fn from(node: Enum) -> AdtDef { AdtDef::Enum(node) }
-}
-impl From<Union> for AdtDef {
-    fn from(node: Union) -> AdtDef { AdtDef::Union(node) }
-}
-impl AstNode for AdtDef {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        match kind {
-            STRUCT | ENUM | UNION => true,
-            _ => false,
-        }
-    }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
-        let res = match syntax.kind() {
-            STRUCT => AdtDef::Struct(Struct { syntax }),
-            ENUM => AdtDef::Enum(Enum { syntax }),
-            UNION => AdtDef::Union(Union { syntax }),
-            _ => return None,
-        };
-        Some(res)
-    }
-    fn syntax(&self) -> &SyntaxNode {
-        match self {
-            AdtDef::Struct(it) => &it.syntax,
-            AdtDef::Enum(it) => &it.syntax,
-            AdtDef::Union(it) => &it.syntax,
-        }
-    }
-}
 impl std::fmt::Display for Item {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self.syntax(), f)
     }
 }
-impl std::fmt::Display for TypeRef {
+impl std::fmt::Display for Type {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self.syntax(), f)
     }
@@ -3420,6 +3420,11 @@ impl std::fmt::Display for FieldList {
     }
 }
 impl std::fmt::Display for Expr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl std::fmt::Display for AdtDef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self.syntax(), f)
     }
@@ -3440,11 +3445,6 @@ impl std::fmt::Display for GenericParam {
     }
 }
 impl std::fmt::Display for Stmt {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(self.syntax(), f)
-    }
-}
-impl std::fmt::Display for AdtDef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self.syntax(), f)
     }

--- a/crates/ra_syntax/src/ast/make.rs
+++ b/crates/ra_syntax/src/ast/make.rs
@@ -17,7 +17,7 @@ pub fn name_ref(text: &str) -> ast::NameRef {
     ast_from_text(&format!("fn f() {{ {}; }}", text))
 }
 
-pub fn type_ref(text: &str) -> ast::TypeRef {
+pub fn type_ref(text: &str) -> ast::Type {
     ast_from_text(&format!("impl {} for D {{}};", text))
 }
 
@@ -75,7 +75,7 @@ pub fn record_field(name: ast::NameRef, expr: Option<ast::Expr>) -> ast::RecordE
     }
 }
 
-pub fn record_field_def(name: ast::NameRef, ty: ast::TypeRef) -> ast::RecordField {
+pub fn record_field_def(name: ast::NameRef, ty: ast::Type) -> ast::RecordField {
     ast_from_text(&format!("struct S {{ {}: {}, }}", name, ty))
 }
 

--- a/crates/ra_syntax/src/ast/node_ext.rs
+++ b/crates/ra_syntax/src/ast/node_ext.rs
@@ -82,7 +82,7 @@ impl ast::Attr {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PathSegmentKind {
     Name(ast::NameRef),
-    Type { type_ref: Option<ast::TypeRef>, trait_ref: Option<ast::PathType> },
+    Type { type_ref: Option<ast::Type>, trait_ref: Option<ast::PathType> },
     SelfKw,
     SuperKw,
     CrateKw,
@@ -108,8 +108,8 @@ impl ast::PathSegment {
                     // <T> or <T as Trait>
                     // T is any TypeRef, Trait has to be a PathType
                     let mut type_refs =
-                        self.syntax().children().filter(|node| ast::TypeRef::can_cast(node.kind()));
-                    let type_ref = type_refs.next().and_then(ast::TypeRef::cast);
+                        self.syntax().children().filter(|node| ast::Type::can_cast(node.kind()));
+                    let type_ref = type_refs.next().and_then(ast::Type::cast);
                     let trait_ref = type_refs.next().and_then(ast::PathType::cast);
                     PathSegmentKind::Type { type_ref, trait_ref }
                 }
@@ -136,21 +136,21 @@ impl ast::UseTreeList {
 }
 
 impl ast::Impl {
-    pub fn target_type(&self) -> Option<ast::TypeRef> {
+    pub fn target_type(&self) -> Option<ast::Type> {
         match self.target() {
             (Some(t), None) | (_, Some(t)) => Some(t),
             _ => None,
         }
     }
 
-    pub fn target_trait(&self) -> Option<ast::TypeRef> {
+    pub fn target_trait(&self) -> Option<ast::Type> {
         match self.target() {
             (Some(t), Some(_)) => Some(t),
             _ => None,
         }
     }
 
-    fn target(&self) -> (Option<ast::TypeRef>, Option<ast::TypeRef>) {
+    fn target(&self) -> (Option<ast::Type>, Option<ast::Type>) {
         let mut types = support::children(self.syntax());
         let first = types.next();
         let second = types.next();

--- a/crates/ra_syntax/src/lib.rs
+++ b/crates/ra_syntax/src/lib.rs
@@ -194,7 +194,7 @@ impl ast::Item {
     }
 }
 
-impl ast::TypeRef {
+impl ast::Type {
     /// Returns `text`, parsed as an type reference, but only if it has no errors.
     pub fn parse(text: &str) -> Result<Self, ()> {
         parsing::parse_text_fragment(text, ra_parser::FragmentKind::Type)

--- a/crates/ra_syntax/src/tests.rs
+++ b/crates/ra_syntax/src/tests.rs
@@ -98,7 +98,7 @@ fn type_parser_tests() {
     fragment_parser_dir_test(
         &["parser/fragments/type/ok"],
         &["parser/fragments/type/err"],
-        crate::ast::TypeRef::parse,
+        crate::ast::Type::parse,
     );
 }
 

--- a/xtask/src/codegen/gen_syntax.rs
+++ b/xtask/src/codegen/gen_syntax.rs
@@ -476,7 +476,13 @@ impl Field {
                 };
                 format_ident!("{}_token", name)
             }
-            Field::Node { name, .. } => format_ident!("{}", name),
+            Field::Node { name, .. } => {
+                if name == "type" {
+                    format_ident!("ty")
+                } else {
+                    format_ident!("{}", name)
+                }
+            }
         }
     }
     fn ty(&self) -> proc_macro2::Ident {

--- a/xtask/src/codegen/rust.ungram
+++ b/xtask/src/codegen/rust.ungram
@@ -61,22 +61,22 @@ ParamList =
 SelfParam =
   Attr* (
     ('&' 'lifetime'?)? 'mut'? 'self'
-  | 'mut'? 'self' ':' ty:TypeRef
+  | 'mut'? 'self' ':' Type
   )
 
 Param =
   Attr* (
-    Pat (':' ty:TypeRef)
-  | ty:TypeRef
+    Pat (':' Type)
+  | Type
   | '...'
   )
 
 RetType =
-  '->' ty:TypeRef
+  '->' Type
 
 TypeAlias =
   Attr* Visibility? 'default'? 'type' Name GenericParamList? (':' TypeBoundList?)? WhereClause?
-  '=' ty:TypeRef ';'
+  '=' Type ';'
 
 Struct =
   Attr* Visibility? 'struct' Name GenericParamList? (
@@ -88,13 +88,13 @@ RecordFieldList =
  '{' fields:(RecordField (',' RecordField)* ','?)? '}'
 
 RecordField =
-  Attr* Visibility? Name ':' ty:TypeRef
+  Attr* Visibility? Name ':' Type
 
 TupleFieldList =
   '(' fields:(TupleField (',' TupleField)* ','?)? ')'
 
 TupleField =
-  Attr* Visibility? ty:TypeRef
+  Attr* Visibility? Type
 
 FieldList =
   RecordFieldList
@@ -120,11 +120,11 @@ AdtDef =
 | Union
 
 Const =
-  Attr* Visibility? 'default'? 'const' (Name | '_') ':' ty:TypeRef
+  Attr* Visibility? 'default'? 'const' (Name | '_') ':' Type
   '=' body:Expr ';'
 
 Static =
-  Attr* Visibility? 'static'? 'mut'? Name ':' ty:TypeRef
+  Attr* Visibility? 'static'? 'mut'? Name ':' Type
   '=' body:Expr ';'
 
 Trait =
@@ -144,8 +144,8 @@ AssocItem =
 Impl =
  Attr* Visibility?
  'default'? 'unsafe'? 'impl' 'const'? GenericParamList? (
-   TypeRef
- | '!'? TypeRef 'for' TypeRef
+   Type
+ | '!'? Type 'for' Type
  ) WhereClause?
  AssocItemList
 
@@ -168,10 +168,10 @@ GenericParam =
 
 TypeParam =
   Attr* Name (':' TypeBoundList?)?
-  ('=' default_type:TypeRef)?
+  ('=' default_type:Type)?
 
 ConstParam =
-  Attr* 'const' Name ':' ty:TypeRef
+  Attr* 'const' Name ':' Type
   ('=' default_val:Expr)?
 
 LifetimeParam =
@@ -188,7 +188,7 @@ Visibility =
 Attr =
   '#' '!'? '[' Path ('=' Literal | TokenTree)? ']'
 
-TypeRef =
+Type =
   ParenType
 | TupleType
 | NeverType
@@ -204,10 +204,10 @@ TypeRef =
 | DynTraitType
 
 ParenType =
-  '(' ty:TypeRef ')'
+  '(' Type ')'
 
 TupleType =
-  '(' fields:TypeRef* ')'
+  '(' fields:Type* ')'
 
 NeverType =
   '!'
@@ -216,16 +216,16 @@ PathType =
   Path
 
 PointerType =
-  '*' ('const' | 'mut') ty:TypeRef
+  '*' ('const' | 'mut') Type
 
 ArrayType =
-  '[' ty:TypeRef ';' Expr ']'
+  '[' Type ';' Expr ']'
 
 SliceType =
-  '[' ty:TypeRef ']'
+  '[' Type ']'
 
 ReferenceType =
-  '&' 'lifetime'? 'mut'? ty:TypeRef
+  '&' 'lifetime'? 'mut'? Type
 
 PlaceholderType =
    '_'
@@ -234,7 +234,7 @@ FnPointerType =
    Abi 'unsafe'? 'fn' ParamList RetType?
 
 ForType =
-   'for' GenericParamList ty:TypeRef
+   'for' GenericParamList Type
 
 ImplTraitType =
   'impl' TypeBoundList
@@ -322,7 +322,7 @@ TryExpr =
   Attr* Expr '?'
 
 CastExpr =
-  Attr* Expr 'as' ty:TypeRef
+  Attr* Expr 'as' Type
 
 RefExpr =
   Attr* '&' ('raw' | 'mut' | 'const') Expr
@@ -444,13 +444,13 @@ MacroStmts =
   Expr?
 
 TypeBound =
-  'lifetime' | 'const'? TypeRef
+  'lifetime' | 'const'? Type
 
 TypeBoundList =
    bounds:TypeBound*
 
 WherePred =
-  ('for' GenericParamList)?  ('lifetime' | TypeRef) ':' TypeBoundList
+  ('for' GenericParamList)?  ('lifetime' | Type) ':' TypeBoundList
 
 WhereClause =
   'where' predicates:WherePred*
@@ -459,7 +459,7 @@ ExprStmt =
   Attr* Expr ';'
 
 LetStmt =
-  Attr* 'let' Pat (':' ty:TypeRef)
+  Attr* 'let' Pat (':' Type)
   '=' initializer:Expr ';'
 
 Path =
@@ -478,10 +478,10 @@ TypeArgList =
   '>'
 
 TypeArg =
-  TypeRef
+  Type
 
 AssocTypeArg =
-  NameRef (':' TypeBoundList | '=' TypeRef)
+  NameRef (':' TypeBoundList | '=' Type)
 
 LifetimeArg =
   'lifetime'

--- a/xtask/src/codegen/rust.ungram
+++ b/xtask/src/codegen/rust.ungram
@@ -114,6 +114,11 @@ Union =
   Attr* Visibility? 'union' Name GenericParamList? WhereClause?
   RecordFieldList
 
+AdtDef =
+  Struct
+| Enum
+| Union
+
 Const =
   Attr* Visibility? 'default'? 'const' (Name | '_') ':' ty:TypeRef
   '=' body:Expr ';'
@@ -182,6 +187,21 @@ Visibility =
 
 Attr =
   '#' '!'? '[' Path ('=' Literal | TokenTree)? ']'
+
+TypeRef =
+  ParenType
+| TupleType
+| NeverType
+| PathType
+| PointerType
+| ArrayType
+| SliceType
+| ReferenceType
+| PlaceholderType
+| FnPointerType
+| ForType
+| ImplTraitType
+| DynTraitType
 
 ParenType =
   '(' ty:TypeRef ')'
@@ -468,26 +488,6 @@ LifetimeArg =
 
 ConstArg =
   Literal | BlockExpr BlockExpr
-
-AdtDef =
-  Struct
-| Enum
-| Union
-
-TypeRef =
-  ParenType
-| TupleType
-| NeverType
-| PathType
-| PointerType
-| ArrayType
-| SliceType
-| ReferenceType
-| PlaceholderType
-| FnPointerType
-| ForType
-| ImplTraitType
-| DynTraitType
 
 Stmt =
   LetStmt


### PR DESCRIPTION
The TypeRef name comes from IntelliJ days, where you often have both
type *syntax* as well as *semantical* representation of types in
scope. And naming both Type is confusing.

In rust-analyzer however, we use ast types as `ast::Type`, and have
many more semantic counterparts to ast types, so avoiding name clash
here is just confusing.



bors r+
🤖