### PR TITLE
Add rust-analyzer.serverEnv to set the environment variables of the server

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -476,6 +476,11 @@
                     "default": null,
                     "description": "Path to rust-analyzer executable (points to bundled binary by default). If this is set, then \"rust-analyzer.updates.channel\" setting is not used"
                 },
+                "rust-analyzer.serverEnv": {
+                    "type": "object",
+                    "default": null,
+                    "description": "Environment variables to set for the rust-analyzer executable in form of { \"key\": \"value\"}"
+                },
                 "rust-analyzer.trace.server": {
                     "type": "string",
                     "scope": "window",

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -18,14 +18,14 @@ function renderHoverActions(actions: ra.CommandLinkGroup[]): vscode.MarkdownStri
     return result;
 }
 
-export function createClient(serverPath: string, cwd: string): lc.LanguageClient {
+export function createClient(serverPath: string, cwd: string, env: Record<string, string>): lc.LanguageClient {
     // '.' Is the fallback if no folder is open
     // TODO?: Workspace folders support Uri's (eg: file://test.txt).
     // It might be a good idea to test if the uri points to a file.
 
     const run: lc.Executable = {
         command: serverPath,
-        options: { cwd },
+        options: { cwd, env },
     };
     const serverOptions: lc.ServerOptions = {
         run,

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -5,6 +5,7 @@ export type UpdatesChannel = "stable" | "nightly";
 
 export const NIGHTLY_TAG = "nightly";
 
+export type ServerEnvCfg = undefined | Record<string, string>;
 export type RunnableEnvCfg = undefined | Record<string, string> | { mask?: string; env: Record<string, string> }[];
 
 export class Config {
@@ -13,6 +14,7 @@ export class Config {
     readonly rootSection = "rust-analyzer";
     private readonly requiresReloadOpts = [
         "serverPath",
+        "serverEnv",
         "cargo",
         "procMacro",
         "files",
@@ -92,6 +94,7 @@ export class Config {
     }
 
     get serverPath() { return this.get<null | string>("serverPath"); }
+    get serverEnv() { return this.get<ServerEnvCfg>("serverEnv"); }
     get channel() { return this.get<UpdatesChannel>("updates.channel"); }
     get askBeforeDownload() { return this.get<boolean>("updates.askBeforeDownload"); }
     get traceExtension() { return this.get<boolean>("trace.extension"); }

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -23,8 +23,9 @@ export class Ctx {
         extCtx: vscode.ExtensionContext,
         serverPath: string,
         cwd: string,
+        env: Record<string, string>,
     ): Promise<Ctx> {
-        const client = createClient(serverPath, cwd);
+        const client = createClient(serverPath, cwd, env);
 
         const statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
         extCtx.subscriptions.push(statusBar);

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -65,6 +65,7 @@ async function tryActivate(context: vscode.ExtensionContext) {
         log.error("Bootstrap error", err);
         throw new Error(message);
     });
+    const env = config.serverEnv ?? {};
 
     const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
     if (workspaceFolder === undefined) {
@@ -75,7 +76,7 @@ async function tryActivate(context: vscode.ExtensionContext) {
     // registers its `onDidChangeDocument` handler before us.
     //
     // This a horribly, horribly wrong way to deal with this problem.
-    ctx = await Ctx.create(config, context, serverPath, workspaceFolder.uri.fsPath);
+    ctx = await Ctx.create(config, context, serverPath, workspaceFolder.uri.fsPath, env);
 
     setContextValue(RUST_PROJECT_CONTEXT_NAME, true);
 


### PR DESCRIPTION
This PR simply adds a `rust-analyzer.serverEnv` settings in the VSCode extension to set the environment variables used when launching the rust-analyzer server.

I don't know if it is a common use case, but I have a build script that depends on an environment variable to locate a system dependency. If the environment variable changes, the build script is re-run (which takes some time). The environment variables changes frequently, as I jump from version to version. I was setting the environment variable in the terminal of VS Code, but it kept re-running the build script because rust-analyzer was overiding the build script hash value. A quick fix was to launch VS Code from a terminal with the environment variable set, but it seemed like a nice feature to add without much effort needed, so there it is.