### PR TITLE
Gate autoimports begind experimental completions flag

### DIFF
--- a/crates/completion/src/completions/unqualified_path.rs
+++ b/crates/completion/src/completions/unqualified_path.rs
@@ -44,7 +44,9 @@ pub(crate) fn complete_unqualified_path(acc: &mut Completions, ctx: &CompletionC
         acc.add_resolution(ctx, name.to_string(), &res)
     });
 
-    fuzzy_completion(acc, ctx).unwrap_or_default()
+    if ctx.config.enable_experimental_completions {
+        fuzzy_completion(acc, ctx).unwrap_or_default()
+    }
 }
 
 fn complete_enum_variants(acc: &mut Completions, ctx: &CompletionContext, ty: &Type) {

--- a/crates/completion/src/config.rs
+++ b/crates/completion/src/config.rs
@@ -9,6 +9,7 @@ use assists::utils::MergeBehaviour;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CompletionConfig {
     pub enable_postfix_completions: bool,
+    pub enable_experimental_completions: bool,
     pub add_call_parenthesis: bool,
     pub add_call_argument_snippets: bool,
     pub snippet_cap: Option<SnippetCap>,
@@ -30,6 +31,7 @@ impl Default for CompletionConfig {
     fn default() -> Self {
         CompletionConfig {
             enable_postfix_completions: true,
+            enable_experimental_completions: true,
             add_call_parenthesis: true,
             add_call_argument_snippets: true,
             snippet_cap: Some(SnippetCap { _private: () }),

--- a/crates/completion/src/lib.rs
+++ b/crates/completion/src/lib.rs
@@ -67,6 +67,13 @@ pub use crate::{
 //     fn test_name() {}
 // }
 // ```
+//
+// And experimental completions, enabled with the `rust-analyzer.completion.enableExperimental` setting.
+// This flag enables or disables:
+//
+// - Auto import: additional completion options with automatic `use` import and options from all project importable items, matched for the input
+//
+// Experimental completions might cause issues with performance and completion list look.
 
 /// Main entry point for completion. We run completion as a two-phase process.
 ///

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -184,6 +184,7 @@ impl Config {
             },
             completion: CompletionConfig {
                 enable_postfix_completions: true,
+                enable_experimental_completions: true,
                 add_call_parenthesis: true,
                 add_call_argument_snippets: true,
                 ..CompletionConfig::default()
@@ -306,6 +307,7 @@ impl Config {
         };
 
         self.completion.enable_postfix_completions = data.completion_postfix_enable;
+        self.completion.enable_experimental_completions = data.completion_enableExperimental;
         self.completion.add_call_parenthesis = data.completion_addCallParenthesis;
         self.completion.add_call_argument_snippets = data.completion_addCallArgumentSnippets;
         self.completion.merge = self.assist.insert_use.merge;
@@ -506,6 +508,7 @@ config_data! {
         completion_addCallArgumentSnippets: bool = true,
         completion_addCallParenthesis: bool      = true,
         completion_postfix_enable: bool          = true,
+        completion_enableExperimental: bool      = true,
 
         diagnostics_enable: bool                = true,
         diagnostics_enableExperimental: bool    = true,

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -460,6 +460,11 @@
                     "default": true,
                     "markdownDescription": "Whether to show postfix snippets like `dbg`, `if`, `not`, etc."
                 },
+                "rust-analyzer.completion.enableExperimental": {
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Display additional completions with potential false positives and performance issues"
+                },
                 "rust-analyzer.callInfo.full": {
                     "type": "boolean",
                     "default": true,


### PR DESCRIPTION
Part of https://github.com/rust-analyzer/rust-analyzer/issues/6612

Adds a possibility to disable autoimports:

<img width="598" alt="image" src="https://user-images.githubusercontent.com/2690773/100156673-f8037f80-2eb1-11eb-8e74-59ebe4260ba3.png">

and other experimental completions we might want to add later.