### PR TITLE
Show alias underlying type

### DIFF
--- a/crates/ide/src/display/short_label.rs
+++ b/crates/ide/src/display/short_label.rs
@@ -61,7 +61,11 @@ impl ShortLabel for ast::BlockExpr {
 
 impl ShortLabel for ast::TypeAlias {
     fn short_label(&self) -> Option<String> {
-        short_label_from_node(self, "type ")
+        let mut buf = short_label_from_node(self, "type ")?;
+        if let Some(type_ref) = self.ty() {
+            format_to!(buf, " = {}", type_ref.syntax());
+        }
+        Some(buf)
     }
 }
 


### PR DESCRIPTION
Closes #7511 

Display underlying type in the tooltip:
```rust
pub type SomeAlias = f64
```
instead of:
```rust
pub type SomeAlias
```