### PR TITLE
Use `cfg(target_arch)` instead of a Cargo feature

### DIFF
--- a/crates/ide_db/Cargo.toml
+++ b/crates/ide_db/Cargo.toml
@@ -9,9 +9,6 @@ edition = "2018"
 [lib]
 doctest = false
 
-[features]
-wasm = []
-
 [dependencies]
 log = "0.4.8"
 rayon = "1.5.0"

--- a/crates/ide_db/src/apply_change.rs
+++ b/crates/ide_db/src/apply_change.rs
@@ -67,7 +67,7 @@ impl RootDatabase {
     }
 
     pub fn collect_garbage(&mut self) {
-        if cfg!(feature = "wasm") {
+        if cfg!(target_arch = "wasm32") {
             return;
         }
 


### PR DESCRIPTION
Not that WASM works right now anyways...

bors r+