### PR TITLE
Textmate grammar: prevent early termination of raw strings with hash (closes #6042)

### DIFF
--- a/editors/code/rust.tmGrammar.json
+++ b/editors/code/rust.tmGrammar.json
@@ -966,9 +966,28 @@
                     ]
                 },
                 {
-                    "comment": "double-quoted raw strings and raw byte strings",
+                    "comment": "double-quoted raw strings and raw byte strings (no hash)",
                     "name": "string.quoted.double.rust",
-                    "begin": "(b?r)(#*)(\")",
+                    "begin": "(b?r)(\")",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "string.quoted.byte.raw.rust"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.string.rust"
+                        }
+                    },
+                    "end": "\"",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.rust"
+                        }
+                    }
+                },
+                {
+                    "comment": "double-quoted raw strings and raw byte strings (with hash)",
+                    "name": "string.quoted.double.rust",
+                    "begin": "(b?r)(#+)(\")",
                     "beginCaptures": {
                         "1": {
                             "name": "string.quoted.byte.raw.rust"
@@ -980,7 +999,7 @@
                             "name": "punctuation.definition.string.rust"
                         }
                     },
-                    "end": "(\")(#*)",
+                    "end": "(\")(#+)",
                     "endCaptures": {
                         "1": {
                             "name": "punctuation.definition.string.rust"


### PR DESCRIPTION
Problematic sample code from #6042:

```rust
#[derive(Debug, Clone, Logos)]
enum Quoted<'source> {
    #[regex(r#"[^\\"']+"#)]
    Text(&'source str),
    #[token("\\")]
    StartEscape,
    #[token("\'", |_| Quote::Single)]
    #[token("\"", |_| Quote::Double)]
    End(Quote),

    #[error]
    Error,
}
```

Before fix:

<img width="400" alt="Screen Shot 2020-10-16 at 10 45 59" src="https://user-images.githubusercontent.com/6304651/96198390-6a726d00-0fa0-11eb-8428-e76b2866836b.png">

After fix:

<img width="400" alt="Screen Shot 2020-10-16 at 10 45 33" src="https://user-images.githubusercontent.com/6304651/96198408-7a8a4c80-0fa0-11eb-9104-ca708009fe63.png">

