### PR TITLE
Textmate grammar: allow variables to terminate ranges

### DIFF
--- a/editors/code/rust.tmGrammar.json
+++ b/editors/code/rust.tmGrammar.json
@@ -1127,7 +1127,7 @@
                 {
                     "comment": "variables",
                     "name": "variable.other.rust",
-                    "match": "\\b(?<!\\.)(?:r#(?!(crate|[Ss]elf|super)))?[a-z0-9_]+\\b"
+                    "match": "\\b(?<!(?<!\\.)\\.)(?:r#(?!(crate|[Ss]elf|super)))?[a-z0-9_]+\\b"
                 }
             ]
         }


### PR DESCRIPTION
Variables were originally designed not to match after a dot, in order to avoid matching struct field access, however this resulted in variables that end ranges not being highlighted. In order to fix this we match a preceding dot, only if it's preceded by at least one other dot. Attempting to match on `(\.{2,})?` won't work, because the optional group allows struct field access to match even when one dot is present.