### PR TITLE
Remove various redundant clones

### DIFF
--- a/crates/assists/src/assist_context.rs
+++ b/crates/assists/src/assist_context.rs
@@ -162,7 +162,7 @@ impl Assists {
         } else {
             None
         };
-        assist.source_change = source_change.clone();
+        assist.source_change = source_change;
 
         self.buf.push(assist);
         Some(())
@@ -242,7 +242,7 @@ impl AssistBuilder {
     }
     pub(crate) fn create_file(&mut self, dst: AnchoredPathBuf, content: impl Into<String>) {
         let file_system_edit =
-            FileSystemEdit::CreateFile { dst: dst.clone(), initial_contents: content.into() };
+            FileSystemEdit::CreateFile { dst: dst, initial_contents: content.into() };
         self.source_change.push_file_system_edit(file_system_edit);
     }
 

--- a/crates/hir_def/src/body/lower.rs
+++ b/crates/hir_def/src/body/lower.rs
@@ -712,7 +712,7 @@ impl ExprCollector<'_> {
         let statements =
             block.statements().filter_map(|s| self.collect_stmt(s)).flatten().collect();
         let tail = block.tail_expr().map(|e| self.collect_expr(e));
-        let syntax_node_ptr = AstPtr::new(&block.clone().into());
+        let syntax_node_ptr = AstPtr::new(&block.into());
         let expr_id = self.alloc_expr(
             Expr::Block { id: block_id, statements, tail, label: None },
             syntax_node_ptr,

--- a/crates/hir_def/src/data.rs
+++ b/crates/hir_def/src/data.rs
@@ -43,7 +43,7 @@ impl FunctionData {
             name: func.name.clone(),
             params: func.params.iter().map(|id| item_tree[*id].clone()).collect(),
             ret_type: item_tree[func.ret_type].clone(),
-            attrs: item_tree.attrs(db, krate, ModItem::from(loc.id.value).into()).clone(),
+            attrs: item_tree.attrs(db, krate, ModItem::from(loc.id.value).into()),
             has_self_param: func.has_self_param,
             has_body: func.has_body,
             is_unsafe: func.is_unsafe,

--- a/crates/hir_def/src/test_db.rs
+++ b/crates/hir_def/src/test_db.rs
@@ -161,7 +161,7 @@ impl TestDB {
             let node = src.map(|ptr| ptr.to_node(&root));
             let frange = node.as_ref().original_file_range(db);
 
-            let message = d.message().to_owned();
+            let message = d.message();
             actual.entry(frange.file_id).or_default().push((frange.range, message));
         });
 

--- a/crates/hir_ty/src/diagnostics.rs
+++ b/crates/hir_ty/src/diagnostics.rs
@@ -480,7 +480,7 @@ mod tests {
             // FIXME: macros...
             let file_id = src.file_id.original_file(&db);
             let range = src.value.to_node(&root).text_range();
-            let message = d.message().to_owned();
+            let message = d.message();
             actual.entry(file_id).or_default().push((range, message));
         });
 

--- a/crates/proc_macro_api/src/rpc.rs
+++ b/crates/proc_macro_api/src/rpc.rs
@@ -262,7 +262,7 @@ mod tests {
 
         assert_eq!(task.macro_body, back.macro_body);
 
-        let result = ExpansionResult { expansion: tt.clone() };
+        let result = ExpansionResult { expansion: tt };
         let json = serde_json::to_string(&result).unwrap();
         let back: ExpansionResult = serde_json::from_str(&json).unwrap();
 

--- a/crates/test_utils/src/fixture.rs
+++ b/crates/test_utils/src/fixture.rs
@@ -95,16 +95,7 @@ impl Fixture {
             }
         }
 
-        Fixture {
-            path,
-            text: String::new(),
-            krate: krate,
-            deps,
-            cfg_atoms,
-            cfg_key_values,
-            edition,
-            env,
-        }
+        Fixture { path, text: String::new(), krate, deps, cfg_atoms, cfg_key_values, edition, env }
     }
 }
 


### PR DESCRIPTION
I noticed when running clippy through RA that there are a few instances where `clone` is called where it's not actually needed. I figured a small patch to remove these might be welcome here.

Thanks!