### PR TITLE
Allow code extension to download binary in apple arm

### DIFF
--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -287,7 +287,7 @@ async function getServer(config: Config, state: PersistentState): Promise<string
     if (config.package.releaseTag === null) return "rust-analyzer";
 
     let platform: string | undefined;
-    if (process.arch === "x64" || process.arch === "ia32") {
+    if (process.arch === "x64" || process.arch === "ia32" || process.arch === "arm64") {
         if (process.platform === "linux") platform = "linux";
         if (process.platform === "darwin") platform = "mac";
         if (process.platform === "win32") platform = "windows";


### PR DESCRIPTION
Apple chip has a new `arch`. It subsequently downloads Intel version of `rust-analyzer` but it works regardless.