### PR TITLE
Fix eslint errors on .eslintrc.js and rollup.config.js

### DIFF
--- a/editors/code/.eslintignore
+++ b/editors/code/.eslintignore
@@ -1,0 +1,3 @@
+node_modules
+.eslintrc.js
+rollup.config.js


### PR DESCRIPTION
Eslint complains if these two files does not include in the `tsconfig.json`.
```
Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser.
The file does not match your project config: .eslintrc.js.
The file must be included in at least one of the projects provided.eslint
```
![image](https://user-images.githubusercontent.com/20750310/90338269-176d4f80-e01b-11ea-8710-3ea817b235d2.png)

