### PR TITLE
Avoid nesting Subtrees when parsing TokenStream

### DIFF
--- a/crates/proc_macro_srv/src/rustc_server.rs
+++ b/crates/proc_macro_srv/src/rustc_server.rs
@@ -184,8 +184,7 @@ pub mod token_stream {
             let (subtree, _token_map) =
                 mbe::parse_to_token_tree(src).ok_or("Failed to parse from mbe")?;
 
-            let tt: tt::TokenTree = subtree.into();
-            Ok(tt.into())
+            Ok(TokenStream { subtree })
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/6744

bors r+