### PR TITLE
Diagnose #[cfg]s in bodies

### DIFF
--- a/crates/hir/src/code_model.rs
+++ b/crates/hir/src/code_model.rs
@@ -781,6 +781,7 @@ impl Function {
     }
 
     pub fn diagnostics(self, db: &dyn HirDatabase, sink: &mut DiagnosticSink) {
+        hir_def::diagnostics::validate_body(db.upcast(), self.id.into(), sink);
         hir_ty::diagnostics::validate_module_item(db, self.id.into(), sink);
         hir_ty::diagnostics::validate_body(db, self.id.into(), sink);
     }

--- a/crates/hir_def/src/body/diagnostics.rs
+++ b/crates/hir_def/src/body/diagnostics.rs
@@ -1,0 +1,20 @@
+//! Diagnostics emitted during body lowering.
+
+use hir_expand::diagnostics::DiagnosticSink;
+
+use crate::diagnostics::InactiveCode;
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum BodyDiagnostic {
+    InactiveCode(InactiveCode),
+}
+
+impl BodyDiagnostic {
+    pub fn add_to(&self, sink: &mut DiagnosticSink<'_>) {
+        match self {
+            BodyDiagnostic::InactiveCode(diag) => {
+                sink.push(diag.clone());
+            }
+        }
+    }
+}

--- a/crates/hir_def/src/body/tests.rs
+++ b/crates/hir_def/src/body/tests.rs
@@ -1,0 +1,75 @@
+use base_db::{fixture::WithFixture, SourceDatabase};
+use test_utils::mark;
+
+use crate::{test_db::TestDB, ModuleDefId};
+
+use super::*;
+
+fn lower(ra_fixture: &str) -> Arc<Body> {
+    let (db, file_id) = crate::test_db::TestDB::with_single_file(ra_fixture);
+
+    let krate = db.crate_graph().iter().next().unwrap();
+    let def_map = db.crate_def_map(krate);
+    let module = def_map.modules_for_file(file_id).next().unwrap();
+    let module = &def_map[module];
+    let fn_def = match module.scope.declarations().next().unwrap() {
+        ModuleDefId::FunctionId(it) => it,
+        _ => panic!(),
+    };
+
+    db.body(fn_def.into())
+}
+
+fn check_diagnostics(ra_fixture: &str) {
+    let db: TestDB = TestDB::with_files(ra_fixture);
+    db.check_diagnostics();
+}
+
+#[test]
+fn your_stack_belongs_to_me() {
+    mark::check!(your_stack_belongs_to_me);
+    lower(
+        "
+macro_rules! n_nuple {
+    ($e:tt) => ();
+    ($($rest:tt)*) => {{
+        (n_nuple!($($rest)*)None,)
+    }};
+}
+fn main() { n_nuple!(1,2,3); }
+",
+    );
+}
+
+#[test]
+fn cfg_diagnostics() {
+    check_diagnostics(
+        r"
+fn f() {
+    // The three g̶e̶n̶d̶e̶r̶s̶ statements:
+
+    #[cfg(a)] fn f() {}  // Item statement
+  //^^^^^^^^^^^^^^^^^^^ code is inactive due to #[cfg] directives: a is disabled
+    #[cfg(a)] {}         // Expression statement
+  //^^^^^^^^^^^^ code is inactive due to #[cfg] directives: a is disabled
+    #[cfg(a)] let x = 0; // let statement
+  //^^^^^^^^^^^^^^^^^^^^ code is inactive due to #[cfg] directives: a is disabled
+
+    abc(#[cfg(a)] 0);
+      //^^^^^^^^^^^ code is inactive due to #[cfg] directives: a is disabled
+    let x = Struct {
+        #[cfg(a)] f: 0,
+      //^^^^^^^^^^^^^^ code is inactive due to #[cfg] directives: a is disabled
+    };
+    match () {
+        () => (),
+        #[cfg(a)] () => (),
+      //^^^^^^^^^^^^^^^^^^ code is inactive due to #[cfg] directives: a is disabled
+    }
+
+    #[cfg(a)] 0          // Trailing expression of block
+  //^^^^^^^^^^^ code is inactive due to #[cfg] directives: a is disabled
+}
+    ",
+    );
+}

--- a/crates/hir_def/src/diagnostics.rs
+++ b/crates/hir_def/src/diagnostics.rs
@@ -95,7 +95,7 @@ impl Diagnostic for UnresolvedImport {
     }
 }
 
-// Diagnostic: unconfigured-code
+// Diagnostic: inactive-code
 //
 // This diagnostic is shown for code with inactive `#[cfg]` attributes.
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/crates/hir_def/src/diagnostics.rs
+++ b/crates/hir_def/src/diagnostics.rs
@@ -4,9 +4,16 @@ use std::any::Any;
 use stdx::format_to;
 
 use cfg::{CfgExpr, CfgOptions, DnfExpr};
-use hir_expand::diagnostics::{Diagnostic, DiagnosticCode};
+use hir_expand::diagnostics::{Diagnostic, DiagnosticCode, DiagnosticSink};
 use hir_expand::{HirFileId, InFile};
 use syntax::{ast, AstPtr, SyntaxNodePtr};
+
+use crate::{db::DefDatabase, DefWithBodyId};
+
+pub fn validate_body(db: &dyn DefDatabase, owner: DefWithBodyId, sink: &mut DiagnosticSink<'_>) {
+    let source_map = db.body_with_source_map(owner).1;
+    source_map.add_diagnostics(db, sink);
+}
 
 // Diagnostic: unresolved-module
 //
@@ -91,7 +98,7 @@ impl Diagnostic for UnresolvedImport {
 // Diagnostic: unconfigured-code
 //
 // This diagnostic is shown for code with inactive `#[cfg]` attributes.
-#[derive(Debug)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct InactiveCode {
     pub file: HirFileId,
     pub node: SyntaxNodePtr,

--- a/crates/hir_def/src/nameres/tests/diagnostics.rs
+++ b/crates/hir_def/src/nameres/tests/diagnostics.rs
@@ -1,42 +1,10 @@
 use base_db::fixture::WithFixture;
-use base_db::FileId;
-use base_db::SourceDatabaseExt;
-use hir_expand::db::AstDatabase;
-use rustc_hash::FxHashMap;
-use syntax::TextRange;
-use syntax::TextSize;
 
 use crate::test_db::TestDB;
 
 fn check_diagnostics(ra_fixture: &str) {
     let db: TestDB = TestDB::with_files(ra_fixture);
-    let annotations = db.extract_annotations();
-    assert!(!annotations.is_empty());
-
-    let mut actual: FxHashMap<FileId, Vec<(TextRange, String)>> = FxHashMap::default();
-    db.diagnostics(|d| {
-        let src = d.display_source();
-        let root = db.parse_or_expand(src.file_id).unwrap();
-        // FIXME: macros...
-        let file_id = src.file_id.original_file(&db);
-        let range = src.value.to_node(&root).text_range();
-        let message = d.message().to_owned();
-        actual.entry(file_id).or_default().push((range, message));
-    });
-
-    for (file_id, diags) in actual.iter_mut() {
-        diags.sort_by_key(|it| it.0.start());
-        let text = db.file_text(*file_id);
-        // For multiline spans, place them on line start
-        for (range, content) in diags {
-            if text[*range].contains('\n') {
-                *range = TextRange::new(range.start(), range.start() + TextSize::from(1));
-                *content = format!("... {}", content);
-            }
-        }
-    }
-
-    assert_eq!(annotations, actual);
+    db.check_diagnostics();
 }
 
 #[test]

--- a/docs/user/generated_diagnostic.adoc
+++ b/docs/user/generated_diagnostic.adoc
@@ -82,24 +82,24 @@ This diagnostic is triggered if created structure does not have field provided i
 
 
 === unconfigured-code
-**Source:** https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/hir_def/src/diagnostics.rs#L90[diagnostics.rs]
+**Source:** https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/hir_def/src/diagnostics.rs#L98[diagnostics.rs]
 
 This diagnostic is shown for code with inactive `#[cfg]` attributes.
 
 
 === unresolved-extern-crate
-**Source:** https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/hir_def/src/diagnostics.rs#L35[diagnostics.rs]
+**Source:** https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/hir_def/src/diagnostics.rs#L43[diagnostics.rs]
 
 This diagnostic is triggered if rust-analyzer is unable to discover referred extern crate.
 
 
 === unresolved-import
-**Source:** https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/hir_def/src/diagnostics.rs#L59[diagnostics.rs]
+**Source:** https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/hir_def/src/diagnostics.rs#L67[diagnostics.rs]
 
 This diagnostic is triggered if rust-analyzer is unable to discover imported module.
 
 
 === unresolved-module
-**Source:** https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/hir_def/src/diagnostics.rs#L10[diagnostics.rs]
+**Source:** https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/hir_def/src/diagnostics.rs#L18[diagnostics.rs]
 
 This diagnostic is triggered if rust-analyzer is unable to discover referred module.

--- a/docs/user/generated_diagnostic.adoc
+++ b/docs/user/generated_diagnostic.adoc
@@ -5,6 +5,12 @@
 This diagnostic is triggered if `break` keyword is used outside of a loop.
 
 
+=== inactive-code
+**Source:** https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/hir_def/src/diagnostics.rs#L98[diagnostics.rs]
+
+This diagnostic is shown for code with inactive `#[cfg]` attributes.
+
+
 === incorrect-ident-case
 **Source:** https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/hir_ty/src/diagnostics.rs#L319[diagnostics.rs]
 
@@ -79,12 +85,6 @@ This diagnostic is triggered if operation marked as `unsafe` is used outside of 
 **Source:** https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/hir_ty/src/diagnostics.rs#L39[diagnostics.rs]
 
 This diagnostic is triggered if created structure does not have field provided in record.
-
-
-=== unconfigured-code
-**Source:** https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/hir_def/src/diagnostics.rs#L98[diagnostics.rs]
-
-This diagnostic is shown for code with inactive `#[cfg]` attributes.
 
 
 === unresolved-extern-crate


### PR DESCRIPTION
This PR threads diagnostics through body lowering using the `BodySourceMap`, and emits `InactiveCode` diagnostics for expressions, statements, and match arms that are `#[cfg]`d out.