### PR TITLE
Link rustc error page and clippy lint page via CodeDescription

### DIFF
--- a/crates/rust-analyzer/src/diagnostics/test_data/clippy_pass_by_ref.txt
+++ b/crates/rust-analyzer/src/diagnostics/test_data/clippy_pass_by_ref.txt
@@ -27,7 +27,24 @@
                     "trivially_copy_pass_by_ref",
                 ),
             ),
-            code_description: None,
+            code_description: Some(
+                CodeDescription {
+                    href: Url {
+                        scheme: "https",
+                        host: Some(
+                            Domain(
+                                "rust-lang.github.io",
+                            ),
+                        ),
+                        port: None,
+                        path: "/rust-clippy/master/index.html",
+                        query: None,
+                        fragment: Some(
+                            "trivially_copy_pass_by_ref",
+                        ),
+                    },
+                },
+            ),
             source: Some(
                 "clippy",
             ),

--- a/crates/rust-analyzer/src/diagnostics/test_data/handles_macro_location.txt
+++ b/crates/rust-analyzer/src/diagnostics/test_data/handles_macro_location.txt
@@ -27,7 +27,24 @@
                     "E0277",
                 ),
             ),
-            code_description: None,
+            code_description: Some(
+                CodeDescription {
+                    href: Url {
+                        scheme: "https",
+                        host: Some(
+                            Domain(
+                                "doc.rust-lang.org",
+                            ),
+                        ),
+                        port: None,
+                        path: "/error-index.html",
+                        query: None,
+                        fragment: Some(
+                            "E0277",
+                        ),
+                    },
+                },
+            ),
             source: Some(
                 "rustc",
             ),

--- a/crates/rust-analyzer/src/diagnostics/test_data/rustc_incompatible_type_for_trait.txt
+++ b/crates/rust-analyzer/src/diagnostics/test_data/rustc_incompatible_type_for_trait.txt
@@ -27,7 +27,24 @@
                     "E0053",
                 ),
             ),
-            code_description: None,
+            code_description: Some(
+                CodeDescription {
+                    href: Url {
+                        scheme: "https",
+                        host: Some(
+                            Domain(
+                                "doc.rust-lang.org",
+                            ),
+                        ),
+                        port: None,
+                        path: "/error-index.html",
+                        query: None,
+                        fragment: Some(
+                            "E0053",
+                        ),
+                    },
+                },
+            ),
             source: Some(
                 "rustc",
             ),

--- a/crates/rust-analyzer/src/diagnostics/test_data/rustc_mismatched_type.txt
+++ b/crates/rust-analyzer/src/diagnostics/test_data/rustc_mismatched_type.txt
@@ -27,7 +27,24 @@
                     "E0308",
                 ),
             ),
-            code_description: None,
+            code_description: Some(
+                CodeDescription {
+                    href: Url {
+                        scheme: "https",
+                        host: Some(
+                            Domain(
+                                "doc.rust-lang.org",
+                            ),
+                        ),
+                        port: None,
+                        path: "/error-index.html",
+                        query: None,
+                        fragment: Some(
+                            "E0308",
+                        ),
+                    },
+                },
+            ),
             source: Some(
                 "rustc",
             ),

--- a/crates/rust-analyzer/src/diagnostics/test_data/rustc_wrong_number_of_parameters.txt
+++ b/crates/rust-analyzer/src/diagnostics/test_data/rustc_wrong_number_of_parameters.txt
@@ -27,7 +27,24 @@
                     "E0061",
                 ),
             ),
-            code_description: None,
+            code_description: Some(
+                CodeDescription {
+                    href: Url {
+                        scheme: "https",
+                        host: Some(
+                            Domain(
+                                "doc.rust-lang.org",
+                            ),
+                        ),
+                        port: None,
+                        path: "/error-index.html",
+                        query: None,
+                        fragment: Some(
+                            "E0061",
+                        ),
+                    },
+                },
+            ),
             source: Some(
                 "rustc",
             ),

--- a/crates/rust-analyzer/src/diagnostics/test_data/snap_multi_line_fix.txt
+++ b/crates/rust-analyzer/src/diagnostics/test_data/snap_multi_line_fix.txt
@@ -27,7 +27,24 @@
                     "let_and_return",
                 ),
             ),
-            code_description: None,
+            code_description: Some(
+                CodeDescription {
+                    href: Url {
+                        scheme: "https",
+                        host: Some(
+                            Domain(
+                                "rust-lang.github.io",
+                            ),
+                        ),
+                        port: None,
+                        path: "/rust-clippy/master/index.html",
+                        query: None,
+                        fragment: Some(
+                            "let_and_return",
+                        ),
+                    },
+                },
+            ),
             source: Some(
                 "clippy",
             ),

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -1129,7 +1129,14 @@ pub(crate) fn publish_diagnostics(
             range: to_proto::range(&line_index, d.range),
             severity: Some(to_proto::diagnostic_severity(d.severity)),
             code: d.code.map(|d| d.as_str().to_owned()).map(NumberOrString::String),
-            code_description: None,
+            code_description: d.code.and_then(|code| {
+                lsp_types::Url::parse(&format!(
+                    "https://rust-analyzer.github.io/manual.html#{}",
+                    code.as_str()
+                ))
+                .ok()
+                .map(|href| lsp_types::CodeDescription { href })
+            }),
             source: Some("rust-analyzer".to_string()),
             message: d.message,
             related_information: None,


### PR DESCRIPTION
Fixes #6371

This makes the error code in here clickable, same for clippy lints
![image](https://user-images.githubusercontent.com/3757771/99459468-6d110b00-292e-11eb-9cde-d43ec9cebc09.png)

For clippy I just chose the master build of the site as I believe that to be pretty much always the best fitting.