### PR TITLE
honour hover.content_format client capability

### DIFF
--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -46,6 +46,7 @@ mod syntax_highlighting;
 mod syntax_tree;
 mod typing;
 mod link_rewrite;
+mod markdown_remove;
 
 use std::sync::Arc;
 
@@ -376,8 +377,9 @@ impl Analysis {
         &self,
         position: FilePosition,
         links_in_hover: bool,
+        markdown: bool,
     ) -> Cancelable<Option<RangeInfo<HoverResult>>> {
-        self.with_db(|db| hover::hover(db, position, links_in_hover))
+        self.with_db(|db| hover::hover(db, position, links_in_hover, markdown))
     }
 
     /// Computes parameter information for the given call expression.

--- a/crates/ide/src/markdown_remove.rs
+++ b/crates/ide/src/markdown_remove.rs
@@ -1,5 +1,8 @@
+//! Removes markdown from strings.
+
 use pulldown_cmark::{Event, Parser};
 
+/// Removes all markdown, keeping the text and code blocks
 pub fn remove_markdown(markdown: &str) -> String {
     let mut out = String::new();
     let parser = Parser::new(markdown);

--- a/crates/ide/src/markdown_remove.rs
+++ b/crates/ide/src/markdown_remove.rs
@@ -1,0 +1,16 @@
+use pulldown_cmark::{Event, Parser};
+
+pub fn remove_markdown(markdown: &str) -> String {
+    let mut out = String::new();
+    let parser = Parser::new(markdown);
+
+    for event in parser {
+        match event {
+            Event::Text(text) | Event::Code(text) => out.push_str(&text),
+            Event::SoftBreak | Event::HardBreak | Event::Rule => out.push('\n'),
+            _ => {}
+        }
+    }
+
+    out
+}

--- a/crates/ide/src/markdown_remove.rs
+++ b/crates/ide/src/markdown_remove.rs
@@ -3,6 +3,8 @@
 use pulldown_cmark::{Event, Parser};
 
 /// Removes all markdown, keeping the text and code blocks
+///
+/// Currently limited in styling, i.e. no ascii tables or lists
 pub fn remove_markdown(markdown: &str) -> String {
     let mut out = String::new();
     let parser = Parser::new(markdown);

--- a/crates/ide/src/markdown_remove.rs
+++ b/crates/ide/src/markdown_remove.rs
@@ -1,6 +1,6 @@
 //! Removes markdown from strings.
 
-use pulldown_cmark::{Event, Parser};
+use pulldown_cmark::{Event, Parser, Tag};
 
 /// Removes all markdown, keeping the text and code blocks
 ///
@@ -12,7 +12,9 @@ pub fn remove_markdown(markdown: &str) -> String {
     for event in parser {
         match event {
             Event::Text(text) | Event::Code(text) => out.push_str(&text),
-            Event::SoftBreak | Event::HardBreak | Event::Rule => out.push('\n'),
+            Event::SoftBreak | Event::HardBreak | Event::Rule | Event::End(Tag::CodeBlock(_)) => {
+                out.push('\n')
+            }
             _ => {}
         }
     }

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -14,7 +14,7 @@ use ide::{
     AssistConfig, CompletionConfig, DiagnosticsConfig, HoverConfig, InlayHintsConfig,
     MergeBehaviour,
 };
-use lsp_types::ClientCapabilities;
+use lsp_types::{ClientCapabilities, MarkupKind};
 use project_model::{CargoConfig, ProjectJson, ProjectJsonData, ProjectManifest};
 use rustc_hash::FxHashSet;
 use serde::Deserialize;
@@ -327,6 +327,7 @@ impl Config {
             debug: data.hoverActions_enable && data.hoverActions_debug,
             goto_type_def: data.hoverActions_enable && data.hoverActions_gotoTypeDef,
             links_in_hover: data.hoverActions_linksInHover,
+            markdown: true,
         };
 
         log::info!("Config::update() = {:#?}", self);
@@ -334,6 +335,9 @@ impl Config {
 
     pub fn update_caps(&mut self, caps: &ClientCapabilities) {
         if let Some(doc_caps) = caps.text_document.as_ref() {
+            if let Some(value) = doc_caps.hover.as_ref().and_then(|it| it.content_format.as_ref()) {
+                self.hover.markdown = value.contains(&MarkupKind::Markdown)
+            }
             if let Some(value) = doc_caps.definition.as_ref().and_then(|it| it.link_support) {
                 self.client_caps.location_link = value;
             }

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -618,7 +618,11 @@ pub(crate) fn handle_hover(
 ) -> Result<Option<lsp_ext::Hover>> {
     let _p = profile::span("handle_hover");
     let position = from_proto::file_position(&snap, params.text_document_position_params)?;
-    let info = match snap.analysis.hover(position, snap.config.hover.links_in_hover)? {
+    let info = match snap.analysis.hover(
+        position,
+        snap.config.hover.links_in_hover,
+        snap.config.hover.markdown,
+    )? {
         None => return Ok(None),
         Some(info) => info,
     };


### PR DESCRIPTION
This removes all markdown when the client does not support the markdown MarkupKind.

Otherwise the output on the editor will have some markdown boilerplate, making it less readable.

For example kak_lsp does not currently support markdown.
![image](https://user-images.githubusercontent.com/22073483/95112949-ef0ff080-0741-11eb-82a7-0594fa2cd736.png)

after:
![image](https://user-images.githubusercontent.com/22073483/95113089-2bdbe780-0742-11eb-94fa-bcfec6d7347a.png)

