### PR TITLE
Treat BlockExpr as a potential module origin

### DIFF
--- a/crates/hir_def/src/attr.rs
+++ b/crates/hir_def/src/attr.rs
@@ -207,6 +207,7 @@ impl Attrs {
                         mod_data.definition_source(db).as_ref().map(|src| match src {
                             ModuleSource::SourceFile(file) => file as &dyn AttrsOwner,
                             ModuleSource::Module(module) => module as &dyn AttrsOwner,
+                            ModuleSource::BlockExpr(block) => block as &dyn AttrsOwner,
                         }),
                     ),
                 }

--- a/crates/ide/src/display/navigation_target.rs
+++ b/crates/ide/src/display/navigation_target.rs
@@ -294,6 +294,7 @@ impl ToNav for hir::Module {
             ModuleSource::Module(node) => {
                 (node.syntax(), node.name().map(|it| it.syntax().text_range()))
             }
+            ModuleSource::BlockExpr(node) => (node.syntax(), None),
         };
         let frange = src.with_value(syntax).original_file_range(db);
         NavigationTarget::from_syntax(frange.file_id, name, focus, frange.range, SymbolKind::Module)

--- a/crates/ide/src/display/short_label.rs
+++ b/crates/ide/src/display/short_label.rs
@@ -53,6 +53,12 @@ impl ShortLabel for ast::SourceFile {
     }
 }
 
+impl ShortLabel for ast::BlockExpr {
+    fn short_label(&self) -> Option<String> {
+        None
+    }
+}
+
 impl ShortLabel for ast::TypeAlias {
     fn short_label(&self) -> Option<String> {
         short_label_from_node(self, "type ")

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -321,6 +321,7 @@ fn hover_for_definition(db: &RootDatabase, def: Definition) -> Option<Markup> {
                 match it.definition_source(db).value {
                     ModuleSource::Module(it) => it.short_label(),
                     ModuleSource::SourceFile(it) => it.short_label(),
+                    ModuleSource::BlockExpr(it) => it.short_label(),
                 },
                 mod_path,
             ),

--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -131,6 +131,7 @@ fn runnables_mod(sema: &Semantics<RootDatabase>, acc: &mut Vec<Runnable>, module
             match submodule.definition_source(sema.db).value {
                 hir::ModuleSource::Module(_) => runnables_mod(sema, acc, submodule),
                 hir::ModuleSource::SourceFile(_) => mark::hit!(dont_recurse_in_outline_submodules),
+                hir::ModuleSource::BlockExpr(_) => {} // inner items aren't runnable
             }
         }
     }

--- a/crates/ide_db/src/search.rs
+++ b/crates/ide_db/src/search.rs
@@ -228,6 +228,15 @@ impl Definition {
                             // so do nothing.
                         }
                     }
+                    ModuleSource::BlockExpr(b) => {
+                        if is_first {
+                            let range = Some(b.syntax().text_range());
+                            res.insert(file_id, range);
+                        } else {
+                            // We have already added the enclosing file to the search scope,
+                            // so do nothing.
+                        }
+                    }
                     ModuleSource::SourceFile(_) => {
                         res.insert(file_id, None);
                     }
@@ -257,6 +266,7 @@ impl Definition {
         let mut res = FxHashMap::default();
         let range = match module_src.value {
             ModuleSource::Module(m) => Some(m.syntax().text_range()),
+            ModuleSource::BlockExpr(b) => Some(b.syntax().text_range()),
             ModuleSource::SourceFile(_) => None,
         };
         res.insert(file_id, range);


### PR DESCRIPTION
A block containing inner items acts like the root module of a crate, so it needs to be representable as a `ModuleSource` and `ModuleOrigin`.