### PR TITLE
format-postfix completion takes format instead of fmt

### DIFF
--- a/crates/completion/src/completions/postfix.rs
+++ b/crates/completion/src/completions/postfix.rs
@@ -502,7 +502,7 @@ fn main() {
     #[test]
     fn postfix_completion_for_format_like_strings() {
         check_edit(
-            "fmt",
+            "format",
             r#"fn main() { "{some_var:?}".<|> }"#,
             r#"fn main() { format!("{:?}", some_var) }"#,
         );

--- a/crates/completion/src/completions/postfix/format_like.rs
+++ b/crates/completion/src/completions/postfix/format_like.rs
@@ -22,7 +22,7 @@ use syntax::ast::{self, AstToken};
 
 /// Mapping ("postfix completion item" => "macro to use")
 static KINDS: &[(&str, &str)] = &[
-    ("fmt", "format!"),
+    ("format", "format!"),
     ("panic", "panic!"),
     ("println", "println!"),
     ("eprintln", "eprintln!"),


### PR DESCRIPTION
See https://github.com/rust-analyzer/rust-analyzer/issues/6843
this brings it back in line with the documentation