### PR TITLE
Bring back the enhanced enter key

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -194,12 +194,22 @@
                 "command": "rust-analyzer.joinLines",
                 "key": "ctrl+shift+j",
                 "when": "editorTextFocus && editorLangId == rust"
+            },
+            {
+                "key": "Enter",
+                "command": "rust-analyzer.onEnter",
+                "when": "editorTextFocus && !suggestWidgetVisible && editorLangId == rust"
             }
         ],
         "configuration": {
             "type": "object",
             "title": "Rust Analyzer",
             "properties": {
+                "rust-analyzer.enhancedEnter": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enhanced enter key (comment completion and auto-indent)"
+                },
                 "rust-analyzer.lruCapacity": {
                     "type": [
                         "null",

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -152,7 +152,7 @@ export function onEnter(ctx: Ctx): Cmd {
     }
 
     return async () => {
-        if (await handleKeypress()) return;
+        if (ctx.config.enhancedEnter && await handleKeypress()) return;
 
         await vscode.commands.executeCommand('default:type', { text: '\n' });
     };

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -95,6 +95,7 @@ export class Config {
     get channel() { return this.get<UpdatesChannel>("updates.channel"); }
     get askBeforeDownload() { return this.get<boolean>("updates.askBeforeDownload"); }
     get traceExtension() { return this.get<boolean>("trace.extension"); }
+    get enhancedEnter() { return this.get<boolean>("enhancedEnter"); }
 
     get inlayHints() {
         return {


### PR DESCRIPTION
...except as a client-side toggle that's off by default.

This was turned off by default in https://github.com/rust-analyzer/rust-analyzer/pull/4107, and enabling it currently requires adding a fairly obscure key binding. This PR adds the key binding back, but gates it behind a new config option. In particular, no request is sent to the server if the option is off, which can break if the server hangs.

It's a bit suboptimal that we cannot add the key binding dynamically, but VS Code doesn't seem to have an API for that (or I'm reading the docs wrong).