### PR TITLE
Fix infer error of macro invocation in array expr

### DIFF
--- a/crates/hir_expand/src/db.rs
+++ b/crates/hir_expand/src/db.rs
@@ -404,7 +404,7 @@ fn to_fragment_kind(db: &dyn AstDatabase, id: MacroCallId) -> FragmentKind {
         TRY_EXPR => FragmentKind::Expr,
         TUPLE_EXPR => FragmentKind::Expr,
         PAREN_EXPR => FragmentKind::Expr,
-
+        ARRAY_EXPR => FragmentKind::Expr,
         FOR_EXPR => FragmentKind::Expr,
         PATH_EXPR => FragmentKind::Expr,
         CLOSURE_EXPR => FragmentKind::Expr,

--- a/crates/hir_ty/src/tests/regression.rs
+++ b/crates/hir_ty/src/tests/regression.rs
@@ -326,6 +326,24 @@ fn infer_paren_macro_call() {
 }
 
 #[test]
+fn infer_array_macro_call() {
+    check_infer(
+        r#"
+        macro_rules! bar { () => {0u32} }
+        fn test() {
+            let a = [bar!()];
+        }
+        "#,
+        expect![[r#"
+            !0..4 '0u32': u32
+            44..69 '{     ...()]; }': ()
+            54..55 'a': [u32; _]
+            58..66 '[bar!()]': [u32; _]
+        "#]],
+    );
+}
+
+#[test]
 fn bug_1030() {
     check_infer(
         r#"


### PR DESCRIPTION
Fixed following infer error:

```rust
macro_rules! bar { () => {0u32} }
fn test() {
    let a = [bar!()];   // a : [unknown]
}
```

bors r+