### PR TITLE
Refactor rename name checking

### DIFF
--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -175,12 +175,7 @@ fn show_implementations_action(db: &RootDatabase, def: Definition) -> Option<Hov
         Definition::SelfType(it) => it.target_ty(db).as_adt(),
         _ => None,
     }?;
-    match adt {
-        Adt::Struct(it) => it.try_to_nav(db),
-        Adt::Union(it) => it.try_to_nav(db),
-        Adt::Enum(it) => it.try_to_nav(db),
-    }
-    .map(to_action)
+    adt.try_to_nav(db).map(to_action)
 }
 
 fn runnable_action(


### PR DESCRIPTION
Improves the user facing error messages a bit and prevents renaming to `_` when the name is referenced as this would change source to not compile anymore since `_` is only a pattern, not a proper identifier.