### PR TITLE
Report better errors in project.json/sysroot

### DIFF
--- a/crates/project_model/src/project_json.rs
+++ b/crates/project_model/src/project_json.rs
@@ -7,12 +7,12 @@ use paths::{AbsPath, AbsPathBuf};
 use rustc_hash::FxHashMap;
 use serde::{de, Deserialize};
 
-use crate::{cfg_flag::CfgFlag, Sysroot};
+use crate::cfg_flag::CfgFlag;
 
 /// Roots and crates that compose this Rust project.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProjectJson {
-    pub(crate) sysroot: Option<Sysroot>,
+    pub(crate) sysroot_src: Option<AbsPathBuf>,
     crates: Vec<Crate>,
 }
 
@@ -35,7 +35,7 @@ pub struct Crate {
 impl ProjectJson {
     pub fn new(base: &AbsPath, data: ProjectJsonData) -> ProjectJson {
         ProjectJson {
-            sysroot: data.sysroot_src.map(|it| base.join(it)).map(|it| Sysroot::load(&it)),
+            sysroot_src: data.sysroot_src.map(|it| base.join(it)),
             crates: data
                 .crates
                 .into_iter()

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -109,7 +109,7 @@ impl GlobalState {
                             )
                         }
                         LinkedProject::InlineJsonProject(it) => {
-                            Ok(project_model::ProjectWorkspace::Json { project: it.clone() })
+                            project_model::ProjectWorkspace::load_inline(it.clone())
                         }
                     })
                     .collect::<Vec<_>>();


### PR DESCRIPTION
This does a bunch of light refactoring so that the `Sysroot` is loaded later, which makes sure that any errors are reported to the user. I then added a check that reports an error if libcore is missing in the loaded sysroot. Since a sysroot without libcore is very useless, this indicates a configuration error.