### PR TITLE
adt: correctly inherit field visibility from enum

### DIFF
--- a/crates/assists/src/handlers/fix_visibility.rs
+++ b/crates/assists/src/handlers/fix_visibility.rs
@@ -324,14 +324,14 @@ pub struct Foo { pub bar: () }
 
     #[test]
     fn fix_visibility_of_enum_variant_field() {
-        check_assist(
+        // Enum variants, as well as their fields, always get the enum's visibility. In fact, rustc
+        // rejects any visibility specifiers on them, so this assist should never fire on them.
+        check_assist_not_applicable(
             fix_visibility,
             r"mod foo { pub enum Foo { Bar { bar: () } } }
               fn main() { foo::Foo::Bar { <|>bar: () }; } ",
-            r"mod foo { pub enum Foo { Bar { $0pub(crate) bar: () } } }
-              fn main() { foo::Foo::Bar { bar: () }; } ",
         );
-        check_assist(
+        check_assist_not_applicable(
             fix_visibility,
             r"
 //- /lib.rs
@@ -339,8 +339,6 @@ mod foo;
 fn main() { foo::Foo::Bar { <|>bar: () }; }
 //- /foo.rs
 pub enum Foo { Bar { bar: () } }
-",
-            r"pub enum Foo { Bar { $0pub(crate) bar: () } }
 ",
         );
         check_assist_not_applicable(

--- a/crates/ide/src/references.rs
+++ b/crates/ide/src/references.rs
@@ -732,6 +732,30 @@ fn f(e: En) {
         );
     }
 
+    #[test]
+    fn test_find_all_refs_enum_var_privacy() {
+        check(
+            r#"
+mod m {
+    pub enum En {
+        Variant {
+            field<|>: u8,
+        }
+    }
+}
+
+fn f() -> m::En {
+    m::En::Variant { field: 0 }
+}
+"#,
+            expect![[r#"
+                field RECORD_FIELD FileId(0) 56..65 56..61 Other
+
+                FileId(0) 125..130 Other Read
+            "#]],
+        );
+    }
+
     fn check(ra_fixture: &str, expect: Expect) {
         check_with_scope(ra_fixture, None, expect)
     }


### PR DESCRIPTION
Previously, "find all references" on a variant field wouldn't find any
references outside the defining module. This is because variant fields
were incorrectly assumed to be private, like struct fields without
explicit visibility, but they actually inherit the enum's visibility.

bors r+ :robot: 