### PR TITLE
Some more proc macro cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,6 +1187,7 @@ dependencies = [
 name = "proc_macro_api"
 version = "0.0.0"
 dependencies = [
+ "base_db",
  "crossbeam-channel 0.5.0",
  "jod-thread",
  "log",

--- a/crates/base_db/src/input.rs
+++ b/crates/base_db/src/input.rs
@@ -143,9 +143,17 @@ impl CrateDisplayName {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct ProcMacroId(pub u32);
 
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum ProcMacroKind {
+    CustomDerive,
+    FuncLike,
+    Attr,
+}
+
 #[derive(Debug, Clone)]
 pub struct ProcMacro {
     pub name: SmolStr,
+    pub kind: ProcMacroKind,
     pub expander: Arc<dyn TokenExpander>,
 }
 
@@ -198,11 +206,8 @@ impl CrateGraph {
         display_name: Option<CrateDisplayName>,
         cfg_options: CfgOptions,
         env: Env,
-        proc_macro: Vec<(SmolStr, Arc<dyn tt::TokenExpander>)>,
+        proc_macro: Vec<ProcMacro>,
     ) -> CrateId {
-        let proc_macro =
-            proc_macro.into_iter().map(|(name, it)| ProcMacro { name, expander: it }).collect();
-
         let data = CrateData {
             root_file_id: file_id,
             edition,

--- a/crates/base_db/src/lib.rs
+++ b/crates/base_db/src/lib.rs
@@ -14,7 +14,7 @@ pub use crate::{
     change::Change,
     input::{
         CrateData, CrateDisplayName, CrateGraph, CrateId, CrateName, Dependency, Edition, Env,
-        ProcMacroId, SourceRoot, SourceRootId,
+        ProcMacro, ProcMacroId, ProcMacroKind, SourceRoot, SourceRootId,
     },
 };
 pub use salsa;

--- a/crates/hir_expand/src/proc_macro.rs
+++ b/crates/hir_expand/src/proc_macro.rs
@@ -26,7 +26,6 @@ impl ProcMacroExpander {
 
     pub fn dummy(krate: CrateId) -> Self {
         // FIXME: Should store the name for better errors
-        // FIXME: I think this is the second layer of "dummy" expansion, we should reduce that
         Self { krate, proc_macro_id: None }
     }
 

--- a/crates/proc_macro_api/Cargo.toml
+++ b/crates/proc_macro_api/Cargo.toml
@@ -17,3 +17,4 @@ crossbeam-channel = "0.5.0"
 jod-thread = "0.1.1"
 
 tt = { path = "../tt", version = "0.0.0" }
+base_db = { path = "../base_db", version = "0.0.0" }

--- a/crates/proc_macro_api/src/lib.rs
+++ b/crates/proc_macro_api/src/lib.rs
@@ -23,7 +23,7 @@ use crate::process::{ProcMacroProcessSrv, ProcMacroProcessThread};
 pub use rpc::{ExpansionResult, ExpansionTask, ListMacrosResult, ListMacrosTask, ProcMacroKind};
 
 #[derive(Debug, Clone)]
-pub struct ProcMacroProcessExpander {
+struct ProcMacroProcessExpander {
     process: Arc<ProcMacroProcessSrv>,
     dylib_path: PathBuf,
     name: SmolStr,

--- a/crates/proc_macro_api/src/lib.rs
+++ b/crates/proc_macro_api/src/lib.rs
@@ -42,9 +42,17 @@ impl tt::TokenExpander for ProcMacroProcessExpander {
     fn expand(
         &self,
         subtree: &Subtree,
-        _attr: Option<&Subtree>,
+        attr: Option<&Subtree>,
     ) -> Result<Subtree, tt::ExpansionError> {
-        self.process.custom_derive(&self.dylib_path, subtree, &self.name)
+        let task = ExpansionTask {
+            macro_body: subtree.clone(),
+            macro_name: self.name.to_string(),
+            attributes: attr.cloned(),
+            lib: self.dylib_path.to_path_buf(),
+        };
+
+        let result: ExpansionResult = self.process.send_task(msg::Request::ExpansionMacro(task))?;
+        Ok(result.expansion)
     }
 }
 

--- a/crates/proc_macro_api/src/process.rs
+++ b/crates/proc_macro_api/src/process.rs
@@ -10,11 +10,10 @@ use std::{
 };
 
 use crossbeam_channel::{bounded, Receiver, Sender};
-use tt::Subtree;
 
 use crate::{
     msg::{ErrorCode, Message, Request, Response, ResponseError},
-    rpc::{ExpansionResult, ExpansionTask, ListMacrosResult, ListMacrosTask, ProcMacroKind},
+    rpc::{ListMacrosResult, ListMacrosTask, ProcMacroKind},
 };
 
 #[derive(Debug, Default)]
@@ -56,23 +55,6 @@ impl ProcMacroProcessSrv {
 
         let result: ListMacrosResult = self.send_task(Request::ListMacro(task))?;
         Ok(result.macros)
-    }
-
-    pub(crate) fn custom_derive(
-        &self,
-        dylib_path: &Path,
-        subtree: &Subtree,
-        derive_name: &str,
-    ) -> Result<Subtree, tt::ExpansionError> {
-        let task = ExpansionTask {
-            macro_body: subtree.clone(),
-            macro_name: derive_name.to_string(),
-            attributes: None,
-            lib: dylib_path.to_path_buf(),
-        };
-
-        let result: ExpansionResult = self.send_task(Request::ExpansionMacro(task))?;
-        Ok(result.expansion)
     }
 
     pub(crate) fn send_task<R>(&self, req: Request) -> Result<R, tt::ExpansionError>

--- a/crates/proc_macro_api/src/rpc.rs
+++ b/crates/proc_macro_api/src/rpc.rs
@@ -19,7 +19,7 @@ pub struct ListMacrosTask {
     pub lib: PathBuf,
 }
 
-#[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub enum ProcMacroKind {
     CustomDerive,
     FuncLike,

--- a/crates/rust-analyzer/src/cli/load_cargo.rs
+++ b/crates/rust-analyzer/src/cli/load_cargo.rs
@@ -33,12 +33,12 @@ pub fn load_cargo(
 
     let proc_macro_client = if with_proc_macro {
         let path = std::env::current_exe()?;
-        ProcMacroClient::extern_process(path, &["proc-macro"]).unwrap()
+        Some(ProcMacroClient::extern_process(path, &["proc-macro"]).unwrap())
     } else {
-        ProcMacroClient::dummy()
+        None
     };
 
-    let crate_graph = ws.to_crate_graph(None, &proc_macro_client, &mut |path: &AbsPath| {
+    let crate_graph = ws.to_crate_graph(None, proc_macro_client.as_ref(), &mut |path: &AbsPath| {
         let contents = loader.load_sync(path);
         let path = vfs::VfsPath::from(path.to_path_buf());
         vfs.set_file_contents(path.clone(), contents);

--- a/crates/rust-analyzer/src/global_state.rs
+++ b/crates/rust-analyzer/src/global_state.rs
@@ -75,7 +75,7 @@ pub(crate) struct GlobalState {
     pub(crate) shutdown_requested: bool,
     pub(crate) status: Status,
     pub(crate) source_root_config: SourceRootConfig,
-    pub(crate) proc_macro_client: ProcMacroClient,
+    pub(crate) proc_macro_client: Option<ProcMacroClient>,
     pub(crate) workspaces: Arc<Vec<ProjectWorkspace>>,
     latest_requests: Arc<RwLock<LatestRequests>>,
 }
@@ -127,7 +127,7 @@ impl GlobalState {
             shutdown_requested: false,
             status: Status::default(),
             source_root_config: SourceRootConfig::default(),
-            proc_macro_client: ProcMacroClient::dummy(),
+            proc_macro_client: None,
             workspaces: Arc::new(Vec::new()),
             latest_requests: Default::default(),
         }

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -171,16 +171,16 @@ impl GlobalState {
         let project_folders = ProjectFolders::new(&workspaces);
 
         self.proc_macro_client = match &self.config.proc_macro_srv {
-            None => ProcMacroClient::dummy(),
+            None => None,
             Some((path, args)) => match ProcMacroClient::extern_process(path.into(), args) {
-                Ok(it) => it,
+                Ok(it) => Some(it),
                 Err(err) => {
                     log::error!(
                         "Failed to run proc_macro_srv from path {}, error: {:?}",
                         path.display(),
                         err
                     );
-                    ProcMacroClient::dummy()
+                    None
                 }
             },
         };
@@ -212,7 +212,7 @@ impl GlobalState {
             for ws in workspaces.iter() {
                 crate_graph.extend(ws.to_crate_graph(
                     self.config.cargo.target.as_deref(),
-                    &self.proc_macro_client,
+                    self.proc_macro_client.as_ref(),
                     &mut load,
                 ));
             }


### PR DESCRIPTION
* Remove `ProcMacroClient::dummy` and just use `Option<ProcMacroClient>` instead
* Remember the type of proc macros (later allows us to reject using an incorrect macro type)
* Prepare a few internals for procedural attribute macros

bors r+