### PR TITLE
Update `original_module` when ascending `DefMap`s

### DIFF
--- a/crates/hir_def/src/nameres/path_resolution.rs
+++ b/crates/hir_def/src/nameres/path_resolution.rs
@@ -103,7 +103,7 @@ impl DefMap {
         &self,
         db: &dyn DefDatabase,
         mode: ResolveMode,
-        original_module: LocalModuleId,
+        mut original_module: LocalModuleId,
         path: &ModPath,
         shadow: BuiltinShadowMode,
     ) -> ResolvePathResult {
@@ -130,7 +130,10 @@ impl DefMap {
             result.segment_index = result.segment_index.min(new.segment_index);
 
             match &current_map.block {
-                Some(block) => current_map = &block.parent,
+                Some(block) => {
+                    current_map = &block.parent;
+                    original_module = block.parent_module;
+                }
                 None => return result,
             }
         }


### PR DESCRIPTION
Otherwise this might cause us to resolve the path from the wrong module, or even from a module that doesn't exist in the used `DefMap`.

bors r+