### PR TITLE
Force XCode version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -157,8 +157,12 @@ jobs:
     runs-on: macos-latest
     env:
       RA_TARGET: x86_64-apple-darwin
+      SELECT_XCODE: /Applications/Xcode_12.2.app
 
     steps:
+    - name: Select XCode version
+      run: sudo xcode-select -s "${SELECT_XCODE}"
+
     - name: Checkout repository
       uses: actions/checkout@v2
 
@@ -183,8 +187,12 @@ jobs:
     runs-on: macos-latest
     env:
       RA_TARGET: aarch64-apple-darwin
+      SELECT_XCODE: /Applications/Xcode_12.2.app
 
     steps:
+    - name: Select XCode version
+      run: sudo xcode-select -s "${SELECT_XCODE}"
+
     - name: Checkout repository
       uses: actions/checkout@v2
 


### PR DESCRIPTION
Pin an Xcode version in the release workflow to avoid:

```
Run SDKROOT=$(xcrun -sdk macosx11.0 --show-sdk-path) MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.0 --show-sdk-platform-version) cargo xtask dist
xcodebuild: error: SDK "macosx11.0" cannot be located.
xcodebuild: error: SDK "macosx11.0" cannot be located.
xcrun: error: unable to lookup item 'Path' in SDK 'macosx11.0'
xcodebuild: error: SDK "macosx11.0" cannot be located.
xcodebuild: error: SDK "macosx11.0" cannot be located.
xcrun: error: unable to lookup item 'PlatformVersion' in SDK 'macosx11.0'
```