### PR TITLE
Use Attrs::docs in NavigationTarget instead of DocCommentsOwner

### DIFF
--- a/crates/hir_def/src/attr.rs
+++ b/crates/hir_def/src/attr.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 
 /// Holds documentation
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Documentation(String);
 
 impl Documentation {


### PR DESCRIPTION
That should be the last place where the AST comment machinery is referred to.