### PR TITLE
Use the right `def_crate` for builtin macros

### DIFF
--- a/crates/hir_expand/src/hygiene.rs
+++ b/crates/hir_expand/src/hygiene.rs
@@ -30,7 +30,7 @@ impl Hygiene {
                     let loc = db.lookup_intern_macro(id);
                     match loc.def.kind {
                         MacroDefKind::Declarative => (loc.def.krate, loc.def.local_inner),
-                        MacroDefKind::BuiltIn(_) => (None, false),
+                        MacroDefKind::BuiltIn(_) => (loc.def.krate, false),
                         MacroDefKind::BuiltInDerive(_) => (None, false),
                         MacroDefKind::BuiltInEager(_) => (None, false),
                         MacroDefKind::ProcMacro(_) => (None, false),


### PR DESCRIPTION
Fixes the incorrect macro resolution in https://github.com/rust-analyzer/rust-analyzer/issues/6716

No test, because diagnostics do not get remapped correctly for some reason. I've checked manually that this fixes the resolution errors.

bors r+