### PR TITLE
Extract `fn load_workspace(…)` from `fn load_cargo(…)`

### DIFF
--- a/crates/rust-analyzer/src/cli.rs
+++ b/crates/rust-analyzer/src/cli.rs
@@ -18,7 +18,7 @@ pub use self::{
     analysis_bench::{BenchCmd, BenchWhat, Position},
     analysis_stats::AnalysisStatsCmd,
     diagnostics::diagnostics,
-    load_cargo::load_cargo,
+    load_cargo::{load_workspace, load_workspace_at, LoadCargoConfig},
     ssr::{apply_ssr_rules, search_for_patterns},
 };
 

--- a/crates/rust-analyzer/src/cli/analysis_bench.rs
+++ b/crates/rust-analyzer/src/cli/analysis_bench.rs
@@ -17,7 +17,7 @@ use ide_db::{
 use vfs::AbsPathBuf;
 
 use crate::cli::{
-    load_cargo::{load_cargo, LoadCargoConfig},
+    load_cargo::{load_workspace_at, LoadCargoConfig},
     print_memory_usage, Verbosity,
 };
 
@@ -63,13 +63,13 @@ impl BenchCmd {
         let start = Instant::now();
         eprint!("loading: ");
 
+        let cargo_config = Default::default();
         let load_cargo_config = LoadCargoConfig {
-            cargo_config: Default::default(),
             load_out_dirs_from_check: self.load_output_dirs,
             with_proc_macro: self.with_proc_macro,
         };
-
-        let (mut host, vfs) = load_cargo(&self.path, &load_cargo_config)?;
+        let (mut host, vfs) =
+            load_workspace_at(&self.path, &cargo_config, &load_cargo_config, &|_| {})?;
         eprintln!("{:?}\n", start.elapsed());
 
         let file_id = {

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -25,7 +25,7 @@ use stdx::format_to;
 use syntax::AstNode;
 
 use crate::cli::{
-    load_cargo::{load_cargo, LoadCargoConfig},
+    load_cargo::{load_workspace_at, LoadCargoConfig},
     print_memory_usage,
     progress_report::ProgressReport,
     report_metric, Result, Verbosity,
@@ -59,12 +59,13 @@ impl AnalysisStatsCmd {
         };
 
         let mut db_load_sw = self.stop_watch();
+        let cargo_config = Default::default();
         let load_cargo_config = LoadCargoConfig {
-            cargo_config: Default::default(),
             load_out_dirs_from_check: self.load_output_dirs,
             with_proc_macro: self.with_proc_macro,
         };
-        let (host, vfs) = load_cargo(&self.path, &load_cargo_config)?;
+        let (host, vfs) =
+            load_workspace_at(&self.path, &cargo_config, &load_cargo_config, &|_| {})?;
         let db = host.raw_database();
         eprintln!("{:<20} {}", "Database loaded:", db_load_sw.elapsed());
 

--- a/crates/rust-analyzer/src/cli/diagnostics.rs
+++ b/crates/rust-analyzer/src/cli/diagnostics.rs
@@ -11,7 +11,7 @@ use ide::{DiagnosticsConfig, Severity};
 use ide_db::base_db::SourceDatabaseExt;
 
 use crate::cli::{
-    load_cargo::{load_cargo, LoadCargoConfig},
+    load_cargo::{load_workspace_at, LoadCargoConfig},
     Result,
 };
 
@@ -33,12 +33,9 @@ pub fn diagnostics(
     load_out_dirs_from_check: bool,
     with_proc_macro: bool,
 ) -> Result<()> {
-    let load_cargo_config = LoadCargoConfig {
-        cargo_config: Default::default(),
-        load_out_dirs_from_check,
-        with_proc_macro,
-    };
-    let (host, _vfs) = load_cargo(path, &load_cargo_config)?;
+    let cargo_config = Default::default();
+    let load_cargo_config = LoadCargoConfig { load_out_dirs_from_check, with_proc_macro };
+    let (host, _vfs) = load_workspace_at(path, &cargo_config, &load_cargo_config, &|_| {})?;
     let db = host.raw_database();
     let analysis = host.analysis();
 

--- a/crates/rust-analyzer/src/cli/ssr.rs
+++ b/crates/rust-analyzer/src/cli/ssr.rs
@@ -1,19 +1,18 @@
 //! Applies structured search replace rules from the command line.
 
 use crate::cli::{
-    load_cargo::{load_cargo, LoadCargoConfig},
+    load_cargo::{load_workspace_at, LoadCargoConfig},
     Result,
 };
 use ssr::{MatchFinder, SsrPattern, SsrRule};
 
 pub fn apply_ssr_rules(rules: Vec<SsrRule>) -> Result<()> {
     use ide_db::base_db::SourceDatabaseExt;
-    let load_cargo_config = LoadCargoConfig {
-        cargo_config: Default::default(),
-        load_out_dirs_from_check: true,
-        with_proc_macro: true,
-    };
-    let (host, vfs) = load_cargo(&std::env::current_dir()?, &load_cargo_config)?;
+    let cargo_config = Default::default();
+    let load_cargo_config =
+        LoadCargoConfig { load_out_dirs_from_check: true, with_proc_macro: true };
+    let (host, vfs) =
+        load_workspace_at(&std::env::current_dir()?, &cargo_config, &load_cargo_config, &|_| {})?;
     let db = host.raw_database();
     let mut match_finder = MatchFinder::at_first_file(db)?;
     for rule in rules {
@@ -36,12 +35,11 @@ pub fn apply_ssr_rules(rules: Vec<SsrRule>) -> Result<()> {
 pub fn search_for_patterns(patterns: Vec<SsrPattern>, debug_snippet: Option<String>) -> Result<()> {
     use ide_db::base_db::SourceDatabaseExt;
     use ide_db::symbol_index::SymbolsDatabase;
-    let load_cargo_config = LoadCargoConfig {
-        cargo_config: Default::default(),
-        load_out_dirs_from_check: true,
-        with_proc_macro: true,
-    };
-    let (host, _vfs) = load_cargo(&std::env::current_dir()?, &load_cargo_config)?;
+    let cargo_config = Default::default();
+    let load_cargo_config =
+        LoadCargoConfig { load_out_dirs_from_check: true, with_proc_macro: true };
+    let (host, _vfs) =
+        load_workspace_at(&std::env::current_dir()?, &cargo_config, &load_cargo_config, &|_| {})?;
     let db = host.raw_database();
     let mut match_finder = MatchFinder::at_first_file(db)?;
     for pattern in patterns {


### PR DESCRIPTION
Unfortunately in https://github.com/rust-analyzer/rust-analyzer/pull/7595 I forgot to `pub use` (rather than just `use`) the newly introduced `LoadCargoConfig`.

So this PR fixes this now.

It also:

- splits up `fn load_cargo` into a "workspace loading" and a "project loading" phase
- adds a `progress: &dyn Fn(String)` to allow third-parties to provide CLI progress updates, too

The motivation behind both of these is the fact that rust-analyzer currently does not support caching.
As such any third-party making use of `ra_ap_…` needs to providing a caching layer itself.
Unlike for rust-analyzer itself however a common use-pattern of third-parties is to analyze a specific target (`--lib`/`--bin <BIN>`/…) from a specific package (`--package`). The targets/packages of a crate can be obtained via `ProjectWorkspace::load(…)`, which currently is performed inside of `fn load_cargo`, effectively making the returned `ProjectWorkspace` inaccessible to the outer caller. With this information one can then provide early error handling via CLI (in case of ambiguities or invalid arguments, etc), instead of `fn load_cargo` failing with a possibly obscure error message. It also allows for annotating the persisted caches with its specific associated package/target selector and short-circuit quickly if a matching cache is found on disk, significantly cutting load times.

Before:

```rust
pub struct LoadCargoConfig {
    pub cargo_config: &CargoConfig,
    pub load_out_dirs_from_check: bool,
    pub with_proc_macro: bool,
}

pub fn load_cargo(
    root: &Path,
    config: &LoadCargoConfig
) -> Result<(AnalysisHost, vfs::Vfs)> {
    // ...
}
```

After:

```rust
pub fn load_workspace(
    root: &Path,
    config: &CargoConfig,
    progress: &dyn Fn(String),
) -> Result<ProjectWorkspace> {
        // ...
}

pub struct LoadCargoConfig {
    pub load_out_dirs_from_check: bool,
    pub with_proc_macro: bool,
}

pub fn load_cargo(
    ws: ProjectWorkspace,
    config: &LoadCargoConfig,
    progress: &dyn Fn(String),
) -> Result<(AnalysisHost, vfs::Vfs)> {
    // ...
}
```
