### PR TITLE
Factor macro_rules and format-string highlighting out into submodules

### DIFF
--- a/crates/ide/src/syntax_highlighting.rs
+++ b/crates/ide/src/syntax_highlighting.rs
@@ -74,7 +74,7 @@ pub(crate) fn highlight(
 
     let mut current_macro_call: Option<ast::MacroCall> = None;
     let mut format_string_highlighter = FormatStringHighlighter::default();
-    let mut macro_rules_highlighter = MacroRulesHighlighter::new();
+    let mut macro_rules_highlighter = MacroRulesHighlighter::default();
 
     // Walk all nodes, keeping track of whether we are inside a macro or not.
     // If in macro, expand it first and highlight the expanded code.
@@ -125,8 +125,8 @@ pub(crate) fn highlight(
             WalkEvent::Leave(Some(mc)) => {
                 assert!(current_macro_call == Some(mc));
                 current_macro_call = None;
-                format_string_highlighter.reset();
-                macro_rules_highlighter.reset();
+                format_string_highlighter = FormatStringHighlighter::default();
+                macro_rules_highlighter = MacroRulesHighlighter::default();
             }
             _ => (),
         }

--- a/crates/ide/src/syntax_highlighting/format.rs
+++ b/crates/ide/src/syntax_highlighting/format.rs
@@ -12,10 +12,6 @@ pub(super) struct FormatStringHighlighter {
 }
 
 impl FormatStringHighlighter {
-    pub(super) fn reset(&mut self) {
-        self.format_string = None;
-    }
-
     pub(super) fn check_for_format_string(&mut self, parent: &SyntaxNode) {
         // Check if macro takes a format string and remember it for highlighting later.
         // The macros that accept a format string expand to a compiler builtin macros

--- a/crates/ide/src/syntax_highlighting/format.rs
+++ b/crates/ide/src/syntax_highlighting/format.rs
@@ -1,0 +1,82 @@
+//! Syntax highlighting for format macro strings.
+use syntax::{
+    ast::{self, FormatSpecifier, HasFormatSpecifier},
+    AstNode, AstToken, SyntaxElement, SyntaxKind, SyntaxNode, TextRange,
+};
+
+use crate::{syntax_highlighting::HighlightedRangeStack, HighlightTag, HighlightedRange};
+
+#[derive(Default)]
+pub(super) struct FormatStringHighlighter {
+    format_string: Option<SyntaxElement>,
+}
+
+impl FormatStringHighlighter {
+    pub(super) fn reset(&mut self) {
+        self.format_string = None;
+    }
+
+    pub(super) fn check_for_format_string(&mut self, parent: &SyntaxNode) {
+        // Check if macro takes a format string and remember it for highlighting later.
+        // The macros that accept a format string expand to a compiler builtin macros
+        // `format_args` and `format_args_nl`.
+        if let Some(name) = parent
+            .parent()
+            .and_then(ast::MacroCall::cast)
+            .and_then(|mc| mc.path())
+            .and_then(|p| p.segment())
+            .and_then(|s| s.name_ref())
+        {
+            match name.text().as_str() {
+                "format_args" | "format_args_nl" => {
+                    self.format_string = parent
+                        .children_with_tokens()
+                        .filter(|t| t.kind() != SyntaxKind::WHITESPACE)
+                        .nth(1)
+                        .filter(|e| {
+                            ast::String::can_cast(e.kind()) || ast::RawString::can_cast(e.kind())
+                        })
+                }
+                _ => {}
+            }
+        }
+    }
+    pub(super) fn highlight_format_string(
+        &self,
+        range_stack: &mut HighlightedRangeStack,
+        string: &impl HasFormatSpecifier,
+        range: TextRange,
+    ) {
+        if self.format_string.as_ref() == Some(&SyntaxElement::from(string.syntax().clone())) {
+            range_stack.push();
+            string.lex_format_specifier(|piece_range, kind| {
+                if let Some(highlight) = highlight_format_specifier(kind) {
+                    range_stack.add(HighlightedRange {
+                        range: piece_range + range.start(),
+                        highlight: highlight.into(),
+                        binding_hash: None,
+                    });
+                }
+            });
+            range_stack.pop();
+        }
+    }
+}
+
+fn highlight_format_specifier(kind: FormatSpecifier) -> Option<HighlightTag> {
+    Some(match kind {
+        FormatSpecifier::Open
+        | FormatSpecifier::Close
+        | FormatSpecifier::Colon
+        | FormatSpecifier::Fill
+        | FormatSpecifier::Align
+        | FormatSpecifier::Sign
+        | FormatSpecifier::NumberSign
+        | FormatSpecifier::DollarSign
+        | FormatSpecifier::Dot
+        | FormatSpecifier::Asterisk
+        | FormatSpecifier::QuestionMark => HighlightTag::FormatSpecifier,
+        FormatSpecifier::Integer | FormatSpecifier::Zero => HighlightTag::NumericLiteral,
+        FormatSpecifier::Identifier => HighlightTag::Local,
+    })
+}

--- a/crates/ide/src/syntax_highlighting/macro_rules.rs
+++ b/crates/ide/src/syntax_highlighting/macro_rules.rs
@@ -3,21 +3,14 @@ use syntax::{SyntaxElement, SyntaxKind, SyntaxToken, TextRange, T};
 
 use crate::{HighlightTag, HighlightedRange};
 
+#[derive(Default)]
 pub(super) struct MacroRulesHighlighter {
     state: Option<MacroMatcherParseState>,
 }
 
 impl MacroRulesHighlighter {
-    pub(super) fn new() -> Self {
-        MacroRulesHighlighter { state: None }
-    }
-
     pub(super) fn init(&mut self) {
-        self.state = Some(MacroMatcherParseState::new());
-    }
-
-    pub(super) fn reset(&mut self) {
-        self.state = None;
+        self.state = Some(MacroMatcherParseState::default());
     }
 
     pub(super) fn advance(&mut self, token: &SyntaxToken) {
@@ -51,8 +44,8 @@ struct MacroMatcherParseState {
     in_invoc_body: bool,
 }
 
-impl MacroMatcherParseState {
-    fn new() -> Self {
+impl Default for MacroMatcherParseState {
+    fn default() -> Self {
         MacroMatcherParseState {
             paren_ty: None,
             paren_level: 0,


### PR DESCRIPTION
This moves `format`-like macro string highlighting and macro_rules highlight skipping out of the main module.