### PR TITLE
Disable the unaligned feature of the object crate

### DIFF
--- a/crates/proc_macro_srv/Cargo.toml
+++ b/crates/proc_macro_srv/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 doctest = false
 
 [dependencies]
-object = { version = "0.23", default-features = false, features = ["std", "read_core", "elf", "macho", "pe", "unaligned"] }
+object = { version = "0.23", default-features = false, features = ["std", "read_core", "elf", "macho", "pe"] }
 libloading = "0.6.0"
 memmap = "0.7"
 


### PR DESCRIPTION
We `mmap` the files so they should be reasonably aligned.

Let's see what https://github.com/rust-analyzer/rust-analyzer/pull/6817#issuecomment-744866239 is about.