### PR TITLE
Publish diagnostics for macro expansion errors

### DIFF
--- a/crates/hir/src/diagnostics.rs
+++ b/crates/hir/src/diagnostics.rs
@@ -1,5 +1,5 @@
 //! FIXME: write short doc here
-pub use hir_def::diagnostics::{InactiveCode, UnresolvedModule};
+pub use hir_def::diagnostics::{InactiveCode, UnresolvedModule, UnresolvedProcMacro};
 pub use hir_expand::diagnostics::{
     Diagnostic, DiagnosticCode, DiagnosticSink, DiagnosticSinkBuilder,
 };

--- a/crates/hir_def/src/diagnostics.rs
+++ b/crates/hir_def/src/diagnostics.rs
@@ -6,7 +6,7 @@ use stdx::format_to;
 use cfg::{CfgExpr, CfgOptions, DnfExpr};
 use hir_expand::diagnostics::{Diagnostic, DiagnosticCode, DiagnosticSink};
 use hir_expand::{HirFileId, InFile};
-use syntax::{ast, AstPtr, SyntaxNodePtr};
+use syntax::{ast, AstPtr, SyntaxNodePtr, TextRange};
 
 use crate::{db::DefDatabase, DefWithBodyId};
 
@@ -137,6 +137,9 @@ impl Diagnostic for InactiveCode {
 pub struct UnresolvedProcMacro {
     pub file: HirFileId,
     pub node: SyntaxNodePtr,
+    /// If the diagnostic can be pinpointed more accurately than via `node`, this is the `TextRange`
+    /// to use instead.
+    pub precise_location: Option<TextRange>,
     pub macro_name: Option<String>,
 }
 

--- a/crates/hir_def/src/diagnostics.rs
+++ b/crates/hir_def/src/diagnostics.rs
@@ -127,3 +127,65 @@ impl Diagnostic for InactiveCode {
         self
     }
 }
+
+// Diagnostic: unresolved-proc-macro
+//
+// This diagnostic is shown when a procedural macro can not be found. This usually means that
+// procedural macro support is simply disabled (and hence is only a weak hint instead of an error),
+// but can also indicate project setup problems.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct UnresolvedProcMacro {
+    pub file: HirFileId,
+    pub node: SyntaxNodePtr,
+    pub macro_name: Option<String>,
+}
+
+impl Diagnostic for UnresolvedProcMacro {
+    fn code(&self) -> DiagnosticCode {
+        DiagnosticCode("unresolved-proc-macro")
+    }
+
+    fn message(&self) -> String {
+        match &self.macro_name {
+            Some(name) => format!("proc macro `{}` not expanded", name),
+            None => "proc macro not expanded".to_string(),
+        }
+    }
+
+    fn display_source(&self) -> InFile<SyntaxNodePtr> {
+        InFile::new(self.file, self.node.clone())
+    }
+
+    fn as_any(&self) -> &(dyn Any + Send + 'static) {
+        self
+    }
+}
+
+// Diagnostic: macro-error
+//
+// This diagnostic is shown for macro expansion errors.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct MacroError {
+    pub file: HirFileId,
+    pub node: SyntaxNodePtr,
+    pub message: String,
+}
+
+impl Diagnostic for MacroError {
+    fn code(&self) -> DiagnosticCode {
+        DiagnosticCode("macro-error")
+    }
+    fn message(&self) -> String {
+        self.message.clone()
+    }
+    fn display_source(&self) -> InFile<SyntaxNodePtr> {
+        InFile::new(self.file, self.node.clone())
+    }
+    fn as_any(&self) -> &(dyn Any + Send + 'static) {
+        self
+    }
+    fn is_experimental(&self) -> bool {
+        // Newly added and not very well-tested, might contain false positives.
+        true
+    }
+}

--- a/crates/hir_def/src/nameres.rs
+++ b/crates/hir_def/src/nameres.rs
@@ -286,8 +286,8 @@ mod diagnostics {
     use cfg::{CfgExpr, CfgOptions};
     use hir_expand::diagnostics::DiagnosticSink;
     use hir_expand::hygiene::Hygiene;
-    use hir_expand::InFile;
-    use syntax::{ast, AstPtr};
+    use hir_expand::{InFile, MacroCallKind};
+    use syntax::{ast, AstPtr, SyntaxNodePtr};
 
     use crate::path::ModPath;
     use crate::{db::DefDatabase, diagnostics::*, nameres::LocalModuleId, AstId};
@@ -301,6 +301,10 @@ mod diagnostics {
         UnresolvedImport { ast: AstId<ast::Use>, index: usize },
 
         UnconfiguredCode { ast: AstId<ast::Item>, cfg: CfgExpr, opts: CfgOptions },
+
+        UnresolvedProcMacro { ast: MacroCallKind },
+
+        MacroError { ast: MacroCallKind, message: String },
     }
 
     #[derive(Debug, PartialEq, Eq)]
@@ -346,6 +350,18 @@ mod diagnostics {
             opts: CfgOptions,
         ) -> Self {
             Self { in_module: container, kind: DiagnosticKind::UnconfiguredCode { ast, cfg, opts } }
+        }
+
+        pub(super) fn unresolved_proc_macro(container: LocalModuleId, ast: MacroCallKind) -> Self {
+            Self { in_module: container, kind: DiagnosticKind::UnresolvedProcMacro { ast } }
+        }
+
+        pub(super) fn macro_error(
+            container: LocalModuleId,
+            ast: MacroCallKind,
+            message: String,
+        ) -> Self {
+            Self { in_module: container, kind: DiagnosticKind::MacroError { ast, message } }
         }
 
         pub(super) fn add_to(
@@ -406,6 +422,38 @@ mod diagnostics {
                         cfg: cfg.clone(),
                         opts: opts.clone(),
                     });
+                }
+
+                DiagnosticKind::UnresolvedProcMacro { ast } => {
+                    let (file, ast, name) = match ast {
+                        MacroCallKind::FnLike(ast) => {
+                            let node = ast.to_node(db.upcast());
+                            (ast.file_id, SyntaxNodePtr::from(AstPtr::new(&node)), None)
+                        }
+                        MacroCallKind::Attr(ast, name) => {
+                            let node = ast.to_node(db.upcast());
+                            (
+                                ast.file_id,
+                                SyntaxNodePtr::from(AstPtr::new(&node)),
+                                Some(name.to_string()),
+                            )
+                        }
+                    };
+                    sink.push(UnresolvedProcMacro { file, node: ast, macro_name: name });
+                }
+
+                DiagnosticKind::MacroError { ast, message } => {
+                    let (file, ast) = match ast {
+                        MacroCallKind::FnLike(ast) => {
+                            let node = ast.to_node(db.upcast());
+                            (ast.file_id, SyntaxNodePtr::from(AstPtr::new(&node)))
+                        }
+                        MacroCallKind::Attr(ast, _) => {
+                            let node = ast.to_node(db.upcast());
+                            (ast.file_id, SyntaxNodePtr::from(AstPtr::new(&node)))
+                        }
+                    };
+                    sink.push(MacroError { file, node: ast, message: message.clone() });
                 }
             }
         }

--- a/crates/hir_expand/src/lib.rs
+++ b/crates/hir_expand/src/lib.rs
@@ -255,7 +255,7 @@ pub enum MacroDefKind {
 pub struct MacroCallLoc {
     pub(crate) def: MacroDefId,
     pub(crate) krate: CrateId,
-    pub(crate) kind: MacroCallKind,
+    pub kind: MacroCallKind,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/hir_expand/src/proc_macro.rs
+++ b/crates/hir_expand/src/proc_macro.rs
@@ -50,7 +50,7 @@ impl ProcMacroExpander {
 
                 proc_macro.expander.expand(&tt, None).map_err(mbe::ExpandError::from)
             }
-            None => Err(err!("Unresolved proc macro")),
+            None => Err(mbe::ExpandError::UnresolvedProcMacro),
         }
     }
 }

--- a/crates/ide/src/diagnostics.rs
+++ b/crates/ide/src/diagnostics.rs
@@ -143,11 +143,13 @@ pub(crate) fn diagnostics(
             );
         })
         .on::<hir::diagnostics::UnresolvedProcMacro, _>(|d| {
+            // Use more accurate position if available.
+            let display_range =
+                d.precise_location.unwrap_or_else(|| sema.diagnostics_display_range(d).range);
+
             // FIXME: it would be nice to tell the user whether proc macros are currently disabled
-            res.borrow_mut().push(
-                Diagnostic::hint(sema.diagnostics_display_range(d).range, d.message())
-                    .with_code(Some(d.code())),
-            );
+            res.borrow_mut()
+                .push(Diagnostic::hint(display_range, d.message()).with_code(Some(d.code())));
         })
         // Only collect experimental diagnostics when they're enabled.
         .filter(|diag| !(diag.is_experimental() && config.disable_experimental))

--- a/crates/ide/src/diagnostics.rs
+++ b/crates/ide/src/diagnostics.rs
@@ -142,6 +142,13 @@ pub(crate) fn diagnostics(
                     .with_code(Some(d.code())),
             );
         })
+        .on::<hir::diagnostics::UnresolvedProcMacro, _>(|d| {
+            // FIXME: it would be nice to tell the user whether proc macros are currently disabled
+            res.borrow_mut().push(
+                Diagnostic::hint(sema.diagnostics_display_range(d).range, d.message())
+                    .with_code(Some(d.code())),
+            );
+        })
         // Only collect experimental diagnostics when they're enabled.
         .filter(|diag| !(diag.is_experimental() && config.disable_experimental))
         .filter(|diag| !config.disabled.contains(diag.code().as_str()));

--- a/crates/mbe/src/lib.rs
+++ b/crates/mbe/src/lib.rs
@@ -35,6 +35,7 @@ pub enum ExpandError {
     ConversionError,
     InvalidRepeat,
     ProcMacroError(tt::ExpansionError),
+    UnresolvedProcMacro,
     Other(String),
 }
 
@@ -53,6 +54,7 @@ impl fmt::Display for ExpandError {
             ExpandError::ConversionError => f.write_str("could not convert tokens"),
             ExpandError::InvalidRepeat => f.write_str("invalid repeat expression"),
             ExpandError::ProcMacroError(e) => e.fmt(f),
+            ExpandError::UnresolvedProcMacro => f.write_str("unresolved proc macro"),
             ExpandError::Other(e) => f.write_str(e),
         }
     }

--- a/docs/user/generated_diagnostic.adoc
+++ b/docs/user/generated_diagnostic.adoc
@@ -17,6 +17,12 @@ This diagnostic is shown for code with inactive `#[cfg]` attributes.
 This diagnostic is triggered if item name doesn't follow https://doc.rust-lang.org/1.0.0/style/style/naming/README.html[Rust naming convention].
 
 
+=== macro-error
+**Source:** https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/hir_def/src/diagnostics.rs#L164[diagnostics.rs]
+
+This diagnostic is shown for macro expansion errors.
+
+
 === mismatched-arg-count
 **Source:** https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/hir_ty/src/diagnostics.rs#L267[diagnostics.rs]
 
@@ -103,3 +109,11 @@ This diagnostic is triggered if rust-analyzer is unable to discover imported mod
 **Source:** https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/hir_def/src/diagnostics.rs#L18[diagnostics.rs]
 
 This diagnostic is triggered if rust-analyzer is unable to discover referred module.
+
+
+=== unresolved-proc-macro
+**Source:** https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/hir_def/src/diagnostics.rs#L131[diagnostics.rs]
+
+This diagnostic is shown when a procedural macro can not be found. This usually means that
+procedural macro support is simply disabled (and hence is only a weak hint instead of an error),
+but can also indicate project setup problems.

--- a/docs/user/generated_diagnostic.adoc
+++ b/docs/user/generated_diagnostic.adoc
@@ -18,7 +18,7 @@ This diagnostic is triggered if item name doesn't follow https://doc.rust-lang.o
 
 
 === macro-error
-**Source:** https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/hir_def/src/diagnostics.rs#L164[diagnostics.rs]
+**Source:** https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/hir_def/src/diagnostics.rs#L167[diagnostics.rs]
 
 This diagnostic is shown for macro expansion errors.
 


### PR DESCRIPTION
This adds 2 new diagnostics, emitted during name resolution:

* `unresolved-proc-macro`, a weak warning that is emitted when a proc macro is supposed to be expanded, but was not provided by the build system. This usually means that proc macro support is turned off, but may also indicate setup issues when using rust-project.json. Being a weak warning, this should help set expectations when users see it, while not being too obstructive. We do not yet emit this for attribute macros though, just custom derives and `!` macros.
* `macro-error`, which is emitted when any macro (procedural or `macro_rules!`) fails to expand due to some error. This is an error-level diagnostic, but currently still marked as experimental, because there might be spurious errors and this hasn't been tested too well.

This does not yet emit diagnostics when expansion in item bodies fails, just for module-level macros.

Known bug: The "proc macro not found" diagnostic points at the whole item for custom derives, it should just point at the macro's name in the `#[derive]` list, but I haven't found an easy way to do that.

Screenshots:

![screenshot-2020-11-26-19:54:14](https://user-images.githubusercontent.com/1786438/100385782-f8bc2300-3023-11eb-9f27-e8f8ce9d6114.png)
![screenshot-2020-11-26-19:55:39](https://user-images.githubusercontent.com/1786438/100385784-f954b980-3023-11eb-9617-ac2eb0a0a9dc.png)
