### PR TITLE
Improve "Generate From impl"

### DIFF
--- a/crates/assists/src/handlers/generate_from_impl_for_enum.rs
+++ b/crates/assists/src/handlers/generate_from_impl_for_enum.rs
@@ -3,7 +3,10 @@ use ide_db::helpers::FamousDefs;
 use ide_db::RootDatabase;
 use itertools::Itertools;
 use stdx::format_to;
-use syntax::{SmolStr, ast::{self, AstNode, NameOwner}};
+use syntax::{
+    ast::{self, AstNode, NameOwner},
+    SmolStr,
+};
 use test_utils::mark;
 
 use crate::{AssistContext, AssistId, AssistKind, Assists};

--- a/crates/assists/src/handlers/generate_from_impl_for_enum.rs
+++ b/crates/assists/src/handlers/generate_from_impl_for_enum.rs
@@ -21,7 +21,7 @@ use crate::{AssistContext, AssistId, AssistKind, Assists};
 //
 // impl From<u32> for A {
 //     fn from(v: u32) -> Self {
-//         A::One(v)
+//         Self::One(v)
 //     }
 // }
 // ```

--- a/crates/assists/src/handlers/generate_from_impl_for_enum.rs
+++ b/crates/assists/src/handlers/generate_from_impl_for_enum.rs
@@ -56,7 +56,7 @@ pub(crate) fn generate_from_impl_for_enum(acc: &mut Assists, ctx: &AssistContext
 
 impl From<{0}> for {1} {{
     fn from(v: {0}) -> Self {{
-        {1}::{2}(v)
+        Self::{2}(v)
     }}
 }}"#,
                 path.syntax(),
@@ -106,7 +106,7 @@ mod tests {
 
 impl From<u32> for A {
     fn from(v: u32) -> Self {
-        A::One(v)
+        Self::One(v)
     }
 }"#,
         );
@@ -121,7 +121,7 @@ impl From<u32> for A {
 
 impl From<foo::bar::baz::Boo> for A {
     fn from(v: foo::bar::baz::Boo) -> Self {
-        A::One(v)
+        Self::One(v)
     }
 }"#,
         );
@@ -157,7 +157,7 @@ enum A { $0One(u32), }
 
 impl From<u32> for A {
     fn from(v: u32) -> Self {
-        A::One(v)
+        Self::One(v)
     }
 }
 "#,
@@ -183,7 +183,7 @@ pub trait From<T> {
 
 impl From<u32> for A {
     fn from(v: u32) -> Self {
-        A::One(v)
+        Self::One(v)
     }
 }
 

--- a/crates/assists/src/tests/generated.rs
+++ b/crates/assists/src/tests/generated.rs
@@ -499,7 +499,7 @@ enum A { One(u32) }
 
 impl From<u32> for A {
     fn from(v: u32) -> Self {
-        A::One(v)
+        Self::One(v)
     }
 }
 "#####,


### PR DESCRIPTION
* Allows any field type. Previously it was restricted to path types, but I don't see why it couldn't apply to all other types too. (the main reason for is PR is that I'm too lazy to write out `From<&'static str>` by hand 😄)
* More correct handling for generic enums - previously it wouldn't emit generic params on the impl.
* Also accepts variants with named field.

The impl generation code got mostly copy-pasted from generate_impl assist - please tell if there's an easy way to avoid this duplication.