### PR TITLE
Don't highlight parent nodes of comments on hover

### DIFF
--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -139,6 +139,11 @@ pub(crate) fn hover(
         }
     }
 
+    if token.kind() == syntax::SyntaxKind::COMMENT {
+        // don't highlight the entire parent node on comment hover
+        return None;
+    }
+
     let node = token.ancestors().find(|n| {
         ast::Expr::can_cast(n.kind())
             || ast::Pat::can_cast(n.kind())
@@ -3417,6 +3422,17 @@ mod Foo<|> {
                 Be quick;
                 time is mana
             "#]],
+        );
+    }
+
+    #[test]
+    fn hover_comments_dont_highlight_parent() {
+        check_hover_no_result(
+            r#"
+fn no_hover() {
+    // no<|>hover
+}
+"#,
         );
     }
 }


### PR DESCRIPTION
Fixes #6815