### PR TITLE
Fuzzy import assoc item traits

### DIFF
--- a/crates/assists/src/assist_config.rs
+++ b/crates/assists/src/assist_config.rs
@@ -4,7 +4,7 @@
 //! module, and we use to statically check that we only produce snippet
 //! assists if we are allowed to.
 
-use ide_db::helpers::{insert_use::MergeBehavior, SnippetCap};
+use ide_db::helpers::{insert_use::InsertUseConfig, SnippetCap};
 
 use crate::AssistKind;
 
@@ -13,10 +13,4 @@ pub struct AssistConfig {
     pub snippet_cap: Option<SnippetCap>,
     pub allowed: Option<Vec<AssistKind>>,
     pub insert_use: InsertUseConfig,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct InsertUseConfig {
-    pub merge: Option<MergeBehavior>,
-    pub prefix_kind: hir::PrefixKind,
 }

--- a/crates/assists/src/handlers/auto_import.rs
+++ b/crates/assists/src/handlers/auto_import.rs
@@ -94,7 +94,8 @@ pub(crate) fn auto_import(acc: &mut Assists, ctx: &AssistContext) -> Option<()> 
         } else {
             None
         }?;
-    let proposed_imports = import_assets.search_for_imports(&ctx.sema, &ctx.config.insert_use);
+    let proposed_imports =
+        import_assets.search_for_imports(&ctx.sema, &ctx.config.insert_use.prefix_kind);
     if proposed_imports.is_empty() {
         return None;
     }

--- a/crates/assists/src/handlers/auto_import.rs
+++ b/crates/assists/src/handlers/auto_import.rs
@@ -84,7 +84,7 @@ use crate::{AssistContext, AssistId, AssistKind, Assists, GroupLabel};
 pub(crate) fn auto_import(acc: &mut Assists, ctx: &AssistContext) -> Option<()> {
     let import_assets =
         if let Some(path_under_caret) = ctx.find_node_at_offset_with_descend::<ast::Path>() {
-            ImportAssets::for_regular_path(path_under_caret, &ctx.sema)
+            ImportAssets::for_exact_path(path_under_caret, &ctx.sema)
         } else if let Some(method_under_caret) =
             ctx.find_node_at_offset_with_descend::<ast::MethodCallExpr>()
         {

--- a/crates/assists/src/handlers/auto_import.rs
+++ b/crates/assists/src/handlers/auto_import.rs
@@ -122,7 +122,7 @@ pub(crate) fn auto_import(acc: &mut Assists, ctx: &AssistContext) -> Option<()> 
 
 fn import_group_message(import_candidate: &ImportCandidate) -> GroupLabel {
     let name = match import_candidate {
-        ImportCandidate::Name(candidate) => format!("Import {}", candidate.name.text()),
+        ImportCandidate::Path(candidate) => format!("Import {}", candidate.name.text()),
         ImportCandidate::TraitAssocItem(candidate) => {
             format!("Import a trait for item {}", candidate.name.text())
         }

--- a/crates/assists/src/handlers/auto_import.rs
+++ b/crates/assists/src/handlers/auto_import.rs
@@ -95,7 +95,7 @@ pub(crate) fn auto_import(acc: &mut Assists, ctx: &AssistContext) -> Option<()> 
             None
         }?;
     let proposed_imports =
-        import_assets.search_for_imports(&ctx.sema, &ctx.config.insert_use.prefix_kind);
+        import_assets.search_for_imports(&ctx.sema, ctx.config.insert_use.prefix_kind);
     if proposed_imports.is_empty() {
         return None;
     }

--- a/crates/assists/src/handlers/auto_import.rs
+++ b/crates/assists/src/handlers/auto_import.rs
@@ -1,13 +1,11 @@
 use ide_db::helpers::{
+    import_assets::{ImportAssets, ImportCandidate},
     insert_use::{insert_use, ImportScope},
     mod_path_to_ast,
 };
 use syntax::ast;
 
-use crate::{
-    utils::import_assets::{ImportAssets, ImportCandidate},
-    AssistContext, AssistId, AssistKind, Assists, GroupLabel,
-};
+use crate::{AssistContext, AssistId, AssistKind, Assists, GroupLabel};
 
 // Feature: Auto Import
 //

--- a/crates/assists/src/handlers/qualify_path.rs
+++ b/crates/assists/src/handlers/qualify_path.rs
@@ -1,7 +1,10 @@
 use std::iter;
 
 use hir::AsName;
-use ide_db::helpers::mod_path_to_ast;
+use ide_db::helpers::{
+    import_assets::{ImportAssets, ImportCandidate},
+    mod_path_to_ast,
+};
 use ide_db::RootDatabase;
 use syntax::{
     ast,
@@ -12,7 +15,6 @@ use test_utils::mark;
 
 use crate::{
     assist_context::{AssistContext, Assists},
-    utils::import_assets::{ImportAssets, ImportCandidate},
     AssistId, AssistKind, GroupLabel,
 };
 

--- a/crates/assists/src/handlers/qualify_path.rs
+++ b/crates/assists/src/handlers/qualify_path.rs
@@ -38,7 +38,7 @@ use crate::{
 pub(crate) fn qualify_path(acc: &mut Assists, ctx: &AssistContext) -> Option<()> {
     let import_assets =
         if let Some(path_under_caret) = ctx.find_node_at_offset_with_descend::<ast::Path>() {
-            ImportAssets::for_regular_path(path_under_caret, &ctx.sema)
+            ImportAssets::for_exact_path(path_under_caret, &ctx.sema)
         } else if let Some(method_under_caret) =
             ctx.find_node_at_offset_with_descend::<ast::MethodCallExpr>()
         {

--- a/crates/assists/src/lib.rs
+++ b/crates/assists/src/lib.rs
@@ -24,7 +24,7 @@ use syntax::TextRange;
 
 pub(crate) use crate::assist_context::{AssistContext, Assists};
 
-pub use assist_config::{AssistConfig, InsertUseConfig};
+pub use assist_config::AssistConfig;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AssistKind {

--- a/crates/assists/src/tests.rs
+++ b/crates/assists/src/tests.rs
@@ -3,16 +3,17 @@ mod generated;
 use hir::Semantics;
 use ide_db::{
     base_db::{fixture::WithFixture, FileId, FileRange, SourceDatabaseExt},
-    helpers::{insert_use::MergeBehavior, SnippetCap},
+    helpers::{
+        insert_use::{InsertUseConfig, MergeBehavior},
+        SnippetCap,
+    },
     source_change::FileSystemEdit,
     RootDatabase,
 };
 use syntax::TextRange;
 use test_utils::{assert_eq_text, extract_offset, extract_range};
 
-use crate::{
-    handlers::Handler, Assist, AssistConfig, AssistContext, AssistKind, Assists, InsertUseConfig,
-};
+use crate::{handlers::Handler, Assist, AssistConfig, AssistContext, AssistKind, Assists};
 use stdx::{format_to, trim_indent};
 
 pub(crate) const TEST_CONFIG: AssistConfig = AssistConfig {

--- a/crates/assists/src/utils.rs
+++ b/crates/assists/src/utils.rs
@@ -1,3 +1,4 @@
+//! Assorted functions shared by several assists.
 use std::ops;
 
 use hir::HasSource;

--- a/crates/assists/src/utils.rs
+++ b/crates/assists/src/utils.rs
@@ -1,6 +1,3 @@
-//! Assorted functions shared by several assists.
-pub(crate) mod import_assets;
-
 use std::ops;
 
 use hir::HasSource;

--- a/crates/assists/src/utils/import_assets.rs
+++ b/crates/assists/src/utils/import_assets.rs
@@ -5,8 +5,6 @@ use ide_db::{imports_locator, RootDatabase};
 use rustc_hash::FxHashSet;
 use syntax::{ast, AstNode, SyntaxNode};
 
-use crate::assist_config::InsertUseConfig;
-
 #[derive(Debug)]
 pub(crate) enum ImportCandidate {
     /// Simple name like 'HashMap'
@@ -179,10 +177,9 @@ impl ImportAssets {
         };
 
         let name_to_import = self.get_search_query().to_string();
-        let unfiltered_imports = match self.import_candidate {
-            ImportCandidate::TraitAssocItem(_) | ImportCandidate::TraitMethod(_) => {}
-            _ => imports_locator::find_exact_imports(sema, current_crate, name_to_import),
-        };
+        let unfiltered_imports =
+            // TODO kb search differently for queries
+            imports_locator::find_exact_imports(sema, current_crate, name_to_import);
 
         let mut res = unfiltered_imports
             .filter_map(filter)

--- a/crates/completion/src/completions.rs
+++ b/crates/completion/src/completions.rs
@@ -13,6 +13,7 @@ pub(crate) mod postfix;
 pub(crate) mod macro_in_item_position;
 pub(crate) mod trait_impl;
 pub(crate) mod mod_;
+pub(crate) mod fuzzy_imports;
 
 use hir::{ModPath, ScopeDef, Type};
 

--- a/crates/completion/src/completions/dot.rs
+++ b/crates/completion/src/completions/dot.rs
@@ -1,7 +1,6 @@
 //! Completes references after dot (fields and method calls).
 
 use hir::{HasVisibility, Type};
-use ide_db::imports_locator;
 use rustc_hash::FxHashSet;
 use test_utils::mark;
 
@@ -57,27 +56,7 @@ fn complete_methods(acc: &mut Completions, ctx: &CompletionContext, receiver: &T
             }
             None::<()>
         });
-
-        if ctx.config.enable_autoimport_completions && ctx.config.resolve_additional_edits_lazily()
-        {
-            fuzzy_dot_trait_completion(acc, ctx);
-        }
     }
-}
-
-fn fuzzy_dot_trait_completion(acc: &mut Completions, ctx: &CompletionContext) -> Option<()> {
-    let potential_import_name = ctx.token.to_string();
-    let _p = profile::span("fuzzy_dot_trait_completion").detail(|| potential_import_name.clone());
-
-    let zz = imports_locator::find_similar_associated_items(
-        &ctx.sema,
-        ctx.krate?,
-        Some(40),
-        potential_import_name,
-    )
-    .collect::<Vec<_>>();
-    dbg!(zz);
-    None
 }
 
 #[cfg(test)]

--- a/crates/completion/src/completions/fuzzy_imports.rs
+++ b/crates/completion/src/completions/fuzzy_imports.rs
@@ -94,7 +94,6 @@ pub(crate) fn complete_fuzzy(acc: &mut Completions, ctx: &CompletionContext) -> 
         None => imports_locator::find_similar_imports(
             &ctx.sema,
             ctx.krate?,
-            Some(40),
             potential_import_name.clone(),
             true,
         )

--- a/crates/completion/src/completions/fuzzy_imports.rs
+++ b/crates/completion/src/completions/fuzzy_imports.rs
@@ -350,7 +350,7 @@ fn main() {
 use dep::test_mod::TestTrait;
 
 fn main() {
-    dep::test_mod::TestStruct::SOME_CONST$0
+    dep::test_mod::TestStruct::SOME_CONST
 }
 "#,
         );
@@ -395,6 +395,30 @@ fn main() {
     test_struct.random_number()$0
 }
 "#,
+        );
+    }
+
+    #[test]
+    fn no_trait_type_fuzzy_completion() {
+        check(
+            r#"
+        //- /lib.rs crate:dep
+        pub mod test_mod {
+            pub trait TestTrait {
+                type SpecialType;
+            }
+            pub struct TestStruct {}
+            impl TestTrait for TestStruct {
+                type SpecialType = ();
+            }
+        }
+
+        //- /main.rs crate:main deps:dep
+        fn main() {
+            dep::test_mod::TestStruct::spe$0
+        }
+        "#,
+            expect![[r#""#]],
         );
     }
 }

--- a/crates/completion/src/completions/fuzzy_imports.rs
+++ b/crates/completion/src/completions/fuzzy_imports.rs
@@ -316,4 +316,86 @@ fn main() {
 "#,
         );
     }
+
+    #[test]
+    fn trait_const_fuzzy_completion() {
+        let fixture = r#"
+        //- /lib.rs crate:dep
+        pub mod test_mod {
+            pub trait TestTrait {
+                const SOME_CONST: u8;
+            }
+            pub struct TestStruct {}
+            impl TestTrait for TestStruct {
+                const SOME_CONST: u8 = 42;
+            }
+        }
+
+        //- /main.rs crate:main deps:dep
+        fn main() {
+            dep::test_mod::TestStruct::som$0
+        }
+        "#;
+
+        check(
+            fixture,
+            expect![[r#"
+            ct SOME_CONST [dep::test_mod::TestTrait]
+        "#]],
+        );
+
+        check_edit(
+            "SOME_CONST",
+            fixture,
+            r#"
+use dep::test_mod::TestTrait;
+
+fn main() {
+    dep::test_mod::TestStruct::SOME_CONST$0
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn trait_method_fuzzy_completion() {
+        let fixture = r#"
+        //- /lib.rs crate:dep
+        pub mod test_mod {
+            pub trait TestTrait {
+                fn random_number(&self);
+            }
+            pub struct TestStruct {}
+            impl TestTrait for TestStruct {
+                fn random_number(&self) {}
+            }
+        }
+
+        //- /main.rs crate:main deps:dep
+        fn main() {
+            let test_struct = dep::test_mod::TestStruct {};
+            test_struct.ran$0
+        }
+        "#;
+
+        check(
+            fixture,
+            expect![[r#"
+            me random_number() [dep::test_mod::TestTrait] fn random_number(&self)
+        "#]],
+        );
+
+        check_edit(
+            "random_number",
+            fixture,
+            r#"
+use dep::test_mod::TestTrait;
+
+fn main() {
+    let test_struct = dep::test_mod::TestStruct {};
+    test_struct.random_number()$0
+}
+"#,
+        );
+    }
 }

--- a/crates/completion/src/completions/fuzzy_imports.rs
+++ b/crates/completion/src/completions/fuzzy_imports.rs
@@ -1,0 +1,280 @@
+//! Feature: Fuzzy Completion and Autoimports
+//!
+//! When completing names in the current scope, proposes additional imports from other modules or crates,
+//! if they can be qualified in the scope and their name contains all symbols from the completion input
+//! (case-insensitive, in any order or places).
+//!
+//! ```
+//! fn main() {
+//!     pda<|>
+//! }
+//! # pub mod std { pub mod marker { pub struct PhantomData { } } }
+//! ```
+//! ->
+//! ```
+//! use std::marker::PhantomData;
+//!
+//! fn main() {
+//!     PhantomData
+//! }
+//! # pub mod std { pub mod marker { pub struct PhantomData { } } }
+//! ```
+//!
+//! .Fuzzy search details
+//!
+//! To avoid an excessive amount of the results returned, completion input is checked for inclusion in the names only
+//! (i.e. in `HashMap` in the `std::collections::HashMap` path).
+//! For the same reasons, avoids searching for any imports for inputs with their length less that 2 symbols.
+//!
+//! .Merge Behavior
+//!
+//! It is possible to configure how use-trees are merged with the `importMergeBehavior` setting.
+//! Mimics the corresponding behavior of the `Auto Import` feature.
+//!
+//! .LSP and performance implications
+//!
+//! The feature is enabled only if the LSP client supports LSP protocol version 3.16+ and reports the `additionalTextEdits`
+//! (case sensitive) resolve client capability in its client capabilities.
+//! This way the server is able to defer the costly computations, doing them for a selected completion item only.
+//! For clients with no such support, all edits have to be calculated on the completion request, including the fuzzy search completion ones,
+//! which might be slow ergo the feature is automatically disabled.
+//!
+//! .Feature toggle
+//!
+//! The feature can be forcefully turned off in the settings with the `rust-analyzer.completion.enableAutoimportCompletions` flag.
+//! Note that having this flag set to `true` does not guarantee that the feature is enabled: your client needs to have the corredponding
+//! capability enabled.
+
+use either::Either;
+use hir::{ModPath, ScopeDef};
+use ide_db::{helpers::insert_use::ImportScope, imports_locator};
+use syntax::AstNode;
+use test_utils::mark;
+
+use crate::{
+    context::CompletionContext,
+    item::CompletionKind,
+    render::{render_resolution_with_import, RenderContext},
+    ImportEdit,
+};
+
+use super::Completions;
+
+pub(crate) fn complete_fuzzy(acc: &mut Completions, ctx: &CompletionContext) -> Option<()> {
+    fuzzy_completion(acc, ctx);
+    fuzzy_dot_trait_completion(acc, ctx);
+    None
+}
+
+// integrate it with ImportAssets, make them distinguins fuzzy/not fuzzy and assoc items/regular paths searches.
+fn fuzzy_dot_trait_completion(acc: &mut Completions, ctx: &CompletionContext) -> Option<()> {
+    let potential_import_name = ctx.token.to_string();
+    let _p = profile::span("fuzzy_dot_trait_completion").detail(|| potential_import_name.clone());
+
+    let zz = imports_locator::find_similar_associated_items(
+        &ctx.sema,
+        ctx.krate?,
+        Some(40),
+        potential_import_name,
+    )
+    .collect::<Vec<_>>();
+    dbg!(zz);
+    None
+}
+
+fn fuzzy_completion(acc: &mut Completions, ctx: &CompletionContext) -> Option<()> {
+    let potential_import_name = ctx.token.to_string();
+    let _p = profile::span("fuzzy_completion").detail(|| potential_import_name.clone());
+
+    if potential_import_name.len() < 2 {
+        return None;
+    }
+
+    let current_module = ctx.scope.module()?;
+    let anchor = ctx.name_ref_syntax.as_ref()?;
+    let import_scope = ImportScope::find_insert_use_container(anchor.syntax(), &ctx.sema)?;
+
+    let user_input_lowercased = potential_import_name.to_lowercase();
+    let mut all_mod_paths = imports_locator::find_similar_imports(
+        &ctx.sema,
+        ctx.krate?,
+        Some(40),
+        potential_import_name,
+        true,
+    )
+    .filter_map(|import_candidate| {
+        Some(match import_candidate {
+            Either::Left(module_def) => {
+                (current_module.find_use_path(ctx.db, module_def)?, ScopeDef::ModuleDef(module_def))
+            }
+            Either::Right(macro_def) => {
+                (current_module.find_use_path(ctx.db, macro_def)?, ScopeDef::MacroDef(macro_def))
+            }
+        })
+    })
+    .filter(|(mod_path, _)| mod_path.len() > 1)
+    .collect::<Vec<_>>();
+
+    all_mod_paths.sort_by_cached_key(|(mod_path, _)| {
+        compute_fuzzy_completion_order_key(mod_path, &user_input_lowercased)
+    });
+
+    acc.add_all(all_mod_paths.into_iter().filter_map(|(import_path, definition)| {
+        let mut item = render_resolution_with_import(
+            RenderContext::new(ctx),
+            ImportEdit { import_path, import_scope: import_scope.clone() },
+            &definition,
+        )?;
+        item.completion_kind = CompletionKind::Magic;
+
+        Some(item)
+    }));
+    Some(())
+}
+
+fn compute_fuzzy_completion_order_key(
+    proposed_mod_path: &ModPath,
+    user_input_lowercased: &str,
+) -> usize {
+    mark::hit!(certain_fuzzy_order_test);
+    let proposed_import_name = match proposed_mod_path.segments.last() {
+        Some(name) => name.to_string().to_lowercase(),
+        None => return usize::MAX,
+    };
+    match proposed_import_name.match_indices(user_input_lowercased).next() {
+        Some((first_matching_index, _)) => first_matching_index,
+        None => usize::MAX,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use expect_test::{expect, Expect};
+    use test_utils::mark;
+
+    use crate::{
+        item::CompletionKind,
+        test_utils::{check_edit, completion_list},
+    };
+
+    fn check(ra_fixture: &str, expect: Expect) {
+        let actual = completion_list(ra_fixture, CompletionKind::Magic);
+        expect.assert_eq(&actual);
+    }
+
+    #[test]
+    fn function_fuzzy_completion() {
+        check_edit(
+            "stdin",
+            r#"
+//- /lib.rs crate:dep
+pub mod io {
+    pub fn stdin() {}
+};
+
+//- /main.rs crate:main deps:dep
+fn main() {
+    stdi<|>
+}
+"#,
+            r#"
+use dep::io::stdin;
+
+fn main() {
+    stdin()$0
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn macro_fuzzy_completion() {
+        check_edit(
+            "macro_with_curlies!",
+            r#"
+//- /lib.rs crate:dep
+/// Please call me as macro_with_curlies! {}
+#[macro_export]
+macro_rules! macro_with_curlies {
+    () => {}
+}
+
+//- /main.rs crate:main deps:dep
+fn main() {
+    curli<|>
+}
+"#,
+            r#"
+use dep::macro_with_curlies;
+
+fn main() {
+    macro_with_curlies! {$0}
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn struct_fuzzy_completion() {
+        check_edit(
+            "ThirdStruct",
+            r#"
+//- /lib.rs crate:dep
+pub struct FirstStruct;
+pub mod some_module {
+    pub struct SecondStruct;
+    pub struct ThirdStruct;
+}
+
+//- /main.rs crate:main deps:dep
+use dep::{FirstStruct, some_module::SecondStruct};
+
+fn main() {
+    this<|>
+}
+"#,
+            r#"
+use dep::{FirstStruct, some_module::{SecondStruct, ThirdStruct}};
+
+fn main() {
+    ThirdStruct
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn fuzzy_completions_come_in_specific_order() {
+        mark::check!(certain_fuzzy_order_test);
+        check(
+            r#"
+//- /lib.rs crate:dep
+pub struct FirstStruct;
+pub mod some_module {
+    // already imported, omitted
+    pub struct SecondStruct;
+    // does not contain all letters from the query, omitted
+    pub struct UnrelatedOne;
+    // contains all letters from the query, but not in sequence, displayed last
+    pub struct ThiiiiiirdStruct;
+    // contains all letters from the query, but not in the beginning, displayed second
+    pub struct AfterThirdStruct;
+    // contains all letters from the query in the begginning, displayed first
+    pub struct ThirdStruct;
+}
+
+//- /main.rs crate:main deps:dep
+use dep::{FirstStruct, some_module::SecondStruct};
+
+fn main() {
+    hir<|>
+}
+"#,
+            expect![[r#"
+                st dep::some_module::ThirdStruct
+                st dep::some_module::AfterThirdStruct
+                st dep::some_module::ThiiiiiirdStruct
+            "#]],
+        );
+    }
+}

--- a/crates/completion/src/completions/fuzzy_imports.rs
+++ b/crates/completion/src/completions/fuzzy_imports.rs
@@ -26,9 +26,11 @@
 //! (i.e. in `HashMap` in the `std::collections::HashMap` path).
 //! For the same reasons, avoids searching for any imports for inputs with their length less that 2 symbols.
 //!
-//! .Merge Behavior
+//! .Import configuration
 //!
 //! It is possible to configure how use-trees are merged with the `importMergeBehavior` setting.
+//! The style of imports in the same crate is configurable through the `importPrefix` setting.
+//!
 //! Mimics the corresponding behavior of the `Auto Import` feature.
 //!
 //! .LSP and performance implications
@@ -71,8 +73,7 @@ pub(crate) fn complete_fuzzy(acc: &mut Completions, ctx: &CompletionContext) -> 
 
     let user_input_lowercased = potential_import_name.to_lowercase();
     let mut all_mod_paths = import_assets(ctx, potential_import_name)?
-        // TODO kb unite the hir prefix setting with auto_imports
-        .search_for_imports(&ctx.sema, hir::PrefixKind::Plain)
+        .search_for_imports(&ctx.sema, ctx.config.insert_use.prefix_kind)
         .into_iter()
         .map(|(mod_path, item_in_ns)| {
             let scope_item = match item_in_ns {

--- a/crates/completion/src/completions/fuzzy_imports.rs
+++ b/crates/completion/src/completions/fuzzy_imports.rs
@@ -61,6 +61,7 @@ use crate::{
 
 use super::Completions;
 
+// TODO kb filter out already imported items
 pub(crate) fn complete_fuzzy(acc: &mut Completions, ctx: &CompletionContext) -> Option<()> {
     if !ctx.config.enable_autoimport_completions {
         return None;
@@ -282,35 +283,41 @@ fn main() {
         //- /lib.rs crate:dep
         pub mod test_mod {
             pub trait TestTrait {
-                fn random_number();
+                const SPECIAL_CONST: u8;
+                type HumbleType;
+                fn weird_function();
+                fn random_method(&self);
             }
             pub struct TestStruct {}
             impl TestTrait for TestStruct {
-                fn random_number() {}
+                const SPECIAL_CONST: u8 = 42;
+                type HumbleType = ();
+                fn weird_function() {}
+                fn random_method(&self) {}
             }
         }
 
         //- /main.rs crate:main deps:dep
         fn main() {
-            dep::test_mod::TestStruct::ran$0
+            dep::test_mod::TestStruct::wei$0
         }
         "#;
 
         check(
             fixture,
             expect![[r#"
-            fn random_number() [dep::test_mod::TestTrait] fn random_number()
+            fn weird_function() [dep::test_mod::TestTrait] fn weird_function()
         "#]],
         );
 
         check_edit(
-            "random_number",
+            "weird_function",
             fixture,
             r#"
 use dep::test_mod::TestTrait;
 
 fn main() {
-    dep::test_mod::TestStruct::random_number()$0
+    dep::test_mod::TestStruct::weird_function()$0
 }
 "#,
         );
@@ -322,35 +329,41 @@ fn main() {
         //- /lib.rs crate:dep
         pub mod test_mod {
             pub trait TestTrait {
-                const SOME_CONST: u8;
+                const SPECIAL_CONST: u8;
+                type HumbleType;
+                fn weird_function();
+                fn random_method(&self);
             }
             pub struct TestStruct {}
             impl TestTrait for TestStruct {
-                const SOME_CONST: u8 = 42;
+                const SPECIAL_CONST: u8 = 42;
+                type HumbleType = ();
+                fn weird_function() {}
+                fn random_method(&self) {}
             }
         }
 
         //- /main.rs crate:main deps:dep
         fn main() {
-            dep::test_mod::TestStruct::som$0
+            dep::test_mod::TestStruct::spe$0
         }
         "#;
 
         check(
             fixture,
             expect![[r#"
-            ct SOME_CONST [dep::test_mod::TestTrait]
+            ct SPECIAL_CONST [dep::test_mod::TestTrait]
         "#]],
         );
 
         check_edit(
-            "SOME_CONST",
+            "SPECIAL_CONST",
             fixture,
             r#"
 use dep::test_mod::TestTrait;
 
 fn main() {
-    dep::test_mod::TestStruct::SOME_CONST
+    dep::test_mod::TestStruct::SPECIAL_CONST
 }
 "#,
         );
@@ -362,11 +375,17 @@ fn main() {
         //- /lib.rs crate:dep
         pub mod test_mod {
             pub trait TestTrait {
-                fn random_number(&self);
+                const SPECIAL_CONST: u8;
+                type HumbleType;
+                fn weird_function();
+                fn random_method(&self);
             }
             pub struct TestStruct {}
             impl TestTrait for TestStruct {
-                fn random_number(&self) {}
+                const SPECIAL_CONST: u8 = 42;
+                type HumbleType = ();
+                fn weird_function() {}
+                fn random_method(&self) {}
             }
         }
 
@@ -380,19 +399,19 @@ fn main() {
         check(
             fixture,
             expect![[r#"
-            me random_number() [dep::test_mod::TestTrait] fn random_number(&self)
+            me random_method() [dep::test_mod::TestTrait] fn random_method(&self)
         "#]],
         );
 
         check_edit(
-            "random_number",
+            "random_method",
             fixture,
             r#"
 use dep::test_mod::TestTrait;
 
 fn main() {
     let test_struct = dep::test_mod::TestStruct {};
-    test_struct.random_number()$0
+    test_struct.random_method()$0
 }
 "#,
         );
@@ -405,17 +424,23 @@ fn main() {
         //- /lib.rs crate:dep
         pub mod test_mod {
             pub trait TestTrait {
-                type SpecialType;
+                const SPECIAL_CONST: u8;
+                type HumbleType;
+                fn weird_function();
+                fn random_method(&self);
             }
             pub struct TestStruct {}
             impl TestTrait for TestStruct {
-                type SpecialType = ();
+                const SPECIAL_CONST: u8 = 42;
+                type HumbleType = ();
+                fn weird_function() {}
+                fn random_method(&self) {}
             }
         }
 
         //- /main.rs crate:main deps:dep
         fn main() {
-            dep::test_mod::TestStruct::spe$0
+            dep::test_mod::TestStruct::hum$0
         }
         "#,
             expect![[r#""#]],

--- a/crates/completion/src/completions/unqualified_path.rs
+++ b/crates/completion/src/completions/unqualified_path.rs
@@ -2,17 +2,11 @@
 
 use std::iter;
 
-use either::Either;
-use hir::{Adt, ModPath, ModuleDef, ScopeDef, Type};
-use ide_db::helpers::insert_use::ImportScope;
-use ide_db::imports_locator;
+use hir::{Adt, ModuleDef, ScopeDef, Type};
 use syntax::AstNode;
 use test_utils::mark;
 
-use crate::{
-    render::{render_resolution_with_import, RenderContext},
-    CompletionContext, Completions, ImportEdit,
-};
+use crate::{CompletionContext, Completions};
 
 pub(crate) fn complete_unqualified_path(acc: &mut Completions, ctx: &CompletionContext) {
     if !(ctx.is_trivial_path || ctx.is_pat_binding_or_const) {
@@ -45,10 +39,6 @@ pub(crate) fn complete_unqualified_path(acc: &mut Completions, ctx: &CompletionC
         }
         acc.add_resolution(ctx, name.to_string(), &res)
     });
-
-    if ctx.config.enable_autoimport_completions {
-        fuzzy_completion(acc, ctx);
-    }
 }
 
 fn complete_enum_variants(acc: &mut Completions, ctx: &CompletionContext, ty: &Type) {
@@ -77,123 +67,13 @@ fn complete_enum_variants(acc: &mut Completions, ctx: &CompletionContext, ty: &T
     }
 }
 
-// Feature: Fuzzy Completion and Autoimports
-//
-// When completing names in the current scope, proposes additional imports from other modules or crates,
-// if they can be qualified in the scope and their name contains all symbols from the completion input
-// (case-insensitive, in any order or places).
-//
-// ```
-// fn main() {
-//     pda$0
-// }
-// # pub mod std { pub mod marker { pub struct PhantomData { } } }
-// ```
-// ->
-// ```
-// use std::marker::PhantomData;
-//
-// fn main() {
-//     PhantomData
-// }
-// # pub mod std { pub mod marker { pub struct PhantomData { } } }
-// ```
-//
-// .Fuzzy search details
-//
-// To avoid an excessive amount of the results returned, completion input is checked for inclusion in the names only
-// (i.e. in `HashMap` in the `std::collections::HashMap` path).
-// For the same reasons, avoids searching for any imports for inputs with their length less that 2 symbols.
-//
-// .Merge Behavior
-//
-// It is possible to configure how use-trees are merged with the `importMergeBehavior` setting.
-// Mimics the corresponding behavior of the `Auto Import` feature.
-//
-// .LSP and performance implications
-//
-// The feature is enabled only if the LSP client supports LSP protocol version 3.16+ and reports the `additionalTextEdits`
-// (case sensitive) resolve client capability in its client capabilities.
-// This way the server is able to defer the costly computations, doing them for a selected completion item only.
-// For clients with no such support, all edits have to be calculated on the completion request, including the fuzzy search completion ones,
-// which might be slow ergo the feature is automatically disabled.
-//
-// .Feature toggle
-//
-// The feature can be forcefully turned off in the settings with the `rust-analyzer.completion.enableAutoimportCompletions` flag.
-// Note that having this flag set to `true` does not guarantee that the feature is enabled: your client needs to have the corredponding
-// capability enabled.
-fn fuzzy_completion(acc: &mut Completions, ctx: &CompletionContext) -> Option<()> {
-    let potential_import_name = ctx.token.to_string();
-    let _p = profile::span("fuzzy_completion").detail(|| potential_import_name.clone());
-
-    if potential_import_name.len() < 2 {
-        return None;
-    }
-
-    let current_module = ctx.scope.module()?;
-    let anchor = ctx.name_ref_syntax.as_ref()?;
-    let import_scope = ImportScope::find_insert_use_container(anchor.syntax(), &ctx.sema)?;
-
-    let user_input_lowercased = potential_import_name.to_lowercase();
-    let mut all_mod_paths = imports_locator::find_similar_imports(
-        &ctx.sema,
-        ctx.krate?,
-        Some(40),
-        potential_import_name,
-        true,
-    )
-    .filter_map(|import_candidate| {
-        Some(match import_candidate {
-            Either::Left(module_def) => {
-                (current_module.find_use_path(ctx.db, module_def)?, ScopeDef::ModuleDef(module_def))
-            }
-            Either::Right(macro_def) => {
-                (current_module.find_use_path(ctx.db, macro_def)?, ScopeDef::MacroDef(macro_def))
-            }
-        })
-    })
-    .filter(|(mod_path, _)| mod_path.len() > 1)
-    .collect::<Vec<_>>();
-
-    all_mod_paths.sort_by_cached_key(|(mod_path, _)| {
-        compute_fuzzy_completion_order_key(mod_path, &user_input_lowercased)
-    });
-
-    acc.add_all(all_mod_paths.into_iter().filter_map(|(import_path, definition)| {
-        render_resolution_with_import(
-            RenderContext::new(ctx),
-            ImportEdit { import_path, import_scope: import_scope.clone() },
-            &definition,
-        )
-    }));
-    Some(())
-}
-
-fn compute_fuzzy_completion_order_key(
-    proposed_mod_path: &ModPath,
-    user_input_lowercased: &str,
-) -> usize {
-    mark::hit!(certain_fuzzy_order_test);
-    let proposed_import_name = match proposed_mod_path.segments.last() {
-        Some(name) => name.to_string().to_lowercase(),
-        None => return usize::MAX,
-    };
-    match proposed_import_name.match_indices(user_input_lowercased).next() {
-        Some((first_matching_index, _)) => first_matching_index,
-        None => usize::MAX,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use expect_test::{expect, Expect};
     use test_utils::mark;
 
     use crate::{
-        test_utils::{
-            check_edit, check_edit_with_config, completion_list_with_config, TEST_CONFIG,
-        },
+        test_utils::{check_edit, completion_list_with_config, TEST_CONFIG},
         CompletionConfig, CompletionKind,
     };
 
@@ -853,129 +733,5 @@ impl My$0
                 st MyStruct
             "#]],
         )
-    }
-
-    #[test]
-    fn function_fuzzy_completion() {
-        check_edit_with_config(
-            TEST_CONFIG,
-            "stdin",
-            r#"
-//- /lib.rs crate:dep
-pub mod io {
-    pub fn stdin() {}
-};
-
-//- /main.rs crate:main deps:dep
-fn main() {
-    stdi$0
-}
-"#,
-            r#"
-use dep::io::stdin;
-
-fn main() {
-    stdin()$0
-}
-"#,
-        );
-    }
-
-    #[test]
-    fn macro_fuzzy_completion() {
-        check_edit_with_config(
-            TEST_CONFIG,
-            "macro_with_curlies!",
-            r#"
-//- /lib.rs crate:dep
-/// Please call me as macro_with_curlies! {}
-#[macro_export]
-macro_rules! macro_with_curlies {
-    () => {}
-}
-
-//- /main.rs crate:main deps:dep
-fn main() {
-    curli$0
-}
-"#,
-            r#"
-use dep::macro_with_curlies;
-
-fn main() {
-    macro_with_curlies! {$0}
-}
-"#,
-        );
-    }
-
-    #[test]
-    fn struct_fuzzy_completion() {
-        check_edit_with_config(
-            TEST_CONFIG,
-            "ThirdStruct",
-            r#"
-//- /lib.rs crate:dep
-pub struct FirstStruct;
-pub mod some_module {
-    pub struct SecondStruct;
-    pub struct ThirdStruct;
-}
-
-//- /main.rs crate:main deps:dep
-use dep::{FirstStruct, some_module::SecondStruct};
-
-fn main() {
-    this$0
-}
-"#,
-            r#"
-use dep::{FirstStruct, some_module::{SecondStruct, ThirdStruct}};
-
-fn main() {
-    ThirdStruct
-}
-"#,
-        );
-    }
-
-    #[test]
-    fn fuzzy_completions_come_in_specific_order() {
-        mark::check!(certain_fuzzy_order_test);
-        check_with_config(
-            TEST_CONFIG,
-            r#"
-//- /lib.rs crate:dep
-pub struct FirstStruct;
-pub mod some_module {
-    // already imported, omitted
-    pub struct SecondStruct;
-    // does not contain all letters from the query, omitted
-    pub struct UnrelatedOne;
-    // contains all letters from the query, but not in sequence, displayed last
-    pub struct ThiiiiiirdStruct;
-    // contains all letters from the query, but not in the beginning, displayed second
-    pub struct AfterThirdStruct;
-    // contains all letters from the query in the begginning, displayed first
-    pub struct ThirdStruct;
-}
-
-//- /main.rs crate:main deps:dep
-use dep::{FirstStruct, some_module::SecondStruct};
-
-fn main() {
-    hir$0
-}
-"#,
-            expect![[r#"
-                fn main()           fn main()
-                st SecondStruct
-                st FirstStruct
-                md dep
-                st dep::some_module::ThirdStruct
-                st dep::some_module::AfterThirdStruct
-                st dep::some_module::ThiiiiiirdStruct
-            "#]],
-        );
     }
 }

--- a/crates/completion/src/completions/unqualified_path.rs
+++ b/crates/completion/src/completions/unqualified_path.rs
@@ -142,7 +142,6 @@ fn fuzzy_completion(acc: &mut Completions, ctx: &CompletionContext) -> Option<()
         Some(40),
         potential_import_name,
         true,
-        true,
     )
     .filter_map(|import_candidate| {
         Some(match import_candidate {

--- a/crates/completion/src/config.rs
+++ b/crates/completion/src/config.rs
@@ -4,7 +4,7 @@
 //! module, and we use to statically check that we only produce snippet
 //! completions if we are allowed to.
 
-use ide_db::helpers::{insert_use::MergeBehavior, SnippetCap};
+use ide_db::helpers::{insert_use::InsertUseConfig, SnippetCap};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CompletionConfig {
@@ -13,5 +13,5 @@ pub struct CompletionConfig {
     pub add_call_parenthesis: bool,
     pub add_call_argument_snippets: bool,
     pub snippet_cap: Option<SnippetCap>,
-    pub merge: Option<MergeBehavior>,
+    pub insert_use: InsertUseConfig,
 }

--- a/crates/completion/src/item.rs
+++ b/crates/completion/src/item.rs
@@ -270,6 +270,7 @@ impl CompletionItem {
 pub struct ImportEdit {
     pub import_path: ModPath,
     pub import_scope: ImportScope,
+    pub import_for_trait_assoc_item: bool,
 }
 
 impl ImportEdit {
@@ -321,17 +322,21 @@ impl Builder {
         let mut insert_text = self.insert_text;
 
         if let Some(import_to_add) = self.import_to_add.as_ref() {
-            let mut import_path_without_last_segment = import_to_add.import_path.to_owned();
-            let _ = import_path_without_last_segment.segments.pop();
+            if import_to_add.import_for_trait_assoc_item {
+                label = format!("{} [{}]", label, import_to_add.import_path)
+            } else {
+                let mut import_path_without_last_segment = import_to_add.import_path.to_owned();
+                let _ = import_path_without_last_segment.segments.pop();
 
-            if !import_path_without_last_segment.segments.is_empty() {
-                if lookup.is_none() {
-                    lookup = Some(label.clone());
+                if !import_path_without_last_segment.segments.is_empty() {
+                    if lookup.is_none() {
+                        lookup = Some(label.clone());
+                    }
+                    if insert_text.is_none() {
+                        insert_text = Some(label.clone());
+                    }
+                    label = format!("{}::{}", import_path_without_last_segment, label);
                 }
-                if insert_text.is_none() {
-                    insert_text = Some(label.clone());
-                }
-                label = format!("{}::{}", import_path_without_last_segment, label);
             }
         }
 

--- a/crates/completion/src/item.rs
+++ b/crates/completion/src/item.rs
@@ -325,7 +325,7 @@ impl Builder {
             if import_to_add.import_for_trait_assoc_item {
                 lookup = lookup.or_else(|| Some(label.clone()));
                 insert_text = insert_text.or_else(|| Some(label.clone()));
-                label = format!("{} [{}]", label, import_to_add.import_path);
+                label = format!("{} ({})", label, import_to_add.import_path);
             } else {
                 let mut import_path_without_last_segment = import_to_add.import_path.to_owned();
                 let _ = import_path_without_last_segment.segments.pop();

--- a/crates/completion/src/item.rs
+++ b/crates/completion/src/item.rs
@@ -323,18 +323,16 @@ impl Builder {
 
         if let Some(import_to_add) = self.import_to_add.as_ref() {
             if import_to_add.import_for_trait_assoc_item {
-                label = format!("{} [{}]", label, import_to_add.import_path)
+                lookup = lookup.or_else(|| Some(label.clone()));
+                insert_text = insert_text.or_else(|| Some(label.clone()));
+                label = format!("{} [{}]", label, import_to_add.import_path);
             } else {
                 let mut import_path_without_last_segment = import_to_add.import_path.to_owned();
                 let _ = import_path_without_last_segment.segments.pop();
 
                 if !import_path_without_last_segment.segments.is_empty() {
-                    if lookup.is_none() {
-                        lookup = Some(label.clone());
-                    }
-                    if insert_text.is_none() {
-                        insert_text = Some(label.clone());
-                    }
+                    lookup = lookup.or_else(|| Some(label.clone()));
+                    insert_text = insert_text.or_else(|| Some(label.clone()));
                     label = format!("{}::{}", import_path_without_last_segment, label);
                 }
             }

--- a/crates/completion/src/lib.rs
+++ b/crates/completion/src/lib.rs
@@ -159,7 +159,7 @@ pub fn resolve_completion_edits(
         .find(|mod_path| mod_path.to_string() == full_import_path)?;
 
     ImportEdit { import_path, import_scope, import_for_trait_assoc_item }
-        .to_text_edit(config.merge)
+        .to_text_edit(config.insert_use.merge)
         .map(|edit| vec![edit])
 }
 

--- a/crates/completion/src/lib.rs
+++ b/crates/completion/src/lib.rs
@@ -127,10 +127,7 @@ pub fn completions(
     completions::macro_in_item_position::complete_macro_in_item_position(&mut acc, &ctx);
     completions::trait_impl::complete_trait_impl(&mut acc, &ctx);
     completions::mod_::complete_mod(&mut acc, &ctx);
-
-    if ctx.config.enable_autoimport_completions {
-        completions::fuzzy_imports::complete_fuzzy(&mut acc, &ctx);
-    }
+    completions::fuzzy_imports::complete_fuzzy(&mut acc, &ctx);
 
     Some(acc)
 }

--- a/crates/completion/src/lib.rs
+++ b/crates/completion/src/lib.rs
@@ -142,6 +142,7 @@ pub fn resolve_completion_edits(
     position: FilePosition,
     full_import_path: &str,
     imported_name: String,
+    import_for_trait_assoc_item: bool,
 ) -> Option<Vec<TextEdit>> {
     let ctx = CompletionContext::new(db, position, config)?;
     let anchor = ctx.name_ref_syntax.as_ref()?;
@@ -157,7 +158,9 @@ pub fn resolve_completion_edits(
         })
         .find(|mod_path| mod_path.to_string() == full_import_path)?;
 
-    ImportEdit { import_path, import_scope }.to_text_edit(config.merge).map(|edit| vec![edit])
+    ImportEdit { import_path, import_scope, import_for_trait_assoc_item }
+        .to_text_edit(config.merge)
+        .map(|edit| vec![edit])
 }
 
 #[cfg(test)]

--- a/crates/completion/src/lib.rs
+++ b/crates/completion/src/lib.rs
@@ -128,6 +128,10 @@ pub fn completions(
     completions::trait_impl::complete_trait_impl(&mut acc, &ctx);
     completions::mod_::complete_mod(&mut acc, &ctx);
 
+    if ctx.config.enable_autoimport_completions {
+        completions::fuzzy_imports::complete_fuzzy(&mut acc, &ctx);
+    }
+
     Some(acc)
 }
 

--- a/crates/completion/src/render.rs
+++ b/crates/completion/src/render.rs
@@ -181,7 +181,6 @@ impl<'a> Render<'a> {
             // FIXME: add CompletionItemKind::Union
             ScopeDef::ModuleDef(Adt(hir::Adt::Union(_))) => CompletionItemKind::Struct,
             ScopeDef::ModuleDef(Adt(hir::Adt::Enum(_))) => CompletionItemKind::Enum,
-            // TODO kb this is not working for trait imports properly
             ScopeDef::ModuleDef(Const(..)) => CompletionItemKind::Const,
             ScopeDef::ModuleDef(Static(..)) => CompletionItemKind::Static,
             ScopeDef::ModuleDef(Trait(..)) => CompletionItemKind::Trait,

--- a/crates/completion/src/render.rs
+++ b/crates/completion/src/render.rs
@@ -49,13 +49,10 @@ pub(crate) fn render_resolution<'a>(
 pub(crate) fn render_resolution_with_import<'a>(
     ctx: RenderContext<'a>,
     import_edit: ImportEdit,
+    local_name: String,
     resolution: &ScopeDef,
 ) -> Option<CompletionItem> {
-    Render::new(ctx).render_resolution(
-        import_edit.import_path.segments.last()?.to_string(),
-        Some(import_edit),
-        resolution,
-    )
+    Render::new(ctx).render_resolution(local_name, Some(import_edit), resolution)
 }
 
 /// Interface for data and methods required for items rendering.

--- a/crates/completion/src/render.rs
+++ b/crates/completion/src/render.rs
@@ -57,7 +57,10 @@ pub(crate) fn render_resolution_with_import<'a>(
         ScopeDef::ModuleDef(ModuleDef::TypeAlias(t)) => t.name(ctx.completion.db).to_string(),
         _ => import_edit.import_path.segments.last()?.to_string(),
     };
-    Render::new(ctx).render_resolution(local_name, Some(import_edit), resolution)
+    Render::new(ctx).render_resolution(local_name, Some(import_edit), resolution).map(|mut item| {
+        item.completion_kind = CompletionKind::Magic;
+        item
+    })
 }
 
 /// Interface for data and methods required for items rendering.

--- a/crates/completion/src/test_utils.rs
+++ b/crates/completion/src/test_utils.rs
@@ -1,9 +1,12 @@
 //! Runs completion for testing purposes.
 
-use hir::Semantics;
+use hir::{PrefixKind, Semantics};
 use ide_db::{
     base_db::{fixture::ChangeFixture, FileLoader, FilePosition},
-    helpers::{insert_use::MergeBehavior, SnippetCap},
+    helpers::{
+        insert_use::{InsertUseConfig, MergeBehavior},
+        SnippetCap,
+    },
     RootDatabase,
 };
 use itertools::Itertools;
@@ -19,7 +22,10 @@ pub(crate) const TEST_CONFIG: CompletionConfig = CompletionConfig {
     add_call_parenthesis: true,
     add_call_argument_snippets: true,
     snippet_cap: SnippetCap::new(true),
-    merge: Some(MergeBehavior::Full),
+    insert_use: InsertUseConfig {
+        merge: Some(MergeBehavior::Full),
+        prefix_kind: PrefixKind::Plain,
+    },
 };
 
 /// Creates analysis from a multi-file fixture, returns positions marked with $0.
@@ -110,7 +116,7 @@ pub(crate) fn check_edit_with_config(
 
     let mut combined_edit = completion.text_edit().to_owned();
     if let Some(import_text_edit) =
-        completion.import_to_add().and_then(|edit| edit.to_text_edit(config.merge))
+        completion.import_to_add().and_then(|edit| edit.to_text_edit(config.insert_use.merge))
     {
         combined_edit.union(import_text_edit).expect(
             "Failed to apply completion resolve changes: change ranges overlap, but should not",

--- a/crates/hir/src/code_model.rs
+++ b/crates/hir/src/code_model.rs
@@ -272,6 +272,15 @@ impl ModuleDef {
 
         hir_ty::diagnostics::validate_module_item(db, module.id.krate, id, sink)
     }
+
+    pub fn as_assoc_item(self, db: &dyn HirDatabase) -> Option<AssocItem> {
+        match self {
+            ModuleDef::Function(f) => f.as_assoc_item(db),
+            ModuleDef::Const(c) => c.as_assoc_item(db),
+            ModuleDef::TypeAlias(t) => t.as_assoc_item(db),
+            _ => None,
+        }
+    }
 }
 
 impl Module {
@@ -1089,6 +1098,13 @@ impl AssocItem {
             AssocContainerId::TraitId(id) => AssocItemContainer::Trait(id.into()),
             AssocContainerId::ImplId(id) => AssocItemContainer::Impl(id.into()),
             AssocContainerId::ContainerId(_) => panic!("invalid AssocItem"),
+        }
+    }
+
+    pub fn containing_trait(self, db: &dyn HirDatabase) -> Option<Trait> {
+        match self.container(db) {
+            AssocItemContainer::Trait(t) => Some(t),
+            _ => None,
         }
     }
 }

--- a/crates/ide/src/doc_links.rs
+++ b/crates/ide/src/doc_links.rs
@@ -440,8 +440,8 @@ fn get_symbol_fragment(db: &dyn HirDatabase, field_or_assoc: &FieldOrAssocItem) 
             AssocItem::Function(function) => {
                 let is_trait_method = function
                     .as_assoc_item(db)
-                    .map(|assoc| assoc.containing_trait(db).is_some())
-                    .unwrap_or(false);
+                    .and_then(|assoc| assoc.containing_trait(db))
+                    .is_some();
                 // This distinction may get more complicated when specialization is available.
                 // Rustdoc makes this decision based on whether a method 'has defaultness'.
                 // Currently this is only the case for provided trait methods.

--- a/crates/ide/src/doc_links.rs
+++ b/crates/ide/src/doc_links.rs
@@ -438,10 +438,10 @@ fn get_symbol_fragment(db: &dyn HirDatabase, field_or_assoc: &FieldOrAssocItem) 
         FieldOrAssocItem::Field(field) => format!("#structfield.{}", field.name(db)),
         FieldOrAssocItem::AssocItem(assoc) => match assoc {
             AssocItem::Function(function) => {
-                let is_trait_method = matches!(
-                    function.as_assoc_item(db).map(|assoc| assoc.container(db)),
-                    Some(AssocItemContainer::Trait(..))
-                );
+                let is_trait_method = function
+                    .as_assoc_item(db)
+                    .map(|assoc| assoc.containing_trait(db).is_some())
+                    .unwrap_or(false);
                 // This distinction may get more complicated when specialization is available.
                 // Rustdoc makes this decision based on whether a method 'has defaultness'.
                 // Currently this is only the case for provided trait methods.

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -481,6 +481,7 @@ impl Analysis {
         position: FilePosition,
         full_import_path: &str,
         imported_name: String,
+        import_for_trait_assoc_item: bool,
     ) -> Cancelable<Vec<TextEdit>> {
         Ok(self
             .with_db(|db| {
@@ -490,6 +491,7 @@ impl Analysis {
                     position,
                     full_import_path,
                     imported_name,
+                    import_for_trait_assoc_item,
                 )
             })?
             .unwrap_or_default())

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -80,7 +80,7 @@ pub use crate::{
         HlRange,
     },
 };
-pub use assists::{Assist, AssistConfig, AssistId, AssistKind, InsertUseConfig};
+pub use assists::{Assist, AssistConfig, AssistId, AssistKind};
 pub use completion::{
     CompletionConfig, CompletionItem, CompletionItemKind, CompletionScore, ImportEdit,
     InsertTextFormat,

--- a/crates/ide_db/src/helpers.rs
+++ b/crates/ide_db/src/helpers.rs
@@ -1,5 +1,6 @@
 //! A module with ide helpers for high-level ide features.
 pub mod insert_use;
+pub mod import_assets;
 
 use hir::{Crate, Enum, Module, ScopeDef, Semantics, Trait};
 use syntax::ast::{self, make};

--- a/crates/ide_db/src/helpers/import_assets.rs
+++ b/crates/ide_db/src/helpers/import_assets.rs
@@ -1,12 +1,13 @@
 //! Look up accessible paths for items.
 use either::Either;
 use hir::{AsAssocItem, AssocItemContainer, ModuleDef, PrefixKind, Semantics};
-use ide_db::{imports_locator, RootDatabase};
 use rustc_hash::FxHashSet;
 use syntax::{ast, AstNode, SyntaxNode};
 
+use crate::{imports_locator, RootDatabase};
+
 #[derive(Debug)]
-pub(crate) enum ImportCandidate {
+pub enum ImportCandidate {
     /// Simple name like 'HashMap'
     UnqualifiedName(PathImportCandidate),
     /// First part of the qualified name.
@@ -23,14 +24,14 @@ pub(crate) enum ImportCandidate {
 }
 
 #[derive(Debug)]
-pub(crate) struct TraitImportCandidate {
-    pub(crate) ty: hir::Type,
-    pub(crate) name: ast::NameRef,
+pub struct TraitImportCandidate {
+    pub ty: hir::Type,
+    pub name: ast::NameRef,
 }
 
 #[derive(Debug)]
-pub(crate) struct PathImportCandidate {
-    pub(crate) name: ast::NameRef,
+pub struct PathImportCandidate {
+    pub name: ast::NameRef,
 }
 
 #[derive(Debug)]
@@ -71,11 +72,11 @@ impl ImportAssets {
         })
     }
 
-    pub(crate) fn syntax_under_caret(&self) -> &SyntaxNode {
+    pub fn syntax_under_caret(&self) -> &SyntaxNode {
         &self.syntax_under_caret
     }
 
-    pub(crate) fn import_candidate(&self) -> &ImportCandidate {
+    pub fn import_candidate(&self) -> &ImportCandidate {
         &self.import_candidate
     }
 
@@ -98,7 +99,7 @@ impl ImportAssets {
     }
 
     /// This may return non-absolute paths if a part of the returned path is already imported into scope.
-    pub(crate) fn search_for_relative_paths(
+    pub fn search_for_relative_paths(
         &self,
         sema: &Semantics<RootDatabase>,
     ) -> Vec<(hir::ModPath, hir::ItemInNs)> {

--- a/crates/ide_db/src/helpers/import_assets.rs
+++ b/crates/ide_db/src/helpers/import_assets.rs
@@ -233,11 +233,9 @@ impl ImportAssets {
             }
         };
 
-        // TODO kb useless collects due to different opaque types + stupid clone()'s
         let unfiltered_imports = match self.name_to_import() {
             NameToImport::Exact(exact_name) => {
                 imports_locator::find_exact_imports(sema, current_crate, exact_name.clone())
-                    .collect::<Vec<_>>()
             }
             NameToImport::Fuzzy(fuzzy_name) => imports_locator::find_similar_imports(
                 sema,
@@ -249,10 +247,8 @@ impl ImportAssets {
                     }
                     _ => AssocItemSearch::Exclude,
                 },
-            )
-            .collect::<Vec<_>>(),
-        }
-        .into_iter();
+            ),
+        };
 
         let mut res = unfiltered_imports
             .filter_map(filter)

--- a/crates/ide_db/src/helpers/import_assets.rs
+++ b/crates/ide_db/src/helpers/import_assets.rs
@@ -58,19 +58,19 @@ pub struct ImportAssets {
 
 impl ImportAssets {
     pub fn for_method_call(
-        method_call: ast::MethodCallExpr,
+        method_call: &ast::MethodCallExpr,
         sema: &Semantics<RootDatabase>,
     ) -> Option<Self> {
         let syntax_under_caret = method_call.syntax().to_owned();
         let module_with_candidate = sema.scope(&syntax_under_caret).module()?;
         Some(Self {
-            import_candidate: ImportCandidate::for_method_call(sema, &method_call)?,
+            import_candidate: ImportCandidate::for_method_call(sema, method_call)?,
             module_with_candidate,
         })
     }
 
     pub fn for_exact_path(
-        fully_qualified_path: ast::Path,
+        fully_qualified_path: &ast::Path,
         sema: &Semantics<RootDatabase>,
     ) -> Option<Self> {
         let syntax_under_caret = fully_qualified_path.syntax().to_owned();
@@ -80,7 +80,7 @@ impl ImportAssets {
 
         let module_with_candidate = sema.scope(&syntax_under_caret).module()?;
         Some(Self {
-            import_candidate: ImportCandidate::for_regular_path(sema, &fully_qualified_path)?,
+            import_candidate: ImportCandidate::for_regular_path(sema, fully_qualified_path)?,
             module_with_candidate,
         })
     }

--- a/crates/ide_db/src/helpers/import_assets.rs
+++ b/crates/ide_db/src/helpers/import_assets.rs
@@ -55,23 +55,33 @@ impl ImportAssets {
         })
     }
 
-    pub fn for_regular_path(
-        path_under_caret: ast::Path,
+    pub fn for_exact_path(
+        fully_qualified_path: ast::Path,
         sema: &Semantics<RootDatabase>,
     ) -> Option<Self> {
-        let syntax_under_caret = path_under_caret.syntax().to_owned();
+        let syntax_under_caret = fully_qualified_path.syntax().to_owned();
         if syntax_under_caret.ancestors().find_map(ast::Use::cast).is_some() {
             return None;
         }
 
         let module_with_name_to_import = sema.scope(&syntax_under_caret).module()?;
         Some(Self {
-            import_candidate: ImportCandidate::for_regular_path(sema, &path_under_caret)?,
+            import_candidate: ImportCandidate::for_regular_path(sema, &fully_qualified_path)?,
             module_with_name_to_import,
             syntax_under_caret,
         })
     }
 
+    pub fn for_fuzzy_path(
+        qualifier: ast::Path,
+        fuzzy_name: &str,
+        sema: &Semantics<RootDatabase>,
+    ) -> Option<Self> {
+        todo!()
+    }
+}
+
+impl ImportAssets {
     pub fn syntax_under_caret(&self) -> &SyntaxNode {
         &self.syntax_under_caret
     }
@@ -94,7 +104,7 @@ impl ImportAssets {
         sema: &Semantics<RootDatabase>,
         prefix_kind: PrefixKind,
     ) -> Vec<(hir::ModPath, hir::ItemInNs)> {
-        let _p = profile::span("import_assists::search_for_imports");
+        let _p = profile::span("import_assets::search_for_imports");
         self.search_for(sema, Some(prefix_kind))
     }
 
@@ -103,7 +113,7 @@ impl ImportAssets {
         &self,
         sema: &Semantics<RootDatabase>,
     ) -> Vec<(hir::ModPath, hir::ItemInNs)> {
-        let _p = profile::span("import_assists::search_for_relative_paths");
+        let _p = profile::span("import_assets::search_for_relative_paths");
         self.search_for(sema, None)
     }
 

--- a/crates/ide_db/src/helpers/import_assets.rs
+++ b/crates/ide_db/src/helpers/import_assets.rs
@@ -258,7 +258,6 @@ impl ImportAssets {
             }
             NameToImport::Fuzzy(fuzzy_name) => match self.import_candidate {
                 ImportCandidate::TraitAssocItem(_) | ImportCandidate::TraitMethod(_) => {
-                    // TODO kb for the associated items, we need to return the assoc item in the rendered completion, not the trait itself
                     imports_locator::find_similar_associated_items(
                         sema,
                         current_crate,

--- a/crates/ide_db/src/helpers/insert_use.rs
+++ b/crates/ide_db/src/helpers/insert_use.rs
@@ -15,6 +15,12 @@ use syntax::{
 };
 use test_utils::mark;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct InsertUseConfig {
+    pub merge: Option<MergeBehavior>,
+    pub prefix_kind: hir::PrefixKind,
+}
+
 #[derive(Debug, Clone)]
 pub enum ImportScope {
     File(ast::SourceFile),

--- a/crates/ide_db/src/imports_locator.rs
+++ b/crates/ide_db/src/imports_locator.rs
@@ -79,6 +79,8 @@ pub fn find_similar_associated_items<'a>(
         .search_mode(import_map::SearchMode::Fuzzy)
         .assoc_items_only();
 
+    // TODO kb do we need local queries at all?
+    // Seems like `import_map` contains all necessary for the importing
     let mut local_query = symbol_index::Query::new(fuzzy_search_string);
 
     if let Some(limit) = limit {

--- a/crates/ide_db/src/imports_locator.rs
+++ b/crates/ide_db/src/imports_locator.rs
@@ -64,7 +64,6 @@ pub fn find_similar_imports<'a>(
         .filter(move |import_candidate| !is_assoc_item(import_candidate, db))
 }
 
-// TODO kb not like we can import an assoc item, so the name and location are wrong
 pub fn find_similar_associated_items<'a>(
     sema: &Semantics<'a, RootDatabase>,
     krate: Crate,

--- a/crates/ide_db/src/imports_locator.rs
+++ b/crates/ide_db/src/imports_locator.rs
@@ -1,7 +1,10 @@
 //! This module contains an import search functionality that is provided to the assists module.
 //! Later, this should be moved away to a separate crate that is accessible from the assists module.
 
-use hir::{import_map, AsAssocItem, Crate, MacroDef, ModuleDef, Semantics};
+use hir::{
+    import_map::{self, ImportKind},
+    AsAssocItem, Crate, MacroDef, ModuleDef, Semantics,
+};
 use syntax::{ast, AstNode, SyntaxKind::NAME};
 
 use crate::{
@@ -40,13 +43,13 @@ pub fn find_similar_imports<'a>(
     krate: Crate,
     limit: Option<usize>,
     fuzzy_search_string: String,
-    ignore_assoc_items: bool,
     name_only: bool,
 ) -> impl Iterator<Item = Either<ModuleDef, MacroDef>> + 'a {
     let _p = profile::span("find_similar_imports");
 
     let mut external_query = import_map::Query::new(fuzzy_search_string.clone())
-        .search_mode(import_map::SearchMode::Fuzzy);
+        .search_mode(import_map::SearchMode::Fuzzy)
+        .exclude_import_kind(ImportKind::AssociatedItem);
     if name_only {
         external_query = external_query.name_only();
     }
@@ -59,20 +62,42 @@ pub fn find_similar_imports<'a>(
     }
 
     let db = sema.db;
-    find_imports(sema, krate, local_query, external_query).filter(move |import_candidate| {
-        if ignore_assoc_items {
-            match import_candidate {
-                Either::Left(ModuleDef::Function(function)) => function.as_assoc_item(db).is_none(),
-                Either::Left(ModuleDef::Const(const_)) => const_.as_assoc_item(db).is_none(),
-                Either::Left(ModuleDef::TypeAlias(type_alias)) => {
-                    type_alias.as_assoc_item(db).is_none()
-                }
-                _ => true,
-            }
-        } else {
-            true
-        }
-    })
+    find_imports(sema, krate, local_query, external_query)
+        .filter(move |import_candidate| !is_assoc_item(import_candidate, db))
+}
+
+// TODO kb not like we can import an assoc item, so the name and location are wrong
+pub fn find_similar_associated_items<'a>(
+    sema: &Semantics<'a, RootDatabase>,
+    krate: Crate,
+    limit: Option<usize>,
+    fuzzy_search_string: String,
+) -> impl Iterator<Item = Either<ModuleDef, MacroDef>> + 'a {
+    let _p = profile::span("find_similar_associated_items");
+
+    let mut external_query = import_map::Query::new(fuzzy_search_string.clone())
+        .search_mode(import_map::SearchMode::Fuzzy)
+        .assoc_items_only();
+
+    let mut local_query = symbol_index::Query::new(fuzzy_search_string);
+
+    if let Some(limit) = limit {
+        local_query.limit(limit);
+        external_query = external_query.limit(limit);
+    }
+
+    let db = sema.db;
+    find_imports(sema, krate, local_query, external_query)
+        .filter(move |import_candidate| is_assoc_item(import_candidate, db))
+}
+
+fn is_assoc_item(import_candidate: &Either<ModuleDef, MacroDef>, db: &RootDatabase) -> bool {
+    match import_candidate {
+        Either::Left(ModuleDef::Function(function)) => function.as_assoc_item(db).is_some(),
+        Either::Left(ModuleDef::Const(const_)) => const_.as_assoc_item(db).is_some(),
+        Either::Left(ModuleDef::TypeAlias(type_alias)) => type_alias.as_assoc_item(db).is_some(),
+        _ => false,
+    }
 }
 
 fn find_imports<'a>(

--- a/crates/ide_db/src/imports_locator.rs
+++ b/crates/ide_db/src/imports_locator.rs
@@ -79,8 +79,6 @@ pub fn find_similar_associated_items<'a>(
         .search_mode(import_map::SearchMode::Fuzzy)
         .assoc_items_only();
 
-    // TODO kb do we need local queries at all?
-    // Seems like `import_map` contains all necessary for the importing
     let mut local_query = symbol_index::Query::new(fuzzy_search_string);
 
     if let Some(limit) = limit {

--- a/crates/rust-analyzer/src/cli/analysis_bench.rs
+++ b/crates/rust-analyzer/src/cli/analysis_bench.rs
@@ -3,6 +3,7 @@
 use std::{env, path::PathBuf, str::FromStr, sync::Arc, time::Instant};
 
 use anyhow::{bail, format_err, Result};
+use hir::PrefixKind;
 use ide::{
     Analysis, AnalysisHost, Change, CompletionConfig, DiagnosticsConfig, FilePosition, LineCol,
 };
@@ -11,7 +12,7 @@ use ide_db::{
         salsa::{Database, Durability},
         FileId,
     },
-    helpers::SnippetCap,
+    helpers::{insert_use::InsertUseConfig, SnippetCap},
 };
 use vfs::AbsPathBuf;
 
@@ -96,7 +97,7 @@ impl BenchCmd {
                         add_call_parenthesis: true,
                         add_call_argument_snippets: true,
                         snippet_cap: SnippetCap::new(true),
-                        merge: None,
+                        insert_use: InsertUseConfig { merge: None, prefix_kind: PrefixKind::Plain },
                     };
                     let res = do_work(&mut host, file_id, |analysis| {
                         analysis.completions(&options, file_position)

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -11,11 +11,11 @@ use std::{convert::TryFrom, ffi::OsString, iter, path::PathBuf};
 
 use flycheck::FlycheckConfig;
 use hir::PrefixKind;
-use ide::{
-    AssistConfig, CompletionConfig, DiagnosticsConfig, HoverConfig, InlayHintsConfig,
-    InsertUseConfig,
+use ide::{AssistConfig, CompletionConfig, DiagnosticsConfig, HoverConfig, InlayHintsConfig};
+use ide_db::helpers::{
+    insert_use::{InsertUseConfig, MergeBehavior},
+    SnippetCap,
 };
-use ide_db::helpers::{insert_use::MergeBehavior, SnippetCap};
 use itertools::Itertools;
 use lsp_types::{ClientCapabilities, MarkupKind};
 use project_model::{CargoConfig, ProjectJson, ProjectJsonData, ProjectManifest};
@@ -542,11 +542,18 @@ impl Config {
             max_length: self.data.inlayHints_maxLength,
         }
     }
-    fn merge_behavior(&self) -> Option<MergeBehavior> {
-        match self.data.assist_importMergeBehavior {
-            MergeBehaviorDef::None => None,
-            MergeBehaviorDef::Full => Some(MergeBehavior::Full),
-            MergeBehaviorDef::Last => Some(MergeBehavior::Last),
+    fn insert_use_config(&self) -> InsertUseConfig {
+        InsertUseConfig {
+            merge: match self.data.assist_importMergeBehavior {
+                MergeBehaviorDef::None => None,
+                MergeBehaviorDef::Full => Some(MergeBehavior::Full),
+                MergeBehaviorDef::Last => Some(MergeBehavior::Last),
+            },
+            prefix_kind: match self.data.assist_importPrefix {
+                ImportPrefixDef::Plain => PrefixKind::Plain,
+                ImportPrefixDef::ByCrate => PrefixKind::ByCrate,
+                ImportPrefixDef::BySelf => PrefixKind::BySelf,
+            },
         }
     }
     pub fn completion(&self) -> CompletionConfig {
@@ -556,7 +563,7 @@ impl Config {
                 && completion_item_edit_resolve(&self.caps),
             add_call_parenthesis: self.data.completion_addCallParenthesis,
             add_call_argument_snippets: self.data.completion_addCallArgumentSnippets,
-            merge: self.merge_behavior(),
+            insert_use: self.insert_use_config(),
             snippet_cap: SnippetCap::new(try_or!(
                 self.caps
                     .text_document
@@ -574,14 +581,7 @@ impl Config {
         AssistConfig {
             snippet_cap: SnippetCap::new(self.experimental("snippetTextEdit")),
             allowed: None,
-            insert_use: InsertUseConfig {
-                merge: self.merge_behavior(),
-                prefix_kind: match self.data.assist_importPrefix {
-                    ImportPrefixDef::Plain => PrefixKind::Plain,
-                    ImportPrefixDef::ByCrate => PrefixKind::ByCrate,
-                    ImportPrefixDef::BySelf => PrefixKind::BySelf,
-                },
-            },
+            insert_use: self.insert_use_config(),
         }
     }
     pub fn call_info_full(&self) -> bool {

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -703,6 +703,7 @@ pub(crate) fn handle_completion_resolve(
             FilePosition { file_id, offset },
             &resolve_data.full_import_path,
             resolve_data.imported_name,
+            resolve_data.import_for_trait_assoc_item,
         )?
         .into_iter()
         .flat_map(|edit| {
@@ -1694,6 +1695,7 @@ struct CompletionResolveData {
     position: lsp_types::TextDocumentPositionParams,
     full_import_path: String,
     imported_name: String,
+    import_for_trait_assoc_item: bool,
 }
 
 fn fill_resolve_data(
@@ -1710,6 +1712,7 @@ fn fill_resolve_data(
             position: position.to_owned(),
             full_import_path,
             imported_name,
+            import_for_trait_assoc_item: import_edit.import_for_trait_assoc_item,
         })
         .unwrap(),
     );

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -861,8 +861,9 @@ pub(crate) fn rename_error(err: RenameError) -> crate::LspError {
 
 #[cfg(test)]
 mod tests {
+    use hir::PrefixKind;
     use ide::Analysis;
-    use ide_db::helpers::SnippetCap;
+    use ide_db::helpers::{insert_use::InsertUseConfig, SnippetCap};
 
     use super::*;
 
@@ -887,7 +888,7 @@ mod tests {
                     add_call_parenthesis: true,
                     add_call_argument_snippets: true,
                     snippet_cap: SnippetCap::new(true),
-                    merge: None,
+                    insert_use: InsertUseConfig { merge: None, prefix_kind: PrefixKind::Plain },
                 },
                 ide_db::base_db::FilePosition { file_id, offset },
             )


### PR DESCRIPTION
Part of https://github.com/rust-analyzer/rust-analyzer/issues/7248
We still do not propose assoc items when there's no input at all (i.e. `struct.$0`) after this PR so it's not time to close the issue yet.

But the PR is massive already and does a big groundwork refactoring various import-related things, using `import_assets` for all of them.

For the "no input at all" completion case, I plan to reuse the same `fst`, but add there more assoc items, not only for the traits as we do now. 
If you think there's a better way to do this (for instance, if we somehow can actually determine a whole set of traits that are implemented for a certain `Ty`), please let me know.