### PR TITLE
Avoid transmitting unchanged diagnostics

### DIFF
--- a/crates/rust-analyzer/src/diagnostics.rs
+++ b/crates/rust-analyzer/src/diagnostics.rs
@@ -65,6 +65,17 @@ impl DiagnosticCollection {
         file_id: FileId,
         diagnostics: Vec<lsp_types::Diagnostic>,
     ) {
+        if let Some(existing_diagnostics) = self.native.get(&file_id) {
+            if existing_diagnostics.len() == diagnostics.len()
+                && diagnostics
+                    .iter()
+                    .zip(existing_diagnostics)
+                    .all(|(new, existing)| are_diagnostics_equal(new, existing))
+            {
+                return;
+            }
+        }
+
         self.native.insert(file_id, diagnostics);
         self.changes.insert(file_id);
     }


### PR DESCRIPTION
Reading through the code for diagnostics and observing debug logs, I noticed
that diagnostics are transmitted after every change for every opened file,
even if they haven't changed (especially visible for files with no diagnostics).

This change avoids marking files as "changed" if diagnostics are the same to what
was already sent before. This will only work if diagnostics are always produced in
the same order, but from my limited testing it seems this is the case.