### PR TITLE
Format docs in to_proto::markup_content

### DIFF
--- a/crates/ra_ide/src/hover.rs
+++ b/crates/ra_ide/src/hover.rs
@@ -509,6 +509,37 @@ fn main() { }
     }
 
     #[test]
+    fn hover_shows_fn_doc() {
+        check(
+            r#"
+/// # Example
+/// ```
+/// # use std::path::Path;
+/// #
+/// foo(Path::new("hello, world!"))
+/// ```
+pub fn foo<|>(_: &Path) {}
+
+fn main() { }
+"#,
+            expect![[r#"
+                *foo*
+                ```rust
+                pub fn foo(_: &Path)
+                ```
+                ___
+
+                # Example
+                ```
+                # use std::path::Path;
+                #
+                foo(Path::new("hello, world!"))
+                ```
+            "#]],
+        );
+    }
+
+    #[test]
     fn hover_shows_struct_field_info() {
         // Hovering over the field when instantiating
         check(

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -755,7 +755,8 @@ pub(crate) fn runnable(
 }
 
 pub(crate) fn markup_content(markup: Markup) -> lsp_types::MarkupContent {
-    lsp_types::MarkupContent { kind: lsp_types::MarkupKind::Markdown, value: markup.into() }
+    let value = crate::markdown::format_docs(markup.as_str());
+    lsp_types::MarkupContent { kind: lsp_types::MarkupKind::Markdown, value }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

Close #5442 

Removing # was handled in rust_analyzer::markdown::format_docs(). However, this function is no longer called in rust_analyzer::handlers::handle_hover() since commit e8bb153 (PR #5273). This pr add this formatting function back.