### PR TITLE
Revert "Fix memory usage metrics"

### DIFF
--- a/xtask/src/metrics.rs
+++ b/xtask/src/metrics.rs
@@ -81,9 +81,7 @@ impl Metrics {
     }
     fn measure_analysis_stats_path(&mut self, name: &str, path: &str) -> Result<()> {
         eprintln!("\nMeasuring analysis-stats/{}", name);
-        let output =
-            cmd!("./target/release/rust-analyzer analysis-stats --quiet --memory-usage {path}")
-                .read()?;
+        let output = cmd!("./target/release/rust-analyzer analysis-stats --quiet {path}").read()?;
         for (metric, value, unit) in parse_metrics(&output) {
             self.report(&format!("analysis-stats/{}/{}", name, metric), value, unit.into());
         }


### PR DESCRIPTION
Reverts rust-analyzer/rust-analyzer#6825

It broke metrics entirely. Will debug this later, unless someone else gets to it first.

bors r+