### PR TITLE
Do not spawn redundant hints

### DIFF
--- a/crates/ide/src/completion.rs
+++ b/crates/ide/src/completion.rs
@@ -233,12 +233,28 @@ mod tests {
 
     #[test]
     fn test_no_completions_required() {
+        // There must be no hint for 'in' keyword.
         check_no_completion(
             r#"
             fn foo() {
                 for i i<|>
             }
             "#,
-        )
+        );
+        // After 'in' keyword hints may be spawned.
+        check_detail_and_documentation(
+            r#"
+            /// Do the foo
+            fn foo() -> &'static str { "foo" }
+
+            fn bar() {
+                for c in fo<|>
+            }
+            "#,
+            DetailAndDocumentation {
+                detail: "fn foo() -> &'static str",
+                documentation: "Do the foo",
+            },
+        );
     }
 }

--- a/crates/ide/src/completion.rs
+++ b/crates/ide/src/completion.rs
@@ -112,6 +112,11 @@ pub(crate) fn completions(
 ) -> Option<Completions> {
     let ctx = CompletionContext::new(db, position, config)?;
 
+    if ctx.no_completion_required() {
+        // No work required here.
+        return None;
+    }
+
     let mut acc = Completions::default();
     complete_attribute::complete_attribute(&mut acc, &ctx);
     complete_fn_param::complete_fn_param(&mut acc, &ctx);
@@ -155,6 +160,23 @@ mod tests {
             }
         }
         panic!("completion detail not found: {}", expected.detail)
+    }
+
+    fn check_no_completion(ra_fixture: &str) {
+        let (analysis, position) = fixture::position(ra_fixture);
+        let config = CompletionConfig::default();
+        analysis.completions(&config, position).unwrap();
+
+        let completions: Option<Vec<String>> = analysis
+            .completions(&config, position)
+            .unwrap()
+            .and_then(|completions| if completions.is_empty() { None } else { Some(completions) })
+            .map(|completions| {
+                completions.into_iter().map(|completion| format!("{:?}", completion)).collect()
+            });
+
+        // `assert_eq` instead of `assert!(completions.is_none())` to get the list of completions if test will panic.
+        assert_eq!(completions, None, "Completions were generated, but weren't expected");
     }
 
     #[test]
@@ -207,5 +229,16 @@ mod tests {
             "#,
             DetailAndDocumentation { detail: "fn foo(&self)", documentation: " Do the foo" },
         );
+    }
+
+    #[test]
+    fn test_no_completions_required() {
+        check_no_completion(
+            r#"
+            fn foo() {
+                for i i<|>
+            }
+            "#,
+        )
     }
 }

--- a/crates/ide/src/completion/completion_context.rs
+++ b/crates/ide/src/completion/completion_context.rs
@@ -18,8 +18,8 @@ use crate::{
         patterns::{
             fn_is_prev, for_is_prev2, has_bind_pat_parent, has_block_expr_parent,
             has_field_list_parent, has_impl_as_prev_sibling, has_impl_parent,
-            has_impl_trait_parent, has_item_list_or_source_file_parent, has_ref_parent,
-            has_trait_as_prev_sibling, has_trait_parent, if_is_prev, is_in_loop_body, is_match_arm,
+            has_item_list_or_source_file_parent, has_ref_parent, has_trait_as_prev_sibling,
+            has_trait_parent, if_is_prev, inside_impl_trait_block, is_in_loop_body, is_match_arm,
             unsafe_is_prev,
         },
         CompletionConfig,
@@ -87,7 +87,7 @@ pub(crate) struct CompletionContext<'a> {
     pub(super) in_loop_body: bool,
     pub(super) has_trait_parent: bool,
     pub(super) has_impl_parent: bool,
-    pub(super) has_impl_trait_parent: bool,
+    pub(super) inside_impl_trait_block: bool,
     pub(super) has_field_list_parent: bool,
     pub(super) trait_as_prev_sibling: bool,
     pub(super) impl_as_prev_sibling: bool,
@@ -172,7 +172,7 @@ impl<'a> CompletionContext<'a> {
             block_expr_parent: false,
             has_trait_parent: false,
             has_impl_parent: false,
-            has_impl_trait_parent: false,
+            inside_impl_trait_block: false,
             has_field_list_parent: false,
             trait_as_prev_sibling: false,
             impl_as_prev_sibling: false,
@@ -234,7 +234,7 @@ impl<'a> CompletionContext<'a> {
     ///   Exception for this case is `impl Trait for Foo`, where we would like to hint trait method names.
     /// - `for _ i<|>` -- obviously, it'll be "in" keyword.
     pub(crate) fn no_completion_required(&self) -> bool {
-        (self.fn_is_prev && !self.has_impl_trait_parent) || self.for_is_prev2
+        (self.fn_is_prev && !self.inside_impl_trait_block) || self.for_is_prev2
     }
 
     /// The range of the identifier that is being completed.
@@ -260,7 +260,7 @@ impl<'a> CompletionContext<'a> {
         self.in_loop_body = is_in_loop_body(syntax_element.clone());
         self.has_trait_parent = has_trait_parent(syntax_element.clone());
         self.has_impl_parent = has_impl_parent(syntax_element.clone());
-        self.has_impl_trait_parent = has_impl_trait_parent(syntax_element.clone());
+        self.inside_impl_trait_block = inside_impl_trait_block(syntax_element.clone());
         self.has_field_list_parent = has_field_list_parent(syntax_element.clone());
         self.impl_as_prev_sibling = has_impl_as_prev_sibling(syntax_element.clone());
         self.trait_as_prev_sibling = has_trait_as_prev_sibling(syntax_element.clone());

--- a/crates/ide/src/completion/completion_context.rs
+++ b/crates/ide/src/completion/completion_context.rs
@@ -18,8 +18,9 @@ use crate::{
         patterns::{
             fn_is_prev, for_is_prev2, has_bind_pat_parent, has_block_expr_parent,
             has_field_list_parent, has_impl_as_prev_sibling, has_impl_parent,
-            has_item_list_or_source_file_parent, has_ref_parent, has_trait_as_prev_sibling,
-            has_trait_parent, if_is_prev, is_in_loop_body, is_match_arm, unsafe_is_prev,
+            has_impl_trait_parent, has_item_list_or_source_file_parent, has_ref_parent,
+            has_trait_as_prev_sibling, has_trait_parent, if_is_prev, is_in_loop_body, is_match_arm,
+            unsafe_is_prev,
         },
         CompletionConfig,
     },
@@ -86,6 +87,7 @@ pub(crate) struct CompletionContext<'a> {
     pub(super) in_loop_body: bool,
     pub(super) has_trait_parent: bool,
     pub(super) has_impl_parent: bool,
+    pub(super) has_impl_trait_parent: bool,
     pub(super) has_field_list_parent: bool,
     pub(super) trait_as_prev_sibling: bool,
     pub(super) impl_as_prev_sibling: bool,
@@ -170,6 +172,7 @@ impl<'a> CompletionContext<'a> {
             block_expr_parent: false,
             has_trait_parent: false,
             has_impl_parent: false,
+            has_impl_trait_parent: false,
             has_field_list_parent: false,
             trait_as_prev_sibling: false,
             impl_as_prev_sibling: false,
@@ -228,9 +231,10 @@ impl<'a> CompletionContext<'a> {
     /// Checks whether completions in that particular case don't make much sense.
     /// Examples:
     /// - `fn <|>` -- we expect function name, it's unlikely that "hint" will be helpful.
+    ///   Exception for this case is `impl Trait for Foo`, where we would like to hint trait method names.
     /// - `for _ i<|>` -- obviously, it'll be "in" keyword.
     pub(crate) fn no_completion_required(&self) -> bool {
-        self.fn_is_prev || self.for_is_prev2
+        (self.fn_is_prev && !self.has_impl_trait_parent) || self.for_is_prev2
     }
 
     /// The range of the identifier that is being completed.
@@ -256,6 +260,7 @@ impl<'a> CompletionContext<'a> {
         self.in_loop_body = is_in_loop_body(syntax_element.clone());
         self.has_trait_parent = has_trait_parent(syntax_element.clone());
         self.has_impl_parent = has_impl_parent(syntax_element.clone());
+        self.has_impl_trait_parent = has_impl_trait_parent(syntax_element.clone());
         self.has_field_list_parent = has_field_list_parent(syntax_element.clone());
         self.impl_as_prev_sibling = has_impl_as_prev_sibling(syntax_element.clone());
         self.trait_as_prev_sibling = has_trait_as_prev_sibling(syntax_element.clone());

--- a/crates/ide/src/completion/patterns.rs
+++ b/crates/ide/src/completion/patterns.rs
@@ -9,7 +9,7 @@ use syntax::{
 };
 
 #[cfg(test)]
-use crate::completion::test_utils::check_pattern_is_applicable;
+use crate::completion::test_utils::{check_pattern_is_applicable, check_pattern_is_not_applicable};
 
 pub(crate) fn has_trait_parent(element: SyntaxElement) -> bool {
     not_same_range_ancestor(element)
@@ -34,6 +34,22 @@ pub(crate) fn has_impl_parent(element: SyntaxElement) -> bool {
 fn test_has_impl_parent() {
     check_pattern_is_applicable(r"impl A { f<|> }", has_impl_parent);
 }
+
+pub(crate) fn has_impl_trait_parent(element: SyntaxElement) -> bool {
+    not_same_range_ancestor(element)
+        .filter(|it| it.kind() == ASSOC_ITEM_LIST)
+        .and_then(|it| it.parent())
+        .filter(|it| it.kind() == IMPL)
+        .map(|it| ast::Impl::cast(it).unwrap())
+        .map(|it| it.trait_().is_some())
+        .unwrap_or(false)
+}
+#[test]
+fn test_has_impl_trait_parent() {
+    check_pattern_is_applicable(r"impl Foo for Bar { f<|> }", has_impl_trait_parent);
+    check_pattern_is_not_applicable(r"impl A { f<|> }", has_impl_trait_parent);
+}
+
 pub(crate) fn has_field_list_parent(element: SyntaxElement) -> bool {
     not_same_range_ancestor(element).filter(|it| it.kind() == RECORD_FIELD_LIST).is_some()
 }

--- a/crates/ide/src/completion/patterns.rs
+++ b/crates/ide/src/completion/patterns.rs
@@ -35,19 +35,22 @@ fn test_has_impl_parent() {
     check_pattern_is_applicable(r"impl A { f<|> }", has_impl_parent);
 }
 
-pub(crate) fn has_impl_trait_parent(element: SyntaxElement) -> bool {
-    not_same_range_ancestor(element)
-        .filter(|it| it.kind() == ASSOC_ITEM_LIST)
-        .and_then(|it| it.parent())
-        .filter(|it| it.kind() == IMPL)
+pub(crate) fn inside_impl_trait_block(element: SyntaxElement) -> bool {
+    // Here we search `impl` keyword up through the all ancestors, unlike in `has_impl_parent`,
+    // where we only check the first parent with different text range.
+    element
+        .ancestors()
+        .find(|it| it.kind() == IMPL)
         .map(|it| ast::Impl::cast(it).unwrap())
         .map(|it| it.trait_().is_some())
         .unwrap_or(false)
 }
 #[test]
-fn test_has_impl_trait_parent() {
-    check_pattern_is_applicable(r"impl Foo for Bar { f<|> }", has_impl_trait_parent);
-    check_pattern_is_not_applicable(r"impl A { f<|> }", has_impl_trait_parent);
+fn test_inside_impl_trait_block() {
+    check_pattern_is_applicable(r"impl Foo for Bar { f<|> }", inside_impl_trait_block);
+    check_pattern_is_applicable(r"impl Foo for Bar { fn f<|> }", inside_impl_trait_block);
+    check_pattern_is_not_applicable(r"impl A { f<|> }", inside_impl_trait_block);
+    check_pattern_is_not_applicable(r"impl A { fn f<|> }", inside_impl_trait_block);
 }
 
 pub(crate) fn has_field_list_parent(element: SyntaxElement) -> bool {

--- a/crates/ide/src/completion/patterns.rs
+++ b/crates/ide/src/completion/patterns.rs
@@ -116,6 +116,25 @@ pub(crate) fn if_is_prev(element: SyntaxElement) -> bool {
         .is_some()
 }
 
+pub(crate) fn fn_is_prev(element: SyntaxElement) -> bool {
+    element
+        .into_token()
+        .and_then(|it| previous_non_trivia_token(it))
+        .filter(|it| it.kind() == FN_KW)
+        .is_some()
+}
+
+/// Check if the token previous to the previous one is `for`.
+/// For example, `for _ i<|>` => true.
+pub(crate) fn for_is_prev2(element: SyntaxElement) -> bool {
+    element
+        .into_token()
+        .and_then(|it| previous_non_trivia_token(it))
+        .and_then(|it| previous_non_trivia_token(it))
+        .filter(|it| it.kind() == FOR_KW)
+        .is_some()
+}
+
 #[test]
 fn test_if_is_prev() {
     check_pattern_is_applicable(r"if l<|>", if_is_prev);

--- a/crates/ide/src/completion/patterns.rs
+++ b/crates/ide/src/completion/patterns.rs
@@ -123,6 +123,10 @@ pub(crate) fn fn_is_prev(element: SyntaxElement) -> bool {
         .filter(|it| it.kind() == FN_KW)
         .is_some()
 }
+#[test]
+fn test_fn_is_prev() {
+    check_pattern_is_applicable(r"fn l<|>", fn_is_prev);
+}
 
 /// Check if the token previous to the previous one is `for`.
 /// For example, `for _ i<|>` => true.
@@ -133,6 +137,10 @@ pub(crate) fn for_is_prev2(element: SyntaxElement) -> bool {
         .and_then(|it| previous_non_trivia_token(it))
         .filter(|it| it.kind() == FOR_KW)
         .is_some()
+}
+#[test]
+fn test_for_is_prev2() {
+    check_pattern_is_applicable(r"for i i<|>", for_is_prev2);
 }
 
 #[test]

--- a/crates/ide/src/completion/test_utils.rs
+++ b/crates/ide/src/completion/test_utils.rs
@@ -104,6 +104,18 @@ pub(crate) fn check_pattern_is_applicable(code: &str, check: fn(SyntaxElement) -
         .unwrap();
 }
 
+pub(crate) fn check_pattern_is_not_applicable(code: &str, check: fn(SyntaxElement) -> bool) {
+    let (analysis, pos) = fixture::position(code);
+    analysis
+        .with_db(|db| {
+            let sema = Semantics::new(db);
+            let original_file = sema.parse(pos.file_id);
+            let token = original_file.syntax().token_at_offset(pos.offset).left_biased().unwrap();
+            assert!(!check(NodeOrToken::Token(token)));
+        })
+        .unwrap();
+}
+
 pub(crate) fn get_all_completion_items(
     config: CompletionConfig,
     code: &str,


### PR DESCRIPTION
Closes #5206

This is a second part of the fix (first was #5997).

This PR adds a new method to the `CompletionContext`: `no_completion_required`. If this method returns `true`, it essentially means that user is unlikely to expect any hints from the IDE at this cursor position.

Currently, checks for the following cases were added:

- Previous item is `fn`: user creates a new function, names of existing functions won't be helpful. Exception for this case is `impl Foo for Bar` -- we must suggest trait function names.
- User entered `for _ i<|>`: it's obviously going to be `in` keyword, any hints here will be confusing.

More checks may be added there later, but currently I've only figured two cases.

![no_redundant_hints](https://user-images.githubusercontent.com/12111581/96332088-da4d2a00-106a-11eb-89a1-1159ece18f9d.png)

