### PR TITLE
Do insertion lookahead in algo::diff

### DIFF
--- a/crates/ide/src/diagnostics.rs
+++ b/crates/ide/src/diagnostics.rs
@@ -613,7 +613,7 @@ fn main() {
 pub struct Foo { pub a: i32, pub b: i32 }
 "#,
             r#"
-fn some(, b: ()} {}
+fn some(, b: ()) {}
 fn items() {}
 fn here() {}
 


### PR DESCRIPTION
This is the last blocker for #6287 after this I can update that PR to properly fix things through using `SyntaxRewriter`.

This PR also shuffles tests around a bit and adds some more.

Ideally this is just a hack until we implement a "proper" diff algorithm that approximates a minimal diff. Maybe something like [gumtree](https://github.com/GumTreeDiff/gumtree)?