### PR TITLE
Fix missing match arm false positive

### DIFF
--- a/crates/hir_ty/src/diagnostics/expr.rs
+++ b/crates/hir_ty/src/diagnostics/expr.rs
@@ -223,10 +223,10 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
             db.body_with_source_map(self.owner.into());
 
         let match_expr_ty = match infer.type_of_expr.get(match_expr) {
-            Some(ty) => ty,
             // If we can't resolve the type of the match expression
             // we cannot perform exhaustiveness checks.
-            None => return,
+            None | Some(Ty::Unknown) => return,
+            Some(ty) => ty,
         };
 
         let cx = MatchCheckCtx { match_expr, body, infer: infer.clone(), db };

--- a/crates/hir_ty/src/diagnostics/match_check.rs
+++ b/crates/hir_ty/src/diagnostics/match_check.rs
@@ -1342,12 +1342,10 @@ fn panic(a: Category, b: Category) {
 enum Option<T> { Some(T), None }
 
 fn main() {
-    // FIXME: This is a false positive, as the `Never` type is not known here.
     // `Never` is deliberately not defined so that it's an uninferred type.
     match Option::<Never>::None {
         None => (),
         Some(never) => match never {},
-        //                   ^^^^^ Missing match arm
     }
 }
 "#,

--- a/crates/hir_ty/src/diagnostics/match_check.rs
+++ b/crates/hir_ty/src/diagnostics/match_check.rs
@@ -1335,6 +1335,25 @@ fn panic(a: Category, b: Category) {
         );
     }
 
+    #[test]
+    fn unknown_type() {
+        check_diagnostics(
+            r#"
+enum Option<T> { Some(T), None }
+
+fn main() {
+    // FIXME: This is a false positive, as the `Never` type is not known here.
+    // `Never` is deliberately not defined so that it's an uninferred type.
+    match Option::<Never>::None {
+        None => (),
+        Some(never) => match never {},
+        //                   ^^^^^ Missing match arm
+    }
+}
+"#,
+        );
+    }
+
     mod false_negatives {
         //! The implementation of match checking here is a work in progress. As we roll this out, we
         //! prefer false negatives to false positives (ideally there would be no false positives). This


### PR DESCRIPTION
If the type of the match expression is `{unknown}`, don't do exhaustiveness checks, as it could be an uninhabited type.