### PR TITLE
Add doc gen to the `generate_enum_match_method` assist

### DIFF
--- a/crates/assists/src/handlers/generate_enum_match_method.rs
+++ b/crates/assists/src/handlers/generate_enum_match_method.rs
@@ -25,6 +25,7 @@ use crate::{utils::find_struct_impl, AssistContext, AssistId, AssistKind, Assist
 // }
 //
 // impl Version {
+//     /// Returns `true` if the version is [`Minor`].
 //     fn is_minor(&self) -> bool {
 //         matches!(self, Self::Minor)
 //     }
@@ -39,6 +40,7 @@ pub(crate) fn generate_enum_match_method(acc: &mut Assists, ctx: &AssistContext)
         return None;
     }
 
+    let enum_lowercase_name = to_lower_snake_case(&parent_enum.name()?.to_string());
     let fn_name = to_lower_snake_case(&variant_name.to_string());
 
     // Return early if we've found an existing new fn
@@ -64,9 +66,12 @@ pub(crate) fn generate_enum_match_method(acc: &mut Assists, ctx: &AssistContext)
 
             format_to!(
                 buf,
-                "    {}fn is_{}(&self) -> bool {{
+                "    /// Returns `true` if the {} is [`{}`].
+    {}fn is_{}(&self) -> bool {{
         matches!(self, Self::{})
     }}",
+                enum_lowercase_name,
+                variant_name,
                 vis,
                 fn_name,
                 variant_name
@@ -133,6 +138,7 @@ enum Variant {
 }
 
 impl Variant {
+    /// Returns `true` if the variant is [`Minor`].
     fn is_minor(&self) -> bool {
         matches!(self, Self::Minor)
     }
@@ -180,6 +186,7 @@ enum Variant {
 enum Variant { Undefined }
 
 impl Variant {
+    /// Returns `true` if the variant is [`Undefined`].
     fn is_undefined(&self) -> bool {
         matches!(self, Self::Undefined)
     }
@@ -204,6 +211,7 @@ pub(crate) enum Variant {
 }
 
 impl Variant {
+    /// Returns `true` if the variant is [`Minor`].
     pub(crate) fn is_minor(&self) -> bool {
         matches!(self, Self::Minor)
     }

--- a/crates/assists/src/tests/generated.rs
+++ b/crates/assists/src/tests/generated.rs
@@ -451,6 +451,7 @@ enum Version {
 }
 
 impl Version {
+    /// Returns `true` if the version is [`Minor`].
     fn is_minor(&self) -> bool {
         matches!(self, Self::Minor)
     }


### PR DESCRIPTION
Implements a small extension to https://github.com/rust-analyzer/rust-analyzer/pull/7562, generating default comments. I wasn't sure if this would fit the goals of Rust-Analyzer, so I chose to split it into a separate PR. This is especially useful when writing code in a codebase which uses `#![warn(missing_docs)]` lint, as many production-grade libraries do.

The comments we're generating here are similar to the ones found on [`Option::is_some`](https://doc.rust-lang.org/std/option/enum.Option.html#method.is_some) and [`Result::is_err`](https://doc.rust-lang.org/std/result/enum.Result.html#method.is_err). I briefly considered only generating these for `pub` types, but they seem small and unobtrusive enough that they're probably useful in the general case. Thanks!

## Example

__input__
```rust
pub(crate) enum Variant {
    Undefined,
    Minor, // cursor here
    Major,
}
```

__output__
```rust
pub(crate) enum Variant {
    Undefined,
    Minor,
    Major,
}

impl Variant {
    /// Returns `true` if the variant is [`Minor`].
    pub(crate) fn is_minor(&self) -> bool {
        matches!(self, Self::Minor)
    }
}
```

## Future Directions

This opens up the path to adding an assist for generating these comments on existing `is_` methods. This would make it both easy to document new code, and update existing code with documentation.