### PR TITLE
Revert "Replace usage of ast::NameOrNameRef with ast::NameLike"

### DIFF
--- a/crates/hir_expand/src/name.rs
+++ b/crates/hir_expand/src/name.rs
@@ -87,18 +87,11 @@ impl AsName for ast::Name {
     }
 }
 
-impl AsName for ast::Lifetime {
-    fn as_name(&self) -> Name {
-        Name::resolve(self.text())
-    }
-}
-
-impl AsName for ast::NameLike {
+impl AsName for ast::NameOrNameRef {
     fn as_name(&self) -> Name {
         match self {
-            ast::NameLike::Name(it) => it.as_name(),
-            ast::NameLike::NameRef(it) => it.as_name(),
-            ast::NameLike::Lifetime(it) => it.as_name(),
+            ast::NameOrNameRef::Name(it) => it.as_name(),
+            ast::NameOrNameRef::NameRef(it) => it.as_name(),
         }
     }
 }

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -19,8 +19,8 @@ pub use self::{
     expr_ext::{ArrayExprKind, BinOp, Effect, ElseBranch, LiteralKind, PrefixOp, RangeOp},
     generated::{nodes::*, tokens::*},
     node_ext::{
-        AttrKind, FieldKind, Macro, NameLike, PathSegmentKind, SelfParamKind, SlicePatComponents,
-        StructKind, TypeBoundKind, VisibilityKind,
+        AttrKind, FieldKind, Macro, NameLike, NameOrNameRef, PathSegmentKind, SelfParamKind,
+        SlicePatComponents, StructKind, TypeBoundKind, VisibilityKind,
     },
     token_ext::*,
     traits::*,

--- a/crates/syntax/src/ast/node_ext.rs
+++ b/crates/syntax/src/ast/node_ext.rs
@@ -297,7 +297,7 @@ impl ast::RecordExprField {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub enum NameLike {
     NameRef(ast::NameRef),
     Name(ast::Name),
@@ -335,16 +335,6 @@ impl ast::AstNode for NameLike {
     }
 }
 
-impl fmt::Display for NameLike {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            NameLike::Name(it) => fmt::Display::fmt(it, f),
-            NameLike::NameRef(it) => fmt::Display::fmt(it, f),
-            NameLike::Lifetime(it) => fmt::Display::fmt(it, f),
-        }
-    }
-}
-
 mod __ {
     use super::{
         ast::{Lifetime, Name, NameRef},
@@ -353,11 +343,26 @@ mod __ {
     stdx::impl_from!(NameRef, Name, Lifetime for NameLike);
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum NameOrNameRef {
+    Name(ast::Name),
+    NameRef(ast::NameRef),
+}
+
+impl fmt::Display for NameOrNameRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            NameOrNameRef::Name(it) => fmt::Display::fmt(it, f),
+            NameOrNameRef::NameRef(it) => fmt::Display::fmt(it, f),
+        }
+    }
+}
+
 impl ast::RecordPatField {
     pub fn for_field_name_ref(field_name: &ast::NameRef) -> Option<ast::RecordPatField> {
         let candidate = field_name.syntax().parent().and_then(ast::RecordPatField::cast)?;
         match candidate.field_name()? {
-            NameLike::NameRef(name_ref) if name_ref == *field_name => Some(candidate),
+            NameOrNameRef::NameRef(name_ref) if name_ref == *field_name => Some(candidate),
             _ => None,
         }
     }
@@ -366,19 +371,19 @@ impl ast::RecordPatField {
         let candidate =
             field_name.syntax().ancestors().nth(2).and_then(ast::RecordPatField::cast)?;
         match candidate.field_name()? {
-            NameLike::Name(name) if name == *field_name => Some(candidate),
+            NameOrNameRef::Name(name) if name == *field_name => Some(candidate),
             _ => None,
         }
     }
 
     /// Deals with field init shorthand
-    pub fn field_name(&self) -> Option<NameLike> {
+    pub fn field_name(&self) -> Option<NameOrNameRef> {
         if let Some(name_ref) = self.name_ref() {
-            return Some(NameLike::NameRef(name_ref));
+            return Some(NameOrNameRef::NameRef(name_ref));
         }
         if let Some(ast::Pat::IdentPat(pat)) = self.pat() {
             let name = pat.name()?;
-            return Some(NameLike::Name(name));
+            return Some(NameOrNameRef::Name(name));
         }
         None
     }


### PR DESCRIPTION
This reverts commit e1dbf43cf85f84c3a7e40f9731fc1f7ac96f8979.