### PR TITLE
[WIP] Factor out common fields from enum variants

### DIFF
--- a/crates/assists/src/handlers/extract_struct_from_enum_variant.rs
+++ b/crates/assists/src/handlers/extract_struct_from_enum_variant.rs
@@ -11,7 +11,7 @@ use syntax::{
 };
 
 use crate::{
-    utils::{existing_definition, insert_use, mod_path_to_ast, ImportScope},
+    utils::{existing_type_definition, insert_use, mod_path_to_ast, ImportScope},
     AssistContext, AssistId, AssistKind, Assists,
 };
 
@@ -40,7 +40,7 @@ pub(crate) fn extract_struct_from_enum_variant(
 
     let db = ctx.db();
     let module = variant_hir.parent_enum(db).module(db);
-    if existing_definition(db, &variant_name, module) {
+    if existing_type_definition(db, &variant_name, module) {
         return None;
     }
 

--- a/crates/assists/src/handlers/factor_out_from_enum_variants.rs
+++ b/crates/assists/src/handlers/factor_out_from_enum_variants.rs
@@ -1,16 +1,20 @@
 use std::iter;
 
+use ast::edit::IndentLevel;
+use ide_db::{defs::Definition, search::Reference};
+use rustc_hash::{FxHashMap, FxHashSet};
 use syntax::{
-    algo::SyntaxRewriter,
+    algo::{self, SyntaxRewriter},
+    ast::edit::AstNodeEdit,
+    ast::ArgListOwner,
     ast::GenericParamsOwner,
     ast::{self, make, NameOwner, VisibilityOwner},
-    AstNode,
+    AstNode, SourceFile,
 };
 
 use crate::{
     assist_context::{AssistContext, Assists},
-    utils::existing_definition,
-    AssistId, AssistKind,
+    utils, AssistId, AssistKind,
 };
 
 // Assist: factor_out_from_enum_variants
@@ -47,8 +51,9 @@ pub(crate) fn factor_out_from_enum_variants(acc: &mut Assists, ctx: &AssistConte
 
     let new_ty = make::name(&format!("Enum{}", enum_name.text()));
     let db = ctx.db();
-    let module = ctx.sema.to_def(&enum_)?.module(db);
-    if existing_definition(db, &new_ty, module) {
+    let enum_hir = ctx.sema.to_def(&enum_)?;
+    let module = enum_hir.module(db);
+    if utils::existing_definition(db, &new_ty, module) {
         return None;
     }
 
@@ -65,10 +70,9 @@ pub(crate) fn factor_out_from_enum_variants(acc: &mut Assists, ctx: &AssistConte
         AssistId("factor_out_from_enum_variants", AssistKind::RefactorRewrite),
         "Factor out from enum variants",
         target,
-        // FIXME: Find and update creation of the enum.
         // FIXME: Find and update usage of the enum.
         |builder| {
-            let fields = make::record_field_list(
+            let new_fields = make::record_field_list(
                 common_fields
                     .iter()
                     .enumerate()
@@ -83,20 +87,52 @@ pub(crate) fn factor_out_from_enum_variants(acc: &mut Assists, ctx: &AssistConte
                     })),
             );
 
+            let usages = Definition::ModuleDef(hir::ModuleDef::Adt(hir::Adt::Enum(enum_hir)))
+                .usages(&ctx.sema)
+                .all();
+
+            let mut visited_modules_set = FxHashSet::default();
+            visited_modules_set.insert(module);
+            let mut rewriters = FxHashMap::default();
+            for reference in usages {
+                let rewriter = rewriters
+                    .entry(reference.file_range.file_id)
+                    .or_insert_with(SyntaxRewriter::default);
+                let source_file = ctx.sema.parse(reference.file_range.file_id);
+                update_constructor(
+                    rewriter,
+                    reference,
+                    &source_file,
+                    new_ty.text(),
+                    &new_fields,
+                    common_fields.len(),
+                );
+            }
+
+            let mut rewriter = rewriters.remove(&ctx.frange.file_id).unwrap_or_default();
+            for (file_id, rewriter) in rewriters {
+                // FIXME(#6465): Currently broken for multiple files.
+                builder.edit_file(file_id);
+                builder.rewrite(rewriter);
+            }
             builder.edit_file(ctx.frange.file_id);
-            let mut rewriter = SyntaxRewriter::default();
 
             // FIXME: Support generic enums
-            let strukt = make::struct_(enum_vis, enum_name, None, fields.into());
-            rewriter.insert_before(enum_.syntax(), strukt.syntax());
-            rewriter.insert_before(enum_.syntax(), &make::tokens::blank_line());
-            update_tuple_enum(&mut rewriter, &enum_, common_fields.len());
+            let strukt = make::struct_(enum_vis, enum_name.clone(), None, new_fields.into());
 
+            let indent_level = IndentLevel::from_node(enum_.syntax());
+            rewriter.insert_before(enum_.syntax(), strukt.indent(indent_level).syntax());
+            // Just using make::tokens::blank_line() won't work because we're inserting between the
+            // enum_ and its indentation.
+            let ws = make::tokens::whitespace(&format!("\n\n{}", indent_level));
+            rewriter.insert_before(enum_.syntax(), &ws);
+
+            update_tuple_enum(&mut rewriter, &enum_, &enum_name, &new_ty, common_fields.len());
             builder.rewrite(rewriter);
         },
     );
 
-    None
+    Some(())
 }
 
 fn common_tuple_fields(
@@ -129,14 +165,67 @@ fn common_tuple_fields(
     }
 }
 
+fn update_constructor(
+    rewriter: &mut SyntaxRewriter,
+    reference: Reference,
+    source_file: &SourceFile,
+    new_enum_name: &str,
+    struct_fields: &ast::RecordFieldList,
+    n_common_fields: usize,
+) -> Option<()> {
+    // FIXME: check for ast::RecordExpr
+    let path_expr = algo::find_node_at_offset::<ast::PathExpr>(
+        source_file.syntax(),
+        reference.file_range.range.start(),
+    )?;
+    let path = path_expr.path()?;
+    let (old_enum_path, variant) = (path.qualifier()?, path.segment()?);
+
+    let call = path_expr.syntax().parent().and_then(ast::CallExpr::cast)?;
+    let args = call.arg_list()?.args().collect::<Vec<_>>();
+    let (common, unique) = args.split_at(n_common_fields);
+
+    let new_enum_path = make::expr_path(make::path_qualified(
+        make::path_unqualified(make::path_segment(make::name_ref(new_enum_name))),
+        variant,
+    ));
+    let enum_constructor = if unique.is_empty() {
+        new_enum_path
+    } else {
+        make::expr_call(new_enum_path, make::arg_list(unique.iter().cloned()))
+    };
+
+    let enum_record_field = make::record_expr_field(
+        make::name_ref(&stdx::to_lower_snake_case(new_enum_name)),
+        Some(enum_constructor),
+    );
+    let name_refs =
+        struct_fields.fields().filter_map(|it| it.name().map(|it| make::name_ref(it.text())));
+    // Because there's an extra field containing an enum, name_refs.count() == n_common_fields + 1
+    debug_assert_eq!(name_refs.clone().count(), n_common_fields + 1);
+
+    let record_expr_field_list = make::record_expr_field_list(
+        name_refs
+            .zip(common.iter().cloned())
+            .map(|(name_ref, expr)| make::record_expr_field(name_ref, Some(expr)))
+            .chain(iter::once(enum_record_field)),
+    );
+    let constructor = make::record_expr(old_enum_path, record_expr_field_list);
+
+    let level = IndentLevel::from_node(call.syntax());
+    rewriter.replace(call.syntax(), constructor.indent(level).syntax());
+
+    Some(())
+}
+
 fn update_tuple_enum(
     rewriter: &mut SyntaxRewriter,
     enum_: &ast::Enum,
+    enum_name: &ast::Name,
+    new_enum_name: &ast::Name,
     n_common_fields: usize,
 ) -> Option<()> {
-    let name = enum_.name()?;
-    let new_name = make::name(&format!("Enum{}", name.text()));
-    rewriter.replace(name.syntax(), new_name.syntax());
+    rewriter.replace(enum_name.syntax(), new_enum_name.syntax());
 
     for variant in enum_.variant_list()?.variants() {
         let mut fields = match variant.field_list()? {
@@ -146,6 +235,7 @@ fn update_tuple_enum(
 
         let unique_variant = make::variant(
             variant.name()?,
+            // Trying to instead use .map() here makes borrowck very angry :(
             match fields.peek() {
                 Some(_) => Some(make::tuple_field_list(fields).into()),
                 _ => None,
@@ -164,7 +254,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn factor_out_from_enum_variant_works() {
+    fn factor_out_works() {
         check_assist(
             factor_out_from_enum_variants,
             r#"
@@ -172,7 +262,8 @@ pub enum Data {<|>
     A(usize, [String; 2], bool),
     B(usize, [String; 2]),
     C(usize, [String; 2], u32, i16),
-}"#,
+}
+"#,
             r#"
 pub struct Data {
     pub enum_field_0: usize,
@@ -184,7 +275,97 @@ pub enum EnumData {
     A(bool),
     B,
     C(u32, i16),
-}"#,
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn factor_out_update_construction_works() {
+        check_assist(
+            factor_out_from_enum_variants,
+            r#"
+mod also_test_indentation {
+    enum A {<|>
+        One(String, bool, usize, f64),
+        Two(String, bool,),
+    }
+
+    fn func() {
+        let _one = A::One("hi".into(), true, 42, 12.);
+        let _two = A::Two("hi".into(), true);
+    }
+}
+"#,
+            r#"
+mod also_test_indentation {
+    struct A {
+        enum_field_0: String,
+        enum_field_1: bool,
+        enum_a: EnumA,
+    }
+
+    enum EnumA {
+        One(usize, f64),
+        Two,
+    }
+
+    fn func() {
+        let _one = A {
+            enum_field_0: "hi".into(),
+            enum_field_1: true,
+            enum_a: EnumA::One(42, 12.),
+        };
+        let _two = A {
+            enum_field_0: "hi".into(),
+            enum_field_1: true,
+            enum_a: EnumA::Two,
+        };
+    }
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn factor_out_update_match_usage_works() {
+        check_assist(
+            factor_out_from_enum_variants,
+            r#"
+enum A {
+    One(String, usize),<|>
+    Two(String),
+}
+
+fn func(it: A) {
+    match it {
+        A::One(text, n) => {
+            println!("{}", text.repeat(n));
+        }
+        A::Two(text) => println!("{}", text),
+    }
+}
+"#,
+            r#"
+struct A {
+    enum_field_0: String,
+    enum_a: EnumA,
+}
+
+enum EnumA {
+    One(usize),
+    Two,
+}
+
+fn func(it: A) {
+    match it.enum_a {
+        EnumA::One(n) => {
+            println!("{}", it.enum_field_0.repeat(n));
+        }
+        EnumA::Two => println!("{}", it.enum_field_0),
+    }
+}
+"#,
         );
     }
 }

--- a/crates/assists/src/handlers/factor_out_from_enum_variants.rs
+++ b/crates/assists/src/handlers/factor_out_from_enum_variants.rs
@@ -1,0 +1,190 @@
+use std::iter;
+
+use syntax::{
+    algo::SyntaxRewriter,
+    ast::GenericParamsOwner,
+    ast::{self, make, NameOwner, VisibilityOwner},
+    AstNode,
+};
+
+use crate::{
+    assist_context::{AssistContext, Assists},
+    utils::existing_definition,
+    AssistId, AssistKind,
+};
+
+// Assist: factor_out_from_enum_variants
+//
+// Factors out common fields from enum variants.
+//
+// ```
+// enum A {<|>
+//     One(u32, String),
+//     Two(u32, bool),
+// }
+// ```
+// ->
+// ```
+// struct A {
+//     enum_field_0: u32,
+//     enum_a: EnumA,
+// }
+//
+// enum EnumA {
+//     One(String),
+//     Two(bool),
+// }
+// ```
+pub(crate) fn factor_out_from_enum_variants(acc: &mut Assists, ctx: &AssistContext) -> Option<()> {
+    let enum_ = ctx.find_node_at_offset::<ast::Enum>()?;
+    let enum_vis = enum_.visibility();
+    let enum_name = enum_.name()?;
+
+    // FIXME: Support generic enums
+    if enum_.generic_param_list().is_some() {
+        return None;
+    }
+
+    let new_ty = make::name(&format!("Enum{}", enum_name.text()));
+    let db = ctx.db();
+    let module = ctx.sema.to_def(&enum_)?.module(db);
+    if existing_definition(db, &new_ty, module) {
+        return None;
+    }
+
+    let mut variants = enum_.variant_list()?.variants();
+    let first_variant = &variants.next()?;
+    let common_fields = match first_variant.field_list()? {
+        // FIXME: Support record fields.
+        ast::FieldList::RecordFieldList(_) => return None,
+        ast::FieldList::TupleFieldList(f) => common_tuple_fields(f, variants)?,
+    };
+
+    let target = enum_.syntax().text_range();
+    acc.add(
+        AssistId("factor_out_from_enum_variants", AssistKind::RefactorRewrite),
+        "Factor out from enum variants",
+        target,
+        // FIXME: Find and update creation of the enum.
+        // FIXME: Find and update usage of the enum.
+        |builder| {
+            let fields = make::record_field_list(
+                common_fields
+                    .iter()
+                    .enumerate()
+                    .map(|(i, ty)| {
+                        let name = make::name(&format!("enum_field_{}", i));
+                        make::record_field(enum_vis.clone(), name, make::ty(ty))
+                    })
+                    .chain(iter::once({
+                        let ty = make::ty(new_ty.text());
+                        let name = make::name(&stdx::to_lower_snake_case(new_ty.text()));
+                        make::record_field(enum_vis.clone(), name, ty)
+                    })),
+            );
+
+            builder.edit_file(ctx.frange.file_id);
+            let mut rewriter = SyntaxRewriter::default();
+
+            // FIXME: Support generic enums
+            let strukt = make::struct_(enum_vis, enum_name, None, fields.into());
+            rewriter.insert_before(enum_.syntax(), strukt.syntax());
+            rewriter.insert_before(enum_.syntax(), &make::tokens::blank_line());
+            update_tuple_enum(&mut rewriter, &enum_, common_fields.len());
+
+            builder.rewrite(rewriter);
+        },
+    );
+
+    None
+}
+
+fn common_tuple_fields(
+    first_variant: ast::TupleFieldList,
+    variants: ast::AstChildren<ast::Variant>,
+) -> Option<Vec<String>> {
+    let mut common: Vec<_> = first_variant
+        .fields()
+        // FIXME(rust/#68537): Replace the `.scan()`s with .map_while after it's stabilized.
+        // This .scan(..) is equivalent to .map_while(|field| field.ty().map..)
+        .scan((), |(), field| field.ty().map(|ty| ty.syntax().text().to_string()))
+        .collect();
+
+    for variant in variants {
+        let types = match variant.field_list()? {
+            ast::FieldList::TupleFieldList(f) => {
+                f.fields().scan((), |(), field| field.ty().map(|ty| ty.syntax().text().to_string()))
+            }
+            _ => return None,
+        };
+
+        let in_common = common.iter().zip(types).take_while(|(a, b)| *a == b).count();
+        common.drain(in_common..);
+    }
+
+    if common.is_empty() {
+        None
+    } else {
+        Some(common)
+    }
+}
+
+fn update_tuple_enum(
+    rewriter: &mut SyntaxRewriter,
+    enum_: &ast::Enum,
+    n_common_fields: usize,
+) -> Option<()> {
+    let name = enum_.name()?;
+    let new_name = make::name(&format!("Enum{}", name.text()));
+    rewriter.replace(name.syntax(), new_name.syntax());
+
+    for variant in enum_.variant_list()?.variants() {
+        let mut fields = match variant.field_list()? {
+            ast::FieldList::TupleFieldList(f) => f.fields().skip(n_common_fields).peekable(),
+            _ => return None,
+        };
+
+        let unique_variant = make::variant(
+            variant.name()?,
+            match fields.peek() {
+                Some(_) => Some(make::tuple_field_list(fields).into()),
+                _ => None,
+            },
+        );
+        rewriter.replace(variant.syntax(), unique_variant.syntax());
+    }
+
+    Some(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::check_assist;
+
+    use super::*;
+
+    #[test]
+    fn factor_out_from_enum_variant_works() {
+        check_assist(
+            factor_out_from_enum_variants,
+            r#"
+pub enum Data {<|>
+    A(usize, [String; 2], bool),
+    B(usize, [String; 2]),
+    C(usize, [String; 2], u32, i16),
+}"#,
+            r#"
+pub struct Data {
+    pub enum_field_0: usize,
+    pub enum_field_1: [String; 2],
+    pub enum_data: EnumData,
+}
+
+pub enum EnumData {
+    A(bool),
+    B,
+    C(u32, i16),
+}"#,
+        );
+    }
+}

--- a/crates/assists/src/lib.rs
+++ b/crates/assists/src/lib.rs
@@ -131,6 +131,7 @@ mod handlers {
     mod expand_glob_import;
     mod extract_struct_from_enum_variant;
     mod extract_variable;
+    mod factor_out_from_enum_variants;
     mod fill_match_arms;
     mod fix_visibility;
     mod flip_binexpr;
@@ -179,6 +180,7 @@ mod handlers {
             expand_glob_import::expand_glob_import,
             extract_struct_from_enum_variant::extract_struct_from_enum_variant,
             extract_variable::extract_variable,
+            factor_out_from_enum_variants::factor_out_from_enum_variants,
             fill_match_arms::fill_match_arms,
             fix_visibility::fix_visibility,
             flip_binexpr::flip_binexpr,

--- a/crates/assists/src/tests/generated.rs
+++ b/crates/assists/src/tests/generated.rs
@@ -269,6 +269,30 @@ fn main() {
 }
 
 #[test]
+fn doctest_factor_out_from_enum_variants() {
+    check_doc_test(
+        "factor_out_from_enum_variants",
+        r#####"
+enum A {<|>
+    One(u32, String),
+    Two(u32, bool),
+}
+"#####,
+        r#####"
+struct A {
+    enum_field_0: u32,
+    enum_a: EnumA,
+}
+
+enum EnumA {
+    One(String),
+    Two(bool),
+}
+"#####,
+    )
+}
+
+#[test]
 fn doctest_fill_match_arms() {
     check_doc_test(
         "fill_match_arms",

--- a/crates/assists/src/utils.rs
+++ b/crates/assists/src/utils.rs
@@ -24,7 +24,7 @@ use crate::{
 pub use insert_use::MergeBehaviour;
 pub(crate) use insert_use::{insert_use, ImportScope};
 
-pub fn existing_definition(db: &RootDatabase, name: &ast::Name, module: hir::Module) -> bool {
+pub fn existing_type_definition(db: &RootDatabase, name: &ast::Name, module: hir::Module) -> bool {
     module
         .scope(db, None)
         .into_iter()

--- a/crates/base_db/src/fixture.rs
+++ b/crates/base_db/src/fixture.rs
@@ -101,7 +101,8 @@ pub trait WithFixture: Default + SourceDatabaseExt + 'static {
         let fixture = ChangeFixture::parse(ra_fixture);
         let mut db = Self::default();
         fixture.change.apply(&mut db);
-        let (file_id, range_or_offset) = fixture.file_position.unwrap();
+        let (file_id, range_or_offset) =
+            fixture.file_position.expect("Fixture missing a cursor marker: `<|>`");
         (db, file_id, range_or_offset)
     }
 

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -204,6 +204,9 @@ pub fn expr_call(f: ast::Expr, arg_list: ast::ArgList) -> ast::Expr {
 pub fn expr_method_call(receiver: ast::Expr, method: &str, arg_list: ast::ArgList) -> ast::Expr {
     expr_from_text(&format!("{}.{}{}", receiver, method, arg_list))
 }
+pub fn expr_field(expr: ast::Expr, name_ref: ast::NameRef) -> ast::Expr {
+    expr_from_text(&format!("{}.{}", expr, name_ref))
+}
 pub fn expr_ref(expr: ast::Expr, exclusive: bool) -> ast::Expr {
     expr_from_text(&if exclusive { format!("&mut {}", expr) } else { format!("&{}", expr) })
 }


### PR DESCRIPTION
Work in progress. This will soon™ close #6129. 

Still to be done:


- [x] Update code that created the old enum
- [ ] Update usage of the old enum
Mostly done. Still have to deal with rest patterns `..` and converting literal values in patterns into match guard/nested if where required.
- [ ] Support record fields in the enums
- [ ] Support generic enums
- [ ] Maybe prompt user for the name of the enum (and the struct fields if using enums with tuple fields)? Or just make users use the already available renaming feature.
- [ ] Deal with attributes. Probably just copy derives.