### PR TITLE
Add `MacroType`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1839,9 +1839,9 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "ungrammar"
-version = "1.9.0"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b137a875a3b942539dd04bd37d193649f5d67e11407186f5b9d63ae0332b1a93"
+checksum = "58a02e2041a872d56354e843e8e86e6b946fc8e7dc32982fcdc335e29eb4cc8b"
 
 [[package]]
 name = "unicase"

--- a/crates/hir_def/src/type_ref.rs
+++ b/crates/hir_def/src/type_ref.rs
@@ -159,6 +159,8 @@ impl TypeRef {
             ast::Type::DynTraitType(inner) => {
                 TypeRef::DynTrait(type_bounds_from_ast(ctx, inner.type_bound_list()))
             }
+            // FIXME: Macros in type position are not yet supported.
+            ast::Type::MacroType(_) => TypeRef::Error,
         }
     }
 

--- a/crates/parser/src/syntax_kind/generated.rs
+++ b/crates/parser/src/syntax_kind/generated.rs
@@ -143,6 +143,7 @@ pub enum SyntaxKind {
     MACRO_DEF,
     PAREN_TYPE,
     TUPLE_TYPE,
+    MACRO_TYPE,
     NEVER_TYPE,
     PATH_TYPE,
     PTR_TYPE,

--- a/xtask/src/ast_src.rs
+++ b/xtask/src/ast_src.rs
@@ -104,6 +104,7 @@ pub(crate) const KINDS_SRC: KindsSrc = KindsSrc {
         "MACRO_DEF",
         "PAREN_TYPE",
         "TUPLE_TYPE",
+        "MACRO_TYPE",
         "NEVER_TYPE",
         "PATH_TYPE",
         "PTR_TYPE",


### PR DESCRIPTION
Adds syntax-level support for macros in type position.

Based on https://github.com/rust-analyzer/rust-analyzer/pull/7291 due to the ungrammar update