### PR TITLE
Textmate grammar: angle bracket fix (closes #6323)

### DIFF
--- a/editors/code/rust.tmGrammar.json
+++ b/editors/code/rust.tmGrammar.json
@@ -641,10 +641,28 @@
                 },
                 {
                     "comment": "less than, greater than (special case)",
-                    "match": "(^|\\s)(?<!=)([<>])\\s",
+                    "match": "(?:\\b|(?:(\\))|(\\])|(\\})))[ \\t]+([<>])[ \\t]+(?:\\b|(?:(\\()|(\\[)|(\\{)))",
                     "captures": {
+                        "1": {
+                            "name": "punctuation.brackets.round.rust"
+                        },
                         "2": {
+                            "name": "punctuation.brackets.square.rust"
+                        },
+                        "3": {
+                            "name": "punctuation.brackets.curly.rust"
+                        },
+                        "4": {
                             "name": "keyword.operator.comparison.rust"
+                        },
+                        "5": {
+                            "name": "punctuation.brackets.round.rust"
+                        },
+                        "6": {
+                            "name": "punctuation.brackets.square.rust"
+                        },
+                        "7": {
+                            "name": "punctuation.brackets.curly.rust"
                         }
                     }
                 },


### PR DESCRIPTION
Fixes #6323 

After tinkering, it became clear that `<` and `>` should really default to the punctuation interpretation in the vast majority of cases. In addition, the breakage is greater when an angle bracket is missed. So, rather than optimizing for a type parameter `meta` scope and considering every possible parent scope and child scope, the easier fix was to narrow the case where `<` and `>` are treated as comparison operators.