### PR TITLE
Add Lifetimes to the HIR

### DIFF
--- a/crates/assists/src/ast_transform.rs
+++ b/crates/assists/src/ast_transform.rs
@@ -89,7 +89,7 @@ impl<'a> SubstituteTypeParams<'a> {
         let substs = get_syntactic_substs(impl_def).unwrap_or_default();
         let generic_def: hir::GenericDef = trait_.into();
         let substs_by_param: FxHashMap<_, _> = generic_def
-            .params(source_scope.db)
+            .type_params(source_scope.db)
             .into_iter()
             // this is a trait impl, so we need to skip the first type parameter -- this is a bit hacky
             .skip(1)

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -35,8 +35,8 @@ pub use crate::{
     code_model::{
         Access, Adt, AsAssocItem, AssocItem, AssocItemContainer, Callable, CallableKind, Const,
         Crate, CrateDependency, DefWithBody, Enum, EnumVariant, Field, FieldSource, Function,
-        GenericDef, HasVisibility, ImplDef, Local, MacroDef, Module, ModuleDef, ScopeDef, Static,
-        Struct, Trait, Type, TypeAlias, TypeParam, Union, VariantDef,
+        GenericDef, HasVisibility, ImplDef, LifetimeParam, Local, MacroDef, Module, ModuleDef,
+        ScopeDef, Static, Struct, Trait, Type, TypeAlias, TypeParam, Union, VariantDef,
     },
     has_source::HasSource,
     semantics::{PathResolution, Semantics, SemanticsScope},
@@ -56,8 +56,9 @@ pub use hir_def::{
     visibility::Visibility,
 };
 pub use hir_expand::{
-    name::known, name::AsName, name::Name, ExpandResult, HirFileId, InFile, MacroCallId,
-    MacroCallLoc, /* FIXME */ MacroDefId, MacroFile, Origin,
+    name::{known, AsName, Name},
+    ExpandResult, HirFileId, InFile, MacroCallId, MacroCallLoc, /* FIXME */ MacroDefId,
+    MacroFile, Origin,
 };
 pub use hir_ty::display::HirDisplay;
 

--- a/crates/hir_def/src/item_tree.rs
+++ b/crates/hir_def/src/item_tree.rs
@@ -255,7 +255,7 @@ impl GenericParamsStorage {
 }
 
 static EMPTY_GENERICS: GenericParams =
-    GenericParams { types: Arena::new(), where_predicates: Vec::new() };
+    GenericParams { types: Arena::new(), lifetimes: Arena::new(), where_predicates: Vec::new() };
 
 #[derive(Default, Debug, Eq, PartialEq)]
 struct ItemTreeData {

--- a/crates/hir_def/src/lib.rs
+++ b/crates/hir_def/src/lib.rs
@@ -224,6 +224,13 @@ pub struct TypeParamId {
 pub type LocalTypeParamId = Idx<generics::TypeParamData>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct LifetimeParamId {
+    pub parent: GenericDefId,
+    pub local_id: LocalLifetimeParamId,
+}
+pub type LocalLifetimeParamId = Idx<generics::LifetimeParamData>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ContainerId {
     ModuleId(ModuleId),
     DefWithBodyId(DefWithBodyId),

--- a/crates/hir_def/src/path.rs
+++ b/crates/hir_def/src/path.rs
@@ -7,7 +7,7 @@ use std::{
     sync::Arc,
 };
 
-use crate::body::LowerCtx;
+use crate::{body::LowerCtx, type_ref::LifetimeRef};
 use base_db::CrateId;
 use hir_expand::{
     hygiene::Hygiene,
@@ -145,7 +145,7 @@ pub struct AssociatedTypeBinding {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum GenericArg {
     Type(TypeRef),
-    // or lifetime...
+    Lifetime(LifetimeRef),
 }
 
 impl Path {

--- a/crates/hir_def/src/path/lower.rs
+++ b/crates/hir_def/src/path/lower.rs
@@ -15,7 +15,7 @@ use super::AssociatedTypeBinding;
 use crate::{
     body::LowerCtx,
     path::{GenericArg, GenericArgs, ModPath, Path, PathKind},
-    type_ref::{TypeBound, TypeRef},
+    type_ref::{LifetimeRef, TypeBound, TypeRef},
 };
 
 pub(super) use lower_use::lower_use_tree;
@@ -170,8 +170,14 @@ pub(super) fn lower_generic_args(
                     bindings.push(AssociatedTypeBinding { name, type_ref, bounds });
                 }
             }
-            // Lifetimes and constants are ignored for now.
-            ast::GenericArg::LifetimeArg(_) | ast::GenericArg::ConstArg(_) => (),
+            ast::GenericArg::LifetimeArg(lifetime_arg) => {
+                if let Some(lifetime) = lifetime_arg.lifetime_token() {
+                    let lifetime_ref = LifetimeRef::from_token(lifetime);
+                    args.push(GenericArg::Lifetime(lifetime_ref))
+                }
+            }
+            // constants are ignored for now.
+            ast::GenericArg::ConstArg(_) => (),
         }
     }
 

--- a/crates/hir_expand/src/name.rs
+++ b/crates/hir_expand/src/name.rs
@@ -38,7 +38,7 @@ impl Name {
     }
 
     pub fn new_lifetime(lt: &syntax::SyntaxToken) -> Name {
-        assert!(lt.kind() == syntax::SyntaxKind::LIFETIME);
+        assert_eq!(lt.kind(), syntax::SyntaxKind::LIFETIME);
         Name(Repr::Text(lt.text().clone()))
     }
 
@@ -250,6 +250,8 @@ pub mod known {
     pub const SELF_PARAM: super::Name = super::Name::new_inline("self");
     pub const SELF_TYPE: super::Name = super::Name::new_inline("Self");
 
+    pub const STATIC_LIFETIME: super::Name = super::Name::new_inline("'static");
+
     #[macro_export]
     macro_rules! name {
         (self) => {
@@ -257,6 +259,9 @@ pub mod known {
         };
         (Self) => {
             $crate::name::known::SELF_TYPE
+        };
+        ('static) => {
+            $crate::name::known::STATIC_LIFETIME
         };
         ($ident:ident) => {
             $crate::name::known::$ident

--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -4,7 +4,7 @@ use std::fmt;
 
 use crate::{
     db::HirDatabase, utils::generics, ApplicationTy, CallableDefId, FnSig, GenericPredicate,
-    Obligation, OpaqueTyId, ProjectionTy, Substs, TraitRef, Ty, TypeCtor,
+    Lifetime, Obligation, OpaqueTyId, ProjectionTy, Substs, TraitRef, Ty, TypeCtor,
 };
 use hir_def::{
     find_path, generics::TypeParamProvenance, item_scope::ItemInNs, AdtId, AssocContainerId,
@@ -707,6 +707,19 @@ impl HirDisplay for GenericPredicate {
             GenericPredicate::Error => write!(f, "{{error}}")?,
         }
         Ok(())
+    }
+}
+
+impl HirDisplay for Lifetime {
+    fn hir_fmt(&self, f: &mut HirFormatter) -> Result<(), HirDisplayError> {
+        match self {
+            Lifetime::Parameter(id) => {
+                let generics = generics(f.db.upcast(), id.parent);
+                let param_data = &generics.params.lifetimes[id.local_id];
+                write!(f, "{}", &param_data.name)
+            }
+            Lifetime::Static => write!(f, "'static"),
+        }
     }
 }
 

--- a/crates/hir_ty/src/infer/expr.rs
+++ b/crates/hir_ty/src/infer/expr.rs
@@ -848,6 +848,7 @@ impl<'a> InferenceContext<'a> {
                         let ty = self.make_ty(type_ref);
                         substs.push(ty);
                     }
+                    GenericArg::Lifetime(_) => {}
                 }
             }
         };

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -29,8 +29,8 @@ use base_db::{salsa, CrateId};
 use hir_def::{
     expr::ExprId,
     type_ref::{Mutability, Rawness},
-    AdtId, AssocContainerId, DefWithBodyId, GenericDefId, HasModule, Lookup, TraitId, TypeAliasId,
-    TypeParamId,
+    AdtId, AssocContainerId, DefWithBodyId, GenericDefId, HasModule, LifetimeParamId, Lookup,
+    TraitId, TypeAliasId, TypeParamId,
 };
 use itertools::Itertools;
 
@@ -51,6 +51,12 @@ pub use lower::{
 pub use traits::{InEnvironment, Obligation, ProjectionPredicate, TraitEnvironment};
 
 pub use chalk_ir::{BoundVar, DebruijnIndex};
+
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
+pub enum Lifetime {
+    Parameter(LifetimeParamId),
+    Static,
+}
 
 /// A type constructor or type name: this might be something like the primitive
 /// type `bool`, a struct like `Vec`, or things like function pointers or

--- a/crates/hir_ty/src/utils.rs
+++ b/crates/hir_ty/src/utils.rs
@@ -2,11 +2,10 @@
 //! query, but can't be computed directly from `*Data` (ie, which need a `db`).
 use std::sync::Arc;
 
-use hir_def::generics::WherePredicateTarget;
 use hir_def::{
     adt::VariantData,
     db::DefDatabase,
-    generics::{GenericParams, TypeParamData, TypeParamProvenance},
+    generics::{GenericParams, TypeParamData, TypeParamProvenance, WherePredicateTypeTarget},
     path::Path,
     resolver::{HasResolver, TypeNs},
     type_ref::TypeRef,
@@ -27,14 +26,19 @@ fn direct_super_traits(db: &dyn DefDatabase, trait_: TraitId) -> Vec<TraitId> {
     generic_params
         .where_predicates
         .iter()
-        .filter_map(|pred| match &pred.target {
-            WherePredicateTarget::TypeRef(TypeRef::Path(p)) if p == &Path::from(name![Self]) => {
-                pred.bound.as_path()
-            }
-            WherePredicateTarget::TypeParam(local_id) if Some(*local_id) == trait_self => {
-                pred.bound.as_path()
-            }
-            _ => None,
+        .filter_map(|pred| match pred {
+            hir_def::generics::WherePredicate::TypeBound { target, bound } => match target {
+                WherePredicateTypeTarget::TypeRef(TypeRef::Path(p))
+                    if p == &Path::from(name![Self]) =>
+                {
+                    bound.as_path()
+                }
+                WherePredicateTypeTarget::TypeParam(local_id) if Some(*local_id) == trait_self => {
+                    bound.as_path()
+                }
+                _ => None,
+            },
+            hir_def::generics::WherePredicate::Lifetime { .. } => None,
         })
         .filter_map(|path| match resolver.resolve_path_in_type_ns_fully(db, path.mod_path()) {
             Some(TypeNs::TraitId(t)) => Some(t),


### PR DESCRIPTION
This doesn't handle resolve yet as I don't know yet how that will be used. I'll get to that once I start moving the lifetime reference PR to the hir.

This also adds a new `hir` name type for lifetimes and labels, `hir::LifetimeName`.