### PR TITLE
Deduplicate macros when offering completion

### DIFF
--- a/crates/hir_def/src/per_ns.rs
+++ b/crates/hir_def/src/per_ns.rs
@@ -7,7 +7,7 @@ use hir_expand::MacroDefId;
 
 use crate::{item_scope::ItemInNs, visibility::Visibility, ModuleDefId};
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct PerNs {
     pub types: Option<(ModuleDefId, Visibility)>,
     pub values: Option<(ModuleDefId, Visibility)>,

--- a/crates/hir_def/src/resolver.rs
+++ b/crates/hir_def/src/resolver.rs
@@ -510,8 +510,9 @@ impl Scope {
                 if let Some(prelude) = m.crate_def_map.prelude {
                     let prelude_def_map = db.crate_def_map(prelude.krate);
                     prelude_def_map[prelude.local_id].scope.entries().for_each(|(name, def)| {
-                        if !seen.contains(&(name.clone(), def)) {
-                            f(name.clone(), ScopeDef::PerNs(def));
+                        let seen_tuple = (name.clone(), def);
+                        if !seen.contains(&seen_tuple) {
+                            f(seen_tuple.0, ScopeDef::PerNs(def));
                         }
                     });
                 }

--- a/crates/hir_def/src/visibility.rs
+++ b/crates/hir_def/src/visibility.rs
@@ -85,7 +85,7 @@ impl RawVisibility {
 }
 
 /// Visibility of an item, with the path resolved.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Visibility {
     /// Visibility is restricted to a certain module.
     Module(ModuleId),


### PR DESCRIPTION
Closes https://github.com/rust-analyzer/rust-analyzer/issues/7081

When iterating over the names within the `hir_def::resolver::Scope` for a module, track what macros are in the `hir_def::item_scope::ItemScope::legacy_macros` collection for the module. When iterating over names from the prelude, do not proccess the name if it had been in the `legacy_macros` collection.

This is implemented with a `FxHashSet` in the `Scope::process_names` function that is populated when iterating over `legacy_macros` and checked when iterating over the prelude.

Alternative implementation could instead query the `legacy_macros` `FxHashMap` directly when processing names in the prelude.

Also, I'd like to add a test for this, but I'm not sure where it could be added.