### PR TITLE
Don't keep the parent DefMap alive via Arc

### DIFF
--- a/crates/hir_def/src/body/tests.rs
+++ b/crates/hir_def/src/body/tests.rs
@@ -34,7 +34,7 @@ fn check_diagnostics(ra_fixture: &str) {
     db.check_diagnostics();
 }
 
-fn block_def_map_at(ra_fixture: &str) -> Arc<DefMap> {
+fn block_def_map_at(ra_fixture: &str) -> String {
     let (db, position) = crate::test_db::TestDB::with_position(ra_fixture);
 
     let krate = db.crate_graph().iter().next().unwrap();
@@ -51,7 +51,7 @@ fn block_def_map_at(ra_fixture: &str) -> Arc<DefMap> {
                 block = new_block;
             }
             None => {
-                return def_map;
+                return def_map.dump(&db);
             }
         }
     }
@@ -138,8 +138,7 @@ fn block_at_pos(db: &dyn DefDatabase, def_map: &DefMap, position: FilePosition) 
 }
 
 fn check_at(ra_fixture: &str, expect: Expect) {
-    let def_map = block_def_map_at(ra_fixture);
-    let actual = def_map.dump();
+    let actual = block_def_map_at(ra_fixture);
     expect.assert_eq(&actual);
 }
 

--- a/crates/hir_def/src/nameres/collector.rs
+++ b/crates/hir_def/src/nameres/collector.rs
@@ -1449,10 +1449,11 @@ impl ModCollector<'_, '_> {
         if let Some(macro_call_id) =
             ast_id.as_call_id(self.def_collector.db, self.def_collector.def_map.krate, |path| {
                 path.as_ident().and_then(|name| {
-                    self.def_collector
-                        .def_map
-                        .ancestor_maps(self.module_id)
-                        .find_map(|(map, module)| map[module].scope.get_legacy_macro(&name))
+                    self.def_collector.def_map.with_ancestor_maps(
+                        self.def_collector.db,
+                        self.module_id,
+                        &mut |map, module| map[module].scope.get_legacy_macro(&name),
+                    )
                 })
             })
         {

--- a/crates/hir_def/src/nameres/tests.rs
+++ b/crates/hir_def/src/nameres/tests.rs
@@ -11,7 +11,9 @@ use base_db::{fixture::WithFixture, SourceDatabase};
 use expect_test::{expect, Expect};
 use test_utils::mark;
 
-use crate::{db::DefDatabase, nameres::*, test_db::TestDB};
+use crate::{db::DefDatabase, test_db::TestDB};
+
+use super::DefMap;
 
 fn compute_crate_def_map(ra_fixture: &str) -> Arc<DefMap> {
     let db = TestDB::with_files(ra_fixture);
@@ -19,9 +21,14 @@ fn compute_crate_def_map(ra_fixture: &str) -> Arc<DefMap> {
     db.crate_def_map(krate)
 }
 
+fn render_crate_def_map(ra_fixture: &str) -> String {
+    let db = TestDB::with_files(ra_fixture);
+    let krate = db.crate_graph().iter().next().unwrap();
+    db.crate_def_map(krate).dump(&db)
+}
+
 fn check(ra_fixture: &str, expect: Expect) {
-    let def_map = compute_crate_def_map(ra_fixture);
-    let actual = def_map.dump();
+    let actual = render_crate_def_map(ra_fixture);
     expect.assert_eq(&actual);
 }
 


### PR DESCRIPTION
This seems like it could easily leak a lot of memory since we don't
currently run GC

bors r+