### PR TITLE
Unfreeze cargo_metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,12 +127,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
-name = "cargo_metadata"
-version = "0.12.0"
+name = "cargo-platform"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5a5f7b42f606b7f23674f6f4d877628350682bc40687d3fae65679a58d55345"
+checksum = "0226944a63d1bf35a3b5f948dd7c59e263db83695c9e8bffc4037de02e30f1d7"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11a47b6286279a9998588ef7050d1ebc2500c69892a557c90fe5d071c64415dc"
+dependencies = [
+ "cargo-platform",
  "semver",
+ "semver-parser",
  "serde",
  "serde_json",
 ]

--- a/crates/flycheck/Cargo.toml
+++ b/crates/flycheck/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 [dependencies]
 crossbeam-channel = "0.5.0"
 log = "0.4.8"
-cargo_metadata = "=0.12.0"
+cargo_metadata = "0.12.2"
 serde_json = "1.0.48"
 jod-thread = "0.1.1"
 

--- a/crates/proc_macro_srv/Cargo.toml
+++ b/crates/proc_macro_srv/Cargo.toml
@@ -20,7 +20,7 @@ proc_macro_api = { path = "../proc_macro_api", version = "0.0.0" }
 test_utils = { path = "../test_utils", version = "0.0.0" }
 
 [dev-dependencies]
-cargo_metadata = "=0.12.0"
+cargo_metadata = "0.12.2"
 
 # used as proc macro test targets
 serde_derive = "1.0.106"

--- a/crates/project_model/Cargo.toml
+++ b/crates/project_model/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 [dependencies]
 log = "0.4.8"
 rustc-hash = "1.1.0"
-cargo_metadata = "=0.12.0"
+cargo_metadata = "0.12.2"
 serde = { version = "1.0.106", features = ["derive"] }
 serde_json = "1.0.48"
 anyhow = "1.0.26"


### PR DESCRIPTION
It now pulls in a newer version of semver-parser.

This does add a dependency on `cargo-platform` in the interest of correctness.