### PR TITLE
Implement constructor usage search for almost all items

### DIFF
--- a/crates/assists/src/handlers/inline_local_variable.rs
+++ b/crates/assists/src/handlers/inline_local_variable.rs
@@ -1,6 +1,5 @@
-use std::collections::HashMap;
-
 use ide_db::{defs::Definition, search::FileReference};
+use rustc_hash::FxHashMap;
 use syntax::{
     ast::{self, AstNode, AstToken},
     TextRange,
@@ -111,7 +110,7 @@ pub(crate) fn inline_local_variable(acc: &mut Assists, ctx: &AssistContext) -> O
                 .collect::<Result<_, _>>()
                 .map(|b| (file_id, b))
         })
-        .collect::<Result<HashMap<_, Vec<_>>, _>>()?;
+        .collect::<Result<FxHashMap<_, Vec<_>>, _>>()?;
 
     let init_str = initializer_expr.syntax().text().to_string();
     let init_in_paren = format!("({})", &init_str);


### PR DESCRIPTION
This PR moves the filering for enum constructors to the HIR, with this unprefixed variants as well as when the enum has been renamed via use will then still show up properly.
We now walk the ast of the `NameRef` up until we find a `PathExpr`(which also handles `CallExpr` for tuple-type structs and variants already) or a `RecordExpr`. For enum search we then take the `path` out of that expression and do a resolution on it to compare it with the definition enum.
With this PR we now support searching for all constructor literals, Unit-, Tuple- and Record-Structs, Unit-, Tuple- and Record-Variants as well as Unions.

There is one shortcoming due to how the search is triggered. Unit Variants constructors can't be searched as we have no position for it to kick off the search(since a comma doesn't have to exist for the last variant).

Closes #2549 though it doesn't implement it as outlined in the issue since the reference kind was removed recently, though I believe the approach taken here is better personally.