### PR TITLE
Properly attach attributes to Param instead of parent ParamList

### DIFF
--- a/crates/parser/src/grammar/expressions/atom.rs
+++ b/crates/parser/src/grammar/expressions/atom.rs
@@ -156,11 +156,13 @@ fn tuple_expr(p: &mut Parser) -> CompletedMarker {
     let mut saw_expr = false;
     while !p.at(EOF) && !p.at(T![')']) {
         saw_expr = true;
-        if !p.at_ts(EXPR_FIRST) {
-            p.error("expected expression");
+
+        // test tuple_attrs
+        // const A: (i64, i64) = (1, #[cfg(test)] 2);
+        if !expr_with_attrs(p) {
             break;
         }
-        expr(p);
+
         if !p.at(T![')']) {
             saw_comma = true;
             p.expect(T![,]);

--- a/crates/syntax/test_data/parser/inline/ok/0138_self_param_outer_attr.rast
+++ b/crates/syntax/test_data/parser/inline/ok/0138_self_param_outer_attr.rast
@@ -6,16 +6,16 @@ SOURCE_FILE@0..26
       IDENT@3..4 "f"
     PARAM_LIST@4..22
       L_PAREN@4..5 "("
-      ATTR@5..16
-        POUND@5..6 "#"
-        L_BRACK@6..7 "["
-        PATH@7..15
-          PATH_SEGMENT@7..15
-            NAME_REF@7..15
-              IDENT@7..15 "must_use"
-        R_BRACK@15..16 "]"
-      WHITESPACE@16..17 " "
-      SELF_PARAM@17..21
+      SELF_PARAM@5..21
+        ATTR@5..16
+          POUND@5..6 "#"
+          L_BRACK@6..7 "["
+          PATH@7..15
+            PATH_SEGMENT@7..15
+              NAME_REF@7..15
+                IDENT@7..15 "must_use"
+          R_BRACK@15..16 "]"
+        WHITESPACE@16..17 " "
         SELF_KW@17..21 "self"
       R_PAREN@21..22 ")"
     WHITESPACE@22..23 " "

--- a/crates/syntax/test_data/parser/inline/ok/0154_tuple_attrs.rast
+++ b/crates/syntax/test_data/parser/inline/ok/0154_tuple_attrs.rast
@@ -1,0 +1,50 @@
+SOURCE_FILE@0..43
+  CONST@0..42
+    CONST_KW@0..5 "const"
+    WHITESPACE@5..6 " "
+    NAME@6..7
+      IDENT@6..7 "A"
+    COLON@7..8 ":"
+    WHITESPACE@8..9 " "
+    TUPLE_TYPE@9..19
+      L_PAREN@9..10 "("
+      PATH_TYPE@10..13
+        PATH@10..13
+          PATH_SEGMENT@10..13
+            NAME_REF@10..13
+              IDENT@10..13 "i64"
+      COMMA@13..14 ","
+      WHITESPACE@14..15 " "
+      PATH_TYPE@15..18
+        PATH@15..18
+          PATH_SEGMENT@15..18
+            NAME_REF@15..18
+              IDENT@15..18 "i64"
+      R_PAREN@18..19 ")"
+    WHITESPACE@19..20 " "
+    EQ@20..21 "="
+    WHITESPACE@21..22 " "
+    TUPLE_EXPR@22..41
+      L_PAREN@22..23 "("
+      LITERAL@23..24
+        INT_NUMBER@23..24 "1"
+      COMMA@24..25 ","
+      WHITESPACE@25..26 " "
+      LITERAL@26..40
+        ATTR@26..38
+          POUND@26..27 "#"
+          L_BRACK@27..28 "["
+          PATH@28..31
+            PATH_SEGMENT@28..31
+              NAME_REF@28..31
+                IDENT@28..31 "cfg"
+          TOKEN_TREE@31..37
+            L_PAREN@31..32 "("
+            IDENT@32..36 "test"
+            R_PAREN@36..37 ")"
+          R_BRACK@37..38 "]"
+        WHITESPACE@38..39 " "
+        INT_NUMBER@39..40 "2"
+      R_PAREN@40..41 ")"
+    SEMICOLON@41..42 ";"
+  WHITESPACE@42..43 "\n"

--- a/crates/syntax/test_data/parser/inline/ok/0154_tuple_attrs.rs
+++ b/crates/syntax/test_data/parser/inline/ok/0154_tuple_attrs.rs
@@ -1,0 +1,1 @@
+const A: (i64, i64) = (1, #[cfg(test)] 2);

--- a/crates/syntax/test_data/parser/ok/0051_parameter_attrs.rast
+++ b/crates/syntax/test_data/parser/ok/0051_parameter_attrs.rast
@@ -107,16 +107,16 @@ SOURCE_FILE@0..519
                       IDENT@102..104 "i8"
           COMMA@104..105 ","
           WHITESPACE@105..106 " "
-          ATTR@106..113
-            POUND@106..107 "#"
-            L_BRACK@107..108 "["
-            PATH@108..112
-              PATH_SEGMENT@108..112
-                NAME_REF@108..112
-                  IDENT@108..112 "attr"
-            R_BRACK@112..113 "]"
-          WHITESPACE@113..114 " "
-          PARAM@114..117
+          PARAM@106..117
+            ATTR@106..113
+              POUND@106..107 "#"
+              L_BRACK@107..108 "["
+              PATH@108..112
+                PATH_SEGMENT@108..112
+                  NAME_REF@108..112
+                    IDENT@108..112 "attr"
+              R_BRACK@112..113 "]"
+            WHITESPACE@113..114 " "
             DOT3@114..117 "..."
           R_PAREN@117..118 ")"
         WHITESPACE@118..119 " "
@@ -153,16 +153,16 @@ SOURCE_FILE@0..519
                     IDENT@140..145 "FnMut"
                   PARAM_LIST@145..167
                     L_PAREN@145..146 "("
-                    ATTR@146..153
-                      POUND@146..147 "#"
-                      L_BRACK@147..148 "["
-                      PATH@148..152
-                        PATH_SEGMENT@148..152
-                          NAME_REF@148..152
-                            IDENT@148..152 "attr"
-                      R_BRACK@152..153 "]"
-                    WHITESPACE@153..154 " "
-                    PARAM@154..166
+                    PARAM@146..166
+                      ATTR@146..153
+                        POUND@146..147 "#"
+                        L_BRACK@147..148 "["
+                        PATH@148..152
+                          PATH_SEGMENT@148..152
+                            NAME_REF@148..152
+                              IDENT@148..152 "attr"
+                        R_BRACK@152..153 "]"
+                      WHITESPACE@153..154 " "
                       REF_TYPE@154..166
                         AMP@154..155 "&"
                         MUT_KW@155..158 "mut"
@@ -224,17 +224,17 @@ SOURCE_FILE@0..519
                     IDENT@208..211 "u64"
           COMMA@211..212 ","
           WHITESPACE@212..213 " "
-          ATTR@213..221
-            POUND@213..214 "#"
-            WHITESPACE@214..215 " "
-            L_BRACK@215..216 "["
-            PATH@216..220
-              PATH_SEGMENT@216..220
-                NAME_REF@216..220
-                  IDENT@216..220 "attr"
-            R_BRACK@220..221 "]"
-          WHITESPACE@221..222 " "
-          PARAM@222..232
+          PARAM@213..232
+            ATTR@213..221
+              POUND@213..214 "#"
+              WHITESPACE@214..215 " "
+              L_BRACK@215..216 "["
+              PATH@216..220
+                PATH_SEGMENT@216..220
+                  NAME_REF@216..220
+                    IDENT@216..220 "attr"
+              R_BRACK@220..221 "]"
+            WHITESPACE@221..222 " "
             IDENT_PAT@222..227
               MUT_KW@222..225 "mut"
               WHITESPACE@225..226 " "
@@ -271,16 +271,16 @@ SOURCE_FILE@0..519
           IDENT@255..256 "f"
         PARAM_LIST@256..274
           L_PAREN@256..257 "("
-          ATTR@257..268
-            POUND@257..258 "#"
-            L_BRACK@258..259 "["
-            PATH@259..267
-              PATH_SEGMENT@259..267
-                NAME_REF@259..267
-                  IDENT@259..267 "must_use"
-            R_BRACK@267..268 "]"
-          WHITESPACE@268..269 " "
-          SELF_PARAM@269..273
+          SELF_PARAM@257..273
+            ATTR@257..268
+              POUND@257..258 "#"
+              L_BRACK@258..259 "["
+              PATH@259..267
+                PATH_SEGMENT@259..267
+                  NAME_REF@259..267
+                    IDENT@259..267 "must_use"
+              R_BRACK@267..268 "]"
+            WHITESPACE@268..269 " "
             SELF_KW@269..273 "self"
           R_PAREN@273..274 ")"
         WHITESPACE@274..275 " "
@@ -295,16 +295,16 @@ SOURCE_FILE@0..519
           IDENT@286..288 "g1"
         PARAM_LIST@288..302
           L_PAREN@288..289 "("
-          ATTR@289..296
-            POUND@289..290 "#"
-            L_BRACK@290..291 "["
-            PATH@291..295
-              PATH_SEGMENT@291..295
-                NAME_REF@291..295
-                  IDENT@291..295 "attr"
-            R_BRACK@295..296 "]"
-          WHITESPACE@296..297 " "
-          SELF_PARAM@297..301
+          SELF_PARAM@289..301
+            ATTR@289..296
+              POUND@289..290 "#"
+              L_BRACK@290..291 "["
+              PATH@291..295
+                PATH_SEGMENT@291..295
+                  NAME_REF@291..295
+                    IDENT@291..295 "attr"
+              R_BRACK@295..296 "]"
+            WHITESPACE@296..297 " "
             SELF_KW@297..301 "self"
           R_PAREN@301..302 ")"
         WHITESPACE@302..303 " "
@@ -319,16 +319,16 @@ SOURCE_FILE@0..519
           IDENT@314..316 "g2"
         PARAM_LIST@316..331
           L_PAREN@316..317 "("
-          ATTR@317..324
-            POUND@317..318 "#"
-            L_BRACK@318..319 "["
-            PATH@319..323
-              PATH_SEGMENT@319..323
-                NAME_REF@319..323
-                  IDENT@319..323 "attr"
-            R_BRACK@323..324 "]"
-          WHITESPACE@324..325 " "
-          SELF_PARAM@325..330
+          SELF_PARAM@317..330
+            ATTR@317..324
+              POUND@317..318 "#"
+              L_BRACK@318..319 "["
+              PATH@319..323
+                PATH_SEGMENT@319..323
+                  NAME_REF@319..323
+                    IDENT@319..323 "attr"
+              R_BRACK@323..324 "]"
+            WHITESPACE@324..325 " "
             AMP@325..326 "&"
             SELF_KW@326..330 "self"
           R_PAREN@330..331 ")"
@@ -350,16 +350,16 @@ SOURCE_FILE@0..519
           R_ANGLE@348..349 ">"
         PARAM_LIST@349..368
           L_PAREN@349..350 "("
-          ATTR@350..357
-            POUND@350..351 "#"
-            L_BRACK@351..352 "["
-            PATH@352..356
-              PATH_SEGMENT@352..356
-                NAME_REF@352..356
-                  IDENT@352..356 "attr"
-            R_BRACK@356..357 "]"
-          WHITESPACE@357..358 " "
-          SELF_PARAM@358..367
+          SELF_PARAM@350..367
+            ATTR@350..357
+              POUND@350..351 "#"
+              L_BRACK@351..352 "["
+              PATH@352..356
+                PATH_SEGMENT@352..356
+                  NAME_REF@352..356
+                    IDENT@352..356 "attr"
+              R_BRACK@356..357 "]"
+            WHITESPACE@357..358 " "
             AMP@358..359 "&"
             MUT_KW@359..362 "mut"
             WHITESPACE@362..363 " "
@@ -383,16 +383,16 @@ SOURCE_FILE@0..519
           R_ANGLE@385..386 ">"
         PARAM_LIST@386..404
           L_PAREN@386..387 "("
-          ATTR@387..394
-            POUND@387..388 "#"
-            L_BRACK@388..389 "["
-            PATH@389..393
-              PATH_SEGMENT@389..393
-                NAME_REF@389..393
-                  IDENT@389..393 "attr"
-            R_BRACK@393..394 "]"
-          WHITESPACE@394..395 " "
-          SELF_PARAM@395..403
+          SELF_PARAM@387..403
+            ATTR@387..394
+              POUND@387..388 "#"
+              L_BRACK@388..389 "["
+              PATH@389..393
+                PATH_SEGMENT@389..393
+                  NAME_REF@389..393
+                    IDENT@389..393 "attr"
+              R_BRACK@393..394 "]"
+            WHITESPACE@394..395 " "
             AMP@395..396 "&"
             LIFETIME@396..398
               LIFETIME_IDENT@396..398 "\'a"
@@ -417,16 +417,16 @@ SOURCE_FILE@0..519
           R_ANGLE@421..422 ">"
         PARAM_LIST@422..444
           L_PAREN@422..423 "("
-          ATTR@423..430
-            POUND@423..424 "#"
-            L_BRACK@424..425 "["
-            PATH@425..429
-              PATH_SEGMENT@425..429
-                NAME_REF@425..429
-                  IDENT@425..429 "attr"
-            R_BRACK@429..430 "]"
-          WHITESPACE@430..431 " "
-          SELF_PARAM@431..443
+          SELF_PARAM@423..443
+            ATTR@423..430
+              POUND@423..424 "#"
+              L_BRACK@424..425 "["
+              PATH@425..429
+                PATH_SEGMENT@425..429
+                  NAME_REF@425..429
+                    IDENT@425..429 "attr"
+              R_BRACK@429..430 "]"
+            WHITESPACE@430..431 " "
             AMP@431..432 "&"
             LIFETIME@432..434
               LIFETIME_IDENT@432..434 "\'a"
@@ -447,16 +447,16 @@ SOURCE_FILE@0..519
           IDENT@456..457 "c"
         PARAM_LIST@457..477
           L_PAREN@457..458 "("
-          ATTR@458..465
-            POUND@458..459 "#"
-            L_BRACK@459..460 "["
-            PATH@460..464
-              PATH_SEGMENT@460..464
-                NAME_REF@460..464
-                  IDENT@460..464 "attr"
-            R_BRACK@464..465 "]"
-          WHITESPACE@465..466 " "
-          SELF_PARAM@466..476
+          SELF_PARAM@458..476
+            ATTR@458..465
+              POUND@458..459 "#"
+              L_BRACK@459..460 "["
+              PATH@460..464
+                PATH_SEGMENT@460..464
+                  NAME_REF@460..464
+                    IDENT@460..464 "attr"
+              R_BRACK@464..465 "]"
+            WHITESPACE@465..466 " "
             SELF_KW@466..470 "self"
             COLON@470..471 ":"
             WHITESPACE@471..472 " "
@@ -478,16 +478,16 @@ SOURCE_FILE@0..519
           IDENT@489..490 "d"
         PARAM_LIST@490..514
           L_PAREN@490..491 "("
-          ATTR@491..498
-            POUND@491..492 "#"
-            L_BRACK@492..493 "["
-            PATH@493..497
-              PATH_SEGMENT@493..497
-                NAME_REF@493..497
-                  IDENT@493..497 "attr"
-            R_BRACK@497..498 "]"
-          WHITESPACE@498..499 " "
-          SELF_PARAM@499..513
+          SELF_PARAM@491..513
+            ATTR@491..498
+              POUND@491..492 "#"
+              L_BRACK@492..493 "["
+              PATH@493..497
+                PATH_SEGMENT@493..497
+                  NAME_REF@493..497
+                    IDENT@493..497 "attr"
+              R_BRACK@497..498 "]"
+            WHITESPACE@498..499 " "
             SELF_KW@499..503 "self"
             COLON@503..504 ":"
             WHITESPACE@504..505 " "

--- a/crates/syntax/test_data/parser/ok/0063_variadic_fun.rast
+++ b/crates/syntax/test_data/parser/ok/0063_variadic_fun.rast
@@ -92,20 +92,20 @@ SOURCE_FILE@0..126
                       IDENT@88..90 "u8"
           COMMA@90..91 ","
           WHITESPACE@91..92 " "
-          ATTR@92..105
-            POUND@92..93 "#"
-            L_BRACK@93..94 "["
-            PATH@94..97
-              PATH_SEGMENT@94..97
-                NAME_REF@94..97
-                  IDENT@94..97 "cfg"
-            TOKEN_TREE@97..104
-              L_PAREN@97..98 "("
-              IDENT@98..103 "never"
-              R_PAREN@103..104 ")"
-            R_BRACK@104..105 "]"
-          WHITESPACE@105..106 " "
-          PARAM@106..120
+          PARAM@92..120
+            ATTR@92..105
+              POUND@92..93 "#"
+              L_BRACK@93..94 "["
+              PATH@94..97
+                PATH_SEGMENT@94..97
+                  NAME_REF@94..97
+                    IDENT@94..97 "cfg"
+              TOKEN_TREE@97..104
+                L_PAREN@97..98 "("
+                IDENT@98..103 "never"
+                R_PAREN@103..104 ")"
+              R_BRACK@104..105 "]"
+            WHITESPACE@105..106 " "
             SLICE_PAT@106..115
               L_BRACK@106..107 "["
               IDENT_PAT@107..108


### PR DESCRIPTION
Fixes #2783, fixes #2781

The problem with `let _a = [0,#[cfg(feature = "L")]0];` has already been fixed some time ago it seems:
<details>
  <summary>Syntax Tree for the const item</summary>

```
  LET_STMT@200..236
    LET_KW@200..203 "let"
    WHITESPACE@203..204 " "
    IDENT_PAT@204..206
      NAME@204..206
        IDENT@204..206 "_a"
    WHITESPACE@206..207 " "
    EQ@207..208 "="
    WHITESPACE@208..209 " "
    ARRAY_EXPR@209..235
      L_BRACK@209..210 "["
      LITERAL@210..211
        INT_NUMBER@210..211 "0"
      COMMA@211..212 ","
      LITERAL@212..234
        ATTR@212..233
          POUND@212..213 "#"
          L_BRACK@213..214 "["
          PATH@214..217
            PATH_SEGMENT@214..217
              NAME_REF@214..217
                IDENT@214..217 "cfg"
          TOKEN_TREE@217..232
            L_PAREN@217..218 "("
            IDENT@218..225 "feature"
            WHITESPACE@225..226 " "
            EQ@226..227 "="
            WHITESPACE@227..228 " "
            STRING@228..231 "\"L\""
            R_PAREN@231..232 ")"
          R_BRACK@232..233 "]"
        INT_NUMBER@233..234 "0"
      R_BRACK@234..235 "]"
    SEMICOLON@235..236 ";"
```
</details>