### PR TITLE
Remove dead code in handle_rename

### DIFF
--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -12,7 +12,6 @@ use ide::{
     RangeInfo, Runnable, RunnableKind, SearchScope, TextEdit,
 };
 use itertools::Itertools;
-use lsp_server::ErrorCode;
 use lsp_types::{
     CallHierarchyIncomingCall, CallHierarchyIncomingCallsParams, CallHierarchyItem,
     CallHierarchyOutgoingCall, CallHierarchyOutgoingCallsParams, CallHierarchyPrepareParams,

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -659,14 +659,6 @@ pub(crate) fn handle_rename(
     let _p = profile::span("handle_rename");
     let position = from_proto::file_position(&snap, params.text_document_position)?;
 
-    if params.new_name.is_empty() {
-        return Err(LspError::new(
-            ErrorCode::InvalidParams as i32,
-            "New Name cannot be empty".into(),
-        )
-        .into());
-    }
-
     let change = snap.analysis.rename(position, &*params.new_name)??;
     let workspace_edit = to_proto::workspace_edit(&snap, change.info)?;
     Ok(Some(workspace_edit))


### PR DESCRIPTION
On rename, VSCode sends a `textDocument/prepareRename` request. Then it displays the text box requesting the new name. 
It seems VSCode sends the subsequent `textDocument/rename` request only if the new name is not empty.

The proposed change removes the always-`false` condition and its body.

Checked it with the debugger, but I'm wondering if it can be triggered some other way.

_Edit: grammar_