### PR TITLE
Implement async blocks

### DIFF
--- a/crates/hir/src/code_model.rs
+++ b/crates/hir/src/code_model.rs
@@ -1283,6 +1283,8 @@ impl Type {
     /// Checks that particular type `ty` implements `std::future::Future`.
     /// This function is used in `.await` syntax completion.
     pub fn impls_future(&self, db: &dyn HirDatabase) -> bool {
+        // No special case for the type of async block, since Chalk can figure it out.
+
         let krate = self.krate;
 
         let std_future_trait =

--- a/crates/hir/src/code_model.rs
+++ b/crates/hir/src/code_model.rs
@@ -1602,6 +1602,11 @@ impl Type {
                                 cb(type_.derived(ty.clone()));
                             }
                         }
+                        TypeCtor::OpaqueType(..) => {
+                            if let Some(bounds) = ty.impl_trait_bounds(db) {
+                                walk_bounds(db, &type_.derived(ty.clone()), &bounds, cb);
+                            }
+                        }
                         _ => (),
                     }
 

--- a/crates/hir_def/src/body/lower.rs
+++ b/crates/hir_def/src/body/lower.rs
@@ -239,7 +239,10 @@ impl ExprCollector<'_> {
                     None => self.missing_expr(),
                 },
                 // FIXME: we need to record these effects somewhere...
-                ast::Effect::Async(_) => self.collect_block_opt(e.block_expr()),
+                ast::Effect::Async(_) => {
+                    let body = self.collect_block_opt(e.block_expr());
+                    self.alloc_expr(Expr::Async { body }, syntax_ptr)
+                }
             },
             ast::Expr::BlockExpr(e) => self.collect_block(e),
             ast::Expr::LoopExpr(e) => {

--- a/crates/hir_def/src/expr.rs
+++ b/crates/hir_def/src/expr.rs
@@ -111,6 +111,9 @@ pub enum Expr {
     TryBlock {
         body: ExprId,
     },
+    Async {
+        body: ExprId,
+    },
     Cast {
         expr: ExprId,
         type_ref: TypeRef,
@@ -250,7 +253,7 @@ impl Expr {
                     f(*expr);
                 }
             }
-            Expr::TryBlock { body } | Expr::Unsafe { body } => f(*body),
+            Expr::TryBlock { body } | Expr::Unsafe { body } | Expr::Async { body } => f(*body),
             Expr::Loop { body, .. } => f(*body),
             Expr::While { condition, body, .. } => {
                 f(*condition);

--- a/crates/hir_ty/src/tests/simple.rs
+++ b/crates/hir_ty/src/tests/simple.rs
@@ -1889,31 +1889,40 @@ fn fn_pointer_return() {
 fn effects_smoke_test() {
     check_infer(
         r#"
-        fn main() {
+        async fn main() {
             let x = unsafe { 92 };
             let y = async { async { () }.await };
             let z = try { () };
             let t = 'a: { 92 };
         }
+
+        #[prelude_import] use future::*;
+
+        mod future {
+            #[lang = "future_trait"]
+            pub trait Future { type Output; }
+        }
         "#,
         expect![[r#"
-            10..130 '{     ...2 }; }': ()
-            20..21 'x': i32
-            24..37 'unsafe { 92 }': i32
-            31..37 '{ 92 }': i32
-            33..35 '92': i32
-            47..48 'y': {unknown}
-            57..79 '{ asyn...wait }': {unknown}
-            59..77 'async ....await': {unknown}
-            65..71 '{ () }': ()
-            67..69 '()': ()
-            89..90 'z': {unknown}
-            93..103 'try { () }': {unknown}
-            97..103 '{ () }': ()
-            99..101 '()': ()
-            113..114 't': i32
-            121..127 '{ 92 }': i32
-            123..125 '92': i32
+            16..136 '{     ...2 }; }': ()
+            26..27 'x': i32
+            30..43 'unsafe { 92 }': i32
+            37..43 '{ 92 }': i32
+            39..41 '92': i32
+            53..54 'y': impl Future<Output = ()>
+            57..85 'async ...wait }': impl Future<Output = ()>
+            63..85 '{ asyn...wait }': ()
+            65..77 'async { () }': impl Future<Output = ()>
+            65..83 'async ....await': ()
+            71..77 '{ () }': ()
+            73..75 '()': ()
+            95..96 'z': {unknown}
+            99..109 'try { () }': {unknown}
+            103..109 '{ () }': ()
+            105..107 '()': ()
+            119..120 't': i32
+            127..133 '{ 92 }': i32
+            129..131 '92': i32
         "#]],
     )
 }

--- a/crates/hir_ty/src/traits/chalk.rs
+++ b/crates/hir_ty/src/traits/chalk.rs
@@ -11,6 +11,7 @@ use hir_def::{
     lang_item::{lang_attr, LangItemTarget},
     AssocContainerId, AssocItemId, HasModule, Lookup, TypeAliasId,
 };
+use hir_expand::name::name;
 
 use super::ChalkContext;
 use crate::{
@@ -18,7 +19,8 @@ use crate::{
     display::HirDisplay,
     method_resolution::{TyFingerprint, ALL_FLOAT_FPS, ALL_INT_FPS},
     utils::generics,
-    CallableDefId, DebruijnIndex, FnSig, GenericPredicate, Substs, Ty, TypeCtor,
+    BoundVar, CallableDefId, DebruijnIndex, FnSig, GenericPredicate, ProjectionPredicate,
+    ProjectionTy, Substs, TraitRef, Ty, TypeCtor,
 };
 use mapping::{
     convert_where_clauses, generic_predicate_to_inline_bound, make_binders, TypeAliasAsValue,
@@ -166,27 +168,86 @@ impl<'a> chalk_solve::RustIrDatabase<Interner> for ChalkContext<'a> {
     fn opaque_ty_data(&self, id: chalk_ir::OpaqueTyId<Interner>) -> Arc<OpaqueTyDatum> {
         let interned_id = crate::db::InternedOpaqueTyId::from(id);
         let full_id = self.db.lookup_intern_impl_trait_id(interned_id);
-        let (func, idx) = match full_id {
-            crate::OpaqueTyId::ReturnTypeImplTrait(func, idx) => (func, idx),
+        let bound = match full_id {
+            crate::OpaqueTyId::ReturnTypeImplTrait(func, idx) => {
+                let datas = self
+                    .db
+                    .return_type_impl_traits(func)
+                    .expect("impl trait id without impl traits");
+                let data = &datas.value.impl_traits[idx as usize];
+                let bound = OpaqueTyDatumBound {
+                    bounds: make_binders(
+                        data.bounds
+                            .value
+                            .iter()
+                            .cloned()
+                            .filter(|b| !b.is_error())
+                            .map(|b| b.to_chalk(self.db))
+                            .collect(),
+                        1,
+                    ),
+                    where_clauses: make_binders(vec![], 0),
+                };
+                let num_vars = datas.num_binders;
+                make_binders(bound, num_vars)
+            }
+            crate::OpaqueTyId::AsyncBlockTypeImplTrait(..) => {
+                if let Some((future_trait, future_output)) = self
+                    .db
+                    .lang_item(self.krate, "future_trait".into())
+                    .and_then(|item| item.as_trait())
+                    .and_then(|trait_| {
+                        let alias =
+                            self.db.trait_data(trait_).associated_type_by_name(&name![Output])?;
+                        Some((trait_, alias))
+                    })
+                {
+                    // AsyncBlock<T>: Future</* Self */>
+                    // This is required by `fn impls_future` to check if we need to provide `.await` completion.
+                    let impl_bound = GenericPredicate::Implemented(TraitRef {
+                        trait_: future_trait,
+                        // Self type as the first parameter.
+                        substs: Substs::single(Ty::Bound(BoundVar {
+                            debruijn: DebruijnIndex::INNERMOST,
+                            index: 0,
+                        })),
+                    });
+                    // AsyncBlock<T>: Future</* Self, */ Output = T>;
+                    // debruijn:  ^1  ^0
+                    let proj_bound = GenericPredicate::Projection(ProjectionPredicate {
+                        // The parameter of the opaque type.
+                        ty: Ty::Bound(BoundVar { debruijn: DebruijnIndex::ONE, index: 0 }),
+                        projection_ty: ProjectionTy {
+                            associated_ty: future_output,
+                            // Self type as the first parameter.
+                            parameters: Substs::single(Ty::Bound(BoundVar::new(
+                                DebruijnIndex::INNERMOST,
+                                0,
+                            ))),
+                        },
+                    });
+                    let bound = OpaqueTyDatumBound {
+                        bounds: make_binders(
+                            vec![impl_bound.to_chalk(self.db), proj_bound.to_chalk(self.db)],
+                            1,
+                        ),
+                        where_clauses: make_binders(vec![], 0),
+                    };
+                    // The opaque type has 1 parameter.
+                    make_binders(bound, 1)
+                } else {
+                    // If failed to find `Future::Output`, return empty bounds as fallback.
+                    let bound = OpaqueTyDatumBound {
+                        bounds: make_binders(vec![], 0),
+                        where_clauses: make_binders(vec![], 0),
+                    };
+                    // The opaque type has 1 parameter.
+                    make_binders(bound, 1)
+                }
+            }
         };
-        let datas =
-            self.db.return_type_impl_traits(func).expect("impl trait id without impl traits");
-        let data = &datas.value.impl_traits[idx as usize];
-        let bound = OpaqueTyDatumBound {
-            bounds: make_binders(
-                data.bounds
-                    .value
-                    .iter()
-                    .cloned()
-                    .filter(|b| !b.is_error())
-                    .map(|b| b.to_chalk(self.db))
-                    .collect(),
-                1,
-            ),
-            where_clauses: make_binders(vec![], 0),
-        };
-        let num_vars = datas.num_binders;
-        Arc::new(OpaqueTyDatum { opaque_ty_id: id, bound: make_binders(bound, num_vars) })
+
+        Arc::new(OpaqueTyDatum { opaque_ty_id: id, bound })
     }
 
     fn hidden_opaque_type(&self, _id: chalk_ir::OpaqueTyId<Interner>) -> chalk_ir::Ty<Interner> {

--- a/crates/hir_ty/src/traits/chalk/tls.rs
+++ b/crates/hir_ty/src/traits/chalk/tls.rs
@@ -73,6 +73,9 @@ impl DebugContext<'_> {
                 crate::OpaqueTyId::ReturnTypeImplTrait(func, idx) => {
                     write!(f, "{{impl trait {} of {:?}}}", idx, func)?;
                 }
+                crate::OpaqueTyId::AsyncBlockTypeImplTrait(def, idx) => {
+                    write!(f, "{{impl trait of async block {} of {:?}}}", idx.into_raw(), def)?;
+                }
             },
             TypeCtor::Closure { def, expr } => {
                 write!(f, "{{closure {:?} in ", expr.into_raw())?;

--- a/crates/ide/src/completion/complete_keyword.rs
+++ b/crates/ide/src/completion/complete_keyword.rs
@@ -510,6 +510,28 @@ pub mod future {
             expect![[r#"
                 kw await expr.await
             "#]],
+        );
+
+        check(
+            r#"
+//- /main.rs
+use std::future::*;
+fn foo() {
+    let a = async {};
+    a.<|>
+}
+
+//- /std/lib.rs
+pub mod future {
+    #[lang = "future_trait"]
+    pub trait Future {
+        type Output;
+    }
+}
+"#,
+            expect![[r#"
+                kw await expr.await
+            "#]],
         )
     }
 

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -2647,6 +2647,70 @@ fn foo(ar<|>g: &impl Foo + Bar<S>) {}
     }
 
     #[test]
+    fn test_hover_async_block_impl_trait_has_goto_type_action() {
+        check_actions(
+            r#"
+struct S;
+fn foo() {
+    let fo<|>o = async { S };
+}
+
+#[prelude_import] use future::*;
+mod future {
+    #[lang = "future_trait"]
+    pub trait Future { type Output; }
+}
+"#,
+            expect![[r#"
+                [
+                    GoToType(
+                        [
+                            HoverGotoTypeData {
+                                mod_path: "test::future::Future",
+                                nav: NavigationTarget {
+                                    file_id: FileId(
+                                        1,
+                                    ),
+                                    full_range: 101..163,
+                                    focus_range: Some(
+                                        140..146,
+                                    ),
+                                    name: "Future",
+                                    kind: TRAIT,
+                                    container_name: None,
+                                    description: Some(
+                                        "pub trait Future",
+                                    ),
+                                    docs: None,
+                                },
+                            },
+                            HoverGotoTypeData {
+                                mod_path: "test::S",
+                                nav: NavigationTarget {
+                                    file_id: FileId(
+                                        1,
+                                    ),
+                                    full_range: 0..9,
+                                    focus_range: Some(
+                                        7..8,
+                                    ),
+                                    name: "S",
+                                    kind: STRUCT,
+                                    container_name: None,
+                                    description: Some(
+                                        "struct S",
+                                    ),
+                                    docs: None,
+                                },
+                            },
+                        ],
+                    ),
+                ]
+            "#]],
+        );
+    }
+
+    #[test]
     fn test_hover_arg_generic_impl_trait_has_goto_type_action() {
         check_actions(
             r#"


### PR DESCRIPTION
Fix #4018

@flodiebold already gave a generic guide in the issue. Here's some concern about implementation detail:
- Chalk doesn't support generator type yet.
- Adding generator type as a brand new type (ctor) can be complex and need to *re-introduced* builtin impls. (Like how we implement closures before native closure support of chalk, which is already removed in #5401 )
- The output type of async block should be known after type inference of the whole body.
  - We cannot directly get the type from source like return-positon-impl-trait. But we still need to provide trait bounds when chalk asking for `opaque_ty_data`.
  - During the inference, the output type of async block can be temporary unknown and participate the later inference.
    `let a = async { None }; let _: i32 = a.await.unwrap();`

So in this PR, the type of async blocks is inferred as an opaque type parameterized by the `Future::Output` type it should be, like what we do with closure type.
And it really works now.

Well, I still have some questions:
- The bounds `AsyncBlockImplType<T>: Future<Output = T>` is currently generated in `opaque_ty_data`. I'm not sure if we should put this code here.
- Type of async block is now rendered as `impl Future<Output = OutputType>`. Do we need to special display to hint that it's a async block? Note that closure type has its special format, instead of `impl Fn(..) -> ..` or function type.

