### PR TITLE
Use non-deprecated memmap2 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,13 +887,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
-name = "memmap"
-version = "0.7.0"
+name = "memmap2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+checksum = "e73be3b7d04a0123e933fea1d50d126cc7196bbc0362c0ce426694f777194eee"
 dependencies = [
  "libc",
- "winapi",
 ]
 
 [[package]]
@@ -1169,7 +1168,7 @@ dependencies = [
  "cargo_metadata",
  "libloading",
  "mbe",
- "memmap",
+ "memmap2",
  "object",
  "proc_macro_api",
  "proc_macro_test",

--- a/crates/proc_macro_srv/Cargo.toml
+++ b/crates/proc_macro_srv/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 [dependencies]
 object = { version = "0.23", default-features = false, features = ["std", "read_core", "elf", "macho", "pe"] }
 libloading = "0.6.0"
-memmap = "0.7"
+memmap2 = "0.2.0"
 
 tt = { path = "../tt", version = "0.0.0" }
 mbe = { path = "../mbe", version = "0.0.0" }

--- a/crates/proc_macro_srv/src/dylib.rs
+++ b/crates/proc_macro_srv/src/dylib.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use libloading::Library;
-use memmap::Mmap;
+use memmap2::Mmap;
 use object::Object;
 use proc_macro_api::ProcMacroKind;
 


### PR DESCRIPTION
`cargo audit` complains that `memmap` is unmaintained so switch to
RazrFalcon's maintained version.

Removes yet another edge on winapi