### PR TITLE
Add a language configuration file for VS Code

### DIFF
--- a/editors/code/language-configuration.json
+++ b/editors/code/language-configuration.json
@@ -1,0 +1,38 @@
+{
+    "comments": {
+        "lineComment": "//",
+        "blockComment": [ "/*", "*/" ]
+    },
+    "brackets": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["<", ">"]
+    ],
+    "autoClosingPairs": [
+        { "open": "{", "close": "}" },
+        { "open": "[", "close": "]" },
+        { "open": "(", "close": ")" },
+        { "open": "\"", "close": "\"", "notIn": ["string"] },
+        { "open": "/*", "close": " */" }
+    ],
+    "autoCloseBefore": ";:.,=}])> \n\t",
+    "surroundingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["<", ">"],
+        ["\"", "\""],
+        ["'", "'"]
+    ],
+    "indentationRules": {
+        "increaseIndentPattern": "^.*\\{[^}\"']*$|^.*\\([^\\)\"']*$",
+        "decreaseIndentPattern": "^\\s*(\\s*\\/[*].*[*]\\/\\s*)*[})]"
+    },
+    "folding": {
+        "markers": {
+            "start": "^\\s*//\\s*#?region\\b",
+            "end": "^\\s*//\\s*#?endregion\\b"
+        }
+    }
+}

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -734,6 +734,17 @@
                 "extensions": [
                     ".rast"
                 ]
+            },
+            {
+                "id": "rust",
+                "extensions": [
+                    ".rs"
+                ],
+                "aliases": [
+                    "Rust",
+                    "rs"
+                ],
+                "configuration": "language-configuration.json"
             }
         ],
         "grammars": [


### PR DESCRIPTION
There has been recent discussion in #6451 and #6682 about the need to include angle brackets in auto-close and auto-surround functionality. This PR will accomplish that, but only for users of VS Code, as it uses the VS Code-specific `language-configuration.json` to get the job done. Since there are a large number of VS Code users in the Rust Analyzer cohort, it may be reasonable to fix the issue for them, while waiting on a more comprehensive solution in the language server. In addition to the usual brackets, I've added auto-closing of block comments. I avoided autoclosing single quotes, given that lifetimes are more common than chars.