### PR TITLE
Migrate HasSource::source to return Option

### DIFF
--- a/crates/assists/src/handlers/fill_match_arms.rs
+++ b/crates/assists/src/handlers/fill_match_arms.rs
@@ -196,7 +196,7 @@ fn build_pat(db: &RootDatabase, module: hir::Module, var: hir::Variant) -> Optio
     let path = mod_path_to_ast(&module.find_use_path(db, ModuleDef::from(var))?);
 
     // FIXME: use HIR for this; it doesn't currently expose struct vs. tuple vs. unit variants though
-    let pat: ast::Pat = match var.source(db).value.kind() {
+    let pat: ast::Pat = match var.source_old(db).value.kind() {
         ast::StructKind::Tuple(field_list) => {
             let pats = iter::repeat(make::wildcard_pat().into()).take(field_list.fields().count());
             make::tuple_struct_pat(path, pats).into()

--- a/crates/assists/src/handlers/fill_match_arms.rs
+++ b/crates/assists/src/handlers/fill_match_arms.rs
@@ -196,8 +196,7 @@ fn build_pat(db: &RootDatabase, module: hir::Module, var: hir::Variant) -> Optio
     let path = mod_path_to_ast(&module.find_use_path(db, ModuleDef::from(var))?);
 
     // FIXME: use HIR for this; it doesn't currently expose struct vs. tuple vs. unit variants though
-    #[allow(deprecated)]
-    let pat: ast::Pat = match var.source_old(db).value.kind() {
+    let pat: ast::Pat = match var.source(db)?.value.kind() {
         ast::StructKind::Tuple(field_list) => {
             let pats = iter::repeat(make::wildcard_pat().into()).take(field_list.fields().count());
             make::tuple_struct_pat(path, pats).into()

--- a/crates/assists/src/handlers/fill_match_arms.rs
+++ b/crates/assists/src/handlers/fill_match_arms.rs
@@ -196,6 +196,7 @@ fn build_pat(db: &RootDatabase, module: hir::Module, var: hir::Variant) -> Optio
     let path = mod_path_to_ast(&module.find_use_path(db, ModuleDef::from(var))?);
 
     // FIXME: use HIR for this; it doesn't currently expose struct vs. tuple vs. unit variants though
+    #[allow(deprecated)]
     let pat: ast::Pat = match var.source_old(db).value.kind() {
         ast::StructKind::Tuple(field_list) => {
             let pats = iter::repeat(make::wildcard_pat().into()).take(field_list.fields().count());

--- a/crates/assists/src/handlers/fix_visibility.rs
+++ b/crates/assists/src/handlers/fix_visibility.rs
@@ -97,6 +97,7 @@ fn add_vis_to_referenced_record_field(acc: &mut Assists, ctx: &AssistContext) ->
     let parent_name = parent.name(ctx.db());
     let target_module = parent.module(ctx.db());
 
+    #[allow(deprecated)]
     let in_file_source = record_field_def.source_old(ctx.db());
     let (offset, current_visibility, target) = match in_file_source.value {
         hir::FieldSource::Named(it) => {
@@ -150,6 +151,7 @@ fn target_data_for_def(
         S: HasSource<Ast = Ast>,
         Ast: AstNode + ast::VisibilityOwner,
     {
+        #[allow(deprecated)]
         let source = x.source_old(db);
         let in_file_syntax = source.syntax();
         let file_id = in_file_syntax.file_id;

--- a/crates/assists/src/handlers/fix_visibility.rs
+++ b/crates/assists/src/handlers/fix_visibility.rs
@@ -98,7 +98,7 @@ fn add_vis_to_referenced_record_field(acc: &mut Assists, ctx: &AssistContext) ->
     let target_module = parent.module(ctx.db());
 
     #[allow(deprecated)]
-    let in_file_source = record_field_def.source_old(ctx.db());
+    let in_file_source = record_field_def.source(ctx.db())?;
     let (offset, current_visibility, target) = match in_file_source.value {
         hir::FieldSource::Named(it) => {
             let s = it.syntax();
@@ -151,8 +151,7 @@ fn target_data_for_def(
         S: HasSource<Ast = Ast>,
         Ast: AstNode + ast::VisibilityOwner,
     {
-        #[allow(deprecated)]
-        let source = x.source_old(db);
+        let source = x.source(db)?;
         let in_file_syntax = source.syntax();
         let file_id = in_file_syntax.file_id;
         let syntax = in_file_syntax.value;

--- a/crates/assists/src/handlers/fix_visibility.rs
+++ b/crates/assists/src/handlers/fix_visibility.rs
@@ -97,7 +97,7 @@ fn add_vis_to_referenced_record_field(acc: &mut Assists, ctx: &AssistContext) ->
     let parent_name = parent.name(ctx.db());
     let target_module = parent.module(ctx.db());
 
-    let in_file_source = record_field_def.source(ctx.db());
+    let in_file_source = record_field_def.source_old(ctx.db());
     let (offset, current_visibility, target) = match in_file_source.value {
         hir::FieldSource::Named(it) => {
             let s = it.syntax();
@@ -150,7 +150,7 @@ fn target_data_for_def(
         S: HasSource<Ast = Ast>,
         Ast: AstNode + ast::VisibilityOwner,
     {
-        let source = x.source(db);
+        let source = x.source_old(db);
         let in_file_syntax = source.syntax();
         let file_id = in_file_syntax.file_id;
         let syntax = in_file_syntax.value;

--- a/crates/assists/src/handlers/fix_visibility.rs
+++ b/crates/assists/src/handlers/fix_visibility.rs
@@ -146,54 +146,53 @@ fn target_data_for_def(
     fn offset_target_and_file_id<S, Ast>(
         db: &dyn HirDatabase,
         x: S,
-    ) -> (TextSize, Option<ast::Visibility>, TextRange, FileId)
+    ) -> Option<(TextSize, Option<ast::Visibility>, TextRange, FileId)>
     where
         S: HasSource<Ast = Ast>,
         Ast: AstNode + ast::VisibilityOwner,
     {
-        #[allow(deprecated)]
-        let source = x.source_old(db);
+        let source = x.source(db)?;
         let in_file_syntax = source.syntax();
         let file_id = in_file_syntax.file_id;
         let syntax = in_file_syntax.value;
         let current_visibility = source.value.visibility();
-        (
+        Some((
             vis_offset(syntax),
             current_visibility,
             syntax.text_range(),
             file_id.original_file(db.upcast()),
-        )
+        ))
     }
 
     let target_name;
     let (offset, current_visibility, target, target_file) = match def {
         hir::ModuleDef::Function(f) => {
             target_name = Some(f.name(db));
-            offset_target_and_file_id(db, f)
+            offset_target_and_file_id(db, f)?
         }
         hir::ModuleDef::Adt(adt) => {
             target_name = Some(adt.name(db));
             match adt {
-                hir::Adt::Struct(s) => offset_target_and_file_id(db, s),
-                hir::Adt::Union(u) => offset_target_and_file_id(db, u),
-                hir::Adt::Enum(e) => offset_target_and_file_id(db, e),
+                hir::Adt::Struct(s) => offset_target_and_file_id(db, s)?,
+                hir::Adt::Union(u) => offset_target_and_file_id(db, u)?,
+                hir::Adt::Enum(e) => offset_target_and_file_id(db, e)?,
             }
         }
         hir::ModuleDef::Const(c) => {
             target_name = c.name(db);
-            offset_target_and_file_id(db, c)
+            offset_target_and_file_id(db, c)?
         }
         hir::ModuleDef::Static(s) => {
             target_name = s.name(db);
-            offset_target_and_file_id(db, s)
+            offset_target_and_file_id(db, s)?
         }
         hir::ModuleDef::Trait(t) => {
             target_name = Some(t.name(db));
-            offset_target_and_file_id(db, t)
+            offset_target_and_file_id(db, t)?
         }
         hir::ModuleDef::TypeAlias(t) => {
             target_name = Some(t.name(db));
-            offset_target_and_file_id(db, t)
+            offset_target_and_file_id(db, t)?
         }
         hir::ModuleDef::Module(m) => {
             target_name = m.name(db);

--- a/crates/assists/src/handlers/fix_visibility.rs
+++ b/crates/assists/src/handlers/fix_visibility.rs
@@ -151,7 +151,8 @@ fn target_data_for_def(
         S: HasSource<Ast = Ast>,
         Ast: AstNode + ast::VisibilityOwner,
     {
-        let source = x.source(db)?;
+        #[allow(deprecated)]
+        let source = x.source_old(db);
         let in_file_syntax = source.syntax();
         let file_id = in_file_syntax.file_id;
         let syntax = in_file_syntax.value;

--- a/crates/assists/src/utils.rs
+++ b/crates/assists/src/utils.rs
@@ -98,10 +98,13 @@ pub fn filter_assoc_items(
 
     items
         .iter()
-        .map(|i| match i {
-            hir::AssocItem::Function(i) => ast::AssocItem::Fn(i.source_old(db).value),
-            hir::AssocItem::TypeAlias(i) => ast::AssocItem::TypeAlias(i.source_old(db).value),
-            hir::AssocItem::Const(i) => ast::AssocItem::Const(i.source_old(db).value),
+        .map(|i| {
+            #[allow(deprecated)]
+            match i {
+                hir::AssocItem::Function(i) => ast::AssocItem::Fn(i.source_old(db).value),
+                hir::AssocItem::TypeAlias(i) => ast::AssocItem::TypeAlias(i.source_old(db).value),
+                hir::AssocItem::Const(i) => ast::AssocItem::Const(i.source_old(db).value),
+            }
         })
         .filter(has_def_name)
         .filter(|it| match it {

--- a/crates/assists/src/utils.rs
+++ b/crates/assists/src/utils.rs
@@ -99,9 +99,9 @@ pub fn filter_assoc_items(
     items
         .iter()
         .map(|i| match i {
-            hir::AssocItem::Function(i) => ast::AssocItem::Fn(i.source(db).value),
-            hir::AssocItem::TypeAlias(i) => ast::AssocItem::TypeAlias(i.source(db).value),
-            hir::AssocItem::Const(i) => ast::AssocItem::Const(i.source(db).value),
+            hir::AssocItem::Function(i) => ast::AssocItem::Fn(i.source_old(db).value),
+            hir::AssocItem::TypeAlias(i) => ast::AssocItem::TypeAlias(i.source_old(db).value),
+            hir::AssocItem::Const(i) => ast::AssocItem::Const(i.source_old(db).value),
         })
         .filter(has_def_name)
         .filter(|it| match it {

--- a/crates/assists/src/utils.rs
+++ b/crates/assists/src/utils.rs
@@ -98,13 +98,14 @@ pub fn filter_assoc_items(
 
     items
         .iter()
-        .map(|i| {
-            #[allow(deprecated)]
-            match i {
-                hir::AssocItem::Function(i) => ast::AssocItem::Fn(i.source_old(db).value),
-                hir::AssocItem::TypeAlias(i) => ast::AssocItem::TypeAlias(i.source_old(db).value),
-                hir::AssocItem::Const(i) => ast::AssocItem::Const(i.source_old(db).value),
-            }
+        // Note: This throws away items with no source.
+        .filter_map(|i| {
+            let item = match i {
+                hir::AssocItem::Function(i) => ast::AssocItem::Fn(i.source(db)?.value),
+                hir::AssocItem::TypeAlias(i) => ast::AssocItem::TypeAlias(i.source(db)?.value),
+                hir::AssocItem::Const(i) => ast::AssocItem::Const(i.source(db)?.value),
+            };
+            Some(item)
         })
         .filter(has_def_name)
         .filter(|it| match it {

--- a/crates/completion/src/completions.rs
+++ b/crates/completion/src/completions.rs
@@ -106,8 +106,9 @@ impl Completions {
         func: hir::Function,
         local_name: Option<String>,
     ) {
-        let item = render_fn(RenderContext::new(ctx), None, local_name, func);
-        self.add(item)
+        if let Some(item) = render_fn(RenderContext::new(ctx), None, local_name, func) {
+            self.add(item)
+        }
     }
 
     pub(crate) fn add_variant_pat(

--- a/crates/completion/src/completions/trait_impl.rs
+++ b/crates/completion/src/completions/trait_impl.rs
@@ -156,6 +156,7 @@ fn add_function_impl(
     };
     let range = TextRange::new(fn_def_node.text_range().start(), ctx.source_range().end());
 
+    #[allow(deprecated)]
     let function_decl = function_declaration(&func.source_old(ctx.db).value);
     match ctx.config.snippet_cap {
         Some(cap) => {
@@ -200,6 +201,7 @@ fn add_const_impl(
     let const_name = const_.name(ctx.db).map(|n| n.to_string());
 
     if let Some(const_name) = const_name {
+        #[allow(deprecated)]
         let snippet = make_const_compl_syntax(&const_.source_old(ctx.db).value);
 
         let range = TextRange::new(const_def_node.text_range().start(), ctx.source_range().end());

--- a/crates/completion/src/completions/trait_impl.rs
+++ b/crates/completion/src/completions/trait_impl.rs
@@ -156,7 +156,7 @@ fn add_function_impl(
     };
     let range = TextRange::new(fn_def_node.text_range().start(), ctx.source_range().end());
 
-    let function_decl = function_declaration(&func.source(ctx.db).value);
+    let function_decl = function_declaration(&func.source_old(ctx.db).value);
     match ctx.config.snippet_cap {
         Some(cap) => {
             let snippet = format!("{} {{\n    $0\n}}", function_decl);
@@ -200,7 +200,7 @@ fn add_const_impl(
     let const_name = const_.name(ctx.db).map(|n| n.to_string());
 
     if let Some(const_name) = const_name {
-        let snippet = make_const_compl_syntax(&const_.source(ctx.db).value);
+        let snippet = make_const_compl_syntax(&const_.source_old(ctx.db).value);
 
         let range = TextRange::new(const_def_node.text_range().start(), ctx.source_range().end());
 

--- a/crates/completion/src/completions/trait_impl.rs
+++ b/crates/completion/src/completions/trait_impl.rs
@@ -156,20 +156,21 @@ fn add_function_impl(
     };
     let range = TextRange::new(fn_def_node.text_range().start(), ctx.source_range().end());
 
-    #[allow(deprecated)]
-    let function_decl = function_declaration(&func.source_old(ctx.db).value);
-    match ctx.config.snippet_cap {
-        Some(cap) => {
-            let snippet = format!("{} {{\n    $0\n}}", function_decl);
-            builder.snippet_edit(cap, TextEdit::replace(range, snippet))
+    if let Some(src) = func.source(ctx.db) {
+        let function_decl = function_declaration(&src.value);
+        match ctx.config.snippet_cap {
+            Some(cap) => {
+                let snippet = format!("{} {{\n    $0\n}}", function_decl);
+                builder.snippet_edit(cap, TextEdit::replace(range, snippet))
+            }
+            None => {
+                let header = format!("{} {{", function_decl);
+                builder.text_edit(TextEdit::replace(range, header))
+            }
         }
-        None => {
-            let header = format!("{} {{", function_decl);
-            builder.text_edit(TextEdit::replace(range, header))
-        }
+        .kind(completion_kind)
+        .add_to(acc);
     }
-    .kind(completion_kind)
-    .add_to(acc);
 }
 
 fn add_type_alias_impl(
@@ -201,17 +202,19 @@ fn add_const_impl(
     let const_name = const_.name(ctx.db).map(|n| n.to_string());
 
     if let Some(const_name) = const_name {
-        #[allow(deprecated)]
-        let snippet = make_const_compl_syntax(&const_.source_old(ctx.db).value);
+        if let Some(source) = const_.source(ctx.db) {
+            let snippet = make_const_compl_syntax(&source.value);
 
-        let range = TextRange::new(const_def_node.text_range().start(), ctx.source_range().end());
+            let range =
+                TextRange::new(const_def_node.text_range().start(), ctx.source_range().end());
 
-        CompletionItem::new(CompletionKind::Magic, ctx.source_range(), snippet.clone())
-            .text_edit(TextEdit::replace(range, snippet))
-            .lookup_by(const_name)
-            .kind(CompletionItemKind::Const)
-            .set_documentation(const_.docs(ctx.db))
-            .add_to(acc);
+            CompletionItem::new(CompletionKind::Magic, ctx.source_range(), snippet.clone())
+                .text_edit(TextEdit::replace(range, snippet))
+                .lookup_by(const_name)
+                .kind(CompletionItemKind::Const)
+                .set_documentation(const_.docs(ctx.db))
+                .add_to(acc);
+        }
     }
 }
 

--- a/crates/completion/src/render.rs
+++ b/crates/completion/src/render.rs
@@ -157,8 +157,7 @@ impl<'a> Render<'a> {
 
         let kind = match resolution {
             ScopeDef::ModuleDef(Function(func)) => {
-                let item = render_fn(self.ctx, import_to_add, Some(local_name), *func);
-                return Some(item);
+                return render_fn(self.ctx, import_to_add, Some(local_name), *func);
             }
             ScopeDef::ModuleDef(Variant(_))
                 if self.ctx.completion.is_pat_binding_or_const

--- a/crates/completion/src/render/const_.rs
+++ b/crates/completion/src/render/const_.rs
@@ -15,7 +15,7 @@ pub(crate) fn render_const<'a>(
     ctx: RenderContext<'a>,
     const_: hir::Const,
 ) -> Option<CompletionItem> {
-    ConstRender::new(ctx, const_).render()
+    ConstRender::new(ctx, const_)?.render()
 }
 
 #[derive(Debug)]
@@ -26,10 +26,9 @@ struct ConstRender<'a> {
 }
 
 impl<'a> ConstRender<'a> {
-    fn new(ctx: RenderContext<'a>, const_: hir::Const) -> ConstRender<'a> {
-        #[allow(deprecated)]
-        let ast_node = const_.source_old(ctx.db()).value;
-        ConstRender { ctx, const_, ast_node }
+    fn new(ctx: RenderContext<'a>, const_: hir::Const) -> Option<ConstRender<'a>> {
+        let ast_node = const_.source(ctx.db())?.value;
+        Some(ConstRender { ctx, const_, ast_node })
     }
 
     fn render(self) -> Option<CompletionItem> {

--- a/crates/completion/src/render/const_.rs
+++ b/crates/completion/src/render/const_.rs
@@ -27,6 +27,7 @@ struct ConstRender<'a> {
 
 impl<'a> ConstRender<'a> {
     fn new(ctx: RenderContext<'a>, const_: hir::Const) -> ConstRender<'a> {
+        #[allow(deprecated)]
         let ast_node = const_.source_old(ctx.db()).value;
         ConstRender { ctx, const_, ast_node }
     }

--- a/crates/completion/src/render/const_.rs
+++ b/crates/completion/src/render/const_.rs
@@ -27,7 +27,7 @@ struct ConstRender<'a> {
 
 impl<'a> ConstRender<'a> {
     fn new(ctx: RenderContext<'a>, const_: hir::Const) -> ConstRender<'a> {
-        let ast_node = const_.source(ctx.db()).value;
+        let ast_node = const_.source_old(ctx.db()).value;
         ConstRender { ctx, const_, ast_node }
     }
 

--- a/crates/completion/src/render/function.rs
+++ b/crates/completion/src/render/function.rs
@@ -14,9 +14,9 @@ pub(crate) fn render_fn<'a>(
     import_to_add: Option<ImportEdit>,
     local_name: Option<String>,
     fn_: hir::Function,
-) -> CompletionItem {
+) -> Option<CompletionItem> {
     let _p = profile::span("render_fn");
-    FunctionRender::new(ctx, local_name, fn_).render(import_to_add)
+    Some(FunctionRender::new(ctx, local_name, fn_)?.render(import_to_add))
 }
 
 #[derive(Debug)]
@@ -32,12 +32,11 @@ impl<'a> FunctionRender<'a> {
         ctx: RenderContext<'a>,
         local_name: Option<String>,
         fn_: hir::Function,
-    ) -> FunctionRender<'a> {
+    ) -> Option<FunctionRender<'a>> {
         let name = local_name.unwrap_or_else(|| fn_.name(ctx.db()).to_string());
-        #[allow(deprecated)]
-        let ast_node = fn_.source_old(ctx.db()).value;
+        let ast_node = fn_.source(ctx.db())?.value;
 
-        FunctionRender { ctx, name, func: fn_, ast_node }
+        Some(FunctionRender { ctx, name, func: fn_, ast_node })
     }
 
     fn render(self, import_to_add: Option<ImportEdit>) -> CompletionItem {

--- a/crates/completion/src/render/function.rs
+++ b/crates/completion/src/render/function.rs
@@ -34,7 +34,7 @@ impl<'a> FunctionRender<'a> {
         fn_: hir::Function,
     ) -> FunctionRender<'a> {
         let name = local_name.unwrap_or_else(|| fn_.name(ctx.db()).to_string());
-        let ast_node = fn_.source(ctx.db()).value;
+        let ast_node = fn_.source_old(ctx.db()).value;
 
         FunctionRender { ctx, name, func: fn_, ast_node }
     }

--- a/crates/completion/src/render/function.rs
+++ b/crates/completion/src/render/function.rs
@@ -34,6 +34,7 @@ impl<'a> FunctionRender<'a> {
         fn_: hir::Function,
     ) -> FunctionRender<'a> {
         let name = local_name.unwrap_or_else(|| fn_.name(ctx.db()).to_string());
+        #[allow(deprecated)]
         let ast_node = fn_.source_old(ctx.db()).value;
 
         FunctionRender { ctx, name, func: fn_, ast_node }

--- a/crates/completion/src/render/macro_.rs
+++ b/crates/completion/src/render/macro_.rs
@@ -45,7 +45,7 @@ impl<'a> MacroRender<'a> {
                 .set_documentation(self.docs.clone())
                 .set_deprecated(self.ctx.is_deprecated(self.macro_))
                 .add_import(import_to_add)
-                .detail(self.detail()?);
+                .set_detail(self.detail());
 
         let needs_bang = self.needs_bang();
         builder = match self.ctx.snippet_cap() {

--- a/crates/completion/src/render/macro_.rs
+++ b/crates/completion/src/render/macro_.rs
@@ -96,7 +96,7 @@ impl<'a> MacroRender<'a> {
     }
 
     fn detail(&self) -> String {
-        let ast_node = self.macro_.source(self.ctx.db()).value;
+        let ast_node = self.macro_.source_old(self.ctx.db()).value;
         macro_label(&ast_node)
     }
 }

--- a/crates/completion/src/render/macro_.rs
+++ b/crates/completion/src/render/macro_.rs
@@ -96,6 +96,7 @@ impl<'a> MacroRender<'a> {
     }
 
     fn detail(&self) -> String {
+        #[allow(deprecated)]
         let ast_node = self.macro_.source_old(self.ctx.db()).value;
         macro_label(&ast_node)
     }

--- a/crates/completion/src/render/type_alias.rs
+++ b/crates/completion/src/render/type_alias.rs
@@ -15,7 +15,7 @@ pub(crate) fn render_type_alias<'a>(
     ctx: RenderContext<'a>,
     type_alias: hir::TypeAlias,
 ) -> Option<CompletionItem> {
-    TypeAliasRender::new(ctx, type_alias).render()
+    TypeAliasRender::new(ctx, type_alias)?.render()
 }
 
 #[derive(Debug)]
@@ -26,10 +26,9 @@ struct TypeAliasRender<'a> {
 }
 
 impl<'a> TypeAliasRender<'a> {
-    fn new(ctx: RenderContext<'a>, type_alias: hir::TypeAlias) -> TypeAliasRender<'a> {
-        #[allow(deprecated)]
-        let ast_node = type_alias.source_old(ctx.db()).value;
-        TypeAliasRender { ctx, type_alias, ast_node }
+    fn new(ctx: RenderContext<'a>, type_alias: hir::TypeAlias) -> Option<TypeAliasRender<'a>> {
+        let ast_node = type_alias.source(ctx.db())?.value;
+        Some(TypeAliasRender { ctx, type_alias, ast_node })
     }
 
     fn render(self) -> Option<CompletionItem> {

--- a/crates/completion/src/render/type_alias.rs
+++ b/crates/completion/src/render/type_alias.rs
@@ -27,7 +27,7 @@ struct TypeAliasRender<'a> {
 
 impl<'a> TypeAliasRender<'a> {
     fn new(ctx: RenderContext<'a>, type_alias: hir::TypeAlias) -> TypeAliasRender<'a> {
-        let ast_node = type_alias.source(ctx.db()).value;
+        let ast_node = type_alias.source_old(ctx.db()).value;
         TypeAliasRender { ctx, type_alias, ast_node }
     }
 

--- a/crates/completion/src/render/type_alias.rs
+++ b/crates/completion/src/render/type_alias.rs
@@ -27,6 +27,7 @@ struct TypeAliasRender<'a> {
 
 impl<'a> TypeAliasRender<'a> {
     fn new(ctx: RenderContext<'a>, type_alias: hir::TypeAlias) -> TypeAliasRender<'a> {
+        #[allow(deprecated)]
         let ast_node = type_alias.source_old(ctx.db()).value;
         TypeAliasRender { ctx, type_alias, ast_node }
     }

--- a/crates/hir/src/code_model.rs
+++ b/crates/hir/src/code_model.rs
@@ -989,6 +989,7 @@ impl MacroDef {
         if self.is_proc_macro() {
             return None;
         }
+        #[allow(deprecated)]
         self.source_old(db).value.name().map(|it| it.as_name())
     }
 
@@ -1378,6 +1379,7 @@ impl Impl {
     }
 
     pub fn is_builtin_derive(self, db: &dyn HirDatabase) -> Option<InFile<ast::Attr>> {
+        #[allow(deprecated)]
         let src = self.source_old(db);
         let item = src.file_id.is_builtin_derive(db.upcast())?;
         let hygenic = hir_expand::hygiene::Hygiene::new(db.upcast(), item.file_id);

--- a/crates/hir/src/code_model.rs
+++ b/crates/hir/src/code_model.rs
@@ -983,14 +983,7 @@ impl MacroDef {
 
     /// XXX: this parses the file
     pub fn name(self, db: &dyn HirDatabase) -> Option<Name> {
-        // FIXME: Currently proc-macro do not have ast-node,
-        // such that it does not have source
-        // more discussion: https://github.com/rust-analyzer/rust-analyzer/issues/6913
-        if self.is_proc_macro() {
-            return None;
-        }
-        #[allow(deprecated)]
-        self.source_old(db).value.name().map(|it| it.as_name())
+        self.source(db)?.value.name().map(|it| it.as_name())
     }
 
     /// Indicate it is a proc-macro

--- a/crates/hir/src/code_model.rs
+++ b/crates/hir/src/code_model.rs
@@ -1372,8 +1372,7 @@ impl Impl {
     }
 
     pub fn is_builtin_derive(self, db: &dyn HirDatabase) -> Option<InFile<ast::Attr>> {
-        #[allow(deprecated)]
-        let src = self.source_old(db);
+        let src = self.source(db)?;
         let item = src.file_id.is_builtin_derive(db.upcast())?;
         let hygenic = hir_expand::hygiene::Hygiene::new(db.upcast(), item.file_id);
 

--- a/crates/hir/src/code_model.rs
+++ b/crates/hir/src/code_model.rs
@@ -989,7 +989,7 @@ impl MacroDef {
         if self.is_proc_macro() {
             return None;
         }
-        self.source(db).value.name().map(|it| it.as_name())
+        self.source_old(db).value.name().map(|it| it.as_name())
     }
 
     /// Indicate it is a proc-macro
@@ -1378,7 +1378,7 @@ impl Impl {
     }
 
     pub fn is_builtin_derive(self, db: &dyn HirDatabase) -> Option<InFile<ast::Attr>> {
-        let src = self.source(db);
+        let src = self.source_old(db);
         let item = src.file_id.is_builtin_derive(db.upcast())?;
         let hygenic = hir_expand::hygiene::Hygiene::new(db.upcast(), item.file_id);
 

--- a/crates/hir/src/has_source.rs
+++ b/crates/hir/src/has_source.rs
@@ -16,6 +16,7 @@ use crate::{
 
 pub trait HasSource {
     type Ast;
+    #[deprecated = "migrating to source() method that returns an Option"]
     fn source_old(self, db: &dyn HirDatabase) -> InFile<Self::Ast>;
     fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>>;
 }

--- a/crates/hir/src/has_source.rs
+++ b/crates/hir/src/has_source.rs
@@ -17,6 +17,7 @@ use crate::{
 pub trait HasSource {
     type Ast;
     fn source_old(self, db: &dyn HirDatabase) -> InFile<Self::Ast>;
+    fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>>;
 }
 
 /// NB: Module is !HasSource, because it has two source nodes at the same time:
@@ -54,11 +55,25 @@ impl HasSource for Field {
             Either::Right(it) => FieldSource::Named(it),
         })
     }
+
+    fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
+        let var = VariantId::from(self.parent);
+        let src = var.child_source(db.upcast());
+        let field_source = src.map(|it| match it[self.id].clone() {
+            Either::Left(it) => FieldSource::Pos(it),
+            Either::Right(it) => FieldSource::Named(it),
+        });
+        Some(field_source)
+    }
 }
 impl HasSource for Struct {
     type Ast = ast::Struct;
     fn source_old(self, db: &dyn HirDatabase) -> InFile<ast::Struct> {
         self.id.lookup(db.upcast()).source(db.upcast())
+    }
+
+    fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
+        Some(self.id.lookup(db.upcast()).source(db.upcast()))
     }
 }
 impl HasSource for Union {
@@ -66,11 +81,19 @@ impl HasSource for Union {
     fn source_old(self, db: &dyn HirDatabase) -> InFile<ast::Union> {
         self.id.lookup(db.upcast()).source(db.upcast())
     }
+
+    fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
+        Some(self.id.lookup(db.upcast()).source(db.upcast()))
+    }
 }
 impl HasSource for Enum {
     type Ast = ast::Enum;
     fn source_old(self, db: &dyn HirDatabase) -> InFile<ast::Enum> {
         self.id.lookup(db.upcast()).source(db.upcast())
+    }
+
+    fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
+        Some(self.id.lookup(db.upcast()).source(db.upcast()))
     }
 }
 impl HasSource for Variant {
@@ -78,11 +101,19 @@ impl HasSource for Variant {
     fn source_old(self, db: &dyn HirDatabase) -> InFile<ast::Variant> {
         self.parent.id.child_source(db.upcast()).map(|map| map[self.id].clone())
     }
+
+    fn source(self, db: &dyn HirDatabase) -> Option<InFile<ast::Variant>> {
+        Some(self.parent.id.child_source(db.upcast()).map(|map| map[self.id].clone()))
+    }
 }
 impl HasSource for Function {
     type Ast = ast::Fn;
     fn source_old(self, db: &dyn HirDatabase) -> InFile<ast::Fn> {
         self.id.lookup(db.upcast()).source(db.upcast())
+    }
+
+    fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
+        Some(self.id.lookup(db.upcast()).source(db.upcast()))
     }
 }
 impl HasSource for Const {
@@ -90,11 +121,19 @@ impl HasSource for Const {
     fn source_old(self, db: &dyn HirDatabase) -> InFile<ast::Const> {
         self.id.lookup(db.upcast()).source(db.upcast())
     }
+
+    fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
+        Some(self.id.lookup(db.upcast()).source(db.upcast()))
+    }
 }
 impl HasSource for Static {
     type Ast = ast::Static;
     fn source_old(self, db: &dyn HirDatabase) -> InFile<ast::Static> {
         self.id.lookup(db.upcast()).source(db.upcast())
+    }
+
+    fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
+        Some(self.id.lookup(db.upcast()).source(db.upcast()))
     }
 }
 impl HasSource for Trait {
@@ -102,11 +141,19 @@ impl HasSource for Trait {
     fn source_old(self, db: &dyn HirDatabase) -> InFile<ast::Trait> {
         self.id.lookup(db.upcast()).source(db.upcast())
     }
+
+    fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
+        Some(self.id.lookup(db.upcast()).source(db.upcast()))
+    }
 }
 impl HasSource for TypeAlias {
     type Ast = ast::TypeAlias;
     fn source_old(self, db: &dyn HirDatabase) -> InFile<ast::TypeAlias> {
         self.id.lookup(db.upcast()).source(db.upcast())
+    }
+
+    fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
+        Some(self.id.lookup(db.upcast()).source(db.upcast()))
     }
 }
 impl HasSource for MacroDef {
@@ -117,11 +164,20 @@ impl HasSource for MacroDef {
             value: self.id.ast_id.expect("MacroDef without ast_id").to_node(db.upcast()),
         }
     }
+
+    fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
+        let ast_id = self.id.ast_id?;
+        Some(InFile { file_id: ast_id.file_id, value: ast_id.to_node(db.upcast()) })
+    }
 }
 impl HasSource for Impl {
     type Ast = ast::Impl;
     fn source_old(self, db: &dyn HirDatabase) -> InFile<ast::Impl> {
         self.id.lookup(db.upcast()).source(db.upcast())
+    }
+
+    fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
+        Some(self.id.lookup(db.upcast()).source(db.upcast()))
     }
 }
 
@@ -131,6 +187,11 @@ impl HasSource for TypeParam {
         let child_source = self.id.parent.child_source(db.upcast());
         child_source.map(|it| it[self.id.local_id].clone())
     }
+
+    fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
+        let child_source = self.id.parent.child_source(db.upcast());
+        Some(child_source.map(|it| it[self.id.local_id].clone()))
+    }
 }
 
 impl HasSource for LifetimeParam {
@@ -138,6 +199,11 @@ impl HasSource for LifetimeParam {
     fn source_old(self, db: &dyn HirDatabase) -> InFile<Self::Ast> {
         let child_source = self.id.parent.child_source(db.upcast());
         child_source.map(|it| it[self.id.local_id].clone())
+    }
+
+    fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
+        let child_source = self.id.parent.child_source(db.upcast());
+        Some(child_source.map(|it| it[self.id.local_id].clone()))
     }
 }
 

--- a/crates/hir/src/has_source.rs
+++ b/crates/hir/src/has_source.rs
@@ -16,7 +16,7 @@ use crate::{
 
 pub trait HasSource {
     type Ast;
-    fn source(self, db: &dyn HirDatabase) -> InFile<Self::Ast>;
+    fn source_old(self, db: &dyn HirDatabase) -> InFile<Self::Ast>;
 }
 
 /// NB: Module is !HasSource, because it has two source nodes at the same time:
@@ -46,7 +46,7 @@ impl Module {
 
 impl HasSource for Field {
     type Ast = FieldSource;
-    fn source(self, db: &dyn HirDatabase) -> InFile<FieldSource> {
+    fn source_old(self, db: &dyn HirDatabase) -> InFile<FieldSource> {
         let var = VariantId::from(self.parent);
         let src = var.child_source(db.upcast());
         src.map(|it| match it[self.id].clone() {
@@ -57,61 +57,61 @@ impl HasSource for Field {
 }
 impl HasSource for Struct {
     type Ast = ast::Struct;
-    fn source(self, db: &dyn HirDatabase) -> InFile<ast::Struct> {
+    fn source_old(self, db: &dyn HirDatabase) -> InFile<ast::Struct> {
         self.id.lookup(db.upcast()).source(db.upcast())
     }
 }
 impl HasSource for Union {
     type Ast = ast::Union;
-    fn source(self, db: &dyn HirDatabase) -> InFile<ast::Union> {
+    fn source_old(self, db: &dyn HirDatabase) -> InFile<ast::Union> {
         self.id.lookup(db.upcast()).source(db.upcast())
     }
 }
 impl HasSource for Enum {
     type Ast = ast::Enum;
-    fn source(self, db: &dyn HirDatabase) -> InFile<ast::Enum> {
+    fn source_old(self, db: &dyn HirDatabase) -> InFile<ast::Enum> {
         self.id.lookup(db.upcast()).source(db.upcast())
     }
 }
 impl HasSource for Variant {
     type Ast = ast::Variant;
-    fn source(self, db: &dyn HirDatabase) -> InFile<ast::Variant> {
+    fn source_old(self, db: &dyn HirDatabase) -> InFile<ast::Variant> {
         self.parent.id.child_source(db.upcast()).map(|map| map[self.id].clone())
     }
 }
 impl HasSource for Function {
     type Ast = ast::Fn;
-    fn source(self, db: &dyn HirDatabase) -> InFile<ast::Fn> {
+    fn source_old(self, db: &dyn HirDatabase) -> InFile<ast::Fn> {
         self.id.lookup(db.upcast()).source(db.upcast())
     }
 }
 impl HasSource for Const {
     type Ast = ast::Const;
-    fn source(self, db: &dyn HirDatabase) -> InFile<ast::Const> {
+    fn source_old(self, db: &dyn HirDatabase) -> InFile<ast::Const> {
         self.id.lookup(db.upcast()).source(db.upcast())
     }
 }
 impl HasSource for Static {
     type Ast = ast::Static;
-    fn source(self, db: &dyn HirDatabase) -> InFile<ast::Static> {
+    fn source_old(self, db: &dyn HirDatabase) -> InFile<ast::Static> {
         self.id.lookup(db.upcast()).source(db.upcast())
     }
 }
 impl HasSource for Trait {
     type Ast = ast::Trait;
-    fn source(self, db: &dyn HirDatabase) -> InFile<ast::Trait> {
+    fn source_old(self, db: &dyn HirDatabase) -> InFile<ast::Trait> {
         self.id.lookup(db.upcast()).source(db.upcast())
     }
 }
 impl HasSource for TypeAlias {
     type Ast = ast::TypeAlias;
-    fn source(self, db: &dyn HirDatabase) -> InFile<ast::TypeAlias> {
+    fn source_old(self, db: &dyn HirDatabase) -> InFile<ast::TypeAlias> {
         self.id.lookup(db.upcast()).source(db.upcast())
     }
 }
 impl HasSource for MacroDef {
     type Ast = ast::Macro;
-    fn source(self, db: &dyn HirDatabase) -> InFile<ast::Macro> {
+    fn source_old(self, db: &dyn HirDatabase) -> InFile<ast::Macro> {
         InFile {
             file_id: self.id.ast_id.expect("MacroDef without ast_id").file_id,
             value: self.id.ast_id.expect("MacroDef without ast_id").to_node(db.upcast()),
@@ -120,14 +120,14 @@ impl HasSource for MacroDef {
 }
 impl HasSource for Impl {
     type Ast = ast::Impl;
-    fn source(self, db: &dyn HirDatabase) -> InFile<ast::Impl> {
+    fn source_old(self, db: &dyn HirDatabase) -> InFile<ast::Impl> {
         self.id.lookup(db.upcast()).source(db.upcast())
     }
 }
 
 impl HasSource for TypeParam {
     type Ast = Either<ast::Trait, ast::TypeParam>;
-    fn source(self, db: &dyn HirDatabase) -> InFile<Self::Ast> {
+    fn source_old(self, db: &dyn HirDatabase) -> InFile<Self::Ast> {
         let child_source = self.id.parent.child_source(db.upcast());
         child_source.map(|it| it[self.id.local_id].clone())
     }
@@ -135,7 +135,7 @@ impl HasSource for TypeParam {
 
 impl HasSource for LifetimeParam {
     type Ast = ast::LifetimeParam;
-    fn source(self, db: &dyn HirDatabase) -> InFile<Self::Ast> {
+    fn source_old(self, db: &dyn HirDatabase) -> InFile<Self::Ast> {
         let child_source = self.id.parent.child_source(db.upcast());
         child_source.map(|it| it[self.id.local_id].clone())
     }

--- a/crates/hir/src/has_source.rs
+++ b/crates/hir/src/has_source.rs
@@ -142,8 +142,8 @@ impl HasSource for LifetimeParam {
 
 impl HasSource for ConstParam {
     type Ast = ast::ConstParam;
-    fn source(self, db: &dyn HirDatabase) -> InFile<Self::Ast> {
+    fn source(self, db: &dyn HirDatabase) -> Option<InFile<Self::Ast>> {
         let child_source = self.id.parent.child_source(db.upcast());
-        child_source.map(|it| it[self.id.local_id].clone())
+        Some(child_source.map(|it| it[self.id.local_id].clone()))
     }
 }

--- a/crates/ide/src/call_hierarchy.rs
+++ b/crates/ide/src/call_hierarchy.rs
@@ -8,7 +8,7 @@ use ide_db::RootDatabase;
 use syntax::{ast, match_ast, AstNode, TextRange};
 
 use crate::{
-    display::ToNav, goto_definition, references, FilePosition, NavigationTarget, RangeInfo,
+    display::TryToNav, goto_definition, references, FilePosition, NavigationTarget, RangeInfo,
 };
 
 #[derive(Debug, Clone)]
@@ -61,7 +61,7 @@ pub(crate) fn incoming_calls(db: &RootDatabase, position: FilePosition) -> Optio
                 match node {
                     ast::Fn(it) => {
                         let def = sema.to_def(&it)?;
-                        Some(def.to_nav(sema.db))
+                        def.try_to_nav(sema.db)
                     },
                     _ => None,
                 }
@@ -99,7 +99,7 @@ pub(crate) fn outgoing_calls(db: &RootDatabase, position: FilePosition) -> Optio
                     match callable.kind() {
                         hir::CallableKind::Function(it) => {
                             let fn_def: hir::Function = it.into();
-                            let nav = fn_def.to_nav(db);
+                            let nav = fn_def.try_to_nav(db)?;
                             Some(nav)
                         }
                         _ => None,
@@ -107,7 +107,7 @@ pub(crate) fn outgoing_calls(db: &RootDatabase, position: FilePosition) -> Optio
                 }
                 FnCallNode::MethodCallExpr(expr) => {
                     let function = sema.resolve_method_call(&expr)?;
-                    Some(function.to_nav(db))
+                    function.try_to_nav(db)
                 }
             } {
                 Some((func_target, name_ref.syntax().text_range()))

--- a/crates/ide/src/diagnostics/fixes.rs
+++ b/crates/ide/src/diagnostics/fixes.rs
@@ -157,7 +157,7 @@ fn missing_record_expr_field_fix(
         VariantDef::Struct(s) => {
             module = s.module(sema.db);
             #[allow(deprecated)]
-            let source = s.source_old(sema.db);
+            let source = s.source(sema.db)?;
             def_file_id = source.file_id;
             let fields = source.value.field_list()?;
             record_field_list(fields)?
@@ -165,14 +165,14 @@ fn missing_record_expr_field_fix(
         VariantDef::Union(u) => {
             module = u.module(sema.db);
             #[allow(deprecated)]
-            let source = u.source_old(sema.db);
+            let source = u.source(sema.db)?;
             def_file_id = source.file_id;
             source.value.record_field_list()?
         }
         VariantDef::Variant(e) => {
             module = e.module(sema.db);
             #[allow(deprecated)]
-            let source = e.source_old(sema.db);
+            let source = e.source(sema.db)?;
             def_file_id = source.file_id;
             let fields = source.value.field_list()?;
             record_field_list(fields)?

--- a/crates/ide/src/diagnostics/fixes.rs
+++ b/crates/ide/src/diagnostics/fixes.rs
@@ -156,20 +156,20 @@ fn missing_record_expr_field_fix(
     let record_fields = match VariantDef::from(def_id) {
         VariantDef::Struct(s) => {
             module = s.module(sema.db);
-            let source = s.source(sema.db);
+            let source = s.source_old(sema.db);
             def_file_id = source.file_id;
             let fields = source.value.field_list()?;
             record_field_list(fields)?
         }
         VariantDef::Union(u) => {
             module = u.module(sema.db);
-            let source = u.source(sema.db);
+            let source = u.source_old(sema.db);
             def_file_id = source.file_id;
             source.value.record_field_list()?
         }
         VariantDef::Variant(e) => {
             module = e.module(sema.db);
-            let source = e.source(sema.db);
+            let source = e.source_old(sema.db);
             def_file_id = source.file_id;
             let fields = source.value.field_list()?;
             record_field_list(fields)?

--- a/crates/ide/src/diagnostics/fixes.rs
+++ b/crates/ide/src/diagnostics/fixes.rs
@@ -156,6 +156,7 @@ fn missing_record_expr_field_fix(
     let record_fields = match VariantDef::from(def_id) {
         VariantDef::Struct(s) => {
             module = s.module(sema.db);
+            #[allow(deprecated)]
             let source = s.source_old(sema.db);
             def_file_id = source.file_id;
             let fields = source.value.field_list()?;
@@ -163,12 +164,14 @@ fn missing_record_expr_field_fix(
         }
         VariantDef::Union(u) => {
             module = u.module(sema.db);
+            #[allow(deprecated)]
             let source = u.source_old(sema.db);
             def_file_id = source.file_id;
             source.value.record_field_list()?
         }
         VariantDef::Variant(e) => {
             module = e.module(sema.db);
+            #[allow(deprecated)]
             let source = e.source_old(sema.db);
             def_file_id = source.file_id;
             let fields = source.value.field_list()?;

--- a/crates/ide/src/display/navigation_target.rs
+++ b/crates/ide/src/display/navigation_target.rs
@@ -285,7 +285,7 @@ where
     D::Ast: ast::NameOwner + ShortLabel,
 {
     fn to_nav(&self, db: &RootDatabase) -> NavigationTarget {
-        let src = self.source(db);
+        let src = self.source_old(db);
         let mut res = NavigationTarget::from_named(
             db,
             src.as_ref().map(|it| it as &dyn ast::NameOwner),
@@ -314,7 +314,7 @@ impl ToNav for hir::Module {
 
 impl ToNav for hir::Impl {
     fn to_nav(&self, db: &RootDatabase) -> NavigationTarget {
-        let src = self.source(db);
+        let src = self.source_old(db);
         let derive_attr = self.is_builtin_derive(db);
         let frange = if let Some(item) = &derive_attr {
             item.syntax().original_file_range(db)
@@ -339,7 +339,7 @@ impl ToNav for hir::Impl {
 
 impl ToNav for hir::Field {
     fn to_nav(&self, db: &RootDatabase) -> NavigationTarget {
-        let src = self.source(db);
+        let src = self.source_old(db);
 
         match &src.value {
             FieldSource::Named(it) => {
@@ -365,7 +365,7 @@ impl ToNav for hir::Field {
 
 impl ToNav for hir::MacroDef {
     fn to_nav(&self, db: &RootDatabase) -> NavigationTarget {
-        let src = self.source(db);
+        let src = self.source_old(db);
         log::debug!("nav target {:#?}", src.value.syntax());
         let mut res = NavigationTarget::from_named(
             db,
@@ -448,7 +448,7 @@ impl ToNav for hir::Label {
 
 impl ToNav for hir::TypeParam {
     fn to_nav(&self, db: &RootDatabase) -> NavigationTarget {
-        let src = self.source(db);
+        let src = self.source_old(db);
         let full_range = match &src.value {
             Either::Left(it) => it.syntax().text_range(),
             Either::Right(it) => it.syntax().text_range(),
@@ -472,7 +472,7 @@ impl ToNav for hir::TypeParam {
 
 impl ToNav for hir::LifetimeParam {
     fn to_nav(&self, db: &RootDatabase) -> NavigationTarget {
-        let src = self.source(db);
+        let src = self.source_old(db);
         let full_range = src.value.syntax().text_range();
         NavigationTarget {
             file_id: src.file_id.original_file(db),

--- a/crates/ide/src/display/navigation_target.rs
+++ b/crates/ide/src/display/navigation_target.rs
@@ -218,7 +218,7 @@ impl TryToNav for Definition {
             Definition::TypeParam(it) => it.try_to_nav(db),
             Definition::LifetimeParam(it) => it.try_to_nav(db),
             Definition::Label(it) => Some(it.to_nav(db)),
-            Definition::ConstParam(it) => Some(it.to_nav(db)),
+            Definition::ConstParam(it) => it.try_to_nav(db),
         }
     }
 }
@@ -479,11 +479,11 @@ impl TryToNav for hir::LifetimeParam {
     }
 }
 
-impl ToNav for hir::ConstParam {
-    fn to_nav(&self, db: &RootDatabase) -> NavigationTarget {
-        let src = self.source(db);
+impl TryToNav for hir::ConstParam {
+    fn try_to_nav(&self, db: &RootDatabase) -> Option<NavigationTarget> {
+        let src = self.source(db)?;
         let full_range = src.value.syntax().text_range();
-        NavigationTarget {
+        Some(NavigationTarget {
             file_id: src.file_id.original_file(db),
             name: self.name(db).to_string().into(),
             kind: Some(SymbolKind::ConstParam),
@@ -492,7 +492,7 @@ impl ToNav for hir::ConstParam {
             container_name: None,
             description: None,
             docs: None,
-        }
+        })
     }
 }
 

--- a/crates/ide/src/display/navigation_target.rs
+++ b/crates/ide/src/display/navigation_target.rs
@@ -285,6 +285,7 @@ where
     D::Ast: ast::NameOwner + ShortLabel,
 {
     fn to_nav(&self, db: &RootDatabase) -> NavigationTarget {
+        #[allow(deprecated)]
         let src = self.source_old(db);
         let mut res = NavigationTarget::from_named(
             db,
@@ -314,6 +315,7 @@ impl ToNav for hir::Module {
 
 impl ToNav for hir::Impl {
     fn to_nav(&self, db: &RootDatabase) -> NavigationTarget {
+        #[allow(deprecated)]
         let src = self.source_old(db);
         let derive_attr = self.is_builtin_derive(db);
         let frange = if let Some(item) = &derive_attr {
@@ -339,6 +341,7 @@ impl ToNav for hir::Impl {
 
 impl ToNav for hir::Field {
     fn to_nav(&self, db: &RootDatabase) -> NavigationTarget {
+        #[allow(deprecated)]
         let src = self.source_old(db);
 
         match &src.value {
@@ -365,6 +368,7 @@ impl ToNav for hir::Field {
 
 impl ToNav for hir::MacroDef {
     fn to_nav(&self, db: &RootDatabase) -> NavigationTarget {
+        #[allow(deprecated)]
         let src = self.source_old(db);
         log::debug!("nav target {:#?}", src.value.syntax());
         let mut res = NavigationTarget::from_named(
@@ -448,6 +452,7 @@ impl ToNav for hir::Label {
 
 impl ToNav for hir::TypeParam {
     fn to_nav(&self, db: &RootDatabase) -> NavigationTarget {
+        #[allow(deprecated)]
         let src = self.source_old(db);
         let full_range = match &src.value {
             Either::Left(it) => it.syntax().text_range(),
@@ -472,6 +477,7 @@ impl ToNav for hir::TypeParam {
 
 impl ToNav for hir::LifetimeParam {
     fn to_nav(&self, db: &RootDatabase) -> NavigationTarget {
+        #[allow(deprecated)]
         let src = self.source_old(db);
         let full_range = src.value.syntax().text_range();
         NavigationTarget {

--- a/crates/ide/src/goto_implementation.rs
+++ b/crates/ide/src/goto_implementation.rs
@@ -2,7 +2,7 @@ use hir::{Crate, Impl, Semantics};
 use ide_db::RootDatabase;
 use syntax::{algo::find_node_at_offset, ast, AstNode};
 
-use crate::{display::ToNav, FilePosition, NavigationTarget, RangeInfo};
+use crate::{display::TryToNav, FilePosition, NavigationTarget, RangeInfo};
 
 // Feature: Go to Implementation
 //
@@ -55,7 +55,7 @@ fn impls_for_def(
         impls
             .into_iter()
             .filter(|impl_def| ty.is_equal_for_find_impls(&impl_def.target_ty(sema.db)))
-            .map(|imp| imp.to_nav(sema.db))
+            .filter_map(|imp| imp.try_to_nav(sema.db))
             .collect(),
     )
 }
@@ -69,7 +69,7 @@ fn impls_for_trait(
 
     let impls = Impl::for_trait(sema.db, krate, tr);
 
-    Some(impls.into_iter().map(|imp| imp.to_nav(sema.db)).collect())
+    Some(impls.into_iter().filter_map(|imp| imp.try_to_nav(sema.db)).collect())
 }
 
 #[cfg(test)]

--- a/crates/ide/src/goto_type_definition.rs
+++ b/crates/ide/src/goto_type_definition.rs
@@ -1,7 +1,7 @@
 use ide_db::RootDatabase;
 use syntax::{ast, match_ast, AstNode, SyntaxKind::*, SyntaxToken, TokenAtOffset, T};
 
-use crate::{display::ToNav, FilePosition, NavigationTarget, RangeInfo};
+use crate::{display::TryToNav, FilePosition, NavigationTarget, RangeInfo};
 
 // Feature: Go to Type Definition
 //
@@ -37,7 +37,7 @@ pub(crate) fn goto_type_definition(
 
     let adt_def = ty.autoderef(db).filter_map(|ty| ty.as_adt()).last()?;
 
-    let nav = adt_def.to_nav(db);
+    let nav = adt_def.try_to_nav(db)?;
     Some(RangeInfo::new(node.text_range(), vec![nav]))
 }
 

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -206,7 +206,7 @@ fn runnable_action(
                 _ => None,
             },
             ModuleDef::Function(it) => {
-                let src = it.source(sema.db);
+                let src = it.source_old(sema.db);
                 if src.file_id != file_id.into() {
                     mark::hit!(hover_macro_generated_struct_fn_doc_comment);
                     mark::hit!(hover_macro_generated_struct_fn_doc_attr);
@@ -332,11 +332,11 @@ fn hover_for_definition(db: &RootDatabase, def: Definition) -> Option<Markup> {
             if it.is_proc_macro() {
                 return None;
             }
-            let label = macro_label(&it.source(db).value);
+            let label = macro_label(&it.source_old(db).value);
             from_def_source_labeled(db, it, Some(label), mod_path)
         }
         Definition::Field(def) => {
-            let src = def.source(db).value;
+            let src = def.source_old(db).value;
             if let FieldSource::Named(it) = src {
                 from_def_source_labeled(db, def, it.short_label(), mod_path)
             } else {
@@ -385,7 +385,7 @@ fn hover_for_definition(db: &RootDatabase, def: Definition) -> Option<Markup> {
         D: HasSource<Ast = A> + HasAttrs + Copy,
         A: ShortLabel,
     {
-        let short_label = def.source(db).value.short_label();
+        let short_label = def.source_old(db).value.short_label();
         from_def_source_labeled(db, def, short_label, mod_path)
     }
 

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -207,7 +207,7 @@ fn runnable_action(
             },
             ModuleDef::Function(it) => {
                 #[allow(deprecated)]
-                let src = it.source_old(sema.db);
+                let src = it.source(sema.db)?;
                 if src.file_id != file_id.into() {
                     mark::hit!(hover_macro_generated_struct_fn_doc_comment);
                     mark::hit!(hover_macro_generated_struct_fn_doc_attr);
@@ -332,7 +332,7 @@ fn hover_for_definition(db: &RootDatabase, def: Definition) -> Option<Markup> {
         }
         Definition::Field(def) => {
             #[allow(deprecated)]
-            let src = def.source_old(db).value;
+            let src = def.source(db)?.value;
             if let FieldSource::Named(it) = src {
                 from_def_source_labeled(db, def, it.short_label(), mod_path)
             } else {
@@ -382,7 +382,7 @@ fn hover_for_definition(db: &RootDatabase, def: Definition) -> Option<Markup> {
         A: ShortLabel,
     {
         #[allow(deprecated)]
-        let short_label = def.source_old(db).value.short_label();
+        let short_label = def.source(db)?.value.short_label();
         from_def_source_labeled(db, def, short_label, mod_path)
     }
 

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -327,14 +327,7 @@ fn hover_for_definition(db: &RootDatabase, def: Definition) -> Option<Markup> {
     let mod_path = definition_mod_path(db, &def);
     return match def {
         Definition::Macro(it) => {
-            // FIXME: Currently proc-macro do not have ast-node,
-            // such that it does not have source
-            // more discussion: https://github.com/rust-analyzer/rust-analyzer/issues/6913
-            if it.is_proc_macro() {
-                return None;
-            }
-            #[allow(deprecated)]
-            let label = macro_label(&it.source_old(db).value);
+            let label = macro_label(&it.source(db)?.value);
             from_def_source_labeled(db, it, Some(label), mod_path)
         }
         Definition::Field(def) => {

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -13,7 +13,7 @@ use syntax::{ast, match_ast, AstNode, SyntaxKind::*, SyntaxToken, TokenAtOffset,
 use test_utils::mark;
 
 use crate::{
-    display::{macro_label, ShortLabel, ToNav, TryToNav},
+    display::{macro_label, ShortLabel, TryToNav},
     doc_links::{remove_links, rewrite_links},
     markdown_remove::remove_markdown,
     markup::Markup,
@@ -183,10 +183,10 @@ fn show_implementations_action(db: &RootDatabase, def: Definition) -> Option<Hov
 
     match def {
         Definition::ModuleDef(it) => match it {
-            ModuleDef::Adt(Adt::Struct(it)) => Some(to_action(it.to_nav(db))),
-            ModuleDef::Adt(Adt::Union(it)) => Some(to_action(it.to_nav(db))),
-            ModuleDef::Adt(Adt::Enum(it)) => Some(to_action(it.to_nav(db))),
-            ModuleDef::Trait(it) => Some(to_action(it.to_nav(db))),
+            ModuleDef::Adt(Adt::Struct(it)) => Some(to_action(it.try_to_nav(db)?)),
+            ModuleDef::Adt(Adt::Union(it)) => Some(to_action(it.try_to_nav(db)?)),
+            ModuleDef::Adt(Adt::Enum(it)) => Some(to_action(it.try_to_nav(db)?)),
+            ModuleDef::Trait(it) => Some(to_action(it.try_to_nav(db)?)),
             _ => None,
         },
         _ => None,

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -206,6 +206,7 @@ fn runnable_action(
                 _ => None,
             },
             ModuleDef::Function(it) => {
+                #[allow(deprecated)]
                 let src = it.source_old(sema.db);
                 if src.file_id != file_id.into() {
                     mark::hit!(hover_macro_generated_struct_fn_doc_comment);
@@ -332,10 +333,12 @@ fn hover_for_definition(db: &RootDatabase, def: Definition) -> Option<Markup> {
             if it.is_proc_macro() {
                 return None;
             }
+            #[allow(deprecated)]
             let label = macro_label(&it.source_old(db).value);
             from_def_source_labeled(db, it, Some(label), mod_path)
         }
         Definition::Field(def) => {
+            #[allow(deprecated)]
             let src = def.source_old(db).value;
             if let FieldSource::Named(it) = src {
                 from_def_source_labeled(db, def, it.short_label(), mod_path)
@@ -385,6 +388,7 @@ fn hover_for_definition(db: &RootDatabase, def: Definition) -> Option<Markup> {
         D: HasSource<Ast = A> + HasAttrs + Copy,
         A: ShortLabel,
     {
+        #[allow(deprecated)]
         let short_label = def.source_old(db).value.short_label();
         from_def_source_labeled(db, def, short_label, mod_path)
     }

--- a/crates/ide_db/src/search.rs
+++ b/crates/ide_db/src/search.rs
@@ -120,6 +120,7 @@ impl Definition {
         let file_id = module_src.file_id.original_file(db);
 
         if let Definition::Local(var) = self {
+            #[allow(deprecated)]
             let range = match var.parent(db) {
                 DefWithBody::Function(f) => f.source_old(db).value.syntax().text_range(),
                 DefWithBody::Const(c) => c.source_old(db).value.syntax().text_range(),
@@ -131,6 +132,7 @@ impl Definition {
         }
 
         if let Definition::LifetimeParam(param) = self {
+            #[allow(deprecated)]
             let range = match param.parent(db) {
                 hir::GenericDef::Function(it) => it.source_old(db).value.syntax().text_range(),
                 hir::GenericDef::Adt(it) => match it {

--- a/crates/ide_db/src/search.rs
+++ b/crates/ide_db/src/search.rs
@@ -122,9 +122,15 @@ impl Definition {
         if let Definition::Local(var) = self {
             #[allow(deprecated)]
             let range = match var.parent(db) {
-                DefWithBody::Function(f) => f.source_old(db).value.syntax().text_range(),
-                DefWithBody::Const(c) => c.source_old(db).value.syntax().text_range(),
-                DefWithBody::Static(s) => s.source_old(db).value.syntax().text_range(),
+                DefWithBody::Function(f) => {
+                    f.source(db).and_then(|src| src.value.syntax().text_range())
+                }
+                DefWithBody::Const(c) => {
+                    c.source(db).and_then(|src| src.value.syntax().text_range())
+                }
+                DefWithBody::Static(s) => {
+                    s.source(db).and_then(|src| src.value.syntax().text_range())
+                }
             };
             let mut res = FxHashMap::default();
             res.insert(file_id, Some(range));
@@ -134,17 +140,35 @@ impl Definition {
         if let Definition::LifetimeParam(param) = self {
             #[allow(deprecated)]
             let range = match param.parent(db) {
-                hir::GenericDef::Function(it) => it.source_old(db).value.syntax().text_range(),
+                hir::GenericDef::Function(it) => {
+                    it.source(db).and_then(|src| src.value.syntax().text_range())
+                }
                 hir::GenericDef::Adt(it) => match it {
-                    hir::Adt::Struct(it) => it.source_old(db).value.syntax().text_range(),
-                    hir::Adt::Union(it) => it.source_old(db).value.syntax().text_range(),
-                    hir::Adt::Enum(it) => it.source_old(db).value.syntax().text_range(),
+                    hir::Adt::Struct(it) => {
+                        it.source(db).and_then(|src| src.value.syntax().text_range())
+                    }
+                    hir::Adt::Union(it) => {
+                        it.source(db).and_then(|src| src.value.syntax().text_range())
+                    }
+                    hir::Adt::Enum(it) => {
+                        it.source(db).and_then(|src| src.value.syntax().text_range())
+                    }
                 },
-                hir::GenericDef::Trait(it) => it.source_old(db).value.syntax().text_range(),
-                hir::GenericDef::TypeAlias(it) => it.source_old(db).value.syntax().text_range(),
-                hir::GenericDef::Impl(it) => it.source_old(db).value.syntax().text_range(),
-                hir::GenericDef::Variant(it) => it.source_old(db).value.syntax().text_range(),
-                hir::GenericDef::Const(it) => it.source_old(db).value.syntax().text_range(),
+                hir::GenericDef::Trait(it) => {
+                    it.source(db).and_then(|src| src.value.syntax().text_range())
+                }
+                hir::GenericDef::TypeAlias(it) => {
+                    it.source(db).and_then(|src| src.value.syntax().text_range())
+                }
+                hir::GenericDef::Impl(it) => {
+                    it.source(db).and_then(|src| src.value.syntax().text_range())
+                }
+                hir::GenericDef::Variant(it) => {
+                    it.source(db).and_then(|src| src.value.syntax().text_range())
+                }
+                hir::GenericDef::Const(it) => {
+                    it.source(db).and_then(|src| src.value.syntax().text_range())
+                }
             };
             let mut res = FxHashMap::default();
             res.insert(file_id, Some(range));

--- a/crates/ide_db/src/search.rs
+++ b/crates/ide_db/src/search.rs
@@ -120,20 +120,19 @@ impl Definition {
         let file_id = module_src.file_id.original_file(db);
 
         if let Definition::Local(var) = self {
-            #[allow(deprecated)]
             let range = match var.parent(db) {
                 DefWithBody::Function(f) => {
-                    f.source(db).and_then(|src| src.value.syntax().text_range())
+                    f.source(db).and_then(|src| Some(src.value.syntax().text_range()))
                 }
                 DefWithBody::Const(c) => {
-                    c.source(db).and_then(|src| src.value.syntax().text_range())
+                    c.source(db).and_then(|src| Some(src.value.syntax().text_range()))
                 }
                 DefWithBody::Static(s) => {
-                    s.source(db).and_then(|src| src.value.syntax().text_range())
+                    s.source(db).and_then(|src| Some(src.value.syntax().text_range()))
                 }
             };
             let mut res = FxHashMap::default();
-            res.insert(file_id, Some(range));
+            res.insert(file_id, range);
             return SearchScope::new(res);
         }
 
@@ -141,37 +140,37 @@ impl Definition {
             #[allow(deprecated)]
             let range = match param.parent(db) {
                 hir::GenericDef::Function(it) => {
-                    it.source(db).and_then(|src| src.value.syntax().text_range())
+                    it.source(db).and_then(|src| Some(src.value.syntax().text_range()))
                 }
                 hir::GenericDef::Adt(it) => match it {
                     hir::Adt::Struct(it) => {
-                        it.source(db).and_then(|src| src.value.syntax().text_range())
+                        it.source(db).and_then(|src| Some(src.value.syntax().text_range()))
                     }
                     hir::Adt::Union(it) => {
-                        it.source(db).and_then(|src| src.value.syntax().text_range())
+                        it.source(db).and_then(|src| Some(src.value.syntax().text_range()))
                     }
                     hir::Adt::Enum(it) => {
-                        it.source(db).and_then(|src| src.value.syntax().text_range())
+                        it.source(db).and_then(|src| Some(src.value.syntax().text_range()))
                     }
                 },
                 hir::GenericDef::Trait(it) => {
-                    it.source(db).and_then(|src| src.value.syntax().text_range())
+                    it.source(db).and_then(|src| Some(src.value.syntax().text_range()))
                 }
                 hir::GenericDef::TypeAlias(it) => {
-                    it.source(db).and_then(|src| src.value.syntax().text_range())
+                    it.source(db).and_then(|src| Some(src.value.syntax().text_range()))
                 }
                 hir::GenericDef::Impl(it) => {
-                    it.source(db).and_then(|src| src.value.syntax().text_range())
+                    it.source(db).and_then(|src| Some(src.value.syntax().text_range()))
                 }
                 hir::GenericDef::Variant(it) => {
-                    it.source(db).and_then(|src| src.value.syntax().text_range())
+                    it.source(db).and_then(|src| Some(src.value.syntax().text_range()))
                 }
                 hir::GenericDef::Const(it) => {
-                    it.source(db).and_then(|src| src.value.syntax().text_range())
+                    it.source(db).and_then(|src| Some(src.value.syntax().text_range()))
                 }
             };
             let mut res = FxHashMap::default();
-            res.insert(file_id, Some(range));
+            res.insert(file_id, range);
             return SearchScope::new(res);
         }
 

--- a/crates/ide_db/src/search.rs
+++ b/crates/ide_db/src/search.rs
@@ -121,9 +121,9 @@ impl Definition {
 
         if let Definition::Local(var) = self {
             let range = match var.parent(db) {
-                DefWithBody::Function(f) => f.source(db).value.syntax().text_range(),
-                DefWithBody::Const(c) => c.source(db).value.syntax().text_range(),
-                DefWithBody::Static(s) => s.source(db).value.syntax().text_range(),
+                DefWithBody::Function(f) => f.source_old(db).value.syntax().text_range(),
+                DefWithBody::Const(c) => c.source_old(db).value.syntax().text_range(),
+                DefWithBody::Static(s) => s.source_old(db).value.syntax().text_range(),
             };
             let mut res = FxHashMap::default();
             res.insert(file_id, Some(range));
@@ -132,17 +132,17 @@ impl Definition {
 
         if let Definition::LifetimeParam(param) = self {
             let range = match param.parent(db) {
-                hir::GenericDef::Function(it) => it.source(db).value.syntax().text_range(),
+                hir::GenericDef::Function(it) => it.source_old(db).value.syntax().text_range(),
                 hir::GenericDef::Adt(it) => match it {
-                    hir::Adt::Struct(it) => it.source(db).value.syntax().text_range(),
-                    hir::Adt::Union(it) => it.source(db).value.syntax().text_range(),
-                    hir::Adt::Enum(it) => it.source(db).value.syntax().text_range(),
+                    hir::Adt::Struct(it) => it.source_old(db).value.syntax().text_range(),
+                    hir::Adt::Union(it) => it.source_old(db).value.syntax().text_range(),
+                    hir::Adt::Enum(it) => it.source_old(db).value.syntax().text_range(),
                 },
-                hir::GenericDef::Trait(it) => it.source(db).value.syntax().text_range(),
-                hir::GenericDef::TypeAlias(it) => it.source(db).value.syntax().text_range(),
-                hir::GenericDef::Impl(it) => it.source(db).value.syntax().text_range(),
-                hir::GenericDef::Variant(it) => it.source(db).value.syntax().text_range(),
-                hir::GenericDef::Const(it) => it.source(db).value.syntax().text_range(),
+                hir::GenericDef::Trait(it) => it.source_old(db).value.syntax().text_range(),
+                hir::GenericDef::TypeAlias(it) => it.source_old(db).value.syntax().text_range(),
+                hir::GenericDef::Impl(it) => it.source_old(db).value.syntax().text_range(),
+                hir::GenericDef::Variant(it) => it.source_old(db).value.syntax().text_range(),
+                hir::GenericDef::Const(it) => it.source_old(db).value.syntax().text_range(),
             };
             let mut res = FxHashMap::default();
             res.insert(file_id, Some(range));

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -161,7 +161,7 @@ impl AnalysisStatsCmd {
             }
             let mut msg = format!("processing: {}", full_name);
             if verbosity.is_verbose() {
-                let src = f.source(db);
+                let src = f.source_old(db);
                 let original_file = src.file_id.original_file(db);
                 let path = vfs.file_path(original_file);
                 let syntax_range = src.value.syntax().text_range();

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -161,12 +161,12 @@ impl AnalysisStatsCmd {
             }
             let mut msg = format!("processing: {}", full_name);
             if verbosity.is_verbose() {
-                #[allow(deprecated)]
-                let src = f.source_old(db);
-                let original_file = src.file_id.original_file(db);
-                let path = vfs.file_path(original_file);
-                let syntax_range = src.value.syntax().text_range();
-                format_to!(msg, " ({} {:?})", path, syntax_range);
+                if let Some(src) = f.source(db) {
+                    let original_file = src.file_id.original_file(db);
+                    let path = vfs.file_path(original_file);
+                    let syntax_range = src.value.syntax().text_range();
+                    format_to!(msg, " ({} {:?})", path, syntax_range);
+                }
             }
             if verbosity.is_spammy() {
                 bar.println(msg.to_string());

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -161,6 +161,7 @@ impl AnalysisStatsCmd {
             }
             let mut msg = format!("processing: {}", full_name);
             if verbosity.is_verbose() {
+                #[allow(deprecated)]
                 let src = f.source_old(db);
                 let original_file = src.file_id.original_file(db);
                 let path = vfs.file_path(original_file);


### PR DESCRIPTION
I've made a start on fixing #6913 based on the provided work plan, migrating `HasSource::source` to return an `Option`. The simple cases are migrated but there are a few that I'm unsure exactly how they should be handled:

- Logging the processing of functions in `AnalysisStatsCmd::run`: In verbose mode it includes the path to the module containing the function and the syntax range. I've handled this with an if-let but would it be better to blow up here with `expect`? I'm not 100% on the code paths but if we're processing a function definition then the source should exist.

I've handled `source()` in all code paths as `None` being a valid return value but are there some cases where we should just blow up? Also, all I've done is bubble up the returned `None`s, there may be some places where we can recover and still provide something.