### PR TITLE
SSR: Explicitly autoderef and ref placeholders as needed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,6 +1450,7 @@ dependencies = [
  "expect",
  "hir",
  "ide_db",
+ "itertools",
  "rustc-hash",
  "syntax",
  "test_utils",

--- a/crates/ssr/Cargo.toml
+++ b/crates/ssr/Cargo.toml
@@ -12,6 +12,7 @@ doctest = false
 
 [dependencies]
 rustc-hash = "1.1.0"
+itertools = "0.9.0"
 
 text_edit = { path = "../text_edit" }
 syntax = { path = "../syntax" }

--- a/crates/ssr/src/lib.rs
+++ b/crates/ssr/src/lib.rs
@@ -21,7 +21,10 @@
 // code in the `foo` module, we'll insert just `Bar`.
 //
 // Inherent method calls should generally be written in UFCS form. e.g. `foo::Bar::baz($s, $a)` will
-// match `$s.baz($a)`, provided the method call `baz` resolves to the method `foo::Bar::baz`.
+// match `$s.baz($a)`, provided the method call `baz` resolves to the method `foo::Bar::baz`. When a
+// placeholder is the receiver of a method call in the search pattern (e.g. `$s.foo()`), but not in
+// the replacement template (e.g. `bar($s)`), then *, & and &mut will be added as needed to mirror
+// whatever autoderef and autoref was happening implicitly in the matched code.
 //
 // The scope of the search / replace will be restricted to the current selection if any, otherwise
 // it will apply to the whole workspace.

--- a/crates/ssr/src/replacing.rs
+++ b/crates/ssr/src/replacing.rs
@@ -1,6 +1,5 @@
 //! Code for applying replacement templates for matches that have previously been found.
 
-use crate::matching::Var;
 use crate::{resolving::ResolvedRule, Match, SsrMatches};
 use rustc_hash::{FxHashMap, FxHashSet};
 use syntax::ast::{self, AstToken};
@@ -114,7 +113,7 @@ impl ReplacementRenderer<'_> {
     fn render_token(&mut self, token: &SyntaxToken) {
         if let Some(placeholder) = self.rule.get_placeholder(&token) {
             if let Some(placeholder_value) =
-                self.match_info.placeholder_values.get(&Var(placeholder.ident.to_string()))
+                self.match_info.placeholder_values.get(&placeholder.ident)
             {
                 let range = &placeholder_value.range.range;
                 let mut matched_text =

--- a/crates/ssr/src/tests.rs
+++ b/crates/ssr/src/tests.rs
@@ -31,7 +31,7 @@ fn parser_two_delimiters() {
 fn parser_repeated_name() {
     assert_eq!(
         parse_error_text("foo($a, $a) ==>>"),
-        "Parse error: Name `a` repeats more than once"
+        "Parse error: Placeholder `$a` repeats more than once"
     );
 }
 

--- a/crates/ssr/src/tests.rs
+++ b/crates/ssr/src/tests.rs
@@ -1179,6 +1179,7 @@ fn replace_autoref_autoderef_capture() {
     // second, we already have a reference, so it isn't. When $a is used in a context where autoref
     // doesn't apply, we need to prefix it with `&`. Finally, we have some cases where autoderef
     // needs to be applied.
+    mark::check!(replace_autoref_autoderef_capture);
     let code = r#"
         struct Foo {}
         impl Foo {

--- a/crates/ssr/src/tests.rs
+++ b/crates/ssr/src/tests.rs
@@ -1172,3 +1172,109 @@ fn match_trait_method_call() {
     assert_matches("Bar::foo($a, $b)", code, &["v1.foo(1)", "Bar::foo(&v1, 3)", "v1_ref.foo(5)"]);
     assert_matches("Bar2::foo($a, $b)", code, &["v2.foo(2)", "Bar2::foo(&v2, 4)", "v2_ref.foo(6)"]);
 }
+
+#[test]
+fn replace_autoref_autoderef_capture() {
+    // Here we have several calls to `$a.foo()`. In the first case autoref is applied, in the
+    // second, we already have a reference, so it isn't. When $a is used in a context where autoref
+    // doesn't apply, we need to prefix it with `&`. Finally, we have some cases where autoderef
+    // needs to be applied.
+    let code = r#"
+        struct Foo {}
+        impl Foo {
+            fn foo(&self) {}
+            fn foo2(&self) {}
+        }
+        fn bar(_: &Foo) {}
+        fn main() {
+            let f = Foo {};
+            let fr = &f;
+            let fr2 = &fr;
+            let fr3 = &fr2;
+            f.foo();
+            fr.foo();
+            fr2.foo();
+            fr3.foo();
+        }
+        "#;
+    assert_ssr_transform(
+        "Foo::foo($a) ==>> bar($a)",
+        code,
+        expect![[r#"
+            struct Foo {}
+            impl Foo {
+                fn foo(&self) {}
+                fn foo2(&self) {}
+            }
+            fn bar(_: &Foo) {}
+            fn main() {
+                let f = Foo {};
+                let fr = &f;
+                let fr2 = &fr;
+                let fr3 = &fr2;
+                bar(&f);
+                bar(&*fr);
+                bar(&**fr2);
+                bar(&***fr3);
+            }
+        "#]],
+    );
+    // If the placeholder is used as the receiver of another method call, then we don't need to
+    // explicitly autoderef or autoref.
+    assert_ssr_transform(
+        "Foo::foo($a) ==>> $a.foo2()",
+        code,
+        expect![[r#"
+            struct Foo {}
+            impl Foo {
+                fn foo(&self) {}
+                fn foo2(&self) {}
+            }
+            fn bar(_: &Foo) {}
+            fn main() {
+                let f = Foo {};
+                let fr = &f;
+                let fr2 = &fr;
+                let fr3 = &fr2;
+                f.foo2();
+                fr.foo2();
+                fr2.foo2();
+                fr3.foo2();
+            }
+        "#]],
+    );
+}
+
+#[test]
+fn replace_autoref_mut() {
+    let code = r#"
+        struct Foo {}
+        impl Foo {
+            fn foo(&mut self) {}
+        }
+        fn bar(_: &mut Foo) {}
+        fn main() {
+            let mut f = Foo {};
+            f.foo();
+            let fr = &mut f;
+            fr.foo();
+        }
+        "#;
+    assert_ssr_transform(
+        "Foo::foo($a) ==>> bar($a)",
+        code,
+        expect![[r#"
+            struct Foo {}
+            impl Foo {
+                fn foo(&mut self) {}
+            }
+            fn bar(_: &mut Foo) {}
+            fn main() {
+                let mut f = Foo {};
+                bar(&mut f);
+                let fr = &mut f;
+                bar(&mut *fr);
+            }
+        "#]],
+    );
+}


### PR DESCRIPTION
Structural search replace now inserts *, & and &mut in the replacement to match any auto[de]ref in the matched code.

e.g. `$a.foo() ==>> bar($a)` might convert `x.foo()` to `bar(&mut x)`