### PR TITLE
Update chalk to 0.30.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,9 +162,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chalk-derive"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a7f257e3bcdc56d8877ae31c012bd69fba0be66929d588e603905f2632c0c59"
+checksum = "a6696d18587b7470c1e357a3fa120a2b7e6ac95e91d5c408f087455f7dc31f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "chalk-ir"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a4050029ecb2b5a1ff3bfc64c39279179b294821ec2e8891a4a5c6e3a08db0"
+checksum = "8c9538918d3e1fd6edda042d717c969a4099af67a40372dfb0a00b45d3a5a946"
 dependencies = [
  "chalk-derive",
  "lazy_static",
@@ -184,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "chalk-recursive"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c04417735238af3b7998b0fa3a97850d0ef0698c5aa14a597cc20bf0a2a17ce8"
+checksum = "97ec8d95c808f2b540c39da889536e1ae0d15182107f61fe80000ec3a5c3959a"
 dependencies = [
  "chalk-derive",
  "chalk-ir",
@@ -197,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "chalk-solve"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "828c1f80d4eaf681027cce02050c54a3c97370f81988d31bf2a56df54048746c"
+checksum = "f373dff4bcff66004424b72bcc56ae62889c21887c1cac875f083f69a7da4448"
 dependencies = [
  "chalk-derive",
  "chalk-ir",

--- a/crates/hir_ty/Cargo.toml
+++ b/crates/hir_ty/Cargo.toml
@@ -17,9 +17,9 @@ ena = "0.14.0"
 log = "0.4.8"
 rustc-hash = "1.1.0"
 scoped-tls = "1"
-chalk-solve = { version = "0.29.0" }
-chalk-ir = { version = "0.29.0" }
-chalk-recursive = { version = "0.29.0" }
+chalk-solve = { version = "0.30.0" }
+chalk-ir = { version = "0.30.0" }
+chalk-recursive = { version = "0.30.0" }
 
 stdx = { path = "../stdx", version = "0.0.0" }
 hir_def = { path = "../hir_def", version = "0.0.0" }


### PR DESCRIPTION
Fixes #6078 and CI failures.

