### PR TITLE
Revert "Stop setting CompletionItem::deprecated"

### DIFF
--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -281,7 +281,7 @@ pub(crate) fn handle_document_symbol(
             detail: symbol.detail,
             kind: to_proto::symbol_kind(symbol.kind),
             tags: Some(tags),
-            deprecated: None,
+            deprecated: Some(symbol.deprecated),
             range: to_proto::range(&line_index, symbol.node_range),
             selection_range: to_proto::range(&line_index, symbol.navigation_range),
             children: None,


### PR DESCRIPTION
We should keep setting it, according to https://github.com/rust-analyzer/rust-analyzer/pull/6974#issuecomment-748983789.