### PR TITLE
update match for textmate grammar for underscore prefixed elements 

### DIFF
--- a/editors/code/rust.tmGrammar.json
+++ b/editors/code/rust.tmGrammar.json
@@ -319,7 +319,7 @@
                 {
                     "comment": "inferred types, wildcard patterns, ignored params",
                     "name": "comment.char.underscore.rust",
-                    "match": "\\b_\\w*\\b"
+                    "match": "\\b_\\w*\\b[^!\\(]"
                 }
             ]
         },


### PR DESCRIPTION
close #6311 

Do not consider function or macro prefixed by _ as an unused function/macro