### PR TITLE
Don't filter code suggestions on Applicability

### DIFF
--- a/crates/rust-analyzer/src/diagnostics/test_data/clippy_pass_by_ref.txt
+++ b/crates/rust-analyzer/src/diagnostics/test_data/clippy_pass_by_ref.txt
@@ -266,6 +266,51 @@
             tags: None,
             data: None,
         },
-        fixes: [],
+        fixes: [
+            CodeAction {
+                title: "consider passing by value instead",
+                group: None,
+                kind: Some(
+                    CodeActionKind(
+                        "quickfix",
+                    ),
+                ),
+                edit: Some(
+                    SnippetWorkspaceEdit {
+                        changes: Some(
+                            {
+                                Url {
+                                    scheme: "file",
+                                    host: None,
+                                    port: None,
+                                    path: "/test/compiler/mir/tagset.rs",
+                                    query: None,
+                                    fragment: None,
+                                }: [
+                                    TextEdit {
+                                        range: Range {
+                                            start: Position {
+                                                line: 41,
+                                                character: 23,
+                                            },
+                                            end: Position {
+                                                line: 41,
+                                                character: 28,
+                                            },
+                                        },
+                                        new_text: "self",
+                                    },
+                                ],
+                            },
+                        ),
+                        document_changes: None,
+                    },
+                ),
+                is_preferred: Some(
+                    true,
+                ),
+                data: None,
+            },
+        ],
     },
 ]

--- a/crates/rust-analyzer/src/diagnostics/to_proto.rs
+++ b/crates/rust-analyzer/src/diagnostics/to_proto.rs
@@ -2,7 +2,7 @@
 //! `cargo check` json format to the LSP diagnostic format.
 use std::{collections::HashMap, path::Path};
 
-use flycheck::{Applicability, DiagnosticLevel, DiagnosticSpan};
+use flycheck::{DiagnosticLevel, DiagnosticSpan};
 use stdx::format_to;
 
 use crate::{lsp_ext, to_proto::url_from_abs_path};
@@ -97,9 +97,7 @@ fn map_rust_child_diagnostic(
 
     let mut edit_map: HashMap<lsp_types::Url, Vec<lsp_types::TextEdit>> = HashMap::new();
     for &span in &spans {
-        if let (Some(Applicability::MachineApplicable), Some(suggested_replacement)) =
-            (&span.suggestion_applicability, &span.suggested_replacement)
-        {
+        if let Some(suggested_replacement) = &span.suggested_replacement {
             let location = location(workspace_root, span);
             let edit = lsp_types::TextEdit::new(location.range, suggested_replacement.clone());
             edit_map.entry(location.uri).or_default().push(edit);


### PR DESCRIPTION
I've noticed that there are various suggestions that rust-analyzer seems to filter out, even if they make sense.

Here's an example of where it seems like there should be a suggestion, but there isn't:

![https://i.imgur.com/wsjM6iz.png](https://i.imgur.com/wsjM6iz.png)

It turns out that this specific suggestion is not considered `MachineApplicable`, which are the only suggestions that rust-analyzer accepts. However if you read the documentation for `MachineApplicable`,

[Source](https://github.com/rust-lang/rust/blob/b3897e3d1302391ed02efbac1dce8073646b8173/compiler/rustc_lint_defs/src/lib.rs#L27-L29)
```rust
/// The suggestion is definitely what the user intended. This suggestion should be
/// automatically applied.
MachineApplicable,
```

then you realize that these are specifically only those suggestions that rust-analyzer could even automatically apply (in some distant future, behind some setting or command or so). Other suggestions that may have some semantic impact do not use `MachineApplicable`. So all other suggestions are still intended to be suggested to the user, just not automatically applied without the user being consulted.

[Source](https://github.com/rust-lang/rust/blob/b3897e3d1302391ed02efbac1dce8073646b8173/compiler/rustc_lint_defs/src/lib.rs#L22-L24)
```rust
/// All suggestions are marked with an `Applicability`. Tools use the applicability of a suggestion
/// to determine whether it should be automatically applied or if the user should be consulted
/// before applying the suggestion.
```

So with that in mind, rust-analyzer should almost definitely not filter out `MaybeIncorrect` (which honestly is named horribly, it just means that it's a semantic change, not just a syntactical one).

Then there's `HasPlaceholders` which basically is just another semantic one, but with placeholders. The user will have to make some adjustments, but the suggestion still is perfectly valid. rust-analyzer could probably detect those placeholders and put proper "tab through" markers there for the IDE, but that's not necessary for now.

Then the last one is `Unspecified` which is so unknown that I don't even know how to judge it, meaning that the suggestion should probably also just be suggested to the user and then they can decide.

So with all that in mind, I'm proposing to get rid of the check for Applicability entirely.