### PR TITLE
Flush stdout when clearing the progress bar

### DIFF
--- a/crates/rust-analyzer/src/cli/progress_report.rs
+++ b/crates/rust-analyzer/src/cli/progress_report.rs
@@ -1,7 +1,7 @@
 //! A simple progress bar
 //!
 //! A single thread non-optimized progress bar
-use std::io::Write;
+use std::io::{self, Write};
 
 /// A Simple ASCII Progress Bar
 pub(crate) struct ProgressReport {
@@ -97,8 +97,8 @@ impl ProgressReport {
             }
         }
 
-        let _ = std::io::stdout().write(output.as_bytes());
-        let _ = std::io::stdout().flush();
+        let _ = io::stdout().write(output.as_bytes());
+        let _ = io::stdout().flush();
         self.text = text.to_string();
     }
 
@@ -115,6 +115,8 @@ impl ProgressReport {
         let spaces = " ".repeat(self.text.len());
         let backspaces = "\x08".repeat(self.text.len());
         print!("{}{}{}", backspaces, spaces, backspaces);
+        let _ = io::stdout().flush();
+
         self.text = String::new();
     }
 }


### PR DESCRIPTION
To prevent this from happening:

```
Database loaded 496.24ms, 288mi
Crates in this dir: 1
Total modules found: 14
Total declarations: 159
Total functions: 122
Item Collection: 6.02s, 61846mi
122/122 100% processing: archive::sizeTotal expressions: 6592       
Expressions of unknown type: 4 (0%)
Expressions of partially unknown type: 104 (1%)
Type mismatches: 3
Inference: 1.03s, 8622mi
Total: 7.05s, 70468mi
```