### PR TITLE
Shorten hir::TypeParam ranges for traits in NavigationTarget

### DIFF
--- a/crates/ide/src/display/navigation_target.rs
+++ b/crates/ide/src/display/navigation_target.rs
@@ -435,13 +435,16 @@ impl TryToNav for hir::TypeParam {
     fn try_to_nav(&self, db: &RootDatabase) -> Option<NavigationTarget> {
         let src = self.source(db)?;
         let full_range = match &src.value {
-            Either::Left(it) => it.syntax().text_range(),
+            Either::Left(it) => it
+                .name()
+                .map_or_else(|| it.syntax().text_range(), |name| name.syntax().text_range()),
             Either::Right(it) => it.syntax().text_range(),
         };
         let focus_range = match &src.value {
-            Either::Left(_) => None,
-            Either::Right(it) => it.name().map(|it| it.syntax().text_range()),
-        };
+            Either::Left(it) => it.name(),
+            Either::Right(it) => it.name(),
+        }
+        .map(|it| it.syntax().text_range());
         Some(NavigationTarget {
             file_id: src.file_id.original_file(db),
             name: self.name(db).to_string().into(),

--- a/crates/ide/src/references.rs
+++ b/crates/ide/src/references.rs
@@ -1098,4 +1098,20 @@ fn foo<const FOO$0: usize>() -> usize {
             "#]],
         );
     }
+
+    #[test]
+    fn test_find_self_ty_in_trait_def() {
+        check(
+            r#"
+trait Foo {
+    fn f() -> Self$0;
+}
+"#,
+            expect![[r#"
+                Self TypeParam FileId(0) 6..9 6..9 Other
+
+                FileId(0) 26..30 Other
+            "#]],
+        );
+    }
 }


### PR DESCRIPTION
I noticed that selecting `Self` here highlights the entire trait,
![Code_a8DMOEUuWY](https://user-images.githubusercontent.com/3757771/105779993-d2592c00-5f6f-11eb-81d1-bd99f9369cf7.png)
this should cut it down to just the trait name and the `Self` which imo seems better.
![image](https://user-images.githubusercontent.com/3757771/105780410-ac805700-5f70-11eb-882b-10ed63b951f2.png)
