### PR TITLE
Textmate grammar: fix raw string highlighting

### DIFF
--- a/editors/code/rust.tmGrammar.json
+++ b/editors/code/rust.tmGrammar.json
@@ -958,28 +958,9 @@
                     ]
                 },
                 {
-                    "comment": "double-quoted raw strings and raw byte strings (no hash)",
+                    "comment": "double-quoted raw strings and raw byte strings",
                     "name": "string.quoted.double.rust",
-                    "begin": "(b?r)(\")",
-                    "beginCaptures": {
-                        "1": {
-                            "name": "string.quoted.byte.raw.rust"
-                        },
-                        "2": {
-                            "name": "punctuation.definition.string.rust"
-                        }
-                    },
-                    "end": "\"",
-                    "endCaptures": {
-                        "0": {
-                            "name": "punctuation.definition.string.rust"
-                        }
-                    }
-                },
-                {
-                    "comment": "double-quoted raw strings and raw byte strings (with hash)",
-                    "name": "string.quoted.double.rust",
-                    "begin": "(b?r)(#+)(\")",
+                    "begin": "(b?r)(#*)(\")",
                     "beginCaptures": {
                         "1": {
                             "name": "string.quoted.byte.raw.rust"
@@ -991,7 +972,7 @@
                             "name": "punctuation.definition.string.rust"
                         }
                     },
-                    "end": "(\")(#+)",
+                    "end": "(\")(\\2)",
                     "endCaptures": {
                         "1": {
                             "name": "punctuation.definition.string.rust"


### PR DESCRIPTION
1. Fixes the raw string highlighting issue noted by @matklad in https://github.com/rust-analyzer/rust-analyzer/pull/6275.
2. Improves raw string highlighting by requiring the number of surrounding `#` to match.