### PR TITLE
Basic support for macros 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,7 +1827,9 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "ungrammar"
-version = "1.2.2"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7311ee93faac43aa9da26b043eb244092a29a3078c79af9396f63f800cc3a59a"
 
 [[package]]
 name = "unicase"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,8 +1828,6 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 [[package]]
 name = "ungrammar"
 version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873186a460627379e7e28880a0d33b729c205634f6f021321f50b323235e62d7"
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,4 @@ debug = 0 # Set this to 1 or 2 to get more useful backtraces in debugger.
 # chalk-ir = { path = "../chalk/chalk-ir" }
 # chalk-recursive = { path = "../chalk/chalk-recursive" }
 
-# ungrammar = { path = "../ungrammar" }
+ungrammar = { path = "../ungrammar" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,4 @@ debug = 0 # Set this to 1 or 2 to get more useful backtraces in debugger.
 # chalk-ir = { path = "../chalk/chalk-ir" }
 # chalk-recursive = { path = "../chalk/chalk-recursive" }
 
-ungrammar = { path = "../ungrammar" }
+# ungrammar = { path = "../ungrammar" }

--- a/crates/hir/src/code_model.rs
+++ b/crates/hir/src/code_model.rs
@@ -970,7 +970,7 @@ impl MacroDef {
     /// defines this macro. The reasons for this is that macros are expanded
     /// early, in `hir_expand`, where modules simply do not exist yet.
     pub fn module(self, db: &dyn HirDatabase) -> Option<Module> {
-        let krate = self.id.krate?;
+        let krate = self.id.krate;
         let module_id = db.crate_def_map(krate).root;
         Some(Module::new(Crate { id: krate }, module_id))
     }

--- a/crates/hir/src/has_source.rs
+++ b/crates/hir/src/has_source.rs
@@ -110,8 +110,8 @@ impl HasSource for TypeAlias {
     }
 }
 impl HasSource for MacroDef {
-    type Ast = ast::MacroRules;
-    fn source(self, db: &dyn HirDatabase) -> InFile<ast::MacroRules> {
+    type Ast = ast::Macro;
+    fn source(self, db: &dyn HirDatabase) -> InFile<ast::Macro> {
         InFile {
             file_id: self.id.ast_id.expect("MacroDef without ast_id").file_id,
             value: self.id.ast_id.expect("MacroDef without ast_id").to_node(db.upcast()),

--- a/crates/hir/src/semantics/source_to_def.rs
+++ b/crates/hir/src/semantics/source_to_def.rs
@@ -158,7 +158,7 @@ impl SourceToDefCtx<'_, '_> {
         let krate = self.file_to_def(file_id)?.krate;
         let file_ast_id = self.db.ast_id_map(src.file_id).ast_id(&src.value);
         let ast_id = Some(AstId::new(src.file_id, file_ast_id.upcast()));
-        Some(MacroDefId { krate: Some(krate), ast_id, kind, local_inner: false })
+        Some(MacroDefId { krate, ast_id, kind, local_inner: false })
     }
 
     pub(super) fn find_container(&mut self, src: InFile<&SyntaxNode>) -> Option<ChildContainer> {

--- a/crates/hir/src/semantics/source_to_def.rs
+++ b/crates/hir/src/semantics/source_to_def.rs
@@ -157,7 +157,7 @@ impl SourceToDefCtx<'_, '_> {
         let file_id = src.file_id.original_file(self.db.upcast());
         let krate = self.file_to_def(file_id)?.krate;
         let file_ast_id = self.db.ast_id_map(src.file_id).ast_id(&src.value);
-        let ast_id = Some(AstId::new(src.file_id, file_ast_id));
+        let ast_id = Some(AstId::new(src.file_id, file_ast_id.upcast()));
         Some(MacroDefId { krate: Some(krate), ast_id, kind, local_inner: false })
     }
 

--- a/crates/hir_def/src/body/lower.rs
+++ b/crates/hir_def/src/body/lower.rs
@@ -772,7 +772,10 @@ impl ExprCollector<'_> {
                     | ast::Item::Module(_)
                     | ast::Item::MacroCall(_) => return None,
                     ast::Item::MacroRules(def) => {
-                        return Some(Either::Right(def));
+                        return Some(Either::Right(ast::Macro::from(def)));
+                    }
+                    ast::Item::MacroDef(def) => {
+                        return Some(Either::Right(ast::Macro::from(def)));
                     }
                 };
 

--- a/crates/hir_def/src/body/lower.rs
+++ b/crates/hir_def/src/body/lower.rs
@@ -803,7 +803,7 @@ impl ExprCollector<'_> {
                 }
                 Either::Right(e) => {
                     let mac = MacroDefId {
-                        krate: Some(self.expander.module.krate),
+                        krate: self.expander.module.krate,
                         ast_id: Some(self.expander.ast_id(&e)),
                         kind: MacroDefKind::Declarative,
                         local_inner: false,

--- a/crates/hir_def/src/item_scope.rs
+++ b/crates/hir_def/src/item_scope.rs
@@ -363,7 +363,7 @@ impl ItemInNs {
                 ModuleDefId::TypeAliasId(id) => id.lookup(db).module(db).krate,
                 ModuleDefId::BuiltinType(_) => return None,
             },
-            ItemInNs::Macros(id) => return id.krate,
+            ItemInNs::Macros(id) => return Some(id.krate),
         })
     }
 }

--- a/crates/hir_expand/src/builtin_macro.rs
+++ b/crates/hir_expand/src/builtin_macro.rs
@@ -63,7 +63,7 @@ macro_rules! register_builtin {
 pub fn find_builtin_macro(
     ident: &name::Name,
     krate: CrateId,
-    ast_id: AstId<ast::MacroRules>,
+    ast_id: AstId<ast::Macro>,
 ) -> Option<MacroDefId> {
     let kind = find_by_name(ident)?;
 
@@ -515,16 +515,19 @@ mod tests {
     fn expand_builtin_macro(ra_fixture: &str) -> String {
         let (db, file_id) = TestDB::with_single_file(&ra_fixture);
         let parsed = db.parse(file_id);
-        let macro_rules: Vec<_> =
+        let mut macro_rules: Vec<_> =
             parsed.syntax_node().descendants().filter_map(ast::MacroRules::cast).collect();
-        let macro_calls: Vec<_> =
+        let mut macro_calls: Vec<_> =
             parsed.syntax_node().descendants().filter_map(ast::MacroCall::cast).collect();
 
         let ast_id_map = db.ast_id_map(file_id.into());
 
         assert_eq!(macro_rules.len(), 1, "test must contain exactly 1 `macro_rules!`");
         assert_eq!(macro_calls.len(), 1, "test must contain exactly 1 macro call");
-        let expander = find_by_name(&macro_rules[0].name().unwrap().as_name()).unwrap();
+        let macro_rules = ast::Macro::from(macro_rules.pop().unwrap());
+        let macro_call = macro_calls.pop().unwrap();
+
+        let expander = find_by_name(&macro_rules.name().unwrap().as_name()).unwrap();
 
         let krate = CrateId(0);
         let file_id = match expander {
@@ -532,7 +535,7 @@ mod tests {
                 // the first one should be a macro_rules
                 let def = MacroDefId {
                     krate: Some(CrateId(0)),
-                    ast_id: Some(AstId::new(file_id.into(), ast_id_map.ast_id(&macro_rules[0]))),
+                    ast_id: Some(AstId::new(file_id.into(), ast_id_map.ast_id(&macro_rules))),
                     kind: MacroDefKind::BuiltIn(expander),
                     local_inner: false,
                 };
@@ -542,7 +545,7 @@ mod tests {
                     krate,
                     kind: MacroCallKind::FnLike(AstId::new(
                         file_id.into(),
-                        ast_id_map.ast_id(&macro_calls[0]),
+                        ast_id_map.ast_id(&macro_call),
                     )),
                 };
 
@@ -553,12 +556,12 @@ mod tests {
                 // the first one should be a macro_rules
                 let def = MacroDefId {
                     krate: Some(krate),
-                    ast_id: Some(AstId::new(file_id.into(), ast_id_map.ast_id(&macro_rules[0]))),
+                    ast_id: Some(AstId::new(file_id.into(), ast_id_map.ast_id(&macro_rules))),
                     kind: MacroDefKind::BuiltInEager(expander),
                     local_inner: false,
                 };
 
-                let args = macro_calls[0].token_tree().unwrap();
+                let args = macro_call.token_tree().unwrap();
                 let parsed_args = mbe::ast_to_token_tree(&args).unwrap().0;
 
                 let arg_id = db.intern_eager_expansion({

--- a/crates/hir_expand/src/builtin_macro.rs
+++ b/crates/hir_expand/src/builtin_macro.rs
@@ -69,13 +69,13 @@ pub fn find_builtin_macro(
 
     match kind {
         Either::Left(kind) => Some(MacroDefId {
-            krate: Some(krate),
+            krate,
             ast_id: Some(ast_id),
             kind: MacroDefKind::BuiltIn(kind),
             local_inner: false,
         }),
         Either::Right(kind) => Some(MacroDefId {
-            krate: Some(krate),
+            krate,
             ast_id: Some(ast_id),
             kind: MacroDefKind::BuiltInEager(kind),
             local_inner: false,
@@ -534,7 +534,7 @@ mod tests {
             Either::Left(expander) => {
                 // the first one should be a macro_rules
                 let def = MacroDefId {
-                    krate: Some(CrateId(0)),
+                    krate: CrateId(0),
                     ast_id: Some(AstId::new(file_id.into(), ast_id_map.ast_id(&macro_rules))),
                     kind: MacroDefKind::BuiltIn(expander),
                     local_inner: false,
@@ -555,7 +555,7 @@ mod tests {
             Either::Right(expander) => {
                 // the first one should be a macro_rules
                 let def = MacroDefId {
-                    krate: Some(krate),
+                    krate,
                     ast_id: Some(AstId::new(file_id.into(), ast_id_map.ast_id(&macro_rules))),
                     kind: MacroDefKind::BuiltInEager(expander),
                     local_inner: false,

--- a/crates/hir_expand/src/db.rs
+++ b/crates/hir_expand/src/db.rs
@@ -129,7 +129,10 @@ fn ast_id_map(db: &dyn AstDatabase, file_id: HirFileId) -> Arc<AstIdMap> {
 fn macro_def(db: &dyn AstDatabase, id: MacroDefId) -> Option<Arc<(TokenExpander, mbe::TokenMap)>> {
     match id.kind {
         MacroDefKind::Declarative => {
-            let macro_call = id.ast_id?.to_node(db);
+            let macro_call = match id.ast_id?.to_node(db) {
+                syntax::ast::Macro::MacroRules(mac) => mac,
+                syntax::ast::Macro::MacroDef(_) => return None,
+            };
             let arg = macro_call.token_tree()?;
             let (tt, tmap) = mbe::ast_to_token_tree(&arg).or_else(|| {
                 log::warn!("fail on macro_def to token tree: {:#?}", arg);

--- a/crates/hir_expand/src/hygiene.rs
+++ b/crates/hir_expand/src/hygiene.rs
@@ -29,8 +29,8 @@ impl Hygiene {
                 MacroCallId::LazyMacro(id) => {
                     let loc = db.lookup_intern_macro(id);
                     match loc.def.kind {
-                        MacroDefKind::Declarative => (loc.def.krate, loc.def.local_inner),
-                        MacroDefKind::BuiltIn(_) => (loc.def.krate, false),
+                        MacroDefKind::Declarative => (Some(loc.def.krate), loc.def.local_inner),
+                        MacroDefKind::BuiltIn(_) => (Some(loc.def.krate), false),
                         MacroDefKind::BuiltInDerive(_) => (None, false),
                         MacroDefKind::BuiltInEager(_) => (None, false),
                         MacroDefKind::ProcMacro(_) => (None, false),

--- a/crates/hir_expand/src/lib.rs
+++ b/crates/hir_expand/src/lib.rs
@@ -224,13 +224,7 @@ impl From<EagerMacroId> for MacroCallId {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MacroDefId {
-    // FIXME: krate and ast_id are currently optional because we don't have a
-    // definition location for built-in derives. There is one, though: the
-    // standard library defines them. The problem is that it uses the new
-    // `macro` syntax for this, which we don't support yet. As soon as we do
-    // (which will probably require touching this code), we can instead use
-    // that (and also remove the hacks for resolving built-in derives).
-    pub krate: Option<CrateId>,
+    pub krate: CrateId,
     pub ast_id: Option<AstId<ast::Macro>>,
     pub kind: MacroDefKind,
 

--- a/crates/hir_expand/src/lib.rs
+++ b/crates/hir_expand/src/lib.rs
@@ -145,7 +145,10 @@ impl HirFileId {
                 let arg_tt = loc.kind.arg(db)?;
 
                 let def = loc.def.ast_id.and_then(|id| {
-                    let def_tt = id.to_node(db).token_tree()?;
+                    let def_tt = match id.to_node(db) {
+                        ast::Macro::MacroRules(mac) => mac.token_tree()?,
+                        ast::Macro::MacroDef(_) => return None,
+                    };
                     Some(InFile::new(id.file_id, def_tt))
                 });
 
@@ -228,7 +231,7 @@ pub struct MacroDefId {
     // (which will probably require touching this code), we can instead use
     // that (and also remove the hacks for resolving built-in derives).
     pub krate: Option<CrateId>,
-    pub ast_id: Option<AstId<ast::MacroRules>>,
+    pub ast_id: Option<AstId<ast::Macro>>,
     pub kind: MacroDefKind,
 
     pub local_inner: bool,

--- a/crates/hir_ty/src/tests/macros.rs
+++ b/crates/hir_ty/src/tests/macros.rs
@@ -686,6 +686,8 @@ mod clone {
     trait Clone {
         fn clone(&self) -> Self;
     }
+    #[rustc_builtin_macro]
+    macro Clone {}
 }
 "#,
     );
@@ -702,6 +704,8 @@ mod clone {
     trait Clone {
         fn clone(&self) -> Self;
     }
+    #[rustc_builtin_macro]
+    macro Clone {}
 }
 #[derive(Clone)]
 pub struct S;
@@ -737,6 +741,8 @@ mod clone {
     trait Clone {
         fn clone(&self) -> Self;
     }
+    #[rustc_builtin_macro]
+    macro Clone {}
 }
 "#,
     );

--- a/crates/ide/src/goto_implementation.rs
+++ b/crates/ide/src/goto_implementation.rs
@@ -221,6 +221,8 @@ struct Foo<|>;
 mod marker {
     trait Copy {}
 }
+#[rustc_builtin_macro]
+macro Copy {}
 "#,
         );
     }

--- a/crates/ide/src/syntax_highlighting/test_data/highlighting.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlighting.html
@@ -38,6 +38,9 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 <pre><code><span class="keyword">use</span> <span class="module">inner</span><span class="operator">::</span><span class="punctuation">{</span><span class="self_keyword">self</span> <span class="keyword">as</span> <span class="module declaration">inner_mod</span><span class="punctuation">}</span><span class="punctuation">;</span>
 <span class="keyword">mod</span> <span class="module declaration">inner</span> <span class="punctuation">{</span><span class="punctuation">}</span>
 
+<span class="attribute attribute">#</span><span class="attribute attribute">[</span><span class="function attribute">rustc_builtin_macro</span><span class="attribute attribute">]</span>
+<span class="keyword">macro</span> <span class="unresolved_reference declaration">Copy</span> <span class="punctuation">{</span><span class="punctuation">}</span>
+
 <span class="comment">// Needed for function consuming vs normal</span>
 <span class="keyword">pub</span> <span class="keyword">mod</span> <span class="module declaration">marker</span> <span class="punctuation">{</span>
     <span class="attribute attribute">#</span><span class="attribute attribute">[</span><span class="function attribute">lang</span><span class="attribute attribute"> </span><span class="operator attribute">=</span><span class="attribute attribute"> </span><span class="string_literal attribute">"copy"</span><span class="attribute attribute">]</span>
@@ -119,7 +122,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
     <span class="value_param callable">f</span><span class="punctuation">(</span><span class="punctuation">)</span>
 <span class="punctuation">}</span>
 
-<span class="keyword">fn</span> <span class="function declaration">foobar</span><span class="punctuation">(</span><span class="punctuation">)</span> <span class="operator">-&gt;</span> <span class="keyword">impl</span> <span class="unresolved_reference">Copy</span> <span class="punctuation">{</span><span class="punctuation">}</span>
+<span class="keyword">fn</span> <span class="function declaration">foobar</span><span class="punctuation">(</span><span class="punctuation">)</span> <span class="operator">-&gt;</span> <span class="keyword">impl</span> <span class="macro">Copy</span> <span class="punctuation">{</span><span class="punctuation">}</span>
 
 <span class="keyword">fn</span> <span class="function declaration">foo</span><span class="punctuation">(</span><span class="punctuation">)</span> <span class="punctuation">{</span>
     <span class="keyword">let</span> <span class="variable declaration">bar</span> <span class="operator">=</span> <span class="function">foobar</span><span class="punctuation">(</span><span class="punctuation">)</span><span class="punctuation">;</span>

--- a/crates/ide/src/syntax_highlighting/tests.rs
+++ b/crates/ide/src/syntax_highlighting/tests.rs
@@ -12,6 +12,9 @@ fn test_highlighting() {
 use inner::{self as inner_mod};
 mod inner {}
 
+#[rustc_builtin_macro]
+macro Copy {}
+
 // Needed for function consuming vs normal
 pub mod marker {
     #[lang = "copy"]

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -19,8 +19,8 @@ pub use self::{
     expr_ext::{ArrayExprKind, BinOp, Effect, ElseBranch, LiteralKind, PrefixOp, RangeOp},
     generated::{nodes::*, tokens::*},
     node_ext::{
-        AttrKind, FieldKind, NameOrNameRef, PathSegmentKind, SelfParamKind, SlicePatComponents,
-        StructKind, TypeBoundKind, VisibilityKind,
+        AttrKind, FieldKind, Macro, NameOrNameRef, PathSegmentKind, SelfParamKind,
+        SlicePatComponents, StructKind, TypeBoundKind, VisibilityKind,
     },
     token_ext::*,
     traits::*,

--- a/crates/syntax/src/display.rs
+++ b/crates/syntax/src/display.rs
@@ -76,8 +76,20 @@ pub fn type_label(node: &ast::TypeAlias) -> String {
     label.trim().to_owned()
 }
 
-pub fn macro_label(node: &ast::MacroRules) -> String {
+pub fn macro_label(node: &ast::Macro) -> String {
     let name = node.name().map(|name| name.syntax().text().to_string()).unwrap_or_default();
-    let vis = if node.has_atom_attr("macro_export") { "#[macro_export]\n" } else { "" };
-    format!("{}macro_rules! {}", vis, name)
+    match node {
+        ast::Macro::MacroRules(node) => {
+            let vis = if node.has_atom_attr("macro_export") { "#[macro_export]\n" } else { "" };
+            format!("{}macro_rules! {}", vis, name)
+        }
+        ast::Macro::MacroDef(node) => {
+            let mut s = String::new();
+            if let Some(vis) = node.visibility() {
+                format_to!(s, "{} ", vis);
+            }
+            format_to!(s, "macro {}", name);
+            s
+        }
+    }
 }


### PR DESCRIPTION
This adds support for (built-in-only) macros 2.0, and removes some hacks used for builtin derives, which are declared via macros 2.0 in libcore.

First steps for https://github.com/rust-analyzer/rust-analyzer/issues/2248.

Blocked on https://github.com/rust-analyzer/ungrammar/pull/16.