### PR TITLE
do not add to `pub use` in assists that insert a use statement

### DIFF
--- a/crates/ra_assists/src/handlers/replace_qualified_name_with_use.rs
+++ b/crates/ra_assists/src/handlers/replace_qualified_name_with_use.rs
@@ -643,4 +643,46 @@ fn main() {
     ",
         );
     }
+
+    #[test]
+    fn does_not_replace_pub_use() {
+        check_assist(
+            replace_qualified_name_with_use,
+            r"
+pub use std::fmt;
+
+impl std::io<|> for Foo {
+}
+    ",
+            r"
+use std::io;
+
+pub use std::fmt;
+
+impl io for Foo {
+}
+    ",
+        );
+    }
+
+    #[test]
+    fn does_not_replace_pub_crate_use() {
+        check_assist(
+            replace_qualified_name_with_use,
+            r"
+pub(crate) use std::fmt;
+
+impl std::io<|> for Foo {
+}
+    ",
+            r"
+use std::io;
+
+pub(crate) use std::fmt;
+
+impl io for Foo {
+}
+    ",
+        );
+    }
 }

--- a/crates/ra_assists/src/utils/insert_use.rs
+++ b/crates/ra_assists/src/utils/insert_use.rs
@@ -4,7 +4,7 @@
 
 use hir::{self, ModPath};
 use ra_syntax::{
-    ast::{self, NameOwner},
+    ast::{self, NameOwner, VisibilityOwner},
     AstNode, Direction, SmolStr,
     SyntaxKind::{PATH, PATH_SEGMENT},
     SyntaxNode, T,
@@ -378,6 +378,7 @@ fn best_action_for_target(
     let best_action = container
         .children()
         .filter_map(ast::Use::cast)
+        .filter(|u| u.visibility().is_none())
         .filter_map(|it| it.use_tree())
         .map(|u| walk_use_tree_for_best_action(&mut storage, None, u, target))
         .fold(None, |best, a| match best {


### PR DESCRIPTION
closes #5657 , see issue for rationale

Initially I wrote a version of this that changed the signature of `insert_use_statement` to take an `Option<VisibilityKind>` and only add to use statements with the same visibility, but that didn't make sense for any of the current uses of `insert_use_statement` (they all expected private visibility).