### PR TITLE
"Add reference here" diagnostic

### DIFF
--- a/crates/hir/src/diagnostics.rs
+++ b/crates/hir/src/diagnostics.rs
@@ -4,6 +4,6 @@ pub use hir_expand::diagnostics::{
     Diagnostic, DiagnosticCode, DiagnosticSink, DiagnosticSinkBuilder,
 };
 pub use hir_ty::diagnostics::{
-    AddReferenceToArg, IncorrectCase, MismatchedArgCount, MissingFields, MissingMatchArms,
+    AddReferenceToInitializer, IncorrectCase, MismatchedArgCount, MissingFields, MissingMatchArms,
     MissingOkInTailExpr, NoSuchField, RemoveThisSemicolon,
 };

--- a/crates/hir/src/diagnostics.rs
+++ b/crates/hir/src/diagnostics.rs
@@ -4,6 +4,6 @@ pub use hir_expand::diagnostics::{
     Diagnostic, DiagnosticCode, DiagnosticSink, DiagnosticSinkBuilder,
 };
 pub use hir_ty::diagnostics::{
-    IncorrectCase, MismatchedArgCount, MissingFields, MissingMatchArms, MissingOkInTailExpr,
-    NoSuchField, RemoveThisSemicolon,
+    AddReferenceToArg, IncorrectCase, MismatchedArgCount, MissingFields, MissingMatchArms,
+    MissingOkInTailExpr, NoSuchField, RemoveThisSemicolon,
 };

--- a/crates/hir_ty/Cargo.toml
+++ b/crates/hir_ty/Cargo.toml
@@ -20,6 +20,7 @@ scoped-tls = "1"
 chalk-solve = { version = "0.43", default-features = false }
 chalk-ir = "0.43"
 chalk-recursive = "0.43"
+once_cell = { version = "1.5.0", features = ["unstable"] }
 
 stdx = { path = "../stdx", version = "0.0.0" }
 hir_def = { path = "../hir_def", version = "0.0.0" }
@@ -35,4 +36,3 @@ expect-test = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.2", default-features = false, features = ["env-filter", "registry"] }
 tracing-tree = { version = "0.1.4" }
-once_cell = { version = "1.5.0", features = ["unstable"] }

--- a/crates/hir_ty/Cargo.toml
+++ b/crates/hir_ty/Cargo.toml
@@ -20,7 +20,6 @@ scoped-tls = "1"
 chalk-solve = { version = "0.43", default-features = false }
 chalk-ir = "0.43"
 chalk-recursive = "0.43"
-once_cell = { version = "1.5.0", features = ["unstable"] }
 
 stdx = { path = "../stdx", version = "0.0.0" }
 hir_def = { path = "../hir_def", version = "0.0.0" }
@@ -36,3 +35,4 @@ expect-test = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.2", default-features = false, features = ["env-filter", "registry"] }
 tracing-tree = { version = "0.1.4" }
+once_cell = { version = "1.5.0", features = ["unstable"] }

--- a/crates/hir_ty/src/diagnostics.rs
+++ b/crates/hir_ty/src/diagnostics.rs
@@ -6,7 +6,7 @@ mod decl_check;
 
 use std::{any::Any, fmt};
 
-use hir_def::{DefWithBodyId, ModuleDefId};
+use hir_def::{type_ref::Mutability, DefWithBodyId, ModuleDefId};
 use hir_expand::diagnostics::{Diagnostic, DiagnosticCode, DiagnosticSink};
 use hir_expand::{name::Name, HirFileId, InFile};
 use stdx::format_to;
@@ -315,6 +315,31 @@ impl Diagnostic for MismatchedArgCount {
     }
     fn is_experimental(&self) -> bool {
         true
+    }
+}
+
+#[derive(Debug)]
+pub struct AddReferenceToArg {
+    pub file: HirFileId,
+    pub arg_expr: AstPtr<ast::Expr>,
+    pub mutability: Mutability,
+}
+
+impl Diagnostic for AddReferenceToArg {
+    fn code(&self) -> DiagnosticCode {
+        DiagnosticCode("add-reference-to-arg")
+    }
+
+    fn message(&self) -> String {
+        "Consider borrowing this argument".to_string()
+    }
+
+    fn display_source(&self) -> InFile<SyntaxNodePtr> {
+        InFile { file_id: self.file, value: self.arg_expr.clone().into() }
+    }
+
+    fn as_any(&self) -> &(dyn Any + Send + 'static) {
+        self
     }
 }
 

--- a/crates/hir_ty/src/diagnostics.rs
+++ b/crates/hir_ty/src/diagnostics.rs
@@ -341,6 +341,10 @@ impl Diagnostic for AddReferenceToInitializer {
     fn as_any(&self) -> &(dyn Any + Send + 'static) {
         self
     }
+
+    fn is_experimental(&self) -> bool {
+        true
+    }
 }
 
 #[derive(Debug)]

--- a/crates/hir_ty/src/diagnostics.rs
+++ b/crates/hir_ty/src/diagnostics.rs
@@ -319,19 +319,19 @@ impl Diagnostic for MismatchedArgCount {
 }
 
 #[derive(Debug)]
-pub struct AddReferenceToArg {
+pub struct AddReferenceToInitializer {
     pub file: HirFileId,
     pub arg_expr: AstPtr<ast::Expr>,
     pub mutability: Mutability,
 }
 
-impl Diagnostic for AddReferenceToArg {
+impl Diagnostic for AddReferenceToInitializer {
     fn code(&self) -> DiagnosticCode {
         DiagnosticCode("add-reference-to-arg")
     }
 
     fn message(&self) -> String {
-        "Consider borrowing this argument".to_string()
+        "Consider borrowing this initializer".to_string()
     }
 
     fn display_source(&self) -> InFile<SyntaxNodePtr> {

--- a/crates/hir_ty/src/diagnostics/expr.rs
+++ b/crates/hir_ty/src/diagnostics/expr.rs
@@ -410,7 +410,7 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
     }
 }
 
-pub fn check_missing_refs(
+fn check_missing_refs(
     infer: &InferenceResult,
     arg: ExprId,
     param: &Ty,

--- a/crates/hir_ty/src/diagnostics/expr.rs
+++ b/crates/hir_ty/src/diagnostics/expr.rs
@@ -221,6 +221,19 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
                 let arg_ty = infer.type_of_expr.get(*arg)?;
 
                 let (arg, mutability) = match (arg_ty.as_reference(), param.as_reference()) {
+                    (
+                        None,
+                        Some((
+                            Ty::Apply(ApplicationTy { ctor: TypeCtor::Slice, parameters }),
+                            mutability,
+                        )),
+                    ) => {
+                        if arg_ty.substs()?.as_single() != parameters.as_single() {
+                            return None;
+                        }
+
+                        Some((arg, mutability))
+                    }
                     (None, Some((referenced_ty, mutability))) if referenced_ty == arg_ty => {
                         Some((arg, mutability))
                     }

--- a/crates/hir_ty/src/diagnostics/expr.rs
+++ b/crates/hir_ty/src/diagnostics/expr.rs
@@ -636,4 +636,46 @@ fn main() {
 "#,
         )
     }
+
+    #[test]
+    fn add_reference_to_int() {
+        check_diagnostics(
+            r#"
+fn main() {
+    test(123);
+       //^^^ Consider borrowing this argument
+}
+
+fn test(arg: &i32) {}
+            "#,
+        )
+    }
+
+    #[test]
+    fn add_mutable_reference_to_int() {
+        check_diagnostics(
+            r#"
+fn main() {
+    test(123);
+       //^^^ Consider borrowing this argument
+}
+
+fn test(arg: &mut i32) {}
+            "#,
+        )
+    }
+
+    #[test]
+    fn add_reference_to_array() {
+        check_diagnostics(
+            r#"
+fn main() {
+    test([1, 2, 3]);
+       //^^^^^^^^^ Consider borrowing this argument
+}
+
+fn test(arg: &[i32]) {}
+            "#,
+        )
+    }
 }

--- a/crates/hir_ty/src/diagnostics/expr.rs
+++ b/crates/hir_ty/src/diagnostics/expr.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 
 use hir_def::{expr::Statement, path::path, resolver::HasResolver, AdtId, DefWithBodyId};
 use hir_expand::diagnostics::DiagnosticSink;
-use once_cell::unsync::Lazy;
 use rustc_hash::FxHashSet;
 use syntax::{ast, AstPtr};
 
@@ -91,14 +90,14 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
         let sink = &mut self.sink;
         let owner = self.owner;
 
-        let source_map = Lazy::new(move || db.body_with_source_map(owner).1);
-
         infer
             .type_mismatches
             .iter()
             .filter_map(|(expr, mismatch)| {
                 let (expr_without_ref, mutability) =
                     check_missing_refs(infer, expr, &mismatch.expected)?;
+
+                let (_, source_map) = db.body_with_source_map(owner);
 
                 Some((source_map.expr_syntax(expr_without_ref).ok()?, mutability))
             })

--- a/crates/hir_ty/src/diagnostics/expr.rs
+++ b/crates/hir_ty/src/diagnostics/expr.rs
@@ -682,7 +682,7 @@ fn main() {
             r#"
 fn main() {
     test(123);
-       //^^^ Consider borrowing this argument
+       //^^^ Consider borrowing this initializer
 }
 
 fn test(arg: &i32) {}
@@ -696,7 +696,7 @@ fn test(arg: &i32) {}
             r#"
 fn main() {
     test(123);
-       //^^^ Consider borrowing this argument
+       //^^^ Consider borrowing this initializer
 }
 
 fn test(arg: &mut i32) {}
@@ -710,7 +710,7 @@ fn test(arg: &mut i32) {}
             r#"
 fn main() {
     test([1, 2, 3]);
-       //^^^^^^^^^ Consider borrowing this argument
+       //^^^^^^^^^ Consider borrowing this initializer
 }
 
 fn test(arg: &[i32]) {}
@@ -724,7 +724,7 @@ fn test(arg: &[i32]) {}
             r#"
 fn main() {
     Test.call_by_ref(123);
-                   //^^^ Consider borrowing this argument
+                   //^^^ Consider borrowing this initializer
 }
 
 struct Test;

--- a/crates/hir_ty/src/diagnostics/expr.rs
+++ b/crates/hir_ty/src/diagnostics/expr.rs
@@ -88,11 +88,13 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
 
         let infer = &self.infer;
         let sink = &mut self.sink;
-        
-        infer.type_mismatches
+
+        infer
+            .type_mismatches
             .iter()
             .filter_map(|(expr, mismatch)| {
-                let (expr_without_ref, mutability) = check_missing_refs(infer, expr, &mismatch.expected)?;
+                let (expr_without_ref, mutability) =
+                    check_missing_refs(infer, expr, &mismatch.expected)?;
 
                 Some((source_map.expr_syntax(expr_without_ref).ok()?, mutability))
             })
@@ -208,7 +210,7 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
 
         let mut param_count = params.len();
         let mut arg_count = args.len();
-        
+
         if arg_count != param_count {
             let (_, source_map) = db.body_with_source_map(self.owner.into());
             if let Ok(source_ptr) = source_map.expr_syntax(call_id) {

--- a/crates/hir_ty/src/diagnostics/expr.rs
+++ b/crates/hir_ty/src/diagnostics/expr.rs
@@ -678,4 +678,22 @@ fn test(arg: &[i32]) {}
             "#,
         )
     }
+
+    #[test]
+    fn add_reference_to_method_call() {
+        check_diagnostics(
+            r#"
+fn main() {
+    Test.call_by_ref(123);
+                   //^^^ Consider borrowing this argument
+}
+
+struct Test;
+
+impl Test {
+    fn call_by_ref(&self, arg: &i32) {}
+}
+            "#,
+        )
+    }
 }

--- a/crates/ide/src/diagnostics.rs
+++ b/crates/ide/src/diagnostics.rs
@@ -134,7 +134,7 @@ pub(crate) fn diagnostics(
         .on::<hir::diagnostics::RemoveThisSemicolon, _>(|d| {
             res.borrow_mut().push(diagnostic_with_fix(d, &sema));
         })
-        .on::<hir::diagnostics::AddReferenceToArg, _>(|d| {
+        .on::<hir::diagnostics::AddReferenceToInitializer, _>(|d| {
             res.borrow_mut().push(diagnostic_with_fix(d, &sema));
         })
         .on::<hir::diagnostics::IncorrectCase, _>(|d| {
@@ -981,6 +981,38 @@ struct Test;
 
 impl Test {
     fn call_by_ref(&self, arg: &i32) {}
+}
+            "#,
+        );
+    }
+
+    #[test]
+    fn test_add_reference_to_let_stmt() {
+        check_fixes(
+            r#"
+fn main() {
+    let test: &i32 = <|>123;
+}
+            "#,
+            r#"
+fn main() {
+    let test: &i32 = &123;
+}
+            "#,
+        );
+    }
+
+    #[test]
+    fn test_add_mutable_reference_to_let_stmt() {
+        check_fixes(
+            r#"
+fn main() {
+    let test: &mut i32 = <|>123;
+}
+            "#,
+            r#"
+fn main() {
+    let test: &mut i32 = &mut 123;
 }
             "#,
         );

--- a/crates/ide/src/diagnostics.rs
+++ b/crates/ide/src/diagnostics.rs
@@ -134,6 +134,9 @@ pub(crate) fn diagnostics(
         .on::<hir::diagnostics::RemoveThisSemicolon, _>(|d| {
             res.borrow_mut().push(diagnostic_with_fix(d, &sema));
         })
+        .on::<hir::diagnostics::AddReferenceToArg, _>(|d| {
+            res.borrow_mut().push(diagnostic_with_fix(d, &sema));
+        })
         .on::<hir::diagnostics::IncorrectCase, _>(|d| {
             res.borrow_mut().push(warning_with_fix(d, &sema));
         })

--- a/crates/ide/src/diagnostics.rs
+++ b/crates/ide/src/diagnostics.rs
@@ -897,4 +897,92 @@ impl TestStruct {
 "#,
         );
     }
+
+    #[test]
+    fn test_add_reference_to_int() {
+        check_fixes(
+            r#"
+fn main() {
+    test(<|>123);
+}
+
+fn test(arg: &i32) {}
+            "#,
+            r#"
+fn main() {
+    test(&123);
+}
+
+fn test(arg: &i32) {}
+            "#,
+        );
+    }
+
+    #[test]
+    fn test_add_mutable_reference_to_int() {
+        check_fixes(
+            r#"
+fn main() {
+    test(<|>123);
+}
+
+fn test(arg: &mut i32) {}
+            "#,
+            r#"
+fn main() {
+    test(&mut 123);
+}
+
+fn test(arg: &mut i32) {}
+            "#,
+        );
+    }
+
+    #[test]
+    fn test_add_reference_to_array() {
+        check_fixes(
+            r#"
+fn main() {
+    test(<|>[1, 2, 3]);
+}
+
+fn test(arg: &[i32]) {}
+            "#,
+            r#"
+fn main() {
+    test(&[1, 2, 3]);
+}
+
+fn test(arg: &[i32]) {}
+            "#,
+        );
+    }
+
+    #[test]
+    fn test_add_reference_to_method_call() {
+        check_fixes(
+            r#"
+fn main() {
+    Test.call_by_ref(<|>123);
+}
+
+struct Test;
+
+impl Test {
+    fn call_by_ref(&self, arg: &i32) {}
+}
+            "#,
+            r#"
+fn main() {
+    Test.call_by_ref(&123);
+}
+
+struct Test;
+
+impl Test {
+    fn call_by_ref(&self, arg: &i32) {}
+}
+            "#,
+        );
+    }
 }

--- a/crates/ide/src/diagnostics/fixes.rs
+++ b/crates/ide/src/diagnostics/fixes.rs
@@ -3,7 +3,7 @@
 use hir::{
     db::AstDatabase,
     diagnostics::{
-        AddReferenceToArg, Diagnostic, IncorrectCase, MissingFields, MissingOkInTailExpr,
+        AddReferenceToInitializer, Diagnostic, IncorrectCase, MissingFields, MissingOkInTailExpr,
         NoSuchField, RemoveThisSemicolon, UnresolvedModule,
     },
     HasSource, HirDisplay, InFile, Mutability, Semantics, VariantDef,
@@ -126,7 +126,7 @@ impl DiagnosticWithFix for RemoveThisSemicolon {
     }
 }
 
-impl DiagnosticWithFix for AddReferenceToArg {
+impl DiagnosticWithFix for AddReferenceToInitializer {
     fn fix(&self, sema: &Semantics<RootDatabase>) -> Option<Fix> {
         let root = sema.db.parse_or_expand(self.file)?;
         let arg_expr = self.arg_expr.to_node(&root);

--- a/crates/ide/src/diagnostics/fixes.rs
+++ b/crates/ide/src/diagnostics/fixes.rs
@@ -136,7 +136,7 @@ impl DiagnosticWithFix for AddReferenceToInitializer {
             Mutability::Mut => format!("&mut {}", arg_expr.syntax()),
         };
 
-        let text_range = arg_expr.syntax().text_range();
+        let text_range = sema.original_range(arg_expr.syntax()).range;
 
         let edit = TextEdit::replace(text_range, arg_with_ref);
         let source_change =


### PR DESCRIPTION
Closes #6814 

- [x] Fix incorrect suggestions in macro calls
```rust
fn main() {
      //^^^ Suggestion somehow got here
    assert!(test(true));
}

fn test(b: &bool) -> bool {
    *b
}
```

- [ ] Decide what to do with substs, if they are unknown
```rust
fn main() {
    // No suggestion here, because types are different
    test(Vec::new());
}

fn test(buf: &mut Vec<i32>) {}
```