### PR TITLE
Make find_path_prefixed configurable

### DIFF
--- a/crates/assists/src/assist_config.rs
+++ b/crates/assists/src/assist_config.rs
@@ -4,6 +4,8 @@
 //! module, and we use to statically check that we only produce snippet
 //! assists if we are allowed to.
 
+use hir::PrefixKind;
+
 use crate::{utils::MergeBehaviour, AssistKind};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -37,10 +39,11 @@ impl Default for AssistConfig {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct InsertUseConfig {
     pub merge: Option<MergeBehaviour>,
+    pub prefix_kind: PrefixKind,
 }
 
 impl Default for InsertUseConfig {
     fn default() -> Self {
-        InsertUseConfig { merge: Some(MergeBehaviour::Full) }
+        InsertUseConfig { merge: Some(MergeBehaviour::Full), prefix_kind: PrefixKind::Plain }
     }
 }

--- a/crates/assists/src/handlers/auto_import.rs
+++ b/crates/assists/src/handlers/auto_import.rs
@@ -191,12 +191,16 @@ impl AutoImportAssets {
                 _ => Some(candidate),
             })
             .filter_map(|candidate| match candidate {
-                Either::Left(module_def) => {
-                    self.module_with_name_to_import.find_use_path_prefixed(db, module_def)
-                }
-                Either::Right(macro_def) => {
-                    self.module_with_name_to_import.find_use_path_prefixed(db, macro_def)
-                }
+                Either::Left(module_def) => self.module_with_name_to_import.find_use_path_prefixed(
+                    db,
+                    module_def,
+                    ctx.config.insert_use.prefix_kind,
+                ),
+                Either::Right(macro_def) => self.module_with_name_to_import.find_use_path_prefixed(
+                    db,
+                    macro_def,
+                    ctx.config.insert_use.prefix_kind,
+                ),
             })
             .filter(|use_path| !use_path.segments.is_empty())
             .take(20)

--- a/crates/hir/src/code_model.rs
+++ b/crates/hir/src/code_model.rs
@@ -4,6 +4,7 @@ use std::{iter, sync::Arc};
 use arrayvec::ArrayVec;
 use base_db::{CrateId, Edition, FileId};
 use either::Either;
+use hir_def::find_path::PrefixKind;
 use hir_def::{
     adt::ReprKind,
     adt::StructKind,
@@ -391,7 +392,7 @@ impl Module {
         db: &dyn DefDatabase,
         item: impl Into<ItemInNs>,
     ) -> Option<ModPath> {
-        hir_def::find_path::find_path_prefixed(db, item.into(), self.into())
+        hir_def::find_path::find_path_prefixed(db, item.into(), self.into(), PrefixKind::Plain)
     }
 }
 

--- a/crates/hir/src/code_model.rs
+++ b/crates/hir/src/code_model.rs
@@ -391,8 +391,9 @@ impl Module {
         self,
         db: &dyn DefDatabase,
         item: impl Into<ItemInNs>,
+        prefix_kind: PrefixKind,
     ) -> Option<ModPath> {
-        hir_def::find_path::find_path_prefixed(db, item.into(), self.into(), PrefixKind::Plain)
+        hir_def::find_path::find_path_prefixed(db, item.into(), self.into(), prefix_kind)
     }
 }
 

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -48,6 +48,7 @@ pub use hir_def::{
     body::scope::ExprScopes,
     builtin_type::BuiltinType,
     docs::Documentation,
+    find_path::PrefixKind,
     item_scope::ItemInNs,
     nameres::ModuleSource,
     path::ModPath,

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -10,6 +10,7 @@
 use std::{ffi::OsString, path::PathBuf};
 
 use flycheck::FlycheckConfig;
+use hir::PrefixKind;
 use ide::{
     AssistConfig, CompletionConfig, DiagnosticsConfig, HoverConfig, InlayHintsConfig,
     MergeBehaviour,
@@ -289,6 +290,11 @@ impl Config {
             MergeBehaviourDef::Full => Some(MergeBehaviour::Full),
             MergeBehaviourDef::Last => Some(MergeBehaviour::Last),
         };
+        self.assist.insert_use.prefix_kind = match data.assist_importPrefix {
+            ImportPrefixDef::Plain => PrefixKind::Plain,
+            ImportPrefixDef::ByCrate => PrefixKind::ByCrate,
+            ImportPrefixDef::BySelf => PrefixKind::BySelf,
+        };
 
         self.call_info_full = data.callInfo_full;
 
@@ -403,11 +409,19 @@ enum ManifestOrProjectJson {
 }
 
 #[derive(Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 enum MergeBehaviourDef {
     None,
     Full,
     Last,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ImportPrefixDef {
+    Plain,
+    BySelf,
+    ByCrate,
 }
 
 macro_rules! config_data {
@@ -434,6 +448,7 @@ macro_rules! config_data {
 config_data! {
     struct ConfigData {
         assist_importMergeBehaviour: MergeBehaviourDef = MergeBehaviourDef::None,
+        assist_importPrefix: ImportPrefixDef           = ImportPrefixDef::Plain,
 
         callInfo_full: bool = true,
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -652,6 +652,21 @@
                     "default": "full",
                     "description": "The strategy to use when inserting new imports or merging imports."
                 },
+                "rust-analyzer.assist.importPrefix": {
+                    "type": "string",
+                    "enum": [
+                        "plain",
+                        "by_self",
+                        "by_crate"
+                    ],
+                    "enumDescriptions": [
+                        "Insert import paths relative to the current module, using up to one `super` prefix if the parent module contains the requested item.",
+                        "Prefix all import paths with `self` if they don't begin with `self`, `super`, `crate` or a crate name",
+                        "Force import paths to be absolute by always starting them with `crate` or the crate name they refer to."
+                    ],
+                    "default": "plain",
+                    "description": "The path structure for newly inserted paths to use."
+                },
                 "rust-analyzer.runnables.overrideCargo": {
                     "type": [
                         "null",


### PR DESCRIPTION
This makes `find_path_prefixed` more configurable allowing one to choose whether it always returns absolute paths, self-prefixed paths or to ignore local imports when building the path. 

The config names are just thrown in here, taking better names if they exist :)

This should fix #6131 as well?