### PR TITLE
Use Attrs::docs in runnables instead of DocCommentsOwner

### DIFF
--- a/crates/hir_def/src/attr.rs
+++ b/crates/hir_def/src/attr.rs
@@ -32,9 +32,9 @@ impl Documentation {
     }
 }
 
-impl Into<String> for Documentation {
-    fn into(self) -> String {
-        self.0
+impl From<Documentation> for String {
+    fn from(Documentation(string): Documentation) -> Self {
+        string
     }
 }
 


### PR DESCRIPTION
I figured that we should probably move as much of the doc usage to the HIR as possible hence this PR. If we should keep this AST-based feel free to close.

This change does have the nice(but not really useful as I doubt anyones gonna write doc tests like these) side effect that these two doc string snippets allow being run now.
![image](https://user-images.githubusercontent.com/3757771/101945607-bf241400-3bee-11eb-96ce-ccae80028b1f.png)
![image](https://user-images.githubusercontent.com/3757771/101946375-2e9a0380-3bef-11eb-9950-e35168fdd048.png)
