### PR TITLE
add suggestion ..Default::default() for remaining struct fields in a constructor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,7 @@ dependencies = [
 name = "completion"
 version = "0.0.0"
 dependencies = [
+ "assists",
  "base_db",
  "expect-test",
  "hir",

--- a/crates/assists/src/utils.rs
+++ b/crates/assists/src/utils.rs
@@ -257,6 +257,12 @@ pub mod convert {
     }
 }
 
+pub mod default {
+    pub trait Default: Sized {
+       fn default() -> Self;
+    }
+}
+
 pub mod iter {
     pub use self::traits::{collect::IntoIterator, iterator::Iterator};
     mod traits {
@@ -327,7 +333,7 @@ pub mod option {
 }
 
 pub mod prelude {
-    pub use crate::{convert::From, iter::{IntoIterator, Iterator}, option::Option::{self, *}};
+    pub use crate::{convert::From, iter::{IntoIterator, Iterator}, option::Option::{self, *}, default::Default};
 }
 #[prelude_import]
 pub use prelude::*;
@@ -343,6 +349,10 @@ pub use prelude::*;
 
     pub(crate) fn core_option_Option(&self) -> Option<Enum> {
         self.find_enum("core:option:Option")
+    }
+
+    pub fn core_default_Default(&self) -> Option<Trait> {
+        self.find_trait("core:default:Default")
     }
 
     pub fn core_iter_Iterator(&self) -> Option<Trait> {

--- a/crates/assists/src/utils.rs
+++ b/crates/assists/src/utils.rs
@@ -258,7 +258,7 @@ pub mod convert {
 }
 
 pub mod default {
-    pub trait Default: Sized {
+    pub trait Default {
        fn default() -> Self;
     }
 }

--- a/crates/completion/Cargo.toml
+++ b/crates/completion/Cargo.toml
@@ -14,6 +14,7 @@ itertools = "0.9.0"
 log = "0.4.8"
 rustc-hash = "1.1.0"
 
+assists = { path = "../assists", version = "0.0.0" }
 stdx = { path = "../stdx", version = "0.0.0" }
 syntax = { path = "../syntax", version = "0.0.0" }
 text_edit = { path = "../text_edit", version = "0.0.0" }


### PR DESCRIPTION
I'm not sure I should import `assists` crate inside `completions`, maybe we should move out `FamousDefs` from `assists` ? Let me know :) 

close #6492

Signed-off-by: Benjamin Coenen <5719034+bnjjj@users.noreply.github.com>