### PR TITLE
fix nightly warning `legacy_derive_helpers`

### DIFF
--- a/crates/rust-analyzer/src/lsp_ext.rs
+++ b/crates/rust-analyzer/src/lsp_ext.rs
@@ -230,8 +230,8 @@ pub struct SsrParams {
 
 pub enum StatusNotification {}
 
-#[serde(rename_all = "camelCase")]
 #[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub enum Status {
     Loading,
     ReadyPartial,

--- a/docs/dev/lsp-extensions.md
+++ b/docs/dev/lsp-extensions.md
@@ -1,5 +1,5 @@
 <!---
-lsp_ext.rs hash: 7609fd6d7b4ab231
+lsp_ext.rs hash: 8f1ae8530f69e3a3
 
 If you need to change the above hash to make the test pass, please check if you
 need to adjust this doc as well and ping this  issue:


### PR DESCRIPTION
With a recent nightly (e.g. 2021-02-10) a warning comes up. This PR reorders the attributes to fix the warning.

See https://github.com/rust-lang/rust/issues/79202