### PR TITLE
Draft: Show reason for failed rename refactoring

### DIFF
--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -77,7 +77,9 @@ pub use crate::{
     hover::{HoverAction, HoverConfig, HoverGotoTypeData, HoverResult},
     inlay_hints::{InlayHint, InlayHintsConfig, InlayKind},
     markup::Markup,
-    references::{Declaration, Reference, ReferenceAccess, ReferenceKind, ReferenceSearchResult},
+    references::{
+        Declaration, Reference, ReferenceAccess, ReferenceKind, ReferenceSearchResult, RenameError,
+    },
     runnables::{Runnable, RunnableKind, TestId},
     syntax_highlighting::{
         Highlight, HighlightModifier, HighlightModifiers, HighlightTag, HighlightedRange,
@@ -490,7 +492,7 @@ impl Analysis {
         &self,
         position: FilePosition,
         new_name: &str,
-    ) -> Cancelable<Option<RangeInfo<SourceChange>>> {
+    ) -> Cancelable<Result<RangeInfo<SourceChange>, RenameError>> {
         self.with_db(|db| references::rename(db, position, new_name))
     }
 

--- a/crates/ide/src/references.rs
+++ b/crates/ide/src/references.rs
@@ -26,6 +26,7 @@ use syntax::{
 use crate::{display::TryToNav, FilePosition, FileRange, NavigationTarget, RangeInfo};
 
 pub(crate) use self::rename::rename;
+pub use self::rename::RenameError;
 
 pub use ide_db::search::{Reference, ReferenceAccess, ReferenceKind};
 

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -646,14 +646,9 @@ pub(crate) fn handle_prepare_rename(
     let _p = profile::span("handle_prepare_rename");
     let position = from_proto::file_position(&snap, params)?;
 
-    let optional_change = snap.analysis.rename(position, "dummy")?;
-    let range = match optional_change {
-        None => return Ok(None),
-        Some(it) => it.range,
-    };
-
+    let change = snap.analysis.rename(position, "dummy")??;
     let line_index = snap.analysis.file_line_index(position.file_id)?;
-    let range = to_proto::range(&line_index, range);
+    let range = to_proto::range(&line_index, change.range);
     Ok(Some(PrepareRenameResponse::Range(range)))
 }
 
@@ -672,12 +667,8 @@ pub(crate) fn handle_rename(
         .into());
     }
 
-    let optional_change = snap.analysis.rename(position, &*params.new_name)?;
-    let source_change = match optional_change {
-        None => return Ok(None),
-        Some(it) => it.info,
-    };
-    let workspace_edit = to_proto::workspace_edit(&snap, source_change)?;
+    let change = snap.analysis.rename(position, &*params.new_name)??;
+    let workspace_edit = to_proto::workspace_edit(&snap, change.info)?;
     Ok(Some(workspace_edit))
 }
 


### PR DESCRIPTION
Return an error with a meaningful message for requests to
`textDocument/rename` if the operation cannot be performed.
Pass errors, raised by rename handling code to the LSP runtime.

As a consequence, the VS Code client shows and logs the request
as if a server-side programming error occured.
Screenshot of a rename error showing in VS Code
![invalid-rename-ui](https://user-images.githubusercontent.com/607182/91059560-2c08a380-e62a-11ea-9297-f092db935a3b.png)

I would kindly ask to get feedback from the maintainers if they can spare the time:
* Is the general direction of the proposed changes acceptable?
* I'm new to Rust. The code feels clumsy and redundant, please suggest improvements
if you find the time for. E.g. is there a simple replacement for `RenameError`?
* Should presenting the error with proper severity (i.e. not as a programming error) be part of this change or in a followup change?

See https://github.com/rust-analyzer/rust-analyzer/issues/3981