### PR TITLE
Store invocation site for eager macros

### DIFF
--- a/crates/hir_expand/src/builtin_macro.rs
+++ b/crates/hir_expand/src/builtin_macro.rs
@@ -563,6 +563,7 @@ mod tests {
 
                 let args = macro_call.token_tree().unwrap();
                 let parsed_args = mbe::ast_to_token_tree(&args).unwrap().0;
+                let call_id = AstId::new(file_id.into(), ast_id_map.ast_id(&macro_call));
 
                 let arg_id = db.intern_eager_expansion({
                     EagerCallLoc {
@@ -570,7 +571,7 @@ mod tests {
                         fragment: FragmentKind::Expr,
                         subtree: Arc::new(parsed_args.clone()),
                         krate,
-                        file_id: file_id.into(),
+                        call: call_id,
                     }
                 });
 
@@ -580,7 +581,7 @@ mod tests {
                     fragment,
                     subtree: Arc::new(subtree),
                     krate,
-                    file_id: file_id.into(),
+                    call: call_id,
                 };
 
                 let id: MacroCallId = db.intern_eager_expansion(eager).into();

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -750,6 +750,31 @@ fn test() {
     }
 
     #[test]
+    fn goto_through_included_file() {
+        check(
+            r#"
+//- /main.rs
+#[rustc_builtin_macro]
+macro_rules! include {}
+
+  include!("foo.rs");
+//^^^^^^^^^^^^^^^^^^^
+
+fn f() {
+    foo<|>();
+}
+
+mod confuse_index {
+    pub fn foo() {}
+}
+
+//- /foo.rs
+fn foo() {}
+        "#,
+        );
+    }
+
+    #[test]
     fn goto_for_type_param() {
         check(
             r#"


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/6992

r? @edwin0cheng 

I'm not sure if this is totally correct, it looks like we create **two** `EagerCallLoc`s per macro invocation, one for the arguments (?), and one for the actual macro call. I gave both the same `AstId`, hopefully that's correct.