### PR TITLE
Handle #![cfg] in crate root

### DIFF
--- a/crates/hir_def/src/nameres/tests.rs
+++ b/crates/hir_def/src/nameres/tests.rs
@@ -691,3 +691,20 @@ mod tr {
         "#]],
     );
 }
+
+#[test]
+fn cfg_the_entire_crate() {
+    check(
+        r#"
+//- /main.rs
+#![cfg(never)]
+
+pub struct S;
+pub enum E {}
+pub fn f() {}
+    "#,
+        expect![[r#"
+            crate
+        "#]],
+    );
+}


### PR DESCRIPTION
Now we correctly skip analysis of winapi on non-Windows platforms.

bors r+ :robot: