### PR TITLE
shrink_to_fit `TokenMap`'s backing storage

### DIFF
--- a/crates/hir_expand/src/hygiene.rs
+++ b/crates/hir_expand/src/hygiene.rs
@@ -76,6 +76,8 @@ pub struct HygieneFrame {
 
 impl HygieneFrames {
     fn new(db: &dyn AstDatabase, file_id: HirFileId) -> Self {
+        // Note that this intentionally avoids the `hygiene_frame` query to avoid blowing up memory
+        // usage. The query is only helpful for nested `HygieneFrame`s as it avoids redundant work.
         HygieneFrames(Arc::new(HygieneFrame::new(db, file_id)))
     }
 

--- a/crates/mbe/src/syntax_bridge.rs
+++ b/crates/mbe/src/syntax_bridge.rs
@@ -51,6 +51,7 @@ pub fn syntax_node_to_token_tree(node: &SyntaxNode) -> Option<(tt::Subtree, Toke
     let global_offset = node.text_range().start();
     let mut c = Convertor::new(node, global_offset);
     let subtree = c.go()?;
+    c.id_alloc.map.entries.shrink_to_fit();
     Some((subtree, c.id_alloc.map))
 }
 
@@ -593,7 +594,8 @@ impl<'a> TtTreeSink<'a> {
         }
     }
 
-    fn finish(self) -> (Parse<SyntaxNode>, TokenMap) {
+    fn finish(mut self) -> (Parse<SyntaxNode>, TokenMap) {
+        self.token_map.entries.shrink_to_fit();
         (self.inner.finish(), self.token_map)
     }
 }


### PR DESCRIPTION
Reduces `HygieneFrameQuery`'s memory usage by like 10 MB or so

bors r+