### PR TITLE
Highlight errors in macros

### DIFF
--- a/crates/rust-analyzer/src/diagnostics/test_data/macro_compiler_error.txt
+++ b/crates/rust-analyzer/src/diagnostics/test_data/macro_compiler_error.txt
@@ -44,4 +44,49 @@
         },
         fixes: [],
     },
+    MappedRustDiagnostic {
+        url: "file:///test/crates/hir_def/src/path.rs",
+        diagnostic: Diagnostic {
+            range: Range {
+                start: Position {
+                    line: 264,
+                    character: 8,
+                },
+                end: Position {
+                    line: 264,
+                    character: 76,
+                },
+            },
+            severity: Some(
+                Error,
+            ),
+            code: None,
+            source: Some(
+                "rustc",
+            ),
+            message: "Please register your known path in the path module",
+            related_information: Some(
+                [
+                    DiagnosticRelatedInformation {
+                        location: Location {
+                            uri: "file:///test/crates/hir_def/src/data.rs",
+                            range: Range {
+                                start: Position {
+                                    line: 79,
+                                    character: 15,
+                                },
+                                end: Position {
+                                    line: 79,
+                                    character: 41,
+                                },
+                            },
+                        },
+                        message: "Exact error occured here",
+                    },
+                ],
+            ),
+            tags: None,
+        },
+        fixes: [],
+    },
 ]


### PR DESCRIPTION
Resolves #4924 

This PR makes rust-analyzer highlight not only the source place when error originates in macro, but also the exact places in macro which caused an error.

This is done by creating an inverse diagnostic, which points to the macro and cross-references the source place.

![изображение](https://user-images.githubusercontent.com/12111581/92319594-b71e6c00-f022-11ea-94c1-f412905269dd.png)
