### PR TITLE
Don't insert blank lines between doc attributes

### DIFF
--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -1525,9 +1525,7 @@ fn foo() { let bar = Ba<|>r; }
                 ---
 
                 bar docs 0
-
                 bar docs 1
-
                 bar docs 2
             "#]],
         );


### PR DESCRIPTION
Fixes #6742.
Doc attributes should be concatenated via a single linebreak as written in the [rustdoc book](https://doc.rust-lang.org/nightly/rustdoc/the-doc-attribute.html).
Also changed the loop to use an iterator to get rid of the `docs.trim_end_matches("\n\n").to_owned()` part using `Itertools::intersperse`.