### PR TITLE
Improve autoimports on completion speed

### DIFF
--- a/crates/completion/src/completions/unqualified_path.rs
+++ b/crates/completion/src/completions/unqualified_path.rs
@@ -79,32 +79,34 @@ fn fuzzy_completion(acc: &mut Completions, ctx: &CompletionContext) -> Option<()
 
     let potential_import_name = ctx.token.to_string();
 
-    let possible_imports =
-        imports_locator::find_similar_imports(&ctx.sema, ctx.krate?, &potential_import_name, 400)
-            .filter_map(|import_candidate| match import_candidate {
-                // when completing outside the use declaration, modules are pretty useless
-                // and tend to bloat the completion suggestions a lot
-                Either::Left(ModuleDef::Module(_)) => None,
-                Either::Left(module_def) => Some((
-                    current_module.find_use_path(ctx.db, module_def)?,
-                    ScopeDef::ModuleDef(module_def),
-                )),
-                Either::Right(macro_def) => Some((
-                    current_module.find_use_path(ctx.db, macro_def)?,
-                    ScopeDef::MacroDef(macro_def),
-                )),
-            })
-            .filter(|(mod_path, _)| mod_path.len() > 1)
-            .filter_map(|(import_path, definition)| {
-                render_resolution_with_import(
-                    RenderContext::new(ctx),
-                    import_path.clone(),
-                    import_scope.clone(),
-                    ctx.config.merge,
-                    &definition,
-                )
-            })
-            .take(20);
+    let possible_imports = imports_locator::find_similar_imports(
+        &ctx.sema,
+        ctx.krate?,
+        &potential_import_name,
+        50,
+        true,
+    )
+    .filter_map(|import_candidate| {
+        Some(match import_candidate {
+            Either::Left(module_def) => {
+                (current_module.find_use_path(ctx.db, module_def)?, ScopeDef::ModuleDef(module_def))
+            }
+            Either::Right(macro_def) => {
+                (current_module.find_use_path(ctx.db, macro_def)?, ScopeDef::MacroDef(macro_def))
+            }
+        })
+    })
+    .filter(|(mod_path, _)| mod_path.len() > 1)
+    .take(20)
+    .filter_map(|(import_path, definition)| {
+        render_resolution_with_import(
+            RenderContext::new(ctx),
+            import_path.clone(),
+            import_scope.clone(),
+            ctx.config.merge,
+            &definition,
+        )
+    });
 
     acc.add_all(possible_imports);
     Some(())

--- a/crates/completion/src/render.rs
+++ b/crates/completion/src/render.rs
@@ -150,6 +150,7 @@ impl<'a> Render<'a> {
         import_data: Option<(ModPath, ImportScope, Option<MergeBehaviour>)>,
         resolution: &ScopeDef,
     ) -> Option<CompletionItem> {
+        let _p = profile::span("render_resolution");
         use hir::ModuleDef::*;
 
         let completion_kind = match resolution {

--- a/crates/ide_db/src/imports_locator.rs
+++ b/crates/ide_db/src/imports_locator.rs
@@ -36,8 +36,15 @@ pub fn find_similar_imports<'a>(
     krate: Crate,
     name_to_import: &str,
     limit: usize,
+    ignore_modules: bool,
 ) -> impl Iterator<Item = Either<ModuleDef, MacroDef>> {
     let _p = profile::span("find_similar_imports");
+
+    let mut external_query = import_map::Query::new(name_to_import).limit(limit);
+    if ignore_modules {
+        external_query = external_query.exclude_import_kind(import_map::ImportKind::Module);
+    }
+
     find_imports(
         sema,
         krate,
@@ -46,7 +53,7 @@ pub fn find_similar_imports<'a>(
             local_query.limit(limit);
             local_query
         },
-        import_map::Query::new(name_to_import).limit(limit),
+        external_query,
     )
 }
 


### PR DESCRIPTION
Presumably closes https://github.com/rust-analyzer/rust-analyzer/issues/6594
May help https://github.com/rust-analyzer/rust-analyzer/issues/6612

* Ignore modules eaferly
* Do less completion string rendering