### PR TITLE
Allow `true` and `false` keywords in const generics

### DIFF
--- a/crates/parser/src/grammar/type_args.rs
+++ b/crates/parser/src/grammar/type_args.rs
@@ -26,7 +26,7 @@ pub(super) fn opt_generic_arg_list(p: &mut Parser, colon_colon_required: bool) {
 }
 
 // test type_arg
-// type A = B<'static, i32, 1, { 2 }, Item=u64>;
+// type A = B<'static, i32, 1, { 2 }, Item=u64, true, false>;
 fn generic_arg(p: &mut Parser) {
     let m = p.start();
     match p.current() {
@@ -52,6 +52,10 @@ fn generic_arg(p: &mut Parser) {
             m.complete(p, CONST_ARG);
         }
         k if k.is_literal() => {
+            expressions::literal(p);
+            m.complete(p, CONST_ARG);
+        }
+        TRUE_KW | FALSE_KW => {
             expressions::literal(p);
             m.complete(p, CONST_ARG);
         }

--- a/crates/syntax/test_data/parser/inline/ok/0039_type_arg.rast
+++ b/crates/syntax/test_data/parser/inline/ok/0039_type_arg.rast
@@ -1,5 +1,5 @@
-SOURCE_FILE@0..46
-  TYPE_ALIAS@0..45
+SOURCE_FILE@0..59
+  TYPE_ALIAS@0..58
     TYPE_KW@0..4 "type"
     WHITESPACE@4..5 " "
     NAME@5..6
@@ -7,12 +7,12 @@ SOURCE_FILE@0..46
     WHITESPACE@6..7 " "
     EQ@7..8 "="
     WHITESPACE@8..9 " "
-    PATH_TYPE@9..44
-      PATH@9..44
-        PATH_SEGMENT@9..44
+    PATH_TYPE@9..57
+      PATH@9..57
+        PATH_SEGMENT@9..57
           NAME_REF@9..10
             IDENT@9..10 "B"
-          GENERIC_ARG_LIST@10..44
+          GENERIC_ARG_LIST@10..57
             L_ANGLE@10..11 "<"
             LIFETIME_ARG@11..18
               LIFETIME@11..18
@@ -51,6 +51,16 @@ SOURCE_FILE@0..46
                   PATH_SEGMENT@40..43
                     NAME_REF@40..43
                       IDENT@40..43 "u64"
-            R_ANGLE@43..44 ">"
-    SEMICOLON@44..45 ";"
-  WHITESPACE@45..46 "\n"
+            COMMA@43..44 ","
+            WHITESPACE@44..45 " "
+            CONST_ARG@45..49
+              LITERAL@45..49
+                TRUE_KW@45..49 "true"
+            COMMA@49..50 ","
+            WHITESPACE@50..51 " "
+            CONST_ARG@51..56
+              LITERAL@51..56
+                FALSE_KW@51..56 "false"
+            R_ANGLE@56..57 ">"
+    SEMICOLON@57..58 ";"
+  WHITESPACE@58..59 "\n"

--- a/crates/syntax/test_data/parser/inline/ok/0039_type_arg.rs
+++ b/crates/syntax/test_data/parser/inline/ok/0039_type_arg.rs
@@ -1,1 +1,1 @@
-type A = B<'static, i32, 1, { 2 }, Item=u64>;
+type A = B<'static, i32, 1, { 2 }, Item=u64, true, false>;


### PR DESCRIPTION
This should fix #7232 - hopefully I've done it right, it passes the tests and the rast file looks like it's picking up the true and false in the test