### PR TITLE
Remove text_edit_builder api from AssistBuilder

### DIFF
--- a/crates/assists/src/assist_context.rs
+++ b/crates/assists/src/assist_context.rs
@@ -275,12 +275,6 @@ impl AssistBuilder {
         algo::diff(&node, &new).into_text_edit(&mut self.edit);
     }
 
-    // FIXME: kill this API
-    /// Get access to the raw `TextEditBuilder`.
-    pub(crate) fn text_edit_builder(&mut self) -> &mut TextEditBuilder {
-        &mut self.edit
-    }
-
     fn finish(mut self) -> SourceChange {
         self.commit();
         let mut change = mem::take(&mut self.change);

--- a/crates/assists/src/handlers/reorder_fields.rs
+++ b/crates/assists/src/handlers/reorder_fields.rs
@@ -47,9 +47,11 @@ fn reorder<R: AstNode>(acc: &mut Assists, ctx: &AssistContext) -> Option<()> {
         "Reorder record fields",
         target,
         |edit| {
+            let mut rewriter = algo::SyntaxRewriter::default();
             for (old, new) in fields.iter().zip(&sorted_fields) {
-                algo::diff(old, new).into_text_edit(edit.text_edit_builder());
+                rewriter.replace(old, new);
             }
+            edit.rewrite(rewriter);
         },
     )
 }


### PR DESCRIPTION
Also fixes a small bug in `expand_glob_import` in regards to the very nice looking `something::{*}` import when only one item was used. Before it would duplicate the path and just append it, causing the following wrong import `something::something::UsedItem`.