### PR TITLE
Don't underline function definition if self is &mut

### DIFF
--- a/crates/ide/src/syntax_highlighting.rs
+++ b/crates/ide/src/syntax_highlighting.rs
@@ -747,12 +747,6 @@ fn highlight_def(db: &RootDatabase, def: Definition) -> Highlight {
                 if func.is_unsafe(db) {
                     h |= HighlightModifier::Unsafe;
                 }
-                if let Some(self_param) = func.self_param(db) {
-                    match self_param.access(db) {
-                        hir::Access::Exclusive => h |= HighlightModifier::Mutable,
-                        hir::Access::Shared | hir::Access::Owned => (),
-                    }
-                }
                 return h;
             }
             hir::ModuleDef::Adt(hir::Adt::Struct(_)) => HighlightTag::Struct,

--- a/crates/ide/test_data/highlighting.html
+++ b/crates/ide/test_data/highlighting.html
@@ -65,7 +65,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
         <span class="self_keyword">self</span><span class="punctuation">.</span><span class="field">x</span>
     <span class="punctuation">}</span>
 
-    <span class="keyword">fn</span> <span class="function declaration mutable">qux</span><span class="punctuation">(</span><span class="operator">&</span><span class="keyword">mut</span> <span class="self_keyword mutable">self</span><span class="punctuation">)</span> <span class="punctuation">{</span>
+    <span class="keyword">fn</span> <span class="function declaration">qux</span><span class="punctuation">(</span><span class="operator">&</span><span class="keyword">mut</span> <span class="self_keyword mutable">self</span><span class="punctuation">)</span> <span class="punctuation">{</span>
         <span class="self_keyword mutable">self</span><span class="punctuation">.</span><span class="field">x</span> <span class="operator">=</span> <span class="numeric_literal">0</span><span class="punctuation">;</span>
     <span class="punctuation">}</span>
 
@@ -84,7 +84,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
         <span class="self_keyword">self</span><span class="punctuation">.</span><span class="field">x</span>
     <span class="punctuation">}</span>
 
-    <span class="keyword">fn</span> <span class="function declaration mutable">qux</span><span class="punctuation">(</span><span class="operator">&</span><span class="keyword">mut</span> <span class="self_keyword mutable">self</span><span class="punctuation">)</span> <span class="punctuation">{</span>
+    <span class="keyword">fn</span> <span class="function declaration">qux</span><span class="punctuation">(</span><span class="operator">&</span><span class="keyword">mut</span> <span class="self_keyword mutable">self</span><span class="punctuation">)</span> <span class="punctuation">{</span>
         <span class="self_keyword mutable">self</span><span class="punctuation">.</span><span class="field">x</span> <span class="operator">=</span> <span class="numeric_literal">0</span><span class="punctuation">;</span>
     <span class="punctuation">}</span>
 


### PR DESCRIPTION
The self is right there, and is already underlined, so it makes little
sense to emit even more underlines.

before:
![before](https://user-images.githubusercontent.com/1711539/90672843-0d379500-e257-11ea-840f-b0caed4410f1.png)
after:
![after](https://user-images.githubusercontent.com/1711539/90672840-0c9efe80-e257-11ea-9739-23af433841c6.png)

