### PR TITLE
Rename `CrateDefMap` to `DefMap`

### DIFF
--- a/crates/hir_def/src/body.rs
+++ b/crates/hir_def/src/body.rs
@@ -29,7 +29,7 @@ use crate::{
     expr::{Expr, ExprId, Label, LabelId, Pat, PatId},
     item_scope::BuiltinShadowMode,
     item_scope::ItemScope,
-    nameres::CrateDefMap,
+    nameres::DefMap,
     path::{ModPath, Path},
     src::HasSource,
     AsMacroCall, DefWithBodyId, HasModule, Lookup, ModuleId,
@@ -45,7 +45,7 @@ pub(crate) struct CfgExpander {
 
 pub(crate) struct Expander {
     cfg_expander: CfgExpander,
-    crate_def_map: Arc<CrateDefMap>,
+    crate_def_map: Arc<DefMap>,
     current_file_id: HirFileId,
     ast_id_map: Arc<AstIdMap>,
     module: ModuleId,

--- a/crates/hir_def/src/db.rs
+++ b/crates/hir_def/src/db.rs
@@ -15,7 +15,7 @@ use crate::{
     import_map::ImportMap,
     item_tree::ItemTree,
     lang_item::{LangItemTarget, LangItems},
-    nameres::CrateDefMap,
+    nameres::DefMap,
     AttrDefId, ConstId, ConstLoc, DefWithBodyId, EnumId, EnumLoc, FunctionId, FunctionLoc,
     GenericDefId, ImplId, ImplLoc, LocalEnumVariantId, LocalFieldId, StaticId, StaticLoc, StructId,
     StructLoc, TraitId, TraitLoc, TypeAliasId, TypeAliasLoc, UnionId, UnionLoc, VariantId,
@@ -50,10 +50,10 @@ pub trait DefDatabase: InternDatabase + AstDatabase + Upcast<dyn AstDatabase> {
 
     #[salsa::invoke(crate_def_map_wait)]
     #[salsa::transparent]
-    fn crate_def_map(&self, krate: CrateId) -> Arc<CrateDefMap>;
+    fn crate_def_map(&self, krate: CrateId) -> Arc<DefMap>;
 
-    #[salsa::invoke(CrateDefMap::crate_def_map_query)]
-    fn crate_def_map_query(&self, krate: CrateId) -> Arc<CrateDefMap>;
+    #[salsa::invoke(DefMap::crate_def_map_query)]
+    fn crate_def_map_query(&self, krate: CrateId) -> Arc<DefMap>;
 
     #[salsa::invoke(StructData::struct_data_query)]
     fn struct_data(&self, id: StructId) -> Arc<StructData>;
@@ -112,7 +112,7 @@ pub trait DefDatabase: InternDatabase + AstDatabase + Upcast<dyn AstDatabase> {
     fn import_map(&self, krate: CrateId) -> Arc<ImportMap>;
 }
 
-fn crate_def_map_wait(db: &impl DefDatabase, krate: CrateId) -> Arc<CrateDefMap> {
+fn crate_def_map_wait(db: &impl DefDatabase, krate: CrateId) -> Arc<DefMap> {
     let _p = profile::span("crate_def_map:wait");
     db.crate_def_map_query(krate)
 }

--- a/crates/hir_def/src/find_path.rs
+++ b/crates/hir_def/src/find_path.rs
@@ -4,7 +4,7 @@ use hir_expand::name::{known, AsName, Name};
 use rustc_hash::FxHashSet;
 use test_utils::mark;
 
-use crate::nameres::CrateDefMap;
+use crate::nameres::DefMap;
 use crate::{
     db::DefDatabase,
     item_scope::ItemInNs,
@@ -47,7 +47,7 @@ impl ModPath {
     }
 }
 
-fn check_self_super(def_map: &CrateDefMap, item: ItemInNs, from: ModuleId) -> Option<ModPath> {
+fn check_self_super(def_map: &DefMap, item: ItemInNs, from: ModuleId) -> Option<ModPath> {
     if item == ItemInNs::Types(from.into()) {
         // - if the item is the module we're in, use `self`
         Some(ModPath::from_segments(PathKind::Super(0), Vec::new()))

--- a/crates/hir_def/src/nameres.rs
+++ b/crates/hir_def/src/nameres.rs
@@ -74,7 +74,7 @@ use crate::{
 
 /// Contains all top-level defs from a macro-expanded crate
 #[derive(Debug, PartialEq, Eq)]
-pub struct CrateDefMap {
+pub struct DefMap {
     pub root: LocalModuleId,
     pub modules: Arena<ModuleData>,
     pub(crate) krate: CrateId,
@@ -88,7 +88,7 @@ pub struct CrateDefMap {
     diagnostics: Vec<DefDiagnostic>,
 }
 
-impl std::ops::Index<LocalModuleId> for CrateDefMap {
+impl std::ops::Index<LocalModuleId> for DefMap {
     type Output = ModuleData;
     fn index(&self, id: LocalModuleId) -> &ModuleData {
         &self.modules[id]
@@ -169,8 +169,8 @@ pub struct ModuleData {
     pub origin: ModuleOrigin,
 }
 
-impl CrateDefMap {
-    pub(crate) fn crate_def_map_query(db: &dyn DefDatabase, krate: CrateId) -> Arc<CrateDefMap> {
+impl DefMap {
+    pub(crate) fn crate_def_map_query(db: &dyn DefDatabase, krate: CrateId) -> Arc<DefMap> {
         let _p = profile::span("crate_def_map_query").detail(|| {
             db.crate_graph()[krate].display_name.as_deref().unwrap_or_default().to_string()
         });
@@ -178,7 +178,7 @@ impl CrateDefMap {
             let edition = db.crate_graph()[krate].edition;
             let mut modules: Arena<ModuleData> = Arena::default();
             let root = modules.alloc(ModuleData::default());
-            CrateDefMap {
+            DefMap {
                 krate,
                 edition,
                 extern_prelude: FxHashMap::default(),
@@ -227,7 +227,7 @@ impl CrateDefMap {
         go(&mut buf, self, "crate", self.root);
         return buf;
 
-        fn go(buf: &mut String, map: &CrateDefMap, path: &str, module: LocalModuleId) {
+        fn go(buf: &mut String, map: &DefMap, path: &str, module: LocalModuleId) {
             format_to!(buf, "{}\n", path);
 
             let mut entries: Vec<_> = map.modules[module].scope.resolutions().collect();

--- a/crates/hir_def/src/nameres/path_resolution.rs
+++ b/crates/hir_def/src/nameres/path_resolution.rs
@@ -19,7 +19,7 @@ use test_utils::mark;
 use crate::{
     db::DefDatabase,
     item_scope::BUILTIN_SCOPE,
-    nameres::{BuiltinShadowMode, CrateDefMap},
+    nameres::{BuiltinShadowMode, DefMap},
     path::{ModPath, PathKind},
     per_ns::PerNs,
     visibility::{RawVisibility, Visibility},
@@ -61,7 +61,7 @@ impl ResolvePathResult {
     }
 }
 
-impl CrateDefMap {
+impl DefMap {
     pub(super) fn resolve_name_in_extern_prelude(&self, name: &Name) -> PerNs {
         self.extern_prelude
             .get(name)

--- a/crates/hir_def/src/nameres/tests.rs
+++ b/crates/hir_def/src/nameres/tests.rs
@@ -13,7 +13,7 @@ use test_utils::mark;
 
 use crate::{db::DefDatabase, nameres::*, test_db::TestDB};
 
-fn compute_crate_def_map(ra_fixture: &str) -> Arc<CrateDefMap> {
+fn compute_crate_def_map(ra_fixture: &str) -> Arc<DefMap> {
     let db = TestDB::with_files(ra_fixture);
     let krate = db.crate_graph().iter().next().unwrap();
     db.crate_def_map(krate)

--- a/crates/hir_def/src/resolver.rs
+++ b/crates/hir_def/src/resolver.rs
@@ -16,7 +16,7 @@ use crate::{
     expr::{ExprId, PatId},
     generics::GenericParams,
     item_scope::{BuiltinShadowMode, BUILTIN_SCOPE},
-    nameres::CrateDefMap,
+    nameres::DefMap,
     path::{ModPath, PathKind},
     per_ns::PerNs,
     visibility::{RawVisibility, Visibility},
@@ -34,7 +34,7 @@ pub struct Resolver {
 // FIXME how to store these best
 #[derive(Debug, Clone)]
 struct ModuleItemMap {
-    crate_def_map: Arc<CrateDefMap>,
+    crate_def_map: Arc<DefMap>,
     module_id: LocalModuleId,
 }
 
@@ -425,7 +425,7 @@ impl Resolver {
         traits
     }
 
-    fn module_scope(&self) -> Option<(&CrateDefMap, LocalModuleId)> {
+    fn module_scope(&self) -> Option<(&DefMap, LocalModuleId)> {
         self.scopes.iter().rev().find_map(|scope| match scope {
             Scope::ModuleScope(m) => Some((&*m.crate_def_map, m.module_id)),
 
@@ -588,11 +588,7 @@ impl Resolver {
         self.push_scope(Scope::ImplDefScope(impl_def))
     }
 
-    fn push_module_scope(
-        self,
-        crate_def_map: Arc<CrateDefMap>,
-        module_id: LocalModuleId,
-    ) -> Resolver {
+    fn push_module_scope(self, crate_def_map: Arc<DefMap>, module_id: LocalModuleId) -> Resolver {
         self.push_scope(Scope::ModuleScope(ModuleItemMap { crate_def_map, module_id }))
     }
 

--- a/crates/hir_def/src/visibility.rs
+++ b/crates/hir_def/src/visibility.rs
@@ -5,7 +5,7 @@ use syntax::ast;
 
 use crate::{
     db::DefDatabase,
-    nameres::CrateDefMap,
+    nameres::DefMap,
     path::{ModPath, PathKind},
     ModuleId,
 };
@@ -116,7 +116,7 @@ impl Visibility {
 
     pub(crate) fn is_visible_from_def_map(
         self,
-        def_map: &CrateDefMap,
+        def_map: &DefMap,
         from_module: crate::LocalModuleId,
     ) -> bool {
         let to_module = match self {
@@ -135,7 +135,7 @@ impl Visibility {
     ///
     /// If there is no subset relation between `self` and `other`, returns `None` (ie. they're only
     /// visible in unrelated modules).
-    pub(crate) fn max(self, other: Visibility, def_map: &CrateDefMap) -> Option<Visibility> {
+    pub(crate) fn max(self, other: Visibility, def_map: &DefMap) -> Option<Visibility> {
         match (self, other) {
             (Visibility::Module(_), Visibility::Public)
             | (Visibility::Public, Visibility::Module(_))

--- a/crates/hir_ty/src/tests.rs
+++ b/crates/hir_ty/src/tests.rs
@@ -18,7 +18,7 @@ use hir_def::{
     db::DefDatabase,
     item_scope::ItemScope,
     keys,
-    nameres::CrateDefMap,
+    nameres::DefMap,
     AssocItemId, DefWithBodyId, LocalModuleId, Lookup, ModuleDefId,
 };
 use hir_expand::{db::AstDatabase, InFile};
@@ -221,7 +221,7 @@ fn infer_with_mismatches(content: &str, include_mismatches: bool) -> String {
 
 fn visit_module(
     db: &TestDB,
-    crate_def_map: &CrateDefMap,
+    crate_def_map: &DefMap,
     module_id: LocalModuleId,
     cb: &mut dyn FnMut(DefWithBodyId),
 ) {
@@ -249,7 +249,7 @@ fn visit_module(
 
     fn visit_scope(
         db: &TestDB,
-        crate_def_map: &CrateDefMap,
+        crate_def_map: &DefMap,
         scope: &ItemScope,
         cb: &mut dyn FnMut(DefWithBodyId),
     ) {


### PR DESCRIPTION
I propose handling local items by computing a `DefMap` for every block expression, using the regular (early) name resolution algorithm. The result of that will be a `DefMap` that has a reference to the parent `DefMap`, which is either the one computed for the containing block expression, or the crate's root `DefMap`. Name resolution will fall back to a name in the parent `DefMap` if it cannot be resolved in the inner block.

The `DefMap`s computed for block expressions will go through a separate query that can be garbage-collected much more aggressively, since these `DefMap`s should be cheap to compute and are never part of a crate's public API.

The first step towards that is to make `CrateDefMap` not specific to crates anymore, hence this rename (if this plans sounds reasonable).

cc https://github.com/rust-analyzer/rust-analyzer/issues/7325 and https://github.com/rust-analyzer/rust-analyzer/issues/1165