### PR TITLE
Upgrade Chalk to 0.36

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,9 +168,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chalk-derive"
-version = "0.34.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e9f986750ecb4df889d0a95d4586bd921889497b33908cc75bb80eadb4c600a"
+checksum = "9f88ce4deae1dace71e49b7611cfae2d5489de3530d6daba5758043c47ac3a10"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -180,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "chalk-ir"
-version = "0.34.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c352c4649f1408bb3de5d86a248fda78d3d9cd1cbbd9502e7eca1be1e7ac368"
+checksum = "63362c629c2014ab639b04029070763fb8224df136d1363d30e9ece4c8877da3"
 dependencies = [
  "chalk-derive",
  "lazy_static",
@@ -190,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "chalk-recursive"
-version = "0.34.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7294bb2ac5446fcb83ec9524b9113f59a8913f174a9c1dea6db60532f17a1579"
+checksum = "5274a882b664121d5827d4f116f5bd8331e0eac3d501ab8038e9d5c5bc5a2689"
 dependencies = [
  "chalk-derive",
  "chalk-ir",
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "chalk-solve"
-version = "0.34.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbca06963ed6f3d22faed840847a685f02feefa3825c0b94f9b791d03a0ac6f"
+checksum = "cac338a67af52a7f50bb2f8232e730a3518ce432dbe303246acfe525ddd838c7"
 dependencies = [
  "chalk-derive",
  "chalk-ir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ debug = 0 # Set this to 1 or 2 to get more useful backtraces in debugger.
 [patch.'crates-io']
 # rowan = { path = "../rowan" }
 
-[patch.'https://github.com/rust-lang/chalk.git']
 # chalk-solve = { path = "../chalk/chalk-solve" }
-# chalk-rust-ir = { path = "../chalk/chalk-rust-ir" }
 # chalk-ir = { path = "../chalk/chalk-ir" }
+# chalk-recursive = { path = "../chalk/chalk-recursive" }

--- a/crates/hir_ty/Cargo.toml
+++ b/crates/hir_ty/Cargo.toml
@@ -17,9 +17,9 @@ ena = "0.14.0"
 log = "0.4.8"
 rustc-hash = "1.1.0"
 scoped-tls = "1"
-chalk-solve = { version = "0.34", default-features = false }
-chalk-ir = "0.34"
-chalk-recursive = "0.34"
+chalk-solve = { version = "0.36", default-features = false }
+chalk-ir = "0.36"
+chalk-recursive = "0.36"
 
 stdx = { path = "../stdx", version = "0.0.0" }
 hir_def = { path = "../hir_def", version = "0.0.0" }

--- a/crates/hir_ty/src/traits/chalk/interner.rs
+++ b/crates/hir_ty/src/traits/chalk/interner.rs
@@ -122,13 +122,6 @@ impl chalk_ir::interner::Interner for Interner {
         tls::with_current_program(|prog| Some(prog?.debug_program_clause_implication(pci, fmt)))
     }
 
-    fn debug_application_ty(
-        application_ty: &chalk_ir::ApplicationTy<Interner>,
-        fmt: &mut fmt::Formatter<'_>,
-    ) -> Option<fmt::Result> {
-        tls::with_current_program(|prog| Some(prog?.debug_application_ty(application_ty, fmt)))
-    }
-
     fn debug_substitution(
         substitution: &chalk_ir::Substitution<Interner>,
         fmt: &mut fmt::Formatter<'_>,


### PR DESCRIPTION
Quite a few changes, because Chalk got rid of the `ApplicationTy` nesting.