### PR TITLE
Lookup ADT and associated type names for chalk debugging / tweak chalk interner

### DIFF
--- a/crates/hir_ty/src/traits/chalk.rs
+++ b/crates/hir_ty/src/traits/chalk.rs
@@ -244,13 +244,17 @@ impl<'a> chalk_solve::RustIrDatabase<Interner> for ChalkContext<'a> {
         let id = from_chalk(self.db, trait_id);
         self.db.trait_data(id).name.to_string()
     }
-    // FIXME: lookup names
-    fn adt_name(&self, struct_id: chalk_ir::AdtId<Interner>) -> String {
-        let datum = self.db.struct_datum(self.krate, struct_id);
-        format!("{:?}", datum.name(&Interner))
+    fn adt_name(&self, adt_id: chalk_ir::AdtId<Interner>) -> String {
+        let id = from_chalk(self.db, adt_id);
+        match id {
+            hir_def::AdtId::StructId(id) => self.db.struct_data(id).name.to_string(),
+            hir_def::AdtId::EnumId(id) => self.db.enum_data(id).name.to_string(),
+            hir_def::AdtId::UnionId(id) => self.db.union_data(id).name.to_string(),
+        }
     }
     fn assoc_type_name(&self, assoc_ty_id: chalk_ir::AssocTypeId<Interner>) -> String {
-        format!("Assoc_{}", assoc_ty_id.0)
+        let id = self.db.associated_ty_data(assoc_ty_id).name;
+        self.db.type_alias_data(id).name.to_string()
     }
     fn opaque_type_name(&self, opaque_ty_id: chalk_ir::OpaqueTyId<Interner>) -> String {
         format!("Opaque_{}", opaque_ty_id.0)

--- a/crates/hir_ty/src/traits/chalk/interner.rs
+++ b/crates/hir_ty/src/traits/chalk/interner.rs
@@ -26,7 +26,7 @@ pub type OpaqueTyId = chalk_ir::OpaqueTyId<Interner>;
 pub type OpaqueTyDatum = chalk_solve::rust_ir::OpaqueTyDatum<Interner>;
 
 impl chalk_ir::interner::Interner for Interner {
-    type InternedType = Box<chalk_ir::TyData<Self>>; // FIXME use Arc?
+    type InternedType = Arc<chalk_ir::TyData<Self>>;
     type InternedLifetime = chalk_ir::LifetimeData<Self>;
     type InternedConst = Arc<chalk_ir::ConstData<Self>>;
     type InternedConcreteConst = ();
@@ -34,7 +34,7 @@ impl chalk_ir::interner::Interner for Interner {
     type InternedGoal = Arc<GoalData<Self>>;
     type InternedGoals = Vec<Goal<Self>>;
     type InternedSubstitution = Vec<GenericArg<Self>>;
-    type InternedProgramClause = chalk_ir::ProgramClauseData<Self>;
+    type InternedProgramClause = Arc<chalk_ir::ProgramClauseData<Self>>;
     type InternedProgramClauses = Arc<[chalk_ir::ProgramClause<Self>]>;
     type InternedQuantifiedWhereClauses = Vec<chalk_ir::QuantifiedWhereClause<Self>>;
     type InternedVariableKinds = Vec<chalk_ir::VariableKind<Self>>;
@@ -197,11 +197,11 @@ impl chalk_ir::interner::Interner for Interner {
         tls::with_current_program(|prog| Some(prog?.debug_quantified_where_clauses(clauses, fmt)))
     }
 
-    fn intern_ty(&self, ty: chalk_ir::TyData<Self>) -> Box<chalk_ir::TyData<Self>> {
-        Box::new(ty)
+    fn intern_ty(&self, ty: chalk_ir::TyData<Self>) -> Arc<chalk_ir::TyData<Self>> {
+        Arc::new(ty)
     }
 
-    fn ty_data<'a>(&self, ty: &'a Box<chalk_ir::TyData<Self>>) -> &'a chalk_ir::TyData<Self> {
+    fn ty_data<'a>(&self, ty: &'a Arc<chalk_ir::TyData<Self>>) -> &'a chalk_ir::TyData<Self> {
         ty
     }
 
@@ -230,7 +230,7 @@ impl chalk_ir::interner::Interner for Interner {
         constant
     }
 
-    fn const_eq(&self, _ty: &Box<chalk_ir::TyData<Self>>, _c1: &(), _c2: &()) -> bool {
+    fn const_eq(&self, _ty: &Arc<chalk_ir::TyData<Self>>, _c1: &(), _c2: &()) -> bool {
         true
     }
 
@@ -284,13 +284,13 @@ impl chalk_ir::interner::Interner for Interner {
     fn intern_program_clause(
         &self,
         data: chalk_ir::ProgramClauseData<Self>,
-    ) -> chalk_ir::ProgramClauseData<Self> {
-        data
+    ) -> Arc<chalk_ir::ProgramClauseData<Self>> {
+        Arc::new(data)
     }
 
     fn program_clause_data<'a>(
         &self,
-        clause: &'a chalk_ir::ProgramClauseData<Self>,
+        clause: &'a Arc<chalk_ir::ProgramClauseData<Self>>,
     ) -> &'a chalk_ir::ProgramClauseData<Self> {
         clause
     }

--- a/crates/hir_ty/src/traits/chalk/mapping.rs
+++ b/crates/hir_ty/src/traits/chalk/mapping.rs
@@ -464,6 +464,18 @@ impl ToChalk for hir_def::ImplId {
     }
 }
 
+impl ToChalk for hir_def::AdtId {
+    type Chalk = AdtId;
+
+    fn to_chalk(self, _db: &dyn HirDatabase) -> Self::Chalk {
+        chalk_ir::AdtId(self.into())
+    }
+
+    fn from_chalk(_db: &dyn HirDatabase, id: AdtId) -> Self {
+        id.0
+    }
+}
+
 impl ToChalk for CallableDefId {
     type Chalk = FnDefId;
 


### PR DESCRIPTION
This PR improves the chalk program writing integration by looking up the names for ADTs and associated types, making the output much more readable.

There are also a few small changes to the interner, which gives some nice performance improvements. We clone `Ty`s and `ProgramClause`s relatively often in chalk, so wrapping them in `Arc`s is a perf win. This takes the time for performing type inference on the rust-analyzer codebase from 40s to 33s on my machine.