### PR TITLE
Follow RFC 430 naming for ArenaMap Id type parameter

### DIFF
--- a/lib/arena/src/map.rs
+++ b/lib/arena/src/map.rs
@@ -6,9 +6,9 @@ use crate::Idx;
 
 /// A map from arena IDs to some other type. Space requirement is O(highest ID).
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ArenaMap<ID, V> {
+pub struct ArenaMap<Id, V> {
     v: Vec<Option<V>>,
-    _ty: PhantomData<ID>,
+    _ty: PhantomData<Id>,
 }
 
 impl<T, V> ArenaMap<Idx<T>, V> {


### PR DESCRIPTION
From the [RFC text](https://github.com/rust-lang/rfcs/blob/c81b18cdcc7590756315525789bf09622f471135/text/0430-finalizing-naming-conventions.md#fine-points):

> In `UpperCamelCase`, acronyms count as one word: use `Uuid` rather than `UUID`.