### PR TITLE
Document project_model::PackageData and project_model::TargetData

### DIFF
--- a/crates/project_model/src/cargo_workspace.rs
+++ b/crates/project_model/src/cargo_workspace.rs
@@ -118,12 +118,18 @@ pub struct PackageDependency {
     pub name: String,
 }
 
+/// Information associated with a package's target
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct TargetData {
+    /// Package that provided this target
     pub package: Package,
+    /// Name as given in the `Cargo.toml` or generated from the file name
     pub name: String,
+    /// Path to the main source file of the target
     pub root: AbsPathBuf,
+    /// Kind of target
     pub kind: TargetKind,
+    /// Is this target a proc-macro
     pub is_proc_macro: bool,
 }
 

--- a/crates/project_model/src/cargo_workspace.rs
+++ b/crates/project_model/src/cargo_workspace.rs
@@ -80,19 +80,35 @@ pub type Package = Idx<PackageData>;
 
 pub type Target = Idx<TargetData>;
 
+/// Information associated with a cargo crate
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct PackageData {
+    /// Version given in the `Cargo.toml`
     pub version: String,
+    /// Name as given in the `Cargo.toml`
     pub name: String,
+    /// Path containing the `Cargo.toml`
     pub manifest: AbsPathBuf,
+    /// Targets provided by the crate (lib, bin, example, test, ...)
     pub targets: Vec<Target>,
+    /// Is this package a member of the current workspace
     pub is_member: bool,
+    /// List of packages this package depends on
     pub dependencies: Vec<PackageDependency>,
+    /// Rust edition for this package
     pub edition: Edition,
+    /// List of features to activate
     pub features: Vec<String>,
+    /// List of config flags defined by this package's build script
     pub cfgs: Vec<CfgFlag>,
+    /// List of cargo-related environment variables with their value
+    ///
+    /// If the package has a build script which defines environment variables,
+    /// they can also be found here.
     pub envs: Vec<(String, String)>,
+    /// Directory where a build script might place its output
     pub out_dir: Option<AbsPathBuf>,
+    /// Path to the proc-macro library file if this package exposes proc-macros
     pub proc_macro_dylib_path: Option<AbsPathBuf>,
 }
 

--- a/crates/project_model/src/lib.rs
+++ b/crates/project_model/src/lib.rs
@@ -1,9 +1,9 @@
 //! FIXME: write short doc here
 
 mod cargo_workspace;
+mod cfg_flag;
 mod project_json;
 mod sysroot;
-mod cfg_flag;
 mod workspace;
 
 use std::{
@@ -17,7 +17,10 @@ use paths::{AbsPath, AbsPathBuf};
 use rustc_hash::FxHashSet;
 
 pub use crate::{
-    cargo_workspace::{CargoConfig, CargoWorkspace, Package, Target, TargetKind},
+    cargo_workspace::{
+        CargoConfig, CargoWorkspace, Package, PackageData, PackageDependency, Target, TargetData,
+        TargetKind,
+    },
     project_json::{ProjectJson, ProjectJsonData},
     sysroot::Sysroot,
     workspace::{PackageRoot, ProjectWorkspace},


### PR DESCRIPTION
This PR adds some documentation for the `project_model` crate.

Some of the field descriptions were taken directly from their `cargo_metadata` counterpart :
- `PackageData` -> `cargo_metadata::Package`
- `TargetData` -> `cargo_metadata::Target`