### PR TITLE
Fix resolution of `crate` paths from within blocks

### DIFF
--- a/crates/hir_def/src/nameres.rs
+++ b/crates/hir_def/src/nameres.rs
@@ -275,6 +275,11 @@ impl DefMap {
         ModuleId { krate: self.krate, local_id, block }
     }
 
+    pub(crate) fn crate_root(&self) -> ModuleId {
+        let (root_map, _) = self.ancestor_maps(self.root).last().unwrap();
+        root_map.module_id(root_map.root)
+    }
+
     pub(crate) fn resolve_path(
         &self,
         db: &dyn DefDatabase,

--- a/crates/hir_def/src/nameres/path_resolution.rs
+++ b/crates/hir_def/src/nameres/path_resolution.rs
@@ -152,7 +152,7 @@ impl DefMap {
             PathKind::DollarCrate(krate) => {
                 if krate == self.krate {
                     mark::hit!(macro_dollar_crate_self);
-                    PerNs::types(self.module_id(self.root).into(), Visibility::Public)
+                    PerNs::types(self.crate_root().into(), Visibility::Public)
                 } else {
                     let def_map = db.crate_def_map(krate);
                     let module = def_map.module_id(def_map.root);
@@ -160,7 +160,7 @@ impl DefMap {
                     PerNs::types(module.into(), Visibility::Public)
                 }
             }
-            PathKind::Crate => PerNs::types(self.module_id(self.root).into(), Visibility::Public),
+            PathKind::Crate => PerNs::types(self.crate_root().into(), Visibility::Public),
             // plain import or absolute path in 2015: crate-relative with
             // fallback to extern prelude (with the simplification in
             // rust-lang/rust#57745)


### PR DESCRIPTION
They resolve to the crate root, not the DefMap's root module (which
can be a block)

bors r+