### PR TITLE
Remove documentation of obsolete extend selection command

### DIFF
--- a/crates/ide/src/extend_selection.rs
+++ b/crates/ide/src/extend_selection.rs
@@ -12,15 +12,17 @@ use syntax::{
 
 use crate::FileRange;
 
-// Feature: Extend Selection
+// Feature: Expand and Shrink Selection
 //
-// Extends the current selection to the encompassing syntactic construct
+// Extends or shrinks the current selection to the encompassing syntactic construct
 // (expression, statement, item, module, etc). It works with multiple cursors.
+//
+// This is a standard LSP feature and not a protocol extension.
 //
 // |===
 // | Editor  | Shortcut
 //
-// | VS Code | kbd:[Ctrl+Shift+→]
+// | VS Code | kbd:[Alt+Shift+→], kbd:[Alt+Shift+←]
 // |===
 pub(crate) fn extend_selection(db: &RootDatabase, frange: FileRange) -> TextRange {
     let sema = Semantics::new(db);


### PR DESCRIPTION
Closes #7454

This is available in LSP as `textDocument/selectionRange` and no longer exists as a stand-alone command, so we shouldn't mention it in the manual because it's confusing (it doesn't appear in `package.json`).