### PR TITLE
Intern `TypeRef`s in the containing `ItemTree`

### DIFF
--- a/crates/hir_def/src/adt.rs
+++ b/crates/hir_def/src/adt.rs
@@ -351,7 +351,7 @@ fn lower_field(
 ) -> FieldData {
     FieldData {
         name: field.name.clone(),
-        type_ref: field.type_ref.clone(),
+        type_ref: item_tree[field.type_ref].clone(),
         visibility: item_tree[override_visibility.unwrap_or(field.visibility)].clone(),
     }
 }

--- a/crates/hir_def/src/data.rs
+++ b/crates/hir_def/src/data.rs
@@ -41,8 +41,8 @@ impl FunctionData {
 
         Arc::new(FunctionData {
             name: func.name.clone(),
-            params: func.params.to_vec(),
-            ret_type: func.ret_type.clone(),
+            params: func.params.iter().map(|id| item_tree[*id].clone()).collect(),
+            ret_type: item_tree[func.ret_type].clone(),
             attrs: item_tree.attrs(db, krate, ModItem::from(loc.id.value).into()).clone(),
             has_self_param: func.has_self_param,
             has_body: func.has_body,
@@ -75,7 +75,7 @@ impl TypeAliasData {
 
         Arc::new(TypeAliasData {
             name: typ.name.clone(),
-            type_ref: typ.type_ref.clone(),
+            type_ref: typ.type_ref.map(|id| item_tree[id].clone()),
             visibility: item_tree[typ.visibility].clone(),
             is_extern: typ.is_extern,
             bounds: typ.bounds.to_vec(),
@@ -144,8 +144,8 @@ impl ImplData {
 
         let item_tree = db.item_tree(impl_loc.id.file_id);
         let impl_def = &item_tree[impl_loc.id.value];
-        let target_trait = impl_def.target_trait.clone();
-        let target_type = impl_def.target_type.clone();
+        let target_trait = impl_def.target_trait.map(|id| item_tree[id].clone());
+        let target_type = item_tree[impl_def.target_type].clone();
         let is_negative = impl_def.is_negative;
         let module_id = impl_loc.container.module(db);
         let container = AssocContainerId::ImplId(id);
@@ -182,7 +182,7 @@ impl ConstData {
 
         Arc::new(ConstData {
             name: konst.name.clone(),
-            type_ref: konst.type_ref.clone(),
+            type_ref: item_tree[konst.type_ref].clone(),
             visibility: item_tree[konst.visibility].clone(),
         })
     }
@@ -205,7 +205,7 @@ impl StaticData {
 
         Arc::new(StaticData {
             name: Some(statik.name.clone()),
-            type_ref: statik.type_ref.clone(),
+            type_ref: item_tree[statik.type_ref].clone(),
             visibility: item_tree[statik.visibility].clone(),
             mutable: statik.mutable,
             is_extern: statik.is_extern,

--- a/crates/hir_def/src/item_tree/lower.rs
+++ b/crates/hir_def/src/item_tree/lower.rs
@@ -364,6 +364,7 @@ impl Ctx {
                 params.push(type_ref);
             }
         }
+        let params = params.into_iter().map(|param| self.data().type_refs.intern(param)).collect();
 
         let mut is_varargs = false;
         if let Some(params) = func.param_list() {
@@ -385,6 +386,8 @@ impl Ctx {
             ret_type
         };
 
+        let ret_type = self.data().type_refs.intern(ret_type);
+
         let has_body = func.body().is_some();
 
         let ast_id = self.source_ast_id_map.ast_id(func);
@@ -396,7 +399,7 @@ impl Ctx {
             has_body,
             is_unsafe: func.unsafe_token().is_some(),
             is_extern: false,
-            params: params.into_boxed_slice(),
+            params,
             is_varargs,
             ret_type,
             ast_id,
@@ -657,6 +660,7 @@ impl Ctx {
                 generics.fill(&self.body_ctx, sm, node);
                 // lower `impl Trait` in arguments
                 for param in &*func.params {
+                    let param = self.data().type_refs.lookup(*param);
                     generics.fill_implicit_impl_trait_args(param);
                 }
             }
@@ -709,11 +713,15 @@ impl Ctx {
         self.data().vis.alloc(vis)
     }
 
-    fn lower_type_ref(&self, type_ref: &ast::Type) -> TypeRef {
-        TypeRef::from_ast(&self.body_ctx, type_ref.clone())
+    fn lower_type_ref(&mut self, type_ref: &ast::Type) -> Idx<TypeRef> {
+        let tyref = TypeRef::from_ast(&self.body_ctx, type_ref.clone());
+        self.data().type_refs.intern(tyref)
     }
-    fn lower_type_ref_opt(&self, type_ref: Option<ast::Type>) -> TypeRef {
-        type_ref.map(|ty| self.lower_type_ref(&ty)).unwrap_or(TypeRef::Error)
+    fn lower_type_ref_opt(&mut self, type_ref: Option<ast::Type>) -> Idx<TypeRef> {
+        match type_ref.map(|ty| self.lower_type_ref(&ty)) {
+            Some(it) => it,
+            None => self.data().type_refs.intern(TypeRef::Error),
+        }
     }
 
     /// Forces the visibility `vis` to be used for all items lowered during execution of `f`.


### PR DESCRIPTION
This reduces the memory used by `ItemTreeQuery` by ~20%. As it turns out, `TypeRef` is very heavy, and is used a lot in `ItemTree`:

* Many types are frequently repeated throughout the same file. This is what this PR addresses by storing identical `TypeRef`s only once per `ItemTree`.
* The vast majority of `TypeRef` consist of a plain path with only a single element. "Type anchors" like in `<Ty>::func` are used incredibly rarely, and even multi-segment paths are much rarer than single-segment paths.