### PR TITLE
Support labels and lifetimes in reference search

### DIFF
--- a/crates/ide/src/references/rename.rs
+++ b/crates/ide/src/references/rename.rs
@@ -360,6 +360,10 @@ fn rename_reference(
         None => return Err(RenameError("No references found at position".to_string())),
     };
 
+    if refs.declaration().kind == ReferenceKind::Lifetime {
+        return Err(RenameError("Renaming references is not yet suported".to_string()));
+    }
+
     let edit = refs
         .into_iter()
         .map(|reference| source_edit_from_reference(sema, reference, new_name))

--- a/crates/ide_db/src/search.rs
+++ b/crates/ide_db/src/search.rs
@@ -32,7 +32,7 @@ pub enum ReferenceKind {
     StructLiteral,
     RecordFieldExprOrPat,
     SelfKw,
-    Label,
+    Lifetime,
     Other,
 }
 

--- a/crates/ide_db/src/search.rs
+++ b/crates/ide_db/src/search.rs
@@ -32,6 +32,7 @@ pub enum ReferenceKind {
     StructLiteral,
     RecordFieldExprOrPat,
     SelfKw,
+    Label,
     Other,
 }
 


### PR DESCRIPTION
This required a lot of code unfortunately, mainly because it requires a lot of special casing grabbing specific syntax children depending on what kind of Node is being dealt with. I hope the comments will aid a bit in understanding/reviewing.

With this everything should be supported in reference search now I believe.

Lifetime renaming will be enabled in a follow up PR.