### PR TITLE
Widen Highlights root range to covering element

### DIFF
--- a/crates/ide/src/syntax_highlighting.rs
+++ b/crates/ide/src/syntax_highlighting.rs
@@ -72,7 +72,7 @@ pub(crate) fn highlight(
         }
     };
 
-    let mut hl = highlights::Highlights::new(range_to_highlight);
+    let mut hl = highlights::Highlights::new(root.text_range());
     traverse(&mut hl, &sema, &root, range_to_highlight, syntactic_name_ref_highlighting);
     hl.to_vec()
 }


### PR DESCRIPTION
There have been a few issues about/containing spurious syntax highlighting panics, which all seem to come from the `rust_analyzer::handlers::handle_semantic_tokens_range` request, which I believe this to be the cause of as the text range we want to highlight here is currently potentially smaller than that of the covering element, so we might highlight something that is inside the covering element, but outside of the text range we wish to highlight causing the assert to fail.
Unfortunately this isn't really easy to test since I have yet to find a reproducible cause(#7504 doesn't work for me cause I can't seem to checkout the given commit).

See #7504, #7298, #7299 and #7416, all of those contain an assertion failure in syntax highlighting, but only in the range request.