### PR TITLE
Better inlay hints in 'for' loops

### DIFF
--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -254,10 +254,11 @@ fn should_not_display_type_hint(
                 ast::ForExpr(it) => {
                     // We *should* display hint only if user provided "in {expr}" and we know the type of expr (and it's not unit).
                     // Type of expr should be iterable.
-                    let type_is_known = |ty: Option<hir::Type>| ty.map(|ty| !ty.is_unit() && !ty.is_unknown()).unwrap_or(false);
-                    let should_display = it.in_token().is_some()
-                        && it.iterable().map(|expr| type_is_known(sema.type_of_expr(&expr))).unwrap_or(false);
-                    return !should_display;
+                    return it.in_token().is_none() ||
+                        it.iterable()
+                            .and_then(|iterable_expr|sema.type_of_expr(&iterable_expr))
+                            .map(|iterable_ty| iterable_ty.is_unknown() || iterable_ty.is_unit())
+                            .unwrap_or(true)
                 },
                 _ => (),
             }

--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -947,13 +947,46 @@ fn main() {
         );
         check(
             r#"
+//- /main.rs crate:main deps:core
+pub struct Vec<T> {}
+
+impl<T> Vec<T> {
+    pub fn new() -> Self { Vec {} }
+    pub fn push(&mut self, t: T) {}
+}
+
+impl<T> IntoIterator for Vec<T> {
+    type Item=T;
+}
+
 fn main() {
-    let data = &[1i32, 2, 3];
-      //^^^^ &[i32; _]
-    for i in
+    let mut data = Vec::new();
+      //^^^^^^^^ Vec<&str>
+    data.push("foo");
+    for i in 
 
     println!("Unit expr");
-}"#,
+}
+
+//- /core.rs crate:core
+#[prelude_import] use iter::*;
+mod iter {
+    trait IntoIterator {
+        type Item;
+    }
+}
+//- /alloc.rs crate:alloc deps:core
+mod collections {
+    struct Vec<T> {}
+    impl<T> Vec<T> {
+        fn new() -> Self { Vec {} }
+        fn push(&mut self, t: T) { }
+    }
+    impl<T> IntoIterator for Vec<T> {
+        type Item=T;
+    }
+}
+"#,
         );
     }
 
@@ -961,14 +994,48 @@ fn main() {
     fn complete_for_hint() {
         check(
             r#"
+//- /main.rs crate:main deps:core
+pub struct Vec<T> {}
+
+impl<T> Vec<T> {
+    pub fn new() -> Self { Vec {} }
+    pub fn push(&mut self, t: T) {}
+}
+
+impl<T> IntoIterator for Vec<T> {
+    type Item=T;
+}
+
 fn main() {
-    let data = &[ 1, 2, 3 ];
-      //^^^^ &[i32; _]
-    for i in data.into_iter() {
-      //^ &i32
-      println!("{}", i);
+    let mut data = Vec::new();
+      //^^^^^^^^ Vec<&str>
+    data.push("foo");
+    for i in data {
+      //^ &str
+      let z = i;
+        //^ &str
     }
-}"#,
+}
+
+//- /core.rs crate:core
+#[prelude_import] use iter::*;
+mod iter {
+    trait IntoIterator {
+        type Item;
+    }
+}
+//- /alloc.rs crate:alloc deps:core
+mod collections {
+    struct Vec<T> {}
+    impl<T> Vec<T> {
+        fn new() -> Self { Vec {} }
+        fn push(&mut self, t: T) { }
+    }
+    impl<T> IntoIterator for Vec<T> {
+        type Item=T;
+    }
+}
+"#,
         );
     }
 }

--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -506,19 +506,6 @@ fn main() {
     }
 
     #[test]
-    fn for_expression() {
-        check(
-            r#"
-fn main() {
-    let mut start = 0;
-      //^^^^^^^^^ i32
-    for increment in 0..2 { start += increment; }
-      //^^^^^^^^^ i32
-}"#,
-        );
-    }
-
-    #[test]
     fn if_expr() {
         check(
             r#"
@@ -963,7 +950,7 @@ fn main() {
     let mut data = Vec::new();
       //^^^^^^^^ Vec<&str>
     data.push("foo");
-    for i in 
+    for i in
 
     println!("Unit expr");
 }


### PR DESCRIPTION
For #5206 (one part of the fix).

This PR refines the logic of spawning an inlay hints in `for` loops. We only must provide a hint if the following criteria are met:

- User already typed `in` keyword.
- Type of expression is known and it's not unit.

**However:** I don't know why, but I was unable to make `complete_for_hint` test work. Either without or with my changes, I was always getting this test failed because no hint was spawned for the loop variable.

This change works locally, so I would really appreciate an explanation why this test isn't working now and how to fix it.

![image](https://user-images.githubusercontent.com/12111581/93024580-41a53380-f600-11ea-9bb1-1f8ac141be95.png)