### PR TITLE
Gate stream.pipeline workaround on fixed versions of node

### DIFF
--- a/editors/code/src/net.ts
+++ b/editors/code/src/net.ts
@@ -134,6 +134,14 @@ async function downloadFile(
 
     await pipeline(srcStream, destFileStream);
 
+    // Don't apply the workaround in fixed versions of nodejs, since the process
+    // freezes on them, the process waits for no-longer emitted `close` event.
+    // The fix was applied in commit 7eed9d6bcc in v13.11.0
+    // See the nodejs changelog:
+    // https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V13.md
+    const [, major, minor] = /v(\d+)\.(\d+)\.(\d+)/.exec(process.version)!;
+    if (+major > 13 || (+major === 13 && +minor >= 11)) return;
+
     await new Promise<void>(resolve => {
         destFileStream.on("close", resolve);
         destFileStream.destroy();


### PR DESCRIPTION
Fixes the symptom of https://github.com/cdr/code-server/issues/1810
Original report here: https://github.com/rust-analyzer/rust-analyzer/issues/3167#issuecomment-678390564
Thanks to @hjfreyer for precise investigation :D