### PR TITLE
Add hover config `linksInHover` to suppress links

### DIFF
--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -370,8 +370,12 @@ impl Analysis {
     }
 
     /// Returns a short text describing element at position.
-    pub fn hover(&self, position: FilePosition) -> Cancelable<Option<RangeInfo<HoverResult>>> {
-        self.with_db(|db| hover::hover(db, position))
+    pub fn hover(
+        &self,
+        position: FilePosition,
+        links_in_hover: bool,
+    ) -> Cancelable<Option<RangeInfo<HoverResult>>> {
+        self.with_db(|db| hover::hover(db, position, links_in_hover))
     }
 
     /// Computes parameter information for the given call expression.

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -307,6 +307,7 @@ impl Config {
             run: data.hoverActions_enable && data.hoverActions_run,
             debug: data.hoverActions_enable && data.hoverActions_debug,
             goto_type_def: data.hoverActions_enable && data.hoverActions_gotoTypeDef,
+            links_in_hover: data.hoverActions_linksInHover,
         };
 
         log::info!("Config::update() = {:#?}", self);
@@ -451,6 +452,7 @@ config_data! {
         hoverActions_gotoTypeDef: bool     = true,
         hoverActions_implementations: bool = true,
         hoverActions_run: bool             = true,
+        hoverActions_linksInHover: bool    = true,
 
         inlayHints_chainingHints: bool      = true,
         inlayHints_maxLength: Option<usize> = None,

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -597,7 +597,7 @@ pub(crate) fn handle_hover(
 ) -> Result<Option<lsp_ext::Hover>> {
     let _p = profile::span("handle_hover");
     let position = from_proto::file_position(&snap, params.text_document_position_params)?;
-    let info = match snap.analysis.hover(position)? {
+    let info = match snap.analysis.hover(position, snap.config.hover.links_in_hover)? {
         None => return Ok(None),
         Some(info) => info,
     };


### PR DESCRIPTION
This PR solves the problem of using RA under vim8. It should close #6014.

Since vim8's popup-window doesn't capture focus, the URL given by RA is effectively useless. links are neither displayed correctly nor can they be clicked. This makes the hover window ugly and inefficient.

I'm providing this patch so that people who share my confusion (which I'm almost certain vim8 users do) will have a way to remove links from markdown.

I noticed that [gopls has an option](https://github.com/golang/tools/blob/master/gopls/doc/settings.md#linksinhover-bool) for a similar purpose. So I added an option `linksInHover` to enable this behavior. This is a bool value and defaults to `true` to keep the behavior consistent with the master version. But you can suppress the links in the hover text by setting it to `false`.

The name of my option, `linksInHover`, is borrowed from gopls.

Before applying this patch:

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/5546718/93285021-85698a00-f806-11ea-911d-e77fea4a47f0.png">

After applying this patch(with `"rust-analyzer.hoverActions.linksInHover": false,`):
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/5546718/94332256-2e359780-0006-11eb-9724-1aed14130d0d.png">

This is the full test cases:
```
fn main() {
    let args: Vec<String> = std::env::args().collect();
    test();
    println!("args: {:?}", args);
}

/// Test cases:
/// case 1.  bare URL: https://rust-lang.org/
/// case 2.  inline URL with title: [foo](https://rust-lang.org/)
/// case 3.  code refrence: [`Result`]
/// case 4.  code refrence but miss footnote: [`String`]
/// case 5.  autolink: <http://rust-lang.org/>
/// case 6.  email address: <test@example.com>
/// case 7.  refrence: [bing][google]
/// case 8.  collapsed link: [bing][]
/// case 9.  shortcut link: [bing]
/// case 10. inline without URL: [bing]()
/// case 11. refrence: [foo][foo]
/// case 12. refrence: [foo][bar]
/// case 13. collapsed link: [foo][]
/// case 14. shortcut link: [foo]
/// case 15. inline without URL: [foo]()
/// case 16. just escaped text: \[hello]
/// case 17. inline link: [Foo](foo::Foo)
///
/// [`Result`]: ../../std/result/enum.Result.html
/// [^bing]: https://www.bing.com/
/// [^google]: https://www.google.com/
pub fn test() {
    println!("Hello");
}
```

screenshot:
<img width="1278" alt="image" src="https://user-images.githubusercontent.com/5546718/94332055-45738580-0004-11eb-9153-707f508d0c4b.png">