### PR TITLE
Make arena index vs ID naming consistent

### DIFF
--- a/crates/hir_def/src/expr.rs
+++ b/crates/hir_def/src/expr.rs
@@ -13,7 +13,7 @@
 //! See also a neighboring `body` module.
 
 use hir_expand::name::Name;
-use la_arena::{Idx, RawId};
+use la_arena::{Idx, RawIdx};
 use syntax::ast::RangeOp;
 
 use crate::{
@@ -24,7 +24,7 @@ use crate::{
 
 pub type ExprId = Idx<Expr>;
 pub(crate) fn dummy_expr_id() -> ExprId {
-    ExprId::from_raw(RawId::from(!0))
+    ExprId::from_raw(RawIdx::from(!0))
 }
 
 pub type PatId = Idx<Pat>;

--- a/crates/hir_def/src/item_tree.rs
+++ b/crates/hir_def/src/item_tree.rs
@@ -20,7 +20,7 @@ use hir_expand::{
     name::{name, AsName, Name},
     HirFileId, InFile,
 };
-use la_arena::{Arena, Idx, RawId};
+use la_arena::{Arena, Idx, RawIdx};
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 use syntax::{ast, match_ast};

--- a/crates/hir_def/src/item_tree/lower.rs
+++ b/crates/hir_def/src/item_tree/lower.rs
@@ -683,12 +683,12 @@ impl Ctx {
     }
 
     fn next_field_idx(&self) -> Idx<Field> {
-        Idx::from_raw(RawId::from(
+        Idx::from_raw(RawIdx::from(
             self.tree.data.as_ref().map_or(0, |data| data.fields.len() as u32),
         ))
     }
     fn next_variant_idx(&self) -> Idx<Variant> {
-        Idx::from_raw(RawId::from(
+        Idx::from_raw(RawIdx::from(
             self.tree.data.as_ref().map_or(0, |data| data.variants.len() as u32),
         ))
     }

--- a/crates/hir_def/src/trace.rs
+++ b/crates/hir_def/src/trace.rs
@@ -9,7 +9,7 @@
 //! absolute offsets. The `Trace` structure (inspired, at least in name, by
 //! Kotlin's `BindingTrace`) allows use the same code to compute both
 //! projections.
-use la_arena::{Arena, ArenaMap, Idx, RawId};
+use la_arena::{Arena, ArenaMap, Idx, RawIdx};
 
 pub(crate) struct Trace<T, V> {
     arena: Option<Arena<T>>,
@@ -30,7 +30,7 @@ impl<T, V> Trace<T, V> {
         let id = if let Some(arena) = &mut self.arena {
             arena.alloc(data())
         } else {
-            let id = Idx::<T>::from_raw(RawId::from(self.len));
+            let id = Idx::<T>::from_raw(RawIdx::from(self.len));
             self.len += 1;
             id
         };

--- a/lib/arena/src/lib.rs
+++ b/lib/arena/src/lib.rs
@@ -1,4 +1,4 @@
-//! Yet another ID-based arena.
+//! Yet another index-based arena.
 
 #![warn(missing_docs)]
 
@@ -13,37 +13,37 @@ use std::{
 mod map;
 pub use map::ArenaMap;
 
-/// The raw ID of a value in an arena.
+/// The raw index of a value in an arena.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct RawId(u32);
+pub struct RawIdx(u32);
 
-impl From<RawId> for u32 {
-    fn from(raw: RawId) -> u32 {
+impl From<RawIdx> for u32 {
+    fn from(raw: RawIdx) -> u32 {
         raw.0
     }
 }
 
-impl From<u32> for RawId {
-    fn from(id: u32) -> RawId {
-        RawId(id)
+impl From<u32> for RawIdx {
+    fn from(idx: u32) -> RawIdx {
+        RawIdx(idx)
     }
 }
 
-impl fmt::Debug for RawId {
+impl fmt::Debug for RawIdx {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
     }
 }
 
-impl fmt::Display for RawId {
+impl fmt::Display for RawIdx {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
     }
 }
 
-/// The ID of a value allocated in an arena that holds `T`s.
+/// The index of a value allocated in an arena that holds `T`s.
 pub struct Idx<T> {
-    raw: RawId,
+    raw: RawIdx,
     _ty: PhantomData<fn() -> T>,
 }
 
@@ -78,18 +78,18 @@ impl<T> fmt::Debug for Idx<T> {
 }
 
 impl<T> Idx<T> {
-    /// Creates a new ID from a [`RawId`].
-    pub fn from_raw(raw: RawId) -> Self {
+    /// Creates a new index from a [`RawIdx`].
+    pub fn from_raw(raw: RawIdx) -> Self {
         Idx { raw, _ty: PhantomData }
     }
 
-    /// Converts this ID into the underlying [`RawId`].
-    pub fn into_raw(self) -> RawId {
+    /// Converts this index into the underlying [`RawIdx`].
+    pub fn into_raw(self) -> RawIdx {
         self.raw
     }
 }
 
-/// Yet another ID-based arena.
+/// Yet another index-based arena.
 #[derive(Clone, PartialEq, Eq)]
 pub struct Arena<T> {
     data: Vec<T>,
@@ -161,37 +161,37 @@ impl<T> Arena<T> {
         self.data.is_empty()
     }
 
-    /// Allocates a new value on the arena, returning the value’s ID.
+    /// Allocates a new value on the arena, returning the value’s index.
     ///
     /// ```
     /// let mut arena = la_arena::Arena::new();
-    /// let id = arena.alloc(50);
+    /// let idx = arena.alloc(50);
     ///
-    /// assert_eq!(arena[id], 50);
+    /// assert_eq!(arena[idx], 50);
     /// ```
     pub fn alloc(&mut self, value: T) -> Idx<T> {
-        let id = RawId(self.data.len() as u32);
+        let idx = RawIdx(self.data.len() as u32);
         self.data.push(value);
-        Idx::from_raw(id)
+        Idx::from_raw(idx)
     }
 
     /// Returns an iterator over the arena’s elements.
     ///
     /// ```
     /// let mut arena = la_arena::Arena::new();
-    /// let id1 = arena.alloc(20);
-    /// let id2 = arena.alloc(40);
-    /// let id3 = arena.alloc(60);
+    /// let idx1 = arena.alloc(20);
+    /// let idx2 = arena.alloc(40);
+    /// let idx3 = arena.alloc(60);
     ///
     /// let mut iterator = arena.iter();
-    /// assert_eq!(iterator.next(), Some((id1, &20)));
-    /// assert_eq!(iterator.next(), Some((id2, &40)));
-    /// assert_eq!(iterator.next(), Some((id3, &60)));
+    /// assert_eq!(iterator.next(), Some((idx1, &20)));
+    /// assert_eq!(iterator.next(), Some((idx2, &40)));
+    /// assert_eq!(iterator.next(), Some((idx3, &60)));
     /// ```
     pub fn iter(
         &self,
     ) -> impl Iterator<Item = (Idx<T>, &T)> + ExactSizeIterator + DoubleEndedIterator {
-        self.data.iter().enumerate().map(|(idx, value)| (Idx::from_raw(RawId(idx as u32)), value))
+        self.data.iter().enumerate().map(|(idx, value)| (Idx::from_raw(RawIdx(idx as u32)), value))
     }
 
     /// Reallocates the arena to make it take up as little space as possible.

--- a/lib/arena/src/map.rs
+++ b/lib/arena/src/map.rs
@@ -2,30 +2,33 @@ use std::marker::PhantomData;
 
 use crate::Idx;
 
-/// A map from arena IDs to some other type. Space requirement is O(highest ID).
+/// A map from arena indexes to some other type.
+/// Space requirement is O(highest index).
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ArenaMap<ID, V> {
+pub struct ArenaMap<IDX, V> {
     v: Vec<Option<V>>,
-    _ty: PhantomData<ID>,
+    _ty: PhantomData<IDX>,
 }
 
 impl<T, V> ArenaMap<Idx<T>, V> {
-    /// Inserts a value associated with a given arena ID into the map.
-    pub fn insert(&mut self, id: Idx<T>, t: V) {
-        let idx = Self::to_idx(id);
+    /// Inserts a value associated with a given arena index into the map.
+    pub fn insert(&mut self, idx: Idx<T>, t: V) {
+        let idx = Self::to_idx(idx);
 
         self.v.resize_with((idx + 1).max(self.v.len()), || None);
         self.v[idx] = Some(t);
     }
 
-    /// Returns a reference to the value associated with the provided ID if it is present.
-    pub fn get(&self, id: Idx<T>) -> Option<&V> {
-        self.v.get(Self::to_idx(id)).and_then(|it| it.as_ref())
+    /// Returns a reference to the value associated with the provided index
+    /// if it is present.
+    pub fn get(&self, idx: Idx<T>) -> Option<&V> {
+        self.v.get(Self::to_idx(idx)).and_then(|it| it.as_ref())
     }
 
-    /// Returns a mutable reference to the value associated with the provided ID if it is present.
-    pub fn get_mut(&mut self, id: Idx<T>) -> Option<&mut V> {
-        self.v.get_mut(Self::to_idx(id)).and_then(|it| it.as_mut())
+    /// Returns a mutable reference to the value associated with the provided index
+    /// if it is present.
+    pub fn get_mut(&mut self, idx: Idx<T>) -> Option<&mut V> {
+        self.v.get_mut(Self::to_idx(idx)).and_then(|it| it.as_mut())
     }
 
     /// Returns an iterator over the values in the map.
@@ -38,13 +41,13 @@ impl<T, V> ArenaMap<Idx<T>, V> {
         self.v.iter_mut().filter_map(|o| o.as_mut())
     }
 
-    /// Returns an iterator over the arena IDs and values in the map.
+    /// Returns an iterator over the arena indexes and values in the map.
     pub fn iter(&self) -> impl Iterator<Item = (Idx<T>, &V)> {
         self.v.iter().enumerate().filter_map(|(idx, o)| Some((Self::from_idx(idx), o.as_ref()?)))
     }
 
-    fn to_idx(id: Idx<T>) -> usize {
-        u32::from(id.into_raw()) as usize
+    fn to_idx(idx: Idx<T>) -> usize {
+        u32::from(idx.into_raw()) as usize
     }
 
     fn from_idx(idx: usize) -> Idx<T> {
@@ -54,8 +57,8 @@ impl<T, V> ArenaMap<Idx<T>, V> {
 
 impl<T, V> std::ops::Index<Idx<V>> for ArenaMap<Idx<V>, T> {
     type Output = T;
-    fn index(&self, id: Idx<V>) -> &T {
-        self.v[Self::to_idx(id)].as_ref().unwrap()
+    fn index(&self, idx: Idx<V>) -> &T {
+        self.v[Self::to_idx(idx)].as_ref().unwrap()
     }
 }
 


### PR DESCRIPTION
This makes naming consistent with `la_arena::RawId`. Alternatively, la-arena’s documentation could be updated to use ‘index’ terminology instead of ‘ID’ terminology, and `RawId` renamed to `RawIdx`.

This pull request doesn’t compile because dependencies on la-arena go through crates.io, so existing dependencies on the crate are referencing an old version. As such, this PR will only compile once a new la-arena version has been published.