### PR TITLE
Allow to use a Github Auth token for fetching releases

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -159,6 +159,11 @@
                 "category": "Rust Analyzer"
             },
             {
+                "command": "rust-analyzer.updateGithubToken",
+                "title": "Update Github API token",
+                "category": "Rust Analyzer"
+            },
+            {
                 "command": "rust-analyzer.onEnter",
                 "title": "Enhanced enter key",
                 "category": "Rust Analyzer"
@@ -982,6 +987,10 @@
                 },
                 {
                     "command": "rust-analyzer.reload",
+                    "when": "inRustProject"
+                },
+                {
+                    "command": "rust-analyzer.updateGithubToken",
                     "when": "inRustProject"
                 },
                 {

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -358,7 +358,7 @@ async function performDownloadWithRetryDialog<T>(downloadFunc: () => Promise<T>,
         try {
             return await downloadFunc();
         } catch (e) {
-            const selected = await vscode.window.showErrorMessage("Failed perform download: " + e.message, {}, {
+            const selected = await vscode.window.showErrorMessage("Failed to download: " + e.message, {}, {
                 title: "Update Github Auth Token",
                 updateToken: true,
             }, {

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -200,15 +200,11 @@ async function bootstrapExtension(config: Config, state: PersistentState): Promi
     const dest = path.join(config.globalStoragePath, "rust-analyzer.vsix");
 
     await downloadWithRetryDialog(state, async () => {
-        // Unlinking the exe file before moving new one on its place should prevent ETXTBSY error.
-        await fs.unlink(dest).catch(err => {
-            if (err.code !== "ENOENT") throw err;
-        });
-
         await download({
             url: artifact.browser_download_url,
             dest,
             progressTitle: "Downloading rust-analyzer extension",
+            overwrite: true,
         });
     });
 
@@ -330,17 +326,13 @@ async function getServer(config: Config, state: PersistentState): Promise<string
     assert(!!artifact, `Bad release: ${JSON.stringify(release)}`);
 
     await downloadWithRetryDialog(state, async () => {
-        // Unlinking the exe file before moving new one on its place should prevent ETXTBSY error.
-        await fs.unlink(dest).catch(err => {
-            if (err.code !== "ENOENT") throw err;
-        });
-
         await download({
             url: artifact.browser_download_url,
             dest,
             progressTitle: "Downloading rust-analyzer server",
             gunzip: true,
-            mode: 0o755
+            mode: 0o755,
+            overwrite: true,
         });
     });
 

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -393,8 +393,13 @@ async function queryForGithubToken(state: PersistentState): Promise<void> {
     };
 
     const newToken = await vscode.window.showInputBox(githubTokenOptions);
-    if (newToken) {
-        log.info("Storing new github token");
-        await state.updateGithubToken(newToken);
+    if (newToken !== undefined) {
+        if (newToken === "") {
+            log.info("Clearing github token");
+            await state.updateGithubToken(undefined);
+        } else {
+            log.info("Storing new github token");
+            await state.updateGithubToken(newToken);
+        }
     }
 }

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -344,7 +344,7 @@ async function performDownloadWithRetryDialog<T>(downloadFunc: () => Promise<T>,
         try {
             return await downloadFunc();
         } catch (e) {
-            let selected = await vscode.window.showErrorMessage("Failed perform download: " + e.message, {}, {
+            const selected = await vscode.window.showErrorMessage("Failed perform download: " + e.message, {}, {
                 title: "Update Github Auth Token",
                 updateToken: true,
             }, {
@@ -353,7 +353,7 @@ async function performDownloadWithRetryDialog<T>(downloadFunc: () => Promise<T>,
             }, {
                 title: "Dismiss",
             });
-    
+
             if (selected?.updateToken) {
                 await queryForGithubToken(state);
                 continue;

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -177,7 +177,7 @@ async function bootstrapExtension(config: Config, state: PersistentState): Promi
         if (!shouldCheckForNewNightly) return;
     }
 
-    const release = await performDownloadWithRetryDialog(state, async () => {
+    const release = await downloadWithRetryDialog(state, async () => {
         return await fetchRelease("nightly", state.githubToken);
     }).catch((e) => {
         log.error(e);
@@ -199,7 +199,7 @@ async function bootstrapExtension(config: Config, state: PersistentState): Promi
 
     const dest = path.join(config.globalStoragePath, "rust-analyzer.vsix");
 
-    await performDownloadWithRetryDialog(state, async () => {
+    await downloadWithRetryDialog(state, async () => {
         // Unlinking the exe file before moving new one on its place should prevent ETXTBSY error.
         await fs.unlink(dest).catch(err => {
             if (err.code !== "ENOENT") throw err;
@@ -323,13 +323,13 @@ async function getServer(config: Config, state: PersistentState): Promise<string
     }
 
     const releaseTag = config.package.releaseTag;
-    const release = await performDownloadWithRetryDialog(state, async () => {
+    const release = await downloadWithRetryDialog(state, async () => {
         return await fetchRelease(releaseTag, state.githubToken);
     });
     const artifact = release.assets.find(artifact => artifact.name === `rust-analyzer-${platform}.gz`);
     assert(!!artifact, `Bad release: ${JSON.stringify(release)}`);
 
-    await performDownloadWithRetryDialog(state, async () => {
+    await downloadWithRetryDialog(state, async () => {
         // Unlinking the exe file before moving new one on its place should prevent ETXTBSY error.
         await fs.unlink(dest).catch(err => {
             if (err.code !== "ENOENT") throw err;
@@ -353,7 +353,7 @@ async function getServer(config: Config, state: PersistentState): Promise<string
     return dest;
 }
 
-async function performDownloadWithRetryDialog<T>(state: PersistentState, downloadFunc: () => Promise<T>): Promise<T> {
+async function downloadWithRetryDialog<T>(state: PersistentState, downloadFunc: () => Promise<T>): Promise<T> {
     while (true) {
         try {
             return await downloadFunc();

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -377,7 +377,6 @@ async function performDownloadWithRetryDialog<T>(downloadFunc: () => Promise<T>,
             throw e;
         };
     }
-
 }
 
 async function queryForGithubToken(state: PersistentState): Promise<void> {

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -95,6 +95,10 @@ async function tryActivate(context: vscode.ExtensionContext) {
         await activate(context).catch(log.error);
     });
 
+    ctx.registerCommand('updateGithubToken', ctx => async () => {
+        await queryForGithubToken(new PersistentState(ctx.globalState));
+    });
+
     ctx.registerCommand('analyzerStatus', commands.analyzerStatus);
     ctx.registerCommand('memoryUsage', commands.memoryUsage);
     ctx.registerCommand('reloadWorkspace', commands.reloadWorkspace);

--- a/editors/code/src/net.ts
+++ b/editors/code/src/net.ts
@@ -18,7 +18,8 @@ const OWNER = "rust-analyzer";
 const REPO = "rust-analyzer";
 
 export async function fetchRelease(
-    releaseTag: string
+    releaseTag: string,
+    githubToken: string | null | undefined,
 ): Promise<GithubRelease> {
 
     const apiEndpointPath = `/repos/${OWNER}/${REPO}/releases/tags/${releaseTag}`;
@@ -27,7 +28,12 @@ export async function fetchRelease(
 
     log.debug("Issuing request for released artifacts metadata to", requestUrl);
 
-    const response = await fetch(requestUrl, { headers: { Accept: "application/vnd.github.v3+json" } });
+    var headers: any = { Accept: "application/vnd.github.v3+json" };
+    if (githubToken != null) {
+        headers.Authorization = "token " + githubToken;
+    }
+
+    const response = await fetch(requestUrl, { headers: headers });
 
     if (!response.ok) {
         log.error("Error fetching artifact release info", {

--- a/editors/code/src/net.ts
+++ b/editors/code/src/net.ts
@@ -28,7 +28,7 @@ export async function fetchRelease(
 
     log.debug("Issuing request for released artifacts metadata to", requestUrl);
 
-    var headers: any = { Accept: "application/vnd.github.v3+json" };
+    const headers: Record<string, string> = { Accept: "application/vnd.github.v3+json" };
     if (githubToken != null) {
         headers.Authorization = "token " + githubToken;
     }

--- a/editors/code/src/net.ts
+++ b/editors/code/src/net.ts
@@ -76,6 +76,7 @@ interface DownloadOpts {
     dest: string;
     mode?: number;
     gunzip?: boolean;
+    overwrite?: boolean,
 }
 
 export async function download(opts: DownloadOpts) {
@@ -84,6 +85,13 @@ export async function download(opts: DownloadOpts) {
     const dest = path.parse(opts.dest);
     const randomHex = crypto.randomBytes(5).toString("hex");
     const tempFile = path.join(dest.dir, `${dest.name}${randomHex}`);
+
+    if (opts.overwrite) {
+        // Unlinking the exe file before moving new one on its place should prevent ETXTBSY error.
+        await fs.promises.unlink(opts.dest).catch(err => {
+            if (err.code !== "ENOENT") throw err;
+        });
+    }
 
     await vscode.window.withProgress(
         {

--- a/editors/code/src/net.ts
+++ b/editors/code/src/net.ts
@@ -76,7 +76,7 @@ interface DownloadOpts {
     dest: string;
     mode?: number;
     gunzip?: boolean;
-    overwrite?: boolean,
+    overwrite?: boolean;
 }
 
 export async function download(opts: DownloadOpts) {

--- a/editors/code/src/persistent_state.ts
+++ b/editors/code/src/persistent_state.ts
@@ -38,4 +38,15 @@ export class PersistentState {
     async updateServerVersion(value: string | undefined) {
         await this.globalState.update("serverVersion", value);
     }
+
+    /**
+     * Github authorization token.
+     * This is used for API requests against the Github API.
+     */
+    get githubToken(): string | undefined {
+        return this.globalState.get("githubToken");
+    }
+    async updateGithubToken(value: string | undefined) {
+        await this.globalState.update("githubToken", value);
+    }
 }


### PR DESCRIPTION
This change allows to use a authorization token provided by Github in
order to fetch metadata for a RA release. Using an authorization token
prevents to get rate-limited in environments where lots of RA users use
a shared client IP (e.g. behind a company NAT).

The auth token is stored in `ExtensionContext.globalState`.
As far as I could observe through testing with a local WSL2 environment
that state is synced between an extension installed locally and a remote
version.

The change provides no explicit command to query for an auth token.
However in case a download fails it will provide a retry option as well
as an option to enter the auth token. This should be more discoverable
for most users.

Closes #3688