### PR TITLE
Make inlay hints colors more configurable

### DIFF
--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -367,6 +367,30 @@ include::./generated_assists.adoc[]
 
 == Editor Features
 === VS Code
+
+==== Color configurations
+
+It is possible to change the foreground/background color of inlay hints. Just add this to your
+`settings.json`:
+
+[source,jsonc]
+----
+{
+  "workbench.colorCustomizations": {
+    // Name of the theme you are currently using
+    "[Default Dark+]": {
+      "rust_analyzer.inlayHints.foreground": "#868686f0",
+      "rust_analyzer.inlayHints.background": "#3d3d3d48",
+
+      // Overrides for specific kinds of inlay hints
+      "rust_analyzer.inlayHints.foreground.typeHints": "#fdb6fdf0",
+      "rust_analyzer.inlayHints.foreground.paramHints": "#fdb6fdf0",
+      "rust_analyzer.inlayHints.background.chainingHints": "#6b0c0c81"
+    }
+  }
+}
+----
+
 ==== Special `when` clause context for keybindings.
 You may use `inRustProject` context to configure keybindings for rust projects only. For example:
 [source,json]

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -712,12 +712,75 @@
         ],
         "colors": [
             {
-                "id": "rust_analyzer.inlayHint",
-                "description": "Color for inlay hints",
+                "id": "rust_analyzer.inlayHints.foreground",
+                "description": "Foreground color of inlay hints (is overriden by more specific rust_analyzer.inlayHints.foreground.* configurations)",
                 "defaults": {
                     "dark": "#A0A0A0F0",
                     "light": "#747474",
                     "highContrast": "#BEBEBE"
+                }
+            },
+            {
+                "id": "rust_analyzer.inlayHints.background",
+                "description": "Background color of inlay hints (is overriden by more specific rust_analyzer.inlayHints.background.* configurations)",
+                "defaults": {
+                    "dark": "#11223300",
+                    "light": "#11223300",
+                    "highContrast": "#11223300"
+                }
+            },
+            {
+                "id": "rust_analyzer.inlayHints.foreground.typeHints",
+                "description": "Foreground color of inlay type hints for variables (overrides rust_analyzer.inlayHints.foreground)",
+                "defaults": {
+                    "dark": "rust_analyzer.inlayHints.foreground",
+                    "light": "rust_analyzer.inlayHints.foreground",
+                    "highContrast": "rust_analyzer.inlayHints.foreground"
+                }
+            },
+            {
+                "id": "rust_analyzer.inlayHints.foreground.chainingHints",
+                "description": "Foreground color of inlay type hints for method chains (overrides rust_analyzer.inlayHints.foreground)",
+                "defaults": {
+                    "dark": "rust_analyzer.inlayHints.foreground",
+                    "light": "rust_analyzer.inlayHints.foreground",
+                    "highContrast": "rust_analyzer.inlayHints.foreground"
+                }
+            },
+            {
+                "id": "rust_analyzer.inlayHints.foreground.parameterHints",
+                "description": "Foreground color of function parameter name inlay hints at the call site (overrides rust_analyzer.inlayHints.foreground)",
+                "defaults": {
+                    "dark": "rust_analyzer.inlayHints.foreground",
+                    "light": "rust_analyzer.inlayHints.foreground",
+                    "highContrast": "rust_analyzer.inlayHints.foreground"
+                }
+            },
+            {
+                "id": "rust_analyzer.inlayHints.background.typeHints",
+                "description": "Background color of inlay type hints for variables (overrides rust_analyzer.inlayHints.background)",
+                "defaults": {
+                    "dark": "rust_analyzer.inlayHints.background",
+                    "light": "rust_analyzer.inlayHints.background",
+                    "highContrast": "rust_analyzer.inlayHints.background"
+                }
+            },
+            {
+                "id": "rust_analyzer.inlayHints.background.chainingHints",
+                "description": "Background color of inlay type hints for method chains (overrides rust_analyzer.inlayHints.background)",
+                "defaults": {
+                    "dark": "rust_analyzer.inlayHints.background",
+                    "light": "rust_analyzer.inlayHints.background",
+                    "highContrast": "rust_analyzer.inlayHints.background"
+                }
+            },
+            {
+                "id": "rust_analyzer.inlayHints.background.parameterHints",
+                "description": "Background color of function parameter name inlay hints at the call site (overrides rust_analyzer.inlayHints.background)",
+                "defaults": {
+                    "dark": "rust_analyzer.inlayHints.background",
+                    "light": "rust_analyzer.inlayHints.background",
+                    "highContrast": "rust_analyzer.inlayHints.background"
                 }
             },
             {


### PR DESCRIPTION
**[BREAKING CHANGE]**

Tackles https://github.com/rust-analyzer/rust-analyzer/issues/5337#issuecomment-680018601 and generally related to #5337.

Added `foreground/background` color configurations with optional more specific overrides `foreground.(type|parameter|chaining)Hints`.

One problem I see is that the config keys are long and don't fit into the on-hover hints in the `settings.json` file entirely...

<details>
<summary>Demo</summary>

![demo](https://user-images.githubusercontent.com/36276403/91238334-77fc3b00-e745-11ea-836b-2822015ece98.gif)

</details>