### PR TITLE
Create all `ModuleId`s through a `DefMap` method

### DIFF
--- a/crates/hir_def/src/import_map.rs
+++ b/crates/hir_def/src/import_map.rs
@@ -75,7 +75,7 @@ impl ImportMap {
 
         // We look only into modules that are public(ly reexported), starting with the crate root.
         let empty = ImportPath { segments: vec![] };
-        let root = ModuleId { krate, local_id: def_map.root() };
+        let root = def_map.module_id(def_map.root());
         let mut worklist = vec![(root, empty)];
         while let Some((module, mod_path)) = worklist.pop() {
             let ext_def_map;

--- a/crates/hir_def/src/lib.rs
+++ b/crates/hir_def/src/lib.rs
@@ -78,10 +78,6 @@ pub struct ModuleId {
 }
 
 impl ModuleId {
-    pub fn top_level(krate: CrateId, local_id: LocalModuleId) -> Self {
-        Self { krate, local_id }
-    }
-
     pub fn def_map(&self, db: &dyn db::DefDatabase) -> Arc<DefMap> {
         db.crate_def_map(self.krate)
     }

--- a/crates/hir_def/src/nameres.rs
+++ b/crates/hir_def/src/nameres.rs
@@ -265,6 +265,10 @@ impl DefMap {
         self.extern_prelude.iter()
     }
 
+    pub fn module_id(&self, local_id: LocalModuleId) -> ModuleId {
+        ModuleId { krate: self.krate, local_id }
+    }
+
     pub(crate) fn resolve_path(
         &self,
         db: &dyn DefDatabase,

--- a/crates/hir_def/src/resolver.rs
+++ b/crates/hir_def/src/resolver.rs
@@ -459,7 +459,7 @@ impl Resolver {
 
     pub fn module(&self) -> Option<ModuleId> {
         let (def_map, local_id) = self.module_scope()?;
-        Some(ModuleId { krate: def_map.krate(), local_id })
+        Some(def_map.module_id(local_id))
     }
 
     pub fn krate(&self) -> Option<CrateId> {

--- a/crates/hir_def/src/test_db.rs
+++ b/crates/hir_def/src/test_db.rs
@@ -15,7 +15,7 @@ use rustc_hash::FxHashSet;
 use syntax::{TextRange, TextSize};
 use test_utils::extract_annotations;
 
-use crate::{db::DefDatabase, ModuleDefId};
+use crate::{db::DefDatabase, ModuleDefId, ModuleId};
 
 #[salsa::database(
     base_db::SourceDatabaseExtStorage,
@@ -72,12 +72,12 @@ impl FileLoader for TestDB {
 }
 
 impl TestDB {
-    pub(crate) fn module_for_file(&self, file_id: FileId) -> crate::ModuleId {
+    pub(crate) fn module_for_file(&self, file_id: FileId) -> ModuleId {
         for &krate in self.relevant_crates(file_id).iter() {
             let crate_def_map = self.crate_def_map(krate);
             for (local_id, data) in crate_def_map.modules() {
                 if data.origin.file_id() == Some(file_id) {
-                    return crate::ModuleId { krate, local_id };
+                    return crate_def_map.module_id(local_id);
                 }
             }
         }

--- a/crates/hir_ty/src/test_db.rs
+++ b/crates/hir_ty/src/test_db.rs
@@ -83,7 +83,7 @@ impl TestDB {
             let crate_def_map = self.crate_def_map(krate);
             for (local_id, data) in crate_def_map.modules() {
                 if data.origin.file_id() == Some(file_id) {
-                    return ModuleId::top_level(krate, local_id);
+                    return crate_def_map.module_id(local_id);
                 }
             }
         }


### PR DESCRIPTION
`ModuleId` needs to be able to represent blocks, and only the
associated `DefMap` will know how to construct that `ModuleId`

bors r+