### PR TITLE
Finalize rename infra rewrite

### DIFF
--- a/crates/syntax/src/ast/node_ext.rs
+++ b/crates/syntax/src/ast/node_ext.rs
@@ -3,12 +3,11 @@
 
 use std::fmt;
 
-use ast::AttrsOwner;
 use itertools::Itertools;
 use parser::SyntaxKind;
 
 use crate::{
-    ast::{self, support, AstNode, AstToken, NameOwner, SyntaxNode},
+    ast::{self, support, AstNode, AstToken, AttrsOwner, NameOwner, SyntaxNode},
     SmolStr, SyntaxElement, SyntaxToken, T,
 };
 
@@ -324,7 +323,7 @@ impl ast::RecordPatField {
 
     pub fn for_field_name(field_name: &ast::Name) -> Option<ast::RecordPatField> {
         let candidate =
-            field_name.syntax().ancestors().nth(3).and_then(ast::RecordPatField::cast)?;
+            field_name.syntax().ancestors().nth(2).and_then(ast::RecordPatField::cast)?;
         match candidate.field_name()? {
             NameOrNameRef::Name(name) if name == *field_name => Some(candidate),
             _ => None,


### PR DESCRIPTION
This should be the final PR in regards to rewriting rename stuff, #4290.

It addresses 3 things:
	- Currently renaming import aliases causes some undesired behavior(see #5198) which is why this PR causes us to just return an error if an attempt at renaming an alias is made for the time being. Though this only prevents it from happening when the alias import is renamed, so its not too helpful.
	- Fixes #6898
	- If we are inside a macro file simply rename the input name node as there isn't really a way to do any of the fancy shorthand renames and similar things as for that we would have to exactly know what the macro generates and what not.