### PR TITLE
Fix clippy *errors* in current build

### DIFF
--- a/crates/assists/src/handlers/infer_function_return_type.rs
+++ b/crates/assists/src/handlers/infer_function_return_type.rs
@@ -108,6 +108,7 @@ fn extract_tail(ctx: &AssistContext) -> Option<(FnType, ast::Expr, InsertOrRepla
             (FnType::Function, tail_expr, ret_range, action)
         };
     let frange = ctx.frange.range;
+    #[cfg_attr(not(test), allow(clippy::if_same_then_else))]
     if return_type_range.contains_range(frange) {
         mark::hit!(cursor_in_ret_position);
         mark::hit!(cursor_in_ret_position_closure);

--- a/crates/base_db/src/input.rs
+++ b/crates/base_db/src/input.rs
@@ -169,7 +169,9 @@ pub struct ProcMacro {
 impl Eq for ProcMacro {}
 impl PartialEq for ProcMacro {
     fn eq(&self, other: &ProcMacro) -> bool {
-        self.name == other.name && Arc::ptr_eq(&self.expander, &other.expander)
+        let thisptr = self.expander.as_ref() as *const dyn ProcMacroExpander as *const u8;
+        let otherptr = other.expander.as_ref() as *const dyn ProcMacroExpander as *const u8;
+        self.name == other.name && std::ptr::eq(thisptr, otherptr)
     }
 }
 

--- a/crates/proc_macro_srv/src/proc_macro/mod.rs
+++ b/crates/proc_macro_srv/src/proc_macro/mod.rs
@@ -77,7 +77,10 @@ impl FromStr for TokenStream {
 /// with `Delimiter::None` delimiters and negative numeric literals.
 impl fmt::Display for TokenStream {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.to_string())
+        // NOTE(kinnison)
+        // This differs from the "upstream" because we cannot use the ToString
+        // impl commented out above.
+        f.write_str(&self.0.to_string())
     }
 }
 
@@ -428,7 +431,15 @@ impl From<Literal> for TokenTree {
 /// with `Delimiter::None` delimiters and negative numeric literals.
 impl fmt::Display for TokenTree {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.to_string())
+        // NOTE(kinnison)
+        // This differs from the "upstream" because we cannot use the ToString
+        // impl commented out above.
+        f.write_str(&match self {
+            TokenTree::Group(g) => g.to_string(),
+            TokenTree::Ident(i) => i.to_string(),
+            TokenTree::Punct(p) => p.to_string(),
+            TokenTree::Literal(l) => l.to_string(),
+        })
     }
 }
 
@@ -533,7 +544,11 @@ impl Group {
 /// with `Delimiter::None` delimiters.
 impl fmt::Display for Group {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.to_string())
+        // NOTE(kinnison)
+        // This differs from the "upstream" because we cannot use the ToString
+        // impl commented out above.
+        let stream = TokenStream::from(TokenTree::from(self.clone()));
+        f.write_str(&stream.to_string())
     }
 }
 
@@ -612,7 +627,11 @@ impl Punct {
 /// back into the same character.
 impl fmt::Display for Punct {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.to_string())
+        // NOTE(kinnison)
+        // This differs from the "upstream" because we cannot use the ToString
+        // impl commented out above.
+        let stream = TokenStream::from(TokenTree::from(self.clone()));
+        f.write_str(&stream.to_string())
     }
 }
 
@@ -683,7 +702,11 @@ impl Ident {
 /// back into the same identifier.
 impl fmt::Display for Ident {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.to_string())
+        // NOTE(kinnison)
+        // This differs from the "upstream" because we cannot use the ToString
+        // impl commented out above.
+        let stream = TokenStream::from(TokenTree::from(self.clone()));
+        f.write_str(&stream.to_string())
     }
 }
 
@@ -914,7 +937,11 @@ impl Literal {
 /// back into the same literal (except for possible rounding for floating point literals).
 impl fmt::Display for Literal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.to_string())
+        // NOTE(kinnison)
+        // This differs from the "upstream" because we cannot use the ToString
+        // impl commented out above.
+        let stream = TokenStream::from(TokenTree::from(self.clone()));
+        f.write_str(&stream.to_string())
     }
 }
 

--- a/crates/syntax/src/algo.rs
+++ b/crates/syntax/src/algo.rs
@@ -584,7 +584,9 @@ impl ops::AddAssign for SyntaxRewriter<'_> {
                 indexmap::map::Entry::Occupied(mut occupied) => {
                     occupied.get_mut().extend(insertions)
                 }
-                indexmap::map::Entry::Vacant(vacant) => drop(vacant.insert(insertions)),
+                indexmap::map::Entry::Vacant(vacant) => {
+                    vacant.insert(insertions);
+                }
             }
         }
     }


### PR DESCRIPTION
Given the large number of clippy warnings present in master, I'm assuming there's not a general intention for rust-analyzer to be clippy-clean, however the fixes in this branch deal with things clippy considers an error and which therefore cause vscode to light up red if using clippy by default.

I don't believe the changes to be particularly controversial, and I stopped short of trying to clean up all the clippy warnings and lints.

The only commit I'm not 100% certain on is the proc_macro_srv change since that's obviously delicate stuff.  I believe it to be right, but I'm unsure where to insert tests to confirm compatibility hasn't been disrupted.