### PR TITLE
Peek related tests

### DIFF
--- a/crates/cfg/src/cfg_expr.rs
+++ b/crates/cfg/src/cfg_expr.rs
@@ -49,7 +49,7 @@ impl fmt::Display for CfgAtom {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CfgExpr {
     Invalid,
     Atom(CfgAtom),

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -445,6 +445,15 @@ impl Analysis {
         self.with_db(|db| runnables::runnables(db, file_id))
     }
 
+    /// Returns the set of tests for the given file position.
+    pub fn related_tests(
+        &self,
+        position: FilePosition,
+        search_scope: Option<SearchScope>,
+    ) -> Cancelable<Vec<Runnable>> {
+        self.with_db(|db| runnables::related_tests(db, position, search_scope))
+    }
+
     /// Computes syntax highlighting for the given file
     pub fn highlight(&self, file_id: FileId) -> Cancelable<Vec<HlRange>> {
         self.with_db(|db| syntax_highlighting::highlight(db, file_id, None, false))

--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -1,10 +1,14 @@
 use std::fmt;
 
+use ast::NameOwner;
 use cfg::CfgExpr;
 use hir::{AsAssocItem, HasAttrs, HasSource, Semantics};
 use ide_assists::utils::test_related_attribute;
-use ide_db::{defs::Definition, RootDatabase, SymbolKind};
+use ide_db::{
+    base_db::FilePosition, defs::Definition, search::SearchScope, RootDatabase, SymbolKind,
+};
 use itertools::Itertools;
+use rustc_hash::FxHashSet;
 use syntax::{
     ast::{self, AstNode, AttrsOwner},
     match_ast, SyntaxNode,
@@ -13,17 +17,17 @@ use test_utils::mark;
 
 use crate::{
     display::{ToNav, TryToNav},
-    FileId, NavigationTarget,
+    references, FileId, NavigationTarget,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct Runnable {
     pub nav: NavigationTarget,
     pub kind: RunnableKind,
     pub cfg: Option<CfgExpr>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum TestId {
     Name(String),
     Path(String),
@@ -38,7 +42,7 @@ impl fmt::Display for TestId {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum RunnableKind {
     Test { test_id: TestId, attr: TestAttr },
     TestMod { path: String },
@@ -104,6 +108,102 @@ pub(crate) fn runnables(db: &RootDatabase, file_id: FileId) -> Vec<Runnable> {
     let mut res = Vec::new();
     runnables_mod(&sema, &mut res, module);
     res
+}
+
+// Feature: Run Test
+//
+// Shows a popup suggesting to run a test in which the item **at the current cursor
+// location** is used (if any).
+//
+// |===
+// | Editor  | Action Name
+//
+// | VS Code | **Rust Analyzer: Run Test**
+// |===
+pub(crate) fn related_tests(
+    db: &RootDatabase,
+    position: FilePosition,
+    search_scope: Option<SearchScope>,
+) -> Vec<Runnable> {
+    let sema = Semantics::new(db);
+    let mut res: FxHashSet<Runnable> = FxHashSet::default();
+
+    find_related_tests(&sema, position, search_scope, &mut res);
+
+    res.into_iter().collect_vec()
+}
+
+fn find_related_tests(
+    sema: &Semantics<RootDatabase>,
+    position: FilePosition,
+    search_scope: Option<SearchScope>,
+    tests: &mut FxHashSet<Runnable>,
+) {
+    if let Some(refs) = references::find_all_refs(&sema, position, search_scope) {
+        for (file_id, refs) in refs.references {
+            let file = sema.parse(file_id);
+            let file = file.syntax();
+            let functions = refs.iter().filter_map(|(range, _)| {
+                let token = file.token_at_offset(range.start()).next()?;
+                let token = sema.descend_into_macros(token);
+                let syntax = token.parent();
+                syntax.ancestors().find_map(ast::Fn::cast)
+            });
+
+            for fn_def in functions {
+                if let Some(runnable) = as_test_runnable(&sema, &fn_def) {
+                    // direct test
+                    tests.insert(runnable);
+                } else if let Some(module) = parent_test_module(&sema, &fn_def) {
+                    // indirect test
+                    find_related_tests_in_module(sema, &fn_def, &module, tests);
+                }
+            }
+        }
+    }
+}
+
+fn find_related_tests_in_module(
+    sema: &Semantics<RootDatabase>,
+    fn_def: &ast::Fn,
+    parent_module: &hir::Module,
+    tests: &mut FxHashSet<Runnable>,
+) {
+    if let Some(fn_name) = fn_def.name() {
+        let mod_source = parent_module.definition_source(sema.db);
+        let range = match mod_source.value {
+            hir::ModuleSource::Module(m) => m.syntax().text_range(),
+            hir::ModuleSource::BlockExpr(b) => b.syntax().text_range(),
+            hir::ModuleSource::SourceFile(f) => f.syntax().text_range(),
+        };
+
+        let file_id = mod_source.file_id.original_file(sema.db);
+        let mod_scope = SearchScope::file_part(file_id, range);
+        let fn_pos = FilePosition { file_id, offset: fn_name.syntax().text_range().start() };
+        find_related_tests(sema, fn_pos, Some(mod_scope), tests)
+    }
+}
+
+fn as_test_runnable(sema: &Semantics<RootDatabase>, fn_def: &ast::Fn) -> Option<Runnable> {
+    if test_related_attribute(&fn_def).is_some() {
+        let function = sema.to_def(fn_def)?;
+        runnable_fn(sema, function)
+    } else {
+        None
+    }
+}
+
+fn parent_test_module(sema: &Semantics<RootDatabase>, fn_def: &ast::Fn) -> Option<hir::Module> {
+    fn_def.syntax().ancestors().find_map(|node| {
+        let module = ast::Module::cast(node)?;
+        let module = sema.to_def(&module)?;
+
+        if has_test_function_or_multiple_test_submodules(sema, &module) {
+            Some(module)
+        } else {
+            None
+        }
+    })
 }
 
 fn runnables_mod(sema: &Semantics<RootDatabase>, acc: &mut Vec<Runnable>, module: hir::Module) {
@@ -255,7 +355,7 @@ fn module_def_doctest(sema: &Semantics<RootDatabase>, def: hir::ModuleDef) -> Op
     Some(res)
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct TestAttr {
     pub ignore: bool,
 }
@@ -347,6 +447,12 @@ mod tests {
             actions,
             runnables.into_iter().map(|it| it.action()).collect::<Vec<_>>().as_slice()
         );
+    }
+
+    fn check_tests(ra_fixture: &str, expect: Expect) {
+        let (analysis, position) = fixture::position(ra_fixture);
+        let tests = analysis.related_tests(position, None).unwrap();
+        expect.assert_debug_eq(&tests);
     }
 
     #[test]
@@ -1071,6 +1177,226 @@ mod tests {
             &[],
             expect![[r#"
                 []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn find_no_tests() {
+        check_tests(
+            r#"
+//- /lib.rs
+fn foo$0() {  };
+"#,
+            expect![[r#"
+                []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn find_direct_fn_test() {
+        check_tests(
+            r#"
+//- /lib.rs
+fn foo$0() { };
+
+mod tests {
+    #[test]
+    fn foo_test() {
+        super::foo()
+    }
+}
+"#,
+            expect![[r#"
+                [
+                    Runnable {
+                        nav: NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 31..85,
+                            focus_range: 46..54,
+                            name: "foo_test",
+                            kind: Function,
+                        },
+                        kind: Test {
+                            test_id: Path(
+                                "tests::foo_test",
+                            ),
+                            attr: TestAttr {
+                                ignore: false,
+                            },
+                        },
+                        cfg: None,
+                    },
+                ]
+            "#]],
+        );
+    }
+
+    #[test]
+    fn find_direct_struct_test() {
+        check_tests(
+            r#"
+//- /lib.rs
+struct Fo$0o;
+fn foo(arg: &Foo) { };
+
+mod tests {
+    use super::*;
+
+    #[test]
+    fn foo_test() {
+        foo(Foo);
+    }
+}
+"#,
+            expect![[r#"
+            [
+                Runnable {
+                    nav: NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 71..122,
+                        focus_range: 86..94,
+                        name: "foo_test",
+                        kind: Function,
+                    },
+                    kind: Test {
+                        test_id: Path(
+                            "tests::foo_test",
+                        ),
+                        attr: TestAttr {
+                            ignore: false,
+                        },
+                    },
+                    cfg: None,
+                },
+            ]
+            "#]],
+        );
+    }
+
+    #[test]
+    fn find_indirect_fn_test() {
+        check_tests(
+            r#"
+//- /lib.rs
+fn foo$0() { };
+
+mod tests {
+    use super::foo;
+
+    fn check1() {
+        check2()
+    }
+
+    fn check2() {
+        foo()
+    }
+
+    #[test]
+    fn foo_test() {
+        check1()
+    }
+}
+"#,
+            expect![[r#"
+                [
+                    Runnable {
+                        nav: NavigationTarget {
+                            file_id: FileId(
+                                0,
+                            ),
+                            full_range: 133..183,
+                            focus_range: 148..156,
+                            name: "foo_test",
+                            kind: Function,
+                        },
+                        kind: Test {
+                            test_id: Path(
+                                "tests::foo_test",
+                            ),
+                            attr: TestAttr {
+                                ignore: false,
+                            },
+                        },
+                        cfg: None,
+                    },
+                ]
+            "#]],
+        );
+    }
+
+    #[test]
+    fn tests_are_unique() {
+        check_tests(
+            r#"
+//- /lib.rs
+fn foo$0() { };
+
+mod tests {
+    use super::foo;
+
+    #[test]
+    fn foo_test() {
+        foo();
+        foo();
+    }
+
+    #[test]
+    fn foo2_test() {
+        foo();
+        foo();
+    }
+
+}
+"#,
+            expect![[r#"
+            [
+                Runnable {
+                    nav: NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 52..115,
+                        focus_range: 67..75,
+                        name: "foo_test",
+                        kind: Function,
+                    },
+                    kind: Test {
+                        test_id: Path(
+                            "tests::foo_test",
+                        ),
+                        attr: TestAttr {
+                            ignore: false,
+                        },
+                    },
+                    cfg: None,
+                },
+                Runnable {
+                    nav: NavigationTarget {
+                        file_id: FileId(
+                            0,
+                        ),
+                        full_range: 121..185,
+                        focus_range: 136..145,
+                        name: "foo2_test",
+                        kind: Function,
+                    },
+                    kind: Test {
+                        test_id: Path(
+                            "tests::foo2_test",
+                        ),
+                        attr: TestAttr {
+                            ignore: false,
+                        },
+                    },
+                    cfg: None,
+                },
+            ]
             "#]],
         );
     }

--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -110,16 +110,6 @@ pub(crate) fn runnables(db: &RootDatabase, file_id: FileId) -> Vec<Runnable> {
     res
 }
 
-// Feature: Run Test
-//
-// Shows a popup suggesting to run a test in which the item **at the current cursor
-// location** is used (if any).
-//
-// |===
-// | Editor  | Action Name
-//
-// | VS Code | **Rust Analyzer: Run Test**
-// |===
 pub(crate) fn related_tests(
     db: &RootDatabase,
     position: FilePosition,

--- a/crates/ide_db/src/search.rs
+++ b/crates/ide_db/src/search.rs
@@ -86,6 +86,10 @@ impl SearchScope {
         SearchScope::new(std::iter::once((file, None)).collect())
     }
 
+    pub fn file_part(file: FileId, range: TextRange) -> SearchScope {
+        SearchScope::new(std::iter::once((file, Some(range))).collect())
+    }
+
     pub fn files(files: &[FileId]) -> SearchScope {
         SearchScope::new(files.iter().map(|f| (*f, None)).collect())
     }

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -607,6 +607,24 @@ pub(crate) fn handle_runnables(
     Ok(res)
 }
 
+pub(crate) fn handle_related_tests(
+    snap: GlobalStateSnapshot,
+    params: lsp_ext::RelatedTestsParams,
+) -> Result<Vec<lsp_ext::TestInfo>> {
+    let _p = profile::span("handle_related_tests");
+    let position = from_proto::file_position(&snap, params.text_document_position)?;
+
+    let tests = snap.analysis.related_tests(position, None)?;
+    let mut res = Vec::new();
+    for it in tests {
+        if let Ok(runnable) = to_proto::runnable(&snap, it) {
+            res.push(lsp_ext::TestInfo { runnable })
+        }
+    }
+
+    Ok(res)
+}
+
 pub(crate) fn handle_completion(
     snap: GlobalStateSnapshot,
     params: lsp_types::CompletionParams,

--- a/crates/rust-analyzer/src/lsp_ext.rs
+++ b/crates/rust-analyzer/src/lsp_ext.rs
@@ -177,6 +177,26 @@ pub struct CargoRunnable {
     pub expect_test: Option<bool>,
 }
 
+pub enum RelatedTests {}
+
+impl Request for RelatedTests {
+    type Params = RelatedTestsParams;
+    type Result = Vec<TestInfo>;
+    const METHOD: &'static str = "rust-analyzer/relatedTests";
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct RelatedTestsParams {
+    #[serde(flatten)]
+    pub text_document_position: lsp_types::TextDocumentPositionParams,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct TestInfo {
+    pub runnable: Runnable,
+}
+
 pub enum InlayHints {}
 
 impl Request for InlayHints {

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -500,6 +500,7 @@ impl GlobalState {
             .on::<lsp_ext::ExpandMacro>(handlers::handle_expand_macro)
             .on::<lsp_ext::ParentModule>(handlers::handle_parent_module)
             .on::<lsp_ext::Runnables>(handlers::handle_runnables)
+            .on::<lsp_ext::RelatedTests>(handlers::handle_related_tests)
             .on::<lsp_ext::InlayHints>(handlers::handle_inlay_hints)
             .on::<lsp_ext::CodeActionRequest>(handlers::handle_code_action)
             .on::<lsp_ext::CodeActionResolveRequest>(handlers::handle_code_action_resolve)

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -828,11 +828,10 @@ pub(crate) fn resolved_code_action(
 
 pub(crate) fn runnable(
     snap: &GlobalStateSnapshot,
-    file_id: FileId,
     runnable: Runnable,
 ) -> Result<lsp_ext::Runnable> {
     let config = snap.config.runnables();
-    let spec = CargoTargetSpec::for_file(snap, file_id)?;
+    let spec = CargoTargetSpec::for_file(snap, runnable.nav.file_id)?;
     let workspace_root = spec.as_ref().map(|it| it.workspace_root.clone());
     let target = spec.as_ref().map(|s| s.target.clone());
     let (cargo_args, executable_args) =
@@ -865,7 +864,7 @@ pub(crate) fn code_lens(
             let annotation_range = range(&line_index, annotation.range);
 
             let action = run.action();
-            let r = runnable(&snap, run.nav.file_id, run)?;
+            let r = runnable(&snap, run)?;
 
             let command = if debug {
                 command::debug_single(&r)

--- a/docs/dev/lsp-extensions.md
+++ b/docs/dev/lsp-extensions.md
@@ -1,5 +1,5 @@
 <!---
-lsp_ext.rs hash: d279d971d4f62cd7
+lsp_ext.rs hash: 9d4978a16ab69027
 
 If you need to change the above hash to make the test pass, please check if you
 need to adjust this doc as well and ping this  issue:
@@ -579,3 +579,24 @@ This request is sent from client to server to open the current project's Cargo.t
 ```
 
 `experimental/openCargoToml` returns a single `Link` to the start of the `[package]` keyword.
+
+## Related tests
+
+This request is sent from client to server to get the list of tests for the specified position.
+
+**Method:** `rust-analyzer/relatedTests`
+
+**Request:**
+
+```typescript
+interface RelatedTestsParams : extends TextDocumentPositionParams {    
+}
+```
+
+**Response:** `TestInfo[]`
+
+```typescript
+interface TestInfo {
+    runnable: Runnable;
+}
+```

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -202,6 +202,11 @@
                 "command": "rust-analyzer.openCargoToml",
                 "title": "Open Cargo.toml",
                 "category": "Rust Analyzer"
+            },
+            {
+                "command": "rust-analyzer.peekTests",
+                "title": "Peek related tests",
+                "category": "Rust Analyzer"
             }
         ],
         "keybindings": [

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1164,6 +1164,13 @@
                     "command": "rust-analyzer.openCargoToml",
                     "when": "inRustProject"
                 }
+            ],
+            "editor/context": [
+                {
+                    "command": "rust-analyzer.peekTests",
+                    "when": "inRustProject",
+                    "group": "navigation@1000"
+                }
             ]
         }
     }

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -9,6 +9,7 @@ import { RunnableQuickPick, selectRunnable, createTask, createArgs } from './run
 import { AstInspector } from './ast_inspector';
 import { isRustDocument, sleep, isRustEditor } from './util';
 import { startDebugSession, makeDebugConfig } from './debug';
+import { LanguageClient } from 'vscode-languageclient/node';
 
 export * from './ast_inspector';
 export * from './run';
@@ -456,17 +457,20 @@ export function reloadWorkspace(ctx: Ctx): Cmd {
     return async () => ctx.client.sendRequest(ra.reloadWorkspace);
 }
 
+async function showReferencesImpl(client: LanguageClient, uri: string, position: lc.Position, locations: lc.Location[]) {
+    if (client) {
+        await vscode.commands.executeCommand(
+            'editor.action.showReferences',
+            vscode.Uri.parse(uri),
+            client.protocol2CodeConverter.asPosition(position),
+            locations.map(client.protocol2CodeConverter.asLocation),
+        );
+    }
+}
+
 export function showReferences(ctx: Ctx): Cmd {
     return async (uri: string, position: lc.Position, locations: lc.Location[]) => {
-        const client = ctx.client;
-        if (client) {
-            await vscode.commands.executeCommand(
-                'editor.action.showReferences',
-                vscode.Uri.parse(uri),
-                client.protocol2CodeConverter.asPosition(position),
-                locations.map(client.protocol2CodeConverter.asLocation),
-            );
-        }
+        await showReferencesImpl(ctx.client, uri, position, locations);
     };
 }
 
@@ -554,6 +558,35 @@ export function run(ctx: Ctx): Cmd {
         return await vscode.tasks.executeTask(task);
     };
 }
+
+export function peekTests(ctx: Ctx): Cmd {
+    const client = ctx.client;
+
+    return async () => {
+        const editor = ctx.activeRustEditor;
+        if (!editor || !client) return;
+
+        const uri = editor.document.uri.toString();
+        const position = client.code2ProtocolConverter.asPosition(
+            editor.selection.active,
+        );
+        
+        const tests = await client.sendRequest(ra.relatedTests, {
+            textDocument: { uri: uri },
+            position: position,
+        });
+
+        const locations: lc.Location[] = tests.map( it => {
+            return {
+                uri: it.runnable.location!.targetUri,
+                range: it.runnable.location!.targetSelectionRange
+            };
+        });
+
+        await showReferencesImpl(client, uri, position, locations);
+    };
+}
+
 
 export function runSingle(ctx: Ctx): Cmd {
     return async (runnable: ra.Runnable) => {

--- a/editors/code/src/lsp_ext.ts
+++ b/editors/code/src/lsp_ext.ts
@@ -72,6 +72,15 @@ export interface Runnable {
 }
 export const runnables = new lc.RequestType<RunnablesParams, Runnable[], void>("experimental/runnables");
 
+export interface RelatedTestsParams extends lc.TextDocumentPositionParams {    
+}
+
+export interface TestInfo {
+    runnable: Runnable;
+}
+
+export const relatedTests = new lc.RequestType<RelatedTestsParams, TestInfo[], void>("rust-analyzer/relatedTests");
+
 export type InlayHint = InlayHint.TypeHint | InlayHint.ParamHint | InlayHint.ChainingHint;
 
 export namespace InlayHint {

--- a/editors/code/src/lsp_ext.ts
+++ b/editors/code/src/lsp_ext.ts
@@ -72,7 +72,7 @@ export interface Runnable {
 }
 export const runnables = new lc.RequestType<RunnablesParams, Runnable[], void>("experimental/runnables");
 
-export interface RelatedTestsParams extends lc.TextDocumentPositionParams {    
+export interface RelatedTestsParams extends lc.TextDocumentPositionParams {
 }
 
 export interface TestInfo {

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -113,6 +113,7 @@ async function tryActivate(context: vscode.ExtensionContext) {
     ctx.registerCommand('newDebugConfig', commands.newDebugConfig);
     ctx.registerCommand('openDocs', commands.openDocs);
     ctx.registerCommand('openCargoToml', commands.openCargoToml);
+    ctx.registerCommand('peekTests', commands.peekTests);
 
     defaultOnEnter.dispose();
     ctx.registerCommand('onEnter', commands.onEnter);


### PR DESCRIPTION
![tests](https://user-images.githubusercontent.com/35568079/109396942-24151d80-7945-11eb-82fa-968330d29fd1.gif)
This adds an ability to look for tests for the item under the cursor: function, constant, data type, etc.

The LSP part is bound to change. But the feature itself already works and I'm looking for a feedback :)
