### PR TITLE
Fix typo in settings description

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -607,7 +607,7 @@
                     "items": {
                         "type": "string"
                     },
-                    "description": "List of warnings warnings that should be displayed with hint severity.\nThe warnings will be indicated by faded text or three dots in code and will not show up in the problems panel.",
+                    "description": "List of warnings that should be displayed with hint severity.\nThe warnings will be indicated by faded text or three dots in code and will not show up in the problems panel.",
                     "default": []
                 }
             }


### PR DESCRIPTION
Remove a duplicate word from the description of the `warningsAsHint` setting.