### PR TITLE
Use correct, full substs for self type in impl

### DIFF
--- a/crates/hir_ty/src/method_resolution.rs
+++ b/crates/hir_ty/src/method_resolution.rs
@@ -720,7 +720,13 @@ fn transform_receiver_ty(
             .push(self_ty.value.clone())
             .fill_with_unknown()
             .build(),
-        AssocContainerId::ImplId(impl_id) => inherent_impl_substs(db, impl_id, &self_ty)?,
+        AssocContainerId::ImplId(impl_id) => {
+            let impl_substs = inherent_impl_substs(db, impl_id, &self_ty)?;
+            Substs::build_for_def(db, function_id)
+                .use_parent_substs(&impl_substs)
+                .fill_with_unknown()
+                .build()
+        }
         AssocContainerId::ContainerId(_) => unreachable!(),
     };
     let sig = db.callable_item_signature(function_id.into());

--- a/crates/hir_ty/src/tests/method_resolution.rs
+++ b/crates/hir_ty/src/tests/method_resolution.rs
@@ -1087,3 +1087,22 @@ fn method_resolution_foreign_opaque_type() {
         "#]],
     );
 }
+
+#[test]
+fn method_with_allocator_box_self_type() {
+    check_types(
+        r#"
+struct Slice<T> {}
+struct Box<T, A> {}
+
+impl<T> Slice<T> {
+    pub fn into_vec<A>(self: Box<Self, A>) { }
+}
+
+fn main() {
+    let foo: Slice<u32>;
+    (foo.into_vec()); // we don't actually support arbitrary self types, but we shouldn't crash at least
+} //^ {unknown}
+"#,
+    );
+}


### PR DESCRIPTION
Without arbitrary self types, the self type could never refer to the method type parameters, so this wasn't a problem; but with arbitrary self types, it can.

This fixes the crash from #6668; but it doesn't make method resolution work for these methods.