### PR TITLE
Textmate grammar: allow function declarations without curly brackets

### DIFF
--- a/editors/code/rust.tmGrammar.json
+++ b/editors/code/rust.tmGrammar.json
@@ -462,7 +462,7 @@
                             "name": "punctuation.brackets.angle.rust"
                         }
                     },
-                    "end": "\\{",
+                    "end": "\\{|;",
                     "endCaptures": {
                         "0": {
                             "name": "punctuation.brackets.curly.rust"


### PR DESCRIPTION
Functions inside trait declarations can break subsequent highlighting, because they have no curly brackets. In a case such as:

```rust
pub trait Summary {
    fn summarize(&self) -> String;
}
```

the scope `meta.function.definition.rust` will continue past the end of the block looking for `{` after `fn`. This PR allows `meta.function.definition.rust` to terminate with `;` in these cases. 