### PR TITLE
Add track_env_var to the proc macro server

### DIFF
--- a/crates/proc_macro_srv/src/proc_macro/bridge/client.rs
+++ b/crates/proc_macro_srv/src/proc_macro/bridge/client.rs
@@ -160,6 +160,7 @@ macro_rules! define_handles {
 }
 define_handles! {
     'owned:
+    FreeFunctions,
     TokenStream,
     TokenStreamBuilder,
     TokenStreamIter,

--- a/crates/proc_macro_srv/src/proc_macro/bridge/mod.rs
+++ b/crates/proc_macro_srv/src/proc_macro/bridge/mod.rs
@@ -57,6 +57,10 @@ use std::thread;
 macro_rules! with_api {
     ($S:ident, $self:ident, $m:ident) => {
         $m! {
+            FreeFunctions {
+                fn drop($self: $S::FreeFunctions);
+                fn track_env_var(var: &str, value: Option<&str>);
+            },
             TokenStream {
                 fn drop($self: $S::TokenStream);
                 fn clone($self: &$S::TokenStream) -> $S::TokenStream;

--- a/crates/proc_macro_srv/src/proc_macro/bridge/server.rs
+++ b/crates/proc_macro_srv/src/proc_macro/bridge/server.rs
@@ -11,6 +11,8 @@ use super::client::HandleStore;
 /// Declare an associated item of one of the traits below, optionally
 /// adjusting it (i.e., adding bounds to types and default bodies to methods).
 macro_rules! associated_item {
+    (type FreeFunctions) =>
+        (type FreeFunctions: 'static;);
     (type TokenStream) =>
         (type TokenStream: 'static + Clone;);
     (type TokenStreamBuilder) =>

--- a/crates/proc_macro_srv/src/rustc_server.rs
+++ b/crates/proc_macro_srv/src/rustc_server.rs
@@ -242,6 +242,8 @@ impl TokenStreamBuilder {
     }
 }
 
+pub struct FreeFunctions;
+
 #[derive(Clone)]
 pub struct TokenStreamIter {
     trees: IntoIter<TokenTree>,
@@ -254,6 +256,7 @@ pub struct Rustc {
 }
 
 impl server::Types for Rustc {
+    type FreeFunctions = FreeFunctions;
     type TokenStream = TokenStream;
     type TokenStreamBuilder = TokenStreamBuilder;
     type TokenStreamIter = TokenStreamIter;
@@ -265,6 +268,13 @@ impl server::Types for Rustc {
     type Diagnostic = Diagnostic;
     type Span = Span;
     type MultiSpan = Vec<Span>;
+}
+
+impl server::FreeFunctions for Rustc {
+    fn track_env_var(&mut self, _var: &str, _value: Option<&str>) {
+        // FIXME: track env var accesses
+        // https://github.com/rust-lang/rust/pull/71858
+    }
 }
 
 impl server::TokenStream for Rustc {

--- a/xtask/src/install.rs
+++ b/xtask/src/install.rs
@@ -7,7 +7,7 @@ use anyhow::{bail, format_err, Context, Result};
 use crate::not_bash::{pushd, run};
 
 // Latest stable, feel free to send a PR if this lags behind.
-const REQUIRED_RUST_VERSION: u32 = 46;
+const REQUIRED_RUST_VERSION: u32 = 47;
 
 pub struct InstallCmd {
     pub client: Option<ClientOpt>,


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/74653.

Fixes #6054.
Fixes #5640, maybe.
Fixes #5773, hopefully.

Should be merged when 1.47 is released.

Proc macros still don't work for me, but it no longer crashes.

