### PR TITLE
Hacky support for fn-like proc macros

### DIFF
--- a/crates/proc_macro_api/src/lib.rs
+++ b/crates/proc_macro_api/src/lib.rs
@@ -89,9 +89,8 @@ impl ProcMacroClient {
                 macros
                     .into_iter()
                     .filter_map(|(name, kind)| {
-                        // FIXME: Support custom derive only for now.
                         match kind {
-                            ProcMacroKind::CustomDerive => {
+                            ProcMacroKind::CustomDerive | ProcMacroKind::FuncLike => {
                                 let name = SmolStr::new(&name);
                                 let expander: Arc<dyn tt::TokenExpander> =
                                     Arc::new(ProcMacroProcessExpander {
@@ -101,7 +100,8 @@ impl ProcMacroClient {
                                     });
                                 Some((name, expander))
                             }
-                            _ => None,
+                            // FIXME: Attribute macro are currently unsupported.
+                            ProcMacroKind::Attr => None,
                         }
                     })
                     .collect()


### PR DESCRIPTION
It turns out that this is all that's needed to get something like this working:

```rust
#[proc_macro]
pub fn function_like_macro(_args: TokenStream) -> TokenStream {
    TokenStream::from_str("fn fn_success() {}").unwrap()
}
```

```rust
function_like_macro!();

fn f() {
    fn_success();
}
```

The drawback is that it also makes this work, because there is no distinction between different proc macro kinds in the rest of r-a:

```rust
#[derive(function_like_macro)]
struct S {}

fn f() {
    fn_success();
}
```

Another issue is that it seems to panic, and then panic, when using this on the rustc code base, due to some issue in the inscrutable proc macro bridge code.