### PR TITLE
Add VSCode command to view the hir of a function body

### DIFF
--- a/crates/hir/src/code_model.rs
+++ b/crates/hir/src/code_model.rs
@@ -729,7 +729,8 @@ impl DefWithBody {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Function {
-    pub(crate) id: FunctionId,
+    // DO NOT MERGE: this was previously pub(crate)
+    pub id: FunctionId,
 }
 
 impl Function {

--- a/crates/hir/src/code_model.rs
+++ b/crates/hir/src/code_model.rs
@@ -1,5 +1,5 @@
 //! FIXME: write short doc here
-use std::{fmt::Write, iter, sync::Arc};
+use std::{iter, sync::Arc};
 
 use arrayvec::ArrayVec;
 use base_db::{CrateDisplayName, CrateId, Edition, FileId};
@@ -39,7 +39,7 @@ use hir_ty::{
     TyDefId, TyKind, TypeCtor,
 };
 use rustc_hash::FxHashSet;
-use stdx::impl_from;
+use stdx::{format_to, impl_from};
 use syntax::{
     ast::{self, AttrsOwner, NameOwner},
     AstNode, SmolStr,
@@ -803,9 +803,9 @@ impl Function {
         let body = db.body(self.id.into());
 
         let mut result = String::new();
-        writeln!(&mut result, "HIR expressions in the body of `{}`:", self.name(db)).unwrap();
+        format_to!(result, "HIR expressions in the body of `{}`:\n", self.name(db));
         for (id, expr) in body.exprs.iter() {
-            writeln!(&mut result, "{:?}: {:?}", id, expr).unwrap();
+            format_to!(result, "{:?}: {:?}\n", id, expr);
         }
 
         result

--- a/crates/hir/src/code_model.rs
+++ b/crates/hir/src/code_model.rs
@@ -1,5 +1,5 @@
 //! FIXME: write short doc here
-use std::{iter, sync::Arc};
+use std::{fmt::Write, iter, sync::Arc};
 
 use arrayvec::ArrayVec;
 use base_db::{CrateDisplayName, CrateId, Edition, FileId};
@@ -729,8 +729,7 @@ impl DefWithBody {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Function {
-    // DO NOT MERGE: this was previously pub(crate)
-    pub id: FunctionId,
+    pub(crate) id: FunctionId,
 }
 
 impl Function {
@@ -797,6 +796,19 @@ impl Function {
     /// This is false in the case of required (not provided) trait methods.
     pub fn has_body(self, db: &dyn HirDatabase) -> bool {
         db.function_data(self.id).has_body
+    }
+
+    /// A textual representation of the HIR of this function for debugging purposes.
+    pub fn debug_hir(self, db: &dyn HirDatabase) -> String {
+        let body = db.body(self.id.into());
+
+        let mut result = String::new();
+        writeln!(&mut result, "HIR expressions in the body of `{}`:", self.name(db)).unwrap();
+        for (id, expr) in body.exprs.iter() {
+            writeln!(&mut result, "{:?}: {:?}", id, expr).unwrap();
+        }
+
+        result
     }
 }
 

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -31,6 +31,7 @@ mod folding_ranges;
 mod goto_definition;
 mod goto_implementation;
 mod goto_type_definition;
+mod view_hir;
 mod hover;
 mod inlay_hints;
 mod join_lines;
@@ -269,6 +270,10 @@ impl Analysis {
         text_range: Option<TextRange>,
     ) -> Cancelable<String> {
         self.with_db(|db| syntax_tree::syntax_tree(&db, file_id, text_range))
+    }
+
+    pub fn view_hir(&self, position: FilePosition) -> Cancelable<String> {
+        self.with_db(|db| view_hir::view_hir(&db, position))
     }
 
     pub fn expand_macro(&self, position: FilePosition) -> Cancelable<Option<ExpandedMacro>> {

--- a/crates/ide/src/view_hir.rs
+++ b/crates/ide/src/view_hir.rs
@@ -1,11 +1,9 @@
 use hir::{Function, Semantics};
-use hir::db::DefDatabase;
 use ide_db::base_db::FilePosition;
 use ide_db::RootDatabase;
-use syntax::{AstNode, algo::find_node_at_offset, ast};
-use std::fmt::Write;
+use syntax::{algo::find_node_at_offset, ast, AstNode};
 
-// Feature: View hir
+// Feature: View Hir
 //
 // |===
 // | Editor  | Action Name
@@ -20,20 +18,8 @@ fn body_hir(db: &RootDatabase, position: FilePosition) -> Option<String> {
     let sema = Semantics::new(db);
     let source_file = sema.parse(position.file_id);
 
-    let function = find_node_at_offset::<ast::Fn>(
-        source_file.syntax(),
-        position.offset,
-    )?;
+    let function = find_node_at_offset::<ast::Fn>(source_file.syntax(), position.offset)?;
 
     let function: Function = sema.to_def(&function)?;
-    let body = db.body(function.id.into());
-
-    let mut result = String::new();
-    writeln!(&mut result, "== Body expressions ==").ok()?;
-
-    for (id, expr) in body.exprs.iter() {
-        writeln!(&mut result, "{:?}: {:?}", id, expr).ok()?;
-    }
-
-    Some(result)
+    Some(function.debug_hir(db))
 }

--- a/crates/ide/src/view_hir.rs
+++ b/crates/ide/src/view_hir.rs
@@ -1,0 +1,39 @@
+use hir::{Function, Semantics};
+use hir::db::DefDatabase;
+use ide_db::base_db::FilePosition;
+use ide_db::RootDatabase;
+use syntax::{AstNode, algo::find_node_at_offset, ast};
+use std::fmt::Write;
+
+// Feature: View hir
+//
+// |===
+// | Editor  | Action Name
+//
+// | VS Code | **Rust Analyzer: View Hir**
+// |===
+pub(crate) fn view_hir(db: &RootDatabase, position: FilePosition) -> String {
+    body_hir(db, position).unwrap_or("Not inside a function body".to_string())
+}
+
+fn body_hir(db: &RootDatabase, position: FilePosition) -> Option<String> {
+    let sema = Semantics::new(db);
+    let source_file = sema.parse(position.file_id);
+
+    let function = find_node_at_offset::<ast::Fn>(
+        source_file.syntax(),
+        position.offset,
+    )?;
+
+    let function: Function = sema.to_def(&function)?;
+    let body = db.body(function.id.into());
+
+    let mut result = String::new();
+    writeln!(&mut result, "== Body expressions ==").ok()?;
+
+    for (id, expr) in body.exprs.iter() {
+        writeln!(&mut result, "{:?}: {:?}", id, expr).ok()?;
+    }
+
+    Some(result)
+}

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -104,6 +104,16 @@ pub(crate) fn handle_syntax_tree(
     Ok(res)
 }
 
+pub(crate) fn handle_view_hir(
+    snap: GlobalStateSnapshot,
+    params: lsp_types::TextDocumentPositionParams,
+) -> Result<String> {
+    let _p = profile::span("handle_view_hir");
+    let position = from_proto::file_position(&snap, params)?;
+    let res = snap.analysis.view_hir(position)?;
+    Ok(res)
+}
+
 pub(crate) fn handle_expand_macro(
     snap: GlobalStateSnapshot,
     params: lsp_ext::ExpandMacroParams,

--- a/crates/rust-analyzer/src/lsp_ext.rs
+++ b/crates/rust-analyzer/src/lsp_ext.rs
@@ -53,6 +53,14 @@ pub struct SyntaxTreeParams {
     pub range: Option<Range>,
 }
 
+pub enum ViewHir {}
+
+impl Request for ViewHir {
+    type Params = lsp_types::TextDocumentPositionParams;
+    type Result = String;
+    const METHOD: &'static str = "rust-analyzer/viewHir";
+}
+
 pub enum ExpandMacro {}
 
 impl Request for ExpandMacro {

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -443,6 +443,7 @@ impl GlobalState {
             .on_sync::<lsp_ext::MemoryUsage>(|s, p| handlers::handle_memory_usage(s, p))?
             .on::<lsp_ext::AnalyzerStatus>(handlers::handle_analyzer_status)
             .on::<lsp_ext::SyntaxTree>(handlers::handle_syntax_tree)
+            .on::<lsp_ext::ViewHir>(handlers::handle_view_hir)
             .on::<lsp_ext::ExpandMacro>(handlers::handle_expand_macro)
             .on::<lsp_ext::ParentModule>(handlers::handle_parent_module)
             .on::<lsp_ext::Runnables>(handlers::handle_runnables)

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -227,6 +227,8 @@ There are also two VS Code commands which might be of interest:
 
 * `Rust Analyzer: Syntax Tree` shows syntax tree of the current file/selection.
 
+* `Rust Analyzer: View Hir` shows the HIR expressions within the function containing the cursor.
+
   You can hover over syntax nodes in the opened text file to see the appropriate
   rust code that it refers to and the rust editor will also highlight the proper
   text range.

--- a/docs/dev/lsp-extensions.md
+++ b/docs/dev/lsp-extensions.md
@@ -1,5 +1,5 @@
 <!---
-lsp_ext.rs hash: 203fdf79b21b5987
+lsp_ext.rs hash: 91f2c62457e0a20f
 
 If you need to change the above hash to make the test pass, please check if you
 need to adjust this doc as well and ping this  issue:
@@ -448,6 +448,17 @@ interface SyntaxTeeParams {
 
 Returns textual representation of a parse tree for the file/selected region.
 Primarily for debugging, but very useful for all people working on rust-analyzer itself.
+
+## View Hir
+
+**Method:** `rust-analyzer/viewHir`
+
+**Request:** `TextDocumentPositionParams`
+
+**Response:** `string`
+
+Returns a textual representation of the HIR of the function containing the cursor.
+For debugging or when working on rust-analyzer itself.
 
 ## Expand Macro
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -104,6 +104,11 @@
                 "category": "Rust Analyzer"
             },
             {
+                "command": "rust-analyzer.viewHir",
+                "title": "View Hir",
+                "category": "Rust Analyzer"
+            },
+            {
                 "command": "rust-analyzer.expandMacro",
                 "title": "Expand macro recursively",
                 "category": "Rust Analyzer"
@@ -996,6 +1001,10 @@
             "commandPalette": [
                 {
                     "command": "rust-analyzer.syntaxTree",
+                    "when": "inRustProject"
+                },
+                {
+                    "command": "rust-analyzer.viewHir",
                     "when": "inRustProject"
                 },
                 {

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -340,7 +340,7 @@ export function syntaxTree(ctx: Ctx): Cmd {
     };
 }
 
-// Opens the virtual file that will show hir
+// Opens the virtual file that will show the HIR of the function containing the cursor position
 //
 // The contents of the file come from the `TextDocumentContentProvider`
 export function viewHir(ctx: Ctx): Cmd {
@@ -384,25 +384,11 @@ export function viewHir(ctx: Ctx): Cmd {
         }
     };
 
-    void new AstInspector(ctx);
-
     ctx.pushCleanup(vscode.workspace.registerTextDocumentContentProvider('rust-analyzer', tdcp));
-    ctx.pushCleanup(vscode.languages.setLanguageConfiguration("ra_syntax_tree", {
-        brackets: [["[", ")"]],
-    }));
 
     return async () => {
-        const editor = vscode.window.activeTextEditor;
-        const rangeEnabled = !!editor && !editor.selection.isEmpty;
-
-        const uri = rangeEnabled
-            ? vscode.Uri.parse(`${tdcp.uri.toString()}?range=true`)
-            : tdcp.uri;
-
-        const document = await vscode.workspace.openTextDocument(uri);
-
-        tdcp.eventEmitter.fire(uri);
-
+        const document = await vscode.workspace.openTextDocument(tdcp.uri);
+        tdcp.eventEmitter.fire(tdcp.uri);
         void await vscode.window.showTextDocument(document, {
             viewColumn: vscode.ViewColumn.Two,
             preserveFocus: true

--- a/editors/code/src/lsp_ext.ts
+++ b/editors/code/src/lsp_ext.ts
@@ -24,6 +24,7 @@ export interface SyntaxTreeParams {
 }
 export const syntaxTree = new lc.RequestType<SyntaxTreeParams, string, void>("rust-analyzer/syntaxTree");
 
+export const viewHir = new lc.RequestType<lc.TextDocumentPositionParams, string, void>("rust-analyzer/viewHir");
 
 export interface ExpandMacroParams {
     textDocument: lc.TextDocumentIdentifier;

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -105,6 +105,7 @@ async function tryActivate(context: vscode.ExtensionContext) {
     ctx.registerCommand('joinLines', commands.joinLines);
     ctx.registerCommand('parentModule', commands.parentModule);
     ctx.registerCommand('syntaxTree', commands.syntaxTree);
+    ctx.registerCommand('viewHir', commands.viewHir);
     ctx.registerCommand('expandMacro', commands.expandMacro);
     ctx.registerCommand('run', commands.run);
     ctx.registerCommand('debug', commands.debug);


### PR DESCRIPTION
Will fix https://github.com/rust-analyzer/rust-analyzer/issues/7061. Very rough initial version just to work out where I needed to wire everything up.

@matklad would you be happy merging a hir visualiser of some kind? If so, do you have any thoughts on what you'd like it show, and how?

I've spent very little time on this thus far, so I'm fine with throwing away the contents of this PR, but I want to avoid taking the time to make this more polished/interactive/useful only to discover that no-one else has any interest in this functionality.

![image](https://user-images.githubusercontent.com/1974256/103236081-bb58f700-493b-11eb-9d12-55ae1b870f8f.png)
