### PR TITLE
Remove unnecessary allocation when checking whether to hide argument name hint

### DIFF
--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -354,8 +354,11 @@ fn is_argument_similar_to_param_name(
     match get_string_representation(argument) {
         None => false,
         Some(argument_string) => {
+            let num_leading_underscores =
+                argument_string.bytes().take_while(|&c| c == b'_').count();
+
             // Does the argument name begin with the parameter name? Ignore leading underscores.
-            let mut arg_bytes = argument_string.bytes().skip_while(|&c| c == b'_');
+            let mut arg_bytes = argument_string.bytes().skip(num_leading_underscores);
             let starts_with_pattern = param_name.bytes().all(
                 |expected| matches!(arg_bytes.next(), Some(actual) if expected.eq_ignore_ascii_case(&actual)),
             );
@@ -365,7 +368,7 @@ fn is_argument_similar_to_param_name(
             }
 
             // Does the argument name end with the parameter name?
-            let mut arg_bytes = argument_string.bytes();
+            let mut arg_bytes = argument_string.bytes().skip(num_leading_underscores);
             param_name.bytes().rev().all(
                 |expected| matches!(arg_bytes.next_back(), Some(actual) if expected.eq_ignore_ascii_case(&actual)),
             )

--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -353,13 +353,18 @@ fn is_argument_similar_to_param_name(
     }
     match get_string_representation(argument) {
         None => false,
-        Some(mut repr) => {
-            let param_name = param_name.to_ascii_lowercase();
-            let argument_string = {
-                repr.make_ascii_lowercase();
-                repr.trim_start_matches('_')
-            };
-            argument_string.starts_with(&param_name) || argument_string.ends_with(&param_name)
+        Some(argument_string) => {
+            let mut arg_bytes = argument_string.bytes().skip_while(|&c| c == b'_');
+            let starts_with_pattern = param_name.bytes().all(
+                |expected| matches!(arg_bytes.next(), Some(actual) if expected.eq_ignore_ascii_case(&actual)),
+            );
+
+            let mut arg_bytes = argument_string.bytes();
+            let ends_with_pattern = param_name.bytes().rev().all(
+                |expected| matches!(arg_bytes.next_back(), Some(actual) if expected.eq_ignore_ascii_case(&actual)),
+            );
+
+            starts_with_pattern || ends_with_pattern
         }
     }
 }

--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -354,17 +354,21 @@ fn is_argument_similar_to_param_name(
     match get_string_representation(argument) {
         None => false,
         Some(argument_string) => {
+            // Does the argument name begin with the parameter name? Ignore leading underscores.
             let mut arg_bytes = argument_string.bytes().skip_while(|&c| c == b'_');
             let starts_with_pattern = param_name.bytes().all(
                 |expected| matches!(arg_bytes.next(), Some(actual) if expected.eq_ignore_ascii_case(&actual)),
             );
 
-            let mut arg_bytes = argument_string.bytes();
-            let ends_with_pattern = param_name.bytes().rev().all(
-                |expected| matches!(arg_bytes.next_back(), Some(actual) if expected.eq_ignore_ascii_case(&actual)),
-            );
+            if starts_with_pattern {
+                return true;
+            }
 
-            starts_with_pattern || ends_with_pattern
+            // Does the argument name end with the parameter name?
+            let mut arg_bytes = argument_string.bytes();
+            param_name.bytes().rev().all(
+                |expected| matches!(arg_bytes.next_back(), Some(actual) if expected.eq_ignore_ascii_case(&actual)),
+            )
         }
     }
 }


### PR DESCRIPTION
The case-insensitive prefix/suffix check can be performed
character-by-character. This allows the check to be done without having
to allocate a new string. As a side effect, it's also no longer
necessary to convert the entire string to lowercase, as it's done as
needed. As the only case equality we're handling is ASCII, this
operation can be further optimized by using byte equality, rather than
character equality.

cc @SomeoneToIgnore, as it's an update on my PR from yesterday.