### PR TITLE
Clean up descriptions for settings

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -33,7 +33,7 @@ config_data! {
         callInfo_full: bool = "true",
 
         /// Automatically refresh project info via `cargo metadata` on
-        /// Cargo.toml changes.
+        /// `Cargo.toml` changes.
         cargo_autoreload: bool           = "true",
         /// Activate all available features.
         cargo_allFeatures: bool          = "false",
@@ -52,7 +52,7 @@ config_data! {
         /// Run specified `cargo check` command for diagnostics on save.
         checkOnSave_enable: bool                         = "true",
         /// Check with all features (will be passed as `--all-features`).
-        /// Defaults to `rust-analyzer.cargo.allFeatures`.
+        /// Defaults to `#rust-analyzer.cargo.allFeatures#`.
         checkOnSave_allFeatures: Option<bool>            = "null",
         /// Check all targets and tests (will be passed as `--all-targets`).
         checkOnSave_allTargets: bool                     = "true",
@@ -61,12 +61,12 @@ config_data! {
         /// Do not activate the `default` feature.
         checkOnSave_noDefaultFeatures: Option<bool>      = "null",
         /// Check for a specific target. Defaults to
-        /// `rust-analyzer.cargo.target`.
+        /// `#rust-analyzer.cargo.target#`.
         checkOnSave_target: Option<String>               = "null",
         /// Extra arguments for `cargo check`.
         checkOnSave_extraArgs: Vec<String>               = "[]",
         /// List of features to activate. Defaults to
-        /// `rust-analyzer.cargo.features`.
+        /// `#rust-analyzer.cargo.features#`.
         checkOnSave_features: Option<Vec<String>>        = "null",
         /// Advanced option, fully override the command rust-analyzer uses for
         /// checking. The command should include `--message-format=json` or
@@ -80,7 +80,7 @@ config_data! {
         /// Whether to show postfix snippets like `dbg`, `if`, `not`, etc.
         completion_postfix_enable: bool          = "true",
         /// Toggles the additional completions that automatically add imports when completed.
-        /// Note that your client have to specify the `additionalTextEdits` LSP client capability to truly have this feature enabled.
+        /// Note that your client must specify the `additionalTextEdits` LSP client capability to truly have this feature enabled.
         completion_autoimport_enable: bool       = "true",
 
         /// Whether to show native rust-analyzer diagnostics.
@@ -90,13 +90,13 @@ config_data! {
         diagnostics_enableExperimental: bool    = "true",
         /// List of rust-analyzer diagnostics to disable.
         diagnostics_disabled: FxHashSet<String> = "[]",
-        /// List of warnings that should be displayed with info severity.\nThe
+        /// List of warnings that should be displayed with info severity.\n\nThe
         /// warnings will be indicated by a blue squiggly underline in code and
-        /// a blue icon in the problems panel.
+        /// a blue icon in the `Problems Panel`.
         diagnostics_warningsAsHint: Vec<String> = "[]",
-        /// List of warnings that should be displayed with hint severity.\nThe
+        /// List of warnings that should be displayed with hint severity.\n\nThe
         /// warnings will be indicated by faded text or three dots in code and
-        /// will not show up in the problems panel.
+        /// will not show up in the `Problems Panel`.
         diagnostics_warningsAsInfo: Vec<String> = "[]",
 
         /// Controls file watching implementation.
@@ -121,7 +121,7 @@ config_data! {
 
         /// Whether to show inlay type hints for method chains.
         inlayHints_chainingHints: bool      = "true",
-        /// Maximum length for inlay hints.
+        /// Maximum length for inlay hints. Default is unlimited.
         inlayHints_maxLength: Option<usize> = "null",
         /// Whether to show function parameter name inlay hints at the call
         /// site.
@@ -145,27 +145,27 @@ config_data! {
         lens_methodReferences: bool = "false",
 
         /// Disable project auto-discovery in favor of explicitly specified set
-        /// of projects.  \nElements must be paths pointing to Cargo.toml,
-        /// rust-project.json, or JSON objects in rust-project.json format.
+        /// of projects.\n\nElements must be paths pointing to `Cargo.toml`,
+        /// `rust-project.json`, or JSON objects in `rust-project.json` format.
         linkedProjects: Vec<ManifestOrProjectJson> = "[]",
-        /// Number of syntax trees rust-analyzer keeps in memory.
+        /// Number of syntax trees rust-analyzer keeps in memory.  Defaults to 128.
         lruCapacity: Option<usize>                 = "null",
         /// Whether to show `can't find Cargo.toml` error message.
         notifications_cargoTomlNotFound: bool      = "true",
-        /// Enable Proc macro support, cargo.loadOutDirsFromCheck must be
+        /// Enable Proc macro support, `#rust-analyzer.cargo.loadOutDirsFromCheck#` must be
         /// enabled.
         procMacro_enable: bool                     = "false",
 
         /// Command to be executed instead of 'cargo' for runnables.
         runnables_overrideCargo: Option<String> = "null",
         /// Additional arguments to be passed to cargo for runnables such as
-        /// tests or binaries.\nFor example, it may be '--release'.
+        /// tests or binaries.\nFor example, it may be `--release`.
         runnables_cargoExtraArgs: Vec<String>   = "[]",
 
         /// Path to the rust compiler sources, for usage in rustc_private projects.
         rustcSource : Option<String> = "null",
 
-        /// Additional arguments to rustfmt.
+        /// Additional arguments to `rustfmt`.
         rustfmt_extraArgs: Vec<String>               = "[]",
         /// Advanced option, fully override the command rust-analyzer uses for
         /// formatting.
@@ -758,7 +758,7 @@ fn field_props(field: &str, ty: &str, doc: &[&str], default: &str) -> serde_json
             ],
             "enumDescriptions": [
                 "Insert import paths relative to the current module, using up to one `super` prefix if the parent module contains the requested item.",
-                "Prefix all import paths with `self` if they don't begin with `self`, `super`, `crate` or a crate name",
+                "Prefix all import paths with `self` if they don't begin with `self`, `super`, `crate` or a crate name.",
                 "Force import paths to be absolute by always starting them with `crate` or the crate name they refer to."
             ],
         },

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -5,7 +5,7 @@ rust-analyzer.assist.importPrefix (default: `"plain"`)::
 rust-analyzer.callInfo.full (default: `true`)::
  Show function name and docs in parameter hints.
 rust-analyzer.cargo.autoreload (default: `true`)::
- Automatically refresh project info via `cargo metadata` on  Cargo.toml changes.
+ Automatically refresh project info via `cargo metadata` on  `Cargo.toml` changes.
 rust-analyzer.cargo.allFeatures (default: `false`)::
  Activate all available features.
 rust-analyzer.cargo.features (default: `[]`)::
@@ -21,7 +21,7 @@ rust-analyzer.cargo.noSysroot (default: `false`)::
 rust-analyzer.checkOnSave.enable (default: `true`)::
  Run specified `cargo check` command for diagnostics on save.
 rust-analyzer.checkOnSave.allFeatures (default: `null`)::
- Check with all features (will be passed as `--all-features`).  Defaults to `rust-analyzer.cargo.allFeatures`.
+ Check with all features (will be passed as `--all-features`).  Defaults to `#rust-analyzer.cargo.allFeatures#`.
 rust-analyzer.checkOnSave.allTargets (default: `true`)::
  Check all targets and tests (will be passed as `--all-targets`).
 rust-analyzer.checkOnSave.command (default: `"check"`)::
@@ -29,11 +29,11 @@ rust-analyzer.checkOnSave.command (default: `"check"`)::
 rust-analyzer.checkOnSave.noDefaultFeatures (default: `null`)::
  Do not activate the `default` feature.
 rust-analyzer.checkOnSave.target (default: `null`)::
- Check for a specific target. Defaults to  `rust-analyzer.cargo.target`.
+ Check for a specific target. Defaults to  `#rust-analyzer.cargo.target#`.
 rust-analyzer.checkOnSave.extraArgs (default: `[]`)::
  Extra arguments for `cargo check`.
 rust-analyzer.checkOnSave.features (default: `null`)::
- List of features to activate. Defaults to  `rust-analyzer.cargo.features`.
+ List of features to activate. Defaults to  `#rust-analyzer.cargo.features#`.
 rust-analyzer.checkOnSave.overrideCommand (default: `null`)::
  Advanced option, fully override the command rust-analyzer uses for  checking. The command should include `--message-format=json` or  similar option.
 rust-analyzer.completion.addCallArgumentSnippets (default: `true`)::
@@ -43,7 +43,7 @@ rust-analyzer.completion.addCallParenthesis (default: `true`)::
 rust-analyzer.completion.postfix.enable (default: `true`)::
  Whether to show postfix snippets like `dbg`, `if`, `not`, etc.
 rust-analyzer.completion.autoimport.enable (default: `true`)::
- Toggles the additional completions that automatically add imports when completed.  Note that your client have to specify the `additionalTextEdits` LSP client capability to truly have this feature enabled.
+ Toggles the additional completions that automatically add imports when completed.  Note that your client must specify the `additionalTextEdits` LSP client capability to truly have this feature enabled.
 rust-analyzer.diagnostics.enable (default: `true`)::
  Whether to show native rust-analyzer diagnostics.
 rust-analyzer.diagnostics.enableExperimental (default: `true`)::
@@ -51,9 +51,9 @@ rust-analyzer.diagnostics.enableExperimental (default: `true`)::
 rust-analyzer.diagnostics.disabled (default: `[]`)::
  List of rust-analyzer diagnostics to disable.
 rust-analyzer.diagnostics.warningsAsHint (default: `[]`)::
- List of warnings that should be displayed with info severity.\nThe  warnings will be indicated by a blue squiggly underline in code and  a blue icon in the problems panel.
+ List of warnings that should be displayed with info severity.\n\nThe  warnings will be indicated by a blue squiggly underline in code and  a blue icon in the `Problems Panel`.
 rust-analyzer.diagnostics.warningsAsInfo (default: `[]`)::
- List of warnings that should be displayed with hint severity.\nThe  warnings will be indicated by faded text or three dots in code and  will not show up in the problems panel.
+ List of warnings that should be displayed with hint severity.\n\nThe  warnings will be indicated by faded text or three dots in code and  will not show up in the `Problems Panel`.
 rust-analyzer.files.watcher (default: `"client"`)::
  Controls file watching implementation.
 rust-analyzer.hoverActions.debug (default: `true`)::
@@ -71,7 +71,7 @@ rust-analyzer.hoverActions.linksInHover (default: `true`)::
 rust-analyzer.inlayHints.chainingHints (default: `true`)::
  Whether to show inlay type hints for method chains.
 rust-analyzer.inlayHints.maxLength (default: `null`)::
- Maximum length for inlay hints.
+ Maximum length for inlay hints. Default is unlimited.
 rust-analyzer.inlayHints.parameterHints (default: `true`)::
  Whether to show function parameter name inlay hints at the call  site.
 rust-analyzer.inlayHints.typeHints (default: `true`)::
@@ -87,20 +87,20 @@ rust-analyzer.lens.run (default: `true`)::
 rust-analyzer.lens.methodReferences (default: `false`)::
  Whether to show `Method References` lens. Only applies when  `#rust-analyzer.lens.enable#` is set.
 rust-analyzer.linkedProjects (default: `[]`)::
- Disable project auto-discovery in favor of explicitly specified set  of projects.  \nElements must be paths pointing to Cargo.toml,  rust-project.json, or JSON objects in rust-project.json format.
+ Disable project auto-discovery in favor of explicitly specified set  of projects.\n\nElements must be paths pointing to `Cargo.toml`,  `rust-project.json`, or JSON objects in `rust-project.json` format.
 rust-analyzer.lruCapacity (default: `null`)::
- Number of syntax trees rust-analyzer keeps in memory.
+ Number of syntax trees rust-analyzer keeps in memory.  Defaults to 128.
 rust-analyzer.notifications.cargoTomlNotFound (default: `true`)::
  Whether to show `can't find Cargo.toml` error message.
 rust-analyzer.procMacro.enable (default: `false`)::
- Enable Proc macro support, cargo.loadOutDirsFromCheck must be  enabled.
+ Enable Proc macro support, `#rust-analyzer.cargo.loadOutDirsFromCheck#` must be  enabled.
 rust-analyzer.runnables.overrideCargo (default: `null`)::
  Command to be executed instead of 'cargo' for runnables.
 rust-analyzer.runnables.cargoExtraArgs (default: `[]`)::
- Additional arguments to be passed to cargo for runnables such as  tests or binaries.\nFor example, it may be '--release'.
+ Additional arguments to be passed to cargo for runnables such as  tests or binaries.\nFor example, it may be `--release`.
 rust-analyzer.rustcSource (default: `null`)::
  Path to the rust compiler sources, for usage in rustc_private projects.
 rust-analyzer.rustfmt.extraArgs (default: `[]`)::
- Additional arguments to rustfmt.
+ Additional arguments to `rustfmt`.
 rust-analyzer.rustfmt.overrideCommand (default: `null`)::
  Advanced option, fully override the command rust-analyzer uses for  formatting.

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -250,12 +250,12 @@
                         }
                     ],
                     "default": null,
-                    "description": "Environment variables passed to the runnable launched using `Test ` or `Debug` lens or `rust-analyzer.run` command."
+                    "markdownDescription": "Environment variables passed to the runnable launched using `Test` or `Debug` lens or `rust-analyzer.run` command."
                 },
                 "rust-analyzer.inlayHints.enable": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Whether to show inlay hints"
+                    "description": "Whether to show inlay hints."
                 },
                 "rust-analyzer.updates.channel": {
                     "type": "string",
@@ -265,15 +265,15 @@
                     ],
                     "default": "stable",
                     "markdownEnumDescriptions": [
-                        "`\"stable\"` updates are shipped weekly, they don't contain cutting-edge features from VSCode proposed APIs but have less bugs in general",
-                        "`\"nightly\"` updates are shipped daily (extension updates automatically by downloading artifacts directly from GitHub), they contain cutting-edge features and latest bug fixes. These releases help us get your feedback very quickly and speed up rust-analyzer development **drastically**"
+                        "`stable` updates are shipped weekly, they don't contain cutting-edge features from VSCode proposed APIs but have less bugs in general.",
+                        "`nightly` updates are shipped daily (extension updates automatically by downloading artifacts directly from GitHub), they contain cutting-edge features and latest bug fixes. These releases help us get your feedback very quickly and speed up rust-analyzer development **drastically**."
                     ],
-                    "markdownDescription": "Choose `\"nightly\"` updates to get the latest features and bug fixes every day. While `\"stable\"` releases occur weekly and don't contain cutting-edge features from VSCode proposed APIs"
+                    "markdownDescription": "Choose `nightly` updates to get the latest features and bug fixes every day. While `stable` releases occur weekly and don't contain cutting-edge features from VSCode proposed APIs."
                 },
                 "rust-analyzer.updates.askBeforeDownload": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Whether to ask for permission before downloading any files from the Internet"
+                    "description": "Whether to ask for permission before downloading any files from the Internet."
                 },
                 "rust-analyzer.serverPath": {
                     "type": [
@@ -281,7 +281,7 @@
                         "string"
                     ],
                     "default": null,
-                    "description": "Path to rust-analyzer executable (points to bundled binary by default). If this is set, then \"rust-analyzer.updates.channel\" setting is not used"
+                    "markdownDescription": "Path to rust-analyzer executable (points to bundled binary by default). If this is set, then `#rust-analyzer.updates.channel#` setting is not used"
                 },
                 "rust-analyzer.trace.server": {
                     "type": "string",
@@ -297,10 +297,10 @@
                         "Full log"
                     ],
                     "default": "off",
-                    "description": "Trace requests to the rust-analyzer (this is usually overly verbose and not recommended for regular users)"
+                    "description": "Trace requests to the rust-analyzer (this is usually overly verbose and not recommended for regular users)."
                 },
                 "rust-analyzer.trace.extension": {
-                    "description": "Enable logging of VS Code extensions itself",
+                    "description": "Enable logging of VS Code extensions itself.",
                     "type": "boolean",
                     "default": false
                 },
@@ -327,14 +327,14 @@
                     }
                 },
                 "rust-analyzer.debug.openDebugPane": {
-                    "description": "Whether to open up the Debug Pane on debugging start.",
+                    "markdownDescription": "Whether to open up the `Debug Panel` on debugging start.",
                     "type": "boolean",
                     "default": false
                 },
                 "rust-analyzer.debug.engineSettings": {
                     "type": "object",
                     "default": {},
-                    "description": "Optional settings passed to the debug engine. Example:\n{ \"lldb\": { \"terminal\":\"external\"} }"
+                    "markdownDescription": "Optional settings passed to the debug engine. Example: `{ \"lldb\": { \"terminal\":\"external\"} }`"
                 },
                 "rust-analyzer.assist.importMergeBehaviour": {
                     "markdownDescription": "The strategy to use when inserting new imports or merging imports.",
@@ -362,7 +362,7 @@
                     ],
                     "enumDescriptions": [
                         "Insert import paths relative to the current module, using up to one `super` prefix if the parent module contains the requested item.",
-                        "Prefix all import paths with `self` if they don't begin with `self`, `super`, `crate` or a crate name",
+                        "Prefix all import paths with `self` if they don't begin with `self`, `super`, `crate` or a crate name.",
                         "Force import paths to be absolute by always starting them with `crate` or the crate name they refer to."
                     ]
                 },
@@ -372,7 +372,7 @@
                     "type": "boolean"
                 },
                 "rust-analyzer.cargo.autoreload": {
-                    "markdownDescription": "Automatically refresh project info via `cargo metadata` on Cargo.toml changes.",
+                    "markdownDescription": "Automatically refresh project info via `cargo metadata` on `Cargo.toml` changes.",
                     "default": true,
                     "type": "boolean"
                 },
@@ -418,7 +418,7 @@
                     "type": "boolean"
                 },
                 "rust-analyzer.checkOnSave.allFeatures": {
-                    "markdownDescription": "Check with all features (will be passed as `--all-features`). Defaults to `rust-analyzer.cargo.allFeatures`.",
+                    "markdownDescription": "Check with all features (will be passed as `--all-features`). Defaults to `#rust-analyzer.cargo.allFeatures#`.",
                     "default": null,
                     "type": [
                         "null",
@@ -444,7 +444,7 @@
                     ]
                 },
                 "rust-analyzer.checkOnSave.target": {
-                    "markdownDescription": "Check for a specific target. Defaults to `rust-analyzer.cargo.target`.",
+                    "markdownDescription": "Check for a specific target. Defaults to `#rust-analyzer.cargo.target#`.",
                     "default": null,
                     "type": [
                         "null",
@@ -460,7 +460,7 @@
                     }
                 },
                 "rust-analyzer.checkOnSave.features": {
-                    "markdownDescription": "List of features to activate. Defaults to `rust-analyzer.cargo.features`.",
+                    "markdownDescription": "List of features to activate. Defaults to `#rust-analyzer.cargo.features#`.",
                     "default": null,
                     "type": [
                         "null",
@@ -497,7 +497,7 @@
                     "type": "boolean"
                 },
                 "rust-analyzer.completion.autoimport.enable": {
-                    "markdownDescription": "Toggles the additional completions that automatically add imports when completed. Note that your client have to specify the `additionalTextEdits` LSP client capability to truly have this feature enabled.",
+                    "markdownDescription": "Toggles the additional completions that automatically add imports when completed. Note that your client must specify the `additionalTextEdits` LSP client capability to truly have this feature enabled.",
                     "default": true,
                     "type": "boolean"
                 },
@@ -521,7 +521,7 @@
                     "uniqueItems": true
                 },
                 "rust-analyzer.diagnostics.warningsAsHint": {
-                    "markdownDescription": "List of warnings that should be displayed with info severity.\\nThe warnings will be indicated by a blue squiggly underline in code and a blue icon in the problems panel.",
+                    "markdownDescription": "List of warnings that should be displayed with info severity.\\n\\nThe warnings will be indicated by a blue squiggly underline in code and a blue icon in the `Problems Panel`.",
                     "default": [],
                     "type": "array",
                     "items": {
@@ -529,7 +529,7 @@
                     }
                 },
                 "rust-analyzer.diagnostics.warningsAsInfo": {
-                    "markdownDescription": "List of warnings that should be displayed with hint severity.\\nThe warnings will be indicated by faded text or three dots in code and will not show up in the problems panel.",
+                    "markdownDescription": "List of warnings that should be displayed with hint severity.\\n\\nThe warnings will be indicated by faded text or three dots in code and will not show up in the `Problems Panel`.",
                     "default": [],
                     "type": "array",
                     "items": {
@@ -577,7 +577,7 @@
                     "type": "boolean"
                 },
                 "rust-analyzer.inlayHints.maxLength": {
-                    "markdownDescription": "Maximum length for inlay hints.",
+                    "markdownDescription": "Maximum length for inlay hints. Default is unlimited.",
                     "default": null,
                     "type": [
                         "null",
@@ -621,7 +621,7 @@
                     "type": "boolean"
                 },
                 "rust-analyzer.linkedProjects": {
-                    "markdownDescription": "Disable project auto-discovery in favor of explicitly specified set of projects.  \\nElements must be paths pointing to Cargo.toml, rust-project.json, or JSON objects in rust-project.json format.",
+                    "markdownDescription": "Disable project auto-discovery in favor of explicitly specified set of projects.\\n\\nElements must be paths pointing to `Cargo.toml`, `rust-project.json`, or JSON objects in `rust-project.json` format.",
                     "default": [],
                     "type": "array",
                     "items": {
@@ -632,7 +632,7 @@
                     }
                 },
                 "rust-analyzer.lruCapacity": {
-                    "markdownDescription": "Number of syntax trees rust-analyzer keeps in memory.",
+                    "markdownDescription": "Number of syntax trees rust-analyzer keeps in memory.  Defaults to 128.",
                     "default": null,
                     "type": [
                         "null",
@@ -646,7 +646,7 @@
                     "type": "boolean"
                 },
                 "rust-analyzer.procMacro.enable": {
-                    "markdownDescription": "Enable Proc macro support, cargo.loadOutDirsFromCheck must be enabled.",
+                    "markdownDescription": "Enable Proc macro support, `#rust-analyzer.cargo.loadOutDirsFromCheck#` must be enabled.",
                     "default": false,
                     "type": "boolean"
                 },
@@ -659,7 +659,7 @@
                     ]
                 },
                 "rust-analyzer.runnables.cargoExtraArgs": {
-                    "markdownDescription": "Additional arguments to be passed to cargo for runnables such as tests or binaries.\\nFor example, it may be '--release'.",
+                    "markdownDescription": "Additional arguments to be passed to cargo for runnables such as tests or binaries.\\nFor example, it may be `--release`.",
                     "default": [],
                     "type": "array",
                     "items": {
@@ -675,7 +675,7 @@
                     ]
                 },
                 "rust-analyzer.rustfmt.extraArgs": {
-                    "markdownDescription": "Additional arguments to rustfmt.",
+                    "markdownDescription": "Additional arguments to `rustfmt`.",
                     "default": [],
                     "type": "array",
                     "items": {


### PR DESCRIPTION
Use two consecutive newlines (`\n\n`) to actually continue text on a
new line.

Use proper markup to reference related settings.

Consistently format references to files, command line arguments, etc.
as `code`. Format mentions of UI elements in _italic_.

Fix typos, add missing full-stops, add missing default values.