### PR TITLE
Remove parentheses when inverting `!(cond)`

### DIFF
--- a/crates/assists/src/handlers/invert_if.rs
+++ b/crates/assists/src/handlers/invert_if.rs
@@ -78,6 +78,15 @@ mod tests {
     }
 
     #[test]
+    fn invert_if_remove_not_parentheses() {
+        check_assist(
+            invert_if,
+            "fn f() { i<|>f !(x == 3 || x == 4 || x == 5) { 3 * 2 } else { 1 } }",
+            "fn f() { if x == 3 || x == 4 || x == 5 { 1 } else { 3 * 2 } }",
+        )
+    }
+
+    #[test]
     fn invert_if_remove_inequality() {
         check_assist(
             invert_if,

--- a/crates/assists/src/utils.rs
+++ b/crates/assists/src/utils.rs
@@ -232,7 +232,13 @@ fn invert_special_case(expr: &ast::Expr) -> Option<ast::Expr> {
             };
             Some(make::expr_method_call(receiver, method, arg_list))
         }
-        ast::Expr::PrefixExpr(pe) if pe.op_kind()? == ast::PrefixOp::Not => pe.expr(),
+        ast::Expr::PrefixExpr(pe) if pe.op_kind()? == ast::PrefixOp::Not => {
+            if let ast::Expr::ParenExpr(parexpr) = pe.expr()? {
+                parexpr.expr()
+            } else {
+                pe.expr()
+            }
+        }
         // FIXME:
         // ast::Expr::Literal(true | false )
         _ => None,


### PR DESCRIPTION
Followup to #6894

When inverting a composite condition twice, the parentheses were left. This also removes those unnecessary parentheses when applying the invert-if assist.