### PR TITLE
Completely remove cargo audit

My current feeling is that the build maintenance friction it creates
is not proportional to the benefits it provides.

We are pretty frugal with the set of Rust dependencies, and our
security model is we

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,20 +16,6 @@ env:
   RUSTUP_MAX_RETRIES: 10
 
 jobs:
-  # rust-audit:
-  #   name: Audit Rust vulnerabilities
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - name: Checkout repository
-  #     uses: actions/checkout@v2
-
-  #   - uses: actions-rs/install@v0.1
-  #     with:
-  #       crate: cargo-audit
-  #       use-tool-cache: true
-
-  #   - run: cargo audit
-
   rust:
     name: Rust
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
bors r+
🤖