### PR TITLE
Allow missing trait members assist without needing braces

### DIFF
--- a/crates/assists/src/handlers/add_missing_impl_members.rs
+++ b/crates/assists/src/handlers/add_missing_impl_members.rs
@@ -314,6 +314,25 @@ impl Foo for S {
     }
 
     #[test]
+    fn test_impl_def_without_braces() {
+        check_assist(
+            add_missing_impl_members,
+            r#"
+trait Foo { fn foo(&self); }
+struct S;
+impl Foo for S<|>"#,
+            r#"
+trait Foo { fn foo(&self); }
+struct S;
+impl Foo for S {
+    fn foo(&self) {
+        ${0:todo!()}
+    }
+}"#,
+        );
+    }
+
+    #[test]
     fn fill_in_type_params_1() {
         check_assist(
             add_missing_impl_members,

--- a/crates/assists/src/handlers/add_missing_impl_members.rs
+++ b/crates/assists/src/handlers/add_missing_impl_members.rs
@@ -165,7 +165,7 @@ fn add_missing_impl_members_inner(
             .map(|it| edit::remove_attrs_and_docs(&it));
 
         let new_impl_item_list = impl_item_list.append_items(items);
-        let new_impl_def = impl_def.with_items(new_impl_item_list);
+        let new_impl_def = impl_def.with_assoc_item_list(new_impl_item_list);
         let first_new_item =
             new_impl_def.assoc_item_list().unwrap().assoc_items().nth(n_existing_items).unwrap();
 

--- a/crates/syntax/src/ast/edit.rs
+++ b/crates/syntax/src/ast/edit.rs
@@ -95,7 +95,7 @@ where
 
 impl ast::Impl {
     #[must_use]
-    pub fn with_items(&self, items: ast::AssocItemList) -> ast::Impl {
+    pub fn with_assoc_item_list(&self, items: ast::AssocItemList) -> ast::Impl {
         let mut to_insert: ArrayVec<[SyntaxElement; 2]> = ArrayVec::new();
         if let Some(old_items) = self.assoc_item_list() {
             let to_replace: SyntaxElement = old_items.syntax().clone().into();

--- a/crates/syntax/src/ast/edit.rs
+++ b/crates/syntax/src/ast/edit.rs
@@ -93,6 +93,22 @@ where
     }
 }
 
+impl ast::Impl {
+    #[must_use]
+    pub fn with_items(&self, items: ast::AssocItemList) -> ast::Impl {
+        let mut to_insert: ArrayVec<[SyntaxElement; 2]> = ArrayVec::new();
+        if let Some(old_items) = self.assoc_item_list() {
+            let to_replace: SyntaxElement = old_items.syntax().clone().into();
+            to_insert.push(items.syntax().clone().into());
+            self.replace_children(single_node(to_replace), to_insert)
+        } else {
+            to_insert.push(make::tokens::single_space().into());
+            to_insert.push(items.syntax().clone().into());
+            self.insert_children(InsertPosition::Last, to_insert)
+        }
+    }
+}
+
 impl ast::AssocItemList {
     #[must_use]
     pub fn append_items(

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -21,6 +21,10 @@ pub fn ty(text: &str) -> ast::Type {
     ast_from_text(&format!("impl {} for D {{}};", text))
 }
 
+pub fn assoc_item_list() -> ast::AssocItemList {
+    ast_from_text("impl C for D {};")
+}
+
 pub fn path_segment(name_ref: ast::NameRef) -> ast::PathSegment {
     ast_from_text(&format!("use {};", name_ref))
 }


### PR DESCRIPTION
Assist to complete missing items when implementing a trait does not appear without impl def braces (see #5144 ).

The reason behind this was that this assist is based on `ast::AssocItemList` which only appears in the AST after the braces are added to the impl def.

Instead of relying on and replacing the item list, we now instead replace the entire `ast::Impl` and add the item list if its missing.