### PR TITLE
Temp fixes panic caused by no ast for proc-macro

### DIFF
--- a/crates/completion/src/render/macro_.rs
+++ b/crates/completion/src/render/macro_.rs
@@ -41,6 +41,7 @@ impl<'a> MacroRender<'a> {
     fn render(&self, import_to_add: Option<ImportEdit>) -> Option<CompletionItem> {
         // FIXME: Currently proc-macro do not have ast-node,
         // such that it does not have source
+        // more discussion: https://github.com/rust-analyzer/rust-analyzer/issues/6913
         if self.macro_.is_proc_macro() {
             return None;
         }

--- a/crates/hir/src/code_model.rs
+++ b/crates/hir/src/code_model.rs
@@ -977,6 +977,12 @@ impl MacroDef {
 
     /// XXX: this parses the file
     pub fn name(self, db: &dyn HirDatabase) -> Option<Name> {
+        // FIXME: Currently proc-macro do not have ast-node,
+        // such that it does not have source
+        // more discussion: https://github.com/rust-analyzer/rust-analyzer/issues/6913
+        if self.is_proc_macro() {
+            return None;
+        }
         self.source(db).value.name().map(|it| it.as_name())
     }
 

--- a/crates/ide/src/display/navigation_target.rs
+++ b/crates/ide/src/display/navigation_target.rs
@@ -176,7 +176,15 @@ impl ToNav for FileSymbol {
 impl TryToNav for Definition {
     fn try_to_nav(&self, db: &RootDatabase) -> Option<NavigationTarget> {
         match self {
-            Definition::Macro(it) => Some(it.to_nav(db)),
+            Definition::Macro(it) => {
+                // FIXME: Currently proc-macro do not have ast-node,
+                // such that it does not have source
+                // more discussion: https://github.com/rust-analyzer/rust-analyzer/issues/6913
+                if it.is_proc_macro() {
+                    return None;
+                }
+                Some(it.to_nav(db))
+            }
             Definition::Field(it) => Some(it.to_nav(db)),
             Definition::ModuleDef(it) => it.try_to_nav(db),
             Definition::SelfType(it) => Some(it.to_nav(db)),

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -324,6 +324,12 @@ fn hover_for_definition(db: &RootDatabase, def: Definition) -> Option<Markup> {
     let mod_path = definition_mod_path(db, &def);
     return match def {
         Definition::Macro(it) => {
+            // FIXME: Currently proc-macro do not have ast-node,
+            // such that it does not have source
+            // more discussion: https://github.com/rust-analyzer/rust-analyzer/issues/6913
+            if it.is_proc_macro() {
+                return None;
+            }
             let label = macro_label(&it.source(db).value);
             from_def_source_labeled(db, it, Some(label), mod_path)
         }


### PR DESCRIPTION
There are some panic when hover/goto definition for proc-macro. It is because in current design, we don't have `ast-node` for proc-macro and then it trigger [this](https://github.com/rust-analyzer/rust-analyzer/blob/479d1f7eec22c3564867223e2093f14774092528/crates/hir/src/has_source.rs#L116) line to panic.

This PR is a temp fix for all of these similar to https://github.com/rust-analyzer/rust-analyzer/blob/bd4c352831662762ee7a66da77ec9adf623b0a0a/crates/completion/src/render/macro_.rs#L42