### PR TITLE
Bump smol_str from 0.1.16 to 0.1.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,9 +1465,9 @@ checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 
 [[package]]
 name = "smol_str"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7909a1d8bc166a862124d84fdc11bda0ea4ed3157ccca662296919c2972db1"
+checksum = "6ca0f7ce3a29234210f0f4f0b56f8be2e722488b95cb522077943212da3b32eb"
 dependencies = [
  "serde",
 ]

--- a/crates/hir_expand/src/name.rs
+++ b/crates/hir_expand/src/name.rs
@@ -43,8 +43,8 @@ impl Name {
     }
 
     /// Shortcut to create inline plain text name
-    const fn new_inline_ascii(text: &[u8]) -> Name {
-        Name::new_text(SmolStr::new_inline_from_ascii(text.len(), text))
+    const fn new_inline(text: &str) -> Name {
+        Name::new_text(SmolStr::new_inline(text))
     }
 
     /// Resolve a name from the text of token.
@@ -127,7 +127,7 @@ pub mod known {
             $(
                 #[allow(bad_style)]
                 pub const $ident: super::Name =
-                    super::Name::new_inline_ascii(stringify!($ident).as_bytes());
+                    super::Name::new_inline(stringify!($ident));
             )*
         };
     }
@@ -210,8 +210,8 @@ pub mod known {
     );
 
     // self/Self cannot be used as an identifier
-    pub const SELF_PARAM: super::Name = super::Name::new_inline_ascii(b"self");
-    pub const SELF_TYPE: super::Name = super::Name::new_inline_ascii(b"Self");
+    pub const SELF_PARAM: super::Name = super::Name::new_inline("self");
+    pub const SELF_TYPE: super::Name = super::Name::new_inline("Self");
 
     #[macro_export]
     macro_rules! name {

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -555,7 +555,7 @@ impl<'a> InferenceContext<'a> {
 
     fn resolve_lang_item(&self, name: &str) -> Option<LangItemTarget> {
         let krate = self.resolver.krate()?;
-        let name = SmolStr::new_inline_from_ascii(name.len(), name.as_bytes());
+        let name = SmolStr::new_inline(name);
         self.db.lang_item(krate, name)
     }
 

--- a/crates/mbe/src/syntax_bridge.rs
+++ b/crates/mbe/src/syntax_bridge.rs
@@ -636,7 +636,10 @@ impl<'a> TreeSink for TtTreeSink<'a> {
                     let (text, id) = match leaf {
                         tt::Leaf::Ident(ident) => (ident.text.clone(), ident.id),
                         tt::Leaf::Punct(punct) => {
-                            (SmolStr::new_inline_from_ascii(1, &[punct.char as u8]), punct.id)
+                            assert!(punct.char.is_ascii());
+                            let char = &(punct.char as u8);
+                            let text = std::str::from_utf8(std::slice::from_ref(char)).unwrap();
+                            (SmolStr::new_inline(text), punct.id)
                         }
                         tt::Leaf::Literal(lit) => (lit.text.clone(), lit.id),
                     };


### PR DESCRIPTION
When I built `rust-analyzer` today, I noticed the following warnings.

```
warning: use of deprecated item 'syntax::SmolStr::new_inline_from_ascii': Use `new_inline` instead
   --> crates/mbe/src/syntax_bridge.rs:639:30       
    |                                                                  
639 | ...                   (SmolStr::new_inline_from_ascii(1, &[punct.char as u8]), punct.id)
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^       
    |                                                                  
    = note: `#[warn(deprecated)]` on by default
                                                                       
warning: 1 warning emitted                                             
```

So I thought it would be a nice small PR.