### PR TITLE
Stop setting CompletionItem::deprecated

### DIFF
--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -281,7 +281,7 @@ pub(crate) fn handle_document_symbol(
             detail: symbol.detail,
             kind: to_proto::symbol_kind(symbol.kind),
             tags: Some(tags),
-            deprecated: Some(symbol.deprecated),
+            deprecated: None,
             range: to_proto::range(&line_index, symbol.node_range),
             selection_range: to_proto::range(&line_index, symbol.navigation_range),
             children: None,


### PR DESCRIPTION
Closes #2042

We're now using the `CompletionItem::tags` field to mark `CompletionItem`s as deprecated, and `CompletionItem::deprecated` is gone from LSP.