### PR TITLE
Use builtin scopes more

### DIFF
--- a/crates/rust-analyzer/src/semantic_tokens.rs
+++ b/crates/rust-analyzer/src/semantic_tokens.rs
@@ -40,7 +40,7 @@ macro_rules! define_semantic_token_types {
 define_semantic_token_types![
     (ATTRIBUTE, "attribute"),
     (BOOLEAN, "boolean"),
-    (BUILTIN_TYPE, "type.defaultLibrary"),
+    (BUILTIN_TYPE, "builtinType"),
     (ESCAPE_SEQUENCE, "escapeSequence"),
     (FORMAT_SPECIFIER, "formatSpecifier"),
     (GENERIC, "generic"),
@@ -70,7 +70,7 @@ macro_rules! define_semantic_token_modifiers {
 }
 
 define_semantic_token_modifiers![
-    (CONSTANT, "readonly"),
+    (CONSTANT, "constant"),
     (CONTROL_FLOW, "controlFlow"),
     (INJECTED, "injected"),
     (MUTABLE, "mutable"),

--- a/crates/rust-analyzer/src/semantic_tokens.rs
+++ b/crates/rust-analyzer/src/semantic_tokens.rs
@@ -40,7 +40,7 @@ macro_rules! define_semantic_token_types {
 define_semantic_token_types![
     (ATTRIBUTE, "attribute"),
     (BOOLEAN, "boolean"),
-    (BUILTIN_TYPE, "builtinType"),
+    (BUILTIN_TYPE, "type.defaultLibrary"),
     (ESCAPE_SEQUENCE, "escapeSequence"),
     (FORMAT_SPECIFIER, "formatSpecifier"),
     (GENERIC, "generic"),
@@ -70,7 +70,7 @@ macro_rules! define_semantic_token_modifiers {
 }
 
 define_semantic_token_modifiers![
-    (CONSTANT, "constant"),
+    (CONSTANT, "readonly"),
     (CONTROL_FLOW, "controlFlow"),
     (INJECTED, "injected"),
     (MUTABLE, "mutable"),

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -939,9 +939,6 @@
             {
                 "language": "rust",
                 "scopes": {
-                    "macro": [
-                        "entity.name.function.macro.rust"
-                    ],
                     "attribute": [
                         "meta.attribute.rust"
                     ],
@@ -950,9 +947,6 @@
                     ],
                     "boolean": [
                         "constant.language.boolean.rust"
-                    ],
-                    "builtinType": [
-                        "support.type.primitive.rust"
                     ],
                     "lifetime": [
                         "storage.modifier.lifetime.rust"
@@ -971,9 +965,6 @@
                     ],
                     "keyword.controlFlow": [
                         "keyword.control.rust"
-                    ],
-                    "variable.constant": [
-                        "variable.other.constant.rust"
                     ],
                     "formatSpecifier": [
                         "punctuation.section.embedded.rust"

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -948,6 +948,9 @@
                     "boolean": [
                         "constant.language.boolean.rust"
                     ],
+                    "builtinType": [
+                        "support.type.primitive.rust"
+                    ],
                     "lifetime": [
                         "storage.modifier.lifetime.rust"
                     ],
@@ -965,6 +968,9 @@
                     ],
                     "keyword.controlFlow": [
                         "keyword.control.rust"
+                    ],
+                    "variable.constant": [
+                        "variable.other.constant.rust"
                     ],
                     "formatSpecifier": [
                         "punctuation.section.embedded.rust"


### PR DESCRIPTION
VSCode has added more builtin fallback scopes, so we can remove some of our fallback scopes by aligning with their conventions. 

Note that the macro scope doesn't seem to actually *work* at the moment. I have filed a bug with VSCode: https://github.com/microsoft/vscode/issues/110150