### PR TITLE
Add lazy loading for files

### DIFF
--- a/crates/project_model/src/cargo_workspace.rs
+++ b/crates/project_model/src/cargo_workspace.rs
@@ -332,7 +332,7 @@ impl CargoWorkspace {
         }
 
         let workspace_root = AbsPathBuf::assert(meta.workspace_root);
-        Ok(CargoWorkspace { packages, targets, workspace_root: workspace_root })
+        Ok(CargoWorkspace { packages, targets, workspace_root })
     }
 
     pub fn packages<'a>(&'a self) -> impl Iterator<Item = Package> + ExactSizeIterator + 'a {

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -235,18 +235,21 @@ impl GlobalState {
             FilesWatcher::Client => vec![],
             FilesWatcher::Notify => project_folders.watch,
         };
-        self.loader.handle.set_config(vfs::loader::Config { load: project_folders.load, watch });
+        self.vfs
+            .write()
+            .0
+            .loader
+            .set_config(vfs::loader::Config { load: project_folders.load, watch });
 
         // Create crate graph from all the workspaces
         let crate_graph = {
             let mut crate_graph = CrateGraph::default();
             let vfs = &mut self.vfs.write().0;
-            let loader = &mut self.loader;
             let mem_docs = &self.mem_docs;
             let mut load = |path: &AbsPath| {
                 let vfs_path = vfs::VfsPath::from(path.to_path_buf());
                 if !mem_docs.contains_key(&vfs_path) {
-                    let contents = loader.handle.load_sync(path);
+                    let contents = vfs.loader.load_sync(path);
                     vfs.set_file_contents(vfs_path.clone(), contents);
                 }
                 let res = vfs.file_id(&vfs_path);

--- a/crates/vfs/src/file_set/tests.rs
+++ b/crates/vfs/src/file_set/tests.rs
@@ -1,4 +1,25 @@
 use super::*;
+use crate::loader::*;
+use crate::{AbsPath, AbsPathBuf};
+
+#[derive(Debug)]
+struct DummyLoader;
+
+const NO_WRONG: fn() -> ! = || panic!("dummy loader should not be used");
+impl Handle for DummyLoader {
+    fn spawn(_: Sender) -> Self {
+        NO_WRONG()
+    }
+    fn set_config(&mut self, _: Config) {
+        NO_WRONG()
+    }
+    fn invalidate(&mut self, _: AbsPathBuf) {
+        NO_WRONG()
+    }
+    fn load_sync(&mut self, _: &AbsPath) -> Option<Vec<u8>> {
+        NO_WRONG()
+    }
+}
 
 #[test]
 fn path_prefix() {
@@ -7,7 +28,7 @@ fn path_prefix() {
     file_set.add_file_set(vec![VfsPath::new_virtual_path("/foo/bar/baz".into())]);
     let file_set = file_set.build();
 
-    let mut vfs = Vfs::default();
+    let mut vfs = Vfs::new(Box::new(DummyLoader));
     vfs.set_file_contents(VfsPath::new_virtual_path("/foo/src/lib.rs".into()), Some(Vec::new()));
     vfs.set_file_contents(
         VfsPath::new_virtual_path("/foo/src/bar/baz/lib.rs".into()),
@@ -30,7 +51,7 @@ fn name_prefix() {
     file_set.add_file_set(vec![VfsPath::new_virtual_path("/foo-things".into())]);
     let file_set = file_set.build();
 
-    let mut vfs = Vfs::default();
+    let mut vfs = Vfs::new(Box::new(DummyLoader));
     vfs.set_file_contents(VfsPath::new_virtual_path("/foo/src/lib.rs".into()), Some(Vec::new()));
     vfs.set_file_contents(
         VfsPath::new_virtual_path("/foo-things/src/lib.rs".into()),

--- a/crates/vfs/src/lib.rs
+++ b/crates/vfs/src/lib.rs
@@ -148,16 +148,11 @@ impl Vfs {
     }
 
     /// Returns an iterator over the stored ids and their corresponding paths.
-    ///
-    /// This will skip deleted files.
     pub fn iter(&self) -> impl Iterator<Item = (FileId, &VfsPath)> + '_ {
-        (0..self.data.len())
-            .map(|it| FileId(it as u32))
-            .filter(move |&file_id| self.get(file_id).exists())
-            .map(move |file_id| {
-                let path = self.interner.lookup(file_id);
-                (file_id, path)
-            })
+        (0..self.data.len()).map(|it| FileId(it as u32)).map(move |file_id| {
+            let path = self.interner.lookup(file_id);
+            (file_id, path)
+        })
     }
 
     /// Update the `path` with the given `contents`. `None` means the file was deleted.

--- a/crates/vfs/src/lib.rs
+++ b/crates/vfs/src/lib.rs
@@ -123,9 +123,9 @@ impl Vfs {
         self.data.len()
     }
 
-    /// Id of the given path if it exists in the `Vfs` and is not deleted.
+    /// Id of the given path if it exists in the `Vfs`.
     pub fn file_id(&self, path: &VfsPath) -> Option<FileId> {
-        self.interner.get(path).filter(|&it| self.get(it).exists())
+        self.interner.get(path)
     }
 
     /// File path corresponding to the given `file_id`.


### PR DESCRIPTION
This is a very bad idea and also doesn't work. Happy to iterate to get something more useful, but 'this is not a good idea' is also reasonable feedback.

Context: https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Fwg-rls-2.2E0/topic/VFS.20eagerly.20loads.20all.20.2Ers.20files.20in.20the.20project.20directory

(doesn't work -> doesn't improve memory usage that I can tell, I haven't debugged why)