### PR TITLE
Set remote branch on xtask promote

### DIFF
--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -99,7 +99,7 @@ impl PromoteCmd {
         cmd!("git add src/tools/rust-analyzer").run()?;
         cmd!("git commit -m':arrow_up: rust-analyzer'").run()?;
         if !self.dry_run {
-            cmd!("git push").run()?;
+            cmd!("git push -u").run()?;
             cmd!("xdg-open https://github.com/matklad/rust/pull/new/{branch}?body=r%3F%20%40ghost")
                 .run()?;
         }


### PR DESCRIPTION
to hopefully fix this:

```
$ git switch master
Already on 'master'
Your branch is up to date with 'upstream/master'.
$ git fetch upstream
$ git reset --hard upstream/master
HEAD is now at 921ec4b3fca Auto merge of #81313 - LeSeulArtichaut:revert-32558, r=jyn514
$ git submodule update --recursive
Submodule path 'src/tools/rust-analyzer': checked out '1a59f75cdaa730c16a694a4294eccf6dfe6fe0ad'
$ git switch -c rust-analyzer-2021-02-08
Switched to a new branch 'rust-analyzer-2021-02-08'
$ git fetch origin
$ git reset --hard origin/release
HEAD is now at 336909b63 Merge #7587
$ git add src/tools/rust-analyzer
$ git commit "-m:arrow_up: rust-analyzer"
[rust-analyzer-2021-02-08 1774ec1a683] :arrow_up: rust-analyzer
 1 file changed, 1 insertion(+), 1 deletion(-)
$ git push
fatal: The current branch rust-analyzer-2021-02-08 has no upstream branch.
To push the current branch and set the remote as upstream, use

    git push --set-upstream origin rust-analyzer-2021-02-08

Error: command `git push` failed, exit code: 128
```