### PR TITLE
Add #[track_caller] to assist tests

### DIFF
--- a/crates/assists/src/tests.rs
+++ b/crates/assists/src/tests.rs
@@ -49,14 +49,17 @@ pub(crate) fn check_assist_by_label(
 // FIXME: instead of having a separate function here, maybe use
 // `extract_ranges` and mark the target as `<target> </target>` in the
 // fixture?
+#[track_caller]
 pub(crate) fn check_assist_target(assist: Handler, ra_fixture: &str, target: &str) {
     check(assist, ra_fixture, ExpectedResult::Target(target), None);
 }
 
+#[track_caller]
 pub(crate) fn check_assist_not_applicable(assist: Handler, ra_fixture: &str) {
     check(assist, ra_fixture, ExpectedResult::NotApplicable, None);
 }
 
+#[track_caller]
 fn check_doc_test(assist_id: &str, before: &str, after: &str) {
     let after = trim_indent(after);
     let (db, file_id, selection) = RootDatabase::with_range_or_offset(&before);
@@ -95,6 +98,7 @@ enum ExpectedResult<'a> {
     Target(&'a str),
 }
 
+#[track_caller]
 fn check(handler: Handler, before: &str, expected: ExpectedResult, assist_label: Option<&str>) {
     let (db, file_with_caret_id, range_or_offset) = RootDatabase::with_range_or_offset(before);
     let text_without_caret = db.file_text(file_with_caret_id).to_string();


### PR DESCRIPTION
This points the source of a failed assertion to the code which called it, rather than the location within the assertion helper method. While working on https://github.com/rust-analyzer/rust-analyzer/pull/7617 I had trouble locating some failing tests, and it was only by adding these attributes during development that I was able to locate them.

This is only applied to test helpers, which means it comes at no runtime cost. And even then: I didn't experience any noticeable performance with this enabled or disabled. Mostly just a more pleasant experience debugging test failures (: 