### PR TITLE
Remove fixme from inlay_hints.ts

### DIFF
--- a/editors/code/src/inlay_hints.ts
+++ b/editors/code/src/inlay_hints.ts
@@ -111,7 +111,6 @@ class HintsUpdater implements Disposable {
     }
 
     syncCacheAndRenderHints() {
-        // FIXME: make inlayHints request pass an array of files?
         this.sourceFiles.forEach((file, uri) => this.fetchHints(file).then(hints => {
             if (!hints) return;
 


### PR DESCRIPTION
I have reevaluated the fixme and it doesn't seem necessary to pass an array of files
to the inlay hints request.
This will (a) make the request more compilcated (b), make us wait for
inlay hints for `all` active editors resolve at once before rendering and (c)
doesn't seem required because 99% of the time there is a single active editor
in the IDE