### PR TITLE
Don't classify attribute macros as their path unless it's a function with the proc_macro_attribute attribute

### DIFF
--- a/crates/ide/src/references.rs
+++ b/crates/ide/src/references.rs
@@ -1127,4 +1127,39 @@ impl Foo {
             "#]],
         );
     }
+
+    #[test]
+    fn test_attr_differs_from_fn_with_same_name() {
+        check(
+            r#"
+#[test]
+fn test$0() {
+    test();
+}
+"#,
+            expect![[r#"
+                test Function FileId(0) 0..33 11..15
+
+                FileId(0) 24..28
+            "#]],
+        );
+    }
+
+    #[test]
+    fn test_attr_matches_proc_macro_fn() {
+        check(
+            r#"
+#[proc_macro_attribute]
+fn my_proc_macro() {}
+
+#[my_proc_macro$0]
+fn test() {}
+"#,
+            expect![[r#"
+                my_proc_macro Function FileId(0) 0..45 27..40
+
+                FileId(0) 49..62
+            "#]],
+        );
+    }
 }


### PR DESCRIPTION
bors r+
Closes #6389