### PR TITLE
Add generated diagnostic docs to the manual

### DIFF
--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -366,6 +366,13 @@ Cursor position or selection is signified by `┃` character.
 
 include::./generated_assists.adoc[]
 
+== Diagnostics
+
+While most errors and warnings provided by rust-analyzer come from the `cargo check` integration, there's a growing number of diagnostics implemented using rust-analyzer's own analysis.
+These diagnostics don't respect `#[allow]` or `#[deny]` attributes yet, but can be turned off using the `rust-analyzer.diagnostics.enable`, `rust-analyzer.diagnostics.enableExperimental` or `rust-analyzer.diagnostics.disabled` settings.
+
+include::./generated_diagnostic.adoc[]
+
 == Editor Features
 === VS Code
 


### PR DESCRIPTION
It seemed that we're not actually including the generated diagnostic docs anywhere yet? So I added something to the manual. This is completely untested though.