### PR TITLE
Add support for running name resolution in block expressions

### DIFF
--- a/crates/hir/src/db.rs
+++ b/crates/hir/src/db.rs
@@ -1,13 +1,13 @@
 //! FIXME: write short doc here
 
 pub use hir_def::db::{
-    AttrsQuery, BodyQuery, BodyWithSourceMapQuery, ConstDataQuery, CrateDefMapQueryQuery,
-    CrateLangItemsQuery, DefDatabase, DefDatabaseStorage, EnumDataQuery, ExprScopesQuery,
-    FunctionDataQuery, GenericParamsQuery, ImplDataQuery, ImportMapQuery, InternConstQuery,
-    InternDatabase, InternDatabaseStorage, InternEnumQuery, InternFunctionQuery, InternImplQuery,
-    InternStaticQuery, InternStructQuery, InternTraitQuery, InternTypeAliasQuery, InternUnionQuery,
-    ItemTreeQuery, LangItemQuery, StaticDataQuery, StructDataQuery, TraitDataQuery,
-    TypeAliasDataQuery, UnionDataQuery,
+    AttrsQuery, BlockDefMapQuery, BodyQuery, BodyWithSourceMapQuery, ConstDataQuery,
+    CrateDefMapQueryQuery, CrateLangItemsQuery, DefDatabase, DefDatabaseStorage, EnumDataQuery,
+    ExprScopesQuery, FunctionDataQuery, GenericParamsQuery, ImplDataQuery, ImportMapQuery,
+    InternConstQuery, InternDatabase, InternDatabaseStorage, InternEnumQuery, InternFunctionQuery,
+    InternImplQuery, InternStaticQuery, InternStructQuery, InternTraitQuery, InternTypeAliasQuery,
+    InternUnionQuery, ItemTreeQuery, LangItemQuery, StaticDataQuery, StructDataQuery,
+    TraitDataQuery, TypeAliasDataQuery, UnionDataQuery,
 };
 pub use hir_expand::db::{
     AstDatabase, AstDatabaseStorage, AstIdMapQuery, HygieneFrameQuery, InternEagerExpansionQuery,

--- a/crates/hir_def/src/db.rs
+++ b/crates/hir_def/src/db.rs
@@ -2,9 +2,9 @@
 use std::sync::Arc;
 
 use base_db::{salsa, CrateId, SourceDatabase, Upcast};
-use hir_expand::{db::AstDatabase, HirFileId};
+use hir_expand::{db::AstDatabase, AstId, HirFileId};
 use la_arena::ArenaMap;
-use syntax::SmolStr;
+use syntax::{ast, SmolStr};
 
 use crate::{
     adt::{EnumData, StructData},
@@ -54,6 +54,9 @@ pub trait DefDatabase: InternDatabase + AstDatabase + Upcast<dyn AstDatabase> {
 
     #[salsa::invoke(DefMap::crate_def_map_query)]
     fn crate_def_map_query(&self, krate: CrateId) -> Arc<DefMap>;
+
+    #[salsa::invoke(DefMap::block_def_map_query)]
+    fn block_def_map(&self, krate: CrateId, block: AstId<ast::BlockExpr>) -> Arc<DefMap>;
 
     #[salsa::invoke(StructData::struct_data_query)]
     fn struct_data(&self, id: StructId) -> Arc<StructData>;

--- a/crates/hir_def/src/item_tree.rs
+++ b/crates/hir_def/src/item_tree.rs
@@ -195,6 +195,13 @@ impl ItemTree {
         }
     }
 
+    pub fn inner_items_of_block(&self, block: FileAstId<ast::BlockExpr>) -> &[ModItem] {
+        match &self.data {
+            Some(data) => data.inner_items.get(&block).map(|it| &**it).unwrap_or(&[]),
+            None => &[],
+        }
+    }
+
     pub fn source<S: ItemTreeNode>(&self, db: &dyn DefDatabase, of: ItemTreeId<S>) -> S::Source {
         // This unwrap cannot fail, since it has either succeeded above, or resulted in an empty
         // ItemTree (in which case there is no valid `FileItemTreeId` to call this method with).

--- a/crates/hir_def/src/nameres/tests/block.rs
+++ b/crates/hir_def/src/nameres/tests/block.rs
@@ -45,3 +45,28 @@ fn outer() {
         "#]],
     );
 }
+
+#[test]
+fn merge_namespaces() {
+    check_at(
+        r#"
+//- /lib.rs
+struct name {}
+fn outer() {
+    fn name() {}
+
+    use name as imported; // should import both `name`s
+
+    $0
+}
+"#,
+        expect![[r#"
+            block scope
+            imported: t v
+            name: v
+            crate
+            name: t
+            outer: v
+        "#]],
+    );
+}

--- a/crates/hir_def/src/nameres/tests/block.rs
+++ b/crates/hir_def/src/nameres/tests/block.rs
@@ -1,0 +1,47 @@
+use super::*;
+
+#[test]
+fn inner_item_smoke() {
+    check_at(
+        r#"
+//- /lib.rs
+struct inner {}
+fn outer() {
+    $0
+    fn inner() {}
+}
+"#,
+        expect![[r#"
+            block scope
+            inner: v
+            crate
+            inner: t
+            outer: v
+        "#]],
+    );
+}
+
+#[test]
+fn use_from_crate() {
+    check_at(
+        r#"
+//- /lib.rs
+struct Struct;
+fn outer() {
+    use Struct;
+    use crate::Struct as CrateStruct;
+    use self::Struct as SelfStruct;
+    $0
+}
+"#,
+        expect![[r#"
+            block scope
+            CrateStruct: t v
+            SelfStruct: t v
+            Struct: t v
+            crate
+            Struct: t v
+            outer: v
+        "#]],
+    );
+}

--- a/crates/ide_db/src/apply_change.rs
+++ b/crates/ide_db/src/apply_change.rs
@@ -149,6 +149,7 @@ impl RootDatabase {
 
             // DefDatabase
             hir::db::ItemTreeQuery
+            hir::db::BlockDefMapQuery
             hir::db::CrateDefMapQueryQuery
             hir::db::StructDataQuery
             hir::db::UnionDataQuery


### PR DESCRIPTION
This adds a `block_def_map` query that runs the name resolution algorithm on a block expression, and returns a `DefMap` that stores a link to the parent `DefMap` (either the containing block or the crate-level `DefMap`). Blocks with no inner items return the parent's `DefMap` as-is, to avoid creating unnecessarily long `DefMap` chains.

Path resolution is updated to recurse into the parent `DefMap` after looking up a path in the original `DefMap`.

I've added a few new tests for this, but outside of those this isn't used yet.

bors r+