### PR TITLE
Fix relative path handling for custom rustfmt

### DIFF
--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -709,11 +709,6 @@ pub(crate) fn handle_formatting(
         }
     };
 
-    if let Ok(path) = params.text_document.uri.to_file_path() {
-        if let Some(parent) = path.parent() {
-            rustfmt.current_dir(parent);
-        }
-    }
     let mut rustfmt = rustfmt.stdin(Stdio::piped()).stdout(Stdio::piped()).spawn()?;
 
     rustfmt.stdin.as_mut().unwrap().write_all(file.as_bytes())?;


### PR DESCRIPTION
`current_dir` and relative paths to executables works differently on
unix and windows (unix behavior does not make sense), see:

https://github.com/oconnor663/duct.rs/blob/17e30e83a16b202551df4d70d0b2cc174cb53e5d/src/lib.rs#L295-L324

The original motivation to set cwd was to make rustfmt read the
correct rustfmt.toml, but that was future proofing, rather than a bug
fix.

So, let's just remove this and see if breaks or fixes more use-cases.

If support for per-file config is needed, we could use `--config-path`
flag.



bors r+
🤖