### PR TITLE
Remove map module from la-arena public API

### DIFF
--- a/crates/hir_def/src/adt.rs
+++ b/crates/hir_def/src/adt.rs
@@ -8,7 +8,7 @@ use hir_expand::{
     name::{AsName, Name},
     InFile,
 };
-use la_arena::{map::ArenaMap, Arena};
+use la_arena::{Arena, ArenaMap};
 use syntax::ast::{self, NameOwner, VisibilityOwner};
 use tt::{Delimiter, DelimiterKind, Leaf, Subtree, TokenTree};
 

--- a/crates/hir_def/src/attr.rs
+++ b/crates/hir_def/src/attr.rs
@@ -7,7 +7,7 @@ use cfg::{CfgExpr, CfgOptions};
 use either::Either;
 use hir_expand::{hygiene::Hygiene, name::AsName, AstId, InFile};
 use itertools::Itertools;
-use la_arena::map::ArenaMap;
+use la_arena::ArenaMap;
 use mbe::ast_to_token_tree;
 use syntax::{
     ast::{self, AstNode, AttrsOwner},

--- a/crates/hir_def/src/body.rs
+++ b/crates/hir_def/src/body.rs
@@ -16,7 +16,7 @@ use hir_expand::{
     ast_id_map::AstIdMap, diagnostics::DiagnosticSink, hygiene::Hygiene, AstId, ExpandResult,
     HirFileId, InFile, MacroDefId,
 };
-use la_arena::{map::ArenaMap, Arena};
+use la_arena::{Arena, ArenaMap};
 use rustc_hash::FxHashMap;
 use syntax::{ast, AstNode, AstPtr};
 use test_utils::mark;

--- a/crates/hir_def/src/db.rs
+++ b/crates/hir_def/src/db.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use base_db::{salsa, CrateId, SourceDatabase, Upcast};
 use hir_expand::{db::AstDatabase, HirFileId};
-use la_arena::map::ArenaMap;
+use la_arena::ArenaMap;
 use syntax::SmolStr;
 
 use crate::{

--- a/crates/hir_def/src/generics.rs
+++ b/crates/hir_def/src/generics.rs
@@ -10,7 +10,7 @@ use hir_expand::{
     name::{name, AsName, Name},
     InFile,
 };
-use la_arena::{map::ArenaMap, Arena};
+use la_arena::{Arena, ArenaMap};
 use syntax::ast::{self, GenericParamsOwner, NameOwner, TypeBoundsOwner};
 
 use crate::{

--- a/crates/hir_def/src/src.rs
+++ b/crates/hir_def/src/src.rs
@@ -1,7 +1,7 @@
 //! Utilities for mapping between hir IDs and the surface syntax.
 
 use hir_expand::InFile;
-use la_arena::map::ArenaMap;
+use la_arena::ArenaMap;
 
 use crate::{db::DefDatabase, item_tree::ItemTreeNode, AssocItemLoc, ItemLoc};
 

--- a/crates/hir_def/src/trace.rs
+++ b/crates/hir_def/src/trace.rs
@@ -9,7 +9,7 @@
 //! absolute offsets. The `Trace` structure (inspired, at least in name, by
 //! Kotlin's `BindingTrace`) allows use the same code to compute both
 //! projections.
-use la_arena::{map::ArenaMap, Arena, Idx, RawId};
+use la_arena::{Arena, ArenaMap, Idx, RawId};
 
 pub(crate) struct Trace<T, V> {
     arena: Option<Arena<T>>,

--- a/crates/hir_ty/src/db.rs
+++ b/crates/hir_ty/src/db.rs
@@ -7,7 +7,7 @@ use hir_def::{
     db::DefDatabase, expr::ExprId, ConstParamId, DefWithBodyId, FunctionId, GenericDefId, ImplId,
     LocalFieldId, TypeParamId, VariantId,
 };
-use la_arena::map::ArenaMap;
+use la_arena::ArenaMap;
 
 use crate::{
     method_resolution::{InherentImpls, TraitImpls},

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -30,7 +30,7 @@ use hir_def::{
     TypeAliasId, VariantId,
 };
 use hir_expand::{diagnostics::DiagnosticSink, name::name};
-use la_arena::map::ArenaMap;
+use la_arena::ArenaMap;
 use rustc_hash::FxHashMap;
 use stdx::impl_from;
 use syntax::SmolStr;

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -20,7 +20,7 @@ use hir_def::{
     TypeAliasId, TypeParamId, UnionId, VariantId,
 };
 use hir_expand::name::Name;
-use la_arena::map::ArenaMap;
+use la_arena::ArenaMap;
 use smallvec::SmallVec;
 use stdx::impl_from;
 use test_utils::mark;

--- a/lib/arena/src/lib.rs
+++ b/lib/arena/src/lib.rs
@@ -8,7 +8,8 @@ use std::{
     ops::{Index, IndexMut},
 };
 
-pub mod map;
+mod map;
+pub use map::ArenaMap;
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RawId(u32);

--- a/lib/arena/src/map.rs
+++ b/lib/arena/src/map.rs
@@ -1,5 +1,3 @@
-//! A map from arena IDs to some other type. Space requirement is O(highest ID).
-
 use std::marker::PhantomData;
 
 use crate::Idx;


### PR DESCRIPTION
It’s unlikely that more items will be added to the module, so it’s simpler for users if `ArenaMap` is re-exported and the module made private.

This doesn’t compile for the same reason that #7275 doesn’t:

> This pull request doesn’t compile because dependencies on la-arena go through crates.io, so existing dependencies on the crate are referencing an old version. As such, this PR will only compile once a new la-arena version has been published.