### PR TITLE
Restrict visibilities to the containing DefMap

### DIFF
--- a/crates/hir_def/src/body/tests/block.rs
+++ b/crates/hir_def/src/body/tests/block.rs
@@ -259,3 +259,32 @@ fn main() {
     "#]],
     );
 }
+
+#[test]
+fn underscore_import() {
+    // This used to panic, because the default (private) visibility inside block expressions would
+    // point into the containing `DefMap`, which visibilities should never be able to do.
+    mark::check!(adjust_vis_in_block_def_map);
+    check_at(
+        r#"
+mod m {
+    fn main() {
+        use Tr as _;
+        trait Tr {}
+        $0
+    }
+}
+    "#,
+        expect![[r#"
+        block scope
+        _: t
+        Tr: t
+
+        crate
+        m: t
+
+        crate::m
+        main: v
+    "#]],
+    );
+}


### PR DESCRIPTION
Visibilities must always point into the DefMap where they are used, but in a block expression `self` resolves to the *containing* non-block module, which is in a different DefMap. Restrict visibilities accordingly, turning them into basically `pub(block)`, which Rust has no syntax for.

bors r+