### PR TITLE
Lazy fixes resolving

### DIFF
--- a/crates/hir/src/diagnostics.rs
+++ b/crates/hir/src/diagnostics.rs
@@ -2,6 +2,6 @@
 pub use hir_def::diagnostics::{InactiveCode, UnresolvedModule};
 pub use hir_expand::diagnostics::{Diagnostic, DiagnosticSink, DiagnosticSinkBuilder};
 pub use hir_ty::diagnostics::{
-    IncorrectCase, MismatchedArgCount, MissingFields, MissingMatchArms, MissingOkInTailExpr,
-    NoSuchField,
+    BreakOutsideOfLoop, IncorrectCase, MismatchedArgCount, MissingFields, MissingMatchArms,
+    MissingOkInTailExpr, NoSuchField,
 };

--- a/crates/hir_def/src/diagnostics.rs
+++ b/crates/hir_def/src/diagnostics.rs
@@ -18,7 +18,7 @@ pub fn validate_body(db: &dyn DefDatabase, owner: DefWithBodyId, sink: &mut Diag
 // Diagnostic: unresolved-module
 //
 // This diagnostic is triggered if rust-analyzer is unable to discover referred module.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct UnresolvedModule {
     pub file: HirFileId,
     pub decl: AstPtr<ast::Module>,

--- a/crates/hir_ty/src/diagnostics.rs
+++ b/crates/hir_ty/src/diagnostics.rs
@@ -39,7 +39,7 @@ pub fn validate_body(db: &dyn HirDatabase, owner: DefWithBodyId, sink: &mut Diag
 // Diagnostic: no-such-field
 //
 // This diagnostic is triggered if created structure does not have field provided in record.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NoSuchField {
     pub file: HirFileId,
     pub field: AstPtr<ast::RecordExprField>,
@@ -74,7 +74,7 @@ impl Diagnostic for NoSuchField {
 //
 // let a = A { a: 10 };
 // ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MissingFields {
     pub file: HirFileId,
     pub field_list_parent: AstPtr<ast::RecordExpr>,
@@ -125,7 +125,7 @@ impl Diagnostic for MissingFields {
 //     // ...
 // }
 // ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MissingPatFields {
     pub file: HirFileId,
     pub field_list_parent: AstPtr<ast::RecordPat>,
@@ -162,7 +162,7 @@ impl Diagnostic for MissingPatFields {
 // Diagnostic: missing-match-arm
 //
 // This diagnostic is triggered if `match` block is missing one or more match arms.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MissingMatchArms {
     pub file: HirFileId,
     pub match_expr: AstPtr<ast::Expr>,
@@ -195,7 +195,7 @@ impl Diagnostic for MissingMatchArms {
 //     10
 // }
 // ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MissingOkInTailExpr {
     pub file: HirFileId,
     pub expr: AstPtr<ast::Expr>,
@@ -219,7 +219,7 @@ impl Diagnostic for MissingOkInTailExpr {
 // Diagnostic: break-outside-of-loop
 //
 // This diagnostic is triggered if `break` keyword is used outside of a loop.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BreakOutsideOfLoop {
     pub file: HirFileId,
     pub expr: AstPtr<ast::Expr>,
@@ -243,7 +243,7 @@ impl Diagnostic for BreakOutsideOfLoop {
 // Diagnostic: missing-unsafe
 //
 // This diagnostic is triggered if operation marked as `unsafe` is used outside of `unsafe` function or block.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MissingUnsafe {
     pub file: HirFileId,
     pub expr: AstPtr<ast::Expr>,
@@ -267,7 +267,7 @@ impl Diagnostic for MissingUnsafe {
 // Diagnostic: mismatched-arg-count
 //
 // This diagnostic is triggered if function is invoked with an incorrect amount of arguments.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MismatchedArgCount {
     pub file: HirFileId,
     pub call_expr: AstPtr<ast::Expr>,
@@ -294,7 +294,7 @@ impl Diagnostic for MismatchedArgCount {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum CaseType {
     // `some_var`
     LowerSnakeCase,
@@ -319,7 +319,7 @@ impl fmt::Display for CaseType {
 // Diagnostic: incorrect-ident-case
 //
 // This diagnostic is triggered if item name doesn't follow https://doc.rust-lang.org/1.0.0/style/style/naming/README.html[Rust naming convention].
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct IncorrectCase {
     pub file: HirFileId,
     pub ident: AstPtr<ast::Name>,

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -524,6 +524,14 @@ impl Analysis {
         })
     }
 
+    pub(crate) fn with_semantics<F, T>(&self, f: F) -> T
+    where
+        F: FnOnce(&Semantics<RootDatabase>) -> T,
+    {
+        let sema = Semantics::new(&self.db as &RootDatabase);
+        f(&sema)
+    }
+
     /// Performs an operation on that may be Canceled.
     fn with_db<F, T>(&self, f: F) -> Cancelable<T>
     where


### PR DESCRIPTION
Resolves #6433

Currently, fixes for diagnostics are resolved eagerly, which is not quite a good idea: when we collect diagnostics, we report all of them to user.
Fixes though are reported *only* if cursor is within the fix trigger range, otherwise they're just skipped.
Given the fact that resolving a fix may be an expensive operation (incorrect case diagnostic is a good example: in order to provide fix, we must track all the places where diagnostic is used), doing it just to be rejected because of cursor position is incorrect.

What this PR does: instead of providing a full fix, only the trigger range is provided by default. And only if `rust-analyzer` sees that fix exists and its range is suitable, it will try to resolve the fix.

@matklad I feel weird about `Analysis::with_semantics` method and having to call `parse` manually in the `missing_record_expr_field_fix`. It just doesn't feel right. Could you please tell whether the direction is at least correct?

Also, unfortunately I'm not able to reproduce the issue even with 1ms auto-save enabled, thus will be grateful if someone will check whether this fix works or not. In theory it should, but who knows.

cc @neilyoung @lnicola 
