### PR TITLE
Emit diagnostics for unresolved imports and extern crates

### DIFF
--- a/crates/hir_def/src/diagnostics.rs
+++ b/crates/hir_def/src/diagnostics.rs
@@ -28,3 +28,45 @@ impl Diagnostic for UnresolvedModule {
         self
     }
 }
+
+#[derive(Debug)]
+pub struct UnresolvedExternCrate {
+    pub file: HirFileId,
+    pub item: AstPtr<ast::ExternCrate>,
+}
+
+impl Diagnostic for UnresolvedExternCrate {
+    fn code(&self) -> DiagnosticCode {
+        DiagnosticCode("unresolved-extern-crate")
+    }
+    fn message(&self) -> String {
+        "unresolved extern crate".to_string()
+    }
+    fn display_source(&self) -> InFile<SyntaxNodePtr> {
+        InFile::new(self.file, self.item.clone().into())
+    }
+    fn as_any(&self) -> &(dyn Any + Send + 'static) {
+        self
+    }
+}
+
+#[derive(Debug)]
+pub struct UnresolvedImport {
+    pub file: HirFileId,
+    pub node: AstPtr<ast::UseTree>,
+}
+
+impl Diagnostic for UnresolvedImport {
+    fn code(&self) -> DiagnosticCode {
+        DiagnosticCode("unresolved-import")
+    }
+    fn message(&self) -> String {
+        "unresolved import".to_string()
+    }
+    fn display_source(&self) -> InFile<SyntaxNodePtr> {
+        InFile::new(self.file, self.node.clone().into())
+    }
+    fn as_any(&self) -> &(dyn Any + Send + 'static) {
+        self
+    }
+}

--- a/crates/hir_def/src/item_tree.rs
+++ b/crates/hir_def/src/item_tree.rs
@@ -291,7 +291,6 @@ pub enum AttrOwner {
 
     Variant(Idx<Variant>),
     Field(Idx<Field>),
-    // FIXME: Store variant and field attrs, and stop reparsing them in `attrs_query`.
 }
 
 macro_rules! from_attrs {
@@ -483,6 +482,11 @@ pub struct Import {
     /// AST ID of the `use` or `extern crate` item this import was derived from. Note that many
     /// `Import`s can map to the same `use` item.
     pub ast_id: FileAstId<ast::Use>,
+    /// Index of this `Import` when the containing `Use` is visited via `ModPath::expand_use_item`.
+    ///
+    /// This can be used to get the `UseTree` this `Import` corresponds to and allows emitting
+    /// precise diagnostics.
+    pub index: usize,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/crates/hir_def/src/item_tree/lower.rs
+++ b/crates/hir_def/src/item_tree/lower.rs
@@ -482,7 +482,7 @@ impl Ctx {
         ModPath::expand_use_item(
             InFile::new(self.file, use_item.clone()),
             &self.hygiene,
-            |path, _tree, is_glob, alias| {
+            |path, _use_tree, is_glob, alias| {
                 imports.push(id(tree.imports.alloc(Import {
                     path,
                     alias,
@@ -490,6 +490,7 @@ impl Ctx {
                     is_glob,
                     is_prelude,
                     ast_id,
+                    index: imports.len(),
                 })));
             },
         );

--- a/crates/hir_def/src/item_tree/tests.rs
+++ b/crates/hir_def/src/item_tree/tests.rs
@@ -228,9 +228,9 @@ fn smoke() {
 
             top-level items:
             #[Attrs { entries: Some([Attr { path: ModPath { kind: Plain, segments: [Name(Text("attr_on_use"))] }, input: None }]) }]
-            Import { path: ModPath { kind: Plain, segments: [Name(Text("a"))] }, alias: None, visibility: RawVisibilityId("pub(self)"), is_glob: false, is_prelude: false, ast_id: FileAstId::<syntax::ast::generated::nodes::Use>(0) }
+            Import { path: ModPath { kind: Plain, segments: [Name(Text("a"))] }, alias: None, visibility: RawVisibilityId("pub(self)"), is_glob: false, is_prelude: false, ast_id: FileAstId::<syntax::ast::generated::nodes::Use>(0), index: 0 }
             #[Attrs { entries: Some([Attr { path: ModPath { kind: Plain, segments: [Name(Text("attr_on_use"))] }, input: None }]) }]
-            Import { path: ModPath { kind: Plain, segments: [Name(Text("b"))] }, alias: None, visibility: RawVisibilityId("pub(self)"), is_glob: true, is_prelude: false, ast_id: FileAstId::<syntax::ast::generated::nodes::Use>(0) }
+            Import { path: ModPath { kind: Plain, segments: [Name(Text("b"))] }, alias: None, visibility: RawVisibilityId("pub(self)"), is_glob: true, is_prelude: false, ast_id: FileAstId::<syntax::ast::generated::nodes::Use>(0), index: 1 }
             #[Attrs { entries: Some([Attr { path: ModPath { kind: Plain, segments: [Name(Text("ext_crate"))] }, input: None }]) }]
             ExternCrate { path: ModPath { kind: Plain, segments: [Name(Text("krate"))] }, alias: None, visibility: RawVisibilityId("pub(self)"), is_macro_use: false, ast_id: FileAstId::<syntax::ast::generated::nodes::ExternCrate>(1) }
             #[Attrs { entries: Some([Attr { path: ModPath { kind: Plain, segments: [Name(Text("on_trait"))] }, input: None }]) }]

--- a/crates/hir_def/src/nameres/collector.rs
+++ b/crates/hir_def/src/nameres/collector.rs
@@ -420,7 +420,11 @@ impl DefCollector<'_> {
                     .as_ident()
                     .expect("extern crate should have been desugared to one-element path"),
             );
-            PartialResolvedImport::Resolved(res)
+            if res.is_none() {
+                PartialResolvedImport::Unresolved
+            } else {
+                PartialResolvedImport::Resolved(res)
+            }
         } else {
             let res = self.def_map.resolve_path_fp_with_macro(
                 self.db,

--- a/crates/hir_def/src/nameres/collector.rs
+++ b/crates/hir_def/src/nameres/collector.rs
@@ -1051,13 +1051,11 @@ impl ModCollector<'_, '_> {
                             self.import_all_legacy_macros(module_id);
                         }
                     }
-                    Err(candidate) => self.def_collector.def_map.diagnostics.push(
-                        DefDiagnostic::UnresolvedModule {
-                            module: self.module_id,
-                            declaration: ast_id,
-                            candidate,
-                        },
-                    ),
+                    Err(candidate) => {
+                        self.def_collector.def_map.diagnostics.push(
+                            DefDiagnostic::unresolved_module(self.module_id, ast_id, candidate),
+                        );
+                    }
                 };
             }
         }

--- a/crates/hir_def/src/nameres/tests.rs
+++ b/crates/hir_def/src/nameres/tests.rs
@@ -2,6 +2,7 @@ mod globs;
 mod incremental;
 mod macros;
 mod mod_resolution;
+mod diagnostics;
 mod primitives;
 
 use std::sync::Arc;

--- a/crates/hir_def/src/nameres/tests/diagnostics.rs
+++ b/crates/hir_def/src/nameres/tests/diagnostics.rs
@@ -93,6 +93,30 @@ fn unresolved_extern_crate() {
 }
 
 #[test]
+fn dedup_unresolved_import_from_unresolved_crate() {
+    check_diagnostics(
+        r"
+        //- /main.rs crate:main
+        mod a {
+            extern crate doesnotexist;
+          //^^^^^^^^^^^^^^^^^^^^^^^^^^ unresolved extern crate
+
+            // Should not error, since we already errored for the missing crate.
+            use doesnotexist::{self, bla, *};
+
+            use crate::doesnotexist;
+              //^^^^^^^^^^^^^^^^^^^ unresolved import
+        }
+
+        mod m {
+            use super::doesnotexist;
+              //^^^^^^^^^^^^^^^^^^^ unresolved import
+        }
+        ",
+    );
+}
+
+#[test]
 fn unresolved_module() {
     check_diagnostics(
         r"

--- a/crates/hir_def/src/nameres/tests/diagnostics.rs
+++ b/crates/hir_def/src/nameres/tests/diagnostics.rs
@@ -1,0 +1,107 @@
+use base_db::fixture::WithFixture;
+use base_db::FileId;
+use base_db::SourceDatabaseExt;
+use hir_expand::db::AstDatabase;
+use rustc_hash::FxHashMap;
+use syntax::TextRange;
+use syntax::TextSize;
+
+use crate::test_db::TestDB;
+
+fn check_diagnostics(ra_fixture: &str) {
+    let db: TestDB = TestDB::with_files(ra_fixture);
+    let annotations = db.extract_annotations();
+    assert!(!annotations.is_empty());
+
+    let mut actual: FxHashMap<FileId, Vec<(TextRange, String)>> = FxHashMap::default();
+    db.diagnostics(|d| {
+        let src = d.display_source();
+        let root = db.parse_or_expand(src.file_id).unwrap();
+        // FIXME: macros...
+        let file_id = src.file_id.original_file(&db);
+        let range = src.value.to_node(&root).text_range();
+        let message = d.message().to_owned();
+        actual.entry(file_id).or_default().push((range, message));
+    });
+
+    for (file_id, diags) in actual.iter_mut() {
+        diags.sort_by_key(|it| it.0.start());
+        let text = db.file_text(*file_id);
+        // For multiline spans, place them on line start
+        for (range, content) in diags {
+            if text[*range].contains('\n') {
+                *range = TextRange::new(range.start(), range.start() + TextSize::from(1));
+                *content = format!("... {}", content);
+            }
+        }
+    }
+
+    assert_eq!(annotations, actual);
+}
+
+#[test]
+fn unresolved_import() {
+    check_diagnostics(
+        r"
+        use does_exist;
+        use does_not_exist;
+          //^^^^^^^^^^^^^^ unresolved import
+
+        mod does_exist {}
+        ",
+    );
+}
+
+#[test]
+fn unresolved_import_in_use_tree() {
+    // Only the relevant part of a nested `use` item should be highlighted.
+    check_diagnostics(
+        r"
+        use does_exist::{Exists, DoesntExist};
+                               //^^^^^^^^^^^ unresolved import
+
+        use {does_not_exist::*, does_exist};
+           //^^^^^^^^^^^^^^^^^ unresolved import
+
+        use does_not_exist::{
+            a,
+          //^ unresolved import
+            b,
+          //^ unresolved import
+            c,
+          //^ unresolved import
+        };
+
+        mod does_exist {
+            pub struct Exists;
+        }
+        ",
+    );
+}
+
+#[test]
+fn unresolved_extern_crate() {
+    check_diagnostics(
+        r"
+        //- /main.rs crate:main deps:core
+        extern crate core;
+          extern crate doesnotexist;
+        //^^^^^^^^^^^^^^^^^^^^^^^^^^ unresolved extern crate
+        //- /lib.rs crate:core
+        ",
+    );
+}
+
+#[test]
+fn unresolved_module() {
+    check_diagnostics(
+        r"
+        //- /lib.rs
+        mod foo;
+          mod bar;
+        //^^^^^^^^ unresolved module
+        mod baz {}
+        //- /foo.rs
+        ",
+    );
+}

--- a/crates/hir_def/src/nameres/tests/mod_resolution.rs
+++ b/crates/hir_def/src/nameres/tests/mod_resolution.rs
@@ -672,44 +672,6 @@ pub struct Baz;
 }
 
 #[test]
-fn unresolved_module_diagnostics() {
-    let db = TestDB::with_files(
-        r"
-        //- /lib.rs
-        mod foo;
-        mod bar;
-        mod baz {}
-        //- /foo.rs
-        ",
-    );
-    let krate = db.test_crate();
-
-    let crate_def_map = db.crate_def_map(krate);
-
-    expect![[r#"
-        [
-            DefDiagnostic {
-                in_module: Idx::<ModuleData>(0),
-                kind: UnresolvedModule {
-                    declaration: InFile {
-                        file_id: HirFileId(
-                            FileId(
-                                FileId(
-                                    0,
-                                ),
-                            ),
-                        ),
-                        value: FileAstId::<syntax::ast::generated::nodes::Module>(1),
-                    },
-                    candidate: "bar.rs",
-                },
-            },
-        ]
-    "#]]
-    .assert_debug_eq(&crate_def_map.diagnostics);
-}
-
-#[test]
 fn module_resolution_decl_inside_module_in_non_crate_root_2() {
     check(
         r#"

--- a/crates/hir_def/src/nameres/tests/mod_resolution.rs
+++ b/crates/hir_def/src/nameres/tests/mod_resolution.rs
@@ -688,19 +688,21 @@ fn unresolved_module_diagnostics() {
 
     expect![[r#"
         [
-            UnresolvedModule {
-                module: Idx::<ModuleData>(0),
-                declaration: InFile {
-                    file_id: HirFileId(
-                        FileId(
+            DefDiagnostic {
+                in_module: Idx::<ModuleData>(0),
+                kind: UnresolvedModule {
+                    declaration: InFile {
+                        file_id: HirFileId(
                             FileId(
-                                0,
+                                FileId(
+                                    0,
+                                ),
                             ),
                         ),
-                    ),
-                    value: FileAstId::<syntax::ast::generated::nodes::Module>(1),
+                        value: FileAstId::<syntax::ast::generated::nodes::Module>(1),
+                    },
+                    candidate: "bar.rs",
                 },
-                candidate: "bar.rs",
             },
         ]
     "#]]

--- a/crates/ide/src/diagnostics.rs
+++ b/crates/ide/src/diagnostics.rs
@@ -622,13 +622,65 @@ pub struct Foo { pub a: i32, pub b: i32 }
             r#"
 use a;
 use a::{c, d::e};
+
+mod a {
+    mod c {}
+    mod d {
+        mod e {}
+    }
+}
 "#,
         );
-        check_fix(r#"use {<|>b};"#, r#"use b;"#);
-        check_fix(r#"use {b<|>};"#, r#"use b;"#);
-        check_fix(r#"use a::{c<|>};"#, r#"use a::c;"#);
-        check_fix(r#"use a::{self<|>};"#, r#"use a;"#);
-        check_fix(r#"use a::{c, d::{e<|>}};"#, r#"use a::{c, d::e};"#);
+        check_fix(
+            r"
+            mod b {}
+            use {<|>b};
+            ",
+            r"
+            mod b {}
+            use b;
+            ",
+        );
+        check_fix(
+            r"
+            mod b {}
+            use {b<|>};
+            ",
+            r"
+            mod b {}
+            use b;
+            ",
+        );
+        check_fix(
+            r"
+            mod a { mod c {} }
+            use a::{c<|>};
+            ",
+            r"
+            mod a { mod c {} }
+            use a::c;
+            ",
+        );
+        check_fix(
+            r"
+            mod a {}
+            use a::{self<|>};
+            ",
+            r"
+            mod a {}
+            use a;
+            ",
+        );
+        check_fix(
+            r"
+            mod a { mod c {} mod d { mod e {} } }
+            use a::{c, d::{e<|>}};
+            ",
+            r"
+            mod a { mod c {} mod d { mod e {} } }
+            use a::{c, d::e};
+            ",
+        );
     }
 
     #[test]


### PR DESCRIPTION
AFAIK, we don't have any major bugs in name resolution that would cause a lot of false positives here (except procedural attribute macro support and some rare issues around `#[path]` on module files), so these are *not* marked as experimental diagnostics right now.

I noticed that diagnostics in a file sometimes don't get displayed after opening, but require some edit to be performed. This seems like a preexisting issue though.