### PR TITLE
Smaller inlay hints

### DIFF
--- a/editors/code/src/inlay_hints.ts
+++ b/editors/code/src/inlay_hints.ts
@@ -61,7 +61,7 @@ function createHintStyle(hintKind: "type" | "parameter" | "chaining") {
                 backgroundColor: bg,
                 fontStyle: "normal",
                 fontWeight: "normal",
-                textDecoration: "none",
+                textDecoration: ";font-size:smaller",
             },
         }),
         toDecoration(hint: ra.InlayHint, conv: lc.Protocol2CodeConverter): vscode.DecorationOptions {


### PR DESCRIPTION
This makes things a lot more readable but isn't officially supported by vscode: https://github.com/Microsoft/vscode/issues/9078

Inspired by Visual Studio, IntelliJ and Resharper.