### PR TITLE
Fixup whitespace when adding missing impl items

### DIFF
--- a/crates/assists/src/handlers/add_missing_impl_members.rs
+++ b/crates/assists/src/handlers/add_missing_impl_members.rs
@@ -48,7 +48,6 @@ enum AddMissingImplMembersMode {
 //     fn foo(&self) -> u32 {
 //         ${0:todo!()}
 //     }
-//
 // }
 // ```
 pub(crate) fn add_missing_impl_members(acc: &mut Assists, ctx: &AssistContext) -> Option<()> {
@@ -89,8 +88,8 @@ pub(crate) fn add_missing_impl_members(acc: &mut Assists, ctx: &AssistContext) -
 // impl Trait for () {
 //     Type X = ();
 //     fn foo(&self) {}
-//     $0fn bar(&self) {}
 //
+//     $0fn bar(&self) {}
 // }
 // ```
 pub(crate) fn add_missing_default_members(acc: &mut Assists, ctx: &AssistContext) -> Option<()> {
@@ -240,15 +239,18 @@ struct S;
 
 impl Foo for S {
     fn bar(&self) {}
+
     $0type Output;
+
     const CONST: usize = 42;
+
     fn foo(&self) {
         todo!()
     }
+
     fn baz(&self) {
         todo!()
     }
-
 }"#,
         );
     }
@@ -281,10 +283,10 @@ struct S;
 
 impl Foo for S {
     fn bar(&self) {}
+
     fn foo(&self) {
         ${0:todo!()}
     }
-
 }"#,
         );
     }
@@ -599,6 +601,7 @@ trait Foo {
 struct S;
 impl Foo for S {
     $0type Output;
+
     fn foo(&self) {
         todo!()
     }
@@ -705,6 +708,58 @@ trait Tr {
 
 impl Tr for () {
     $0type Ty;
+}"#,
+        )
+    }
+
+    #[test]
+    fn test_whitespace_fixup_preserves_bad_tokens() {
+        check_assist(
+            add_missing_impl_members,
+            r#"
+trait Tr {
+    fn foo();
+}
+
+impl Tr for ()<|> {
+    +++
+}"#,
+            r#"
+trait Tr {
+    fn foo();
+}
+
+impl Tr for () {
+    fn foo() {
+        ${0:todo!()}
+    }
+    +++
+}"#,
+        )
+    }
+
+    #[test]
+    fn test_whitespace_fixup_preserves_comments() {
+        check_assist(
+            add_missing_impl_members,
+            r#"
+trait Tr {
+    fn foo();
+}
+
+impl Tr for ()<|> {
+    // very important
+}"#,
+            r#"
+trait Tr {
+    fn foo();
+}
+
+impl Tr for () {
+    fn foo() {
+        ${0:todo!()}
+    }
+    // very important
 }"#,
         )
     }

--- a/crates/assists/src/tests/generated.rs
+++ b/crates/assists/src/tests/generated.rs
@@ -82,8 +82,8 @@ trait Trait {
 impl Trait for () {
     Type X = ();
     fn foo(&self) {}
-    $0fn bar(&self) {}
 
+    $0fn bar(&self) {}
 }
 "#####,
     )
@@ -115,7 +115,6 @@ impl Trait<u32> for () {
     fn foo(&self) -> u32 {
         ${0:todo!()}
     }
-
 }
 "#####,
     )

--- a/crates/syntax/src/ast/edit.rs
+++ b/crates/syntax/src/ast/edit.rs
@@ -119,27 +119,23 @@ impl ast::AssocItemList {
 
     /// Remove extra whitespace between last item and closing curly brace.
     fn fixup_trailing_whitespace(&self) -> Option<ast::AssocItemList> {
-        let first_token_after_items = self
-            .assoc_items()
-            .last()?
-            .syntax()
-            .next_sibling_or_token()?;
-        let last_token_before_curly = self
-            .r_curly_token()?
-            .prev_sibling_or_token()?;
+        let first_token_after_items =
+            self.assoc_items().last()?.syntax().next_sibling_or_token()?;
+        let last_token_before_curly = self.r_curly_token()?.prev_sibling_or_token()?;
         if last_token_before_curly != first_token_after_items {
             // there is something more between last item and
             // right curly than just whitespace - bail out
             return None;
         }
-        let whitespace = last_token_before_curly
-            .clone()
-            .into_token()
-            .and_then(ast::Whitespace::cast)?;
+        let whitespace =
+            last_token_before_curly.clone().into_token().and_then(ast::Whitespace::cast)?;
         let text = whitespace.syntax().text();
         let newline = text.rfind("\n")?;
         let keep = tokens::WsBuilder::new(&text[newline..]);
-        Some(self.replace_children(first_token_after_items..=last_token_before_curly, std::iter::once(keep.ws().into())))
+        Some(self.replace_children(
+            first_token_after_items..=last_token_before_curly,
+            std::iter::once(keep.ws().into()),
+        ))
     }
 }
 


### PR DESCRIPTION
Generate properly formatted whitespace when adding impl items - with an empty line between items and removing extra whitespace that often appears at the end.

This is my first time working on rust analyzer so I'm not very familiar with its internal APIs. If there's a better way to do such syntax tree editing I'd be glad to hear it.