### PR TITLE
Fix/no floating promises

### DIFF
--- a/editors/code/.eslintrc.js
+++ b/editors/code/.eslintrc.js
@@ -33,6 +33,7 @@ module.exports = {
             "error",
             "always"
         ],
-        "@typescript-eslint/no-unnecessary-type-assertion": "error"
+        "@typescript-eslint/no-unnecessary-type-assertion": "error",
+        "@typescript-eslint/no-floating-promises": "error"
     }
 };

--- a/editors/code/.eslintrc.js
+++ b/editors/code/.eslintrc.js
@@ -14,7 +14,7 @@ module.exports = {
     "rules": {
         "camelcase": ["error"],
         "eqeqeq": ["error", "always", { "null": "ignore" }],
-        "no-console": ["error"],
+        "no-console": ["error", { allow: ["warn", "error"] }],
         "prefer-const": "error",
         "@typescript-eslint/member-delimiter-style": [
             "error",

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -138,7 +138,7 @@ export function createClient(serverPath: string, cwd: string, extraEnv: Env): lc
                                 command: "rust-analyzer.applyActionGroup",
                                 title: "",
                                 arguments: [items.map((item) => {
-                                    return { label: item.title, arguments: item.command!!.arguments!![0] };
+                                    return { label: item.title, arguments: item.command.arguments[0] };
                                 })],
                             };
 

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -138,7 +138,7 @@ export function createClient(serverPath: string, cwd: string, extraEnv: Env): lc
                                 command: "rust-analyzer.applyActionGroup",
                                 title: "",
                                 arguments: [items.map((item) => {
-                                    return { label: item.title, arguments: item.command.arguments[0] };
+                                    return { label: item.title, arguments: item.command!.arguments![0] };
                                 })],
                             };
 

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -11,7 +11,7 @@ export interface Env {
 }
 
 function renderCommand(cmd: ra.CommandLink) {
-    return `[${cmd.title}](command:${cmd.command}?${encodeURIComponent(JSON.stringify(cmd.arguments))} '${cmd.tooltip!}')`;
+    return `[${cmd.title}](command:${cmd.command}?${encodeURIComponent(JSON.stringify(cmd.arguments))} '${cmd.tooltip}')`;
 }
 
 function renderHoverActions(actions: ra.CommandLinkGroup[]): vscode.MarkdownString {

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -129,7 +129,8 @@ export function joinLines(ctx: Ctx): Cmd {
             client.protocol2CodeConverter.asTextEdits(items).forEach((edit: any) => {
                 builder.replace(edit.range, edit.newText);
             });
-        });
+        })
+        .then(() => {}, console.error);
     };
 }
 
@@ -246,7 +247,8 @@ export function ssr(ctx: Ctx): Cmd {
             });
 
             await vscode.workspace.applyEdit(client.protocol2CodeConverter.asWorkspaceEdit(edit));
-        });
+        })
+        .then(() => {}, console.error);
     };
 }
 
@@ -465,7 +467,8 @@ export function showReferences(ctx: Ctx): Cmd {
                 vscode.Uri.parse(uri),
                 client.protocol2CodeConverter.asPosition(position),
                 locations.map(client.protocol2CodeConverter.asLocation),
-            );
+            )
+            .then(() => {}, console.error);
         }
     };
 }
@@ -477,7 +480,8 @@ export function applyActionGroup(_ctx: Ctx): Cmd {
         vscode.commands.executeCommand(
             'rust-analyzer.resolveCodeAction',
             selectedAction.arguments,
-        );
+        )
+        .then(() => {}, console.error);
     };
 }
 
@@ -510,7 +514,8 @@ export function openDocs(ctx: Ctx): Cmd {
         const doclink = await client.sendRequest(ra.openDocs, { position, textDocument });
 
         if (doclink != null) {
-            vscode.commands.executeCommand("vscode.open", vscode.Uri.parse(doclink));
+            vscode.commands.executeCommand("vscode.open", vscode.Uri.parse(doclink))
+                .then(() => {}, console.error);
         }
     };
 

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -130,7 +130,7 @@ export function joinLines(ctx: Ctx): Cmd {
                 builder.replace(edit.range, edit.newText);
             });
         })
-        .then(() => {}, console.error);
+            .then(() => { }, console.error);
     };
 }
 
@@ -248,7 +248,7 @@ export function ssr(ctx: Ctx): Cmd {
 
             await vscode.workspace.applyEdit(client.protocol2CodeConverter.asWorkspaceEdit(edit));
         })
-        .then(() => {}, console.error);
+            .then(() => { }, console.error);
     };
 }
 
@@ -468,7 +468,7 @@ export function showReferences(ctx: Ctx): Cmd {
                 client.protocol2CodeConverter.asPosition(position),
                 locations.map(client.protocol2CodeConverter.asLocation),
             )
-            .then(() => {}, console.error);
+                .then(() => { }, console.error);
         }
     };
 }
@@ -481,7 +481,7 @@ export function applyActionGroup(_ctx: Ctx): Cmd {
             'rust-analyzer.resolveCodeAction',
             selectedAction.arguments,
         )
-        .then(() => {}, console.error);
+            .then(() => { }, console.error);
     };
 }
 
@@ -515,7 +515,7 @@ export function openDocs(ctx: Ctx): Cmd {
 
         if (doclink != null) {
             vscode.commands.executeCommand("vscode.open", vscode.Uri.parse(doclink))
-                .then(() => {}, console.error);
+                .then(() => { }, console.error);
         }
     };
 

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -125,12 +125,11 @@ export function joinLines(ctx: Ctx): Cmd {
             ranges: editor.selections.map((it) => client.code2ProtocolConverter.asRange(it)),
             textDocument: ctx.client.code2ProtocolConverter.asTextDocumentIdentifier(editor.document),
         });
-        editor.edit((builder) => {
+        await editor.edit((builder) => {
             client.protocol2CodeConverter.asTextEdits(items).forEach((edit: any) => {
                 builder.replace(edit.range, edit.newText);
             });
-        })
-            .then(() => { }, console.error);
+        });
     };
 }
 
@@ -237,7 +236,7 @@ export function ssr(ctx: Ctx): Cmd {
         const request = await vscode.window.showInputBox(options);
         if (!request) return;
 
-        vscode.window.withProgress({
+        await vscode.window.withProgress({
             location: vscode.ProgressLocation.Notification,
             title: "Structured search replace in progress...",
             cancellable: false,
@@ -247,8 +246,7 @@ export function ssr(ctx: Ctx): Cmd {
             });
 
             await vscode.workspace.applyEdit(client.protocol2CodeConverter.asWorkspaceEdit(edit));
-        })
-            .then(() => { }, console.error);
+        });
     };
 }
 
@@ -459,16 +457,15 @@ export function reloadWorkspace(ctx: Ctx): Cmd {
 }
 
 export function showReferences(ctx: Ctx): Cmd {
-    return (uri: string, position: lc.Position, locations: lc.Location[]) => {
+    return async (uri: string, position: lc.Position, locations: lc.Location[]) => {
         const client = ctx.client;
         if (client) {
-            vscode.commands.executeCommand(
+            await vscode.commands.executeCommand(
                 'editor.action.showReferences',
                 vscode.Uri.parse(uri),
                 client.protocol2CodeConverter.asPosition(position),
                 locations.map(client.protocol2CodeConverter.asLocation),
-            )
-                .then(() => { }, console.error);
+            );
         }
     };
 }
@@ -477,11 +474,10 @@ export function applyActionGroup(_ctx: Ctx): Cmd {
     return async (actions: { label: string; arguments: lc.CodeAction }[]) => {
         const selectedAction = await vscode.window.showQuickPick(actions);
         if (!selectedAction) return;
-        vscode.commands.executeCommand(
+        await vscode.commands.executeCommand(
             'rust-analyzer.resolveCodeAction',
             selectedAction.arguments,
-        )
-            .then(() => { }, console.error);
+        );
     };
 }
 
@@ -514,8 +510,7 @@ export function openDocs(ctx: Ctx): Cmd {
         const doclink = await client.sendRequest(ra.openDocs, { position, textDocument });
 
         if (doclink != null) {
-            vscode.commands.executeCommand("vscode.open", vscode.Uri.parse(doclink))
-                .then(() => { }, console.error);
+            await vscode.commands.executeCommand("vscode.open", vscode.Uri.parse(doclink));
         }
     };
 

--- a/editors/code/src/debug.ts
+++ b/editors/code/src/debug.ts
@@ -87,11 +87,11 @@ async function getDebugConfiguration(ctx: Ctx, runnable: ra.Runnable): Promise<v
         debugOutput.show(true);
     }
 
-    const isMultiFolderWorkspace = vscode.workspace.workspaceFolders!.length > 1;
-    const firstWorkspace = vscode.workspace.workspaceFolders![0]; // folder exists or RA is not active.
+    const isMultiFolderWorkspace = vscode.workspace.workspaceFolders.length > 1;
+    const firstWorkspace = vscode.workspace.workspaceFolders[0]; // folder exists or RA is not active.
     const workspace = !isMultiFolderWorkspace || !runnable.args.workspaceRoot ?
         firstWorkspace :
-        vscode.workspace.workspaceFolders!.find(w => runnable.args.workspaceRoot?.includes(w.uri.fsPath)) || firstWorkspace;
+        vscode.workspace.workspaceFolders.find(w => runnable.args.workspaceRoot?.includes(w.uri.fsPath)) || firstWorkspace;
 
     const wsFolder = path.normalize(workspace.uri.fsPath);
     const workspaceQualifier = isMultiFolderWorkspace ? `:${workspace.name}` : '';

--- a/editors/code/src/debug.ts
+++ b/editors/code/src/debug.ts
@@ -79,7 +79,7 @@ async function getDebugConfiguration(ctx: Ctx, runnable: ra.Runnable): Promise<v
     if (!debugEngine) {
         vscode.window.showErrorMessage(`Install [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb)`
             + ` or [MS C++ tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) extension for debugging.`)
-            .then(() => {}, console.error);
+            .then(() => { }, console.error);
         return;
     }
 

--- a/editors/code/src/debug.ts
+++ b/editors/code/src/debug.ts
@@ -87,12 +87,14 @@ async function getDebugConfiguration(ctx: Ctx, runnable: ra.Runnable): Promise<v
     if (ctx.config.debug.openDebugPane) {
         debugOutput.show(true);
     }
-
-    const isMultiFolderWorkspace = vscode.workspace.workspaceFolders.length > 1;
-    const firstWorkspace = vscode.workspace.workspaceFolders[0]; // folder exists or RA is not active.
+    // folder exists or RA is not active.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+    const workspaceFolders = vscode.workspace.workspaceFolders!;
+    const isMultiFolderWorkspace = workspaceFolders.length > 1;
+    const firstWorkspace = workspaceFolders[0];
     const workspace = !isMultiFolderWorkspace || !runnable.args.workspaceRoot ?
         firstWorkspace :
-        vscode.workspace.workspaceFolders.find(w => runnable.args.workspaceRoot?.includes(w.uri.fsPath)) || firstWorkspace;
+        workspaceFolders.find(w => runnable.args.workspaceRoot?.includes(w.uri.fsPath)) || firstWorkspace;
 
     const wsFolder = path.normalize(workspace.uri.fsPath);
     const workspaceQualifier = isMultiFolderWorkspace ? `:${workspace.name}` : '';

--- a/editors/code/src/debug.ts
+++ b/editors/code/src/debug.ts
@@ -78,7 +78,8 @@ async function getDebugConfiguration(ctx: Ctx, runnable: ra.Runnable): Promise<v
 
     if (!debugEngine) {
         vscode.window.showErrorMessage(`Install [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb)`
-            + ` or [MS C++ tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) extension for debugging.`);
+            + ` or [MS C++ tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) extension for debugging.`)
+            .then(() => {}, console.error);
         return;
     }
 

--- a/editors/code/src/debug.ts
+++ b/editors/code/src/debug.ts
@@ -77,9 +77,8 @@ async function getDebugConfiguration(ctx: Ctx, runnable: ra.Runnable): Promise<v
     }
 
     if (!debugEngine) {
-        vscode.window.showErrorMessage(`Install [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb)`
-            + ` or [MS C++ tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) extension for debugging.`)
-            .then(() => { }, console.error);
+        await vscode.window.showErrorMessage(`Install [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb)`
+            + ` or [MS C++ tools](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) extension for debugging.`);
         return;
     }
 

--- a/editors/code/src/inlay_hints.ts
+++ b/editors/code/src/inlay_hints.ts
@@ -36,7 +36,7 @@ export function activateInlayHints(ctx: Ctx) {
         maybeUpdater.onConfigChange, maybeUpdater, ctx.subscriptions
     );
 
-    maybeUpdater.onConfigChange();
+    maybeUpdater.onConfigChange().catch(console.error);
 }
 
 const typeHints = createHintStyle("type");

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -76,7 +76,8 @@ async function tryActivate(context: vscode.ExtensionContext) {
     // This a horribly, horribly wrong way to deal with this problem.
     ctx = await Ctx.create(config, context, serverPath, workspaceFolder.uri.fsPath);
 
-    setContextValue(RUST_PROJECT_CONTEXT_NAME, true);
+    setContextValue(RUST_PROJECT_CONTEXT_NAME, true)
+        .then(() => {}, console.error);
 
     // Commands which invokes manually via command palette, shortcut, etc.
 
@@ -142,7 +143,8 @@ async function tryActivate(context: vscode.ExtensionContext) {
 }
 
 export async function deactivate() {
-    setContextValue(RUST_PROJECT_CONTEXT_NAME, undefined);
+    setContextValue(RUST_PROJECT_CONTEXT_NAME, undefined)
+        .then(() => {}, console.error);
     await ctx?.client.stop();
     ctx = undefined;
 }
@@ -186,7 +188,8 @@ async function bootstrapExtension(config: Config, state: PersistentState): Promi
     }).catch((e) => {
         log.error(e);
         if (state.releaseId === undefined) { // Show error only for the initial download
-            vscode.window.showErrorMessage(`Failed to download rust-analyzer nightly ${e}`);
+            vscode.window.showErrorMessage(`Failed to download rust-analyzer nightly ${e}`)
+                .then(() => {}, console.error);
         }
         return undefined;
     });
@@ -305,7 +308,7 @@ async function getServer(config: Config, state: PersistentState): Promise<string
             "If you feel that your platform should be supported, please create an issue " +
             "about that [here](https://github.com/rust-analyzer/rust-analyzer/issues) and we " +
             "will consider it."
-        );
+        ).then(() => {}, console.error);
         return undefined;
     }
     const ext = platform.indexOf("-windows-") !== -1 ? ".exe" : "";
@@ -433,6 +436,7 @@ function warnAboutExtensionConflicts() {
         vscode.window.showWarningMessage(
             `You have both the ${fst[0]} (${fst[1]}) and ${sec[0]} (${sec[1]}) ` +
             "plugins enabled. These are known to conflict and cause various functions of " +
-            "both plugins to not work correctly. You should disable one of them.", "Got it");
+            "both plugins to not work correctly. You should disable one of them.", "Got it")
+            .then(() => {}, console.error);
     };
 }

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -76,8 +76,7 @@ async function tryActivate(context: vscode.ExtensionContext) {
     // This a horribly, horribly wrong way to deal with this problem.
     ctx = await Ctx.create(config, context, serverPath, workspaceFolder.uri.fsPath);
 
-    setContextValue(RUST_PROJECT_CONTEXT_NAME, true)
-        .then(() => { }, console.error);
+    await setContextValue(RUST_PROJECT_CONTEXT_NAME, true);
 
     // Commands which invokes manually via command palette, shortcut, etc.
 
@@ -143,8 +142,7 @@ async function tryActivate(context: vscode.ExtensionContext) {
 }
 
 export async function deactivate() {
-    setContextValue(RUST_PROJECT_CONTEXT_NAME, undefined)
-        .then(() => { }, console.error);
+    await setContextValue(RUST_PROJECT_CONTEXT_NAME, undefined);
     await ctx?.client.stop();
     ctx = undefined;
 }
@@ -185,11 +183,10 @@ async function bootstrapExtension(config: Config, state: PersistentState): Promi
 
     const release = await downloadWithRetryDialog(state, async () => {
         return await fetchRelease("nightly", state.githubToken);
-    }).catch((e) => {
+    }).catch(async (e) => {
         log.error(e);
         if (state.releaseId === undefined) { // Show error only for the initial download
-            vscode.window.showErrorMessage(`Failed to download rust-analyzer nightly ${e}`)
-                .then(() => { }, console.error);
+            await vscode.window.showErrorMessage(`Failed to download rust-analyzer nightly ${e}`);
         }
         return undefined;
     });
@@ -301,14 +298,14 @@ async function getServer(config: Config, state: PersistentState): Promise<string
     };
     const platform = platforms[`${process.arch} ${process.platform}`];
     if (platform === undefined) {
-        vscode.window.showErrorMessage(
+        await vscode.window.showErrorMessage(
             "Unfortunately we don't ship binaries for your platform yet. " +
             "You need to manually clone rust-analyzer repository and " +
             "run `cargo xtask install --server` to build the language server from sources. " +
             "If you feel that your platform should be supported, please create an issue " +
             "about that [here](https://github.com/rust-analyzer/rust-analyzer/issues) and we " +
             "will consider it."
-        ).then(() => { }, console.error);
+        );
         return undefined;
     }
     const ext = platform.indexOf("-windows-") !== -1 ? ".exe" : "";

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -77,7 +77,7 @@ async function tryActivate(context: vscode.ExtensionContext) {
     ctx = await Ctx.create(config, context, serverPath, workspaceFolder.uri.fsPath);
 
     setContextValue(RUST_PROJECT_CONTEXT_NAME, true)
-        .then(() => {}, console.error);
+        .then(() => { }, console.error);
 
     // Commands which invokes manually via command palette, shortcut, etc.
 
@@ -144,7 +144,7 @@ async function tryActivate(context: vscode.ExtensionContext) {
 
 export async function deactivate() {
     setContextValue(RUST_PROJECT_CONTEXT_NAME, undefined)
-        .then(() => {}, console.error);
+        .then(() => { }, console.error);
     await ctx?.client.stop();
     ctx = undefined;
 }
@@ -189,7 +189,7 @@ async function bootstrapExtension(config: Config, state: PersistentState): Promi
         log.error(e);
         if (state.releaseId === undefined) { // Show error only for the initial download
             vscode.window.showErrorMessage(`Failed to download rust-analyzer nightly ${e}`)
-                .then(() => {}, console.error);
+                .then(() => { }, console.error);
         }
         return undefined;
     });
@@ -308,7 +308,7 @@ async function getServer(config: Config, state: PersistentState): Promise<string
             "If you feel that your platform should be supported, please create an issue " +
             "about that [here](https://github.com/rust-analyzer/rust-analyzer/issues) and we " +
             "will consider it."
-        ).then(() => {}, console.error);
+        ).then(() => { }, console.error);
         return undefined;
     }
     const ext = platform.indexOf("-windows-") !== -1 ? ".exe" : "";
@@ -437,6 +437,6 @@ function warnAboutExtensionConflicts() {
             `You have both the ${fst[0]} (${fst[1]}) and ${sec[0]} (${sec[1]}) ` +
             "plugins enabled. These are known to conflict and cause various functions of " +
             "both plugins to not work correctly. You should disable one of them.", "Got it")
-            .then(() => {}, console.error);
+            .then(() => { }, console.error);
     };
 }

--- a/editors/code/src/run.ts
+++ b/editors/code/src/run.ts
@@ -145,7 +145,7 @@ export async function createTask(runnable: ra.Runnable, config: Config): Promise
         overrideCargo: runnable.args.overrideCargo,
     };
 
-    const target = vscode.workspace.workspaceFolders![0]; // safe, see main activate()
+    const target = vscode.workspace.workspaceFolders[0]; // safe, see main activate()
     const cargoTask = await tasks.buildCargoTask(target, definition, runnable.label, args, config.cargoRunner, true);
     cargoTask.presentationOptions.clear = true;
 

--- a/editors/code/src/run.ts
+++ b/editors/code/src/run.ts
@@ -46,7 +46,7 @@ export async function selectRunnable(ctx: Ctx, prevRunnable?: RunnableQuickPick,
         // it is the debug case, run always has at least 'cargo check ...'
         // see crates\rust-analyzer\src\main_loop\handlers.rs, handle_runnables
         vscode.window.showErrorMessage("There's no debug target!")
-            .then(() => {}, console.error);
+            .then(() => { }, console.error);
         return;
     }
 

--- a/editors/code/src/run.ts
+++ b/editors/code/src/run.ts
@@ -45,7 +45,8 @@ export async function selectRunnable(ctx: Ctx, prevRunnable?: RunnableQuickPick,
     if (items.length === 0) {
         // it is the debug case, run always has at least 'cargo check ...'
         // see crates\rust-analyzer\src\main_loop\handlers.rs, handle_runnables
-        vscode.window.showErrorMessage("There's no debug target!");
+        vscode.window.showErrorMessage("There's no debug target!")
+            .then(() => {}, console.error);
         return;
     }
 

--- a/editors/code/src/run.ts
+++ b/editors/code/src/run.ts
@@ -66,7 +66,7 @@ export async function selectRunnable(ctx: Ctx, prevRunnable?: RunnableQuickPick,
             quickPick.onDidHide(() => close()),
             quickPick.onDidAccept(() => close(quickPick.selectedItems[0])),
             quickPick.onDidTriggerButton((_button) => {
-                (async () => await makeDebugConfig(ctx, quickPick.activeItems[0].runnable))();
+                makeDebugConfig(ctx, quickPick.activeItems[0].runnable).catch(console.error);
                 close();
             }),
             quickPick.onDidChangeActive((active) => {

--- a/editors/code/src/run.ts
+++ b/editors/code/src/run.ts
@@ -146,7 +146,8 @@ export async function createTask(runnable: ra.Runnable, config: Config): Promise
         overrideCargo: runnable.args.overrideCargo,
     };
 
-    const target = vscode.workspace.workspaceFolders[0]; // safe, see main activate()
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+    const target = vscode.workspace.workspaceFolders![0]; // safe, see main activate()
     const cargoTask = await tasks.buildCargoTask(target, definition, runnable.label, args, config.cargoRunner, true);
     cargoTask.presentationOptions.clear = true;
 

--- a/editors/code/src/run.ts
+++ b/editors/code/src/run.ts
@@ -45,8 +45,7 @@ export async function selectRunnable(ctx: Ctx, prevRunnable?: RunnableQuickPick,
     if (items.length === 0) {
         // it is the debug case, run always has at least 'cargo check ...'
         // see crates\rust-analyzer\src\main_loop\handlers.rs, handle_runnables
-        vscode.window.showErrorMessage("There's no debug target!")
-            .then(() => { }, console.error);
+        await vscode.window.showErrorMessage("There's no debug target!");
         return;
     }
 
@@ -66,8 +65,8 @@ export async function selectRunnable(ctx: Ctx, prevRunnable?: RunnableQuickPick,
         disposables.push(
             quickPick.onDidHide(() => close()),
             quickPick.onDidAccept(() => close(quickPick.selectedItems[0])),
-            quickPick.onDidTriggerButton((_button) => {
-                makeDebugConfig(ctx, quickPick.activeItems[0].runnable).catch(console.error);
+            quickPick.onDidTriggerButton(async (_button) => {
+                await makeDebugConfig(ctx, quickPick.activeItems[0].runnable);
                 close();
             }),
             quickPick.onDidChangeActive((active) => {

--- a/editors/code/src/snippets.ts
+++ b/editors/code/src/snippets.ts
@@ -62,6 +62,8 @@ function parseSnippet(snip: string): [string, [number, number]] | undefined {
     const m = snip.match(/\$(0|\{0:([^}]*)\})/);
     if (!m) return undefined;
     const placeholder = m[2] ?? "";
+    if (m.index == null)
+        return undefined;
     const range: [number, number] = [m.index, placeholder.length];
     const insert = snip.replace(m[0], placeholder);
     return [insert, range];

--- a/editors/code/src/snippets.ts
+++ b/editors/code/src/snippets.ts
@@ -62,7 +62,7 @@ function parseSnippet(snip: string): [string, [number, number]] | undefined {
     const m = snip.match(/\$(0|\{0:([^}]*)\})/);
     if (!m) return undefined;
     const placeholder = m[2] ?? "";
-    const range: [number, number] = [m.index!!, placeholder.length];
+    const range: [number, number] = [m.index, placeholder.length];
     const insert = snip.replace(m[0], placeholder);
     return [insert, range];
 }


### PR DESCRIPTION
closes #3515

- added `@typescript-eslint/no-floating-promises: error` rule
- changed `"no-console": ["error"]` to `"no-console": ["error", { allow: ["warn", "error"] }]` (we at least log the error messages of the floating promises)
- fixed lint/compile errors