### PR TITLE
Don't HirDisplay unknown types when displaying for source

### DIFF
--- a/crates/assists/src/handlers/add_missing_impl_members.rs
+++ b/crates/assists/src/handlers/add_missing_impl_members.rs
@@ -784,4 +784,29 @@ impl Test for () {
 "#,
         )
     }
+
+    #[test]
+    fn missing_generic_type() {
+        check_assist(
+            add_missing_impl_members,
+            r#"
+trait Foo<BAR> {
+    fn foo(&self, bar: BAR);
+}
+impl Foo for () {
+    <|>
+}
+"#,
+            r#"
+trait Foo<BAR> {
+    fn foo(&self, bar: BAR);
+}
+impl Foo for () {
+    fn foo(&self, bar: BAR) {
+        ${0:todo!()}
+    }
+}
+"#,
+        )
+    }
 }

--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -178,6 +178,7 @@ impl DisplayTarget {
 #[derive(Debug)]
 pub enum DisplaySourceCodeError {
     PathNotFound,
+    UnknownType,
 }
 
 pub enum HirDisplayError {
@@ -558,7 +559,14 @@ impl HirDisplay for Ty {
                     }
                 };
             }
-            Ty::Unknown => write!(f, "{{unknown}}")?,
+            Ty::Unknown => {
+                if f.display_target.is_source_code() {
+                    return Err(HirDisplayError::DisplaySourceCodeError(
+                        DisplaySourceCodeError::UnknownType,
+                    ));
+                }
+                write!(f, "{{unknown}}")?;
+            }
             Ty::Infer(..) => write!(f, "_")?,
         }
         Ok(())


### PR DESCRIPTION
Was wondering why the add missing impl assist didn't do anything here:
![Code_JCA1Qo0V9P](https://user-images.githubusercontent.com/3757771/101990300-7af44a80-3ca6-11eb-8431-e5eb4de4e78c.png)
Turns out me forgetting to set the Index::Idx type in the trait causes RA to panic due to it trying to to create an unparsable type in the `make` module.
Now we get this instead which imo is definitely better to have.
![Code_MUFPJUCULY](https://user-images.githubusercontent.com/3757771/101990347-c9094e00-3ca6-11eb-9c6a-146bddf64b7c.png)

