### PR TITLE
Use hir::GenericParam in ide_db::Definition instead of relisting all 3

### DIFF
--- a/crates/hir/src/code_model.rs
+++ b/crates/hir/src/code_model.rs
@@ -1263,6 +1263,24 @@ pub enum GenericParam {
 }
 impl_from!(TypeParam, LifetimeParam, ConstParam for GenericParam);
 
+impl GenericParam {
+    pub fn module(self, db: &dyn HirDatabase) -> Module {
+        match self {
+            GenericParam::TypeParam(it) => it.module(db),
+            GenericParam::LifetimeParam(it) => it.module(db),
+            GenericParam::ConstParam(it) => it.module(db),
+        }
+    }
+
+    pub fn name(self, db: &dyn HirDatabase) -> Name {
+        match self {
+            GenericParam::TypeParam(it) => it.name(db),
+            GenericParam::LifetimeParam(it) => it.name(db),
+            GenericParam::ConstParam(it) => it.name(db),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct TypeParam {
     pub(crate) id: TypeParamId,

--- a/crates/ide/src/display/navigation_target.rs
+++ b/crates/ide/src/display/navigation_target.rs
@@ -215,10 +215,8 @@ impl TryToNav for Definition {
             Definition::ModuleDef(it) => it.try_to_nav(db),
             Definition::SelfType(it) => it.try_to_nav(db),
             Definition::Local(it) => Some(it.to_nav(db)),
-            Definition::TypeParam(it) => it.try_to_nav(db),
-            Definition::LifetimeParam(it) => it.try_to_nav(db),
+            Definition::GenericParam(it) => it.try_to_nav(db),
             Definition::Label(it) => Some(it.to_nav(db)),
-            Definition::ConstParam(it) => it.try_to_nav(db),
         }
     }
 }
@@ -385,6 +383,16 @@ impl TryToNav for hir::AssocItem {
             AssocItem::Function(it) => it.try_to_nav(db),
             AssocItem::Const(it) => it.try_to_nav(db),
             AssocItem::TypeAlias(it) => it.try_to_nav(db),
+        }
+    }
+}
+
+impl TryToNav for hir::GenericParam {
+    fn try_to_nav(&self, db: &RootDatabase) -> Option<NavigationTarget> {
+        match self {
+            hir::GenericParam::TypeParam(it) => it.try_to_nav(db),
+            hir::GenericParam::ConstParam(it) => it.try_to_nav(db),
+            hir::GenericParam::LifetimeParam(it) => it.try_to_nav(db),
         }
     }
 }

--- a/crates/ide/src/doc_links.rs
+++ b/crates/ide/src/doc_links.rs
@@ -216,9 +216,7 @@ fn rewrite_intra_doc_link(
         Definition::Field(it) => it.resolve_doc_path(db, link, ns),
         Definition::SelfType(_)
         | Definition::Local(_)
-        | Definition::TypeParam(_)
-        | Definition::ConstParam(_)
-        | Definition::LifetimeParam(_)
+        | Definition::GenericParam(_)
         | Definition::Label(_) => return None,
     }?;
     let krate = resolved.module(db)?.krate();

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -111,9 +111,7 @@ fn def_for_doc_comment(
         Definition::Field(it) => it.resolve_doc_path(db, link, ns),
         Definition::SelfType(_)
         | Definition::Local(_)
-        | Definition::TypeParam(_)
-        | Definition::LifetimeParam(_)
-        | Definition::ConstParam(_)
+        | Definition::GenericParam(_)
         | Definition::Label(_) => return None,
     }
 }

--- a/crates/ide/src/references.rs
+++ b/crates/ide/src/references.rs
@@ -130,7 +130,10 @@ pub(crate) fn find_all_refs(
                 kind = ReferenceKind::FieldShorthandForLocal;
             }
         }
-    } else if matches!(def, Definition::LifetimeParam(_) | Definition::Label(_)) {
+    } else if matches!(
+        def,
+        Definition::GenericParam(hir::GenericParam::LifetimeParam(_)) | Definition::Label(_)
+    ) {
         kind = ReferenceKind::Lifetime;
     };
 

--- a/crates/ide/src/syntax_highlighting/highlight.rs
+++ b/crates/ide/src/syntax_highlighting/highlight.rs
@@ -328,8 +328,11 @@ fn highlight_def(db: &RootDatabase, def: Definition) -> Highlight {
             }
         },
         Definition::SelfType(_) => HlTag::Symbol(SymbolKind::Impl),
-        Definition::TypeParam(_) => HlTag::Symbol(SymbolKind::TypeParam),
-        Definition::ConstParam(_) => HlTag::Symbol(SymbolKind::ConstParam),
+        Definition::GenericParam(it) => match it {
+            hir::GenericParam::TypeParam(_) => HlTag::Symbol(SymbolKind::TypeParam),
+            hir::GenericParam::ConstParam(_) => HlTag::Symbol(SymbolKind::ConstParam),
+            hir::GenericParam::LifetimeParam(_) => HlTag::Symbol(SymbolKind::LifetimeParam),
+        },
         Definition::Local(local) => {
             let tag = if local.is_param(db) {
                 HlTag::Symbol(SymbolKind::ValueParam)
@@ -345,7 +348,6 @@ fn highlight_def(db: &RootDatabase, def: Definition) -> Highlight {
             }
             return h;
         }
-        Definition::LifetimeParam(_) => HlTag::Symbol(SymbolKind::LifetimeParam),
         Definition::Label(_) => HlTag::Symbol(SymbolKind::Label),
     }
     .into()

--- a/crates/ide_db/src/search.rs
+++ b/crates/ide_db/src/search.rs
@@ -136,7 +136,7 @@ impl Definition {
             return SearchScope::new(res);
         }
 
-        if let Definition::LifetimeParam(param) = self {
+        if let Definition::GenericParam(hir::GenericParam::LifetimeParam(param)) = self {
             let range = match param.parent(db) {
                 hir::GenericDef::Function(it) => {
                     it.source(db).and_then(|src| Some(src.value.syntax().text_range()))


### PR DESCRIPTION
Basically just this:
```diff
 pub enum Definition {
     Macro(MacroDef),
     Field(Field),
     ModuleDef(ModuleDef),
     SelfType(Impl),
     Local(Local),
-    TypeParam(TypeParam),
-    LifetimeParam(LifetimeParam),
-    ConstParam(ConstParam),
+    GenericParam(GenericParam),
     Label(Label),
 }
```