### PR TITLE
Display the value of a const on the hover

### DIFF
--- a/crates/ra_ide/src/display/short_label.rs
+++ b/crates/ra_ide/src/display/short_label.rs
@@ -61,7 +61,15 @@ impl ShortLabel for ast::TypeAlias {
 
 impl ShortLabel for ast::Const {
     fn short_label(&self) -> Option<String> {
-        short_label_from_ty(self, self.ty(), "const ")
+        match short_label_from_ty(self, self.ty(), "const ") {
+            Some(buf) => {
+                let mut new_buf = buf;
+                let body = self.body().unwrap();
+                format_to!(new_buf, " = {}", body.syntax());
+                Some(new_buf)
+            }
+            None => None,
+        }
     }
 }
 

--- a/crates/ra_ide/src/display/short_label.rs
+++ b/crates/ra_ide/src/display/short_label.rs
@@ -61,15 +61,11 @@ impl ShortLabel for ast::TypeAlias {
 
 impl ShortLabel for ast::Const {
     fn short_label(&self) -> Option<String> {
-        match short_label_from_ty(self, self.ty(), "const ") {
-            Some(buf) => {
-                let mut new_buf = buf;
-                let body = self.body().unwrap();
-                format_to!(new_buf, " = {}", body.syntax());
-                Some(new_buf)
-            }
-            None => None,
+        let mut new_buf = short_label_from_ty(self, self.ty(), "const ")?;
+        if let Some(expr) = self.body() {
+            format_to!(new_buf, " = {}", expr.syntax());
         }
+        Some(new_buf)
     }
 }
 

--- a/crates/ra_ide/src/hover.rs
+++ b/crates/ra_ide/src/hover.rs
@@ -590,16 +590,16 @@ fn main() {
     #[test]
     fn hover_const_static() {
         check(
-            r#"const foo<|>: u32 = 0;"#,
+            r#"const foo<|>: u32 = 123;"#,
             expect![[r#"
                 *foo*
                 ```rust
-                const foo: u32
+                const foo: u32 = 123
                 ```
             "#]],
         );
         check(
-            r#"static foo<|>: u32 = 0;"#,
+            r#"static foo<|>: u32 = 456;"#,
             expect![[r#"
                 *foo*
                 ```rust
@@ -834,7 +834,7 @@ fn main() {
             expect![[r#"
                 *C*
                 ```rust
-                const C: u32
+                const C: u32 = 1
                 ```
             "#]],
         )


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

Close #4051 

To display the value of a const, I modified the implementation of `ShortLabel` for `ast::Const`.