### PR TITLE
Higher-ranked trait bounds for where clauses

### DIFF
--- a/crates/hir/src/code_model.rs
+++ b/crates/hir/src/code_model.rs
@@ -1266,7 +1266,6 @@ impl LifetimeParam {
     }
 }
 
-// FIXME: rename from `ImplDef` to `Impl`
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Impl {
     pub(crate) id: ImplId,

--- a/crates/hir_ty/src/utils.rs
+++ b/crates/hir_ty/src/utils.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 use hir_def::{
     adt::VariantData,
     db::DefDatabase,
-    generics::{GenericParams, TypeParamData, TypeParamProvenance, WherePredicateTypeTarget},
+    generics::{
+        GenericParams, TypeParamData, TypeParamProvenance, WherePredicate, WherePredicateTypeTarget,
+    },
     path::Path,
     resolver::{HasResolver, TypeNs},
     type_ref::TypeRef,
@@ -27,7 +29,8 @@ fn direct_super_traits(db: &dyn DefDatabase, trait_: TraitId) -> Vec<TraitId> {
         .where_predicates
         .iter()
         .filter_map(|pred| match pred {
-            hir_def::generics::WherePredicate::TypeBound { target, bound } => match target {
+            WherePredicate::ForLifetime { target, bound, .. }
+            | WherePredicate::TypeBound { target, bound } => match target {
                 WherePredicateTypeTarget::TypeRef(TypeRef::Path(p))
                     if p == &Path::from(name![Self]) =>
                 {
@@ -38,7 +41,7 @@ fn direct_super_traits(db: &dyn DefDatabase, trait_: TraitId) -> Vec<TraitId> {
                 }
                 _ => None,
             },
-            hir_def::generics::WherePredicate::Lifetime { .. } => None,
+            WherePredicate::Lifetime { .. } => None,
         })
         .filter_map(|path| match resolver.resolve_path_in_type_ns_fully(db, path.mod_path()) {
             Some(TypeNs::TraitId(t)) => Some(t),

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -1077,4 +1077,32 @@ fn foo<'foobar>(_: &'foobar ()) {
 }"#,
         )
     }
+
+    #[test]
+    #[ignore] // requires the HIR to somehow track these hrtb lifetimes
+    fn goto_lifetime_hrtb() {
+        check(
+            r#"trait Foo<T> {}
+fn foo<T>() where for<'a> T: Foo<&'a<|> (u8, u16)>, {}
+                    //^^
+"#,
+        );
+        check(
+            r#"trait Foo<T> {}
+fn foo<T>() where for<'a<|>> T: Foo<&'a (u8, u16)>, {}
+                    //^^
+"#,
+        );
+    }
+
+    #[test]
+    #[ignore] // requires ForTypes to be implemented
+    fn goto_lifetime_hrtb_for_type() {
+        check(
+            r#"trait Foo<T> {}
+fn foo<T>() where T: for<'a> Foo<&'a<|> (u8, u16)>, {}
+                       //^^
+"#,
+        );
+    }
 }


### PR DESCRIPTION
There is a slight problem with this which is also noted in a FIXME now but `LifetimeParameters` of these ForLifetime where clauses allocate the lifetimes in the corresponding arena as if they were lifetimes of the item itself and not just the clause they belong to. I wasn't entirely sure what I could do about this but given nothing really uses lifetimes like that currently I figured it might be fine? Open to suggestions for that problem.