### PR TITLE
Smarter bracketed `use` diagnostic

### DIFF
--- a/crates/ide/src/diagnostics.rs
+++ b/crates/ide/src/diagnostics.rs
@@ -644,6 +644,22 @@ mod a {
 }
 "#,
         );
+        check_no_diagnostics(
+            r#"
+use a;
+use a::{
+    c,
+    // d::e
+};
+
+mod a {
+    mod c {}
+    mod d {
+        mod e {}
+    }
+}
+"#,
+        );
         check_fix(
             r"
             mod b {}

--- a/crates/ide/src/diagnostics.rs
+++ b/crates/ide/src/diagnostics.rs
@@ -199,6 +199,12 @@ fn check_unnecessary_braces_in_use_statement(
 ) -> Option<()> {
     let use_tree_list = ast::UseTreeList::cast(node.clone())?;
     if let Some((single_use_tree,)) = use_tree_list.use_trees().collect_tuple() {
+        // If there is a comment inside the bracketed `use`,
+        // assume it is a commented out module path and don't show diagnostic.
+        if use_tree_list.has_inner_comment() {
+            return Some(());
+        }
+
         let use_range = use_tree_list.syntax().text_range();
         let edit =
             text_edit_for_remove_unnecessary_braces_with_self_in_use_statement(&single_use_tree)

--- a/crates/syntax/src/ast/node_ext.rs
+++ b/crates/syntax/src/ast/node_ext.rs
@@ -193,6 +193,14 @@ impl ast::UseTreeList {
             .and_then(ast::UseTree::cast)
             .expect("UseTreeLists are always nested in UseTrees")
     }
+
+    pub fn has_inner_comment(&self) -> bool {
+        self.syntax()
+            .children_with_tokens()
+        .filter_map(|it| it.into_token())
+        .find_map(ast::Comment::cast)
+        .is_some()
+    }
 }
 
 impl ast::Impl {

--- a/crates/syntax/src/ast/node_ext.rs
+++ b/crates/syntax/src/ast/node_ext.rs
@@ -197,9 +197,9 @@ impl ast::UseTreeList {
     pub fn has_inner_comment(&self) -> bool {
         self.syntax()
             .children_with_tokens()
-        .filter_map(|it| it.into_token())
-        .find_map(ast::Comment::cast)
-        .is_some()
+            .filter_map(|it| it.into_token())
+            .find_map(ast::Comment::cast)
+            .is_some()
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/rust-analyzer/rust-analyzer/issues/4531

Makes it so that if a bracketed use statement contains a comment inside the braces, no "Unnecessary braces in use statement" diagnostic is shown.