### PR TITLE
Fix expand glob import bugs

### DIFF
--- a/crates/assists/src/assist_context.rs
+++ b/crates/assists/src/assist_context.rs
@@ -73,10 +73,6 @@ impl<'a> AssistContext<'a> {
         self.sema.db
     }
 
-    pub(crate) fn source_file(&self) -> &SourceFile {
-        &self.source_file
-    }
-
     // NB, this ignores active selection.
     pub(crate) fn offset(&self) -> TextSize {
         self.frange.range.start()

--- a/crates/assists/src/handlers/expand_glob_import.rs
+++ b/crates/assists/src/handlers/expand_glob_import.rs
@@ -709,7 +709,7 @@ fn qux(bar: Bar, baz: Baz) {
 
     #[test]
     fn expanding_glob_import_with_macro_defs() {
-        // TODO: this is currently fails because `Definition::find_usages` ignores macros
+        // FIXME: this is currently fails because `Definition::find_usages` ignores macros
         //       https://github.com/rust-analyzer/rust-analyzer/issues/3484
         //
         //         check_assist(

--- a/crates/assists/src/handlers/expand_glob_import.rs
+++ b/crates/assists/src/handlers/expand_glob_import.rs
@@ -98,7 +98,7 @@ impl Def {
         };
 
         let search_scope = SearchScope::single_file(ctx.frange.file_id);
-        !def.find_usages(&ctx.sema, Some(search_scope)).is_empty()
+        def.usages(&ctx.sema).in_scope(search_scope).at_least_one()
     }
 }
 

--- a/crates/assists/src/handlers/expand_glob_import.rs
+++ b/crates/assists/src/handlers/expand_glob_import.rs
@@ -183,10 +183,12 @@ fn replace_ast(
 ) {
     let existing_use_trees = match parent.clone() {
         Either::Left(_) => vec![],
-        Either::Right(u) => u.use_trees().filter(|n| 
+        Either::Right(u) => u
+            .use_trees()
+            .filter(|n|
             // filter out star
-            n.star_token().is_none()
-        ).collect(),
+            n.star_token().is_none())
+            .collect(),
     };
 
     let new_use_trees: Vec<ast::UseTree> = names_to_import

--- a/crates/ide_db/src/defs.rs
+++ b/crates/ide_db/src/defs.rs
@@ -225,7 +225,7 @@ pub fn classify_name(sema: &Semantics<RootDatabase>, name: &ast::Name) -> Option
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NameRefClass {
     ExternCrate(Crate),
     Definition(Definition),

--- a/crates/ide_db/src/defs.rs
+++ b/crates/ide_db/src/defs.rs
@@ -225,7 +225,7 @@ pub fn classify_name(sema: &Semantics<RootDatabase>, name: &ast::Name) -> Option
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum NameRefClass {
     ExternCrate(Crate),
     Definition(Definition),


### PR DESCRIPTION
fixes https://github.com/rust-analyzer/rust-analyzer/issues/5709

TODOs:
- [x] Incorrect node replacing
<details>
    <summary>Details</summary>

```rust
use crate::{
    body::scope::{ExprScopes, ScopeId},
    body::Body,
    builtin_type::BuiltinType,
    db::DefDatabase,
    expr::{ExprId, PatId},
    generics::GenericParams,
    item_scope::{BuiltinShadowMode, BUILTIN_SCOPE},
    nameres::CrateDefMap,
    path::*<|>,
    per_ns::PerNs,
    visibility::{RawVisibility, Visibility},
    AdtId, AssocContainerId, ConstId, ContainerId, DefWithBodyId, EnumId, EnumVariantId,
    FunctionId, GenericDefId, HasModule, ImplId, LocalModuleId, Lookup, ModuleDefId, ModuleId,
    StaticId, StructId, TraitId, TypeAliasId, TypeParamId, VariantId,
};
```
becames
```rust
use crate::{PathKind, name, name, ModPath};
```
</details>

- [x] Ignoring visibility
<details>
    <summary>Details</summary>

```rust
mod foo {
    mod bar {
        pub struct Bar;
    }
}

use foo::bar::*;

fn baz(bar: Bar) {}
```
becames
```rust
mod foo {
    mod bar {
        pub struct Bar;
    }
}

use foo::bar::Bar;

fn baz(bar: Bar) {}
```
although mod `bar` is private
</details>

- [x] Eating attributes