### PR TITLE
Automatically detect the rustc-src directory (fixes #3517)

### DIFF
--- a/crates/project_model/src/cargo_workspace.rs
+++ b/crates/project_model/src/cargo_workspace.rs
@@ -44,6 +44,15 @@ impl ops::Index<Target> for CargoWorkspace {
     }
 }
 
+/// Describes how to set the rustc source directory.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RustcSource {
+    /// Explicit path for the rustc source directory.
+    Path(AbsPathBuf),
+    /// Try to automatically detect where the rustc source directory is.
+    Discover,
+}
+
 #[derive(Default, Clone, Debug, PartialEq, Eq)]
 pub struct CargoConfig {
     /// Do not activate the `default` feature.
@@ -64,7 +73,7 @@ pub struct CargoConfig {
     pub no_sysroot: bool,
 
     /// rustc private crate source
-    pub rustc_source: Option<AbsPathBuf>,
+    pub rustc_source: Option<RustcSource>,
 }
 
 pub type Package = Idx<PackageData>;

--- a/crates/project_model/src/lib.rs
+++ b/crates/project_model/src/lib.rs
@@ -21,8 +21,8 @@ use rustc_hash::FxHashSet;
 pub use crate::{
     build_data::{BuildDataCollector, BuildDataResult},
     cargo_workspace::{
-        CargoConfig, CargoWorkspace, Package, PackageData, PackageDependency, Target, TargetData,
-        TargetKind,
+        CargoConfig, CargoWorkspace, Package, PackageData, PackageDependency, RustcSource, Target,
+        TargetData, TargetKind,
     },
     project_json::{ProjectJson, ProjectJsonData},
     sysroot::Sysroot,

--- a/crates/project_model/src/workspace.rs
+++ b/crates/project_model/src/workspace.rs
@@ -114,6 +114,7 @@ impl ProjectWorkspace {
                             cargo_version
                         )
                     })?;
+
                 let sysroot = if config.no_sysroot {
                     Sysroot::default()
                 } else {
@@ -125,7 +126,17 @@ impl ProjectWorkspace {
                     })?
                 };
 
-                let rustc = if let Some(rustc_dir) = &config.rustc_source {
+                let rustc_dir = if let Some(rustc_source) = &config.rustc_source {
+                    use cargo_workspace::RustcSource;
+                    match rustc_source {
+                        RustcSource::Path(path) => Some(path.clone()),
+                        RustcSource::Discover => Sysroot::discover_rustc(&cargo_toml),
+                    }
+                } else {
+                    None
+                };
+
+                let rustc = if let Some(rustc_dir) = rustc_dir {
                     Some(
                         CargoWorkspace::from_cargo_metadata(&rustc_dir, config, progress)
                             .with_context(|| {

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -105,7 +105,7 @@
 [[rust-analyzer.runnables.cargoExtraArgs]]rust-analyzer.runnables.cargoExtraArgs (default: `[]`)::
  Additional arguments to be passed to cargo for runnables such as  tests or binaries.\nFor example, it may be `--release`.
 [[rust-analyzer.rustcSource]]rust-analyzer.rustcSource (default: `null`)::
- Path to the rust compiler sources, for usage in rustc_private projects.
+ Path to the rust compiler sources, for usage in rustc_private projects, or "discover"  to try to automatically find it.
 [[rust-analyzer.rustfmt.extraArgs]]rust-analyzer.rustfmt.extraArgs (default: `[]`)::
  Additional arguments to `rustfmt`.
 [[rust-analyzer.rustfmt.overrideCommand]]rust-analyzer.rustfmt.overrideCommand (default: `null`)::

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -707,7 +707,7 @@
                     }
                 },
                 "rust-analyzer.rustcSource": {
-                    "markdownDescription": "Path to the rust compiler sources, for usage in rustc_private projects.",
+                    "markdownDescription": "Path to the rust compiler sources, for usage in rustc_private projects, or \"discover\" to try to automatically find it.",
                     "default": null,
                     "type": [
                         "null",


### PR DESCRIPTION
If the configured rustcSource was not set, then try to automatically
detect a source for the sysroot rustc directory.

I wasn't sure how to do it in the case of the project.json file, though.