### PR TITLE
Insert ref for completions

### DIFF
--- a/crates/completion/src/completion_context.rs
+++ b/crates/completion/src/completion_context.rs
@@ -246,6 +246,19 @@ impl<'a> CompletionContext<'a> {
         }
     }
 
+    pub(crate) fn active_name_and_type(&self) -> Option<(String, Type)> {
+        if let Some(record_field) = &self.record_field_syntax {
+            mark::hit!(record_field_type_match);
+            let (struct_field, _local) = self.sema.resolve_record_field(record_field)?;
+            Some((struct_field.name(self.db).to_string(), struct_field.signature_ty(self.db)))
+        } else if let Some(active_parameter) = &self.active_parameter {
+            mark::hit!(active_param_type_match);
+            Some((active_parameter.name.clone(), active_parameter.ty.clone()))
+        } else {
+            None
+        }
+    }
+
     fn fill_keyword_patterns(&mut self, file_with_fake_ident: &SyntaxNode, offset: TextSize) {
         let fake_ident_token = file_with_fake_ident.token_at_offset(offset).right_biased().unwrap();
         let syntax_element = NodeOrToken::Token(fake_ident_token);

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -570,7 +570,7 @@ pub(crate) fn handle_completion(
     let line_endings = snap.file_line_endings(position.file_id);
     let items: Vec<CompletionItem> = items
         .into_iter()
-        .map(|item| to_proto::completion_item(&line_index, line_endings, item))
+        .flat_map(|item| to_proto::completion_item(&line_index, line_endings, item))
         .collect();
 
     Ok(Some(items.into()))


### PR DESCRIPTION
Follow up to https://github.com/rust-analyzer/rust-analyzer/pull/5846. When we have a local in scope which needs a ref or mutable ref to match the name and type of the active in the completion context then a new completion item with `&` or `&mut ` is inserted. E.g.
```rust
fn foo(arg: &i32){};
fn main() {
    let arg = 1_i32;
    foo(a<|>)
}
```
now offers `&arg` as a completion option with the highest score.