### PR TITLE
Don't lower TypeBound::Lifetime as GenericPredicate::Error

### DIFF
--- a/crates/hir/src/code_model.rs
+++ b/crates/hir/src/code_model.rs
@@ -28,7 +28,7 @@ use hir_expand::{
 };
 use hir_ty::{
     autoderef,
-    display::{write_bounds_like_dyn_trait, HirDisplayError, HirFormatter},
+    display::{write_bounds_like_dyn_trait_with_prefix, HirDisplayError, HirFormatter},
     method_resolution,
     traits::{FnTrait, Solution, SolutionVariables},
     ApplicationTy, BoundVar, CallableDefId, Canonical, DebruijnIndex, FnSig, GenericPredicate,
@@ -1379,8 +1379,7 @@ impl HirDisplay for TypeParam {
         let substs = Substs::type_params(f.db, self.id.parent);
         let predicates = bounds.iter().cloned().map(|b| b.subst(&substs)).collect::<Vec<_>>();
         if !(predicates.is_empty() || f.omit_verbose_types()) {
-            write!(f, ": ")?;
-            write_bounds_like_dyn_trait(&predicates, f)?;
+            write_bounds_like_dyn_trait_with_prefix(":", &predicates, f)?;
         }
         Ok(())
     }

--- a/crates/hir_ty/src/tests/method_resolution.rs
+++ b/crates/hir_ty/src/tests/method_resolution.rs
@@ -1114,14 +1114,14 @@ fn method_on_dyn_impl() {
 trait Foo {}
 
 impl Foo for u32 {}
-impl dyn Foo {
+impl dyn Foo + '_ {
     pub fn dyn_foo(&self) -> u32 {
         0
     }
 }
 
 fn main() {
-    let f = &42u32 as &dyn Foo<u32>;
+    let f = &42u32 as &dyn Foo;
     f.dyn_foo();
   // ^u32
 }

--- a/crates/hir_ty/src/tests/traits.rs
+++ b/crates/hir_ty/src/tests/traits.rs
@@ -1410,9 +1410,9 @@ fn weird_bounds() {
         "#,
         expect![[r#"
             23..24 'a': impl Trait
-            50..51 'b': impl 
+            50..51 'b': impl
             69..70 'c': impl Trait
-            86..87 'd': impl 
+            86..87 'd': impl
             107..108 'e': impl {error}
             123..124 'f': impl Trait + {error}
             147..149 '{}': ()

--- a/crates/hir_ty/src/tests/traits.rs
+++ b/crates/hir_ty/src/tests/traits.rs
@@ -1409,10 +1409,10 @@ fn weird_bounds() {
         fn test(a: impl Trait + 'lifetime, b: impl 'lifetime, c: impl (Trait), d: impl ('lifetime), e: impl ?Sized, f: impl Trait + ?Sized) {}
         "#,
         expect![[r#"
-            23..24 'a': impl Trait + {error}
-            50..51 'b': impl {error}
+            23..24 'a': impl Trait
+            50..51 'b': impl 
             69..70 'c': impl Trait
-            86..87 'd': impl {error}
+            86..87 'd': impl 
             107..108 'e': impl {error}
             123..124 'f': impl Trait + {error}
             147..149 '{}': ()

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -3417,7 +3417,7 @@ impl<T> Foo<T$0> {}
                 ```
                 "#]],
         );
-        // lifetimes aren't being substituted yet
+        // lifetimes bounds arent being tracked yet
         check(
             r#"
 struct Foo<T>(T);
@@ -3427,7 +3427,7 @@ impl<T: 'static> Foo<T$0> {}
                 *T*
 
                 ```rust
-                T: {error}
+                T
                 ```
                 "#]],
         );


### PR DESCRIPTION
Basically we just discard the typebound for now instead when lowering to `GenericPredicate`. I think this shouldn't have any other side effects?

Fixes #7683(hopefully for real this time)

I also played around with introducing `GenericPredicate::LifetimeOutlives` and `GenericPredicate::TypeOutlives`(see https://github.com/Veykril/rust-analyzer/commit/b9d69048451a5f2e9c5a72c800369bbeef36fdcf) but that won't fix this issue(at least not for now) due to lifetime predicate mismatches when resolving methods so I figure this is a good way to fix it for now.