### PR TITLE
Use `ExpandResult` instead of `MacroResult`

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -57,7 +57,7 @@ pub use hir_def::{
     visibility::Visibility,
 };
 pub use hir_expand::{
-    db::MacroResult, name::known, name::AsName, name::Name, HirFileId, InFile, MacroCallId,
+    name::known, name::AsName, name::Name, ExpandResult, HirFileId, InFile, MacroCallId,
     MacroCallLoc, /* FIXME */ MacroDefId, MacroFile, Origin,
 };
 pub use hir_ty::display::HirDisplay;

--- a/crates/hir_expand/src/lib.rs
+++ b/crates/hir_expand/src/lib.rs
@@ -15,6 +15,8 @@ pub mod proc_macro;
 pub mod quote;
 pub mod eager;
 
+pub use mbe::{ExpandError, ExpandResult};
+
 use std::hash::Hash;
 use std::sync::Arc;
 

--- a/crates/ide/src/status.rs
+++ b/crates/ide/src/status.rs
@@ -1,6 +1,6 @@
 use std::{fmt, iter::FromIterator, sync::Arc};
 
-use hir::{MacroFile, MacroResult};
+use hir::{ExpandResult, MacroFile};
 use ide_db::base_db::{
     salsa::debug::{DebugQueryTable, TableEntry},
     CrateId, FileId, FileTextQuery, SourceDatabase, SourceRootId,
@@ -115,12 +115,12 @@ impl FromIterator<TableEntry<FileId, Parse<ast::SourceFile>>> for SyntaxTreeStat
     }
 }
 
-impl<M> FromIterator<TableEntry<MacroFile, MacroResult<(Parse<SyntaxNode>, M)>>>
+impl<M> FromIterator<TableEntry<MacroFile, ExpandResult<Option<(Parse<SyntaxNode>, M)>>>>
     for SyntaxTreeStats
 {
     fn from_iter<T>(iter: T) -> SyntaxTreeStats
     where
-        T: IntoIterator<Item = TableEntry<MacroFile, MacroResult<(Parse<SyntaxNode>, M)>>>,
+        T: IntoIterator<Item = TableEntry<MacroFile, ExpandResult<Option<(Parse<SyntaxNode>, M)>>>>,
     {
         let mut res = SyntaxTreeStats::default();
         for entry in iter {

--- a/crates/mbe/src/lib.rs
+++ b/crates/mbe/src/lib.rs
@@ -33,6 +33,7 @@ pub enum ExpandError {
     ConversionError,
     InvalidRepeat,
     ProcMacroError(tt::ExpansionError),
+    Other(String),
 }
 
 impl From<tt::ExpansionError> for ExpandError {
@@ -262,6 +263,13 @@ impl<T> ExpandResult<T> {
         T: Default,
     {
         Self { value: Default::default(), err: Some(err) }
+    }
+
+    pub fn str_err(err: String) -> Self
+    where
+        T: Default,
+    {
+        Self::only_err(ExpandError::Other(err))
     }
 
     pub fn map<U>(self, f: impl FnOnce(T) -> U) -> ExpandResult<U> {


### PR DESCRIPTION
`MacroResult` is redundant.

bors r+ :robot: