### PR TITLE
Make name resolution resolve proc macros instead of relying purely on the build system

### DIFF
--- a/crates/hir_def/src/attr.rs
+++ b/crates/hir_def/src/attr.rs
@@ -171,6 +171,9 @@ pub struct AttrQuery<'a> {
 }
 
 impl<'a> AttrQuery<'a> {
+    /// For an attribute like `#[attr(value)]`, returns the `(value)` subtree.
+    ///
+    /// If the attribute does not have a token tree argument, returns `None`.
     pub fn tt_values(self) -> impl Iterator<Item = &'a Subtree> {
         self.attrs().filter_map(|attr| match attr.input.as_ref()? {
             AttrInput::TokenTree(it) => Some(it),
@@ -178,6 +181,9 @@ impl<'a> AttrQuery<'a> {
         })
     }
 
+    /// For an attribute like `#[key = "value"]`, returns `"value"`.
+    ///
+    /// Returns `None` if the attribute does not have `key = "value"` form.
     pub fn string_value(self) -> Option<&'a SmolStr> {
         self.attrs().find_map(|attr| match attr.input.as_ref()? {
             AttrInput::Literal(it) => Some(it),

--- a/crates/hir_def/src/attr.rs
+++ b/crates/hir_def/src/attr.rs
@@ -171,9 +171,6 @@ pub struct AttrQuery<'a> {
 }
 
 impl<'a> AttrQuery<'a> {
-    /// For an attribute like `#[attr(value)]`, returns the `(value)` subtree.
-    ///
-    /// If the attribute does not have a token tree argument, returns `None`.
     pub fn tt_values(self) -> impl Iterator<Item = &'a Subtree> {
         self.attrs().filter_map(|attr| match attr.input.as_ref()? {
             AttrInput::TokenTree(it) => Some(it),
@@ -181,9 +178,6 @@ impl<'a> AttrQuery<'a> {
         })
     }
 
-    /// For an attribute like `#[key = "value"]`, returns `"value"`.
-    ///
-    /// Returns `None` if the attribute does not have `key = "value"` form.
     pub fn string_value(self) -> Option<&'a SmolStr> {
         self.attrs().find_map(|attr| match attr.input.as_ref()? {
             AttrInput::Literal(it) => Some(it),

--- a/crates/hir_def/src/item_scope.rs
+++ b/crates/hir_def/src/item_scope.rs
@@ -270,15 +270,12 @@ impl ItemScope {
 
     /// Marks everything that is not a procedural macro as private to `this_module`.
     pub(crate) fn censor_non_proc_macros(&mut self, this_module: ModuleId) {
-        for vis in self
-            .types
+        self.types
             .values_mut()
             .chain(self.values.values_mut())
             .map(|(_, v)| v)
             .chain(self.unnamed_trait_imports.values_mut())
-        {
-            *vis = Visibility::Module(this_module);
-        }
+            .for_each(|vis| *vis = Visibility::Module(this_module));
 
         for (mac, vis) in self.macros.values_mut() {
             if let MacroDefKind::ProcMacro(_) = mac.kind {

--- a/crates/hir_def/src/item_scope.rs
+++ b/crates/hir_def/src/item_scope.rs
@@ -5,10 +5,12 @@ use std::collections::hash_map::Entry;
 
 use base_db::CrateId;
 use hir_expand::name::Name;
+use hir_expand::MacroDefKind;
 use once_cell::sync::Lazy;
 use rustc_hash::{FxHashMap, FxHashSet};
 use test_utils::mark;
 
+use crate::ModuleId;
 use crate::{
     db::DefDatabase, per_ns::PerNs, visibility::Visibility, AdtId, BuiltinType, HasModule, ImplId,
     LocalModuleId, Lookup, MacroDefId, ModuleDefId, TraitId,
@@ -264,6 +266,29 @@ impl ItemScope {
 
     pub(crate) fn collect_legacy_macros(&self) -> FxHashMap<Name, MacroDefId> {
         self.legacy_macros.clone()
+    }
+
+    /// Marks everything that is not a procedural macro as private to `this_module`.
+    pub(crate) fn censor_non_proc_macros(&mut self, this_module: ModuleId) {
+        for vis in self
+            .types
+            .values_mut()
+            .chain(self.values.values_mut())
+            .map(|(_, v)| v)
+            .chain(self.unnamed_trait_imports.values_mut())
+        {
+            *vis = Visibility::Module(this_module);
+        }
+
+        for (mac, vis) in self.macros.values_mut() {
+            if let MacroDefKind::ProcMacro(_) = mac.kind {
+                // FIXME: Technically this is insufficient since reexports of proc macros are also
+                // forbidden. Practically nobody does that.
+                continue;
+            }
+
+            *vis = Visibility::Module(this_module);
+        }
     }
 }
 

--- a/crates/hir_def/src/nameres/collector.rs
+++ b/crates/hir_def/src/nameres/collector.rs
@@ -260,25 +260,6 @@ impl DefCollector<'_> {
             self.record_resolved_import(directive)
         }
         self.unresolved_imports = unresolved_imports;
-
-        // Record proc-macros
-        self.collect_proc_macro();
-    }
-
-    fn collect_proc_macro(&mut self) {
-        let proc_macros = std::mem::take(&mut self.proc_macros);
-        for (name, expander) in proc_macros {
-            let krate = self.def_map.krate;
-
-            let macro_id = MacroDefId {
-                ast_id: None,
-                krate: Some(krate),
-                kind: MacroDefKind::ProcMacro(expander),
-                local_inner: false,
-            };
-
-            self.define_proc_macro(name.clone(), macro_id);
-        }
     }
 
     fn resolve_proc_macro(&mut self, name: &Name) {

--- a/crates/hir_def/src/nameres/tests/macros.rs
+++ b/crates/hir_def/src/nameres/tests/macros.rs
@@ -699,3 +699,44 @@ fn resolves_proc_macros() {
         "#]],
     );
 }
+
+#[test]
+fn proc_macro_censoring() {
+    // Make sure that only proc macros are publicly exported from proc-macro crates.
+
+    check(
+        r"
+        //- /main.rs crate:main deps:macros
+        pub use macros::*;
+
+        //- /macros.rs crate:macros
+        pub struct TokenStream;
+
+        #[proc_macro]
+        pub fn function_like_macro(args: TokenStream) -> TokenStream {
+            args
+        }
+
+        #[proc_macro_attribute]
+        pub fn attribute_macro(_args: TokenStream, item: TokenStream) -> TokenStream {
+            item
+        }
+
+        #[proc_macro_derive(DummyTrait)]
+        pub fn derive_macro(_item: TokenStream) -> TokenStream {
+            TokenStream
+        }
+
+        #[macro_export]
+        macro_rules! mbe {
+            () => {};
+        }
+        ",
+        expect![[r#"
+            crate
+            DummyTrait: m
+            attribute_macro: m
+            function_like_macro: m
+        "#]],
+    );
+}

--- a/crates/hir_def/src/nameres/tests/macros.rs
+++ b/crates/hir_def/src/nameres/tests/macros.rs
@@ -667,3 +667,35 @@ b! { static = #[] (); }
         "#]],
     );
 }
+
+#[test]
+fn resolves_proc_macros() {
+    check(
+        r"
+        struct TokenStream;
+
+        #[proc_macro]
+        pub fn function_like_macro(args: TokenStream) -> TokenStream {
+            args
+        }
+
+        #[proc_macro_attribute]
+        pub fn attribute_macro(_args: TokenStream, item: TokenStream) -> TokenStream {
+            item
+        }
+
+        #[proc_macro_derive(DummyTrait)]
+        pub fn derive_macro(_item: TokenStream) -> TokenStream {
+            TokenStream
+        }
+        ",
+        expect![[r#"
+            crate
+            DummyTrait: m
+            TokenStream: t v
+            attribute_macro: v m
+            derive_macro: v
+            function_like_macro: v m
+        "#]],
+    );
+}


### PR DESCRIPTION
This makes name resolution look at proc-macro declaration attributes like `#[proc_macro_derive]` and defines the right proc macro in the macro namespace, fixing unresolved custom derives like `thiserror::Error` (which can cause false positives, now that we emit diagnostics for unresolved imports).

This works even when proc-macro support is turned off, in which case we fall back to a dummy expander that always returns an error. IMO this is the right way to handle at least the name resolution part of proc. macros, while the *expansion* itself should rely on the build system to build and provide the macro DLL. It does mean that they may go out of sync, but we can provide diagnostics if that happens (something like "could not find macro X in crate Y – ensure that all files of crate Y are saved").

I think it is valuable to be able to reason about proc macros even when we can't expand them, since proc macro expansion can break between Rust releases or users might not want to turn it on for performance reasons. It allows us to provide better diagnostics on any proc macro invocation we're not expanding (like a weak warning that informs the user that proc macro support is turned off, or that it has been disabled because the server crashed).

Fixes https://github.com/rust-analyzer/rust-analyzer/issues/5763