### PR TITLE
Fix proc macro token mapping

### DIFF
--- a/crates/hir_def/src/lib.rs
+++ b/crates/hir_def/src/lib.rs
@@ -521,7 +521,7 @@ impl AsMacroCall for AstIdWithPath<ast::MacroCall> {
         error_sink: &mut dyn FnMut(mbe::ExpandError),
     ) -> Option<MacroCallId> {
         let def: MacroDefId = resolver(self.path.clone()).or_else(|| {
-            error_sink(mbe::ExpandError::Other("could not resolve macro".into()));
+            error_sink(mbe::ExpandError::Other(format!("could not resolve macro `{}`", self.path)));
             None
         })?;
 
@@ -556,7 +556,7 @@ impl AsMacroCall for AstIdWithPath<ast::Item> {
         error_sink: &mut dyn FnMut(mbe::ExpandError),
     ) -> Option<MacroCallId> {
         let def: MacroDefId = resolver(self.path.clone()).or_else(|| {
-            error_sink(mbe::ExpandError::Other("could not resolve macro".into()));
+            error_sink(mbe::ExpandError::Other(format!("could not resolve macro `{}`", self.path)));
             None
         })?;
 


### PR DESCRIPTION
Diagnostics inside proc macros are currently incorrectly placed at their original offset, but inside the containing file. This fixes that, by allowing the creation of `ExpansionInfo` from non-`macro_rules!` macro invocations.

bors r+