### PR TITLE
Fix bug for $crate in LHS of mbe

### DIFF
--- a/crates/mbe/src/mbe_expander/transcriber.rs
+++ b/crates/mbe/src/mbe_expander/transcriber.rs
@@ -119,11 +119,10 @@ fn expand_subtree(
 }
 
 fn expand_var(ctx: &mut ExpandCtx, v: &SmolStr, id: tt::TokenId) -> ExpandResult<Fragment> {
-    if v == "crate" {
-        // We simply produce identifier `$crate` here. And it will be resolved when lowering ast to Path.
-        let tt = tt::Leaf::from(tt::Ident { text: "$crate".into(), id }).into();
-        ExpandResult::ok(Fragment::Tokens(tt))
-    } else if !ctx.bindings.contains(v) {
+    // We already handle $crate case in mbe parser
+    debug_assert!(v != "crate");
+
+    if !ctx.bindings.contains(v) {
         // Note that it is possible to have a `$var` inside a macro which is not bound.
         // For example:
         // ```

--- a/crates/mbe/src/parser.rs
+++ b/crates/mbe/src/parser.rs
@@ -109,6 +109,10 @@ fn next_op<'a>(first: &tt::TokenTree, src: &mut TtIter<'a>, mode: Mode) -> Resul
                         let id = punct.id;
                         Op::Var { name, kind, id }
                     }
+                    tt::Leaf::Ident(ident) if ident.text == "crate" => {
+                        // We simply produce identifier `$crate` here. And it will be resolved when lowering ast to Path.
+                        Op::Leaf(tt::Leaf::from(tt::Ident { text: "$crate".into(), id: ident.id }))
+                    }
                     tt::Leaf::Ident(ident) => {
                         let name = ident.text.clone();
                         let kind = eat_fragment_kind(src, mode)?;

--- a/crates/mbe/src/tests.rs
+++ b/crates/mbe/src/tests.rs
@@ -1080,6 +1080,19 @@ fn test_vertical_bar_with_pat() {
 }
 
 #[test]
+fn test_dollar_crate_lhs_is_not_meta() {
+    parse_macro(
+        r#"
+macro_rules! foo {
+    ($crate) => {};
+    () => {0};
+}
+    "#,
+    )
+    .assert_expand_items(r#"foo!{}"#, r#"0"#);
+}
+
+#[test]
 fn test_lifetime() {
     parse_macro(
         r#"


### PR DESCRIPTION
We treated `$crate` as meta variable in LHS of mbe, which should be an `ident`. 

Fixes #7204