### PR TITLE
Textmate grammar: add `+=` to assignment operators

### DIFF
--- a/editors/code/rust.tmGrammar.json
+++ b/editors/code/rust.tmGrammar.json
@@ -693,7 +693,7 @@
                 {
                     "comment": "assignment operators",
                     "name": "keyword.operator.assignment.rust",
-                    "match": "(-=|\\*=|/=|%=|\\^=|&=|\\|=|<<=|>>=)"
+                    "match": "(\\+=|-=|\\*=|/=|%=|\\^=|&=|\\|=|<<=|>>=)"
                 },
                 {
                     "comment": "single equal",


### PR DESCRIPTION
Fixes https://github.com/dustypomerleau/rust-syntax/issues/3.