### PR TITLE
Finalize Types grammar

### DIFF
--- a/crates/ra_hir_def/src/type_ref.rs
+++ b/crates/ra_hir_def/src/type_ref.rs
@@ -1,6 +1,5 @@
 //! HIR for references to types. Paths in these are not yet resolved. They can
 //! be directly created from an ast::TypeRef, without further queries.
-
 use ra_syntax::ast::{self};
 
 use crate::{body::LowerCtx, path::Path};

--- a/crates/ra_syntax/src/ast/generated/nodes.rs
+++ b/crates/ra_syntax/src/ast/generated/nodes.rs
@@ -605,8 +605,10 @@ pub struct FnPointerType {
     pub(crate) syntax: SyntaxNode,
 }
 impl FnPointerType {
-    pub fn abi(&self) -> Option<Abi> { support::child(&self.syntax) }
+    pub fn const_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![const]) }
+    pub fn async_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![async]) }
     pub fn unsafe_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![unsafe]) }
+    pub fn abi(&self) -> Option<Abi> { support::child(&self.syntax) }
     pub fn fn_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![fn]) }
     pub fn param_list(&self) -> Option<ParamList> { support::child(&self.syntax) }
     pub fn ret_type(&self) -> Option<RetType> { support::child(&self.syntax) }

--- a/xtask/src/codegen/rust.ungram
+++ b/xtask/src/codegen/rust.ungram
@@ -231,7 +231,7 @@ InferType =
    '_'
 
 FnPointerType =
-   Abi 'unsafe'? 'fn' ParamList RetType?
+   'const'? 'async'? 'unsafe'? Abi? 'fn' ParamList RetType?
 
 ForType =
    'for' GenericParamList Type


### PR DESCRIPTION
Note that `for` type is rust-analyzer's own invention.
Both the reference and syn allow `for` only for fnptr types, and we
allow them everywhere. This needs to be checked with respect to type
bounds grammar...



bors r+
🤖