### PR TITLE
Textmate grammar: prevent unwanted interpolation scopes

### DIFF
--- a/editors/code/rust.tmGrammar.json
+++ b/editors/code/rust.tmGrammar.json
@@ -694,23 +694,15 @@
         "interpolations": {
             "comment": "curly brace interpolations",
             "name": "meta.interpolation.rust",
-            "begin": "{",
-            "beginCaptures": {
-                "0": {
+            "match": "({)[^\"{}]*(})",
+            "captures": {
+                "1": {
+                    "name": "punctuation.definition.interpolation.rust"
+                },
+                "2": {
                     "name": "punctuation.definition.interpolation.rust"
                 }
-            },
-            "end": "}",
-            "endCaptures": {
-                "0": {
-                    "name": "punctuation.definition.interpolation.rust"
-                }
-            },
-            "patterns": [
-                {
-                    "include": "#interpolations"
-                }
-            ]
+            }
         },
         "lifetimes": {
             "patterns": [


### PR DESCRIPTION
Fixes the issues noted by @matklad after merging #6248. 

1. prevent accidental interpolation scopes when `{` is used in a string
1. prevent interpolations from extending beyond the end of a string