### PR TITLE
Simplify file download code

### DIFF
--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -208,7 +208,6 @@ async function bootstrapExtension(config: Config, state: PersistentState): Promi
             url: artifact.browser_download_url,
             dest,
             progressTitle: "Downloading rust-analyzer extension",
-            overwrite: true,
         });
     });
 
@@ -340,7 +339,6 @@ async function getServer(config: Config, state: PersistentState): Promise<string
             progressTitle: "Downloading rust-analyzer server",
             gunzip: true,
             mode: 0o755,
-            overwrite: true,
         });
     });
 

--- a/editors/code/src/net.ts
+++ b/editors/code/src/net.ts
@@ -73,22 +73,15 @@ interface DownloadOpts {
     dest: string;
     mode?: number;
     gunzip?: boolean;
-    overwrite?: boolean;
 }
 
 export async function download(opts: DownloadOpts) {
     // Put artifact into a temporary file (in the same dir for simplicity)
     // to prevent partially downloaded files when user kills vscode
+    // This also avoids overwriting running executables
     const dest = path.parse(opts.dest);
     const randomHex = crypto.randomBytes(5).toString("hex");
     const tempFile = path.join(dest.dir, `${dest.name}${randomHex}`);
-
-    if (opts.overwrite) {
-        // Unlinking the exe file before moving new one on its place should prevent ETXTBSY error.
-        await fs.promises.unlink(opts.dest).catch(err => {
-            if (err.code !== "ENOENT") throw err;
-        });
-    }
 
     await vscode.window.withProgress(
         {


### PR DESCRIPTION
This avoids leaving the user with no LSP binary available if their network goes down during the download, and should not keep the current behavior: overwriting a running executable works on Unix and fails on Windows.

It also removes the `overwrite` argument, which is always enabled and wasn't working anyway.

Nominally closes #3896 (although that's already fixed)