### PR TITLE
Depend on local copy of la-arena instead of crates.io’s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,7 +552,7 @@ dependencies = [
  "hir_expand",
  "indexmap",
  "itertools 0.10.0",
- "la-arena 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "la-arena",
  "log",
  "mbe",
  "once_cell",
@@ -571,7 +571,7 @@ version = "0.0.0"
 dependencies = [
  "base_db",
  "either",
- "la-arena 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "la-arena",
  "log",
  "mbe",
  "parser",
@@ -596,7 +596,7 @@ dependencies = [
  "hir_def",
  "hir_expand",
  "itertools 0.10.0",
- "la-arena 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "la-arena",
  "log",
  "once_cell",
  "profile",
@@ -770,12 +770,6 @@ dependencies = [
 [[package]]
 name = "la-arena"
 version = "0.1.1"
-
-[[package]]
-name = "la-arena"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "383ed2a74426d1051751f6483a7160b98f36068224857cd4c953b34719476fc3"
 
 [[package]]
 name = "lazy_static"
@@ -1203,7 +1197,7 @@ name = "profile"
 version = "0.0.0"
 dependencies = [
  "cfg-if 1.0.0",
- "la-arena 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "la-arena",
  "libc",
  "once_cell",
  "perf-event",
@@ -1218,7 +1212,7 @@ dependencies = [
  "cargo_metadata",
  "cfg",
  "itertools 0.10.0",
- "la-arena 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "la-arena",
  "log",
  "paths",
  "proc_macro_api",

--- a/crates/hir_def/Cargo.toml
+++ b/crates/hir_def/Cargo.toml
@@ -20,7 +20,7 @@ fst = { version = "0.4", default-features = false }
 itertools = "0.10.0"
 indexmap = "1.4.0"
 smallvec = "1.4.0"
-la-arena = "0.1.0"
+la-arena = { version = "0.1.0", path = "../../lib/arena" }
 
 stdx = { path = "../stdx", version = "0.0.0" }
 base_db = { path = "../base_db", version = "0.0.0" }

--- a/crates/hir_expand/Cargo.toml
+++ b/crates/hir_expand/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 log = "0.4.8"
 either = "1.5.3"
 rustc-hash = "1.0.0"
-la-arena = "0.1.0"
+la-arena = { version = "0.1.0", path = "../../lib/arena" }
 
 base_db = { path = "../base_db", version = "0.0.0" }
 syntax = { path = "../syntax", version = "0.0.0" }

--- a/crates/hir_ty/Cargo.toml
+++ b/crates/hir_ty/Cargo.toml
@@ -20,7 +20,7 @@ scoped-tls = "1"
 chalk-solve = { version = "0.47", default-features = false }
 chalk-ir = "0.47"
 chalk-recursive = "0.47"
-la-arena = "0.1.0"
+la-arena = { version = "0.1.0", path = "../../lib/arena" }
 
 stdx = { path = "../stdx", version = "0.0.0" }
 hir_def = { path = "../hir_def", version = "0.0.0" }

--- a/crates/profile/Cargo.toml
+++ b/crates/profile/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 once_cell = "1.3.1"
 cfg-if = "1"
 libc = "0.2.73"
-la-arena = "0.1.0"
+la-arena = { version = "0.1.0", path = "../../lib/arena" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 perf-event = "0.4"

--- a/crates/project_model/Cargo.toml
+++ b/crates/project_model/Cargo.toml
@@ -17,7 +17,7 @@ serde = { version = "1.0.106", features = ["derive"] }
 serde_json = "1.0.48"
 anyhow = "1.0.26"
 itertools = "0.10.0"
-la-arena = "0.1.0"
+la-arena = { version = "0.1.0", path = "../../lib/arena" }
 
 cfg = { path = "../cfg", version = "0.0.0" }
 base_db = { path = "../base_db", version = "0.0.0" }


### PR DESCRIPTION
This addresses [this comment](https://github.com/rust-analyzer/rust-analyzer/pull/7276#issuecomment-760909936). #7275 and #7276 should start compiling if this is merged.