### PR TITLE
Remove workaround & fix fetch$1 is not a function

### DIFF
--- a/editors/code/src/net.ts
+++ b/editors/code/src/net.ts
@@ -1,7 +1,4 @@
-// Replace with `import fetch from "node-fetch"` once this is fixed in rollup:
-// https://github.com/rollup/plugins/issues/491
-const fetch = require("node-fetch") as typeof import("node-fetch")["default"];
-
+import fetch from "node-fetch";
 import * as vscode from "vscode";
 import * as stream from "stream";
 import * as crypto from "crypto";


### PR DESCRIPTION
Remove workaround for https://github.com/rollup/plugins/issues/491
because it's fixed in 15.0
https://github.com/rollup/plugins/blob/master/packages/commonjs/CHANGELOG.md#v1500.

Also fix fetch$1 is not a function error
https://github.com/rust-analyzer/rust-analyzer/issues/6757.