### PR TITLE
Default to host platform for cargo metadata

### DIFF
--- a/crates/project_model/src/cargo_workspace.rs
+++ b/crates/project_model/src/cargo_workspace.rs
@@ -178,8 +178,7 @@ impl CargoWorkspace {
             match utf8_stdout(rustc) {
                 Ok(stdout) => {
                     let field = "host: ";
-                    let target =
-                        stdout.lines().find_map(|l| l.strip_prefix(field));
+                    let target = stdout.lines().find_map(|l| l.strip_prefix(field));
                     if let Some(target) = target {
                         Some(target.to_string())
                     } else {

--- a/crates/project_model/src/cargo_workspace.rs
+++ b/crates/project_model/src/cargo_workspace.rs
@@ -179,7 +179,7 @@ impl CargoWorkspace {
                 Ok(stdout) => {
                     let field = "host: ";
                     let target =
-                        stdout.lines().find(|l| l.starts_with(field)).map(|l| &l[field.len()..]);
+                        stdout.lines().find_map(|l| l.strip_prefix(field));
                     if let Some(target) = target {
                         Some(target.to_string())
                     } else {


### PR DESCRIPTION
This modifies the logic for calling cargo metadata so that it will use
the host platform if no explicit target platform is given. This is
needed since cargo metadata defaults to outputting information for _all_
targets.

Fixes #6908.