### PR TITLE
Add an option for extra env vars in the Code extension

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -283,6 +283,14 @@
                     "default": null,
                     "markdownDescription": "Path to rust-analyzer executable (points to bundled binary by default). If this is set, then `#rust-analyzer.updates.channel#` setting is not used"
                 },
+                "rust-analyzer.server.extraEnv": {
+                    "type": [
+                        "null",
+                        "object"
+                    ],
+                    "default": null,
+                    "markdownDescription": "Extra environment variables that will be passed to the rust-analyzer executable. Useful for passing e.g. `RA_LOG` for debugging."
+                },
                 "rust-analyzer.trace.server": {
                     "type": "string",
                     "scope": "window",

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -6,6 +6,10 @@ import { DocumentSemanticsTokensSignature, DocumentSemanticsTokensEditsSignature
 import { assert } from './util';
 import { WorkspaceEdit } from 'vscode';
 
+export interface Env {
+    [name: string]: string;
+}
+
 function renderCommand(cmd: ra.CommandLink) {
     return `[${cmd.title}](command:${cmd.command}?${encodeURIComponent(JSON.stringify(cmd.arguments))} '${cmd.tooltip!}')`;
 }
@@ -27,14 +31,17 @@ async function semanticHighlightingWorkaround<R, F extends (...args: any[]) => v
     return res;
 }
 
-export function createClient(serverPath: string, cwd: string): lc.LanguageClient {
+export function createClient(serverPath: string, cwd: string, extraEnv: Env): lc.LanguageClient {
     // '.' Is the fallback if no folder is open
     // TODO?: Workspace folders support Uri's (eg: file://test.txt).
     // It might be a good idea to test if the uri points to a file.
 
+    const newEnv = Object.assign({}, process.env);
+    Object.assign(newEnv, extraEnv);
+
     const run: lc.Executable = {
         command: serverPath,
-        options: { cwd },
+        options: { cwd, env: newEnv },
     };
     const serverOptions: lc.ServerOptions = {
         run,

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { Env } from './client';
 import { log } from "./util";
 
 export type UpdatesChannel = "stable" | "nightly";
@@ -13,6 +14,7 @@ export class Config {
     readonly rootSection = "rust-analyzer";
     private readonly requiresReloadOpts = [
         "serverPath",
+        "server",
         "cargo",
         "procMacro",
         "files",
@@ -92,6 +94,7 @@ export class Config {
     }
 
     get serverPath() { return this.get<null | string>("serverPath"); }
+    get serverExtraEnv() { return this.get<Env | null>("server.extraEnv") ?? {}; }
     get channel() { return this.get<UpdatesChannel>("updates.channel"); }
     get askBeforeDownload() { return this.get<boolean>("updates.askBeforeDownload"); }
     get traceExtension() { return this.get<boolean>("trace.extension"); }

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -24,7 +24,7 @@ export class Ctx {
         serverPath: string,
         cwd: string,
     ): Promise<Ctx> {
-        const client = createClient(serverPath, cwd);
+        const client = createClient(serverPath, cwd, config.serverExtraEnv);
 
         const statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
         extCtx.subscriptions.push(statusBar);


### PR DESCRIPTION
I was debugging some issues with the RA extension around getting `cargo check` to work and it was particularly frustrating to get the RA_LOG variable set on the server since I had to change it in a login file. This should make that easier.