### PR TITLE
Read version of rustc that compiled proc macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.23.0",
+ "object",
  "rustc-demangle",
 ]
 
@@ -892,6 +892,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
+name = "memmap"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "memmap2"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,16 +1016,6 @@ checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
  "libc",
-]
-
-[[package]]
-name = "object"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
-dependencies = [
- "flate2",
- "wasmparser",
 ]
 
 [[package]]
@@ -1164,7 +1164,8 @@ dependencies = [
  "crossbeam-channel",
  "jod-thread",
  "log",
- "object 0.22.0",
+ "memmap",
+ "object",
  "serde",
  "serde_json",
  "snap",
@@ -1180,7 +1181,7 @@ dependencies = [
  "libloading",
  "mbe",
  "memmap2",
- "object 0.23.0",
+ "object",
  "proc_macro_api",
  "proc_macro_test",
  "serde_derive",
@@ -1897,12 +1898,6 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasmparser"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32fddd575d477c6e9702484139cf9f23dcd554b06d185ed0f56c857dd3a47aa6"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.23.0",
  "rustc-demangle",
 ]
 
@@ -1010,6 +1010,16 @@ dependencies = [
 
 [[package]]
 name = "object"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
+dependencies = [
+ "flate2",
+ "wasmparser",
+]
+
+[[package]]
+name = "object"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
@@ -1154,8 +1164,10 @@ dependencies = [
  "crossbeam-channel",
  "jod-thread",
  "log",
+ "object 0.22.0",
  "serde",
  "serde_json",
+ "snap",
  "stdx",
  "tt",
 ]
@@ -1168,7 +1180,7 @@ dependencies = [
  "libloading",
  "mbe",
  "memmap2",
- "object",
+ "object 0.23.0",
  "proc_macro_api",
  "proc_macro_test",
  "serde_derive",
@@ -1541,6 +1553,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "snap"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc725476a1398f0480d56cd0ad381f6f32acf2642704456f8f59a35df464b59a"
+
+[[package]]
 name = "socket2"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1879,6 +1897,12 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasmparser"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32fddd575d477c6e9702484139cf9f23dcd554b06d185ed0f56c857dd3a47aa6"
 
 [[package]]
 name = "winapi"

--- a/crates/proc_macro_api/Cargo.toml
+++ b/crates/proc_macro_api/Cargo.toml
@@ -21,3 +21,4 @@ base_db = { path = "../base_db", version = "0.0.0" }
 stdx = { path = "../stdx", version = "0.0.0" }
 snap = "1"
 object = { version = "0.23.0", default-features = false, features = ["std", "read_core", "elf", "macho", "pe", "unaligned"] }
+memmap = "0.7.0"

--- a/crates/proc_macro_api/Cargo.toml
+++ b/crates/proc_macro_api/Cargo.toml
@@ -19,3 +19,5 @@ jod-thread = "0.1.1"
 tt = { path = "../tt", version = "0.0.0" }
 base_db = { path = "../base_db", version = "0.0.0" }
 stdx = { path = "../stdx", version = "0.0.0" }
+snap = "1"
+object = "0.22.0"

--- a/crates/proc_macro_api/Cargo.toml
+++ b/crates/proc_macro_api/Cargo.toml
@@ -20,4 +20,4 @@ tt = { path = "../tt", version = "0.0.0" }
 base_db = { path = "../base_db", version = "0.0.0" }
 stdx = { path = "../stdx", version = "0.0.0" }
 snap = "1"
-object = "0.22.0"
+object = { version = "0.23.0", default-features = false, features = ["std", "read_core", "elf", "macho", "pe", "unaligned"] }

--- a/crates/proc_macro_api/src/lib.rs
+++ b/crates/proc_macro_api/src/lib.rs
@@ -155,7 +155,7 @@ impl ProcMacroClient {
         let header = &dot_rustc[..8];
         const EXPECTED_HEADER: [u8; 8] = [b'r', b'u', b's', b't', 0, 0, 0, 5];
         // check if header is valid
-        if !(header == EXPECTED_HEADER) {
+        if header != EXPECTED_HEADER {
             return Err(io::Error::new(io::ErrorKind::InvalidData, format!(".rustc section should start with header {:?}; header {:?} is actually presented.",EXPECTED_HEADER ,header)));
         }
 

--- a/crates/proc_macro_api/src/lib.rs
+++ b/crates/proc_macro_api/src/lib.rs
@@ -76,10 +76,7 @@ impl ProcMacroClient {
         args: impl IntoIterator<Item = impl AsRef<OsStr>>,
     ) -> io::Result<ProcMacroClient> {
         let (thread, process) = ProcMacroProcessSrv::run(process_path, args)?;
-        Ok(ProcMacroClient {
-            process: Arc::new(process),
-            thread,
-        })
+        Ok(ProcMacroClient { process: Arc::new(process), thread })
     }
 
     pub fn by_dylib_path(&self, dylib_path: &Path) -> Vec<ProcMacro> {
@@ -106,11 +103,7 @@ impl ProcMacroClient {
                     dylib_path: dylib_path.into(),
                 });
 
-                ProcMacro {
-                    name,
-                    kind,
-                    expander,
-                }
+                ProcMacro { name, kind, expander }
             })
             .collect()
     }
@@ -156,7 +149,10 @@ impl ProcMacroClient {
         const EXPECTED_HEADER: [u8; 8] = [b'r', b'u', b's', b't', 0, 0, 0, 5];
         // check if header is valid
         if header != EXPECTED_HEADER {
-            return Err(io::Error::new(io::ErrorKind::InvalidData, format!(".rustc section should start with header {:?}; header {:?} is actually presented.",EXPECTED_HEADER ,header)));
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("only metadata version 5 is supported, section header was: {:?}", header),
+            ));
         }
 
         let snappy_portion = &dot_rustc[8..];

--- a/crates/proc_macro_api/src/lib.rs
+++ b/crates/proc_macro_api/src/lib.rs
@@ -5,16 +5,11 @@
 //! is used to provide basic infrastructure for communication between two
 //! processes: Client (RA itself), Server (the external program)
 
-mod rpc;
-mod process;
 pub mod msg;
+mod process;
+mod rpc;
 
-use std::{
-    ffi::OsStr,
-    io,
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::{ffi::OsStr, fs::read as fsread, io::{self, Read}, path::{Path, PathBuf}, sync::Arc};
 
 use base_db::{Env, ProcMacro};
 use tt::{SmolStr, Subtree};
@@ -22,6 +17,9 @@ use tt::{SmolStr, Subtree};
 use crate::process::{ProcMacroProcessSrv, ProcMacroProcessThread};
 
 pub use rpc::{ExpansionResult, ExpansionTask, ListMacrosResult, ListMacrosTask, ProcMacroKind};
+
+use object::read::{File as BinaryFile, Object, ObjectSection};
+use snap::read::FrameDecoder as SnapDecoder;
 
 #[derive(Debug, Clone)]
 struct ProcMacroProcessExpander {
@@ -71,7 +69,10 @@ impl ProcMacroClient {
         args: impl IntoIterator<Item = impl AsRef<OsStr>>,
     ) -> io::Result<ProcMacroClient> {
         let (thread, process) = ProcMacroProcessSrv::run(process_path, args)?;
-        Ok(ProcMacroClient { process: Arc::new(process), thread })
+        Ok(ProcMacroClient {
+            process: Arc::new(process),
+            thread,
+        })
     }
 
     pub fn by_dylib_path(&self, dylib_path: &Path) -> Vec<ProcMacro> {
@@ -98,8 +99,69 @@ impl ProcMacroClient {
                     dylib_path: dylib_path.into(),
                 });
 
-                ProcMacro { name, kind, expander }
+                ProcMacro {
+                    name,
+                    kind,
+                    expander,
+                }
             })
             .collect()
+    }
+
+    // This is used inside self.read_version() to locate the ".rustc" section
+    // from a proc macro crate's binary file.
+    fn read_section<'a>(&self, dylib_binary: &'a [u8], section_name: &str) -> &'a [u8] {
+        BinaryFile::parse(dylib_binary)
+            .unwrap()
+            .section_by_name(section_name)
+            .unwrap()
+            .data()
+            .unwrap()
+    }
+
+    // Check the version of rustc that was used to compile a proc macro crate's
+    // binary file.
+    // A proc macro crate binary's ".rustc" section has following byte layout:
+    // * [b'r',b'u',b's',b't',0,0,0,5] is the first 8 bytes
+    // * ff060000 734e6150 is followed, it's the snappy format magic bytes,
+    //   means bytes from here(including this sequence) are compressed in
+    //   snappy compression format. Version info is here inside, so decompress
+    //   this.
+    // The bytes you get after decompressing the snappy format portion has
+    // following layout:
+    // * [b'r',b'u',b's',b't',0,0,0,5] is the first 8 bytes(again)
+    // * [crate root bytes] next 4 bytes is to store crate root position,
+    //   according to rustc's source code comment
+    // * [length byte] next 1 byte tells us how many bytes we should read next
+    //   for the version string's utf8 bytes
+    // * [version string bytes encoded in utf8] <- GET THIS BOI
+    // * [some more bytes that we don really care but still there] :-)
+    // Check this issue for more about the bytes layout:
+    // https://github.com/rust-analyzer/rust-analyzer/issues/6174
+    fn read_version(&self, dylib_path: &Path) -> String {
+        let dylib_binary = fsread(dylib_path).unwrap();
+
+        let dot_rustc = self.read_section(&dylib_binary, ".rustc");
+
+        let snappy_portion = &dot_rustc[8..];
+
+        let mut snappy_decoder = SnapDecoder::new(snappy_portion);
+
+        // the bytes before version string bytes, so this basically is:
+        // 8 bytes for [b'r',b'u',b's',b't',0,0,0,5]
+        // 4 bytes for [crate root bytes]
+        // 1 byte for length of version string
+        // so 13 bytes in total, and we should check the 13th byte
+        // to know the length
+        let mut bytes_before_version = [0u8; 13];
+        snappy_decoder
+            .read_exact(&mut bytes_before_version)
+            .unwrap();
+        let length = bytes_before_version[12]; // what? can't use -1 indexing?
+
+        let mut version_string_utf8 = vec![0u8; length as usize];
+        snappy_decoder.read_exact(&mut version_string_utf8).unwrap();
+        let version_string = String::from_utf8(version_string_utf8).unwrap();
+        version_string
     }
 }

--- a/crates/proc_macro_api/src/lib.rs
+++ b/crates/proc_macro_api/src/lib.rs
@@ -132,7 +132,7 @@ impl ProcMacroClient {
     // * [b'r',b'u',b's',b't',0,0,0,5] is the first 8 bytes
     // * ff060000 734e6150 is followed, it's the snappy format magic bytes,
     //   means bytes from here(including this sequence) are compressed in
-    //   snappy compression format. Version info is here inside, so decompress
+    //   snappy compression format. Version info is inside here, so decompress
     //   this.
     // The bytes you get after decompressing the snappy format portion has
     // following layout:

--- a/crates/proc_macro_api/src/version.rs
+++ b/crates/proc_macro_api/src/version.rs
@@ -1,0 +1,131 @@
+//! Reading proc-macro rustc version information from binary data
+
+use std::{
+    fs::File,
+    io::{self, Read},
+    path::Path,
+};
+
+use memmap::Mmap;
+use object::read::{File as BinaryFile, Object, ObjectSection};
+use snap::read::FrameDecoder as SnapDecoder;
+
+#[derive(Debug)]
+pub(crate) struct RustCInfo {
+    pub(crate) version: (usize, usize, usize),
+    pub(crate) channel: String,
+    pub(crate) commit: String,
+    pub(crate) date: String,
+}
+
+pub(crate) fn read_info(dylib_path: &Path) -> io::Result<RustCInfo> {
+    macro_rules! err {
+        ($e:literal) => {
+            io::Error::new(io::ErrorKind::InvalidData, $e)
+        };
+    }
+
+    let ver_str = read_version(dylib_path)?;
+    let mut items = ver_str.split_whitespace();
+    let tag = items.next().ok_or(err!("version format error"))?;
+    if tag != "rustc" {
+        return Err(err!("version format error (No rustc tag)"));
+    }
+
+    let version_part = items.next().ok_or(err!("no version string"))?;
+    let mut version_parts = version_part.split("-");
+    let version = version_parts.next().ok_or(err!("no version"))?;
+    let channel = version_parts.next().unwrap_or_default().to_string();
+
+    let commit = items.next().ok_or(err!("no commit info"))?;
+    // remove (
+    if commit.len() == 0 {
+        return Err(err!("commit format error"));
+    }
+    let commit = commit[1..].to_string();
+    let date = items.next().ok_or(err!("no date info"))?;
+    // remove )
+    if date.len() == 0 {
+        return Err(err!("date format error"));
+    }
+    let date = date[0..date.len() - 2].to_string();
+
+    let version_numbers = version
+        .split(".")
+        .map(|it| it.parse::<usize>())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|_| err!("version number error"))?;
+
+    if version_numbers.len() != 3 {
+        return Err(err!("version number format error"));
+    }
+    let version = (version_numbers[0], version_numbers[1], version_numbers[2]);
+
+    Ok(RustCInfo { version, channel, commit, date })
+}
+
+// This is used inside read_version() to locate the ".rustc" section
+// from a proc macro crate's binary file.
+fn read_section<'a>(dylib_binary: &'a [u8], section_name: &str) -> io::Result<&'a [u8]> {
+    BinaryFile::parse(dylib_binary)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
+        .section_by_name(section_name)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "section read error"))?
+        .data()
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+}
+
+// Check the version of rustc that was used to compile a proc macro crate's
+// binary file.
+// A proc macro crate binary's ".rustc" section has following byte layout:
+// * [b'r',b'u',b's',b't',0,0,0,5] is the first 8 bytes
+// * ff060000 734e6150 is followed, it's the snappy format magic bytes,
+//   means bytes from here(including this sequence) are compressed in
+//   snappy compression format. Version info is inside here, so decompress
+//   this.
+// The bytes you get after decompressing the snappy format portion has
+// following layout:
+// * [b'r',b'u',b's',b't',0,0,0,5] is the first 8 bytes(again)
+// * [crate root bytes] next 4 bytes is to store crate root position,
+//   according to rustc's source code comment
+// * [length byte] next 1 byte tells us how many bytes we should read next
+//   for the version string's utf8 bytes
+// * [version string bytes encoded in utf8] <- GET THIS BOI
+// * [some more bytes that we don really care but still there] :-)
+// Check this issue for more about the bytes layout:
+// https://github.com/rust-analyzer/rust-analyzer/issues/6174
+fn read_version(dylib_path: &Path) -> io::Result<String> {
+    let dylib_file = File::open(dylib_path)?;
+    let dylib_mmaped = unsafe { Mmap::map(&dylib_file) }?;
+
+    let dot_rustc = read_section(&dylib_mmaped, ".rustc")?;
+
+    let header = &dot_rustc[..8];
+    const EXPECTED_HEADER: [u8; 8] = [b'r', b'u', b's', b't', 0, 0, 0, 5];
+    // check if header is valid
+    if header != EXPECTED_HEADER {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("only metadata version 5 is supported, section header was: {:?}", header),
+        ));
+    }
+
+    let snappy_portion = &dot_rustc[8..];
+
+    let mut snappy_decoder = SnapDecoder::new(snappy_portion);
+
+    // the bytes before version string bytes, so this basically is:
+    // 8 bytes for [b'r',b'u',b's',b't',0,0,0,5]
+    // 4 bytes for [crate root bytes]
+    // 1 byte for length of version string
+    // so 13 bytes in total, and we should check the 13th byte
+    // to know the length
+    let mut bytes_before_version = [0u8; 13];
+    snappy_decoder.read_exact(&mut bytes_before_version)?;
+    let length = bytes_before_version[12]; // what? can't use -1 indexing?
+
+    let mut version_string_utf8 = vec![0u8; length as usize];
+    snappy_decoder.read_exact(&mut version_string_utf8)?;
+    let version_string = String::from_utf8(version_string_utf8);
+    version_string.map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+}

--- a/crates/proc_macro_api/src/version.rs
+++ b/crates/proc_macro_api/src/version.rs
@@ -64,8 +64,8 @@ pub(crate) fn read_info(dylib_path: &Path) -> io::Result<RustCInfo> {
     Ok(RustCInfo { version, channel, commit, date })
 }
 
-// This is used inside read_version() to locate the ".rustc" section
-// from a proc macro crate's binary file.
+/// This is used inside read_version() to locate the ".rustc" section
+/// from a proc macro crate's binary file.
 fn read_section<'a>(dylib_binary: &'a [u8], section_name: &str) -> io::Result<&'a [u8]> {
     BinaryFile::parse(dylib_binary)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
@@ -75,25 +75,26 @@ fn read_section<'a>(dylib_binary: &'a [u8], section_name: &str) -> io::Result<&'
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
 }
 
-// Check the version of rustc that was used to compile a proc macro crate's
-// binary file.
-// A proc macro crate binary's ".rustc" section has following byte layout:
-// * [b'r',b'u',b's',b't',0,0,0,5] is the first 8 bytes
-// * ff060000 734e6150 is followed, it's the snappy format magic bytes,
-//   means bytes from here(including this sequence) are compressed in
-//   snappy compression format. Version info is inside here, so decompress
-//   this.
-// The bytes you get after decompressing the snappy format portion has
-// following layout:
-// * [b'r',b'u',b's',b't',0,0,0,5] is the first 8 bytes(again)
-// * [crate root bytes] next 4 bytes is to store crate root position,
-//   according to rustc's source code comment
-// * [length byte] next 1 byte tells us how many bytes we should read next
-//   for the version string's utf8 bytes
-// * [version string bytes encoded in utf8] <- GET THIS BOI
-// * [some more bytes that we don really care but still there] :-)
-// Check this issue for more about the bytes layout:
-// https://github.com/rust-analyzer/rust-analyzer/issues/6174
+/// Check the version of rustc that was used to compile a proc macro crate's
+///
+/// binary file.
+/// A proc macro crate binary's ".rustc" section has following byte layout:
+/// * [b'r',b'u',b's',b't',0,0,0,5] is the first 8 bytes
+/// * ff060000 734e6150 is followed, it's the snappy format magic bytes,
+///   means bytes from here(including this sequence) are compressed in
+///   snappy compression format. Version info is inside here, so decompress
+///   this.
+/// The bytes you get after decompressing the snappy format portion has
+/// following layout:
+/// * [b'r',b'u',b's',b't',0,0,0,5] is the first 8 bytes(again)
+/// * [crate root bytes] next 4 bytes is to store crate root position,
+///   according to rustc's source code comment
+/// * [length byte] next 1 byte tells us how many bytes we should read next
+///   for the version string's utf8 bytes
+/// * [version string bytes encoded in utf8] <- GET THIS BOI
+/// * [some more bytes that we don really care but still there] :-)
+/// Check this issue for more about the bytes layout:
+/// https://github.com/rust-analyzer/rust-analyzer/issues/6174
 fn read_version(dylib_path: &Path) -> io::Result<String> {
     let dylib_file = File::open(dylib_path)?;
     let dylib_mmaped = unsafe { Mmap::map(&dylib_file) }?;


### PR DESCRIPTION
Signed-off-by: Jay Somedon <jay.somedon@outlook.com>

This PR is to fix #6174.

I basically
* added two methods, `read_version` and `read_section`(used by `read_version`)
* two new crates `snap` and `object` to be used by those two methods

I just noticed that some part of code were auto-reformatted by rust-analyzer on file save. Does it matter?