### PR TITLE
Make use of `block_def_map` in body lowering

### DIFF
--- a/crates/hir_def/src/data.rs
+++ b/crates/hir_def/src/data.rs
@@ -262,7 +262,7 @@ fn collect_items(
                 let root = db.parse_or_expand(file_id).unwrap();
                 let call = ast_id_map.get(call.ast_id).to_node(&root);
 
-                if let Some((mark, mac)) = expander.enter_expand(db, None, call).value {
+                if let Some((mark, mac)) = expander.enter_expand(db, call).value {
                     let src: InFile<ast::MacroItems> = expander.to_source(mac);
                     let item_tree = db.item_tree(src.file_id);
                     let iter =


### PR DESCRIPTION
Removes the `local_scope` argument from `Expander` in favor of tracking the `DefMap` in use during body lowering.

For now, we still collect inner items as usual, because other code still relies on `item_scope`.

bors r+