### PR TITLE
Add `config: &CargoConfig` parameter to `fn load_cargo(…)`

### DIFF
--- a/crates/rust-analyzer/src/cli/analysis_bench.rs
+++ b/crates/rust-analyzer/src/cli/analysis_bench.rs
@@ -59,7 +59,12 @@ impl BenchCmd {
 
         let start = Instant::now();
         eprint!("loading: ");
-        let (mut host, vfs) = load_cargo(&self.path, self.load_output_dirs, self.with_proc_macro)?;
+        let (mut host, vfs) = load_cargo(
+            &self.path,
+            &Default::default(),
+            self.load_output_dirs,
+            self.with_proc_macro,
+        )?;
         eprintln!("{:?}\n", start.elapsed());
 
         let file_id = {

--- a/crates/rust-analyzer/src/cli/analysis_bench.rs
+++ b/crates/rust-analyzer/src/cli/analysis_bench.rs
@@ -16,7 +16,10 @@ use ide_db::{
 };
 use vfs::AbsPathBuf;
 
-use crate::cli::{load_cargo::load_cargo, print_memory_usage, Verbosity};
+use crate::cli::{
+    load_cargo::{load_cargo, LoadCargoConfig},
+    print_memory_usage, Verbosity,
+};
 
 pub struct BenchCmd {
     pub path: PathBuf,
@@ -59,12 +62,14 @@ impl BenchCmd {
 
         let start = Instant::now();
         eprint!("loading: ");
-        let (mut host, vfs) = load_cargo(
-            &self.path,
-            &Default::default(),
-            self.load_output_dirs,
-            self.with_proc_macro,
-        )?;
+
+        let load_cargo_config = LoadCargoConfig {
+            cargo_config: Default::default(),
+            load_out_dirs_from_check: self.load_output_dirs,
+            with_proc_macro: self.with_proc_macro,
+        };
+
+        let (mut host, vfs) = load_cargo(&self.path, &load_cargo_config)?;
         eprintln!("{:?}\n", start.elapsed());
 
         let file_id = {

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -57,7 +57,12 @@ impl AnalysisStatsCmd {
         };
 
         let mut db_load_sw = self.stop_watch();
-        let (host, vfs) = load_cargo(&self.path, self.load_output_dirs, self.with_proc_macro)?;
+        let (host, vfs) = load_cargo(
+            &self.path,
+            &Default::default(),
+            self.load_output_dirs,
+            self.with_proc_macro,
+        )?;
         let db = host.raw_database();
         eprintln!("{:<20} {}", "Database loaded:", db_load_sw.elapsed());
 

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -25,8 +25,10 @@ use stdx::format_to;
 use syntax::AstNode;
 
 use crate::cli::{
-    load_cargo::load_cargo, print_memory_usage, progress_report::ProgressReport, report_metric,
-    Result, Verbosity,
+    load_cargo::{load_cargo, LoadCargoConfig},
+    print_memory_usage,
+    progress_report::ProgressReport,
+    report_metric, Result, Verbosity,
 };
 use profile::StopWatch;
 
@@ -57,12 +59,12 @@ impl AnalysisStatsCmd {
         };
 
         let mut db_load_sw = self.stop_watch();
-        let (host, vfs) = load_cargo(
-            &self.path,
-            &Default::default(),
-            self.load_output_dirs,
-            self.with_proc_macro,
-        )?;
+        let load_cargo_config = LoadCargoConfig {
+            cargo_config: Default::default(),
+            load_out_dirs_from_check: self.load_output_dirs,
+            with_proc_macro: self.with_proc_macro,
+        };
+        let (host, vfs) = load_cargo(&self.path, &load_cargo_config)?;
         let db = host.raw_database();
         eprintln!("{:<20} {}", "Database loaded:", db_load_sw.elapsed());
 

--- a/crates/rust-analyzer/src/cli/diagnostics.rs
+++ b/crates/rust-analyzer/src/cli/diagnostics.rs
@@ -10,7 +10,10 @@ use hir::{db::HirDatabase, Crate, Module};
 use ide::{DiagnosticsConfig, Severity};
 use ide_db::base_db::SourceDatabaseExt;
 
-use crate::cli::{load_cargo::load_cargo, Result};
+use crate::cli::{
+    load_cargo::{load_cargo, LoadCargoConfig},
+    Result,
+};
 
 fn all_modules(db: &dyn HirDatabase) -> Vec<Module> {
     let mut worklist: Vec<_> =
@@ -25,8 +28,17 @@ fn all_modules(db: &dyn HirDatabase) -> Vec<Module> {
     modules
 }
 
-pub fn diagnostics(path: &Path, load_output_dirs: bool, with_proc_macro: bool) -> Result<()> {
-    let (host, _vfs) = load_cargo(path, &Default::default(), load_output_dirs, with_proc_macro)?;
+pub fn diagnostics(
+    path: &Path,
+    load_out_dirs_from_check: bool,
+    with_proc_macro: bool,
+) -> Result<()> {
+    let load_cargo_config = LoadCargoConfig {
+        cargo_config: Default::default(),
+        load_out_dirs_from_check,
+        with_proc_macro,
+    };
+    let (host, _vfs) = load_cargo(path, &load_cargo_config)?;
     let db = host.raw_database();
     let analysis = host.analysis();
 

--- a/crates/rust-analyzer/src/cli/diagnostics.rs
+++ b/crates/rust-analyzer/src/cli/diagnostics.rs
@@ -26,7 +26,7 @@ fn all_modules(db: &dyn HirDatabase) -> Vec<Module> {
 }
 
 pub fn diagnostics(path: &Path, load_output_dirs: bool, with_proc_macro: bool) -> Result<()> {
-    let (host, _vfs) = load_cargo(path, load_output_dirs, with_proc_macro)?;
+    let (host, _vfs) = load_cargo(path, &Default::default(), load_output_dirs, with_proc_macro)?;
     let db = host.raw_database();
     let analysis = host.analysis();
 

--- a/crates/rust-analyzer/src/cli/load_cargo.rs
+++ b/crates/rust-analyzer/src/cli/load_cargo.rs
@@ -15,12 +15,13 @@ use crate::reload::{ProjectFolders, SourceRootConfig};
 
 pub fn load_cargo(
     root: &Path,
+    config: &CargoConfig,
     load_out_dirs_from_check: bool,
     with_proc_macro: bool,
 ) -> Result<(AnalysisHost, vfs::Vfs)> {
     let root = AbsPathBuf::assert(std::env::current_dir()?.join(root));
     let root = ProjectManifest::discover_single(&root)?;
-    let ws = ProjectWorkspace::load(root, &CargoConfig::default(), &|_| {})?;
+    let ws = ProjectWorkspace::load(root, config, &|_| {})?;
 
     let (sender, receiver) = unbounded();
     let mut vfs = vfs::Vfs::default();
@@ -116,7 +117,7 @@ mod tests {
     #[test]
     fn test_loading_rust_analyzer() {
         let path = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap().parent().unwrap();
-        let (host, _vfs) = load_cargo(path, false, false).unwrap();
+        let (host, _vfs) = load_cargo(path, &Default::default(), false, false).unwrap();
         let n_crates = Crate::all(host.raw_database()).len();
         // RA has quite a few crates, but the exact count doesn't matter
         assert!(n_crates > 20);

--- a/crates/rust-analyzer/src/cli/ssr.rs
+++ b/crates/rust-analyzer/src/cli/ssr.rs
@@ -5,7 +5,7 @@ use ssr::{MatchFinder, SsrPattern, SsrRule};
 
 pub fn apply_ssr_rules(rules: Vec<SsrRule>) -> Result<()> {
     use ide_db::base_db::SourceDatabaseExt;
-    let (host, vfs) = load_cargo(&std::env::current_dir()?, true, true)?;
+    let (host, vfs) = load_cargo(&std::env::current_dir()?, &Default::default(), true, true)?;
     let db = host.raw_database();
     let mut match_finder = MatchFinder::at_first_file(db)?;
     for rule in rules {
@@ -28,7 +28,7 @@ pub fn apply_ssr_rules(rules: Vec<SsrRule>) -> Result<()> {
 pub fn search_for_patterns(patterns: Vec<SsrPattern>, debug_snippet: Option<String>) -> Result<()> {
     use ide_db::base_db::SourceDatabaseExt;
     use ide_db::symbol_index::SymbolsDatabase;
-    let (host, _vfs) = load_cargo(&std::env::current_dir()?, true, true)?;
+    let (host, _vfs) = load_cargo(&std::env::current_dir()?, &Default::default(), true, true)?;
     let db = host.raw_database();
     let mut match_finder = MatchFinder::at_first_file(db)?;
     for pattern in patterns {

--- a/crates/rust-analyzer/src/cli/ssr.rs
+++ b/crates/rust-analyzer/src/cli/ssr.rs
@@ -1,11 +1,19 @@
 //! Applies structured search replace rules from the command line.
 
-use crate::cli::{load_cargo::load_cargo, Result};
+use crate::cli::{
+    load_cargo::{load_cargo, LoadCargoConfig},
+    Result,
+};
 use ssr::{MatchFinder, SsrPattern, SsrRule};
 
 pub fn apply_ssr_rules(rules: Vec<SsrRule>) -> Result<()> {
     use ide_db::base_db::SourceDatabaseExt;
-    let (host, vfs) = load_cargo(&std::env::current_dir()?, &Default::default(), true, true)?;
+    let load_cargo_config = LoadCargoConfig {
+        cargo_config: Default::default(),
+        load_out_dirs_from_check: true,
+        with_proc_macro: true,
+    };
+    let (host, vfs) = load_cargo(&std::env::current_dir()?, &load_cargo_config)?;
     let db = host.raw_database();
     let mut match_finder = MatchFinder::at_first_file(db)?;
     for rule in rules {
@@ -28,7 +36,12 @@ pub fn apply_ssr_rules(rules: Vec<SsrRule>) -> Result<()> {
 pub fn search_for_patterns(patterns: Vec<SsrPattern>, debug_snippet: Option<String>) -> Result<()> {
     use ide_db::base_db::SourceDatabaseExt;
     use ide_db::symbol_index::SymbolsDatabase;
-    let (host, _vfs) = load_cargo(&std::env::current_dir()?, &Default::default(), true, true)?;
+    let load_cargo_config = LoadCargoConfig {
+        cargo_config: Default::default(),
+        load_out_dirs_from_check: true,
+        with_proc_macro: true,
+    };
+    let (host, _vfs) = load_cargo(&std::env::current_dir()?, &load_cargo_config)?;
     let db = host.raw_database();
     let mut match_finder = MatchFinder::at_first_file(db)?;
     for pattern in patterns {


### PR DESCRIPTION
For projects using rust-analyzer as a library it is desirable to be able to provide a custom-config to `fn load_cargo(…)` to pass features, etc, rather than having to copy & paste `fn load_cargo(…)` into one's project and maintain a fork of it and keep it in sync with upstream.