### PR TITLE
Properly attach inner attributes in Attrs::new

### DIFF
--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -3357,4 +3357,66 @@ impl Foo {
             "#]],
         );
     }
+
+    #[test]
+    fn hover_doc_outer_inner() {
+        check(
+            r#"
+/// Be quick;
+mod Foo<|> {
+    //! time is mana
+
+    /// This comment belongs to the function
+    fn foo() {}
+}
+"#,
+            expect![[r#"
+                *Foo*
+
+                ```rust
+                test
+                ```
+
+                ```rust
+                mod Foo
+                ```
+
+                ---
+
+                Be quick;
+                time is mana
+            "#]],
+        );
+    }
+
+    #[test]
+    fn hover_doc_outer_inner_attribue() {
+        check(
+            r#"
+#[doc = "Be quick;"]
+mod Foo<|> {
+    #![doc = "time is mana"]
+
+    #[doc = "This comment belongs to the function"]
+    fn foo() {}
+}
+"#,
+            expect![[r#"
+                *Foo*
+
+                ```rust
+                test
+                ```
+
+                ```rust
+                mod Foo
+                ```
+
+                ---
+
+                Be quick;
+                time is mana
+            "#]],
+        );
+    }
 }

--- a/crates/syntax/src/ast/token_ext.rs
+++ b/crates/syntax/src/ast/token_ext.rs
@@ -17,6 +17,14 @@ impl ast::Comment {
         CommentKind::from_text(self.text())
     }
 
+    pub fn is_inner(&self) -> bool {
+        self.kind().doc == Some(CommentPlacement::Inner)
+    }
+
+    pub fn is_outer(&self) -> bool {
+        self.kind().doc == Some(CommentPlacement::Outer)
+    }
+
     pub fn prefix(&self) -> &'static str {
         let &(prefix, _kind) = CommentKind::BY_PREFIX
             .iter()


### PR DESCRIPTION
Properly attach inner and outer attributes to the things they actually belong to in the HIR. ~~I can add some tests for this if wanted once I know where to put them/how to test for this.~~ Put some tests into `hover.rs`.
 
So the following snippet
```rust
mod foo {
	//! Hello
}
```
now shows `Hello` on hover 🎉

Fixes #2148
