### PR TITLE
refactor impl generation in assists

### DIFF
--- a/crates/assists/src/handlers/generate_from_impl_for_enum.rs
+++ b/crates/assists/src/handlers/generate_from_impl_for_enum.rs
@@ -3,7 +3,7 @@ use ide_db::RootDatabase;
 use syntax::ast::{self, AstNode, NameOwner};
 use test_utils::mark;
 
-use crate::{AssistContext, AssistId, AssistKind, Assists, utils::generate_trait_impl_text};
+use crate::{utils::generate_trait_impl_text, AssistContext, AssistId, AssistKind, Assists};
 
 // Assist: generate_from_impl_for_enum
 //

--- a/crates/assists/src/handlers/generate_impl.rs
+++ b/crates/assists/src/handlers/generate_impl.rs
@@ -1,6 +1,6 @@
 use syntax::ast::{self, AstNode, NameOwner};
 
-use crate::{AssistContext, AssistId, AssistKind, Assists, utils::generate_impl_text};
+use crate::{utils::generate_impl_text, AssistContext, AssistId, AssistKind, Assists};
 
 // Assist: generate_impl
 //

--- a/crates/assists/src/handlers/generate_impl.rs
+++ b/crates/assists/src/handlers/generate_impl.rs
@@ -1,11 +1,6 @@
-use itertools::Itertools;
-use stdx::format_to;
-use syntax::{
-    ast::{self, AstNode, AttrsOwner, GenericParamsOwner, NameOwner},
-    SmolStr,
-};
+use syntax::ast::{self, AstNode, NameOwner};
 
-use crate::{AssistContext, AssistId, AssistKind, Assists};
+use crate::{AssistContext, AssistId, AssistKind, Assists, utils::generate_impl_text};
 
 // Assist: generate_impl
 //
@@ -36,44 +31,15 @@ pub(crate) fn generate_impl(acc: &mut Assists, ctx: &AssistContext) -> Option<()
         format!("Generate impl for `{}`", name),
         target,
         |edit| {
-            let type_params = nominal.generic_param_list();
             let start_offset = nominal.syntax().text_range().end();
-            let mut buf = String::new();
-            buf.push_str("\n\n");
-            nominal
-                .attrs()
-                .filter(|attr| {
-                    attr.as_simple_call().map(|(name, _arg)| name == "cfg").unwrap_or(false)
-                })
-                .for_each(|attr| buf.push_str(format!("{}\n", attr.to_string()).as_str()));
-
-            buf.push_str("impl");
-            if let Some(type_params) = &type_params {
-                format_to!(buf, "{}", type_params.syntax());
-            }
-            buf.push_str(" ");
-            buf.push_str(name.text());
-            if let Some(type_params) = type_params {
-                let lifetime_params = type_params
-                    .lifetime_params()
-                    .filter_map(|it| it.lifetime())
-                    .map(|it| SmolStr::from(it.text()));
-                let type_params = type_params
-                    .type_params()
-                    .filter_map(|it| it.name())
-                    .map(|it| SmolStr::from(it.text()));
-
-                let generic_params = lifetime_params.chain(type_params).format(", ");
-                format_to!(buf, "<{}>", generic_params)
-            }
             match ctx.config.snippet_cap {
                 Some(cap) => {
-                    buf.push_str(" {\n    $0\n}");
-                    edit.insert_snippet(cap, start_offset, buf);
+                    let snippet = generate_impl_text(&nominal, "    $0");
+                    edit.insert_snippet(cap, start_offset, snippet);
                 }
                 None => {
-                    buf.push_str(" {\n}");
-                    edit.insert(start_offset, buf);
+                    let snippet = generate_impl_text(&nominal, "");
+                    edit.insert(start_offset, snippet);
                 }
             }
         },

--- a/crates/assists/src/handlers/replace_derive_with_manual_impl.rs
+++ b/crates/assists/src/handlers/replace_derive_with_manual_impl.rs
@@ -1,9 +1,20 @@
 use ide_db::helpers::mod_path_to_ast;
 use ide_db::imports_locator;
 use itertools::Itertools;
-use syntax::{SyntaxKind::{IDENT, WHITESPACE}, TextSize, ast::{self, AstNode, NameOwner, make}};
+use syntax::{
+    ast::{self, make, AstNode, NameOwner},
+    SyntaxKind::{IDENT, WHITESPACE},
+    TextSize,
+};
 
-use crate::{AssistId, AssistKind, assist_context::{AssistBuilder, AssistContext, Assists}, utils::{Cursor, DefaultMethods, add_trait_assoc_items_to_impl, filter_assoc_items, generate_trait_impl_text, render_snippet}};
+use crate::{
+    assist_context::{AssistBuilder, AssistContext, Assists},
+    utils::{
+        add_trait_assoc_items_to_impl, filter_assoc_items, generate_trait_impl_text,
+        render_snippet, Cursor, DefaultMethods,
+    },
+    AssistId, AssistKind,
+};
 
 // Assist: replace_derive_with_manual_impl
 //
@@ -105,10 +116,9 @@ fn add_assist(
             update_attribute(builder, &input, &trait_name, &attr);
             let trait_path = format!("{}", trait_path);
             match (ctx.config.snippet_cap, impl_def_with_items) {
-                (None, _) => builder.insert(
-                    insert_pos,
-                    generate_trait_impl_text(adt, &trait_path, ""),
-                ),
+                (None, _) => {
+                    builder.insert(insert_pos, generate_trait_impl_text(adt, &trait_path, ""))
+                }
                 (Some(cap), None) => builder.insert_snippet(
                     cap,
                     insert_pos,

--- a/crates/assists/src/handlers/replace_derive_with_manual_impl.rs
+++ b/crates/assists/src/handlers/replace_derive_with_manual_impl.rs
@@ -1,20 +1,9 @@
 use ide_db::helpers::mod_path_to_ast;
 use ide_db::imports_locator;
 use itertools::Itertools;
-use syntax::{
-    ast::{self, make, AstNode},
-    Direction,
-    SyntaxKind::{IDENT, WHITESPACE},
-    TextSize,
-};
+use syntax::{SyntaxKind::{IDENT, WHITESPACE}, TextSize, ast::{self, AstNode, NameOwner, make}};
 
-use crate::{
-    assist_context::{AssistBuilder, AssistContext, Assists},
-    utils::{
-        add_trait_assoc_items_to_impl, filter_assoc_items, render_snippet, Cursor, DefaultMethods,
-    },
-    AssistId, AssistKind,
-};
+use crate::{AssistId, AssistKind, assist_context::{AssistBuilder, AssistContext, Assists}, utils::{Cursor, DefaultMethods, add_trait_assoc_items_to_impl, filter_assoc_items, generate_trait_impl_text, render_snippet}};
 
 // Assist: replace_derive_with_manual_impl
 //
@@ -57,8 +46,9 @@ pub(crate) fn replace_derive_with_manual_impl(
     let trait_token = ctx.token_at_offset().find(|t| t.kind() == IDENT && t.text() != "derive")?;
     let trait_path = make::path_unqualified(make::path_segment(make::name_ref(trait_token.text())));
 
-    let annotated_name = attr.syntax().siblings(Direction::Next).find_map(ast::Name::cast)?;
-    let insert_pos = annotated_name.syntax().parent()?.text_range().end();
+    let adt = attr.syntax().parent().and_then(ast::Adt::cast)?;
+    let annotated_name = adt.name()?;
+    let insert_pos = adt.syntax().text_range().end();
 
     let current_module = ctx.sema.scope(annotated_name.syntax()).module()?;
     let current_crate = current_module.krate();
@@ -82,10 +72,10 @@ pub(crate) fn replace_derive_with_manual_impl(
 
     let mut no_traits_found = true;
     for (trait_path, trait_) in found_traits.inspect(|_| no_traits_found = false) {
-        add_assist(acc, ctx, &attr, &trait_path, Some(trait_), &annotated_name, insert_pos)?;
+        add_assist(acc, ctx, &attr, &trait_path, Some(trait_), &adt, &annotated_name, insert_pos)?;
     }
     if no_traits_found {
-        add_assist(acc, ctx, &attr, &trait_path, None, &annotated_name, insert_pos)?;
+        add_assist(acc, ctx, &attr, &trait_path, None, &adt, &annotated_name, insert_pos)?;
     }
     Some(())
 }
@@ -96,6 +86,7 @@ fn add_assist(
     attr: &ast::Attr,
     trait_path: &ast::Path,
     trait_: Option<hir::Trait>,
+    adt: &ast::Adt,
     annotated_name: &ast::Name,
     insert_pos: TextSize,
 ) -> Option<()> {
@@ -112,15 +103,16 @@ fn add_assist(
             let impl_def_with_items =
                 impl_def_from_trait(&ctx.sema, annotated_name, trait_, trait_path);
             update_attribute(builder, &input, &trait_name, &attr);
+            let trait_path = format!("{}", trait_path);
             match (ctx.config.snippet_cap, impl_def_with_items) {
                 (None, _) => builder.insert(
                     insert_pos,
-                    format!("\n\nimpl {} for {} {{\n\n}}", trait_path, annotated_name),
+                    generate_trait_impl_text(adt, &trait_path, ""),
                 ),
                 (Some(cap), None) => builder.insert_snippet(
                     cap,
                     insert_pos,
-                    format!("\n\nimpl {} for {} {{\n    $0\n}}", trait_path, annotated_name),
+                    generate_trait_impl_text(adt, &trait_path, "    $0"),
                 ),
                 (Some(cap), Some((impl_def, first_assoc_item))) => {
                     let mut cursor = Cursor::Before(first_assoc_item.syntax());

--- a/crates/assists/src/utils.rs
+++ b/crates/assists/src/utils.rs
@@ -379,7 +379,14 @@ pub(crate) fn generate_trait_impl_text(adt: &ast::Adt, trait_text: &str, code: &
 fn generate_impl_text_inner(adt: &ast::Adt, trait_text: Option<&str>, code: &str) -> String {
     let type_params = adt.generic_param_list();
     let mut buf = String::with_capacity(code.len());
-    buf.push_str("\n\nimpl");
+    buf.push_str("\n\n");
+    adt
+        .attrs()
+        .filter(|attr| {
+            attr.as_simple_call().map(|(name, _arg)| name == "cfg").unwrap_or(false)
+        })
+        .for_each(|attr| buf.push_str(format!("{}\n", attr.to_string()).as_str()));
+    buf.push_str("impl");
     if let Some(type_params) = &type_params {
         format_to!(buf, "{}", type_params.syntax());
     }

--- a/crates/assists/src/utils.rs
+++ b/crates/assists/src/utils.rs
@@ -380,11 +380,8 @@ fn generate_impl_text_inner(adt: &ast::Adt, trait_text: Option<&str>, code: &str
     let type_params = adt.generic_param_list();
     let mut buf = String::with_capacity(code.len());
     buf.push_str("\n\n");
-    adt
-        .attrs()
-        .filter(|attr| {
-            attr.as_simple_call().map(|(name, _arg)| name == "cfg").unwrap_or(false)
-        })
+    adt.attrs()
+        .filter(|attr| attr.as_simple_call().map(|(name, _arg)| name == "cfg").unwrap_or(false))
         .for_each(|attr| buf.push_str(format!("{}\n", attr.to_string()).as_str()));
     buf.push_str("impl");
     if let Some(type_params) = &type_params {

--- a/crates/assists/src/utils.rs
+++ b/crates/assists/src/utils.rs
@@ -367,6 +367,16 @@ pub(crate) fn find_impl_block_end(impl_def: ast::Impl, buf: &mut String) -> Opti
 // Generates the surrounding `impl Type { <code> }` including type and lifetime
 // parameters
 pub(crate) fn generate_impl_text(adt: &ast::Adt, code: &str) -> String {
+    generate_impl_text_inner(adt, None, code)
+}
+
+// Generates the surrounding `impl <trait> for Type { <code> }` including type
+// and lifetime parameters
+pub(crate) fn generate_trait_impl_text(adt: &ast::Adt, trait_text: &str, code: &str) -> String {
+    generate_impl_text_inner(adt, Some(trait_text), code)
+}
+
+fn generate_impl_text_inner(adt: &ast::Adt, trait_text: Option<&str>, code: &str) -> String {
     let type_params = adt.generic_param_list();
     let mut buf = String::with_capacity(code.len());
     buf.push_str("\n\nimpl");
@@ -374,6 +384,10 @@ pub(crate) fn generate_impl_text(adt: &ast::Adt, code: &str) -> String {
         format_to!(buf, "{}", type_params.syntax());
     }
     buf.push(' ');
+    if let Some(trait_text) = trait_text {
+        buf.push_str(trait_text);
+        buf.push_str(" for ");
+    }
     buf.push_str(adt.name().unwrap().text());
     if let Some(type_params) = type_params {
         let lifetime_params = type_params


### PR DESCRIPTION
Follow-up to #7659: all impl generation in assists (at least what I found) is now done through `utils::{generate_impl_text, generate_trait_impl_text}`.