### PR TITLE
Implement ast::AstNode for NameLike and move it to node_ext

### DIFF
--- a/crates/hir_expand/src/name.rs
+++ b/crates/hir_expand/src/name.rs
@@ -87,11 +87,18 @@ impl AsName for ast::Name {
     }
 }
 
-impl AsName for ast::NameOrNameRef {
+impl AsName for ast::Lifetime {
+    fn as_name(&self) -> Name {
+        Name::resolve(self.text())
+    }
+}
+
+impl AsName for ast::NameLike {
     fn as_name(&self) -> Name {
         match self {
-            ast::NameOrNameRef::Name(it) => it.as_name(),
-            ast::NameOrNameRef::NameRef(it) => it.as_name(),
+            ast::NameLike::Name(it) => it.as_name(),
+            ast::NameLike::NameRef(it) => it.as_name(),
+            ast::NameLike::Lifetime(it) => it.as_name(),
         }
     }
 }

--- a/crates/ide/src/references/rename.rs
+++ b/crates/ide/src/references/rename.rs
@@ -6,7 +6,7 @@ use hir::{HasSource, InFile, Module, ModuleDef, ModuleSource, Semantics};
 use ide_db::{
     base_db::{AnchoredPathBuf, FileId},
     defs::{Definition, NameClass, NameRefClass},
-    search::{FileReference, NameLike},
+    search::FileReference,
     RootDatabase,
 };
 use stdx::never;
@@ -47,12 +47,13 @@ pub(crate) fn prepare_rename(
     let sema = Semantics::new(db);
     let source_file = sema.parse(position.file_id);
     let syntax = source_file.syntax();
-    let range = match &find_name_like(&sema, &syntax, position)
+    let range = match &sema
+        .find_node_at_offset_with_descend(&syntax, position.offset)
         .ok_or_else(|| format_err!("No references found at position"))?
     {
-        NameLike::Name(it) => it.syntax(),
-        NameLike::NameRef(it) => it.syntax(),
-        NameLike::Lifetime(it) => it.syntax(),
+        ast::NameLike::Name(it) => it.syntax(),
+        ast::NameLike::NameRef(it) => it.syntax(),
+        ast::NameLike::Lifetime(it) => it.syntax(),
     }
     .text_range();
     Ok(RangeInfo::new(range, ()))
@@ -121,50 +122,28 @@ fn check_identifier(new_name: &str) -> RenameResult<IdentifierKind> {
     }
 }
 
-fn find_name_like(
-    sema: &Semantics<RootDatabase>,
-    syntax: &SyntaxNode,
-    position: FilePosition,
-) -> Option<NameLike> {
-    let namelike = if let Some(name_ref) =
-        sema.find_node_at_offset_with_descend::<ast::NameRef>(syntax, position.offset)
-    {
-        NameLike::NameRef(name_ref)
-    } else if let Some(name) =
-        sema.find_node_at_offset_with_descend::<ast::Name>(syntax, position.offset)
-    {
-        NameLike::Name(name)
-    } else if let Some(lifetime) =
-        sema.find_node_at_offset_with_descend::<ast::Lifetime>(syntax, position.offset)
-    {
-        NameLike::Lifetime(lifetime)
-    } else {
-        return None;
-    };
-    Some(namelike)
-}
-
 fn find_definition(
     sema: &Semantics<RootDatabase>,
     syntax: &SyntaxNode,
     position: FilePosition,
 ) -> RenameResult<Definition> {
-    match find_name_like(sema, syntax, position)
+    match sema
+        .find_node_at_offset_with_descend(syntax, position.offset)
         .ok_or_else(|| format_err!("No references found at position"))?
     {
         // renaming aliases would rename the item being aliased as the HIR doesn't track aliases yet
-        NameLike::Name(name)
+        ast::NameLike::Name(name)
             if name.syntax().parent().map_or(false, |it| ast::Rename::can_cast(it.kind())) =>
         {
             bail!("Renaming aliases is currently unsupported")
         }
-        NameLike::Name(name) => {
+        ast::NameLike::Name(name) => {
             NameClass::classify(sema, &name).map(|class| class.referenced_or_defined(sema.db))
         }
-        NameLike::NameRef(name_ref) => {
+        ast::NameLike::NameRef(name_ref) => {
             NameRefClass::classify(sema, &name_ref).map(|class| class.referenced(sema.db))
         }
-        NameLike::Lifetime(lifetime) => NameRefClass::classify_lifetime(sema, &lifetime)
+        ast::NameLike::Lifetime(lifetime) => NameRefClass::classify_lifetime(sema, &lifetime)
             .map(|class| NameRefClass::referenced(class, sema.db))
             .or_else(|| {
                 NameClass::classify_lifetime(sema, &lifetime)
@@ -187,10 +166,12 @@ fn source_edit_from_references(
             // if the ranges differ then the node is inside a macro call, we can't really attempt
             // to make special rewrites like shorthand syntax and such, so just rename the node in
             // the macro input
-            NameLike::NameRef(name_ref) if name_ref.syntax().text_range() == reference.range => {
+            ast::NameLike::NameRef(name_ref)
+                if name_ref.syntax().text_range() == reference.range =>
+            {
                 source_edit_from_name_ref(name_ref, new_name, def)
             }
-            NameLike::Name(name) if name.syntax().text_range() == reference.range => {
+            ast::NameLike::Name(name) if name.syntax().text_range() == reference.range => {
                 source_edit_from_name(name, new_name)
             }
             _ => None,

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -19,7 +19,7 @@ pub use self::{
     expr_ext::{ArrayExprKind, BinOp, Effect, ElseBranch, LiteralKind, PrefixOp, RangeOp},
     generated::{nodes::*, tokens::*},
     node_ext::{
-        AttrKind, FieldKind, Macro, NameOrNameRef, PathSegmentKind, SelfParamKind,
+        AttrKind, FieldKind, Macro, NameLike, NameOrNameRef, PathSegmentKind, SelfParamKind,
         SlicePatComponents, StructKind, TypeBoundKind, VisibilityKind,
     },
     token_ext::*,

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -19,8 +19,8 @@ pub use self::{
     expr_ext::{ArrayExprKind, BinOp, Effect, ElseBranch, LiteralKind, PrefixOp, RangeOp},
     generated::{nodes::*, tokens::*},
     node_ext::{
-        AttrKind, FieldKind, Macro, NameLike, NameOrNameRef, PathSegmentKind, SelfParamKind,
-        SlicePatComponents, StructKind, TypeBoundKind, VisibilityKind,
+        AttrKind, FieldKind, Macro, NameLike, PathSegmentKind, SelfParamKind, SlicePatComponents,
+        StructKind, TypeBoundKind, VisibilityKind,
     },
     token_ext::*,
     traits::*,

--- a/crates/syntax/src/ast/node_ext.rs
+++ b/crates/syntax/src/ast/node_ext.rs
@@ -297,6 +297,52 @@ impl ast::RecordExprField {
     }
 }
 
+#[derive(Debug, Clone)]
+pub enum NameLike {
+    NameRef(ast::NameRef),
+    Name(ast::Name),
+    Lifetime(ast::Lifetime),
+}
+
+impl NameLike {
+    pub fn as_name_ref(&self) -> Option<&ast::NameRef> {
+        match self {
+            NameLike::NameRef(name_ref) => Some(name_ref),
+            _ => None,
+        }
+    }
+}
+
+impl ast::AstNode for NameLike {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        matches!(kind, SyntaxKind::NAME | SyntaxKind::NAME_REF | SyntaxKind::LIFETIME)
+    }
+    fn cast(syntax: SyntaxNode) -> Option<Self> {
+        let res = match syntax.kind() {
+            SyntaxKind::NAME => NameLike::Name(ast::Name { syntax }),
+            SyntaxKind::NAME_REF => NameLike::NameRef(ast::NameRef { syntax }),
+            SyntaxKind::LIFETIME => NameLike::Lifetime(ast::Lifetime { syntax }),
+            _ => return None,
+        };
+        Some(res)
+    }
+    fn syntax(&self) -> &SyntaxNode {
+        match self {
+            NameLike::NameRef(it) => it.syntax(),
+            NameLike::Name(it) => it.syntax(),
+            NameLike::Lifetime(it) => it.syntax(),
+        }
+    }
+}
+
+mod __ {
+    use super::{
+        ast::{Lifetime, Name, NameRef},
+        NameLike,
+    };
+    stdx::impl_from!(NameRef, Name, Lifetime for NameLike);
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum NameOrNameRef {
     Name(ast::Name),


### PR DESCRIPTION
With this `search`(and 2 other modules) don't necessarily go through 3 calls of `find_node_at_offset_with_descend` to find the correct node. Also makes the code that searches for NameLikes a bit easier on the eyes imo, though that can be fixed with just a helper function as well so its not that relevant.