### PR TITLE
Add !language-configuration.json to .vscodeignore

### DIFF
--- a/editors/code/.vscodeignore
+++ b/editors/code/.vscodeignore
@@ -1,4 +1,5 @@
 **
+!language-configuration.json
 !out/src/main.js
 !package.json
 !package-lock.json


### PR DESCRIPTION
#6840 added a `language-configuration.json` file to `package.json`, but because `.vscodeignore` was not updated, this file was not uploaded when the extension was published, leading to constant errors in the VS Code dev tools console:
```
[Extension Host] stack trace: Error: ENOENT: no such file or directory, open '/Users/-/.vscode/extensions/matklad.rust-analyzer-0.2.416/language-configuration.json'
```