### PR TITLE
Make `ModuleId`'s `krate` field private and audit uses

### DIFF
--- a/crates/hir_def/src/lib.rs
+++ b/crates/hir_def/src/lib.rs
@@ -73,13 +73,21 @@ use stdx::impl_from;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ModuleId {
-    pub krate: CrateId,
+    krate: CrateId,
     pub local_id: LocalModuleId,
 }
 
 impl ModuleId {
+    pub fn top_level(krate: CrateId, local_id: LocalModuleId) -> Self {
+        Self { krate, local_id }
+    }
+
     pub fn def_map(&self, db: &dyn db::DefDatabase) -> Arc<DefMap> {
         db.crate_def_map(self.krate)
+    }
+
+    pub fn krate(&self) -> CrateId {
+        self.krate
     }
 }
 

--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -617,7 +617,7 @@ impl HirDisplay for FnSig {
 }
 
 fn fn_traits(db: &dyn DefDatabase, trait_: TraitId) -> impl Iterator<Item = TraitId> {
-    let krate = trait_.lookup(db).container.module(db).krate;
+    let krate = trait_.lookup(db).container.module(db).krate();
     let fn_traits = [
         db.lang_item(krate, "fn".into()),
         db.lang_item(krate, "fn_mut".into()),

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -211,19 +211,21 @@ impl TypeCtor {
             | TypeCtor::Tuple { .. } => None,
             // Closure's krate is irrelevant for coherence I would think?
             TypeCtor::Closure { .. } => None,
-            TypeCtor::Adt(adt) => Some(adt.module(db.upcast()).krate),
+            TypeCtor::Adt(adt) => Some(adt.module(db.upcast()).krate()),
             TypeCtor::FnDef(callable) => Some(callable.krate(db)),
             TypeCtor::AssociatedType(type_alias) => {
-                Some(type_alias.lookup(db.upcast()).module(db.upcast()).krate)
+                Some(type_alias.lookup(db.upcast()).module(db.upcast()).krate())
             }
             TypeCtor::ForeignType(type_alias) => {
-                Some(type_alias.lookup(db.upcast()).module(db.upcast()).krate)
+                Some(type_alias.lookup(db.upcast()).module(db.upcast()).krate())
             }
             TypeCtor::OpaqueType(opaque_ty_id) => match opaque_ty_id {
                 OpaqueTyId::ReturnTypeImplTrait(func, _) => {
-                    Some(func.lookup(db.upcast()).module(db.upcast()).krate)
+                    Some(func.lookup(db.upcast()).module(db.upcast()).krate())
                 }
-                OpaqueTyId::AsyncBlockTypeImplTrait(def, _) => Some(def.module(db.upcast()).krate),
+                OpaqueTyId::AsyncBlockTypeImplTrait(def, _) => {
+                    Some(def.module(db.upcast()).krate())
+                }
             },
         }
     }
@@ -870,7 +872,7 @@ impl Ty {
             Ty::Apply(ApplicationTy { ctor: TypeCtor::OpaqueType(opaque_ty_id), .. }) => {
                 match opaque_ty_id {
                     OpaqueTyId::AsyncBlockTypeImplTrait(def, _expr) => {
-                        let krate = def.module(db.upcast()).krate;
+                        let krate = def.module(db.upcast()).krate();
                         if let Some(future_trait) = db
                             .lang_item(krate, "future_trait".into())
                             .and_then(|item| item.as_trait())

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -1147,7 +1147,7 @@ impl CallableDefId {
             CallableDefId::StructId(s) => s.lookup(db).container.module(db),
             CallableDefId::EnumVariantId(e) => e.parent.lookup(db).container.module(db),
         }
-        .krate
+        .krate()
     }
 }
 

--- a/crates/hir_ty/src/method_resolution.rs
+++ b/crates/hir_ty/src/method_resolution.rs
@@ -248,12 +248,12 @@ impl Ty {
         let lang_item_targets = match self {
             Ty::Apply(a_ty) => match a_ty.ctor {
                 TypeCtor::Adt(def_id) => {
-                    return Some(std::iter::once(def_id.module(db.upcast()).krate).collect())
+                    return Some(std::iter::once(def_id.module(db.upcast()).krate()).collect())
                 }
                 TypeCtor::ForeignType(type_alias_id) => {
                     return Some(
                         std::iter::once(
-                            type_alias_id.lookup(db.upcast()).module(db.upcast()).krate,
+                            type_alias_id.lookup(db.upcast()).module(db.upcast()).krate(),
                         )
                         .collect(),
                     )
@@ -280,7 +280,7 @@ impl Ty {
                 LangItemTarget::ImplDefId(it) => Some(it),
                 _ => None,
             })
-            .map(|it| it.lookup(db.upcast()).container.module(db.upcast()).krate)
+            .map(|it| it.lookup(db.upcast()).container.module(db.upcast()).krate())
             .collect();
         Some(res)
     }

--- a/crates/hir_ty/src/test_db.rs
+++ b/crates/hir_ty/src/test_db.rs
@@ -83,7 +83,7 @@ impl TestDB {
             let crate_def_map = self.crate_def_map(krate);
             for (local_id, data) in crate_def_map.modules() {
                 if data.origin.file_id() == Some(file_id) {
-                    return ModuleId { krate, local_id };
+                    return ModuleId::top_level(krate, local_id);
                 }
             }
         }

--- a/crates/hir_ty/src/tests.rs
+++ b/crates/hir_ty/src/tests.rs
@@ -343,7 +343,7 @@ fn typing_whitespace_inside_a_function_should_not_invalidate_types() {
     {
         let events = db.log_executed(|| {
             let module = db.module_for_file(pos.file_id);
-            let crate_def_map = db.crate_def_map(module.krate);
+            let crate_def_map = module.def_map(&db);
             visit_module(&db, &crate_def_map, module.local_id, &mut |def| {
                 db.infer(def);
             });

--- a/crates/hir_ty/src/traits/chalk.rs
+++ b/crates/hir_ty/src/traits/chalk.rs
@@ -426,7 +426,7 @@ pub(crate) fn trait_datum_query(
     let bound_vars = Substs::bound_vars(&generic_params, DebruijnIndex::INNERMOST);
     let flags = rust_ir::TraitFlags {
         auto: trait_data.auto,
-        upstream: trait_.lookup(db.upcast()).container.module(db.upcast()).krate != krate,
+        upstream: trait_.lookup(db.upcast()).container.module(db.upcast()).krate() != krate,
         non_enumerable: true,
         coinductive: false, // only relevant for Chalk testing
         // FIXME: set these flags correctly
@@ -549,7 +549,7 @@ fn impl_def_datum(
     let generic_params = generics(db.upcast(), impl_id.into());
     let bound_vars = Substs::bound_vars(&generic_params, DebruijnIndex::INNERMOST);
     let trait_ = trait_ref.trait_;
-    let impl_type = if impl_id.lookup(db.upcast()).container.module(db.upcast()).krate == krate {
+    let impl_type = if impl_id.lookup(db.upcast()).container.module(db.upcast()).krate() == krate {
         rust_ir::ImplType::Local
     } else {
         rust_ir::ImplType::External


### PR DESCRIPTION
bors r+