### PR TITLE
Resolve attributes during name resolution

### DIFF
--- a/crates/hir_def/src/builtin_attr.rs
+++ b/crates/hir_def/src/builtin_attr.rs
@@ -34,9 +34,12 @@ macro_rules! rustc_attr {
     };
 }
 
-/// Attributes that have a special meaning to rustc or rustdoc.
+/// Built-in macro-like attributes.
+pub const EXTRA_ATTRIBUTES: &[BuiltinAttribute] = &["test", "bench"];
+
+/// "Inert" built-in attributes that have a special meaning to rustc or rustdoc.
 #[rustfmt::skip]
-pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
+pub const INERT_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
     // Stable attributes:
     // ==========================================================================

--- a/crates/hir_def/src/db.rs
+++ b/crates/hir_def/src/db.rs
@@ -106,6 +106,7 @@ pub trait DefDatabase: InternDatabase + AstDatabase + Upcast<dyn AstDatabase> {
 }
 
 fn crate_def_map_wait(db: &impl DefDatabase, krate: CrateId) -> Arc<CrateDefMap> {
-    let _p = profile::span("crate_def_map:wait");
+    let _p = profile::span("crate_def_map:wait")
+        .detail(|| db.crate_graph()[krate].display_name.as_deref().unwrap_or_default().to_string());
     db.crate_def_map_query(krate)
 }

--- a/crates/hir_def/src/diagnostics.rs
+++ b/crates/hir_def/src/diagnostics.rs
@@ -95,6 +95,39 @@ impl Diagnostic for UnresolvedImport {
     }
 }
 
+// Diagnostic: unresolved-attribute
+//
+// This diagnostic is triggered if rust-analyzer is unable to resolve an attribute.
+#[derive(Debug)]
+pub struct UnresolvedAttribute {
+    pub file: HirFileId,
+    pub node: AstPtr<ast::Attr>,
+}
+
+impl Diagnostic for UnresolvedAttribute {
+    fn code(&self) -> DiagnosticCode {
+        DiagnosticCode("unresolved-attribute")
+    }
+
+    fn message(&self) -> String {
+        "unresolved attribute".to_string()
+    }
+
+    fn display_source(&self) -> InFile<SyntaxNodePtr> {
+        InFile::new(self.file, self.node.clone().into())
+    }
+
+    fn as_any(&self) -> &(dyn Any + Send + 'static) {
+        self
+    }
+
+    fn is_experimental(&self) -> bool {
+        // This will fail to resolve any attribute that is consumed by a procedural attribute macro.
+        // Also, this diagnostic in quite new and might have bugs.
+        true
+    }
+}
+
 // Diagnostic: inactive-code
 //
 // This diagnostic is shown for code with inactive `#[cfg]` attributes.

--- a/crates/hir_def/src/nameres.rs
+++ b/crates/hir_def/src/nameres.rs
@@ -432,7 +432,7 @@ mod diagnostics {
                             let node = ast.to_node(db.upcast());
                             (ast.file_id, SyntaxNodePtr::from(AstPtr::new(&node)), None)
                         }
-                        MacroCallKind::Attr(ast, name) => {
+                        MacroCallKind::Derive(ast, name) | MacroCallKind::Attr(ast, name) => {
                             let node = ast.to_node(db.upcast());
 
                             // Compute the precise location of the macro name's token in the derive
@@ -483,7 +483,7 @@ mod diagnostics {
                             let node = ast.to_node(db.upcast());
                             (ast.file_id, SyntaxNodePtr::from(AstPtr::new(&node)))
                         }
-                        MacroCallKind::Attr(ast, _) => {
+                        MacroCallKind::Derive(ast, _) | MacroCallKind::Attr(ast, _) => {
                             let node = ast.to_node(db.upcast());
                             (ast.file_id, SyntaxNodePtr::from(AstPtr::new(&node)))
                         }

--- a/crates/hir_expand/src/builtin_derive.rs
+++ b/crates/hir_expand/src/builtin_derive.rs
@@ -303,7 +303,7 @@ mod tests {
                 local_inner: false,
             },
             krate: CrateId(0),
-            kind: MacroCallKind::Attr(attr_id, name.to_string()),
+            kind: MacroCallKind::Derive(attr_id, name.to_string()),
         };
 
         let id: MacroCallId = db.intern_macro(loc).into();

--- a/crates/hir_expand/src/lib.rs
+++ b/crates/hir_expand/src/lib.rs
@@ -261,6 +261,7 @@ pub struct MacroCallLoc {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum MacroCallKind {
     FnLike(AstId<ast::MacroCall>),
+    Derive(AstId<ast::Item>, String),
     Attr(AstId<ast::Item>, String),
 }
 
@@ -268,6 +269,7 @@ impl MacroCallKind {
     fn file_id(&self) -> HirFileId {
         match self {
             MacroCallKind::FnLike(ast_id) => ast_id.file_id,
+            MacroCallKind::Derive(ast_id, _) => ast_id.file_id,
             MacroCallKind::Attr(ast_id, _) => ast_id.file_id,
         }
     }
@@ -275,6 +277,9 @@ impl MacroCallKind {
     fn node(&self, db: &dyn db::AstDatabase) -> InFile<SyntaxNode> {
         match self {
             MacroCallKind::FnLike(ast_id) => ast_id.with_value(ast_id.to_node(db).syntax().clone()),
+            MacroCallKind::Derive(ast_id, _) => {
+                ast_id.with_value(ast_id.to_node(db).syntax().clone())
+            }
             MacroCallKind::Attr(ast_id, _) => {
                 ast_id.with_value(ast_id.to_node(db).syntax().clone())
             }
@@ -286,6 +291,7 @@ impl MacroCallKind {
             MacroCallKind::FnLike(ast_id) => {
                 Some(ast_id.to_node(db).token_tree()?.syntax().clone())
             }
+            MacroCallKind::Derive(ast_id, _) => Some(ast_id.to_node(db).syntax().clone()),
             MacroCallKind::Attr(ast_id, _) => Some(ast_id.to_node(db).syntax().clone()),
         }
     }

--- a/crates/hir_expand/src/name.rs
+++ b/crates/hir_expand/src/name.rs
@@ -155,6 +155,9 @@ pub mod known {
         derive,
         doc,
         cfg_attr,
+        proc_macro,
+        proc_macro_derive,
+        proc_macro_attribute,
         // Components of known path (value or mod name)
         std,
         core,


### PR DESCRIPTION
Another step required to support procedural attribute macros. This will emit diagnostics when attributes can't be resolved to either a built-in attribute, or to something in macro namespace.

Procedural attribute macros refuse to expand, because they aren't yet fully implemented. Instead, they always get the unresolved-proc-macro diagnostic to let the user know.

Note that we *don't* yet ignore items with unresolved attributes on them. That's the next step required to support attribute macros.

**Notes for users**: This will result in false positive diagnostics when attributes are used that are consumed by procedural macros. The diagnostic can be disabled by adding `"unresolved-attribute"` to the `rust-analyzer.diagnostics.disabled` setting.