### PR TITLE
Log the command flycheck runs to debug misconfigurations

### DIFF
--- a/crates/flycheck/src/lib.rs
+++ b/crates/flycheck/src/lib.rs
@@ -1,4 +1,4 @@
-//! cargo_check provides the functionality needed to run `cargo check` or
+//! Flycheck provides the functionality needed to run `cargo check` or
 //! another compatible command (f.x. clippy) in a background thread and provide
 //! LSP diagnostics based on the output of the command.
 
@@ -147,6 +147,12 @@ impl FlycheckActor {
                     // avoid busy-waiting.
                     let cargo_handle = self.cargo_handle.take().unwrap();
                     let res = cargo_handle.join();
+                    if res.is_err() {
+                        log::error!(
+                            "Flycheck failed to run the following command: {:?}",
+                            self.check_command()
+                        )
+                    }
                     self.send(Message::Progress(Progress::DidFinish(res)));
                 }
                 Event::CheckEvent(Some(message)) => match message {
@@ -253,7 +259,7 @@ impl CargoHandle {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
                 format!(
-                    "Cargo watcher failed,the command produced no valid metadata (exit code: {:?})",
+                    "Cargo watcher failed, the command produced no valid metadata (exit code: {:?})",
                     exit_status
                 ),
             ));


### PR DESCRIPTION
Without this users have no clue why flycheck fails to run.
This is what is printed to the output channel:
```
[ERROR rust_analyzer::main_loop] cargo check failed: Cargo watcher failed,the command produced no valid metadata (exit code: ExitStatus(ExitStatus(25856)))
```

I stumbled with this figuring out that rust-analyzer adds `--all-features` which is not intended
for some crates in the workspace (i.e. they have mutually-exclusive features).
Having the command rust-analyzer ran should help a lot