### PR TITLE
Filter out empty rustc spans

### DIFF
--- a/crates/rust-analyzer/src/diagnostics/to_proto.rs
+++ b/crates/rust-analyzer/src/diagnostics/to_proto.rs
@@ -319,6 +319,10 @@ pub(crate) fn map_rust_diagnostic_to_lsp(
                 message: "original diagnostic".to_string(),
             };
             for info in &related_information {
+                // Filter out empty/non-existent messages, as they greatly confuse VS Code.
+                if info.message.is_empty() {
+                    continue;
+                }
                 diagnostics.push(MappedRustDiagnostic {
                     url: info.location.uri.clone(),
                     fixes: fixes.clone(), // share fixes to make them easier to apply


### PR DESCRIPTION
Hopefully, this fixes https://github.com/rust-analyzer/rust-analyzer/issues/6892 (I couldn't test it since r-a currently requires a too recent version of VS Code)