### PR TITLE
Add ok postfix completion

### DIFF
--- a/crates/ide/src/completion/complete_postfix.rs
+++ b/crates/ide/src/completion/complete_postfix.rs
@@ -179,6 +179,16 @@ pub(super) fn complete_postfix(acc: &mut Completions, ctx: &CompletionContext) {
         ctx,
         cap,
         &dot_receiver,
+        "ok",
+        "Ok(expr)",
+        &format!("Ok({})", receiver_text),
+    )
+    .add_to(acc);
+
+    postfix_snippet(
+        ctx,
+        cap,
+        &dot_receiver,
         "dbg",
         "dbg!(expr)",
         &format!("dbg!({})", receiver_text),
@@ -266,6 +276,7 @@ fn main() {
                 sn if    if expr {}
                 sn match match expr {}
                 sn not   !expr
+                sn ok    Ok(expr)
                 sn ref   &expr
                 sn refm  &mut expr
                 sn while while expr {}
@@ -287,6 +298,7 @@ fn main() {
                 sn call  function(expr)
                 sn dbg   dbg!(expr)
                 sn match match expr {}
+                sn ok    Ok(expr)
                 sn ref   &expr
                 sn refm  &mut expr
             "#]],

--- a/crates/ide/src/completion/complete_postfix.rs
+++ b/crates/ide/src/completion/complete_postfix.rs
@@ -175,15 +175,8 @@ pub(super) fn complete_postfix(acc: &mut Completions, ctx: &CompletionContext) {
     )
     .add_to(acc);
 
-    postfix_snippet(
-        ctx,
-        cap,
-        &dot_receiver,
-        "ok",
-        "Ok(expr)",
-        &format!("Ok({})", receiver_text),
-    )
-    .add_to(acc);
+    postfix_snippet(ctx, cap, &dot_receiver, "ok", "Ok(expr)", &format!("Ok({})", receiver_text))
+        .add_to(acc);
 
     postfix_snippet(
         ctx,


### PR DESCRIPTION
Wrapping values in `Ok(...)` is so pervasive that it seems reasonable for it to
have its own postfix completion.
