### PR TITLE
Shorten iterators in associated params

### DIFF
--- a/crates/hir/src/code_model.rs
+++ b/crates/hir/src/code_model.rs
@@ -1372,7 +1372,7 @@ impl Type {
         r#trait: Trait,
         args: &[Type],
         alias: TypeAlias,
-    ) -> Option<Ty> {
+    ) -> Option<Type> {
         let subst = Substs::build_for_def(db, r#trait.id)
             .push(self.ty.value.clone())
             .fill(args.iter().map(|t| t.ty.value.clone()))
@@ -1393,6 +1393,10 @@ impl Type {
             Solution::Unique(SolutionVariables(subst)) => subst.value.first().cloned(),
             Solution::Ambig(_) => None,
         }
+        .map(|ty| Type {
+            krate: self.krate,
+            ty: InEnvironment { value: ty, environment: Arc::clone(&self.ty.environment) },
+        })
     }
 
     pub fn is_copy(&self, db: &dyn HirDatabase) -> bool {


### PR DESCRIPTION
Applies the same iterator-shortening logic to the iterator associated types, recursively.

Before: 
![image](https://user-images.githubusercontent.com/2690773/95662735-e6ecf200-0b41-11eb-8e54-28493ad4e644.png)

After:
<img width="1192" alt="image" src="https://user-images.githubusercontent.com/2690773/95662894-e9038080-0b42-11eb-897d-527571ccac58.png">
