### PR TITLE
lsp-types 0.85: Fixes OptionalVersionedTextDocumentIdentifier specification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,9 +864,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.84.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b95be71fe205e44de754185bcf86447b65813ce1ceb298f8d3793ade5fff08d"
+checksum = "857650f3e83fb62f89d15410414e0ed7d0735445020da398d37f65d20a5423b9"
 dependencies = [
  "base64",
  "bitflags",

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -21,7 +21,7 @@ env_logger = { version = "0.8.1", default-features = false }
 itertools = "0.9.0"
 jod-thread = "0.1.0"
 log = "0.4.8"
-lsp-types = { version = "0.84.0", features = ["proposed"] }
+lsp-types = { version = "0.85.0", features = ["proposed"] }
 parking_lot = "0.11.0"
 pico-args = "0.3.1"
 oorandom = "11.1.2"

--- a/crates/rust-analyzer/src/semantic_tokens.rs
+++ b/crates/rust-analyzer/src/semantic_tokens.rs
@@ -27,7 +27,7 @@ macro_rules! define_semantic_token_types {
             SemanticTokenType::ENUM_MEMBER,
             SemanticTokenType::TYPE_PARAMETER,
             SemanticTokenType::FUNCTION,
-            SemanticTokenType::MEMBER,
+            SemanticTokenType::METHOD,
             SemanticTokenType::PROPERTY,
             SemanticTokenType::MACRO,
             SemanticTokenType::VARIABLE,


### PR DESCRIPTION
Fixes #6654