### PR TITLE
Add no-buffering file logging and wait for a debugger option.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -120,6 +120,12 @@
       "sourceMaps": true,
       "outFiles": [ "${workspaceFolder}/editors/code/out/tests/unit/**/*.js" ],
       "preLaunchTask": "Pretest"
+    },
+    {
+      "name": "Win Attach to Server",
+      "type": "cppvsdbg",
+      "processId":"${command:pickProcess}",
+      "request": "attach"
     }
   ]
 }

--- a/crates/rust-analyzer/src/bin/args.rs
+++ b/crates/rust-analyzer/src/bin/args.rs
@@ -57,6 +57,7 @@ FLAGS:
 ENVIRONMENTAL VARIABLES:
     RA_LOG            Set log filter in env_logger format
     RA_PROFILE        Enable hierarchical profiler
+    RA_WAIT_DBG       If set acts like a --wait-dbg flag
 
 COMMANDS:
 

--- a/crates/rust-analyzer/src/bin/args.rs
+++ b/crates/rust-analyzer/src/bin/args.rs
@@ -49,7 +49,7 @@ FLAGS:
     -q,  --quiet      Set verbosity
 
     --log-file <PATH> Log to the specified file instead of stderr
-    --no-buffering    Flush log records to the file immediatly
+    --no-buffering    Flush log records to the file immediately
 
 ENVIRONMENTAL VARIABLES:
     RA_LOG            Set log filter in env_logger format

--- a/crates/rust-analyzer/src/bin/args.rs
+++ b/crates/rust-analyzer/src/bin/args.rs
@@ -50,7 +50,8 @@ FLAGS:
     -q,  --quiet      Set verbosity
 
     --log-file <PATH> Log to the specified file instead of stderr
-    --no-buffering    Flush log records to the file immediately
+    --no-log-buffering
+                      Flush log records to the file immediately
 
     --wait-dbg        Wait until a debugger is attached to.
                       The flag is valid for debug builds only
@@ -139,7 +140,7 @@ impl Args {
             (false, true, true) => bail!("Invalid flags: -q conflicts with -v"),
         };
         let log_file = matches.opt_value_from_str("--log-file")?;
-        let no_buffering = matches.contains("--no-buffering");
+        let no_buffering = matches.contains("--no-log-buffering");
         let wait_dbg = matches.contains("--wait-dbg");
 
         if matches.contains(["-h", "--help"]) {

--- a/crates/rust-analyzer/src/bin/args.rs
+++ b/crates/rust-analyzer/src/bin/args.rs
@@ -52,7 +52,8 @@ FLAGS:
     --log-file <PATH> Log to the specified file instead of stderr
     --no-buffering    Flush log records to the file immediately
 
-    --wait-dbg        Wait until a debugger is attached to
+    --wait-dbg        Wait until a debugger is attached to.
+                      The flag is valid for debug builds only
 
 ENVIRONMENTAL VARIABLES:
     RA_LOG            Set log filter in env_logger format

--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -29,7 +29,7 @@ fn main() {
 
 fn try_main() -> Result<()> {
     let args = args::Args::parse()?;
-    if args.wait_dbg {
+    if args.wait_dbg || env::var("RA_WAIT_DBG").is_ok() {
         #[allow(unused_mut)]
         let mut d = 4;
         while d == 4 {

--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -28,7 +28,7 @@ fn main() {
 
 fn try_main() -> Result<()> {
     let args = args::Args::parse()?;
-    setup_logging(args.log_file)?;
+    setup_logging(args.log_file, args.no_buffering)?;
     match args.command {
         args::Command::RunServer => run_server()?,
         args::Command::PrintConfigSchema => {
@@ -56,7 +56,7 @@ fn try_main() -> Result<()> {
     Ok(())
 }
 
-fn setup_logging(log_file: Option<PathBuf>) -> Result<()> {
+fn setup_logging(log_file: Option<PathBuf>, flush_file: bool) -> Result<()> {
     env::set_var("RUST_BACKTRACE", "short");
 
     let log_file = match log_file {
@@ -69,7 +69,7 @@ fn setup_logging(log_file: Option<PathBuf>) -> Result<()> {
         None => None,
     };
     let filter = env::var("RA_LOG").ok();
-    logger::Logger::new(log_file, filter.as_deref()).install();
+    logger::Logger::new(log_file, flush_file, filter.as_deref()).install();
 
     tracing_setup::setup_tracing()?;
 

--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -29,7 +29,7 @@ fn main() {
 
 fn try_main() -> Result<()> {
     let args = args::Args::parse()?;
-    
+
     #[cfg(debug_assertions)]
     if args.wait_dbg || env::var("RA_WAIT_DBG").is_ok() {
         #[allow(unused_mut)]

--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -21,6 +21,7 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 fn main() {
     if let Err(err) = try_main() {
+        log::error!("Unexpected error: {}", err);
         eprintln!("{}", err);
         process::exit(101);
     }
@@ -28,6 +29,14 @@ fn main() {
 
 fn try_main() -> Result<()> {
     let args = args::Args::parse()?;
+    if args.wait_dbg {
+        #[allow(unused_mut)]
+        let mut d = 4;
+        while d == 4 {
+            d = 4;
+        }
+    }
+
     setup_logging(args.log_file, args.no_buffering)?;
     match args.command {
         args::Command::RunServer => run_server()?,
@@ -56,7 +65,7 @@ fn try_main() -> Result<()> {
     Ok(())
 }
 
-fn setup_logging(log_file: Option<PathBuf>, flush_file: bool) -> Result<()> {
+fn setup_logging(log_file: Option<PathBuf>, no_buffering: bool) -> Result<()> {
     env::set_var("RUST_BACKTRACE", "short");
 
     let log_file = match log_file {
@@ -69,7 +78,7 @@ fn setup_logging(log_file: Option<PathBuf>, flush_file: bool) -> Result<()> {
         None => None,
     };
     let filter = env::var("RA_LOG").ok();
-    logger::Logger::new(log_file, flush_file, filter.as_deref()).install();
+    logger::Logger::new(log_file, no_buffering, filter.as_deref()).install();
 
     tracing_setup::setup_tracing()?;
 

--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -29,6 +29,8 @@ fn main() {
 
 fn try_main() -> Result<()> {
     let args = args::Args::parse()?;
+    
+    #[cfg(debug_assertions)]
     if args.wait_dbg || env::var("RA_WAIT_DBG").is_ok() {
         #[allow(unused_mut)]
         let mut d = 4;

--- a/docs/dev/debugging.md
+++ b/docs/dev/debugging.md
@@ -57,6 +57,14 @@ To apply changes to an already running debug process, press <kbd>Ctrl+Shift+P</k
 
 - Go back to the `[Extension Development Host]` instance and hover over a Rust variable and your breakpoint should hit.
 
+If you need to debug the server from the very beginning, including its initialization code, you can use the `--wait-dbg` command line argument or `RA_WAIT_DBG` environment variable. The server will spin at the beginning of the `try_main` function (see `crates\rust-analyzer\src\bin\main.rs`)
+```rust
+    let mut d = 4;
+    while d == 4 { // set a breakpoint here and change the value
+        d = 4;
+    }
+```
+
 ## Demo
 
 - [Debugging TypeScript VScode extension](https://www.youtube.com/watch?v=T-hvpK6s4wM).


### PR DESCRIPTION
Adds two command line flags: `--no-buffering` and `--wait-dbg`. 

Not  sure if someone else needs this, but personally I found both flags extremely useful trying to figure out why RA does not work with Visual Studio. Or better to say why Visual Studio does not work with RA.