### PR TITLE
Fix StatusNotification

### DIFF
--- a/crates/rust-analyzer/src/lsp_ext.rs
+++ b/crates/rust-analyzer/src/lsp_ext.rs
@@ -237,8 +237,13 @@ pub enum Status {
     Invalid,
 }
 
+#[derive(Deserialize, Serialize)]
+pub struct StatusParams {
+    pub status: Status,
+}
+
 impl Notification for StatusNotification {
-    type Params = Status;
+    type Params = StatusParams;
     const METHOD: &'static str = "rust-analyzer/status";
 }
 

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -14,6 +14,7 @@ use crate::{
     lsp_ext,
     main_loop::Task,
 };
+use lsp_ext::StatusParams;
 
 impl GlobalState {
     pub(crate) fn update_configuration(&mut self, config: Config) {
@@ -86,7 +87,9 @@ impl GlobalState {
                 Status::Invalid => lsp_ext::Status::Invalid,
                 Status::NeedsReload => lsp_ext::Status::NeedsReload,
             };
-            self.send_notification::<lsp_ext::StatusNotification>(lsp_status);
+            self.send_notification::<lsp_ext::StatusNotification>(StatusParams {
+                status: lsp_status,
+            });
         }
     }
     pub(crate) fn fetch_workspaces(&mut self) {

--- a/docs/dev/lsp-extensions.md
+++ b/docs/dev/lsp-extensions.md
@@ -412,7 +412,13 @@ Reloads project information (that is, re-executes `cargo metadata`).
 
 **Method:** `rust-analyzer/status`
 
-**Notification:** `"loading" | "ready" | "invalid" | "needsReload"`
+**Notification:**
+
+```typescript
+interface StatusParams {
+    status: "loading" | "ready" | "invalid" | "needsReload",
+}
+```
 
 This notification is sent from server to client.
 The client can use it to display persistent status to the user (in modline).

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -36,7 +36,7 @@ export class Ctx {
 
         res.pushCleanup(client.start());
         await client.onReady();
-        client.onNotification(ra.status, (status) => res.setStatus(status));
+        client.onNotification(ra.status, (params) => res.setStatus(params.status));
         return res;
     }
 

--- a/editors/code/src/lsp_ext.ts
+++ b/editors/code/src/lsp_ext.ts
@@ -8,7 +8,10 @@ export const analyzerStatus = new lc.RequestType<null, string, void>("rust-analy
 export const memoryUsage = new lc.RequestType<null, string, void>("rust-analyzer/memoryUsage");
 
 export type Status = "loading" | "ready" | "invalid" | "needsReload";
-export const status = new lc.NotificationType<Status>("rust-analyzer/status");
+export interface StatusParams {
+    status: Status;
+}
+export const status = new lc.NotificationType<StatusParams>("rust-analyzer/status");
 
 export const reloadWorkspace = new lc.RequestType<null, null, void>("rust-analyzer/reloadWorkspace");
 


### PR DESCRIPTION
This PR fixes the following:

As per specification `params` property in [NotificationMessage ](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#notificationMessage) should be `array | object` while RA uses `"loading" | "ready" | "invalid" | "needsReload"`.