### PR TITLE
Dont unnecessarily unnest imports

### DIFF
--- a/crates/assists/src/handlers/add_missing_impl_members.rs
+++ b/crates/assists/src/handlers/add_missing_impl_members.rs
@@ -415,6 +415,41 @@ impl foo::Foo for S {
     }
 
     #[test]
+    fn test_qualify_path_2() {
+        check_assist(
+            add_missing_impl_members,
+            r#"
+mod foo {
+    pub mod bar {
+        pub struct Bar;
+        pub trait Foo { fn foo(&self, bar: Bar); }
+    }
+}
+
+use foo::bar;
+
+struct S;
+impl bar::Foo for S { <|> }"#,
+            r#"
+mod foo {
+    pub mod bar {
+        pub struct Bar;
+        pub trait Foo { fn foo(&self, bar: Bar); }
+    }
+}
+
+use foo::bar;
+
+struct S;
+impl bar::Foo for S {
+    fn foo(&self, bar: bar::Bar) {
+        ${0:todo!()}
+    }
+}"#,
+        );
+    }
+
+    #[test]
     fn test_qualify_path_generic() {
         check_assist(
             add_missing_impl_members,

--- a/crates/assists/src/handlers/auto_import.rs
+++ b/crates/assists/src/handlers/auto_import.rs
@@ -196,10 +196,10 @@ impl AutoImportAssets {
             })
             .filter_map(|candidate| match candidate {
                 Either::Left(module_def) => {
-                    self.module_with_name_to_import.find_use_path(db, module_def)
+                    self.module_with_name_to_import.find_use_path_prefixed(db, module_def)
                 }
                 Either::Right(macro_def) => {
-                    self.module_with_name_to_import.find_use_path(db, macro_def)
+                    self.module_with_name_to_import.find_use_path_prefixed(db, macro_def)
                 }
             })
             .filter(|use_path| !use_path.segments.is_empty())
@@ -289,6 +289,35 @@ impl ImportCandidate {
 mod tests {
     use super::*;
     use crate::tests::{check_assist, check_assist_not_applicable, check_assist_target};
+
+    #[test]
+    fn applicable_when_found_an_import_partial() {
+        check_assist(
+            auto_import,
+            r"
+            mod std {
+                pub mod fmt {
+                    pub struct Formatter;
+                }
+            }
+
+            use std::fmt;
+
+            <|>Formatter
+            ",
+            r"
+            mod std {
+                pub mod fmt {
+                    pub struct Formatter;
+                }
+            }
+
+            use std::fmt::{self, Formatter};
+
+            Formatter
+            ",
+        );
+    }
 
     #[test]
     fn applicable_when_found_an_import() {

--- a/crates/assists/src/utils/insert_use.rs
+++ b/crates/assists/src/utils/insert_use.rs
@@ -810,16 +810,6 @@ use std::io;",
     }
 
     #[test]
-    #[ignore] // FIXME: Support this
-    fn merge_partial_path() {
-        check_full(
-            "ast::Foo",
-            r"use syntax::{ast, algo};",
-            r"use syntax::{ast::{self, Foo}, algo};",
-        )
-    }
-
-    #[test]
     fn merge_glob_nested() {
         check_full(
             "foo::bar::quux::Fez",

--- a/crates/hir/src/code_model.rs
+++ b/crates/hir/src/code_model.rs
@@ -383,6 +383,16 @@ impl Module {
     pub fn find_use_path(self, db: &dyn DefDatabase, item: impl Into<ItemInNs>) -> Option<ModPath> {
         hir_def::find_path::find_path(db, item.into(), self.into())
     }
+
+    /// Finds a path that can be used to refer to the given item from within
+    /// this module, if possible. This is used for returning import paths for use-statements.
+    pub fn find_use_path_prefixed(
+        self,
+        db: &dyn DefDatabase,
+        item: impl Into<ItemInNs>,
+    ) -> Option<ModPath> {
+        hir_def::find_path::find_path_prefixed(db, item.into(), self.into())
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]


### PR DESCRIPTION
Fixes #6071

This has the side effect that paths that refer to items inside of the current module get prefixed with `self`. Changing this behavior is unfortunately not straightforward should it be unwanted, though I don't see a problem with this as prefixing imports like this with `self` is what I do personally anyways 😅. You can see what I mean with this in one of the tests which had to be changed in `crates/ssr/src/tests.rs`.

There is one test that i still have to look at though, ~~which I by accident pushed with `#[ignore]` on it~~, which is `different_crate_renamed`, for some reason this now doesn't use the crate alias. This also makes me believe that aliases in general will break with this. So maybe this is not as straight forwards as I'd hoped for, but I don't really know how aliases work here.

Edit: The failing test should work now