### PR TITLE
Display snippet in the completion label

### DIFF
--- a/crates/ra_ide/src/completion/complete_snippet.rs
+++ b/crates/ra_ide/src/completion/complete_snippet.rs
@@ -36,7 +36,7 @@ pub(super) fn complete_item_snippet(acc: &mut Completions, ctx: &CompletionConte
     snippet(
         ctx,
         cap,
-        "Test module",
+        "tmod (Test module)",
         "\
 #[cfg(test)]
 mod tests {
@@ -54,7 +54,7 @@ mod tests {
     snippet(
         ctx,
         cap,
-        "Test function",
+        "tfn (Test function)",
         "\
 #[test]
 fn ${1:feature}() {
@@ -106,10 +106,10 @@ mod tests {
 }
 "#,
             expect![[r#"
-                sn Test function
-                sn Test module
                 sn macro_rules
                 sn pub(crate)
+                sn tfn (Test function)
+                sn tmod (Test module)
             "#]],
         )
     }


### PR DESCRIPTION
Before, the completion did not show the actual snippet and it was hard to understand what to input to get the right snippet:

<img width="467" alt="image" src="https://user-images.githubusercontent.com/2690773/89941040-21f6a600-dc23-11ea-94b8-61f77f88feaf.png">
<img width="367" alt="image" src="https://user-images.githubusercontent.com/2690773/89941046-23c06980-dc23-11ea-8034-6c4e14357c94.png">

Now it's more clear:

<img width="315" alt="image" src="https://user-images.githubusercontent.com/2690773/89941124-42befb80-dc23-11ea-9fcc-5fd49cc92b74.png">
<img width="210" alt="image" src="https://user-images.githubusercontent.com/2690773/89941132-4488bf00-dc23-11ea-99c2-12ec66e0a044.png">
