### PR TITLE
Improve prime_caches and display its progress

### DIFF
--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -77,6 +77,7 @@ pub use crate::{
     hover::{HoverAction, HoverConfig, HoverGotoTypeData, HoverResult},
     inlay_hints::{InlayHint, InlayHintsConfig, InlayKind},
     markup::Markup,
+    prime_caches::PrimeCachesProgress,
     references::{
         Declaration, Reference, ReferenceAccess, ReferenceKind, ReferenceSearchResult, RenameError,
     },
@@ -223,8 +224,11 @@ impl Analysis {
         self.with_db(|db| status::status(&*db, file_id))
     }
 
-    pub fn prime_caches(&self, files: Vec<FileId>) -> Cancelable<()> {
-        self.with_db(|db| prime_caches::prime_caches(db, files))
+    pub fn prime_caches<F>(&self, cb: F) -> Cancelable<()>
+    where
+        F: Fn(PrimeCachesProgress) + Sync + std::panic::UnwindSafe,
+    {
+        self.with_db(move |db| prime_caches::prime_caches(db, &cb))
     }
 
     /// Gets the text of the source file.

--- a/crates/ide/src/prime_caches.rs
+++ b/crates/ide/src/prime_caches.rs
@@ -3,10 +3,45 @@
 //! request takes longer to compute. This modules implemented prepopulating of
 //! various caches, it's not really advanced at the moment.
 
-use crate::{FileId, RootDatabase};
+use base_db::SourceDatabase;
+use hir::db::DefDatabase;
 
-pub(crate) fn prime_caches(db: &RootDatabase, files: Vec<FileId>) {
-    for file in files {
-        let _ = crate::syntax_highlighting::highlight(db, file, None, false);
+use crate::RootDatabase;
+
+#[derive(Debug)]
+pub enum PrimeCachesProgress {
+    Started,
+    /// We started indexing a crate.
+    StartedOnCrate {
+        on_crate: String,
+        n_done: usize,
+        n_total: usize,
+    },
+    /// We finished indexing all crates.
+    Finished,
+}
+
+pub(crate) fn prime_caches(db: &RootDatabase, cb: &(dyn Fn(PrimeCachesProgress) + Sync)) {
+    let _p = profile::span("prime_caches");
+    let graph = db.crate_graph();
+    let topo = &graph.crates_in_topological_order();
+
+    cb(PrimeCachesProgress::Started);
+
+    // FIXME: This would be easy to parallelize, since it's in the ideal ordering for that.
+    // Unfortunately rayon prevents panics from propagation out of a `scope`, which breaks
+    // cancellation, so we cannot use rayon.
+    for (i, krate) in topo.iter().enumerate() {
+        let crate_name =
+            graph[*krate].declaration_name.as_ref().map(ToString::to_string).unwrap_or_default();
+
+        cb(PrimeCachesProgress::StartedOnCrate {
+            on_crate: crate_name,
+            n_done: i,
+            n_total: topo.len(),
+        });
+        db.crate_def_map(*krate);
     }
+
+    cb(PrimeCachesProgress::Finished);
 }

--- a/crates/rust-analyzer/src/thread_pool.rs
+++ b/crates/rust-analyzer/src/thread_pool.rs
@@ -23,6 +23,17 @@ impl<T> TaskPool<T> {
         })
     }
 
+    pub(crate) fn spawn_with_sender<F>(&mut self, task: F)
+    where
+        F: FnOnce(Sender<T>) + Send + 'static,
+        T: Send + 'static,
+    {
+        self.inner.execute({
+            let sender = self.sender.clone();
+            move || task(sender)
+        })
+    }
+
     pub(crate) fn len(&self) -> usize {
         self.inner.queued_count()
     }


### PR DESCRIPTION
It now computes the `CrateDefMap` of all crates, which is generally a reasonable approximation for "IDE features ready". There is still some delay after this finishes, I suspect mostly due to impl collection, which takes a while, but this should be an improvement already.

For more accurate progress reports, this topologically sorts all crates before starting this operation. ~~Because that is also the ordering in which parallelization makes sense (which was previously attempted in https://github.com/rust-analyzer/rust-analyzer/pull/3529), I decided to throw that into the mix as well. It still doesn't provide *that* much of a performance boost, but it does scale beyond the current single-core architecture, and adding it was very easy.~~

~~Unfortunately, as written, this will not tell the user which crate is actually causing slowdowns, since the displayed crate is the last one that was *started*, not the one we are currently *blocked* on, but that seems fairly difficult to implement unless I'm missing something.~~

(I have removed rayon for now since it does not work correctly with cancellation.)