### PR TITLE
Resolve `macro-error` diagnostics on asm & llvm_asm

### DIFF
--- a/crates/hir_expand/src/builtin_macro.rs
+++ b/crates/hir_expand/src/builtin_macro.rs
@@ -95,6 +95,8 @@ register_builtin! {
     // format_args_nl only differs in that it adds a newline in the end,
     // so we use the same stub expansion for now
     (format_args_nl, FormatArgsNl) => format_args_expand,
+    (llvm_asm, LlvmAsm) => asm_expand,
+    (asm, Asm) => asm_expand,
 
     EAGER:
     (compile_error, CompileError) => compile_error_expand,
@@ -267,6 +269,19 @@ fn format_args_expand(
     }.token_trees).collect::<Vec<_>>();
     let expanded = quote! {
         std::fmt::Arguments::new_v1(&[], &[##arg_tts])
+    };
+    ExpandResult::ok(expanded)
+}
+
+fn asm_expand(
+    _db: &dyn AstDatabase,
+    _id: LazyMacroId,
+    _tt: &tt::Subtree,
+) -> ExpandResult<tt::Subtree> {
+    // both asm and llvm_asm don't return anything, so we can expand them to nothing,
+    // for now
+    let expanded = quote! {
+        ()
     };
     ExpandResult::ok(expanded)
 }

--- a/crates/hir_expand/src/name.rs
+++ b/crates/hir_expand/src/name.rs
@@ -199,6 +199,8 @@ pub mod known {
         format_args_nl,
         env,
         option_env,
+        llvm_asm,
+        asm,
         // Builtin derives
         Copy,
         Clone,


### PR DESCRIPTION
We currently stub these out as returning unit.

This fixes spurious RA `macro-error` diagnostics introduced somewhere around 0.2.400 in the following:
```rust
unsafe { asm!(""); llvm_asm!(""); }
```

I'd ideally like to write a unit test for this, but I'm not familiar with where the tests for `hir_expand` are.

Thanks to @edwin0cheng for help on resolving this issue.