### PR TITLE
Fix completion of Default struct update syntax

### DIFF
--- a/crates/completion/src/completions/record.rs
+++ b/crates/completion/src/completions/record.rs
@@ -20,11 +20,10 @@ pub(crate) fn complete_record(acc: &mut Completions, ctx: &CompletionContext) ->
 
             let missing_fields = ctx.sema.record_literal_missing_fields(record_lit);
             if impl_default_trait && !missing_fields.is_empty() {
-                let completion_text = if ctx.token.to_string() == "." {
-                    ".Default::default()"
-                } else {
-                    "..Default::default()"
-                };
+                let completion_text = "..Default::default()";
+                let completion_text = completion_text
+                    .strip_prefix(ctx.token.to_string().as_str())
+                    .unwrap_or(completion_text);
                 acc.add(
                     CompletionItem::new(
                         CompletionKind::Snippet,

--- a/crates/completion/src/completions/record.rs
+++ b/crates/completion/src/completions/record.rs
@@ -20,13 +20,18 @@ pub(crate) fn complete_record(acc: &mut Completions, ctx: &CompletionContext) ->
 
             let missing_fields = ctx.sema.record_literal_missing_fields(record_lit);
             if impl_default_trait && !missing_fields.is_empty() {
+                let completion_text = if ctx.token.to_string() == "." {
+                    ".Default::default()"
+                } else {
+                    "..Default::default()"
+                };
                 acc.add(
                     CompletionItem::new(
                         CompletionKind::Snippet,
                         ctx.source_range(),
                         "..Default::default()",
                     )
-                    .insert_text("..Default::default()")
+                    .insert_text(completion_text)
                     .kind(CompletionItemKind::Field)
                     .build(),
                 );


### PR DESCRIPTION
Previously the inserted text was always `..Default::default()` which ends up as `...Default::default()`
if `.` was typed. Now  checks if the current token is `.` and inserts `.Default::default()`
if it is, so `..Default::default()` is correctly completed.

I think there's probably a better way to implement this context aware completion because I've seen it in other parts of rust-analyzer as a user but I'm not sure how to do it.

Fixes #6969