### PR TITLE
Omit lenses for not runnable doctests

### DIFF
--- a/crates/ide/src/completion.rs
+++ b/crates/ide/src/completion.rs
@@ -92,7 +92,7 @@ pub use crate::completion::{
 /// already present, it should give all possible variants for the identifier at
 /// the caret. In other words, for
 ///
-/// ```no-run
+/// ```no_run
 /// fn f() {
 ///     let foo = 92;
 ///     let _ = bar<|>

--- a/crates/syntax/src/algo.rs
+++ b/crates/syntax/src/algo.rs
@@ -32,7 +32,7 @@ pub fn ancestors_at_offset(
 /// imprecise: if the cursor is strictly between two nodes of the desired type,
 /// as in
 ///
-/// ```no-run
+/// ```no_run
 /// struct Foo {}|struct Bar;
 /// ```
 ///


### PR DESCRIPTION
Ideally, we should properly parse the doctest attributes before, but since I need it for the code lens only, this way should suffice for now