### PR TITLE
add a new TextMate grammar

### DIFF
--- a/editors/code/rust.tmGrammar.json
+++ b/editors/code/rust.tmGrammar.json
@@ -1,686 +1,1043 @@
 {
-	"name": "Rust",
-	"scopeName": "source.rust",
-	"patterns": [
-		{
-			"comment": "Implementation",
-			"begin": "\\b(impl)\\b",
-			"end": "\\{",
-			"beginCaptures": {
-				"1": {
-					"name": "storage.type.rust"
-				}
-			},
-			"patterns": [
-				{
-					"include": "#block_comment"
-				},
-				{
-					"include": "#line_comment"
-				},
-				{
-					"include": "#sigils"
-				},
-				{
-					"include": "#mut"
-				},
-				{
-					"include": "#dyn"
-				},
-				{
-					"include": "#ref_lifetime"
-				},
-				{
-					"include": "#core_types"
-				},
-				{
-					"include": "#core_marker"
-				},
-				{
-					"include": "#core_traits"
-				},
-				{
-					"include": "#std_types"
-				},
-				{
-					"include": "#std_traits"
-				},
-				{
-					"include": "#type_params"
-				},
-				{
-					"include": "#where"
-				},
-				{
-					"name": "storage.type.rust",
-					"match": "\\bfor\\b"
-				},
-				{
-					"include": "#type"
-				}
-			]
-		},
-		{
-			"include": "#block_doc_comment"
-		},
-		{
-			"include": "#block_comment"
-		},
-		{
-			"include": "#line_doc_comment"
-		},
-		{
-			"include": "#line_comment"
-		},
-		{
-			"comment": "Attribute",
-			"name": "meta.attribute.rust",
-			"begin": "#\\!?\\[(\\w*)",
-			"end": "\\]",
-			"captures": {
-				"1": {
-					"name": "entity.name.function.attribute.rust"
-				}
-			},
-			"patterns": [
-				{
-					"include": "#string_literal"
-				},
-				{
-					"include": "#block_doc_comment"
-				},
-				{
-					"include": "#block_comment"
-				},
-				{
-					"include": "#line_doc_comment"
-				},
-				{
-					"include": "#line_comment"
-				}
-			]
-		},
-		{
-			"comment": "Single-quote string literal (character)",
-			"name": "string.quoted.single.rust",
-			"match": "b?'([^'\\\\]|\\\\(x[0-9A-Fa-f]{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.))'"
-		},
-		{
-			"include": "#string_literal"
-		},
-		{
-			"include": "#raw_string_literal"
-		},
-		{
-			"comment": "Floating point literal (fraction)",
-			"name": "constant.numeric.float.rust",
-			"match": "\\b[0-9][0-9_]*\\.[0-9][0-9_]*([eE][+-]?[0-9_]+)?(f32|f64)?\\b"
-		},
-		{
-			"comment": "Floating point literal (exponent)",
-			"name": "constant.numeric.float.rust",
-			"match": "\\b[0-9][0-9_]*(\\.[0-9][0-9_]*)?[eE][+-]?[0-9_]+(f32|f64)?\\b"
-		},
-		{
-			"comment": "Floating point literal (typed)",
-			"name": "constant.numeric.float.rust",
-			"match": "\\b[0-9][0-9_]*(\\.[0-9][0-9_]*)?([eE][+-]?[0-9_]+)?(f32|f64)\\b"
-		},
-		{
-			"comment": "Integer literal (decimal)",
-			"name": "constant.numeric.integer.decimal.rust",
-			"match": "\\b[0-9][0-9_]*([ui](8|16|32|64|128|s|size))?\\b"
-		},
-		{
-			"comment": "Integer literal (hexadecimal)",
-			"name": "constant.numeric.integer.hexadecimal.rust",
-			"match": "\\b0x[a-fA-F0-9_]+([ui](8|16|32|64|128|s|size))?\\b"
-		},
-		{
-			"comment": "Integer literal (octal)",
-			"name": "constant.numeric.integer.octal.rust",
-			"match": "\\b0o[0-7_]+([ui](8|16|32|64|128|s|size))?\\b"
-		},
-		{
-			"comment": "Integer literal (binary)",
-			"name": "constant.numeric.integer.binary.rust",
-			"match": "\\b0b[01_]+([ui](8|16|32|64|128|s|size))?\\b"
-		},
-		{
-			"comment": "Static storage modifier",
-			"name": "storage.modifier.static.rust",
-			"match": "\\bstatic\\b"
-		},
-		{
-			"comment": "Boolean constant",
-			"name": "constant.language.boolean.rust",
-			"match": "\\b(true|false)\\b"
-		},
-		{
-			"comment": "Control keyword",
-			"name": "keyword.control.rust",
-			"match": "\\b(async|await|break|continue|else|if|in|for|loop|match|return|try|while)\\b"
-		},
-		{
-			"comment": "Keyword",
-			"name": "keyword.other.rust",
-			"match": "\\b(crate|extern|mod|let|ref|use|super|move|as)\\b"
-		},
-		{
-			"comment": "Reserved keyword",
-			"name": "invalid.deprecated.rust",
-			"match": "\\b(abstract|alignof|become|do|final|macro|offsetof|override|priv|proc|pure|sizeof|typeof|virtual|yield)\\b"
-		},
-		{
-			"include": "#unsafe"
-		},
-		{
-			"include": "#sigils"
-		},
-		{
-			"include": "#self"
-		},
-		{
-			"include": "#mut"
-		},
-		{
-			"include": "#dyn"
-		},
-		{
-			"include": "#impl"
-		},
-		{
-			"include": "#box"
-		},
-		{
-			"include": "#lifetime"
-		},
-		{
-			"include": "#ref_lifetime"
-		},
-		{
-			"include": "#const"
-		},
-		{
-			"include": "#pub"
-		},
-		{
-			"comment": "Miscellaneous operator",
-			"name": "keyword.operator.misc.rust",
-			"match": "(=>|::|\\?)"
-		},
-		{
-			"comment": "Comparison operator",
-			"name": "keyword.operator.comparison.rust",
-			"match": "(&&|\\|\\||==|!=)"
-		},
-		{
-			"comment": "Assignment operator",
-			"name": "keyword.operator.assignment.rust",
-			"match": "(\\+=|-=|/=|\\*=|%=|\\^=|&=|\\|=|<<=|>>=|=)"
-		},
-		{
-			"comment": "Arithmetic operator",
-			"name": "keyword.operator.arithmetic.rust",
-			"match": "(!|\\+|-|/|\\*|%|\\^|&|\\||<<|>>)"
-		},
-		{
-			"comment": "Comparison operator (second group because of regex precedence)",
-			"name": "keyword.operator.comparison.rust",
-			"match": "(<=|>=|<|>)"
-		},
-		{
-			"include": "#core_types"
-		},
-		{
-			"include": "#core_vars"
-		},
-		{
-			"include": "#core_marker"
-		},
-		{
-			"include": "#core_traits"
-		},
-		{
-			"include": "#std_types"
-		},
-		{
-			"include": "#std_traits"
-		},
-		{
-			"comment": "Built-in macro",
-			"name": "support.function.builtin.rust",
-			"match": "\\b(macro_rules|compile_error|format_args|env|option_env|concat_idents|concat|line|column|file|stringify|include|include_str|include_bytes|module_path|cfg)!"
-		},
-		{
-			"comment": "Core macro",
-			"name": "support.function.core.rust",
-			"match": "\\b(panic|assert|assert_eq|assert_ne|debug_assert|debug_assert_eq|debug_assert_ne|try|write|writeln|unreachable|unimplemented)!"
-		},
-		{
-			"comment": "Standard library macro",
-			"name": "support.function.std.rust",
-			"match": "\\b(format|print|println|eprint|eprintln|select|vec)!"
-		},
-		{
-			"comment": "Logging macro",
-			"name": "support.function.log.rust",
-			"match": "\\b(log|error|warn|info|debug|trace|log_enabled)!"
-		},
-		{
-			"comment": "Invocation of a macro",
-			"match": "\\b([a-zA-Z_][a-zA-Z0-9_]*\\!)\\s*[({\\[]",
-			"captures": {
-				"1": {
-					"name": "entity.name.function.macro.rust"
-				}
-			}
-		},
-		{
-			"comment": "Function call",
-			"match": "\\b([A-Za-z][A-Za-z0-9_]*|_[A-Za-z0-9_]+)\\s*\\(",
-			"captures": {
-				"1": {
-					"name": "entity.name.function.rust"
-				}
-			}
-		},
-		{
-			"comment": "Function call with type parameters",
-			"begin": "\\b([A-Za-z][A-Za-z0-9_]*|_[A-Za-z0-9_]+)\\s*(::)(?=\\s*<.*>\\s*\\()",
-			"end": "\\(",
-			"captures": {
-				"1": {
-					"name": "entity.name.function.rust"
-				},
-				"2": {
-					"name": "keyword.operator.misc.rust"
-				}
-			},
-			"patterns": [
-				{
-					"include": "#type_params"
-				}
-			]
-		},
-		{
-			"comment": "Function definition",
-			"begin": "\\b(fn)\\s+([A-Za-z][A-Za-z0-9_]*|_[A-Za-z0-9_]+)",
-			"end": "[\\{;]",
-			"beginCaptures": {
-				"1": {
-					"name": "keyword.other.fn.rust"
-				},
-				"2": {
-					"name": "entity.name.function.rust"
-				}
-			},
-			"patterns": [
-				{
-					"include": "#block_comment"
-				},
-				{
-					"include": "#line_comment"
-				},
-				{
-					"include": "#sigils"
-				},
-				{
-					"include": "#self"
-				},
-				{
-					"include": "#mut"
-				},
-				{
-					"include": "#dyn"
-				},
-				{
-					"include": "#impl"
-				},
-				{
-					"include": "#ref_lifetime"
-				},
-				{
-					"include": "#core_types"
-				},
-				{
-					"include": "#core_marker"
-				},
-				{
-					"include": "#core_traits"
-				},
-				{
-					"include": "#std_types"
-				},
-				{
-					"include": "#std_traits"
-				},
-				{
-					"include": "#type_params"
-				},
-				{
-					"include": "#const"
-				},
-				{
-					"include": "#where"
-				},
-				{
-					"include": "#unsafe"
-				},
-				{
-					"comment": "Function arguments",
-					"match": "\bfn\b",
-					"name": "keyword.other.fn.rust"
-				}
-			]
-		},
-		{
-			"comment": "Type declaration",
-			"begin": "\\b(enum|struct|trait|union)\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
-			"end": "[\\{\\(;]",
-			"beginCaptures": {
-				"1": {
-					"name": "storage.type.rust"
-				},
-				"2": {
-					"name": "entity.name.type.rust"
-				}
-			},
-			"patterns": [
-				{
-					"include": "#block_comment"
-				},
-				{
-					"include": "#line_comment"
-				},
-				{
-					"include": "#core_traits"
-				},
-				{
-					"include": "#std_traits"
-				},
-				{
-					"include": "#type_params"
-				},
-				{
-					"include": "#core_types"
-				},
-				{
-					"include": "#pub"
-				},
-				{
-					"include": "#where"
-				}
-			]
-		},
-		{
-			"comment": "Type alias",
-			"begin": "\\b(type)\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
-			"end": ";",
-			"beginCaptures": {
-				"1": {
-					"name": "storage.type.rust"
-				},
-				"2": {
-					"name": "entity.name.type.rust"
-				}
-			},
-			"patterns": [
-				{
-					"include": "#block_comment"
-				},
-				{
-					"include": "#line_comment"
-				},
-				{
-					"include": "#sigils"
-				},
-				{
-					"include": "#mut"
-				},
-				{
-					"include": "#dyn"
-				},
-				{
-					"include": "#impl"
-				},
-				{
-					"include": "#lifetime"
-				},
-				{
-					"include": "#ref_lifetime"
-				},
-				{
-					"include": "#core_types"
-				},
-				{
-					"include": "#core_marker"
-				},
-				{
-					"include": "#core_traits"
-				},
-				{
-					"include": "#std_types"
-				},
-				{
-					"include": "#std_traits"
-				},
-				{
-					"include": "#type_params"
-				}
-			]
-		}
-	],
-	"repository": {
-		"block_doc_comment": {
-			"comment": "Block documentation comment",
-			"name": "comment.block.documentation.rust",
-			"begin": "/\\*[\\*!](?![\\*/])",
-			"end": "\\*/",
-			"patterns": [
-				{
-					"include": "#block_doc_comment"
-				},
-				{
-					"include": "#block_comment"
-				}
-			]
-		},
-		"block_comment": {
-			"comment": "Block comment",
-			"name": "comment.block.rust",
-			"begin": "/\\*",
-			"end": "\\*/",
-			"patterns": [
-				{
-					"include": "#block_doc_comment"
-				},
-				{
-					"include": "#block_comment"
-				}
-			]
-		},
-		"line_doc_comment": {
-			"comment": "Single-line documentation comment",
-			"name": "comment.line.documentation.rust",
-			"begin": "//[!/](?=[^/])",
-			"end": "$"
-		},
-		"line_comment": {
-			"comment": "Single-line comment",
-			"name": "comment.line.double-slash.rust",
-			"begin": "//",
-			"end": "$"
-		},
-		"escaped_character": {
-			"name": "constant.character.escape.rust",
-			"match": "\\\\(x[0-9A-Fa-f]{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)"
-		},
-		"string_literal": {
-			"comment": "Double-quote string literal",
-			"name": "string.quoted.double.rust",
-			"begin": "b?\"",
-			"end": "\"",
-			"patterns": [
-				{
-					"include": "#escaped_character"
-				}
-			]
-		},
-		"raw_string_literal": {
-			"comment": "Raw double-quote string literal",
-			"name": "string.quoted.double.raw.rust",
-			"begin": "b?r(#*)\"",
-			"end": "\"\\1"
-		},
-		"sigils": {
-			"comment": "Sigil",
-			"name": "keyword.operator.sigil.rust",
-			"match": "[&*](?=[a-zA-Z0-9_\\(\\[\\|\\\"]+)"
-		},
-		"self": {
-			"comment": "Self variable",
-			"name": "variable.language.rust",
-			"match": "\\bself\\b"
-		},
-		"mut": {
-			"comment": "Mutable storage modifier",
-			"name": "storage.modifier.mut.rust",
-			"match": "\\bmut\\b"
-		},
-		"dyn": {
-			"comment": "Dynamic modifier",
-			"name": "storage.modifier.dyn.rust",
-			"match": "\\bdyn\\b"
-		},
-		"impl": {
-			"comment": "Existential type modifier",
-			"name": "storage.modifier.impl.rust",
-			"match": "\\bimpl\\b"
-		},
-		"box": {
-			"comment": "Box storage modifier",
-			"name": "storage.modifier.box.rust",
-			"match": "\\bbox\\b"
-		},
-		"const": {
-			"comment": "Const storage modifier",
-			"name": "storage.modifier.const.rust",
-			"match": "\\bconst\\b"
-		},
-		"pub": {
-			"comment": "Visibility modifier",
-			"name": "storage.modifier.visibility.rust",
-			"match": "\\bpub\\b"
-		},
-		"unsafe": {
-			"comment": "Unsafe code keyword",
-			"name": "keyword.other.unsafe.rust",
-			"match": "\\bunsafe\\b"
-		},
-		"where": {
-			"comment": "Generic where clause",
-			"name": "keyword.other.where.rust",
-			"match": "\\bwhere\\b"
-		},
-		"lifetime": {
-			"comment": "Named lifetime",
-			"name": "storage.modifier.lifetime.rust",
-			"match": "'([a-zA-Z_][a-zA-Z0-9_]*)\\b"
-		},
-		"ref_lifetime": {
-			"comment": "Reference with named lifetime",
-			"match": "(&)('[a-zA-Z_][a-zA-Z0-9_]*)\\b",
-			"captures": {
-				"1": {
-					"name": "keyword.operator.sigil.rust"
-				},
-				"2": {
-					"name": "storage.modifier.lifetime.rust"
-				}
-			}
-		},
-		"core_types": {
-			"comment": "Built-in/core type",
-			"name": "support.type.primitive.rust",
-			"match": "\\b(bool|char|usize|isize|u8|u16|u32|u64|u128|i8|i16|i32|i64|i128|f32|f64|str|Self)\\b"
-		},
-		"core_vars": {
-			"comment": "Core type variant",
-			"name": "support.constant.core.rust",
-			"match": "\\b(Some|None|Ok|Err)\\b"
-		},
-		"core_marker": {
-			"comment": "Core trait (marker)",
-			"name": "entity.name.type.marker.rust",
-			"match": "\\b(Copy|Send|Sized|Sync)\\b"
-		},
-		"core_traits": {
-			"comment": "Core trait",
-			"name": "entity.name.type.core.rust",
-			"match": "\\b(Drop|Fn|FnMut|FnOnce|Clone|PartialEq|PartialOrd|Eq|Ord|AsRef|AsMut|Into|From|Default|Iterator|Extend|IntoIterator|DoubleEndedIterator|ExactSizeIterator)\\b"
-		},
-		"std_types": {
-			"comment": "Standard library type",
-			"name": "entity.name.type.class.std.rust",
-			"match": "\\b(Box|String|Vec|Path|PathBuf|Option|Result)\\b"
-		},
-		"std_traits": {
-			"comment": "Standard library trait",
-			"name": "entity.name.type.std.rust",
-			"match": "\\b(ToOwned|ToString)\\b"
-		},
-		"type": {
-			"comment": "A type",
-			"name": "entity.name.type.rust",
-			"match": "\\b([A-Za-z][_A-Za-z0-9]*|_[_A-Za-z0-9]+)\\b"
-		},
-		"type_params": {
-			"comment": "Type parameters",
-			"name": "meta.type_params.rust",
-			"begin": "<(?![=<])",
-			"end": "(?<![-])>",
-			"patterns": [
-				{
-					"include": "#block_comment"
-				},
-				{
-					"include": "#line_comment"
-				},
-				{
-					"include": "#sigils"
-				},
-				{
-					"include": "#mut"
-				},
-				{
-					"include": "#dyn"
-				},
-				{
-					"include": "#impl"
-				},
-				{
-					"include": "#lifetime"
-				},
-				{
-					"include": "#core_types"
-				},
-				{
-					"include": "#core_marker"
-				},
-				{
-					"include": "#core_traits"
-				},
-				{
-					"include": "#std_types"
-				},
-				{
-					"include": "#std_traits"
-				},
-				{
-					"include": "#type_params"
-				}
-			]
-		}
-	}
+    "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+    "name": "Rust",
+    "fileTypes": [
+        "rs"
+    ],
+    "scopeName": "source.rust",
+    "patterns": [
+        {
+            "comment": "boxed slice literal",
+            "begin": "(<)(\\[)",
+            "beginCaptures": {
+                "1": {
+                    "name": "punctuation.brackets.angle.rust"
+                },
+                "2": {
+                    "name": "punctuation.brackets.square.rust"
+                }
+            },
+            "end": ">",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.brackets.angle.rust"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#comments"
+                },
+                {
+                    "include": "#gtypes"
+                },
+                {
+                    "include": "#lvariables"
+                },
+                {
+                    "include": "#lifetimes"
+                },
+                {
+                    "include": "#punctuation"
+                },
+                {
+                    "include": "#types"
+                }
+            ]
+        },
+        {
+            "comment": "macro type metavariables",
+            "name": "meta.macro.metavariable.type.rust",
+            "match": "(\\$)((crate)|([A-Z][A-Za-z0-9_]*))((:)(block|expr|ident|item|lifetime|literal|meta|pat|path|stmt|tt|ty|vis))?",
+            "captures": {
+                "1": {
+                    "name": "keyword.operator.macro.dollar.rust"
+                },
+                "3": {
+                    "name": "keyword.other.crate.rust"
+                },
+                "4": {
+                    "name": "entity.name.type.metavariable.rust"
+                },
+                "6": {
+                    "name": "keyword.operator.key-value.rust"
+                },
+                "7": {
+                    "name": "variable.other.metavariable.specifier.rust"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#keywords"
+                }
+            ]
+        },
+        {
+            "comment": "macro metavariables",
+            "name": "meta.macro.metavariable.rust",
+            "match": "(\\$)([a-z][A-Za-z0-9_]*)((:)(block|expr|ident|item|lifetime|literal|meta|pat|path|stmt|tt|ty|vis))?",
+            "captures": {
+                "1": {
+                    "name": "keyword.operator.macro.dollar.rust"
+                },
+                "2": {
+                    "name": "variable.other.metavariable.name.rust"
+                },
+                "4": {
+                    "name": "keyword.operator.key-value.rust"
+                },
+                "5": {
+                    "name": "variable.other.metavariable.specifier.rust"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#keywords"
+                }
+            ]
+        },
+        {
+            "comment": "macro rules",
+            "name": "meta.macro.rules.rust",
+            "match": "\\b(macro_rules!)\\s+(([a-z0-9_]+)|([A-Z][a-z0-9_]*))\\s+(\\{)",
+            "captures": {
+                "1": {
+                    "name": "entity.name.function.macro.rules.rust"
+                },
+                "3": {
+                    "name": "entity.name.function.macro.rust"
+                },
+                "4": {
+                    "name": "entity.name.type.macro.rust"
+                },
+                "5": {
+                    "name": "punctuation.brackets.curly.rust"
+                }
+            }
+        },
+        {
+            "comment": "attributes",
+            "name": "meta.attribute.rust",
+            "begin": "(#)(\\!?)(\\[)",
+            "beginCaptures": {
+                "1": {
+                    "name": "punctuation.definition.attribute.rust"
+                },
+                "2": {
+                    "name": "keyword.operator.attribute.inner.rust"
+                },
+                "3": {
+                    "name": "punctuation.brackets.attribute.rust"
+                }
+            },
+            "end": "\\]",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.brackets.attribute.rust"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#keywords"
+                },
+                {
+                    "include": "#punctuation"
+                },
+                {
+                    "include": "#strings"
+                },
+                {
+                    "include": "#gtypes"
+                },
+                {
+                    "include": "#types"
+                }
+            ]
+        },
+        {
+            "comment": "modules",
+            "match": "(mod)\\s+([a-z][A-Za-z0-9_]*)",
+            "captures": {
+                "1": {
+                    "name": "keyword.control.rust"
+                },
+                "2": {
+                    "name": "entity.name.module.rust"
+                }
+            }
+        },
+        {
+            "comment": "external crate imports",
+            "name": "meta.import.rust",
+            "begin": "\\b(extern)\\s+(crate)",
+            "beginCaptures": {
+                "1": {
+                    "name": "keyword.control.rust"
+                },
+                "2": {
+                    "name": "keyword.other.crate.rust"
+                }
+            },
+            "end": ";",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.semi.rust"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#comments"
+                },
+                {
+                    "include": "#keywords"
+                },
+                {
+                    "include": "#punctuation"
+                }
+            ]
+        },
+        {
+            "comment": "use statements",
+            "name": "meta.use.rust",
+            "begin": "\\b(use)\\s",
+            "beginCaptures": {
+                "1": {
+                    "name": "keyword.control.rust"
+                }
+            },
+            "end": ";",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.semi.rust"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#comments"
+                },
+                {
+                    "include": "#keywords"
+                },
+                {
+                    "include": "#namespaces"
+                },
+                {
+                    "include": "#punctuation"
+                },
+                {
+                    "include": "#types"
+                },
+                {
+                    "include": "#lvariables"
+                }
+            ]
+        },
+        {
+            "include": "#comments"
+        },
+        {
+            "include": "#lvariables"
+        },
+        {
+            "include": "#constants"
+        },
+        {
+            "include": "#gtypes"
+        },
+        {
+            "include": "#functions"
+        },
+        {
+            "include": "#types"
+        },
+        {
+            "include": "#keywords"
+        },
+        {
+            "include": "#lifetimes"
+        },
+        {
+            "include": "#macros"
+        },
+        {
+            "include": "#namespaces"
+        },
+        {
+            "include": "#punctuation"
+        },
+        {
+            "include": "#strings"
+        },
+        {
+            "include": "#variables"
+        }
+    ],
+    "repository": {
+        "comments": {
+            "patterns": [
+                {
+                    "comment": "documentation comments",
+                    "name": "comment.line.documentation.rust",
+                    "match": "^\\s*///.*",
+                    "patterns": [
+                        {
+                            "include": "#comments"
+                        }
+                    ]
+                },
+                {
+                    "comment": "line comments",
+                    "name": "comment.line.double-slash.rust",
+                    "match": "\\s*//.*",
+                    "patterns": [
+                        {
+                            "include": "#comments"
+                        }
+                    ]
+                },
+                {
+                    "comment": "block comments",
+                    "name": "comment.block.rust",
+                    "begin": "/\\*(?!\\*)",
+                    "end": "\\*/",
+                    "patterns": [
+                        {
+                            "include": "#comments"
+                        }
+                    ]
+                },
+                {
+                    "comment": "block documentation comments",
+                    "name": "comment.block.documentation.rust",
+                    "begin": "/\\*\\*",
+                    "end": "\\*/",
+                    "patterns": [
+                        {
+                            "include": "#comments"
+                        }
+                    ]
+                },
+                {
+                    "comment": "inferred types, wildcard patterns, ignored params",
+                    "name": "comment.char.underscore.rust",
+                    "match": "\\b_\\w*\\b"
+                }
+            ]
+        },
+        "constants": {
+            "patterns": [
+                {
+                    "comment": "ALL CAPS constants",
+                    "name": "constant.other.caps.rust",
+                    "match": "\\b[A-Z]{2}[A-Z0-9_]*\\b"
+                },
+                {
+                    "comment": "constant declarations",
+                    "match": "\\b(const)\\s+([A-Z][A-Za-z0-9_]*)\\b",
+                    "captures": {
+                        "1": {
+                            "name": "keyword.control.rust"
+                        },
+                        "2": {
+                            "name": "constant.other.caps.rust"
+                        }
+                    }
+                },
+                {
+                    "comment": "decimal integers and floats",
+                    "name": "constant.numeric.decimal.rust",
+                    "match": "\\b\\d[\\d_]*(\\.?)[\\d_]*(?:(E)([+-])([\\d_]+))?(f32|f64|i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)?\\b",
+                    "captures": {
+                        "1": {
+                            "name": "punctuation.separator.dot.decimal.rust"
+                        },
+                        "2": {
+                            "name": "keyword.operator.exponent.rust"
+                        },
+                        "3": {
+                            "name": "keyword.operator.exponent.sign.rust"
+                        },
+                        "4": {
+                            "name": "constant.numeric.decimal.exponent.mantissa.rust"
+                        },
+                        "5": {
+                            "name": "entity.name.type.numeric.rust"
+                        }
+                    }
+                },
+                {
+                    "comment": "hexadecimal integers",
+                    "name": "constant.numeric.hex.rust",
+                    "match": "\\b0x[\\da-fA-F_]+(i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)?\\b",
+                    "captures": {
+                        "1": {
+                            "name": "entity.name.type.numeric.rust"
+                        }
+                    }
+                },
+                {
+                    "comment": "octal integers",
+                    "name": "constant.numeric.oct.rust",
+                    "match": "\\b0o[0-7_]+(i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)?\\b",
+                    "captures": {
+                        "1": {
+                            "name": "entity.name.type.numeric.rust"
+                        }
+                    }
+                },
+                {
+                    "comment": "binary integers",
+                    "name": "constant.numeric.bin.rust",
+                    "match": "\\b0b[01_]+(i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)?\\b",
+                    "captures": {
+                        "1": {
+                            "name": "entity.name.type.numeric.rust"
+                        }
+                    }
+                },
+                {
+                    "comment": "booleans",
+                    "name": "constant.language.bool.rust",
+                    "match": "\\btrue|false\\b"
+                }
+            ]
+        },
+        "escapes": {
+            "comment": "escapes: ASCII, byte, Unicode, quote, regex",
+            "name": "constant.character.escape.rust",
+            "match": "(\\\\)(?:(?:(x[0-7][0-7a-fA-F])|(u(\\{)[\\da-fA-F]{4,6}(\\}))|.))",
+            "captures": {
+                "1": {
+                    "name": "constant.character.escape.backslash.rust"
+                },
+                "2": {
+                    "name": "constant.character.escape.bit.rust"
+                },
+                "3": {
+                    "name": "constant.character.escape.unicode.rust"
+                },
+                "4": {
+                    "name": "constant.character.escape.unicode.punctuation.rust"
+                },
+                "5": {
+                    "name": "constant.character.escape.unicode.punctuation.rust"
+                }
+            }
+        },
+        "functions": {
+            "patterns": [
+                {
+                    "comment": "function definition",
+                    "name": "meta.function.definition.rust",
+                    "begin": "\\b(fn)\\s+([A-Za-z0-9_]+)((\\()|(<))",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.control.fn.rust"
+                        },
+                        "2": {
+                            "name": "entity.name.function.rust"
+                        },
+                        "4": {
+                            "name": "punctuation.brackets.round.rust"
+                        },
+                        "5": {
+                            "name": "punctuation.brackets.angle.rust"
+                        }
+                    },
+                    "end": "\\{",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.brackets.curly.rust"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#comments"
+                        },
+                        {
+                            "include": "#keywords"
+                        },
+                        {
+                            "include": "#lvariables"
+                        },
+                        {
+                            "include": "#constants"
+                        },
+                        {
+                            "include": "#gtypes"
+                        },
+                        {
+                            "include": "#functions"
+                        },
+                        {
+                            "include": "#lifetimes"
+                        },
+                        {
+                            "include": "#macros"
+                        },
+                        {
+                            "include": "#namespaces"
+                        },
+                        {
+                            "include": "#punctuation"
+                        },
+                        {
+                            "include": "#strings"
+                        },
+                        {
+                            "include": "#types"
+                        },
+                        {
+                            "include": "#variables"
+                        }
+                    ]
+                },
+                {
+                    "comment": "function/method calls, chaining",
+                    "name": "meta.function.call.rust",
+                    "begin": "(?:(pub)|(?:(\\.)?([A-Za-z0-9_]+)))(\\()",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.other.rust"
+                        },
+                        "2": {
+                            "name": "keyword.operator.access.dot.rust"
+                        },
+                        "3": {
+                            "name": "entity.name.function.rust"
+                        },
+                        "4": {
+                            "name": "punctuation.brackets.round.rust"
+                        }
+                    },
+                    "end": "\\)",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.brackets.round.rust"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#comments"
+                        },
+                        {
+                            "include": "#keywords"
+                        },
+                        {
+                            "include": "#lvariables"
+                        },
+                        {
+                            "include": "#namespaces"
+                        },
+                        {
+                            "include": "#constants"
+                        },
+                        {
+                            "include": "#gtypes"
+                        },
+                        {
+                            "include": "#functions"
+                        },
+                        {
+                            "include": "#lifetimes"
+                        },
+                        {
+                            "include": "#macros"
+                        },
+                        {
+                            "include": "#punctuation"
+                        },
+                        {
+                            "include": "#strings"
+                        },
+                        {
+                            "include": "#types"
+                        },
+                        {
+                            "include": "#variables"
+                        }
+                    ]
+                }
+            ]
+        },
+        "keywords": {
+            "patterns": [
+                {
+                    "comment": "control flow keywords",
+                    "name": "keyword.control.rust",
+                    "match": "\\b(async|await|break|continue|do|else|for|if|loop|match|move|return|try|where|while|yield)\\b"
+                },
+                {
+                    "comment": "storage keywords",
+                    "name": "storage.type.rust",
+                    "match": "\\b(const|enum|extern|let|macro|mod|struct|trait|type)\\b"
+                },
+                {
+                    "comment": "storage modifiers",
+                    "name": "storage.modifier.rust",
+                    "match": "\\b(abstract|static)\\b"
+                },
+                {
+                    "comment": "other keywords",
+                    "name": "keyword.other.rust",
+                    "match": "\\b(as|become|box|dyn|final|impl|in|override|priv|pub|ref|typeof|union|unsafe|unsized|use|virtual)\\b"
+                },
+                {
+                    "comment": "fn",
+                    "name": "keyword.other.fn.rust",
+                    "match": "\\bfn\\b"
+                },
+                {
+                    "comment": "crate",
+                    "name": "keyword.other.crate.rust",
+                    "match": "\\bcrate\\b"
+                },
+                {
+                    "comment": "mut",
+                    "name": "storage.modifier.mut.rust",
+                    "match": "\\bmut\\b"
+                },
+                {
+                    "comment": "math operators",
+                    "name": "keyword.operator.math.rust",
+                    "match": "(([+%]|(\\*(?!\\w)))(?!=))|(-(?!>))|(/(?!/))"
+                },
+                {
+                    "comment": "logical operators",
+                    "name": "keyword.operator.logical.rust",
+                    "match": "(\\^|\\||\\|\\||&&|<<|>>|!)(?!=)"
+                },
+                {
+                    "comment": "logical AND, borrow references",
+                    "name": "keyword.operator.borrow.and.rust",
+                    "match": "&(?![&=])"
+                },
+                {
+                    "comment": "assignment operators",
+                    "name": "keyword.operator.assignment.rust",
+                    "match": "(-=|\\*=|/=|%=|\\^=|&=|\\|=|<<=|>>=)"
+                },
+                {
+                    "comment": "single equal",
+                    "name": "keyword.operator.assignment.equal.rust",
+                    "match": "(?<![<>])=(?!=|>)"
+                },
+                {
+                    "comment": "comparison operators",
+                    "name": "keyword.operator.comparison.rust",
+                    "match": "(=(=)?(?!>)|!=|<=|(?<!=)>=)"
+                },
+                {
+                    "comment": "less than, greater than (special case)",
+                    "match": "(^|\\s)(?<!=)([<>])\\s",
+                    "captures": {
+                        "2": {
+                            "name": "keyword.operator.comparison.rust"
+                        }
+                    }
+                },
+                {
+                    "comment": "namespace operator",
+                    "name": "keyword.operator.namespace.rust",
+                    "match": "::"
+                },
+                {
+                    "comment": "dereference asterisk",
+                    "match": "(\\*)(?=\\w+)",
+                    "captures": {
+                        "1": {
+                            "name": "keyword.operator.dereference.rust"
+                        }
+                    }
+                },
+                {
+                    "comment": "subpattern binding",
+                    "name": "keyword.operator.subpattern.rust",
+                    "match": "@"
+                },
+                {
+                    "comment": "dot access",
+                    "name": "keyword.operator.access.dot.rust",
+                    "match": "\\.(?!\\.)"
+                },
+                {
+                    "comment": "ranges, range patterns",
+                    "name": "keyword.operator.range.rust",
+                    "match": "\\.{2}(=|\\.)?"
+                },
+                {
+                    "comment": "colon",
+                    "name": "keyword.operator.key-value.rust",
+                    "match": ":(?!:)"
+                },
+                {
+                    "comment": "dashrocket, skinny arrow",
+                    "name": "keyword.operator.arrow.skinny.rust",
+                    "match": "->"
+                },
+                {
+                    "comment": "hashrocket, fat arrow",
+                    "name": "keyword.operator.arrow.fat.rust",
+                    "match": "=>"
+                },
+                {
+                    "comment": "dollar macros",
+                    "name": "keyword.operator.macro.dollar.rust",
+                    "match": "\\$"
+                },
+                {
+                    "comment": "question mark operator, questionably sized, macro kleene matcher",
+                    "name": "keyword.operator.question.rust",
+                    "match": "\\?"
+                }
+            ]
+        },
+        "interpolations": {
+            "comment": "curly brace interpolations",
+            "name": "meta.interpolation.rust",
+            "begin": "{",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.definition.interpolation.rust"
+                }
+            },
+            "end": "}",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.definition.interpolation.rust"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#interpolations"
+                }
+            ]
+        },
+        "lifetimes": {
+            "patterns": [
+                {
+                    "comment": "named lifetime parameters",
+                    "match": "(['])([a-zA-Z_][0-9a-zA-Z_]*)(?!['])\\b",
+                    "captures": {
+                        "1": {
+                            "name": "punctuation.definition.lifetime.rust"
+                        },
+                        "2": {
+                            "name": "entity.name.type.lifetime.rust"
+                        }
+                    }
+                },
+                {
+                    "comment": "borrowing references to named lifetimes",
+                    "match": "(\\&)(['])([a-zA-Z_][0-9a-zA-Z_]*)(?!['])\\b",
+                    "captures": {
+                        "1": {
+                            "name": "keyword.operator.borrow.rust"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.lifetime.rust"
+                        },
+                        "3": {
+                            "name": "entity.name.type.lifetime.rust"
+                        }
+                    }
+                }
+            ]
+        },
+        "macros": {
+            "patterns": [
+                {
+                    "comment": "macros",
+                    "name": "meta.macro.rust",
+                    "match": "(([a-z_][A-Za-z0-9_]*!)|([A-Z_][A-Za-z0-9_]*!))",
+                    "captures": {
+                        "2": {
+                            "name": "entity.name.function.macro.rust"
+                        },
+                        "3": {
+                            "name": "entity.name.type.macro.rust"
+                        }
+                    }
+                }
+            ]
+        },
+        "namespaces": {
+            "patterns": [
+                {
+                    "comment": "namespace (non-type, non-function path segment)",
+                    "match": "(?<![A-Za-z0-9_])([a-z0-9_]+)((?<!super|self)::)",
+                    "captures": {
+                        "1": {
+                            "name": "entity.name.namespace.rust"
+                        },
+                        "2": {
+                            "name": "keyword.operator.namespace.rust"
+                        }
+                    }
+                }
+            ]
+        },
+        "types": {
+            "patterns": [
+                {
+                    "comment": "numeric types",
+                    "match": "(?<![A-Za-z])(f32|f64|i128|i16|i32|i64|i8|isize|u128|u16|u32|u64|u8|usize)\\b",
+                    "captures": {
+                        "1": {
+                            "name": "entity.name.type.numeric.rust"
+                        }
+                    }
+                },
+                {
+                    "comment": "parameterized types",
+                    "begin": "\\b([A-Z][A-Za-z0-9]*)(<)",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "entity.name.type.rust"
+                        },
+                        "2": {
+                            "name": "punctuation.brackets.angle.rust"
+                        }
+                    },
+                    "end": ">",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.brackets.angle.rust"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#comments"
+                        },
+                        {
+                            "include": "#keywords"
+                        },
+                        {
+                            "include": "#lvariables"
+                        },
+                        {
+                            "include": "#lifetimes"
+                        },
+                        {
+                            "include": "#punctuation"
+                        },
+                        {
+                            "include": "#types"
+                        },
+                        {
+                            "include": "#variables"
+                        }
+                    ]
+                },
+                {
+                    "comment": "primitive types",
+                    "name": "entity.name.type.primitive.rust",
+                    "match": "\\b(bool|char|str)\\b"
+                },
+                {
+                    "comment": "trait declarations",
+                    "match": "\\b(trait)\\s+([A-Z][A-Za-z0-9]*)\\b",
+                    "captures": {
+                        "1": {
+                            "name": "storage.type.rust"
+                        },
+                        "2": {
+                            "name": "entity.name.type.trait.rust"
+                        }
+                    }
+                },
+                {
+                    "comment": "struct declarations",
+                    "match": "\\b(struct)\\s+([A-Z][A-Za-z0-9]*)\\b",
+                    "captures": {
+                        "1": {
+                            "name": "storage.type.rust"
+                        },
+                        "2": {
+                            "name": "entity.name.type.struct.rust"
+                        }
+                    }
+                },
+                {
+                    "comment": "enum declarations",
+                    "match": "\\b(enum)\\s+([A-Z][A-Za-z0-9_]*)\\b",
+                    "captures": {
+                        "1": {
+                            "name": "storage.type.rust"
+                        },
+                        "2": {
+                            "name": "entity.name.type.enum.rust"
+                        }
+                    }
+                },
+                {
+                    "comment": "type declarations",
+                    "match": "\\b(type)\\s+([A-Z][A-Za-z0-9_]*)\\b",
+                    "captures": {
+                        "1": {
+                            "name": "storage.type.rust"
+                        },
+                        "2": {
+                            "name": "entity.name.type.declaration.rust"
+                        }
+                    }
+                },
+                {
+                    "comment": "types",
+                    "name": "entity.name.type.rust",
+                    "match": "\\b[A-Z][A-Za-z0-9]*\\b(?!!)"
+                }
+            ]
+        },
+        "gtypes": {
+            "patterns": [
+                {
+                    "comment": "option types",
+                    "name": "entity.name.type.option.rust",
+                    "match": "\\b(Some|None)\\b"
+                },
+                {
+                    "comment": "result types",
+                    "name": "entity.name.type.result.rust",
+                    "match": "\\b(Ok|Err)\\b"
+                }
+            ]
+        },
+        "punctuation": {
+            "patterns": [
+                {
+                    "comment": "comma",
+                    "name": "punctuation.comma.rust",
+                    "match": ","
+                },
+                {
+                    "comment": "curly braces",
+                    "name": "punctuation.brackets.curly.rust",
+                    "match": "[{}]"
+                },
+                {
+                    "comment": "parentheses, round brackets",
+                    "name": "punctuation.brackets.round.rust",
+                    "match": "[()]"
+                },
+                {
+                    "comment": "semicolon",
+                    "name": "punctuation.semi.rust",
+                    "match": ";"
+                },
+                {
+                    "comment": "square brackets",
+                    "name": "punctuation.brackets.square.rust",
+                    "match": "[\\[\\]]"
+                },
+                {
+                    "comment": "angle brackets",
+                    "name": "punctuation.brackets.angle.rust",
+                    "match": "(?<!=)[<>]"
+                }
+            ]
+        },
+        "strings": {
+            "patterns": [
+                {
+                    "comment": "double-quoted strings and byte strings",
+                    "name": "string.quoted.double.rust",
+                    "begin": "(b?)(\")",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "string.quoted.byte.raw.rust"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.string.rust"
+                        }
+                    },
+                    "end": "\"",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.rust"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#escapes"
+                        },
+                        {
+                            "include": "#interpolations"
+                        }
+                    ]
+                },
+                {
+                    "comment": "double-quoted raw strings and raw byte strings",
+                    "name": "string.quoted.double.rust",
+                    "begin": "(b?r)(#*)(\")",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "string.quoted.byte.raw.rust"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.string.raw.rust"
+                        },
+                        "3": {
+                            "name": "punctuation.definition.string.rust"
+                        }
+                    },
+                    "end": "(\")(#*)",
+                    "endCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.string.rust"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.string.raw.rust"
+                        }
+                    }
+                },
+                {
+                    "comment": "characters and bytes",
+                    "name": "string.quoted.single.char.rust",
+                    "begin": "(b)?(')",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "string.quoted.byte.raw.rust"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.char.rust"
+                        }
+                    },
+                    "end": "'",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.char.rust"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#escapes"
+                        }
+                    ]
+                }
+            ]
+        },
+        "lvariables": {
+            "patterns": [
+                {
+                    "comment": "self",
+                    "name": "variable.language.self.rust",
+                    "match": "\\b[Ss]elf\\b"
+                },
+                {
+                    "comment": "super",
+                    "name": "variable.language.super.rust",
+                    "match": "\\bsuper\\b"
+                }
+            ]
+        },
+        "variables": {
+            "patterns": [
+                {
+                    "comment": "variables",
+                    "name": "variable.other.rust",
+                    "match": "\\b(?<!\\.)[a-z0-9_]+\\b"
+                }
+            ]
+        }
+    }
 }


### PR DESCRIPTION
Thanks to everyone working hard on Rust Analyzer - my impression is that it's quickly becoming the community default.

I think it would be helpful to have a more robust TextMate grammar to fall back on, for those who wish to disable semantic highlighting for any reason. It should allow theming of punctuation, and provide scopes for all tokens on the page. This can be done at zero cost to those who enable semantic highlighting, as the TextMate scopes will be invisible to those users.

I can see a couple ways of accomplishing this:

1. Ship a new grammar by merging this PR.
1. Ship no TextMate grammar at all (like the [Rust](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust) extension), and allow users to install a separate extension that provides the grammar of their choice (I have released this one as [Rust Syntax](https://marketplace.visualstudio.com/items?itemName=dustypomerleau.rust-syntax)). If no grammar were installed, they would simply fall back to the default grammar provided by their editor. In the case of VS Code, the default grammar already matches what is currently being shipped, so users who choose not to override it would see no difference.

I have tried to choose sensible default scopes, in the hopes that a wider variety of themes would work out of the box with Rust, even if those themes do not yet supply scopes for semantic highlighting. There is definitely some interest in using this grammar with Rust Analyzer, as this was the very first issue after the syntax extension was shipped: https://github.com/dustypomerleau/rust-syntax/issues/1.

I considered simply using an alternative grammar alongside Rust Analyzer, but this doesn't seem possible. When RA starts, any existing grammar/extension is overridden, and I haven't been able to find a workaround.
