### PR TITLE
Make `compile_error!` message match upstream rustc

### DIFF
--- a/crates/hir_def/src/body/tests.rs
+++ b/crates/hir_def/src/body/tests.rs
@@ -107,7 +107,7 @@ fn f() {
   //^^^^^^^^^^^^^^^ `OUT_DIR` not set, enable "load out dirs from check" to fix
 
     compile_error!("compile_error works");
-  //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `compile_error!` called: compile_error works
+  //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ compile_error works
 
     // Lazy:
 

--- a/crates/hir_expand/src/builtin_macro.rs
+++ b/crates/hir_expand/src/builtin_macro.rs
@@ -271,10 +271,7 @@ fn compile_error_expand(
             let text = it.text.as_str();
             if text.starts_with('"') && text.ends_with('"') {
                 // FIXME: does not handle raw strings
-                mbe::ExpandError::Other(format!(
-                    "`compile_error!` called: {}",
-                    &text[1..text.len() - 1]
-                ))
+                mbe::ExpandError::Other(text[1..text.len() - 1].to_string())
             } else {
                 mbe::ExpandError::BindingError("`compile_error!` argument must be a string".into())
             }


### PR DESCRIPTION
It only consists of the argument passed to it.

bors r+