### PR TITLE
decl_check: don't pass `db` around so often

### DIFF
--- a/crates/hir/src/code_model.rs
+++ b/crates/hir/src/code_model.rs
@@ -267,7 +267,12 @@ impl ModuleDef {
             _ => return,
         };
 
-        hir_ty::diagnostics::validate_module_item(db, id, sink)
+        let module = match self.module(db) {
+            Some(it) => it,
+            None => return,
+        };
+
+        hir_ty::diagnostics::validate_module_item(db, module.id.krate, id, sink)
     }
 }
 
@@ -780,8 +785,9 @@ impl Function {
     }
 
     pub fn diagnostics(self, db: &dyn HirDatabase, sink: &mut DiagnosticSink) {
+        let krate = self.module(db).id.krate;
         hir_def::diagnostics::validate_body(db.upcast(), self.id.into(), sink);
-        hir_ty::diagnostics::validate_module_item(db, self.id.into(), sink);
+        hir_ty::diagnostics::validate_module_item(db, krate, self.id.into(), sink);
         hir_ty::diagnostics::validate_body(db, self.id.into(), sink);
     }
 


### PR DESCRIPTION
Instead, store it in the `DeclValidator`.

Also pass the `CrateId` that defines the checked item along. This is not yet needed, but will be once I've refactored `Attrs` to handle `cfg_attr` internally.

We could also try to extract the crate from the "owner" `ModuleDefId` instead of passing it in, but then it might not be present for builtin types. Open to suggestions.