### PR TITLE
Add rust-analyzer.checkOnSave.target to package.json

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -350,6 +350,14 @@
                     "default": null,
                     "description": "List of features to activate. Defaults to `rust-analyzer.cargo.features`."
                 },
+                "rust-analyzer.checkOnSave.target": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "default": null,
+                    "description": "Check for a specific target. Defaults to `rust-analyzer.cargo.target`."
+                },
                 "rust-analyzer.cargoRunner": {
                     "type": [
                         "null",


### PR DESCRIPTION
This was already implemented, but it's missing from the manifest.