### PR TITLE
Lifetime reference search 

### DIFF
--- a/crates/ide/src/display/navigation_target.rs
+++ b/crates/ide/src/display/navigation_target.rs
@@ -9,7 +9,7 @@ use ide_db::{defs::Definition, RootDatabase};
 use syntax::{
     ast::{self, NameOwner},
     match_ast, AstNode, SmolStr,
-    SyntaxKind::{self, IDENT_PAT, TYPE_PARAM},
+    SyntaxKind::{self, IDENT_PAT, LIFETIME_PARAM, TYPE_PARAM},
     TextRange,
 };
 
@@ -182,6 +182,7 @@ impl TryToNav for Definition {
             Definition::SelfType(it) => Some(it.to_nav(db)),
             Definition::Local(it) => Some(it.to_nav(db)),
             Definition::TypeParam(it) => Some(it.to_nav(db)),
+            Definition::LifetimeParam(it) => Some(it.to_nav(db)),
         }
     }
 }
@@ -369,6 +370,23 @@ impl ToNav for hir::TypeParam {
             kind: TYPE_PARAM,
             full_range,
             focus_range,
+            container_name: None,
+            description: None,
+            docs: None,
+        }
+    }
+}
+
+impl ToNav for hir::LifetimeParam {
+    fn to_nav(&self, db: &RootDatabase) -> NavigationTarget {
+        let src = self.source(db);
+        let full_range = src.value.syntax().text_range();
+        NavigationTarget {
+            file_id: src.file_id.original_file(db),
+            name: self.name(db).to_string().into(),
+            kind: LIFETIME_PARAM,
+            full_range,
+            focus_range: Some(full_range),
             container_name: None,
             description: None,
             docs: None,

--- a/crates/ide/src/doc_links.rs
+++ b/crates/ide/src/doc_links.rs
@@ -190,7 +190,10 @@ fn rewrite_intra_doc_link(
         },
         Definition::Macro(it) => it.resolve_doc_path(db, link, ns),
         Definition::Field(it) => it.resolve_doc_path(db, link, ns),
-        Definition::SelfType(_) | Definition::Local(_) | Definition::TypeParam(_) => return None,
+        Definition::SelfType(_)
+        | Definition::Local(_)
+        | Definition::TypeParam(_)
+        | Definition::LifetimeParam(_) => return None,
     }?;
     let krate = resolved.module(db)?.krate();
     let canonical_path = resolved.canonical_path(db)?;

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -364,7 +364,7 @@ fn hover_for_definition(db: &RootDatabase, def: Definition) -> Option<Markup> {
                 Adt::Enum(it) => from_def_source(db, it, mod_path),
             })
         }
-        Definition::TypeParam(_) => {
+        Definition::TypeParam(_) | Definition::LifetimeParam(_) => {
             // FIXME: Hover for generic param
             None
         }

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -528,6 +528,13 @@ impl Analysis {
         self.with_db(|db| references::rename::rename(db, position, new_name))
     }
 
+    pub fn prepare_rename(
+        &self,
+        position: FilePosition,
+    ) -> Cancelable<Result<RangeInfo<()>, RenameError>> {
+        self.with_db(|db| references::rename::prepare_rename(db, position))
+    }
+
     pub fn structural_search_replace(
         &self,
         query: &str,

--- a/crates/ide/src/syntax_highlighting.rs
+++ b/crates/ide/src/syntax_highlighting.rs
@@ -806,6 +806,7 @@ fn highlight_def(db: &RootDatabase, def: Definition) -> Highlight {
             }
             return h;
         }
+        Definition::LifetimeParam(_) => HighlightTag::Lifetime,
     }
     .into()
 }

--- a/crates/ide_db/src/symbol_index.rs
+++ b/crates/ide_db/src/symbol_index.rs
@@ -209,8 +209,7 @@ pub fn crate_symbols(db: &RootDatabase, krate: CrateId, query: Query) -> Vec<Fil
     query.search(&buf)
 }
 
-pub fn index_resolve(db: &RootDatabase, name_ref: &ast::NameRef) -> Vec<FileSymbol> {
-    let name = name_ref.text();
+pub fn index_resolve(db: &RootDatabase, name: &SmolStr) -> Vec<FileSymbol> {
     let mut query = Query::new(name.to_string());
     query.exact();
     query.limit(4);

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -733,7 +733,7 @@ pub(crate) fn handle_prepare_rename(
     let _p = profile::span("handle_prepare_rename");
     let position = from_proto::file_position(&snap, params)?;
 
-    let change = snap.analysis.rename(position, "dummy")??;
+    let change = snap.analysis.prepare_rename(position)??;
     let line_index = snap.analysis.file_line_index(position.file_id)?;
     let range = to_proto::range(&line_index, change.range);
     Ok(Some(PrepareRenameResponse::Range(range)))


### PR DESCRIPTION
PR #6787 but rewritten to make use of the HIR now. This only applies to Lifetimes, not labels. Also Higher-Ranked Trait Bounds aren't supported yet, but I feel like this PR is big enough as is which is why I left them out after noticing I forgot about them.

Supporting renaming required slight changes in the renaming module as lifetime names aren't allowed for anything but lifetimes(and labels) and vice versa for normal names.