### PR TITLE
Add getter/setter assists

### DIFF
--- a/crates/assists/src/handlers/generate_enum_match_method.rs
+++ b/crates/assists/src/handlers/generate_enum_match_method.rs
@@ -4,7 +4,7 @@ use syntax::ast::{self, AstNode, NameOwner};
 use test_utils::mark;
 
 use crate::{
-    utils::{find_impl_block, find_struct_impl},
+    utils::{find_impl_block, find_struct_impl, generate_impl_text},
     AssistContext, AssistId, AssistKind, Assists,
 };
 
@@ -82,23 +82,13 @@ pub(crate) fn generate_enum_match_method(acc: &mut Assists, ctx: &AssistContext)
             let start_offset = impl_def
                 .and_then(|impl_def| find_impl_block(impl_def, &mut buf))
                 .unwrap_or_else(|| {
-                    buf = generate_impl_text(&parent_enum, &buf);
+                    buf = generate_impl_text(&ast::Adt::Enum(parent_enum.clone()), &buf);
                     parent_enum.syntax().text_range().end()
                 });
 
             builder.insert(start_offset, buf);
         },
     )
-}
-
-// Generates the surrounding `impl Type { <code> }` including type and lifetime
-// parameters
-fn generate_impl_text(strukt: &ast::Enum, code: &str) -> String {
-    let mut buf = String::with_capacity(code.len());
-    buf.push_str("\n\nimpl ");
-    buf.push_str(strukt.name().unwrap().text());
-    format_to!(buf, " {{\n{}\n}}", code);
-    buf
 }
 
 #[cfg(test)]

--- a/crates/assists/src/handlers/generate_getter.rs
+++ b/crates/assists/src/handlers/generate_getter.rs
@@ -1,0 +1,156 @@
+use stdx::{format_to, to_lower_snake_case};
+use syntax::ast::VisibilityOwner;
+use syntax::ast::{self, AstNode, NameOwner};
+
+use crate::{
+    utils::{find_impl_block, find_struct_impl, generate_impl_text},
+    AssistContext, AssistId, AssistKind, Assists,
+};
+
+// Assist: generate_getter
+//
+// Generate a getter method.
+//
+// ```
+// struct Person {
+//     nam$0e: String,
+// }
+// ```
+// ->
+// ```
+// struct Person {
+//     name: String,
+// }
+//
+// impl Person {
+//     /// Get a reference to the person's name.
+//     fn name(&self) -> &String {
+//         &self.name
+//     }
+// }
+// ```
+pub(crate) fn generate_getter(acc: &mut Assists, ctx: &AssistContext) -> Option<()> {
+    let strukt = ctx.find_node_at_offset::<ast::Struct>()?;
+    let field = ctx.find_node_at_offset::<ast::RecordField>()?;
+
+    let strukt_name = strukt.name()?;
+    let field_name = field.name()?;
+    let field_ty = field.ty()?;
+
+    // Return early if we've found an existing fn
+    let fn_name = to_lower_snake_case(&field_name.to_string());
+    let impl_def = find_struct_impl(&ctx, &ast::Adt::Struct(strukt.clone()), fn_name.as_str())?;
+
+    let target = field.syntax().text_range();
+    acc.add(
+        AssistId("generate_getter", AssistKind::Generate),
+        "Generate a getter method",
+        target,
+        |builder| {
+            let mut buf = String::with_capacity(512);
+
+            let fn_name_spaced = fn_name.replace('_', " ");
+            let strukt_name_spaced =
+                to_lower_snake_case(&strukt_name.to_string()).replace('_', " ");
+
+            if impl_def.is_some() {
+                buf.push('\n');
+            }
+
+            let vis = strukt.visibility().map_or(String::new(), |v| format!("{} ", v));
+            format_to!(
+                buf,
+                "    /// Get a reference to the {}'s {}.
+    {}fn {}(&self) -> &{} {{
+        &self.{}
+    }}",
+                strukt_name_spaced,
+                fn_name_spaced,
+                vis,
+                fn_name,
+                field_ty,
+                fn_name,
+            );
+
+            let start_offset = impl_def
+                .and_then(|impl_def| find_impl_block(impl_def, &mut buf))
+                .unwrap_or_else(|| {
+                    buf = generate_impl_text(&ast::Adt::Struct(strukt.clone()), &buf);
+                    strukt.syntax().text_range().end()
+                });
+
+            builder.insert(start_offset, buf);
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::{check_assist, check_assist_not_applicable};
+
+    use super::*;
+
+    fn check_not_applicable(ra_fixture: &str) {
+        check_assist_not_applicable(generate_getter, ra_fixture)
+    }
+
+    #[test]
+    fn test_generate_getter_from_field() {
+        check_assist(
+            generate_getter,
+            r#"
+struct Context<T: Clone> {
+    dat$0a: T,
+}"#,
+            r#"
+struct Context<T: Clone> {
+    data: T,
+}
+
+impl<T: Clone> Context<T> {
+    /// Get a reference to the context's data.
+    fn data(&self) -> &T {
+        &self.data
+    }
+}"#,
+        );
+    }
+
+    #[test]
+    fn test_generate_getter_already_implemented() {
+        check_not_applicable(
+            r#"
+struct Context<T: Clone> {
+    dat$0a: T,
+}
+
+impl<T: Clone> Context<T> {
+    fn data(&self) -> &T {
+        &self.data
+    }
+}"#,
+        );
+    }
+
+    #[test]
+    fn test_generate_getter_from_field_with_visibility_marker() {
+        check_assist(
+            generate_getter,
+            r#"
+pub(crate) struct Context<T: Clone> {
+    dat$0a: T,
+}"#,
+            r#"
+pub(crate) struct Context<T: Clone> {
+    data: T,
+}
+
+impl<T: Clone> Context<T> {
+    /// Get a reference to the context's data.
+    pub(crate) fn data(&self) -> &T {
+        &self.data
+    }
+}"#,
+        );
+    }
+}

--- a/crates/assists/src/handlers/generate_getter_mut.rs
+++ b/crates/assists/src/handlers/generate_getter_mut.rs
@@ -1,0 +1,159 @@
+use stdx::{format_to, to_lower_snake_case};
+use syntax::ast::VisibilityOwner;
+use syntax::ast::{self, AstNode, NameOwner};
+
+use crate::{
+    utils::{find_impl_block, find_struct_impl, generate_impl_text},
+    AssistContext, AssistId, AssistKind, Assists,
+};
+
+// Assist: generate_getter_mut
+//
+// Generate a mut getter method.
+//
+// ```
+// struct Person {
+//     nam$0e: String,
+// }
+// ```
+// ->
+// ```
+// struct Person {
+//     name: String,
+// }
+//
+// impl Person {
+//     /// Get a mutable reference to the person's name.
+//     fn name_mut(&mut self) -> &mut String {
+//         &mut self.name
+//     }
+// }
+// ```
+pub(crate) fn generate_getter_mut(acc: &mut Assists, ctx: &AssistContext) -> Option<()> {
+    let strukt = ctx.find_node_at_offset::<ast::Struct>()?;
+    let field = ctx.find_node_at_offset::<ast::RecordField>()?;
+
+    let strukt_name = strukt.name()?;
+    let field_name = field.name()?;
+    let field_ty = field.ty()?;
+
+    // Return early if we've found an existing fn
+    let fn_name = to_lower_snake_case(&field_name.to_string());
+    let impl_def = find_struct_impl(
+        &ctx,
+        &ast::Adt::Struct(strukt.clone()),
+        format!("{}_mut", fn_name).as_str(),
+    )?;
+
+    let target = field.syntax().text_range();
+    acc.add(
+        AssistId("generate_getter_mut", AssistKind::Generate),
+        "Generate a mut getter method",
+        target,
+        |builder| {
+            let mut buf = String::with_capacity(512);
+            let fn_name_spaced = fn_name.replace('_', " ");
+            let strukt_name_spaced =
+                to_lower_snake_case(&strukt_name.to_string()).replace('_', " ");
+
+            if impl_def.is_some() {
+                buf.push('\n');
+            }
+
+            let vis = strukt.visibility().map_or(String::new(), |v| format!("{} ", v));
+            format_to!(
+                buf,
+                "    /// Get a mutable reference to the {}'s {}.
+    {}fn {}_mut(&mut self) -> &mut {} {{
+        &mut self.{}
+    }}",
+                strukt_name_spaced,
+                fn_name_spaced,
+                vis,
+                fn_name,
+                field_ty,
+                fn_name,
+            );
+
+            let start_offset = impl_def
+                .and_then(|impl_def| find_impl_block(impl_def, &mut buf))
+                .unwrap_or_else(|| {
+                    buf = generate_impl_text(&ast::Adt::Struct(strukt.clone()), &buf);
+                    strukt.syntax().text_range().end()
+                });
+
+            builder.insert(start_offset, buf);
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::{check_assist, check_assist_not_applicable};
+
+    use super::*;
+
+    fn check_not_applicable(ra_fixture: &str) {
+        check_assist_not_applicable(generate_getter_mut, ra_fixture)
+    }
+
+    #[test]
+    fn test_generate_getter_mut_from_field() {
+        check_assist(
+            generate_getter_mut,
+            r#"
+struct Context<T: Clone> {
+    dat$0a: T,
+}"#,
+            r#"
+struct Context<T: Clone> {
+    data: T,
+}
+
+impl<T: Clone> Context<T> {
+    /// Get a mutable reference to the context's data.
+    fn data_mut(&mut self) -> &mut T {
+        &mut self.data
+    }
+}"#,
+        );
+    }
+
+    #[test]
+    fn test_generate_getter_mut_already_implemented() {
+        check_not_applicable(
+            r#"
+struct Context<T: Clone> {
+    dat$0a: T,
+}
+
+impl<T: Clone> Context<T> {
+    fn data_mut(&mut self) -> &mut T {
+        &mut self.data
+    }
+}"#,
+        );
+    }
+
+    #[test]
+    fn test_generate_getter_mut_from_field_with_visibility_marker() {
+        check_assist(
+            generate_getter_mut,
+            r#"
+pub(crate) struct Context<T: Clone> {
+    dat$0a: T,
+}"#,
+            r#"
+pub(crate) struct Context<T: Clone> {
+    data: T,
+}
+
+impl<T: Clone> Context<T> {
+    /// Get a mutable reference to the context's data.
+    pub(crate) fn data_mut(&mut self) -> &mut T {
+        &mut self.data
+    }
+}"#,
+        );
+    }
+}

--- a/crates/assists/src/handlers/generate_setter.rs
+++ b/crates/assists/src/handlers/generate_setter.rs
@@ -1,0 +1,162 @@
+use stdx::{format_to, to_lower_snake_case};
+use syntax::ast::VisibilityOwner;
+use syntax::ast::{self, AstNode, NameOwner};
+
+use crate::{
+    utils::{find_impl_block, find_struct_impl, generate_impl_text},
+    AssistContext, AssistId, AssistKind, Assists,
+};
+
+// Assist: generate_setter
+//
+// Generate a setter method.
+//
+// ```
+// struct Person {
+//     nam$0e: String,
+// }
+// ```
+// ->
+// ```
+// struct Person {
+//     name: String,
+// }
+//
+// impl Person {
+//     /// Set the person's name.
+//     fn set_name(&mut self, name: String) {
+//         self.name = name;
+//     }
+// }
+// ```
+pub(crate) fn generate_setter(acc: &mut Assists, ctx: &AssistContext) -> Option<()> {
+    let strukt = ctx.find_node_at_offset::<ast::Struct>()?;
+    let field = ctx.find_node_at_offset::<ast::RecordField>()?;
+
+    let strukt_name = strukt.name()?;
+    let field_name = field.name()?;
+    let field_ty = field.ty()?;
+
+    // Return early if we've found an existing fn
+    let fn_name = to_lower_snake_case(&field_name.to_string());
+    let impl_def = find_struct_impl(
+        &ctx,
+        &ast::Adt::Struct(strukt.clone()),
+        format!("set_{}", fn_name).as_str(),
+    )?;
+
+    let target = field.syntax().text_range();
+    acc.add(
+        AssistId("generate_setter", AssistKind::Generate),
+        "Generate a setter method",
+        target,
+        |builder| {
+            let mut buf = String::with_capacity(512);
+
+            let fn_name_spaced = fn_name.replace('_', " ");
+            let strukt_name_spaced =
+                to_lower_snake_case(&strukt_name.to_string()).replace('_', " ");
+
+            if impl_def.is_some() {
+                buf.push('\n');
+            }
+
+            let vis = strukt.visibility().map_or(String::new(), |v| format!("{} ", v));
+            format_to!(
+                buf,
+                "    /// Set the {}'s {}.
+    {}fn set_{}(&mut self, {}: {}) {{
+        self.{} = {};
+    }}",
+                strukt_name_spaced,
+                fn_name_spaced,
+                vis,
+                fn_name,
+                fn_name,
+                field_ty,
+                fn_name,
+                fn_name,
+            );
+
+            let start_offset = impl_def
+                .and_then(|impl_def| find_impl_block(impl_def, &mut buf))
+                .unwrap_or_else(|| {
+                    buf = generate_impl_text(&ast::Adt::Struct(strukt.clone()), &buf);
+                    strukt.syntax().text_range().end()
+                });
+
+            builder.insert(start_offset, buf);
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::{check_assist, check_assist_not_applicable};
+
+    use super::*;
+
+    fn check_not_applicable(ra_fixture: &str) {
+        check_assist_not_applicable(generate_setter, ra_fixture)
+    }
+
+    #[test]
+    fn test_generate_setter_from_field() {
+        check_assist(
+            generate_setter,
+            r#"
+struct Person<T: Clone> {
+    dat$0a: T,
+}"#,
+            r#"
+struct Person<T: Clone> {
+    data: T,
+}
+
+impl<T: Clone> Person<T> {
+    /// Set the person's data.
+    fn set_data(&mut self, data: T) {
+        self.data = data;
+    }
+}"#,
+        );
+    }
+
+    #[test]
+    fn test_generate_setter_already_implemented() {
+        check_not_applicable(
+            r#"
+struct Person<T: Clone> {
+    dat$0a: T,
+}
+
+impl<T: Clone> Person<T> {
+    fn set_data(&mut self, data: T) {
+        self.data = data;
+    }
+}"#,
+        );
+    }
+
+    #[test]
+    fn test_generate_setter_from_field_with_visibility_marker() {
+        check_assist(
+            generate_setter,
+            r#"
+pub(crate) struct Person<T: Clone> {
+    dat$0a: T,
+}"#,
+            r#"
+pub(crate) struct Person<T: Clone> {
+    data: T,
+}
+
+impl<T: Clone> Person<T> {
+    /// Set the person's data.
+    pub(crate) fn set_data(&mut self, data: T) {
+        self.data = data;
+    }
+}"#,
+        );
+    }
+}

--- a/crates/assists/src/lib.rs
+++ b/crates/assists/src/lib.rs
@@ -130,8 +130,11 @@ mod handlers {
     mod generate_enum_match_method;
     mod generate_from_impl_for_enum;
     mod generate_function;
+    mod generate_getter;
+    mod generate_getter_mut;
     mod generate_impl;
     mod generate_new;
+    mod generate_setter;
     mod infer_function_return_type;
     mod inline_function;
     mod inline_local_variable;
@@ -189,8 +192,11 @@ mod handlers {
             generate_enum_match_method::generate_enum_match_method,
             generate_from_impl_for_enum::generate_from_impl_for_enum,
             generate_function::generate_function,
+            generate_getter::generate_getter,
+            generate_getter_mut::generate_getter_mut,
             generate_impl::generate_impl,
             generate_new::generate_new,
+            generate_setter::generate_setter,
             infer_function_return_type::infer_function_return_type,
             inline_function::inline_function,
             inline_local_variable::inline_local_variable,

--- a/crates/assists/src/tests.rs
+++ b/crates/assists/src/tests.rs
@@ -169,6 +169,9 @@ fn assist_order_field_struct() {
     let mut assists = assists.iter();
 
     assert_eq!(assists.next().expect("expected assist").label, "Change visibility to pub(crate)");
+    assert_eq!(assists.next().expect("expected assist").label, "Generate a getter method");
+    assert_eq!(assists.next().expect("expected assist").label, "Generate a mut getter method");
+    assert_eq!(assists.next().expect("expected assist").label, "Generate a setter method");
     assert_eq!(assists.next().expect("expected assist").label, "Add `#[derive]`");
 }
 

--- a/crates/assists/src/tests/generated.rs
+++ b/crates/assists/src/tests/generated.rs
@@ -534,6 +534,54 @@ fn bar(arg: &str, baz: Baz) ${0:-> ()} {
 }
 
 #[test]
+fn doctest_generate_getter() {
+    check_doc_test(
+        "generate_getter",
+        r#####"
+struct Person {
+    nam$0e: String,
+}
+"#####,
+        r#####"
+struct Person {
+    name: String,
+}
+
+impl Person {
+    /// Get a reference to the person's name.
+    fn name(&self) -> &String {
+        &self.name
+    }
+}
+"#####,
+    )
+}
+
+#[test]
+fn doctest_generate_getter_mut() {
+    check_doc_test(
+        "generate_getter_mut",
+        r#####"
+struct Person {
+    nam$0e: String,
+}
+"#####,
+        r#####"
+struct Person {
+    name: String,
+}
+
+impl Person {
+    /// Get a mutable reference to the person's name.
+    fn name_mut(&mut self) -> &mut String {
+        &mut self.name
+    }
+}
+"#####,
+    )
+}
+
+#[test]
 fn doctest_generate_impl() {
     check_doc_test(
         "generate_impl",
@@ -571,7 +619,30 @@ struct Ctx<T: Clone> {
 impl<T: Clone> Ctx<T> {
     fn $0new(data: T) -> Self { Self { data } }
 }
+"#####,
+    )
+}
 
+#[test]
+fn doctest_generate_setter() {
+    check_doc_test(
+        "generate_setter",
+        r#####"
+struct Person {
+    nam$0e: String,
+}
+"#####,
+        r#####"
+struct Person {
+    name: String,
+}
+
+impl Person {
+    /// Set the person's name.
+    fn set_name(&mut self, name: String) {
+        self.name = name;
+    }
+}
 "#####,
     )
 }


### PR DESCRIPTION
This patch makes progress towards the design outlined in https://github.com/rust-analyzer/rust-analyzer/issues/5943, and includes a small refactor which closes https://github.com/rust-analyzer/rust-analyzer/issues/7607. All together this patch does 4 things:

- Adds a `generate_getter` assist.
- Adds a `generate_getter_mut` assist.
- Adds a `generate_setter` assist.
- Moves the `generate_impl_text` function from `generate_new` into `utils` (which closes #7607).

## Design Notes

I've chosen to follow the [Rust API guidelines on getters](https://rust-lang.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter) as closely as possible. This deliberately leaves "builder pattern"-style setters out of scope.

Also, similar to https://github.com/rust-analyzer/rust-analyzer/pull/7570 this assist generates doc comments. I think this should work well in most cases, and for the few where it doesn't it's probably easily edited. This makes it slightly less correct than the #7570 implementation, but I think this is still useful enough to include for many of the same reasons.

The reason why this PR contains 3 assists, rather than 1, is because each of them is so similar to the others that it felt more noisy to do them separately than all at once. The amount of code added does not necessarily reflect that, but hope that still makes sense.

## Examples

**Input**
```rust
struct Person {
    name: String,     // <- cursor on "name"
}
```

**generate getter**
```rust
struct Person {
    name: String,
}

impl Person {
    /// Get a reference to the person's name.
    fn name(&self) -> &String {
        &self.name
    }
}
```

**generate mut getter**
```rust
struct Person {
    name: String,
}

impl Person {
    /// Get a mutable reference to the person's name.
    fn name_mut(&mut self) -> &mut String {
        &mut self.name
    }
}
```

**generate setter**
```rust
struct Person {
    name: String,
}

impl Person {
    /// Set the person's name.
    fn set_name(&mut self, name: String) {
        self.name = name;
    }
}
```
