### PR TITLE
Don't discard PathKind::Abs information in lower_use::convert_path

### DIFF
--- a/crates/hir_def/src/nameres/tests/mod_resolution.rs
+++ b/crates/hir_def/src/nameres/tests/mod_resolution.rs
@@ -798,3 +798,24 @@ mod foo;
 "#,
     );
 }
+
+#[test]
+fn abs_path_ignores_local() {
+    check(
+        r#"
+//- /main.rs crate:main deps:core
+pub use ::core::hash::Hash;
+pub mod core {}
+
+//- /lib.rs crate:core
+pub mod hash { pub trait Hash {} }
+"#,
+        expect![[r#"
+            crate
+            Hash: t
+            core: t
+
+            crate::core
+        "#]],
+    );
+}

--- a/crates/hir_def/src/path/lower/lower_use.rs
+++ b/crates/hir_def/src/path/lower/lower_use.rs
@@ -76,7 +76,7 @@ fn convert_path(prefix: Option<ModPath>, path: ast::Path, hygiene: &Hygiene) -> 
                 Either::Left(name) => {
                     // no type args in use
                     let mut res = prefix.unwrap_or_else(|| ModPath {
-                        kind: PathKind::Plain,
+                        kind: segment.coloncolon_token().map_or(PathKind::Plain, |_| PathKind::Abs),
                         segments: Vec::with_capacity(1),
                     });
                     res.segments.push(name);


### PR DESCRIPTION
Fixes #6694