### PR TITLE
Make MergeBehaviour configurable

### DIFF
--- a/crates/assists/src/assist_config.rs
+++ b/crates/assists/src/assist_config.rs
@@ -4,12 +4,13 @@
 //! module, and we use to statically check that we only produce snippet
 //! assists if we are allowed to.
 
-use crate::AssistKind;
+use crate::{utils::MergeBehaviour, AssistKind};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AssistConfig {
     pub snippet_cap: Option<SnippetCap>,
     pub allowed: Option<Vec<AssistKind>>,
+    pub insert_use: InsertUseConfig,
 }
 
 impl AssistConfig {
@@ -25,6 +26,21 @@ pub struct SnippetCap {
 
 impl Default for AssistConfig {
     fn default() -> Self {
-        AssistConfig { snippet_cap: Some(SnippetCap { _private: () }), allowed: None }
+        AssistConfig {
+            snippet_cap: Some(SnippetCap { _private: () }),
+            allowed: None,
+            insert_use: InsertUseConfig::default(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct InsertUseConfig {
+    pub merge: Option<MergeBehaviour>,
+}
+
+impl Default for InsertUseConfig {
+    fn default() -> Self {
+        InsertUseConfig { merge: Some(MergeBehaviour::Full) }
     }
 }

--- a/crates/assists/src/handlers/auto_import.rs
+++ b/crates/assists/src/handlers/auto_import.rs
@@ -14,10 +14,7 @@ use syntax::{
     SyntaxNode,
 };
 
-use crate::{
-    utils::{insert_use, MergeBehaviour},
-    AssistContext, AssistId, AssistKind, Assists, GroupLabel,
-};
+use crate::{utils::insert_use, AssistContext, AssistId, AssistKind, Assists, GroupLabel};
 
 // Assist: auto_import
 //
@@ -60,7 +57,7 @@ pub(crate) fn auto_import(acc: &mut Assists, ctx: &AssistContext) -> Option<()> 
                 let new_syntax = insert_use(
                     &scope,
                     make::path_from_text(&import.to_string()),
-                    Some(MergeBehaviour::Full),
+                    ctx.config.insert_use.merge,
                 );
                 builder.replace(syntax.text_range(), new_syntax.to_string())
             },

--- a/crates/assists/src/handlers/extract_struct_from_enum_variant.rs
+++ b/crates/assists/src/handlers/extract_struct_from_enum_variant.rs
@@ -10,9 +10,7 @@ use syntax::{
 };
 
 use crate::{
-    assist_context::AssistBuilder,
-    utils::{insert_use, MergeBehaviour},
-    AssistContext, AssistId, AssistKind, Assists,
+    assist_context::AssistBuilder, utils::insert_use, AssistContext, AssistId, AssistKind, Assists,
 };
 use ast::make;
 use insert_use::ImportScope;
@@ -117,7 +115,7 @@ fn insert_import(
         let new_syntax = insert_use(
             &scope,
             make::path_from_text(&mod_path.to_string()),
-            Some(MergeBehaviour::Full),
+            ctx.config.insert_use.merge,
         );
         // FIXME: this will currently panic as multiple imports will have overlapping text ranges
         builder.replace(syntax.text_range(), new_syntax.to_string())

--- a/crates/assists/src/handlers/replace_qualified_name_with_use.rs
+++ b/crates/assists/src/handlers/replace_qualified_name_with_use.rs
@@ -2,7 +2,7 @@ use syntax::{algo::SyntaxRewriter, ast, match_ast, AstNode, SyntaxNode, TextRang
 use test_utils::mark;
 
 use crate::{
-    utils::{insert_use, ImportScope, MergeBehaviour},
+    utils::{insert_use, ImportScope},
     AssistContext, AssistId, AssistKind, Assists,
 };
 use ast::make;
@@ -60,7 +60,7 @@ pub(crate) fn replace_qualified_name_with_use(
                 let new_syntax = insert_use(
                     import_scope,
                     make::path_from_text(path_to_import),
-                    Some(MergeBehaviour::Full),
+                    ctx.config.insert_use.merge,
                 );
                 builder.replace(syntax.text_range(), new_syntax.to_string())
             }

--- a/crates/assists/src/utils.rs
+++ b/crates/assists/src/utils.rs
@@ -16,7 +16,8 @@ use syntax::{
 
 use crate::assist_config::SnippetCap;
 
-pub(crate) use insert_use::{insert_use, ImportScope, MergeBehaviour};
+pub use insert_use::MergeBehaviour;
+pub(crate) use insert_use::{insert_use, ImportScope};
 
 pub(crate) fn unwrap_trivial_block(block: ast::BlockExpr) -> ast::Expr {
     extract_trivial_expression(&block)

--- a/crates/assists/src/utils/insert_use.rs
+++ b/crates/assists/src/utils/insert_use.rs
@@ -236,7 +236,7 @@ fn common_prefix(lhs: &ast::Path, rhs: &ast::Path) -> Option<(ast::Path, ast::Pa
 }
 
 /// What type of merges are allowed.
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum MergeBehaviour {
     /// Merge everything together creating deeply nested imports.
     Full,

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -81,7 +81,9 @@ pub use crate::{
     },
 };
 
-pub use assists::{Assist, AssistConfig, AssistId, AssistKind, ResolvedAssist};
+pub use assists::{
+    utils::MergeBehaviour, Assist, AssistConfig, AssistId, AssistKind, ResolvedAssist,
+};
 pub use base_db::{
     Canceled, CrateGraph, CrateId, Edition, FileId, FilePosition, FileRange, SourceRoot,
     SourceRootId,

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -626,6 +626,21 @@
                     },
                     "description": "List of warnings that should be displayed with hint severity.\nThe warnings will be indicated by faded text or three dots in code and will not show up in the problems panel.",
                     "default": []
+                },
+                "rust-analyzer.assist.importMergeBehaviour": {
+                    "type": "string",
+                    "enum": [
+                        "none",
+                        "full",
+                        "last"
+                    ],
+                    "enumDescriptions": [
+                        "No merging",
+                        "Merge all layers of the import trees",
+                        "Only merge the last layer of the import trees"
+                    ],
+                    "default": "full",
+                    "description": "The strategy to use when inserting new imports or merging imports."
                 }
             }
         },


### PR DESCRIPTION
This should make the newly implemented `MergeBehaviour` for import insertion configurable as roughly outlined in https://github.com/rust-analyzer/rust-analyzer/pull/5935#issuecomment-685834257. For the config name and the like I just picked what came to mind so that might be up for bikeshedding.