### PR TITLE
Show goto type actions for Const and TypeParams

### DIFF
--- a/crates/hir/src/code_model.rs
+++ b/crates/hir/src/code_model.rs
@@ -1343,6 +1343,12 @@ impl ConstParam {
     pub fn parent(self, _db: &dyn HirDatabase) -> GenericDef {
         self.id.parent.into()
     }
+
+    pub fn ty(self, db: &dyn HirDatabase) -> Type {
+        let def = self.id.parent;
+        let krate = def.module(db.upcast()).krate;
+        Type::new(db, krate, def, db.const_param_ty(self.id))
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/hir/src/code_model.rs
+++ b/crates/hir/src/code_model.rs
@@ -1276,6 +1276,18 @@ impl TypeParam {
         }
     }
 
+    pub fn trait_bounds(self, db: &dyn HirDatabase) -> Vec<Trait> {
+        db.generic_predicates_for_param(self.id)
+            .into_iter()
+            .filter_map(|pred| match &pred.value {
+                hir_ty::GenericPredicate::Implemented(trait_ref) => {
+                    Some(Trait::from(trait_ref.trait_))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
     pub fn default(self, db: &dyn HirDatabase) -> Option<Type> {
         let params = db.generic_defaults(self.id.parent);
         let local_idx = hir_ty::param_idx(db, self.id)?;


### PR DESCRIPTION
Shows goto type actions for type parameters:
![Code_6hn3rowu9M](https://user-images.githubusercontent.com/3757771/103547890-42aaeb00-4ea5-11eb-8ac7-f166869af5f8.png)

Shows goto type actions for const parameters:
![Code_8UFCcbZL3z](https://user-images.githubusercontent.com/3757771/103547891-43438180-4ea5-11eb-91e8-50681e4d831e.png)

Also shows implementations for `Self`:
![Code_eQj1pWfser](https://user-images.githubusercontent.com/3757771/103547892-43438180-4ea5-11eb-9122-461f2e0fdd01.png)
