### PR TITLE
Textmate grammar: ensure word boundary after `true`

### DIFF
--- a/editors/code/rust.tmGrammar.json
+++ b/editors/code/rust.tmGrammar.json
@@ -409,7 +409,7 @@
                 {
                     "comment": "booleans",
                     "name": "constant.language.bool.rust",
-                    "match": "\\btrue|false\\b"
+                    "match": "\\b(true|false)\\b"
                 }
             ]
         },


### PR DESCRIPTION
Adding round brackets ensures word boundaries on both sides of booleans (reported in https://github.com/dustypomerleau/rust-syntax/issues/7).