### PR TITLE
Add support for Rust 2021.

### DIFF
--- a/crates/base_db/src/input.rs
+++ b/crates/base_db/src/input.rs
@@ -190,10 +190,11 @@ pub struct CrateData {
     pub proc_macro: Vec<ProcMacro>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Edition {
-    Edition2018,
     Edition2015,
+    Edition2018,
+    Edition2021,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
@@ -393,6 +394,7 @@ impl FromStr for Edition {
         let res = match s {
             "2015" => Edition::Edition2015,
             "2018" => Edition::Edition2018,
+            "2021" => Edition::Edition2021,
             _ => return Err(ParseEditionError { invalid_input: s.to_string() }),
         };
         Ok(res)
@@ -404,6 +406,7 @@ impl fmt::Display for Edition {
         f.write_str(match self {
             Edition::Edition2015 => "2015",
             Edition::Edition2018 => "2018",
+            Edition::Edition2021 => "2021",
         })
     }
 }

--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -230,7 +230,7 @@ impl TestAttr {
 
 const RUSTDOC_FENCE: &str = "```";
 const RUSTDOC_CODE_BLOCK_ATTRIBUTES_RUNNABLE: &[&str] =
-    &["", "rust", "should_panic", "edition2015", "edition2018"];
+    &["", "rust", "should_panic", "edition2015", "edition2018", "edition2021"];
 
 fn has_runnable_doc_test(attrs: &hir::Attrs) -> bool {
     attrs.docs().map_or(false, |doc| {

--- a/crates/ide/src/syntax_highlighting/injection.rs
+++ b/crates/ide/src/syntax_highlighting/injection.rs
@@ -55,7 +55,7 @@ type RangesMap = BTreeMap<TextSize, TextSize>;
 
 const RUSTDOC_FENCE: &'static str = "```";
 const RUSTDOC_FENCE_TOKENS: &[&'static str] =
-    &["", "rust", "should_panic", "ignore", "no_run", "compile_fail", "edition2015", "edition2018"];
+    &["", "rust", "should_panic", "ignore", "no_run", "compile_fail", "edition2015", "edition2018", "edition2021"];
 
 /// Extracts Rust code from documentation comments as well as a mapping from
 /// the extracted source code back to the original source ranges.

--- a/crates/ide/src/syntax_highlighting/injection.rs
+++ b/crates/ide/src/syntax_highlighting/injection.rs
@@ -54,8 +54,17 @@ pub(super) fn highlight_injection(
 type RangesMap = BTreeMap<TextSize, TextSize>;
 
 const RUSTDOC_FENCE: &'static str = "```";
-const RUSTDOC_FENCE_TOKENS: &[&'static str] =
-    &["", "rust", "should_panic", "ignore", "no_run", "compile_fail", "edition2015", "edition2018", "edition2021"];
+const RUSTDOC_FENCE_TOKENS: &[&'static str] = &[
+    "",
+    "rust",
+    "should_panic",
+    "ignore",
+    "no_run",
+    "compile_fail",
+    "edition2015",
+    "edition2018",
+    "edition2021",
+];
 
 /// Extracts Rust code from documentation comments as well as a mapping from
 /// the extracted source code back to the original source ranges.

--- a/crates/project_model/src/project_json.rs
+++ b/crates/project_model/src/project_json.rs
@@ -139,6 +139,8 @@ enum EditionData {
     Edition2015,
     #[serde(rename = "2018")]
     Edition2018,
+    #[serde(rename = "2021")]
+    Edition2021,
 }
 
 impl From<EditionData> for Edition {
@@ -146,6 +148,7 @@ impl From<EditionData> for Edition {
         match data {
             EditionData::Edition2015 => Edition::Edition2015,
             EditionData::Edition2018 => Edition::Edition2018,
+            EditionData::Edition2021 => Edition::Edition2021,
         }
     }
 }

--- a/crates/rust-analyzer/src/markdown.rs
+++ b/crates/rust-analyzer/src/markdown.rs
@@ -2,7 +2,7 @@
 
 const RUSTDOC_FENCE: &str = "```";
 const RUSTDOC_CODE_BLOCK_ATTRIBUTES_RUST_SPECIFIC: &[&str] =
-    &["", "rust", "should_panic", "ignore", "no_run", "compile_fail", "edition2015", "edition2018"];
+    &["", "rust", "should_panic", "ignore", "no_run", "compile_fail", "edition2015", "edition2018", "edition2021"];
 
 pub(crate) fn format_docs(src: &str) -> String {
     let mut processed_lines = Vec::new();

--- a/crates/rust-analyzer/src/markdown.rs
+++ b/crates/rust-analyzer/src/markdown.rs
@@ -1,8 +1,17 @@
 //! Transforms markdown
 
 const RUSTDOC_FENCE: &str = "```";
-const RUSTDOC_CODE_BLOCK_ATTRIBUTES_RUST_SPECIFIC: &[&str] =
-    &["", "rust", "should_panic", "ignore", "no_run", "compile_fail", "edition2015", "edition2018", "edition2021"];
+const RUSTDOC_CODE_BLOCK_ATTRIBUTES_RUST_SPECIFIC: &[&str] = &[
+    "",
+    "rust",
+    "should_panic",
+    "ignore",
+    "no_run",
+    "compile_fail",
+    "edition2015",
+    "edition2018",
+    "edition2021",
+];
 
 pub(crate) fn format_docs(src: &str) -> String {
     let mut processed_lines = Vec::new();

--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -339,7 +339,7 @@ interface Crate {
     /// Path to the root module of the crate.
     root_module: string;
     /// Edition of the crate.
-    edition: "2015" | "2018";
+    edition: "2015" | "2018" | "2021";
     /// Dependencies
     deps: Dep[];
     /// Should this crate be treated as a member of current "workspace".


### PR DESCRIPTION
This adds `2021` in all places where rust-analyzer already knew about `2015` and `2018`.

The only edition-specific behaviour I could find in the source code was gated on a direct comparison with `Edition2015`, so `Edition2021` should (correctly) behave the same as `Edition2018`:

https://github.com/rust-analyzer/rust-analyzer/blob/56a7bf7ede12f6bec194265ea4a95911c9e469bd/crates/hir_def/src/nameres/path_resolution.rs#L132