### PR TITLE
Handle box with allocator

### DIFF
--- a/crates/hir_ty/src/infer/expr.rs
+++ b/crates/hir_ty/src/infer/expr.rs
@@ -491,7 +491,10 @@ impl<'a> InferenceContext<'a> {
             Expr::Box { expr } => {
                 let inner_ty = self.infer_expr_inner(*expr, &Expectation::none());
                 if let Some(box_) = self.resolve_boxed_box() {
-                    Ty::apply_one(TypeCtor::Adt(box_), inner_ty)
+                    let mut sb = Substs::build_for_type_ctor(self.db, TypeCtor::Adt(box_));
+                    sb = sb.push(inner_ty);
+                    sb = sb.fill(repeat_with(|| self.table.new_type_var()));
+                    Ty::apply(TypeCtor::Adt(box_), sb.build())
                 } else {
                     Ty::Unknown
                 }

--- a/crates/hir_ty/src/tests/simple.rs
+++ b/crates/hir_ty/src/tests/simple.rs
@@ -29,6 +29,30 @@ mod boxed {
 }
 
 #[test]
+fn infer_box_with_allocator() {
+    check_types(
+        r#"
+//- /main.rs crate:main deps:std
+fn test() {
+    let x = box 1;
+    let t = (x, box x, box &1, box [1]);
+    t;
+} //^ (Box<i32, {unknown}>, Box<Box<i32, {unknown}>, {unknown}>, Box<&i32, {unknown}>, Box<[i32; _], {unknown}>)
+
+//- /std.rs crate:std
+#[prelude_import] use prelude::*;
+mod boxed {
+    #[lang = "owned_box"]
+    pub struct Box<T: ?Sized, A: Allocator> {
+        inner: *mut T,
+        allocator: A,
+    }
+}
+"#,
+    );
+}
+
+#[test]
 fn infer_adt_self() {
     check_types(
         r#"


### PR DESCRIPTION
In 1.49.0, the definition of Box was modified to support an optional
Allocator[1]. Adapt the parsing of the `box` keyword to supply the
expected number of parameters to the constructor.

[1] https://github.com/rust-lang/rust/commit/f288cd2e179f600fa00c2a407206a12f6c5a91e0

Fixes: #6956 
