### PR TITLE
Allow running a test as a binary

### DIFF
--- a/crates/rust-analyzer/src/cargo_target_spec.rs
+++ b/crates/rust-analyzer/src/cargo_target_spec.rs
@@ -72,7 +72,11 @@ impl CargoTargetSpec {
                 extra_args.push("--nocapture".to_string());
             }
             RunnableKind::Bin => {
-                args.push("run".to_string());
+                let subcommand = match spec {
+                    Some(CargoTargetSpec { target_kind: TargetKind::Test, .. }) => "test",
+                    _ => "run",
+                };
+                args.push(subcommand.to_string());
                 if let Some(spec) = spec {
                     spec.push_to(&mut args, kind);
                 }

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -1399,7 +1399,10 @@ fn should_skip_target(runnable: &Runnable, cargo_spec: Option<&CargoTargetSpec>)
         RunnableKind::Bin => {
             // Do not suggest binary run on other target than binary
             match &cargo_spec {
-                Some(spec) => !matches!(spec.target_kind, TargetKind::Bin | TargetKind::Example),
+                Some(spec) => !matches!(
+                    spec.target_kind,
+                    TargetKind::Bin | TargetKind::Example | TargetKind::Test
+                ),
                 None => true,
             }
         }


### PR DESCRIPTION
If a test uses `harness = false`, it just contains an `fn main` that is executed via `cargo test`. This adds support for that.

Note though that Cargo doesn't actually tell us whether `harness = false`, so this hint will always show up when you put an `fn main` into an integration test. Normally people shouldn't be doing that if they do use the harness though.