### PR TITLE
Add force_show_panics flag for proc-macro bridge

### DIFF
--- a/crates/proc_macro_srv/src/dylib.rs
+++ b/crates/proc_macro_srv/src/dylib.rs
@@ -136,6 +136,7 @@ impl Expander {
                         &crate::proc_macro::bridge::server::SameThread,
                         crate::rustc_server::Rustc::default(),
                         parsed_body,
+                        false,
                     );
                     return res.map(|it| it.subtree);
                 }
@@ -144,6 +145,7 @@ impl Expander {
                         &crate::proc_macro::bridge::server::SameThread,
                         crate::rustc_server::Rustc::default(),
                         parsed_body,
+                        false,
                     );
                     return res.map(|it| it.subtree);
                 }
@@ -153,6 +155,7 @@ impl Expander {
                         crate::rustc_server::Rustc::default(),
                         parsed_attributes,
                         parsed_body,
+                        false,
                     );
                     return res.map(|it| it.subtree);
                 }

--- a/crates/proc_macro_srv/src/proc_macro/bridge/mod.rs
+++ b/crates/proc_macro_srv/src/proc_macro/bridge/mod.rs
@@ -225,6 +225,9 @@ pub struct Bridge<'a> {
 
     /// Server-side function that the client uses to make requests.
     dispatch: closure::Closure<'a, Buffer<u8>, Buffer<u8>>,
+
+    /// If 'true', always invoke the default panic hook
+    force_show_panics: bool,
 }
 
 // impl<'a> !Sync for Bridge<'a> {}


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/75082 and https://github.com/rust-lang/rust/pull/76292 added a new flag in `proc_macro::Bridge` such that the ABI was changed. These ABI changing are the reason of some weird panics which caused #6880 and maybe related to the panic mentioned in #6820.

These changes are landed on rust stable 1.48 so I think it is okay to apply it now.

fixes #6880

r @jonas-schievink 
