### PR TITLE
Replace cargo-audit  with cargo-deny

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,19 +16,12 @@ env:
   RUSTUP_MAX_RETRIES: 10
 
 jobs:
-  # rust-audit:
-  #   name: Audit Rust vulnerabilities
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - name: Checkout repository
-  #     uses: actions/checkout@v2
-
-  #   - uses: actions-rs/install@v0.1
-  #     with:
-  #       crate: cargo-audit
-  #       use-tool-cache: true
-
-  #   - run: cargo audit
+  cargo-deny-check:
+    name: Audit Rust codebase
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: EmbarkStudios/cargo-deny-action@v1
 
   rust:
     name: Rust

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,56 @@
+# See docs: https://embarkstudios.github.io/cargo-deny/checks/index.html
+
+[advisories]
+vulnerability = "deny"
+unmaintained = "deny"
+yanked = "deny"
+notice = "deny"
+ignore = [
+    # This crate is used through `vfs-notify`.
+    #
+    # Original error message:
+    # The [`net2`](https://crates.io/crates/net2) crate has been deprecated
+    # and users are encouraged to considered [`socket2`](https://crates.io/crates/socket2) instead.
+    "RUSTSEC-2020-0016"
+]
+
+[bans]
+multiple-versions = "deny"
+skip = [
+    # This older version of winapi is pulled through vfs-notify
+    { version = "=0.2.8", name = "winapi" }
+
+    # { version = "=0.42.0", name = "crate_name_here" },
+]
+skip-tree = [
+    # { version = "=0.42.0", name = "crate_name_here", depth = 6 },
+]
+deny = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []
+
+[licenses]
+unlicensed = "deny"
+copyleft = "deny"
+
+# Run `cargo deny list` to see which crates use which license
+# and add them to this array if you accept them
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "ISC",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC0-1.0",
+    "Zlib",
+]
+deny = []
+default = "deny"
+allow-osi-fsf-free = "neither"
+
+# We want really high confidence when inferring licenses from text
+confidence-threshold = 0.93

--- a/xtask/tests/tidy.rs
+++ b/xtask/tests/tidy.rs
@@ -5,7 +5,7 @@ use std::{
 
 use xtask::{
     codegen::{self, Mode},
-    not_bash::{fs2, run},
+    not_bash::fs2,
     project_root, run_rustfmt, rust_files,
 };
 
@@ -62,42 +62,6 @@ See https://github.com/rust-lang/rust-clippy/issues/5537 for discussion.
             path.display()
         )
     }
-}
-
-#[test]
-fn check_licenses() {
-    let expected = "
-0BSD OR MIT OR Apache-2.0
-Apache-2.0 OR BSL-1.0
-Apache-2.0 OR MIT
-Apache-2.0/MIT
-BSD-2-Clause
-BSD-3-Clause
-CC0-1.0
-ISC
-MIT
-MIT / Apache-2.0
-MIT OR Apache-2.0
-MIT/Apache-2.0
-MIT/Apache-2.0 AND BSD-2-Clause
-Unlicense OR MIT
-Unlicense/MIT
-Zlib
-"
-    .lines()
-    .filter(|it| !it.is_empty())
-    .collect::<Vec<_>>();
-
-    let meta = run!("cargo metadata --format-version 1"; echo = false).unwrap();
-    let mut licenses = meta
-        .split(|c| c == ',' || c == '{' || c == '}')
-        .filter(|it| it.contains(r#""license""#))
-        .map(|it| it.trim())
-        .map(|it| it[r#""license":"#.len()..].trim_matches('"'))
-        .collect::<Vec<_>>();
-    licenses.sort();
-    licenses.dedup();
-    assert_eq!(licenses, expected);
 }
 
 fn check_todo(path: &Path, text: &str) {


### PR DESCRIPTION
`cargo-audit` is likely going to be replaced with `cargo-deny`
See this issue: https://github.com/EmbarkStudios/cargo-deny/issues/194