### PR TITLE
Don't replace entire module and file nodes when inserting imports

### DIFF
--- a/crates/assists/src/handlers/auto_import.rs
+++ b/crates/assists/src/handlers/auto_import.rs
@@ -99,7 +99,6 @@ pub(crate) fn auto_import(acc: &mut Assists, ctx: &AssistContext) -> Option<()> 
     let range = ctx.sema.original_range(import_assets.syntax_under_caret()).range;
     let group = import_group_message(import_assets.import_candidate());
     let scope = ImportScope::find_insert_use_container(import_assets.syntax_under_caret(), ctx)?;
-    let syntax = scope.as_syntax_node();
     for (import, _) in proposed_imports {
         acc.add_group(
             &group,
@@ -107,9 +106,9 @@ pub(crate) fn auto_import(acc: &mut Assists, ctx: &AssistContext) -> Option<()> 
             format!("Import `{}`", &import),
             range,
             |builder| {
-                let new_syntax =
+                let rewriter =
                     insert_use(&scope, mod_path_to_ast(&import), ctx.config.insert_use.merge);
-                builder.replace(syntax.text_range(), new_syntax.to_string())
+                builder.rewrite(rewriter);
             },
         );
     }

--- a/crates/assists/src/handlers/replace_qualified_name_with_use.rs
+++ b/crates/assists/src/handlers/replace_qualified_name_with_use.rs
@@ -45,10 +45,9 @@ pub(crate) fn replace_qualified_name_with_use(
             // affected (that is, all paths inside the node we added the `use` to).
             let mut rewriter = SyntaxRewriter::default();
             shorten_paths(&mut rewriter, syntax.clone(), &path);
-            let rewritten_syntax = rewriter.rewrite(&syntax);
-            if let Some(ref import_scope) = ImportScope::from(rewritten_syntax) {
-                let new_syntax = insert_use(import_scope, path, ctx.config.insert_use.merge);
-                builder.replace(syntax.text_range(), new_syntax.to_string())
+            if let Some(ref import_scope) = ImportScope::from(syntax.clone()) {
+                rewriter += insert_use(import_scope, path, ctx.config.insert_use.merge);
+                builder.rewrite(rewriter);
             }
         },
     )

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -351,6 +351,23 @@ pub fn visibility_pub_crate() -> ast::Visibility {
     ast_from_text("pub(crate) struct S")
 }
 
+pub fn visibility_pub() -> ast::Visibility {
+    ast_from_text("pub struct S")
+}
+
+pub fn tuple_field_list(fields: impl IntoIterator<Item = ast::TupleField>) -> ast::TupleFieldList {
+    let fields = fields.into_iter().join(", ");
+    ast_from_text(&format!("struct f({});", fields))
+}
+
+pub fn tuple_field(visibility: Option<ast::Visibility>, ty: ast::Type) -> ast::TupleField {
+    let visibility = match visibility {
+        None => String::new(),
+        Some(it) => format!("{} ", it),
+    };
+    ast_from_text(&format!("struct f({}{});", visibility, ty))
+}
+
 pub fn fn_(
     visibility: Option<ast::Visibility>,
     fn_name: ast::Name,
@@ -370,6 +387,26 @@ pub fn fn_(
     ast_from_text(&format!(
         "{}fn {}{}{} {}{}",
         visibility, fn_name, type_params, params, ret_type, body
+    ))
+}
+
+pub fn struct_(
+    visibility: Option<ast::Visibility>,
+    strukt_name: ast::Name,
+    type_params: Option<ast::GenericParamList>,
+    field_list: ast::FieldList,
+) -> ast::Struct {
+    let semicolon = if matches!(field_list, ast::FieldList::TupleFieldList(_)) { ";" } else { "" };
+    let type_params =
+        if let Some(type_params) = type_params { format!("<{}>", type_params) } else { "".into() };
+    let visibility = match visibility {
+        None => String::new(),
+        Some(it) => format!("{} ", it),
+    };
+
+    ast_from_text(&format!(
+        "{}struct {}{}{}{}",
+        visibility, strukt_name, type_params, field_list, semicolon
     ))
 }
 


### PR DESCRIPTION
This change minifies the resulting diff of import insertions by inserting or replacing the produced use tree directly through an `action` return value instead replacing the entire container node. This action has to be applied by the caller now. This unfortunately pulls the `AssistBuilder` into scope of `insert_use` back again but I tried to at least keep it away from the `insert_use` fn itself.

I'm open to more/better ideas regarding this :)

Fixes #6196