### PR TITLE
Add full pattern completions for Struct and Variant patterns

### DIFF
--- a/crates/completion/src/completions.rs
+++ b/crates/completion/src/completions.rs
@@ -19,9 +19,14 @@ use hir::{ModPath, ScopeDef, Type};
 use crate::{
     item::Builder,
     render::{
-        const_::render_const, enum_variant::render_variant, function::render_fn,
-        macro_::render_macro, render_field, render_resolution, render_tuple_field,
-        type_alias::render_type_alias, RenderContext,
+        const_::render_const,
+        enum_variant::render_variant,
+        function::render_fn,
+        macro_::render_macro,
+        pattern::{render_struct_pat, render_variant_pat},
+        render_field, render_resolution, render_tuple_field,
+        type_alias::render_type_alias,
+        RenderContext,
     },
     CompletionContext, CompletionItem,
 };
@@ -103,6 +108,28 @@ impl Completions {
     ) {
         let item = render_fn(RenderContext::new(ctx), None, local_name, func);
         self.add(item)
+    }
+
+    pub(crate) fn add_variant_pat(
+        &mut self,
+        ctx: &CompletionContext,
+        variant: hir::Variant,
+        local_name: Option<hir::Name>,
+    ) {
+        if let Some(item) = render_variant_pat(RenderContext::new(ctx), variant, local_name) {
+            self.add(item);
+        }
+    }
+
+    pub(crate) fn add_struct_pat(
+        &mut self,
+        ctx: &CompletionContext,
+        strukt: hir::Struct,
+        local_name: Option<hir::Name>,
+    ) {
+        if let Some(item) = render_struct_pat(RenderContext::new(ctx), strukt, local_name) {
+            self.add(item);
+        }
     }
 
     pub(crate) fn add_const(&mut self, ctx: &CompletionContext, constant: hir::Const) {

--- a/crates/completion/src/completions/pattern.rs
+++ b/crates/completion/src/completions/pattern.rs
@@ -1,10 +1,12 @@
 //! Completes constats and paths in patterns.
 
+use hir::StructKind;
+
 use crate::{CompletionContext, Completions};
 
-/// Completes constats and paths in patterns.
+/// Completes constants and paths in patterns.
 pub(crate) fn complete_pattern(acc: &mut Completions, ctx: &CompletionContext) {
-    if !(ctx.is_pat_binding_or_const || ctx.is_irrefutable_let_pat_binding) {
+    if !(ctx.is_pat_binding_or_const || ctx.is_irrefutable_pat_binding) {
         return;
     }
     if ctx.record_pat_syntax.is_some() {
@@ -15,20 +17,25 @@ pub(crate) fn complete_pattern(acc: &mut Completions, ctx: &CompletionContext) {
     // suggest variants + auto-imports
     ctx.scope.process_all_names(&mut |name, res| {
         let add_resolution = match &res {
-            hir::ScopeDef::ModuleDef(def) => {
-                if ctx.is_irrefutable_let_pat_binding {
-                    matches!(def, hir::ModuleDef::Adt(hir::Adt::Struct(_)))
-                } else {
-                    matches!(
-                        def,
-                        hir::ModuleDef::Adt(hir::Adt::Enum(..))
-                            | hir::ModuleDef::Adt(hir::Adt::Struct(..))
-                            | hir::ModuleDef::Variant(..)
-                            | hir::ModuleDef::Const(..)
-                            | hir::ModuleDef::Module(..)
-                    )
+            hir::ScopeDef::ModuleDef(def) => match def {
+                hir::ModuleDef::Adt(hir::Adt::Struct(strukt)) => {
+                    acc.add_struct_pat(ctx, strukt.clone(), Some(name.clone()));
+                    true
                 }
-            }
+                hir::ModuleDef::Variant(variant)
+                    if !ctx.is_irrefutable_pat_binding
+                        // render_resolution already does some pattern completion tricks for tuple variants
+                        && variant.kind(ctx.db) == StructKind::Record =>
+                {
+                    acc.add_variant_pat(ctx, variant.clone(), Some(name.clone()));
+                    true
+                }
+                hir::ModuleDef::Adt(hir::Adt::Enum(..))
+                | hir::ModuleDef::Variant(..)
+                | hir::ModuleDef::Const(..)
+                | hir::ModuleDef::Module(..) => !ctx.is_irrefutable_pat_binding,
+                _ => false,
+            },
             hir::ScopeDef::MacroDef(_) => true,
             _ => false,
         };
@@ -46,6 +53,11 @@ mod tests {
 
     fn check(ra_fixture: &str, expect: Expect) {
         let actual = completion_list(ra_fixture, CompletionKind::Reference);
+        expect.assert_eq(&actual)
+    }
+
+    fn check_snippet(ra_fixture: &str, expect: Expect) {
+        let actual = completion_list(ra_fixture, CompletionKind::Snippet);
         expect.assert_eq(&actual)
     }
 
@@ -113,5 +125,117 @@ fn foo() {
                 st Bar
             "#]],
         );
+    }
+
+    #[test]
+    fn completes_in_param() {
+        check(
+            r#"
+enum E { X }
+
+static FOO: E = E::X;
+struct Bar { f: u32 }
+
+fn foo(<|>) {
+}
+"#,
+            expect![[r#"
+                st Bar
+            "#]],
+        );
+    }
+
+    #[test]
+    fn completes_pat_in_let() {
+        check_snippet(
+            r#"
+struct Bar { f: u32 }
+
+fn foo() {
+   let <|>
+}
+"#,
+            expect![[r#"
+                bn Bar Bar { f }$0
+            "#]],
+        );
+    }
+
+    #[test]
+    fn completes_param_pattern() {
+        check_snippet(
+            r#"
+struct Foo { bar: String, baz: String }
+struct Bar(String, String);
+struct Baz;
+fn outer(<|>) {}
+"#,
+            expect![[r#"
+                bn Foo Foo { bar, baz }: Foo$0
+                bn Bar Bar($1, $2): Bar$0
+            "#]],
+        )
+    }
+
+    #[test]
+    fn completes_let_pattern() {
+        check_snippet(
+            r#"
+struct Foo { bar: String, baz: String }
+struct Bar(String, String);
+struct Baz;
+fn outer() {
+    let <|>
+}
+"#,
+            expect![[r#"
+                bn Foo Foo { bar, baz }$0
+                bn Bar Bar($1, $2)$0
+            "#]],
+        )
+    }
+
+    #[test]
+    fn completes_refutable_pattern() {
+        check_snippet(
+            r#"
+struct Foo { bar: i32, baz: i32 }
+struct Bar(String, String);
+struct Baz;
+fn outer() {
+    match () {
+        <|>
+    }
+}
+"#,
+            expect![[r#"
+                bn Foo Foo { bar, baz }$0
+                bn Bar Bar($1, $2)$0
+            "#]],
+        )
+    }
+
+    #[test]
+    fn omits_private_fields_pat() {
+        check_snippet(
+            r#"
+mod foo {
+    pub struct Foo { pub bar: i32, baz: i32 }
+    pub struct Bar(pub String, String);
+    pub struct Invisible(String, String);
+}
+use foo::*;
+
+fn outer() {
+    match () {
+        <|>
+    }
+}
+"#,
+            expect![[r#"
+                bn Foo Foo { bar, .. }$0
+                bn Bar Bar($1, ..)$0
+            "#]],
+        )
     }
 }

--- a/crates/completion/src/completions/pattern.rs
+++ b/crates/completion/src/completions/pattern.rs
@@ -156,7 +156,7 @@ fn foo() {
 }
 "#,
             expect![[r#"
-                bn Bar Bar { ${1:f} }$0
+                bn Bar Bar { f$1 }$0
             "#]],
         );
     }
@@ -171,7 +171,7 @@ struct Baz;
 fn outer(<|>) {}
 "#,
             expect![[r#"
-                bn Foo Foo { ${1:bar}, ${2:baz} }: Foo$0
+                bn Foo Foo { bar$1, baz$2 }: Foo$0
                 bn Bar Bar($1, $2): Bar$0
             "#]],
         )
@@ -189,7 +189,7 @@ fn outer() {
 }
 "#,
             expect![[r#"
-                bn Foo Foo { ${1:bar}, ${2:baz} }$0
+                bn Foo Foo { bar$1, baz$2 }$0
                 bn Bar Bar($1, $2)$0
             "#]],
         )
@@ -209,7 +209,7 @@ fn outer() {
 }
 "#,
             expect![[r#"
-                bn Foo Foo { ${1:bar}, ${2:baz} }$0
+                bn Foo Foo { bar$1, baz$2 }$0
                 bn Bar Bar($1, $2)$0
             "#]],
         )
@@ -233,7 +233,7 @@ fn outer() {
 }
 "#,
             expect![[r#"
-                bn Foo Foo { ${1:bar}, .. }$0
+                bn Foo Foo { bar$1, .. }$0
                 bn Bar Bar($1, ..)$0
             "#]],
         )

--- a/crates/completion/src/completions/pattern.rs
+++ b/crates/completion/src/completions/pattern.rs
@@ -156,7 +156,7 @@ fn foo() {
 }
 "#,
             expect![[r#"
-                bn Bar Bar { f }$0
+                bn Bar Bar { ${1:f} }$0
             "#]],
         );
     }
@@ -171,7 +171,7 @@ struct Baz;
 fn outer(<|>) {}
 "#,
             expect![[r#"
-                bn Foo Foo { bar, baz }: Foo$0
+                bn Foo Foo { ${1:bar}, ${2:baz} }: Foo$0
                 bn Bar Bar($1, $2): Bar$0
             "#]],
         )
@@ -189,7 +189,7 @@ fn outer() {
 }
 "#,
             expect![[r#"
-                bn Foo Foo { bar, baz }$0
+                bn Foo Foo { ${1:bar}, ${2:baz} }$0
                 bn Bar Bar($1, $2)$0
             "#]],
         )
@@ -209,7 +209,7 @@ fn outer() {
 }
 "#,
             expect![[r#"
-                bn Foo Foo { bar, baz }$0
+                bn Foo Foo { ${1:bar}, ${2:baz} }$0
                 bn Bar Bar($1, $2)$0
             "#]],
         )
@@ -233,7 +233,7 @@ fn outer() {
 }
 "#,
             expect![[r#"
-                bn Foo Foo { bar, .. }$0
+                bn Foo Foo { ${1:bar}, .. }$0
                 bn Bar Bar($1, ..)$0
             "#]],
         )

--- a/crates/completion/src/render.rs
+++ b/crates/completion/src/render.rs
@@ -160,6 +160,12 @@ impl<'a> Render<'a> {
                 let item = render_fn(self.ctx, import_to_add, Some(local_name), *func);
                 return Some(item);
             }
+            ScopeDef::ModuleDef(Variant(_))
+                if self.ctx.completion.is_pat_binding_or_const
+                    | self.ctx.completion.is_irrefutable_pat_binding =>
+            {
+                CompletionItemKind::EnumVariant
+            }
             ScopeDef::ModuleDef(Variant(var)) => {
                 let item = render_variant(self.ctx, import_to_add, Some(local_name), *var, None);
                 return Some(item);

--- a/crates/completion/src/render.rs
+++ b/crates/completion/src/render.rs
@@ -5,6 +5,7 @@ pub(crate) mod macro_;
 pub(crate) mod function;
 pub(crate) mod enum_variant;
 pub(crate) mod const_;
+pub(crate) mod pattern;
 pub(crate) mod type_alias;
 
 mod builder_ext;

--- a/crates/completion/src/render/builder_ext.rs
+++ b/crates/completion/src/render/builder_ext.rs
@@ -34,7 +34,6 @@ impl Builder {
             return false;
         }
         if ctx.is_pattern_call {
-            mark::hit!(dont_duplicate_pattern_parens);
             return false;
         }
         if ctx.is_call {

--- a/crates/completion/src/render/enum_variant.rs
+++ b/crates/completion/src/render/enum_variant.rs
@@ -126,50 +126,5 @@ fn main() -> Option<i32> {
 }
 "#,
         );
-        check_edit(
-            "Some",
-            r#"
-enum Option<T> { Some(T), None }
-use Option::*;
-fn main(value: Option<i32>) {
-    match value {
-        Som<|>
-    }
-}
-"#,
-            r#"
-enum Option<T> { Some(T), None }
-use Option::*;
-fn main(value: Option<i32>) {
-    match value {
-        Some($0)
-    }
-}
-"#,
-        );
-    }
-
-    #[test]
-    fn dont_duplicate_pattern_parens() {
-        mark::check!(dont_duplicate_pattern_parens);
-        check_edit(
-            "Var",
-            r#"
-enum E { Var(i32) }
-fn main() {
-    match E::Var(92) {
-        E::<|>(92) => (),
-    }
-}
-"#,
-            r#"
-enum E { Var(i32) }
-fn main() {
-    match E::Var(92) {
-        E::Var(92) => (),
-    }
-}
-"#,
-        );
     }
 }

--- a/crates/completion/src/render/pattern.rs
+++ b/crates/completion/src/render/pattern.rs
@@ -121,7 +121,7 @@ fn render_record_as_pat(
             "{name} {{ {}{} }}",
             fields
                 .enumerate()
-                .map(|(idx, field)| format!("${{{}:{}}}", idx + 1, field.name(db)))
+                .map(|(idx, field)| format!("{}${}", field.name(db), idx + 1))
                 .format(", "),
             if fields_omitted { ", .." } else { "" },
             name = name

--- a/crates/completion/src/render/pattern.rs
+++ b/crates/completion/src/render/pattern.rs
@@ -1,6 +1,6 @@
 //! Renderer for patterns.
 
-use hir::{db::HirDatabase, HasVisibility, Name, StructKind};
+use hir::{db::HirDatabase, HasAttrs, HasVisibility, Name, StructKind};
 use itertools::Itertools;
 
 use crate::{
@@ -27,7 +27,8 @@ pub(crate) fn render_struct_pat(
         // Matching a struct without matching its fields is pointless, unlike matching a Variant without its fields
         return None;
     }
-    let fields_omitted = n_fields - fields.len() > 0;
+    let fields_omitted =
+        n_fields - fields.len() > 0 || strukt.attrs(ctx.db()).by_key("non_exhaustive").exists();
 
     let name = local_name.unwrap_or_else(|| strukt.name(ctx.db())).to_string();
     let pat = render_pat(&ctx, &name, strukt.kind(ctx.db()), &fields, fields_omitted)?;
@@ -60,7 +61,8 @@ pub(crate) fn render_variant_pat(
         .filter(|field| field.is_visible_from(ctx.db(), module))
         .collect::<Vec<_>>();
 
-    let fields_omitted = n_fields - fields.len() > 0;
+    let fields_omitted =
+        n_fields - fields.len() > 0 || variant.attrs(ctx.db()).by_key("non_exhaustive").exists();
 
     let name = local_name.unwrap_or_else(|| variant.name(ctx.db())).to_string();
     let pat = render_pat(&ctx, &name, variant.kind(ctx.db()), &fields, fields_omitted)?;

--- a/crates/completion/src/render/pattern.rs
+++ b/crates/completion/src/render/pattern.rs
@@ -1,0 +1,128 @@
+//! Renderer for patterns.
+
+use hir::{db::HirDatabase, HasVisibility, Name, StructKind};
+use itertools::Itertools;
+
+use crate::{item::CompletionKind, render::RenderContext, CompletionItem, CompletionItemKind};
+
+pub(crate) fn render_struct_pat<'a>(
+    ctx: RenderContext<'a>,
+    strukt: hir::Struct,
+    local_name: Option<Name>,
+) -> Option<CompletionItem> {
+    let _p = profile::span("render_struct_pat");
+
+    let module = ctx.completion.scope.module()?;
+    let fields = strukt.fields(ctx.db());
+    let n_fields = fields.len();
+    let fields = fields
+        .into_iter()
+        .filter(|field| field.is_visible_from(ctx.db(), module))
+        .collect::<Vec<_>>();
+
+    if fields.is_empty() {
+        // Matching a struct without matching its fields is pointless, unlike matching a Variant without its fields
+        return None;
+    }
+    let fields_omitted = n_fields - fields.len() > 0;
+
+    let name = local_name.unwrap_or_else(|| strukt.name(ctx.db())).to_string();
+    let mut pat = match strukt.kind(ctx.db()) {
+        StructKind::Tuple if ctx.snippet_cap().is_some() => {
+            render_tuple_as_pat(&fields, &name, fields_omitted)
+        }
+        StructKind::Record => render_record_as_pat(ctx.db(), &fields, &name, fields_omitted),
+        _ => return None,
+    };
+
+    if ctx.completion.is_param {
+        pat.push(':');
+        pat.push(' ');
+        pat.push_str(&name);
+    }
+    if ctx.snippet_cap().is_some() {
+        pat.push_str("$0");
+    }
+
+    let mut completion = CompletionItem::new(CompletionKind::Snippet, ctx.source_range(), name)
+        .kind(CompletionItemKind::Binding)
+        .set_documentation(ctx.docs(strukt))
+        .set_deprecated(ctx.is_deprecated(strukt))
+        .detail(&pat);
+    if let Some(snippet_cap) = ctx.snippet_cap() {
+        completion = completion.insert_snippet(snippet_cap, pat);
+    } else {
+        completion = completion.insert_text(pat);
+    }
+    Some(completion.build())
+}
+
+pub(crate) fn render_variant_pat<'a>(
+    ctx: RenderContext<'a>,
+    variant: hir::Variant,
+    local_name: Option<Name>,
+) -> Option<CompletionItem> {
+    let _p = profile::span("render_variant_pat");
+
+    let module = ctx.completion.scope.module()?;
+    let fields = variant.fields(ctx.db());
+    let n_fields = fields.len();
+    let fields = fields
+        .into_iter()
+        .filter(|field| field.is_visible_from(ctx.db(), module))
+        .collect::<Vec<_>>();
+
+    let fields_omitted = n_fields - fields.len() > 0;
+
+    let name = local_name.unwrap_or_else(|| variant.name(ctx.db())).to_string();
+    let mut pat = match variant.kind(ctx.db()) {
+        StructKind::Tuple if ctx.snippet_cap().is_some() => {
+            render_tuple_as_pat(&fields, &name, fields_omitted)
+        }
+        StructKind::Record => render_record_as_pat(ctx.db(), &fields, &name, fields_omitted),
+        _ => return None,
+    };
+
+    if ctx.completion.is_param {
+        pat.push(':');
+        pat.push(' ');
+        pat.push_str(&name);
+    }
+    if ctx.snippet_cap().is_some() {
+        pat.push_str("$0");
+    }
+    let mut completion = CompletionItem::new(CompletionKind::Snippet, ctx.source_range(), name)
+        .kind(CompletionItemKind::Binding)
+        .set_documentation(ctx.docs(variant))
+        .set_deprecated(ctx.is_deprecated(variant))
+        .detail(&pat);
+    if let Some(snippet_cap) = ctx.snippet_cap() {
+        completion = completion.insert_snippet(snippet_cap, pat);
+    } else {
+        completion = completion.insert_text(pat);
+    }
+    Some(completion.build())
+}
+
+fn render_record_as_pat(
+    db: &dyn HirDatabase,
+    fields: &[hir::Field],
+    name: &str,
+    fields_omitted: bool,
+) -> String {
+    format!(
+        "{name} {{ {}{} }}",
+        fields.into_iter().map(|field| field.name(db)).format(", "),
+        if fields_omitted { ", .." } else { "" },
+        name = name
+    )
+}
+
+fn render_tuple_as_pat(fields: &[hir::Field], name: &str, fields_omitted: bool) -> String {
+    format!(
+        "{name}({}{})",
+        fields.into_iter().enumerate().map(|(idx, _)| format!("${}", idx + 1)).format(", "),
+        if fields_omitted { ", .." } else { "" },
+        name = name
+    )
+}

--- a/crates/hir/src/code_model.rs
+++ b/crates/hir/src/code_model.rs
@@ -511,6 +511,10 @@ impl Struct {
         db.struct_data(self.id).repr.clone()
     }
 
+    pub fn kind(self, db: &dyn HirDatabase) -> StructKind {
+        self.variant_data(db).kind()
+    }
+
     fn variant_data(self, db: &dyn HirDatabase) -> Arc<VariantData> {
         db.struct_data(self.id).variant_data.clone()
     }


### PR DESCRIPTION

Just gonna call it full pattern completion as pattern completion is already implemented in a sense by showing idents in pattern position. What this does is basically complete struct and variant patterns where applicable(function params, let statements and refutable pattern locations).

This does not replace just completing the corresponding idents of the structs and variants, instead two completions are shown for these, a completion for the ident itself and a completion for the pattern(if the pattern make sense to be used that is). I figured in some cases one would rather type out the pattern manually if it has a lot of fields but you only care about one since this completion would cause one more work in the end since you would have to delete all the extra matched fields again.

These completions are tagged as `CompletionKind::Snippet`, not sure if that is the right one here.
<details>
  <summary>some gifs</summary>

![dx2lxgzhj3](https://user-images.githubusercontent.com/3757771/102719967-6987ef80-42f1-11eb-8ae0-8aff53777860.gif)
![EP2E7sJLkB](https://user-images.githubusercontent.com/3757771/102785777-c7264580-439e-11eb-8a64-f142e19fb65b.gif)
![JMNHHWknr9](https://user-images.githubusercontent.com/3757771/102785796-d1e0da80-439e-11eb-934b-218ada31b51c.gif)
</details>