### PR TITLE
Emit macro diagnostics when lowering bodies

### DIFF
--- a/crates/hir_def/src/body/diagnostics.rs
+++ b/crates/hir_def/src/body/diagnostics.rs
@@ -2,12 +2,13 @@
 
 use hir_expand::diagnostics::DiagnosticSink;
 
-use crate::diagnostics::{InactiveCode, MacroError};
+use crate::diagnostics::{InactiveCode, MacroError, UnresolvedProcMacro};
 
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) enum BodyDiagnostic {
     InactiveCode(InactiveCode),
     MacroError(MacroError),
+    UnresolvedProcMacro(UnresolvedProcMacro),
 }
 
 impl BodyDiagnostic {
@@ -17,6 +18,9 @@ impl BodyDiagnostic {
                 sink.push(diag.clone());
             }
             BodyDiagnostic::MacroError(diag) => {
+                sink.push(diag.clone());
+            }
+            BodyDiagnostic::UnresolvedProcMacro(diag) => {
                 sink.push(diag.clone());
             }
         }

--- a/crates/hir_def/src/body/diagnostics.rs
+++ b/crates/hir_def/src/body/diagnostics.rs
@@ -2,17 +2,21 @@
 
 use hir_expand::diagnostics::DiagnosticSink;
 
-use crate::diagnostics::InactiveCode;
+use crate::diagnostics::{InactiveCode, MacroError};
 
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) enum BodyDiagnostic {
     InactiveCode(InactiveCode),
+    MacroError(MacroError),
 }
 
 impl BodyDiagnostic {
     pub(crate) fn add_to(&self, sink: &mut DiagnosticSink<'_>) {
         match self {
             BodyDiagnostic::InactiveCode(diag) => {
+                sink.push(diag.clone());
+            }
+            BodyDiagnostic::MacroError(diag) => {
                 sink.push(diag.clone());
             }
         }

--- a/crates/hir_def/src/body/lower.rs
+++ b/crates/hir_def/src/body/lower.rs
@@ -25,7 +25,7 @@ use crate::{
     body::{Body, BodySourceMap, Expander, PatPtr, SyntheticSyntax},
     builtin_type::{BuiltinFloat, BuiltinInt},
     db::DefDatabase,
-    diagnostics::InactiveCode,
+    diagnostics::{InactiveCode, MacroError},
     expr::{
         dummy_expr_id, ArithOp, Array, BinaryOp, BindingAnnotation, CmpOp, Expr, ExprId, Literal,
         LogicOp, MatchArm, Ordering, Pat, PatId, RecordFieldPat, RecordLitField, Statement,
@@ -561,7 +561,17 @@ impl ExprCollector<'_> {
                     self.alloc_expr(Expr::Missing, syntax_ptr)
                 } else {
                     let macro_call = self.expander.to_source(AstPtr::new(&e));
-                    match self.expander.enter_expand(self.db, Some(&self.body.item_scope), e) {
+                    let res = self.expander.enter_expand(self.db, Some(&self.body.item_scope), e);
+
+                    if let Some(err) = res.err {
+                        self.source_map.diagnostics.push(BodyDiagnostic::MacroError(MacroError {
+                            file: self.expander.current_file_id,
+                            node: syntax_ptr.clone().into(),
+                            message: err.to_string(),
+                        }));
+                    }
+
+                    match res.value {
                         Some((mark, expansion)) => {
                             self.source_map
                                 .expansions

--- a/crates/hir_def/src/body/lower.rs
+++ b/crates/hir_def/src/body/lower.rs
@@ -8,7 +8,7 @@ use either::Either;
 use hir_expand::{
     hygiene::Hygiene,
     name::{name, AsName, Name},
-    HirFileId, MacroDefId, MacroDefKind,
+    ExpandError, HirFileId, MacroDefId, MacroDefKind,
 };
 use rustc_hash::FxHashMap;
 use syntax::{
@@ -25,7 +25,7 @@ use crate::{
     body::{Body, BodySourceMap, Expander, PatPtr, SyntheticSyntax},
     builtin_type::{BuiltinFloat, BuiltinInt},
     db::DefDatabase,
-    diagnostics::{InactiveCode, MacroError},
+    diagnostics::{InactiveCode, MacroError, UnresolvedProcMacro},
     expr::{
         dummy_expr_id, ArithOp, Array, BinaryOp, BindingAnnotation, CmpOp, Expr, ExprId, Literal,
         LogicOp, MatchArm, Ordering, Pat, PatId, RecordFieldPat, RecordLitField, Statement,
@@ -563,12 +563,27 @@ impl ExprCollector<'_> {
                     let macro_call = self.expander.to_source(AstPtr::new(&e));
                     let res = self.expander.enter_expand(self.db, Some(&self.body.item_scope), e);
 
-                    if let Some(err) = res.err {
-                        self.source_map.diagnostics.push(BodyDiagnostic::MacroError(MacroError {
-                            file: self.expander.current_file_id,
-                            node: syntax_ptr.clone().into(),
-                            message: err.to_string(),
-                        }));
+                    match res.err {
+                        Some(ExpandError::UnresolvedProcMacro) => {
+                            self.source_map.diagnostics.push(BodyDiagnostic::UnresolvedProcMacro(
+                                UnresolvedProcMacro {
+                                    file: self.expander.current_file_id,
+                                    node: syntax_ptr.clone().into(),
+                                    precise_location: None,
+                                    macro_name: None,
+                                },
+                            ));
+                        }
+                        Some(err) => {
+                            self.source_map.diagnostics.push(BodyDiagnostic::MacroError(
+                                MacroError {
+                                    file: self.expander.current_file_id,
+                                    node: syntax_ptr.clone().into(),
+                                    message: err.to_string(),
+                                },
+                            ));
+                        }
+                        None => {}
                     }
 
                     match res.value {

--- a/crates/hir_def/src/data.rs
+++ b/crates/hir_def/src/data.rs
@@ -257,7 +257,7 @@ fn collect_items(
                 let root = db.parse_or_expand(file_id).unwrap();
                 let call = ast_id_map.get(call.ast_id).to_node(&root);
 
-                if let Some((mark, mac)) = expander.enter_expand(db, None, call) {
+                if let Some((mark, mac)) = expander.enter_expand(db, None, call).value {
                     let src: InFile<ast::MacroItems> = expander.to_source(mac);
                     let item_tree = db.item_tree(src.file_id);
                     let iter =


### PR DESCRIPTION
Changes `Expander::enter_expand` to return an `ExpandResult`, and adds any contained errors to the body diagnostic list.