### PR TITLE
Obtain `ModuleId`'s `DefMap` through a method

### DIFF
--- a/crates/hir/src/has_source.rs
+++ b/crates/hir/src/has_source.rs
@@ -24,12 +24,12 @@ pub trait HasSource {
 impl Module {
     /// Returns a node which defines this module. That is, a file or a `mod foo {}` with items.
     pub fn definition_source(self, db: &dyn HirDatabase) -> InFile<ModuleSource> {
-        let def_map = db.crate_def_map(self.id.krate);
+        let def_map = self.id.def_map(db.upcast());
         def_map[self.id.local_id].definition_source(db.upcast())
     }
 
     pub fn is_mod_rs(self, db: &dyn HirDatabase) -> bool {
-        let def_map = db.crate_def_map(self.id.krate);
+        let def_map = self.id.def_map(db.upcast());
         match def_map[self.id.local_id].origin {
             ModuleOrigin::File { is_mod_rs, .. } => is_mod_rs,
             _ => false,
@@ -39,7 +39,7 @@ impl Module {
     /// Returns a node which declares this module, either a `mod foo;` or a `mod foo {}`.
     /// `None` for the crate root.
     pub fn declaration_source(self, db: &dyn HirDatabase) -> Option<InFile<ast::Module>> {
-        let def_map = db.crate_def_map(self.id.krate);
+        let def_map = self.id.def_map(db.upcast());
         def_map[self.id.local_id].declaration_source(db.upcast())
     }
 }

--- a/crates/hir/src/semantics/source_to_def.rs
+++ b/crates/hir/src/semantics/source_to_def.rs
@@ -31,6 +31,7 @@ impl SourceToDefCtx<'_, '_> {
     pub(super) fn file_to_def(&mut self, file: FileId) -> Option<ModuleId> {
         let _p = profile::span("SourceBinder::to_module_def");
         let (krate, local_id) = self.db.relevant_crates(file).iter().find_map(|&crate_id| {
+            // FIXME: inner items
             let crate_def_map = self.db.crate_def_map(crate_id);
             let local_id = crate_def_map.modules_for_file(file).next()?;
             Some((crate_id, local_id))
@@ -60,7 +61,7 @@ impl SourceToDefCtx<'_, '_> {
         }?;
 
         let child_name = src.value.name()?.as_name();
-        let def_map = self.db.crate_def_map(parent_module.krate);
+        let def_map = parent_module.def_map(self.db.upcast());
         let child_id = *def_map[parent_module.local_id].children.get(&child_name)?;
         Some(ModuleId { krate: parent_module.krate, local_id: child_id })
     }

--- a/crates/hir_def/src/attr.rs
+++ b/crates/hir_def/src/attr.rs
@@ -196,7 +196,7 @@ impl Attrs {
     pub(crate) fn attrs_query(db: &dyn DefDatabase, def: AttrDefId) -> Attrs {
         let raw_attrs = match def {
             AttrDefId::ModuleId(module) => {
-                let def_map = db.crate_def_map(module.krate);
+                let def_map = module.def_map(db);
                 let mod_data = &def_map[module.local_id];
                 match mod_data.declaration_source(db) {
                     Some(it) => {

--- a/crates/hir_def/src/body.rs
+++ b/crates/hir_def/src/body.rs
@@ -86,7 +86,7 @@ impl Expander {
         module: ModuleId,
     ) -> Expander {
         let cfg_expander = CfgExpander::new(db, current_file_id, module.krate);
-        let crate_def_map = db.crate_def_map(module.krate);
+        let crate_def_map = module.def_map(db);
         let ast_id_map = db.ast_id_map(current_file_id);
         Expander {
             cfg_expander,

--- a/crates/hir_def/src/child_by_source.rs
+++ b/crates/hir_def/src/child_by_source.rs
@@ -74,7 +74,7 @@ impl ChildBySource for ImplId {
 
 impl ChildBySource for ModuleId {
     fn child_by_source(&self, db: &dyn DefDatabase) -> DynMap {
-        let crate_def_map = db.crate_def_map(self.krate);
+        let crate_def_map = self.def_map(db);
         let module_data = &crate_def_map[self.local_id];
         module_data.scope.child_by_source(db)
     }

--- a/crates/hir_def/src/import_map.rs
+++ b/crates/hir_def/src/import_map.rs
@@ -83,7 +83,7 @@ impl ImportMap {
                 &def_map[module.local_id]
             } else {
                 // The crate might reexport a module defined in another crate.
-                ext_def_map = db.crate_def_map(module.krate);
+                ext_def_map = module.def_map(db);
                 &ext_def_map[module.local_id]
             };
 

--- a/crates/hir_def/src/lib.rs
+++ b/crates/hir_def/src/lib.rs
@@ -50,7 +50,10 @@ pub mod import_map;
 #[cfg(test)]
 mod test_db;
 
-use std::hash::{Hash, Hasher};
+use std::{
+    hash::{Hash, Hasher},
+    sync::Arc,
+};
 
 use base_db::{impl_intern_key, salsa, CrateId};
 use hir_expand::{
@@ -58,6 +61,7 @@ use hir_expand::{
     MacroCallId, MacroCallKind, MacroDefId, MacroDefKind,
 };
 use la_arena::Idx;
+use nameres::DefMap;
 use syntax::ast;
 
 use crate::builtin_type::BuiltinType;
@@ -71,6 +75,12 @@ use stdx::impl_from;
 pub struct ModuleId {
     pub krate: CrateId,
     pub local_id: LocalModuleId,
+}
+
+impl ModuleId {
+    pub fn def_map(&self, db: &dyn db::DefDatabase) -> Arc<DefMap> {
+        db.crate_def_map(self.krate)
+    }
 }
 
 /// An ID of a module, **local** to a specific crate

--- a/crates/hir_def/src/nameres/collector.rs
+++ b/crates/hir_def/src/nameres/collector.rs
@@ -578,7 +578,7 @@ impl DefCollector<'_> {
                     } else if m.krate != self.def_map.krate {
                         mark::hit!(glob_across_crates);
                         // glob import from other crate => we can just import everything once
-                        let item_map = self.db.crate_def_map(m.krate);
+                        let item_map = m.def_map(self.db);
                         let scope = &item_map[m.local_id].scope;
 
                         // Module scoped macros is included

--- a/crates/hir_def/src/nameres/path_resolution.rs
+++ b/crates/hir_def/src/nameres/path_resolution.rs
@@ -243,7 +243,7 @@ impl DefMap {
                             kind: PathKind::Super(0),
                         };
                         log::debug!("resolving {:?} in other crate", path);
-                        let defp_map = db.crate_def_map(module.krate);
+                        let defp_map = module.def_map(db);
                         let (def, s) = defp_map.resolve_path(db, module.local_id, &path, shadow);
                         return ResolvePathResult::with(
                             def,
@@ -356,7 +356,7 @@ impl DefMap {
                 self
             } else {
                 // Extend lifetime
-                keep = db.crate_def_map(prelude.krate);
+                keep = prelude.def_map(db);
                 &keep
             };
             def_map[prelude.local_id].scope.get(name)

--- a/crates/hir_def/src/resolver.rs
+++ b/crates/hir_def/src/resolver.rs
@@ -430,7 +430,7 @@ impl Resolver {
         for scope in &self.scopes {
             if let Scope::ModuleScope(m) = scope {
                 if let Some(prelude) = m.crate_def_map.prelude() {
-                    let prelude_def_map = db.crate_def_map(prelude.krate);
+                    let prelude_def_map = prelude.def_map(db);
                     traits.extend(prelude_def_map[prelude.local_id].scope.traits());
                 }
                 traits.extend(m.crate_def_map[m.module_id].scope.traits());
@@ -529,7 +529,7 @@ impl Scope {
                     f(name.clone(), ScopeDef::PerNs(def));
                 });
                 if let Some(prelude) = m.crate_def_map.prelude() {
-                    let prelude_def_map = db.crate_def_map(prelude.krate);
+                    let prelude_def_map = prelude.def_map(db);
                     prelude_def_map[prelude.local_id].scope.entries().for_each(|(name, def)| {
                         let seen_tuple = (name.clone(), def);
                         if !seen.contains(&seen_tuple) {
@@ -633,7 +633,7 @@ pub trait HasResolver: Copy {
 
 impl HasResolver for ModuleId {
     fn resolver(self, db: &dyn DefDatabase) -> Resolver {
-        let def_map = db.crate_def_map(self.krate);
+        let def_map = self.def_map(db);
         Resolver::default().push_module_scope(def_map, self.local_id)
     }
 }

--- a/crates/hir_def/src/visibility.rs
+++ b/crates/hir_def/src/visibility.rs
@@ -103,7 +103,7 @@ impl Visibility {
         if from_module.krate != to_module.krate {
             return false;
         }
-        let def_map = db.crate_def_map(from_module.krate);
+        let def_map = from_module.def_map(db);
         self.is_visible_from_def_map(&def_map, from_module.local_id)
     }
 

--- a/crates/hir_ty/src/tests.rs
+++ b/crates/hir_ty/src/tests.rs
@@ -188,10 +188,10 @@ fn infer_with_mismatches(content: &str, include_mismatches: bool) -> String {
     };
 
     let module = db.module_for_file(file_id);
-    let crate_def_map = db.crate_def_map(module.krate);
+    let def_map = module.def_map(&db);
 
     let mut defs: Vec<DefWithBodyId> = Vec::new();
-    visit_module(&db, &crate_def_map, module.local_id, &mut |it| defs.push(it));
+    visit_module(&db, &def_map, module.local_id, &mut |it| defs.push(it));
     defs.sort_by_key(|def| match def {
         DefWithBodyId::FunctionId(it) => {
             let loc = it.lookup(&db);
@@ -321,7 +321,7 @@ fn typing_whitespace_inside_a_function_should_not_invalidate_types() {
     {
         let events = db.log_executed(|| {
             let module = db.module_for_file(pos.file_id);
-            let crate_def_map = db.crate_def_map(module.krate);
+            let crate_def_map = module.def_map(&db);
             visit_module(&db, &crate_def_map, module.local_id, &mut |def| {
                 db.infer(def);
             });


### PR DESCRIPTION
Once `ModuleId` can represent modules inside block expressions, this will be required in order to obtain the correct `DefMap`. Otherwise existing code might use a `LocalModuleId` from the wrong `DefMap` and cause a panic.

bors r+