### PR TITLE
Shorten type hints for std::iter Iterators

### DIFF
--- a/crates/assists/src/utils.rs
+++ b/crates/assists/src/utils.rs
@@ -3,7 +3,7 @@ pub(crate) mod insert_use;
 
 use std::{iter, ops};
 
-use hir::{Adt, Crate, Enum, ScopeDef, Semantics, Trait, Type};
+use hir::{Adt, Crate, Enum, Module, ScopeDef, Semantics, Trait, Type};
 use ide_db::RootDatabase;
 use itertools::Itertools;
 use rustc_hash::FxHashSet;
@@ -373,6 +373,10 @@ pub use prelude::*;
         self.find_trait("core:iter:traits:iterator:Iterator")
     }
 
+    pub fn core_iter(&self) -> Option<Module> {
+        self.find_module("core:iter")
+    }
+
     fn find_trait(&self, path: &str) -> Option<Trait> {
         match self.find_def(path)? {
             hir::ScopeDef::ModuleDef(hir::ModuleDef::Trait(it)) => Some(it),
@@ -383,6 +387,13 @@ pub use prelude::*;
     fn find_enum(&self, path: &str) -> Option<Enum> {
         match self.find_def(path)? {
             hir::ScopeDef::ModuleDef(hir::ModuleDef::Adt(hir::Adt::Enum(it))) => Some(it),
+            _ => None,
+        }
+    }
+
+    fn find_module(&self, path: &str) -> Option<Module> {
+        match self.find_def(path)? {
+            hir::ScopeDef::ModuleDef(hir::ModuleDef::Module(it)) => Some(it),
             _ => None,
         }
     }

--- a/crates/assists/src/utils.rs
+++ b/crates/assists/src/utils.rs
@@ -286,14 +286,21 @@ pub mod convert {
 }
 
 pub mod iter {
-    pub use self::traits::iterator::Iterator;
-    mod traits { mod iterator {
-        use crate::option::Option;
-        pub trait Iterator {
-            type Item;
-            fn next(&mut self) -> Option<Self::Item>;
+    pub use self::traits::{collect::IntoIterator, iterator::Iterator};
+    mod traits {
+        mod iterator {
+            use crate::option::Option;
+            pub trait Iterator {
+                type Item;
+                fn next(&mut self) -> Option<Self::Item>;
+            }
         }
-    } }
+        mod collect {            
+            pub trait IntoIterator {
+                type Item;
+            }
+        }
+    }
 
     pub use self::sources::*;
     mod sources {
@@ -321,7 +328,7 @@ pub mod option {
 }
 
 pub mod prelude {
-    pub use crate::{convert::From, iter::Iterator, option::Option::{self, *}};
+    pub use crate::{convert::From, iter::{IntoIterator, Iterator}, option::Option::{self, *}};
 }
 #[prelude_import]
 pub use prelude::*;

--- a/crates/assists/src/utils.rs
+++ b/crates/assists/src/utils.rs
@@ -308,7 +308,7 @@ pub mod iter {
                 }
             }
         }
-        pub(crate) mod collect {            
+        pub(crate) mod collect {
             pub trait IntoIterator {
                 type Item;
             }

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -55,7 +55,7 @@ pub use hir_def::{
     type_ref::{Mutability, TypeRef},
 };
 pub use hir_expand::{
-    name::AsName, name::Name, HirFileId, InFile, MacroCallId, MacroCallLoc,
+    name::known, name::AsName, name::Name, HirFileId, InFile, MacroCallId, MacroCallLoc,
     /* FIXME */ MacroDefId, MacroFile, Origin,
 };
 pub use hir_ty::display::HirDisplay;

--- a/crates/hir_expand/src/name.rs
+++ b/crates/hir_expand/src/name.rs
@@ -164,6 +164,7 @@ pub mod known {
         result,
         boxed,
         // Components of known path (type name)
+        Iterator,
         IntoIterator,
         Item,
         Try,

--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -211,7 +211,9 @@ fn hint_iterator(
     ty: &Type,
 ) -> Option<SmolStr> {
     let db = sema.db;
-    let strukt = ty.as_adt()?;
+    let strukt = std::iter::successors(Some(ty.clone()), |ty| ty.remove_ref())
+        .last()
+        .and_then(|strukt| strukt.as_adt())?;
     let krate = strukt.krate(db)?;
     if krate.declaration_name(db).as_deref() != Some("core") {
         return None;
@@ -1169,7 +1171,7 @@ fn main() {
                     InlayHint {
                         range: 175..225,
                         kind: ChainingHint,
-                        label: "&mut Take<&mut MyIter>",
+                        label: "impl Iterator<Item = ()>",
                     },
                     InlayHint {
                         range: 175..207,

--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -412,7 +412,8 @@ mod tests {
     }
 
     fn check_with_config(config: InlayHintsConfig, ra_fixture: &str) {
-        let (analysis, file_id) = fixture::file(ra_fixture);
+        let ra_fixture = format!("{}\n{}", ra_fixture, FamousDefs::FIXTURE);
+        let (analysis, file_id) = fixture::file(&ra_fixture);
         let expected = extract_annotations(&*analysis.file_text(file_id).unwrap());
         let inlay_hints = analysis.inlay_hints(file_id, &config).unwrap();
         let actual =
@@ -1011,13 +1012,6 @@ fn main() {
     println!("Unit expr");
 }
 
-//- /core.rs crate:core
-#[prelude_import] use iter::*;
-mod iter {
-    trait IntoIterator {
-        type Item;
-    }
-}
 //- /alloc.rs crate:alloc deps:core
 mod collections {
     struct Vec<T> {}
@@ -1057,14 +1051,6 @@ fn main() {
       //^ &str
       let z = i;
         //^ &str
-    }
-}
-
-//- /core.rs crate:core
-#[prelude_import] use iter::*;
-mod iter {
-    trait IntoIterator {
-        type Item;
     }
 }
 //- /alloc.rs crate:alloc deps:core
@@ -1125,15 +1111,13 @@ fn main() {
                 chaining_hints: true,
                 max_length: None,
             },
-            &format!(
-                "{}\n{}\n",
-                r#"
+            r#"
 //- /main.rs crate:main deps:std
-use std::{Option::{self, Some, None}, iter};
+use std::iter;
 
 struct MyIter;
 
-impl iter::Iterator for MyIter {
+impl Iterator for MyIter {
     type Item = ();
     fn next(&mut self) -> Option<Self::Item> {
         None
@@ -1154,8 +1138,6 @@ fn main() {
 //- /std.rs crate:std deps:core
 use core::*;
 "#,
-                FamousDefs::FIXTURE
-            ),
         );
     }
 }


### PR DESCRIPTION
Fixes #3750.

This re-exports the `hir_expand::name::known` module to be able to fetch the `Iterator` and `iter` names.
I'm not sure if there is anything to do with `Solution::Ambig` in `normalize_trait_assoc_type` or whether discarding those results is always wanted.