### PR TITLE
Remove obsolete RangeInfo usage in references

### DIFF
--- a/crates/ide/src/call_hierarchy.rs
+++ b/crates/ide/src/call_hierarchy.rs
@@ -47,7 +47,7 @@ pub(crate) fn incoming_calls(db: &RootDatabase, position: FilePosition) -> Optio
 
     let mut calls = CallLocations::default();
 
-    for (&file_id, references) in refs.info.references().iter() {
+    for (&file_id, references) in refs.references().iter() {
         let file = sema.parse(file_id);
         let file = file.syntax();
         for reference in references {

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -369,9 +369,7 @@ impl Analysis {
         position: FilePosition,
         search_scope: Option<SearchScope>,
     ) -> Cancelable<Option<ReferenceSearchResult>> {
-        self.with_db(|db| {
-            references::find_all_refs(&Semantics::new(db), position, search_scope).map(|it| it.info)
-        })
+        self.with_db(|db| references::find_all_refs(&Semantics::new(db), position, search_scope))
     }
 
     /// Finds all methods and free functions for the file. Does not return tests!


### PR DESCRIPTION
Didn't even realize these were only here for renaming as well!

bors r+