### PR TITLE
Swap assert_eq_text\!(expected, actual)

### DIFF
--- a/crates/hir_expand/src/proc_macro.rs
+++ b/crates/hir_expand/src/proc_macro.rs
@@ -135,7 +135,6 @@ mod tests {
         let result = format!("{:#?}", remove_derive_attrs(&tt).unwrap());
 
         assert_eq_text!(
-            &result,
             r#"
 SUBTREE $
   PUNCH   # [alone] 0
@@ -150,7 +149,8 @@ SUBTREE $
     PUNCH   : [alone] 19
     IDENT   u32 20
 "#
-            .trim()
+            .trim(),
+            &result
         );
     }
 }

--- a/crates/ide/src/syntax_tree.rs
+++ b/crates/ide/src/syntax_tree.rs
@@ -111,7 +111,6 @@ mod tests {
         let syn = analysis.syntax_tree(file_id, None).unwrap();
 
         assert_eq_text!(
-            syn.trim(),
             r#"
 SOURCE_FILE@0..11
   FN@0..11
@@ -127,7 +126,8 @@ SOURCE_FILE@0..11
       L_CURLY@9..10 "{"
       R_CURLY@10..11 "}"
 "#
-            .trim()
+            .trim(),
+            syn.trim()
         );
 
         let (analysis, file_id) = fixture::file(
@@ -143,7 +143,6 @@ fn test() {
         let syn = analysis.syntax_tree(file_id, None).unwrap();
 
         assert_eq_text!(
-            syn.trim(),
             r#"
 SOURCE_FILE@0..60
   FN@0..60
@@ -176,7 +175,8 @@ SOURCE_FILE@0..60
       WHITESPACE@58..59 "\n"
       R_CURLY@59..60 "}"
 "#
-            .trim()
+            .trim(),
+            syn.trim()
         );
     }
 
@@ -186,7 +186,6 @@ SOURCE_FILE@0..60
         let syn = analysis.syntax_tree(range.file_id, Some(range.range)).unwrap();
 
         assert_eq_text!(
-            syn.trim(),
             r#"
 FN@0..11
   FN_KW@0..2 "fn"
@@ -201,7 +200,8 @@ FN@0..11
     L_CURLY@9..10 "{"
     R_CURLY@10..11 "}"
 "#
-            .trim()
+            .trim(),
+            syn.trim()
         );
 
         let (analysis, range) = fixture::range(
@@ -216,7 +216,6 @@ FN@0..11
         let syn = analysis.syntax_tree(range.file_id, Some(range.range)).unwrap();
 
         assert_eq_text!(
-            syn.trim(),
             r#"
 EXPR_STMT@16..58
   MACRO_CALL@16..57
@@ -234,7 +233,8 @@ EXPR_STMT@16..58
       R_PAREN@56..57 ")"
   SEMICOLON@57..58 ";"
 "#
-            .trim()
+            .trim(),
+            syn.trim()
         );
     }
 
@@ -253,7 +253,6 @@ fn bar() {
         );
         let syn = analysis.syntax_tree(range.file_id, Some(range.range)).unwrap();
         assert_eq_text!(
-            syn.trim(),
             r#"
 SOURCE_FILE@0..12
   FN@0..12
@@ -270,7 +269,8 @@ SOURCE_FILE@0..12
       WHITESPACE@10..11 "\n"
       R_CURLY@11..12 "}"
 "#
-            .trim()
+            .trim(),
+            syn.trim()
         );
 
         // With a raw string
@@ -287,7 +287,6 @@ fn bar() {
         );
         let syn = analysis.syntax_tree(range.file_id, Some(range.range)).unwrap();
         assert_eq_text!(
-            syn.trim(),
             r#"
 SOURCE_FILE@0..12
   FN@0..12
@@ -304,7 +303,8 @@ SOURCE_FILE@0..12
       WHITESPACE@10..11 "\n"
       R_CURLY@11..12 "}"
 "#
-            .trim()
+            .trim(),
+            syn.trim()
         );
 
         // With a raw string
@@ -320,7 +320,6 @@ fn bar() {
         );
         let syn = analysis.syntax_tree(range.file_id, Some(range.range)).unwrap();
         assert_eq_text!(
-            syn.trim(),
             r#"
 SOURCE_FILE@0..25
   FN@0..12
@@ -351,7 +350,8 @@ SOURCE_FILE@0..25
       WHITESPACE@23..24 "\n"
       R_CURLY@24..25 "}"
 "#
-            .trim()
+            .trim(),
+            syn.trim()
         );
     }
 }

--- a/crates/ide_db/src/helpers/insert_use/tests.rs
+++ b/crates/ide_db/src/helpers/insert_use/tests.rs
@@ -599,7 +599,7 @@ fn check(
 
     let rewriter = insert_use(&file, path, mb);
     let result = rewriter.rewrite(file.as_syntax_node()).to_string();
-    assert_eq_text!(&result, ra_fixture_after);
+    assert_eq_text!(ra_fixture_after, &result);
 }
 
 fn check_full(path: &str, ra_fixture_before: &str, ra_fixture_after: &str) {

--- a/crates/mbe/src/tests.rs
+++ b/crates/mbe/src/tests.rs
@@ -261,7 +261,6 @@ fn test_expr_order() {
 
     let dump = format!("{:#?}", expanded);
     assert_eq_text!(
-        dump.trim(),
         r#"MACRO_ITEMS@0..15
   FN@0..15
     FN_KW@0..2 "fn"
@@ -285,6 +284,7 @@ fn test_expr_order() {
             INT_NUMBER@12..13 "2"
         SEMICOLON@13..14 ";"
       R_CURLY@14..15 "}""#,
+        dump.trim()
     );
 }
 
@@ -989,7 +989,6 @@ fn test_tt_composite2() {
 
     let res = format!("{:#?}", &node);
     assert_eq_text!(
-        res.trim(),
         r###"MACRO_ITEMS@0..10
   MACRO_CALL@0..10
     PATH@0..3
@@ -1003,7 +1002,8 @@ fn test_tt_composite2() {
       R_ANGLE@6..7 ">"
       WHITESPACE@7..8 " "
       POUND@8..9 "#"
-      R_PAREN@9..10 ")""###
+      R_PAREN@9..10 ")""###,
+        res.trim()
     );
 }
 
@@ -1742,7 +1742,7 @@ impl MacroFixture {
     fn assert_expand(&self, invocation: &str, expected: &str) {
         let expansion = self.expand_tt(invocation);
         let actual = format!("{:?}", expansion);
-        test_utils::assert_eq_text!(&actual.trim(), &expected.trim());
+        test_utils::assert_eq_text!(&expected.trim(), &actual.trim());
     }
 
     fn assert_expand_items(&self, invocation: &str, expected: &str) -> &MacroFixture {
@@ -1941,7 +1941,6 @@ fn test_no_space_after_semi_colon() {
 
     let dump = format!("{:#?}", expanded);
     assert_eq_text!(
-        dump.trim(),
         r###"MACRO_ITEMS@0..52
   MODULE@0..26
     ATTR@0..21
@@ -1981,6 +1980,7 @@ fn test_no_space_after_semi_colon() {
     NAME@50..51
       IDENT@50..51 "f"
     SEMICOLON@51..52 ";""###,
+        dump.trim()
     );
 }
 

--- a/crates/proc_macro_srv/src/tests/mod.rs
+++ b/crates/proc_macro_srv/src/tests/mod.rs
@@ -38,9 +38,9 @@ fn test_derive_proc_macro_list() {
     let res = list("serde_derive", "1").join("\n");
 
     assert_eq_text!(
-        &res,
         r#"Serialize [CustomDerive]
-Deserialize [CustomDerive]"#
+Deserialize [CustomDerive]"#,
+        &res
     );
 }
 
@@ -50,9 +50,9 @@ fn list_test_macros() {
     let res = list("proc_macro_test", "0.0.0").join("\n");
 
     assert_eq_text!(
-        &res,
         r#"function_like_macro [FuncLike]
 attribute_macro [Attr]
-DummyTrait [CustomDerive]"#
+DummyTrait [CustomDerive]"#,
+        &res
     );
 }

--- a/crates/proc_macro_srv/src/tests/utils.rs
+++ b/crates/proc_macro_srv/src/tests/utils.rs
@@ -52,7 +52,7 @@ pub fn assert_expand(
     let fixture = parse_string(ra_fixture).unwrap();
 
     let res = expander.expand(macro_name, &fixture.subtree, None).unwrap();
-    assert_eq_text!(&format!("{:?}", res), &expect.trim());
+    assert_eq_text!(&expect.trim(), &format!("{:?}", res));
 }
 
 pub fn list(crate_name: &str, version: &str) -> Vec<String> {


### PR DESCRIPTION
Fixes #7283 

Swap assert_eq_text parameters in the order (expected, actual)