### PR TITLE
correct hover text for items with doc attribute with raw strings

### DIFF
--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -638,6 +638,33 @@ fn main() { }
     }
 
     #[test]
+    fn hover_shows_fn_doc_attr_raw_string() {
+        check(
+            r##"
+#[doc = r#"Raw string doc attr"#]
+pub fn foo<|>(_: &Path) {}
+
+fn main() { }
+"##,
+            expect![[r##"
+                *foo*
+
+                ```rust
+                test
+                ```
+
+                ```rust
+                pub fn foo(_: &Path)
+                ```
+
+                ---
+
+                Raw string doc attr
+            "##]],
+        );
+    }
+
+    #[test]
     fn hover_shows_struct_field_info() {
         // Hovering over the field when instantiating
         check(


### PR DESCRIPTION
Fixes #6300 by improving the handling of raw string literals in attribute style doc comments.

This still has a bug where it could consume too many `"` at the start or end of the comment text, just as the original code had. Not sure if we want to fix that as part of this PR or not? If so, I think I'd prefer to add a unit test for either the `as_simple_key_value` function (I'm not exactly sure where this would belong / how to set this up) or create a `fn(&SmolStr) -> &SmolStr` to unit test by factoring out the `trim` operations from `as_simple_key_value`. Thoughts on this? 