### PR TITLE
Do not overwrite lock file

### DIFF
--- a/docs/dev/debugging.md
+++ b/docs/dev/debugging.md
@@ -10,7 +10,7 @@
 - Install all TypeScript dependencies
   ```bash
   cd editors/code
-  npm install
+  npm ci
   ```
 
 ## Common knowledge

--- a/xtask/src/install.rs
+++ b/xtask/src/install.rs
@@ -129,7 +129,7 @@ fn install_client(client_opt: ClientOpt) -> Result<()> {
 
     let installed_extensions = if cfg!(unix) {
         cmd!("npm --version").run().context("`npm` is required to build the VS Code plugin")?;
-        cmd!("npm install").run()?;
+        cmd!("npm ci").run()?;
 
         cmd!("npm run package --scripts-prepend-node-path").run()?;
 
@@ -140,7 +140,7 @@ fn install_client(client_opt: ClientOpt) -> Result<()> {
         cmd!("cmd.exe /c npm --version")
             .run()
             .context("`npm` is required to build the VS Code plugin")?;
-        cmd!("cmd.exe /c npm install").run()?;
+        cmd!("cmd.exe /c npm ci").run()?;
 
         cmd!("cmd.exe /c npm run package").run()?;
 


### PR DESCRIPTION
Use `npm ci` instead of `npm install`. `npm install` will overwrite
the lock file if you have a newer npm version than the one that
generated the package-lock.json