### PR TITLE
Change recommendation when source can't be loaded from sysroot

### DIFF
--- a/crates/project_model/src/sysroot.rs
+++ b/crates/project_model/src/sysroot.rs
@@ -143,7 +143,7 @@ fn discover_sysroot_src_dir(current_dir: &AbsPath) -> Result<AbsPathBuf> {
 can't load standard library from sysroot
 {}
 (discovered via `rustc --print sysroot`)
-try running `rustup component add rust-src` or set `RUST_SRC_PATH`",
+try installing the Rust source the same way you installed rustc",
                 sysroot_path.display(),
             )
         })


### PR DESCRIPTION
Since we just tried running `rustup component add`, it doesn't make sense to me to recommend trying that again. If we're reaching this case, it's probably more likely that rustc was installed via package manager, in which case the source should be installed the same way (e.g. if you install the rust-src package on Ubuntu it will install a symlink in the right place to make our sysroot
detection work, and IMO we should get other distributors to do the same if they aren't already).