### PR TITLE
Add support for downloading aarch64-apple-darwin binaries

### DIFF
--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -287,12 +287,14 @@ async function getServer(config: Config, state: PersistentState): Promise<string
     if (config.package.releaseTag === null) return "rust-analyzer";
 
     let platform: string | undefined;
-    if (process.arch === "x64" || process.arch === "ia32") {
-        if (process.platform === "linux") platform = "linux";
-        if (process.platform === "darwin") platform = "mac";
-        if (process.platform === "win32") platform = "windows";
+    if ((process.arch === "x64" || process.arch === "ia32") && process.platform === "win32") {
+        platform = "x86_64-pc-windows-msvc";
+    } else if (process.arch === "x64" && process.platform === "linux") {
+        platform = "x86_64-unknown-linux-gnu";
+    } else if (process.arch === "x64" && process.platform === "darwin") {
+        platform = "x86_64-apple-darwin";
     } else if (process.arch === "arm64" && process.platform === "darwin") {
-        platform = "mac";
+        platform = "aarch64-apple-darwin";
     }
     if (platform === undefined) {
         vscode.window.showErrorMessage(
@@ -305,7 +307,7 @@ async function getServer(config: Config, state: PersistentState): Promise<string
         );
         return undefined;
     }
-    const ext = platform === "windows" ? ".exe" : "";
+    const ext = platform.indexOf("-windows-") !== -1 ? ".exe" : "";
     const dest = path.join(config.globalStoragePath, `rust-analyzer-${platform}${ext}`);
     const exists = await fs.stat(dest).then(() => true, () => false);
     if (!exists) {


### PR DESCRIPTION
There's also a slight behavior change here: we no longer download our 64-binaries on 32-bit Darwin and Linux. We still do that on Windows, as I don't know how to detect 32-bit Node on 64 Windows.

But some people install the 32-bit Code by mistake, I doubt 32-bit Windows is that popular in the Rust crowd.