### PR TITLE
Add flexible configuration for runnables

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -128,8 +128,8 @@ pub enum RustfmtConfig {
 /// Configuration for runnable items, such as `main` function or tests.
 #[derive(Debug, Clone, Default)]
 pub struct RunnablesConfig {
-    /// Stuff to be inserted before `cargo`, e.g. `RUST_LOG=info`.
-    pub cargo_prefix: Vec<String>,
+    /// Custom command to be executed instead of `cargo` for runnables.
+    pub override_cargo: Option<String>,
     /// Additional arguments for the `cargo`, e.g. `--release`.
     pub cargo_extra_args: Vec<String>,
 }
@@ -232,7 +232,7 @@ impl Config {
             target: data.cargo_target.clone(),
         };
         self.runnables = RunnablesConfig {
-            cargo_prefix: data.runnables_cargoPrefix,
+            override_cargo: data.runnables_overrideCargo,
             cargo_extra_args: data.runnables_cargoExtraArgs,
         };
 
@@ -489,8 +489,8 @@ config_data! {
         notifications_cargoTomlNotFound: bool      = true,
         procMacro_enable: bool                     = false,
 
-        runnables_cargoPrefix: Vec<String>    = Vec::new(),
-        runnables_cargoExtraArgs: Vec<String> = Vec::new(),
+        runnables_overrideCargo: Option<String> = None,
+        runnables_cargoExtraArgs: Vec<String>   = Vec::new(),
 
         rustfmt_extraArgs: Vec<String>               = Vec::new(),
         rustfmt_overrideCommand: Option<Vec<String>> = None,

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -38,6 +38,7 @@ pub struct Config {
     pub cargo: CargoConfig,
     pub rustfmt: RustfmtConfig,
     pub flycheck: Option<FlycheckConfig>,
+    pub runnables: RunnablesConfig,
 
     pub inlay_hints: InlayHintsConfig,
     pub completion: CompletionConfig,
@@ -124,6 +125,15 @@ pub enum RustfmtConfig {
     CustomCommand { command: String, args: Vec<String> },
 }
 
+/// Configuration for runnable items, such as `main` function or tests.
+#[derive(Debug, Clone, Default)]
+pub struct RunnablesConfig {
+    /// Stuff to be inserted before `cargo`, e.g. `RUST_LOG=info`.
+    pub cargo_prefix: Vec<String>,
+    /// Additional arguments for the `cargo`, e.g. `--release`.
+    pub cargo_extra_args: Vec<String>,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct ClientCapsConfig {
     pub location_link: bool,
@@ -164,6 +174,7 @@ impl Config {
                 extra_args: Vec::new(),
                 features: Vec::new(),
             }),
+            runnables: RunnablesConfig::default(),
 
             inlay_hints: InlayHintsConfig {
                 type_hints: true,
@@ -219,6 +230,10 @@ impl Config {
             features: data.cargo_features.clone(),
             load_out_dirs_from_check: data.cargo_loadOutDirsFromCheck,
             target: data.cargo_target.clone(),
+        };
+        self.runnables = RunnablesConfig {
+            cargo_prefix: data.runnables_cargoPrefix,
+            cargo_extra_args: data.runnables_cargoExtraArgs,
         };
 
         self.proc_macro_srv = if data.procMacro_enable {
@@ -473,6 +488,9 @@ config_data! {
         lruCapacity: Option<usize>                 = None,
         notifications_cargoTomlNotFound: bool      = true,
         procMacro_enable: bool                     = false,
+
+        runnables_cargoPrefix: Vec<String>    = Vec::new(),
+        runnables_cargoExtraArgs: Vec<String> = Vec::new(),
 
         rustfmt_extraArgs: Vec<String>               = Vec::new(),
         rustfmt_overrideCommand: Option<Vec<String>> = None,

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -491,6 +491,7 @@ pub(crate) fn handle_runnables(
     }
 
     // Add `cargo check` and `cargo test` for all targets of the whole package
+    let config = &snap.config.runnables;
     match cargo_spec {
         Some(spec) => {
             for &cmd in ["check", "test"].iter() {
@@ -500,12 +501,14 @@ pub(crate) fn handle_runnables(
                     kind: lsp_ext::RunnableKind::Cargo,
                     args: lsp_ext::CargoRunnable {
                         workspace_root: Some(spec.workspace_root.clone().into()),
+                        cargo_prefix: config.cargo_prefix.clone(),
                         cargo_args: vec![
                             cmd.to_string(),
                             "--package".to_string(),
                             spec.package.clone(),
                             "--all-targets".to_string(),
                         ],
+                        cargo_extra_args: config.cargo_extra_args.clone(),
                         executable_args: Vec::new(),
                         expect_test: None,
                     },
@@ -519,7 +522,9 @@ pub(crate) fn handle_runnables(
                 kind: lsp_ext::RunnableKind::Cargo,
                 args: lsp_ext::CargoRunnable {
                     workspace_root: None,
+                    cargo_prefix: config.cargo_prefix.clone(),
                     cargo_args: vec!["check".to_string(), "--workspace".to_string()],
+                    cargo_extra_args: config.cargo_extra_args.clone(),
                     executable_args: Vec::new(),
                     expect_test: None,
                 },

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -501,7 +501,7 @@ pub(crate) fn handle_runnables(
                     kind: lsp_ext::RunnableKind::Cargo,
                     args: lsp_ext::CargoRunnable {
                         workspace_root: Some(spec.workspace_root.clone().into()),
-                        cargo_prefix: config.cargo_prefix.clone(),
+                        override_cargo: config.override_cargo.clone(),
                         cargo_args: vec![
                             cmd.to_string(),
                             "--package".to_string(),
@@ -522,7 +522,7 @@ pub(crate) fn handle_runnables(
                 kind: lsp_ext::RunnableKind::Cargo,
                 args: lsp_ext::CargoRunnable {
                     workspace_root: None,
-                    cargo_prefix: config.cargo_prefix.clone(),
+                    override_cargo: config.override_cargo.clone(),
                     cargo_args: vec!["check".to_string(), "--workspace".to_string()],
                     cargo_extra_args: config.cargo_extra_args.clone(),
                     executable_args: Vec::new(),

--- a/crates/rust-analyzer/src/lsp_ext.rs
+++ b/crates/rust-analyzer/src/lsp_ext.rs
@@ -171,10 +171,14 @@ pub enum RunnableKind {
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct CargoRunnable {
+    // stuff before `cargo` command, e.g. `RUST_LOG=info`
+    pub cargo_prefix: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workspace_root: Option<PathBuf>,
     // command, --package and --lib stuff
     pub cargo_args: Vec<String>,
+    // user-specified additional cargo args, like `--release`.
+    pub cargo_extra_args: Vec<String>,
     // stuff after --
     pub executable_args: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/rust-analyzer/src/lsp_ext.rs
+++ b/crates/rust-analyzer/src/lsp_ext.rs
@@ -171,8 +171,8 @@ pub enum RunnableKind {
 #[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct CargoRunnable {
-    // stuff before `cargo` command, e.g. `RUST_LOG=info`
-    pub cargo_prefix: Vec<String>,
+    // command to be executed instead of cargo
+    pub override_cargo: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workspace_root: Option<PathBuf>,
     // command, --package and --lib stuff

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -755,7 +755,7 @@ pub(crate) fn runnable(
         kind: lsp_ext::RunnableKind::Cargo,
         args: lsp_ext::CargoRunnable {
             workspace_root: workspace_root.map(|it| it.into()),
-            cargo_prefix: config.cargo_prefix.clone(),
+            override_cargo: config.override_cargo.clone(),
             cargo_args,
             cargo_extra_args: config.cargo_extra_args.clone(),
             executable_args,

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -740,6 +740,7 @@ pub(crate) fn runnable(
     file_id: FileId,
     runnable: Runnable,
 ) -> Result<lsp_ext::Runnable> {
+    let config = &snap.config.runnables;
     let spec = CargoTargetSpec::for_file(snap, file_id)?;
     let workspace_root = spec.as_ref().map(|it| it.workspace_root.clone());
     let target = spec.as_ref().map(|s| s.target.clone());
@@ -754,7 +755,9 @@ pub(crate) fn runnable(
         kind: lsp_ext::RunnableKind::Cargo,
         args: lsp_ext::CargoRunnable {
             workspace_root: workspace_root.map(|it| it.into()),
+            cargo_prefix: config.cargo_prefix.clone(),
             cargo_args,
+            cargo_extra_args: config.cargo_extra_args.clone(),
             executable_args,
             expect_test: None,
         },

--- a/crates/rust-analyzer/tests/rust-analyzer/main.rs
+++ b/crates/rust-analyzer/tests/rust-analyzer/main.rs
@@ -107,6 +107,8 @@ fn main() {}
             "args": {
               "cargoArgs": ["test", "--package", "foo", "--test", "spam"],
               "executableArgs": ["test_eggs", "--exact", "--nocapture"],
+              "cargoExtraArgs": [],
+              "overrideCargo": null,
               "workspaceRoot": server.path().join("foo")
             },
             "kind": "cargo",
@@ -127,6 +129,8 @@ fn main() {}
             "args": {
               "cargoArgs": ["check", "--package", "foo", "--all-targets"],
               "executableArgs": [],
+              "cargoExtraArgs": [],
+              "overrideCargo": null,
               "workspaceRoot": server.path().join("foo")
             },
             "kind": "cargo",
@@ -136,6 +140,8 @@ fn main() {}
             "args": {
               "cargoArgs": ["test", "--package", "foo", "--all-targets"],
               "executableArgs": [],
+              "cargoExtraArgs": [],
+              "overrideCargo": null,
               "workspaceRoot": server.path().join("foo")
             },
             "kind": "cargo",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -651,6 +651,22 @@
                     ],
                     "default": "full",
                     "description": "The strategy to use when inserting new imports or merging imports."
+                },
+                "rust-analyzer.runnables.overrideCargo": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "default": null,
+                    "description": "Command to be executed instead of 'cargo' for runnables."
+                },
+                "rust-analyzer.runnables.cargoExtraArgs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [],
+                    "description": "Additional arguments to be passed to cargo for runnables such as tests or binaries.\nFor example, it may be '--release'"
                 }
             }
         },

--- a/editors/code/src/lsp_ext.ts
+++ b/editors/code/src/lsp_ext.ts
@@ -69,8 +69,10 @@ export interface Runnable {
     args: {
         workspaceRoot?: string;
         cargoArgs: string[];
+        cargoExtraArgs: string[];
         executableArgs: string[];
         expectTest?: boolean;
+        overrideCargo?: string;
     };
 }
 export const runnables = new lc.RequestType<RunnablesParams, Runnable[], void>("experimental/runnables");

--- a/editors/code/src/run.ts
+++ b/editors/code/src/run.ts
@@ -129,6 +129,7 @@ export async function createTask(runnable: ra.Runnable, config: Config): Promise
     }
 
     const args = [...runnable.args.cargoArgs]; // should be a copy!
+    args.push(...runnable.args.cargoExtraArgs); // Append user-specified cargo options.
     if (runnable.args.executableArgs.length > 0) {
         args.push('--', ...runnable.args.executableArgs);
     }
@@ -139,6 +140,7 @@ export async function createTask(runnable: ra.Runnable, config: Config): Promise
         args: args.slice(1),
         cwd: runnable.args.workspaceRoot || ".",
         env: prepareEnv(runnable, config.runnableEnv),
+        overrideCargo: runnable.args.overrideCargo,
     };
 
     const target = vscode.workspace.workspaceFolders![0]; // safe, see main activate()

--- a/editors/code/tests/unit/runnable_env.test.ts
+++ b/editors/code/tests/unit/runnable_env.test.ts
@@ -9,7 +9,8 @@ function makeRunnable(label: string): ra.Runnable {
         kind: "cargo",
         args: {
             cargoArgs: [],
-            executableArgs: []
+            executableArgs: [],
+            cargoExtraArgs: []
         }
     };
 }


### PR DESCRIPTION
This PR introduces two new configuration options for runnables: `overrideCargo` and `cargoExtraArgs`.
These options are applied to all the "run" tasks of rust analyzer, such as binaries and tests.

Overall motivation is that rust-analyzer provides similar options, for example, for `rustfmt`, but not for runnables.

## `overrideCargo`

This option allows user to replace `cargo` command with something else (well, something that is compatible with the cargo arguments).

Motivation is that some projects may have wrappers around cargo (or even whole alternatives to cargo), which do something related to the project, and only then run `cargo`. With this feature, such users will be able to use lens and run tests directly from the IDE rather than from terminal.

![cargo_override](https://user-images.githubusercontent.com/12111581/92306622-2f404f80-ef99-11ea-9bb7-6c6192a2c54a.gif)

## `cargoExtraArgs`

This option allows user to add any additional arguments for `cargo`, such as `--release`.

It may be useful, for example, if project has big integration tests which take too long in debug mode, or if any other `cargo` flag has to be passed.

![cargo_extra_args](https://user-images.githubusercontent.com/12111581/92306658-821a0700-ef99-11ea-8be9-bf0aff78e154.gif)