### PR TITLE
Go to definition for self

### DIFF
--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -139,14 +139,17 @@ pub(crate) fn hover(
         }
     }
 
-    let node = token
-        .ancestors()
-        .find(|n| ast::Expr::cast(n.clone()).is_some() || ast::Pat::cast(n.clone()).is_some())?;
+    let node = token.ancestors().find(|n| {
+        ast::Expr::can_cast(n.kind())
+            || ast::Pat::can_cast(n.kind())
+            || ast::SelfParam::can_cast(n.kind())
+    })?;
 
     let ty = match_ast! {
         match node {
             ast::Expr(it) => sema.type_of_expr(&it)?,
             ast::Pat(it) => sema.type_of_pat(&it)?,
+            ast::SelfParam(self_param) => sema.type_of_self(&self_param)?,
             // If this node is a MACRO_CALL, it means that `descend_into_macros` failed to resolve.
             // (e.g expanding a builtin macro). So we give up here.
             ast::MacroCall(_it) => return None,
@@ -3278,6 +3281,45 @@ fn main() {
 
                 ```rust
                 &i32
+                ```
+            "#]],
+        );
+    }
+
+    #[test]
+    fn hover_self_param_shows_type() {
+        check(
+            r#"
+struct Foo {}
+
+impl Foo {
+    fn bar(&sel<|>f) {}
+}
+"#,
+            expect![[r#"
+                *&self*
+                ```rust
+                &Foo
+                ```
+            "#]],
+        );
+    }
+
+    #[test]
+    fn hover_self_param_shows_type_for_arbitrary_self_type() {
+        check(
+            r#"
+struct Arc<T>(T);
+struct Foo {}
+
+impl Foo {
+    fn bar(sel<|>f: Arc<Foo>) {}
+}
+"#,
+            expect![[r#"
+                *self: Arc<Foo>*
+                ```rust
+                Arc<Foo>
                 ```
             "#]],
         );

--- a/crates/ide/src/references.rs
+++ b/crates/ide/src/references.rs
@@ -21,7 +21,7 @@ use ide_db::{
 use syntax::{
     algo::find_node_at_offset,
     ast::{self, NameOwner},
-    AstNode, SyntaxKind, SyntaxNode, TextRange, TokenAtOffset,
+    match_ast, AstNode, SyntaxKind, SyntaxNode, TextRange, TokenAtOffset,
 };
 
 use crate::{display::TryToNav, FilePosition, FileRange, NavigationTarget, RangeInfo};
@@ -93,6 +93,8 @@ pub(crate) fn find_all_refs(
         get_struct_def_name_for_struct_literal_search(&sema, &syntax, position)
     {
         (Some(name), ReferenceKind::StructLiteral)
+    } else if let Some(res) = try_find_self_references(&syntax, position) {
+        return Some(res);
     } else {
         (
             sema.find_node_at_offset_with_descend::<ast::Name>(&syntax, position.offset),
@@ -192,6 +194,77 @@ fn get_struct_def_name_for_struct_literal_search(
         }
     }
     None
+}
+
+fn try_find_self_references(
+    syntax: &SyntaxNode,
+    position: FilePosition,
+) -> Option<RangeInfo<ReferenceSearchResult>> {
+    let self_token =
+        syntax.token_at_offset(position.offset).find(|t| t.kind() == SyntaxKind::SELF_KW)?;
+    let parent = self_token.parent();
+    match_ast! {
+        match parent {
+            ast::SelfParam(it) => (),
+            ast::PathSegment(segment) => {
+                segment.self_token()?;
+                let path = segment.parent_path();
+                if path.qualifier().is_some() && !ast::PathExpr::can_cast(path.syntax().parent()?.kind()) {
+                    return None;
+                }
+            },
+            _ => return None,
+        }
+    };
+    let function = parent.ancestors().find_map(ast::Fn::cast)?;
+    let self_param = function.param_list()?.self_param()?;
+    let param_self_token = self_param.self_token()?;
+
+    let declaration = Declaration {
+        nav: NavigationTarget {
+            file_id: position.file_id,
+            full_range: self_param.syntax().text_range(),
+            focus_range: Some(param_self_token.text_range()),
+            name: param_self_token.text().clone(),
+            kind: param_self_token.kind(),
+            container_name: None,
+            description: None,
+            docs: None,
+        },
+        kind: ReferenceKind::SelfKw,
+        access: Some(if self_param.mut_token().is_some() {
+            ReferenceAccess::Write
+        } else {
+            ReferenceAccess::Read
+        }),
+    };
+    let references = function
+        .body()
+        .map(|body| {
+            body.syntax()
+                .descendants()
+                .filter_map(ast::PathExpr::cast)
+                .filter_map(|expr| {
+                    let path = expr.path()?;
+                    if path.qualifier().is_none() {
+                        path.segment()?.self_token()
+                    } else {
+                        None
+                    }
+                })
+                .map(|token| Reference {
+                    file_range: FileRange { file_id: position.file_id, range: token.text_range() },
+                    kind: ReferenceKind::SelfKw,
+                    access: declaration.access, // FIXME: properly check access kind here instead of copying it from the declaration
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Some(RangeInfo::new(
+        param_self_token.text_range(),
+        ReferenceSearchResult { declaration, references },
+    ))
 }
 
 #[cfg(test)]

--- a/crates/ide_db/src/search.rs
+++ b/crates/ide_db/src/search.rs
@@ -31,6 +31,7 @@ pub enum ReferenceKind {
     FieldShorthandForLocal,
     StructLiteral,
     RecordFieldExprOrPat,
+    SelfKw,
     Other,
 }
 


### PR DESCRIPTION
### I just realized this PR now adds 3 different things so I am going to close this in favor of of opening 3 smaller PRs.

Hovering over the self parameter now shows the type of self.
Go to definition now works on self showing the self parameter of the enclosing method.
Reference search for self now also works but is purely syntax based, as we do not have a good way to otherwise handle this to my knowledge. The heuristic for `self` usage is basically: is a `PathExpr` with a single `PathSegment` that contains a `self` token. This is so we don't pick up `self` tokens inside of local `UseTree`s.
See https://github.com/rust-analyzer/rust-analyzer/pull/6660#issuecomment-735252631

Reverts #6660.