### PR TITLE
Fix warnings when running `cargo doc --document-private-items`

### DIFF
--- a/crates/base_db/src/input.rs
+++ b/crates/base_db/src/input.rs
@@ -178,7 +178,7 @@ pub struct CrateData {
     pub root_file_id: FileId,
     pub edition: Edition,
     /// A name used in the package's project declaration: for Cargo projects,
-    /// it's [package].name, can be different for other project types or even
+    /// its `[package].name` can be different for other project types or even
     /// absent (a dummy crate for the code snippet, for example).
     ///
     /// For purposes of analysis, crates are anonymous (only names in

--- a/crates/parser/src/event.rs
+++ b/crates/parser/src/event.rs
@@ -38,14 +38,16 @@ pub(crate) enum Event {
     ///
     /// The events for it would look like this:
     ///
-    ///
+    /// ```text
     /// START(PATH) IDENT('foo') FINISH START(PATH) T![::] IDENT('bar') FINISH
     ///       |                          /\
     ///       |                          |
     ///       +------forward-parent------+
+    /// ```
     ///
     /// And the tree would look like this
     ///
+    /// ```text
     ///    +--PATH---------+
     ///    |   |           |
     ///    |   |           |
@@ -54,6 +56,7 @@ pub(crate) enum Event {
     ///   PATH
     ///    |
     ///   'foo'
+    /// ```
     ///
     /// See also `CompletedMarker::precede`.
     Start {

--- a/crates/stdx/src/lib.rs
+++ b/crates/stdx/src/lib.rs
@@ -134,8 +134,10 @@ impl<'a> Iterator for LinesWithEnds<'a> {
 
 /// Returns `idx` such that:
 ///
+/// ```text
 ///     ∀ x in slice[..idx]:  pred(x)
 ///  && ∀ x in slice[idx..]: !pred(x)
+/// ```
 ///
 /// https://github.com/rust-lang/rust/issues/73831
 pub fn partition_point<T, P>(slice: &[T], mut pred: P) -> usize


### PR DESCRIPTION
These were the warnings previously:

<details>

```
warning: could not parse code block as Rust code
   --> crates/stdx/src/lib.rs:137:9
    |
137 |   ///     ∀ x in slice[..idx]:  pred(x)
    |  _________^
138 | | ///  && ∀ x in slice[idx..]: !pred(x)
    | |____^
    |
    = note: error from rustc: unknown start of token: \u{2200}

warning: 1 warning emitted

warning: unresolved link to `package`
   --> crates/base_db/src/input.rs:181:15
    |
181 |     /// it's [package].name, can be different for other project types or even
    |               ^^^^^^^ no item named `package` in scope
    |
    = note: `#[warn(broken_intra_doc_links)]` on by default
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `package`
   --> crates/base_db/src/input.rs:181:15
    |
181 |     /// it's [package].name, can be different for other project types or even
    |               ^^^^^^^ no item named `package` in scope
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: 2 warnings emitted

warning: unresolved link to `package`
   --> crates/base_db/src/input.rs:181:15
    |
181 |     /// it's [package].name, can be different for other project types or even
    |               ^^^^^^^ no item named `package` in scope
    |
    = note: `#[warn(broken_intra_doc_links)]` on by default
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `package`
   --> crates/base_db/src/input.rs:181:15
    |
181 |     /// it's [package].name, can be different for other project types or even
    |               ^^^^^^^ no item named `package` in scope
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: 2 warnings emitted
```

</details>

This does *not* fix the following warning, because it is actually rust
code and rustdoc is being over eager:

```
warning: Rust code block is empty
  --> crates/parser/src/grammar.rs:16:5
   |
16 |   //! ```
   |  _____^
17 | | //! // test function_with_zero_parameters
18 | | //! // fn foo() {}
19 | | //! ```
   | |_______^
   |
help: mark blocks that do not contain Rust code as text
   |
16 | //! ```text
   |     ^^^^^^^
```

https://github.com/rust-lang/rust/pull/79816 should make this
configurable so the warning can be `allow`ed.