### PR TITLE
Add client install support for `code-exploration` builds.

### DIFF
--- a/xtask/src/install.rs
+++ b/xtask/src/install.rs
@@ -16,6 +16,7 @@ pub struct InstallCmd {
 #[derive(Clone, Copy)]
 pub enum ClientOpt {
     VsCode,
+    VsCodeExploration,
     VsCodeInsiders,
     VsCodium,
     VsCodeOss,
@@ -26,10 +27,11 @@ impl ClientOpt {
     pub const fn as_cmds(&self) -> &'static [&'static str] {
         match self {
             ClientOpt::VsCode => &["code"],
+            ClientOpt::VsCodeExploration => &["code-exploration"],
             ClientOpt::VsCodeInsiders => &["code-insiders"],
             ClientOpt::VsCodium => &["codium"],
             ClientOpt::VsCodeOss => &["code-oss"],
-            ClientOpt::Any => &["code", "code-insiders", "codium", "code-oss"],
+            ClientOpt::Any => &["code", "code-exploration", "code-insiders", "codium", "code-oss"],
         }
     }
 }
@@ -44,11 +46,17 @@ impl std::str::FromStr for ClientOpt {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        [ClientOpt::VsCode, ClientOpt::VsCodeInsiders, ClientOpt::VsCodium, ClientOpt::VsCodeOss]
-            .iter()
-            .copied()
-            .find(|c| [s] == c.as_cmds())
-            .ok_or_else(|| anyhow::format_err!("no such client"))
+        [
+            ClientOpt::VsCode,
+            ClientOpt::VsCodeExploration,
+            ClientOpt::VsCodeInsiders,
+            ClientOpt::VsCodium,
+            ClientOpt::VsCodeOss,
+        ]
+        .iter()
+        .copied()
+        .find(|c| [s] == c.as_cmds())
+        .ok_or_else(|| anyhow::format_err!("no such client"))
     }
 }
 


### PR DESCRIPTION
VSCode has a feature to install the command to the PATH. 
<img width="640" alt="Capture d’écran 2020-12-08 à 19 25 43" src="https://user-images.githubusercontent.com/16373039/101525141-2e013300-398b-11eb-8d07-60a92ae9587c.png">

`code-exploration` is the command name for the ARM64 experimental build. As of today, this is the only build running natively on Apple Silicon.

See _ARM64_ Experimental in https://code.visualstudio.com/insiders/#osx.

The `-exploration` prefix seems pretty undocumented, my understanding of it is that it is an insider-like version that uses a different electron version (in this case, maybe the election version that was recently ported to Apple Silicon?).