### PR TITLE
Properly identify camel cased acronyms as UpperCamelCase

### DIFF
--- a/crates/hir_ty/src/diagnostics/decl_check.rs
+++ b/crates/hir_ty/src/diagnostics/decl_check.rs
@@ -708,11 +708,23 @@ fn foo() {
     }
 
     #[test]
-    fn incorrect_struct_name() {
+    fn incorrect_struct_names() {
         check_diagnostics(
             r#"
 struct non_camel_case_name {}
     // ^^^^^^^^^^^^^^^^^^^ Structure `non_camel_case_name` should have CamelCase name, e.g. `NonCamelCaseName`
+
+struct SCREAMING_CASE {}
+    // ^^^^^^^^^^^^^^ Structure `SCREAMING_CASE` should have CamelCase name, e.g. `ScreamingCase`
+"#,
+        );
+    }
+
+    #[test]
+    fn no_diagnostic_for_camel_cased_acronyms_in_struct_name() {
+        check_diagnostics(
+            r#"
+struct AABB {}
 "#,
         );
     }
@@ -728,11 +740,23 @@ struct SomeStruct { SomeField: u8 }
     }
 
     #[test]
-    fn incorrect_enum_name() {
+    fn incorrect_enum_names() {
         check_diagnostics(
             r#"
 enum some_enum { Val(u8) }
   // ^^^^^^^^^ Enum `some_enum` should have CamelCase name, e.g. `SomeEnum`
+
+enum SOME_ENUM
+  // ^^^^^^^^^ Enum `SOME_ENUM` should have CamelCase name, e.g. `SomeEnum`
+"#,
+        );
+    }
+
+    #[test]
+    fn no_diagnostic_for_camel_cased_acronyms_in_enum_name() {
+        check_diagnostics(
+            r#"
+enum AABB {}
 "#,
         );
     }

--- a/crates/hir_ty/src/diagnostics/decl_check/case_conv.rs
+++ b/crates/hir_ty/src/diagnostics/decl_check/case_conv.rs
@@ -29,7 +29,13 @@ fn detect_case(ident: &str) -> DetectedCase {
 
     if has_uppercase {
         if !has_lowercase {
-            DetectedCase::UpperSnakeCase
+            if has_underscore {
+                DetectedCase::UpperSnakeCase
+            } else {
+                // It has uppercase only and no underscores. Ex: "AABB"
+                // This is a camel cased acronym.
+                DetectedCase::UpperCamelCase
+            }
         } else if !has_underscore {
             if first_lowercase {
                 DetectedCase::LowerCamelCase
@@ -180,6 +186,7 @@ mod tests {
         check(to_camel_case, "Weird_Case", expect![["WeirdCase"]]);
         check(to_camel_case, "name", expect![["Name"]]);
         check(to_camel_case, "A", expect![[""]]);
+        check(to_camel_case, "AABB", expect![[""]]);
     }
 
     #[test]


### PR DESCRIPTION
This closes #6305.