### PR TITLE
Properly handle shorthands in destructure patterns when renaming

### DIFF
--- a/crates/ide/src/references.rs
+++ b/crates/ide/src/references.rs
@@ -622,7 +622,7 @@ fn foo() {
             expect![[r#"
                 f RECORD_FIELD FileId(0) 15..21 15..16 Other
 
-                FileId(0) 55..56 Other Read
+                FileId(0) 55..56 RecordFieldExprOrPat Read
                 FileId(0) 68..69 Other Write
             "#]],
         );
@@ -757,7 +757,7 @@ fn f() -> m::En {
             expect![[r#"
                 field RECORD_FIELD FileId(0) 56..65 56..61 Other
 
-                FileId(0) 125..130 Other Read
+                FileId(0) 125..130 RecordFieldExprOrPat Read
             "#]],
         );
     }

--- a/crates/ide/src/references/rename.rs
+++ b/crates/ide/src/references/rename.rs
@@ -1138,4 +1138,58 @@ fn foo(bar: i32) -> Foo {
 "#,
         );
     }
+
+    #[test]
+    fn test_rename_binding_in_destructure_pat_shorthand() {
+        check(
+            "bar",
+            r#"
+struct Foo {
+    i: i32,
+}
+
+fn foo(foo: Foo) {
+    let Foo { i } = foo;
+    let _ = i<|>;
+}
+"#,
+            r#"
+struct Foo {
+    i: i32,
+}
+
+fn foo(foo: Foo) {
+    let Foo { i: bar } = foo;
+    let _ = bar;
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_rename_binding_in_destructure_pat() {
+        check(
+            "bar",
+            r#"
+struct Foo {
+    i: i32,
+}
+
+fn foo(foo: Foo) {
+    let Foo { i: b } = foo;
+    let _ = b<|>;
+}
+"#,
+            r#"
+struct Foo {
+    i: i32,
+}
+
+fn foo(foo: Foo) {
+    let Foo { i: bar } = foo;
+    let _ = bar;
+}
+"#,
+        );
+    }
 }

--- a/crates/ide_db/src/search.rs
+++ b/crates/ide_db/src/search.rs
@@ -30,6 +30,7 @@ pub enum ReferenceKind {
     FieldShorthandForField,
     FieldShorthandForLocal,
     StructLiteral,
+    RecordExprField,
     Other,
 }
 
@@ -278,12 +279,15 @@ impl<'a> FindUsages<'a> {
     ) -> bool {
         match NameRefClass::classify(self.sema, &name_ref) {
             Some(NameRefClass::Definition(def)) if &def == self.def => {
-                let kind = if is_record_lit_name_ref(&name_ref) || is_call_expr_name_ref(&name_ref)
-                {
-                    ReferenceKind::StructLiteral
-                } else {
-                    ReferenceKind::Other
-                };
+                let kind =
+                    if name_ref.syntax().parent().and_then(ast::RecordExprField::cast).is_some() {
+                        ReferenceKind::RecordExprField
+                    } else if is_record_lit_name_ref(&name_ref) || is_call_expr_name_ref(&name_ref)
+                    {
+                        ReferenceKind::StructLiteral
+                    } else {
+                        ReferenceKind::Other
+                    };
 
                 let reference = Reference {
                     file_range: self.sema.original_range(name_ref.syntax()),

--- a/crates/syntax/src/ast/expr_ext.rs
+++ b/crates/syntax/src/ast/expr_ext.rs
@@ -22,6 +22,18 @@ impl ast::Expr {
             _ => false,
         }
     }
+
+    pub fn name_ref(&self) -> Option<ast::NameRef> {
+        if let ast::Expr::PathExpr(expr) = self {
+            let path = expr.path()?;
+            let segment = path.segment()?;
+            let name_ref = segment.name_ref()?;
+            if path.qualifier().is_none() {
+                return Some(name_ref);
+            }
+        }
+        None
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/syntax/src/ast/node_ext.rs
+++ b/crates/syntax/src/ast/node_ext.rs
@@ -203,15 +203,7 @@ impl ast::RecordExprField {
         if let Some(name_ref) = self.name_ref() {
             return Some(name_ref);
         }
-        if let Some(ast::Expr::PathExpr(expr)) = self.expr() {
-            let path = expr.path()?;
-            let segment = path.segment()?;
-            let name_ref = segment.name_ref()?;
-            if path.qualifier().is_none() {
-                return Some(name_ref);
-            }
-        }
-        None
+        self.expr()?.name_ref()
     }
 }
 


### PR DESCRIPTION
Fixes #6548 and #6551.