### PR TITLE
Make sure normal dependencies always have version

### DIFF
--- a/crates/mbe/Cargo.toml
+++ b/crates/mbe/Cargo.toml
@@ -17,5 +17,5 @@ log = "0.4.8"
 syntax = { path = "../syntax", version = "0.0.0" }
 parser = { path = "../parser", version = "0.0.0" }
 tt = { path = "../tt", version = "0.0.0" }
-test_utils = { path = "../test_utils" }
+test_utils = { path = "../test_utils", version = "0.0.0" }
 


### PR DESCRIPTION
How do I prevent this happening in the future by doing something in the CI? IIRC this is the second time.