### PR TITLE
Fix iterator hint shortening heuristic

### DIFF
--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -220,8 +220,8 @@ fn hint_iterator(
     }
     let iter_trait = FamousDefs(sema, krate).core_iter_Iterator()?;
     let iter_mod = FamousDefs(sema, krate).core_iter()?;
-    // assert this type comes from `core::iter`
-    iter_mod.visibility_of(db, &iter_trait.into()).filter(|&vis| vis == hir::Visibility::Public)?;
+    // assert this struct comes from `core::iter`
+    iter_mod.visibility_of(db, &strukt.into()).filter(|&vis| vis == hir::Visibility::Public)?;
     if ty.impls_trait(db, iter_trait, &[]) {
         let assoc_type_item = iter_trait.items(db).into_iter().find_map(|item| match item {
             hir::AssocItem::TypeAlias(alias) if alias.name(db) == known::Item => Some(alias),


### PR DESCRIPTION
Turns out I made a mistake with the heuristic check which is always true, so all iterators exposed from `core` were shortened, including things like ranges. 😅 