### PR TITLE
Use stable instead of beta on macos-11 release runner

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -124,10 +124,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    - name: Install Rust toolchain (beta)
+    - name: Install Rust toolchain
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: beta
+        toolchain: stable
         target: aarch64-apple-darwin
         profile: minimal
         override: true


### PR DESCRIPTION
Because beta was promoted to stable yesterday.

bors r+