### PR TITLE
Remove use of deprecated `std::collections::Bound`

### DIFF
--- a/crates/proc_macro_srv/src/rustc_server.rs
+++ b/crates/proc_macro_srv/src/rustc_server.rs
@@ -10,9 +10,10 @@
 
 use crate::proc_macro::bridge::{self, server};
 
-use std::collections::{Bound, HashMap};
+use std::collections::HashMap;
 use std::hash::Hash;
 use std::iter::FromIterator;
+use std::ops::Bound;
 use std::str::FromStr;
 use std::{ascii, vec::IntoIter};
 


### PR DESCRIPTION
`std::collections::Bound` has been deprecated since Rust 1.26, but due to a bug (https://github.com/rust-lang/rust/issues/82080) it never triggered a visible deprecation warning. Fixing this is being done in https://github.com/rust-lang/rust/pull/82122 , but landing that requires rustc-analyzer to build without triggering any deprecation warnings (https://github.com/rust-lang-ci/rust/runs/1911884006#step:24:19361).