### PR TITLE
Store trait associated items in fst

### DIFF
--- a/crates/completion/src/completions/unqualified_path.rs
+++ b/crates/completion/src/completions/unqualified_path.rs
@@ -124,8 +124,8 @@ fn complete_enum_variants(acc: &mut Completions, ctx: &CompletionContext, ty: &T
 // Note that having this flag set to `true` does not guarantee that the feature is enabled: your client needs to have the corredponding
 // capability enabled.
 fn fuzzy_completion(acc: &mut Completions, ctx: &CompletionContext) -> Option<()> {
-    let _p = profile::span("fuzzy_completion");
     let potential_import_name = ctx.token.to_string();
+    let _p = profile::span("fuzzy_completion").detail(|| potential_import_name.clone());
 
     if potential_import_name.len() < 2 {
         return None;

--- a/crates/completion/src/completions/unqualified_path.rs
+++ b/crates/completion/src/completions/unqualified_path.rs
@@ -3,7 +3,7 @@
 use std::iter;
 
 use either::Either;
-use hir::{Adt, ModPath, ModuleDef, ScopeDef, Type};
+use hir::{Adt, AsAssocItem, ModPath, ModuleDef, ScopeDef, Type};
 use ide_db::helpers::insert_use::ImportScope;
 use ide_db::imports_locator;
 use syntax::AstNode;
@@ -143,6 +143,14 @@ fn fuzzy_completion(acc: &mut Completions, ctx: &CompletionContext) -> Option<()
         potential_import_name,
         true,
     )
+    .filter(|import_candidate| match import_candidate {
+        Either::Left(ModuleDef::Function(function)) => function.as_assoc_item(ctx.db).is_none(),
+        Either::Left(ModuleDef::Const(const_)) => const_.as_assoc_item(ctx.db).is_none(),
+        Either::Left(ModuleDef::TypeAlias(type_alias)) => {
+            type_alias.as_assoc_item(ctx.db).is_none()
+        }
+        _ => true,
+    })
     .filter_map(|import_candidate| {
         Some(match import_candidate {
             Either::Left(module_def) => {

--- a/crates/completion/src/completions/unqualified_path.rs
+++ b/crates/completion/src/completions/unqualified_path.rs
@@ -3,7 +3,7 @@
 use std::iter;
 
 use either::Either;
-use hir::{Adt, AsAssocItem, ModPath, ModuleDef, ScopeDef, Type};
+use hir::{Adt, ModPath, ModuleDef, ScopeDef, Type};
 use ide_db::helpers::insert_use::ImportScope;
 use ide_db::imports_locator;
 use syntax::AstNode;
@@ -142,15 +142,8 @@ fn fuzzy_completion(acc: &mut Completions, ctx: &CompletionContext) -> Option<()
         Some(40),
         potential_import_name,
         true,
+        true,
     )
-    .filter(|import_candidate| match import_candidate {
-        Either::Left(ModuleDef::Function(function)) => function.as_assoc_item(ctx.db).is_none(),
-        Either::Left(ModuleDef::Const(const_)) => const_.as_assoc_item(ctx.db).is_none(),
-        Either::Left(ModuleDef::TypeAlias(type_alias)) => {
-            type_alias.as_assoc_item(ctx.db).is_none()
-        }
-        _ => true,
-    })
     .filter_map(|import_candidate| {
         Some(match import_candidate {
             Either::Left(module_def) => {

--- a/crates/hir_def/src/import_map.rs
+++ b/crates/hir_def/src/import_map.rs
@@ -186,14 +186,16 @@ impl ImportMap {
         is_type_in_ns: bool,
         original_import_info: &ImportInfo,
     ) {
-        mark::hit!(type_aliases_ignored);
         for (assoc_item_name, item) in &db.trait_data(tr).items {
             let module_def_id = match item {
                 AssocItemId::FunctionId(f) => ModuleDefId::from(*f),
                 AssocItemId::ConstId(c) => ModuleDefId::from(*c),
                 // cannot use associated type aliases directly: need a `<Struct as Trait>::TypeAlias`
                 // qualifier, ergo no need to store it for imports in import_map
-                AssocItemId::TypeAliasId(_) => continue,
+                AssocItemId::TypeAliasId(_) => {
+                    mark::hit!(type_aliases_ignored);
+                    continue;
+                }
             };
             let assoc_item = if is_type_in_ns {
                 ItemInNs::Types(module_def_id)

--- a/crates/hir_def/src/import_map.rs
+++ b/crates/hir_def/src/import_map.rs
@@ -8,6 +8,7 @@ use hir_expand::name::Name;
 use indexmap::{map::Entry, IndexMap};
 use itertools::Itertools;
 use rustc_hash::{FxHashSet, FxHasher};
+use test_utils::mark;
 
 use crate::{
     db::DefDatabase, item_scope::ItemInNs, visibility::Visibility, AssocItemId, ModuleDefId,
@@ -185,6 +186,7 @@ impl ImportMap {
         is_type_in_ns: bool,
         original_import_info: &ImportInfo,
     ) {
+        mark::hit!(type_aliases_ignored);
         for (assoc_item_name, item) in &db.trait_data(tr).items {
             let module_def_id = match item {
                 AssocItemId::FunctionId(f) => ModuleDefId::from(*f),
@@ -442,6 +444,7 @@ fn item_import_kind(item: ItemInNs) -> Option<ImportKind> {
 mod tests {
     use base_db::{fixture::WithFixture, SourceDatabase, Upcast};
     use expect_test::{expect, Expect};
+    use test_utils::mark;
 
     use crate::{test_db::TestDB, AssocContainerId, Lookup};
 
@@ -779,6 +782,7 @@ mod tests {
 
     #[test]
     fn fuzzy_import_trait_and_assoc_items() {
+        mark::check!(type_aliases_ignored);
         let ra_fixture = r#"
         //- /main.rs crate:main deps:dep
         //- /dep.rs crate:dep

--- a/crates/hir_def/src/import_map.rs
+++ b/crates/hir_def/src/import_map.rs
@@ -186,10 +186,12 @@ impl ImportMap {
         original_import_info: &ImportInfo,
     ) {
         for (assoc_item_name, item) in &db.trait_data(tr).items {
-            let module_def_id = match *item {
-                AssocItemId::FunctionId(f) => f.into(),
-                AssocItemId::ConstId(c) => c.into(),
-                AssocItemId::TypeAliasId(t) => t.into(),
+            let module_def_id = match item {
+                AssocItemId::FunctionId(f) => ModuleDefId::from(*f),
+                AssocItemId::ConstId(c) => ModuleDefId::from(*c),
+                // cannot use associated type aliases directly: need a `<Struct as Trait>::TypeAlias`
+                // qualifier, ergo no need to store it for imports in import_map
+                AssocItemId::TypeAliasId(_) => continue,
             };
             let assoc_item = if is_type_in_ns {
                 ItemInNs::Types(module_def_id)
@@ -799,7 +801,6 @@ mod tests {
                 dep::fmt (t)
                 dep::fmt::Display (t)
                 dep::fmt::Display::FMT_CONST (a)
-                dep::fmt::Display::FmtTypeAlias (a)
                 dep::fmt::Display::format_function (a)
                 dep::fmt::Display::format_method (a)
             "#]],

--- a/crates/hir_def/src/import_map.rs
+++ b/crates/hir_def/src/import_map.rs
@@ -749,6 +749,30 @@ mod tests {
     }
 
     #[test]
+    fn fuzzy_import_trait() {
+        let ra_fixture = r#"
+        //- /main.rs crate:main deps:dep
+        //- /dep.rs crate:dep
+        pub mod fmt {
+            pub trait Display {
+                fn fmttt();
+            }
+        }
+    "#;
+
+        check_search(
+            ra_fixture,
+            "main",
+            Query::new("fmt".to_string()).search_mode(SearchMode::Fuzzy),
+            expect![[r#"
+                dep::fmt (t)
+                dep::fmt::Display (t)
+                dep::fmt::Display::fmttt (f)
+            "#]],
+        );
+    }
+
+    #[test]
     fn search_mode() {
         let ra_fixture = r#"
             //- /main.rs crate:main deps:dep

--- a/crates/hir_def/src/item_scope.rs
+++ b/crates/hir_def/src/item_scope.rs
@@ -10,11 +10,11 @@ use once_cell::sync::Lazy;
 use rustc_hash::{FxHashMap, FxHashSet};
 use test_utils::mark;
 
-use crate::ModuleId;
 use crate::{
     db::DefDatabase, per_ns::PerNs, visibility::Visibility, AdtId, BuiltinType, HasModule, ImplId,
     LocalModuleId, Lookup, MacroDefId, ModuleDefId, TraitId,
 };
+use crate::{AssocItemId, ModuleId};
 
 #[derive(Copy, Clone)]
 pub(crate) enum ImportType {
@@ -346,6 +346,18 @@ impl ItemInNs {
         match self {
             ItemInNs::Types(id) | ItemInNs::Values(id) => Some(id),
             ItemInNs::Macros(_) => None,
+        }
+    }
+
+    pub fn as_assoc_item_id(self) -> Option<AssocItemId> {
+        match self {
+            ItemInNs::Types(ModuleDefId::FunctionId(id))
+            | ItemInNs::Values(ModuleDefId::FunctionId(id)) => Some(id.into()),
+            ItemInNs::Types(ModuleDefId::ConstId(id))
+            | ItemInNs::Values(ModuleDefId::ConstId(id)) => Some(id.into()),
+            ItemInNs::Types(ModuleDefId::TypeAliasId(id))
+            | ItemInNs::Values(ModuleDefId::TypeAliasId(id)) => Some(id.into()),
+            _ => None,
         }
     }
 

--- a/crates/hir_def/src/item_scope.rs
+++ b/crates/hir_def/src/item_scope.rs
@@ -12,9 +12,8 @@ use test_utils::mark;
 
 use crate::{
     db::DefDatabase, per_ns::PerNs, visibility::Visibility, AdtId, BuiltinType, HasModule, ImplId,
-    LocalModuleId, Lookup, MacroDefId, ModuleDefId, TraitId,
+    LocalModuleId, Lookup, MacroDefId, ModuleDefId, ModuleId, TraitId,
 };
-use crate::{AssocItemId, ModuleId};
 
 #[derive(Copy, Clone)]
 pub(crate) enum ImportType {
@@ -346,18 +345,6 @@ impl ItemInNs {
         match self {
             ItemInNs::Types(id) | ItemInNs::Values(id) => Some(id),
             ItemInNs::Macros(_) => None,
-        }
-    }
-
-    pub fn as_assoc_item_id(self) -> Option<AssocItemId> {
-        match self {
-            ItemInNs::Types(ModuleDefId::FunctionId(id))
-            | ItemInNs::Values(ModuleDefId::FunctionId(id)) => Some(id.into()),
-            ItemInNs::Types(ModuleDefId::ConstId(id))
-            | ItemInNs::Values(ModuleDefId::ConstId(id)) => Some(id.into()),
-            ItemInNs::Types(ModuleDefId::TypeAliasId(id))
-            | ItemInNs::Values(ModuleDefId::TypeAliasId(id)) => Some(id.into()),
-            _ => None,
         }
     }
 


### PR DESCRIPTION
Store imported traits' associated function/methods and constants into `ImportMap.fst` and pefrorm the imports search on them.

This is a first step towards trait autoimport during completion functionality, the way I see it, after this PR, only a few major things are left to be done:

* store all traits' assoc items into fst, not only the ones in scope, as we do now. Any code pointers on how to do this are welcome 😄 
* adjust a few modules in completions crate (`dot.rs`, `qualified_path.rs` at least) to query the import map, reusing the `import_assets` logic heavily

==
With the current import and autoimport implementations, it looks like for a single query, we're either interested in either associated items lookup or in all other `fst` contents lookup, but never both simultaneously.
I would rather not split `fst` in two but add another `Query` parameter to separate those, but let me know if you have any ideas.