### PR TITLE
Introduce TypeCtor::Scalar

### DIFF
--- a/crates/hir/src/code_model.rs
+++ b/crates/hir/src/code_model.rs
@@ -32,8 +32,8 @@ use hir_ty::{
     method_resolution,
     traits::{FnTrait, Solution, SolutionVariables},
     ApplicationTy, BoundVar, CallableDefId, Canonical, DebruijnIndex, FnSig, GenericPredicate,
-    InEnvironment, Obligation, ProjectionPredicate, ProjectionTy, Substs, TraitEnvironment, Ty,
-    TyDefId, TyKind, TypeCtor,
+    InEnvironment, Obligation, ProjectionPredicate, ProjectionTy, Scalar, Substs, TraitEnvironment,
+    Ty, TyDefId, TyKind, TypeCtor,
 };
 use rustc_hash::FxHashSet;
 use stdx::{format_to, impl_from};
@@ -1553,7 +1553,10 @@ impl Type {
         )
     }
     pub fn is_bool(&self) -> bool {
-        matches!(self.ty.value, Ty::Apply(ApplicationTy { ctor: TypeCtor::Bool, .. }))
+        matches!(
+            self.ty.value,
+            Ty::Apply(ApplicationTy { ctor: TypeCtor::Scalar(Scalar::Bool), .. })
+        )
     }
 
     pub fn is_mutable_reference(&self) -> bool {

--- a/crates/hir_def/src/builtin_type.rs
+++ b/crates/hir_def/src/builtin_type.rs
@@ -6,38 +6,32 @@
 use std::fmt;
 
 use hir_expand::name::{name, AsName, Name};
-
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum Signedness {
-    Signed,
-    Unsigned,
+/// Different signed int types.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum BuiltinInt {
+    Isize,
+    I8,
+    I16,
+    I32,
+    I64,
+    I128,
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum IntBitness {
-    Xsize,
-    X8,
-    X16,
-    X32,
-    X64,
-    X128,
+/// Different unsigned int types.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum BuiltinUint {
+    Usize,
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum FloatBitness {
-    X32,
-    X64,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct BuiltinInt {
-    pub signedness: Signedness,
-    pub bitness: IntBitness,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct BuiltinFloat {
-    pub bitness: FloatBitness,
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum BuiltinFloat {
+    F32,
+    F64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -46,6 +40,7 @@ pub enum BuiltinType {
     Bool,
     Str,
     Int(BuiltinInt),
+    Uint(BuiltinUint),
     Float(BuiltinFloat),
 }
 
@@ -56,19 +51,19 @@ impl BuiltinType {
         (name![bool], BuiltinType::Bool),
         (name![str],  BuiltinType::Str),
 
-        (name![isize], BuiltinType::Int(BuiltinInt::ISIZE)),
+        (name![isize], BuiltinType::Int(BuiltinInt::Isize)),
         (name![i8],    BuiltinType::Int(BuiltinInt::I8)),
         (name![i16],   BuiltinType::Int(BuiltinInt::I16)),
         (name![i32],   BuiltinType::Int(BuiltinInt::I32)),
         (name![i64],   BuiltinType::Int(BuiltinInt::I64)),
         (name![i128],  BuiltinType::Int(BuiltinInt::I128)),
 
-        (name![usize], BuiltinType::Int(BuiltinInt::USIZE)),
-        (name![u8],    BuiltinType::Int(BuiltinInt::U8)),
-        (name![u16],   BuiltinType::Int(BuiltinInt::U16)),
-        (name![u32],   BuiltinType::Int(BuiltinInt::U32)),
-        (name![u64],   BuiltinType::Int(BuiltinInt::U64)),
-        (name![u128],  BuiltinType::Int(BuiltinInt::U128)),
+        (name![usize], BuiltinType::Uint(BuiltinUint::Usize)),
+        (name![u8],    BuiltinType::Uint(BuiltinUint::U8)),
+        (name![u16],   BuiltinType::Uint(BuiltinUint::U16)),
+        (name![u32],   BuiltinType::Uint(BuiltinUint::U32)),
+        (name![u64],   BuiltinType::Uint(BuiltinUint::U64)),
+        (name![u128],  BuiltinType::Uint(BuiltinUint::U128)),
 
         (name![f32], BuiltinType::Float(BuiltinFloat::F32)),
         (name![f64], BuiltinType::Float(BuiltinFloat::F64)),
@@ -81,24 +76,25 @@ impl AsName for BuiltinType {
             BuiltinType::Char => name![char],
             BuiltinType::Bool => name![bool],
             BuiltinType::Str => name![str],
-            BuiltinType::Int(BuiltinInt { signedness, bitness }) => match (signedness, bitness) {
-                (Signedness::Signed, IntBitness::Xsize) => name![isize],
-                (Signedness::Signed, IntBitness::X8) => name![i8],
-                (Signedness::Signed, IntBitness::X16) => name![i16],
-                (Signedness::Signed, IntBitness::X32) => name![i32],
-                (Signedness::Signed, IntBitness::X64) => name![i64],
-                (Signedness::Signed, IntBitness::X128) => name![i128],
-
-                (Signedness::Unsigned, IntBitness::Xsize) => name![usize],
-                (Signedness::Unsigned, IntBitness::X8) => name![u8],
-                (Signedness::Unsigned, IntBitness::X16) => name![u16],
-                (Signedness::Unsigned, IntBitness::X32) => name![u32],
-                (Signedness::Unsigned, IntBitness::X64) => name![u64],
-                (Signedness::Unsigned, IntBitness::X128) => name![u128],
+            BuiltinType::Int(it) => match it {
+                BuiltinInt::Isize => name![isize],
+                BuiltinInt::I8 => name![i8],
+                BuiltinInt::I16 => name![i16],
+                BuiltinInt::I32 => name![i32],
+                BuiltinInt::I64 => name![i64],
+                BuiltinInt::I128 => name![i128],
             },
-            BuiltinType::Float(BuiltinFloat { bitness }) => match bitness {
-                FloatBitness::X32 => name![f32],
-                FloatBitness::X64 => name![f64],
+            BuiltinType::Uint(it) => match it {
+                BuiltinUint::Usize => name![usize],
+                BuiltinUint::U8 => name![u8],
+                BuiltinUint::U16 => name![u16],
+                BuiltinUint::U32 => name![u32],
+                BuiltinUint::U64 => name![u64],
+                BuiltinUint::U128 => name![u128],
+            },
+            BuiltinType::Float(it) => match it {
+                BuiltinFloat::F32 => name![f32],
+                BuiltinFloat::F64 => name![f64],
             },
         }
     }
@@ -113,31 +109,26 @@ impl fmt::Display for BuiltinType {
 
 #[rustfmt::skip]
 impl BuiltinInt {
-    pub const ISIZE: BuiltinInt = BuiltinInt { signedness: Signedness::Signed, bitness: IntBitness::Xsize   };
-    pub const I8   : BuiltinInt = BuiltinInt { signedness: Signedness::Signed, bitness: IntBitness::X8      };
-    pub const I16  : BuiltinInt = BuiltinInt { signedness: Signedness::Signed, bitness: IntBitness::X16     };
-    pub const I32  : BuiltinInt = BuiltinInt { signedness: Signedness::Signed, bitness: IntBitness::X32     };
-    pub const I64  : BuiltinInt = BuiltinInt { signedness: Signedness::Signed, bitness: IntBitness::X64     };
-    pub const I128 : BuiltinInt = BuiltinInt { signedness: Signedness::Signed, bitness: IntBitness::X128    };
-
-    pub const USIZE: BuiltinInt = BuiltinInt { signedness: Signedness::Unsigned, bitness: IntBitness::Xsize };
-    pub const U8   : BuiltinInt = BuiltinInt { signedness: Signedness::Unsigned, bitness: IntBitness::X8    };
-    pub const U16  : BuiltinInt = BuiltinInt { signedness: Signedness::Unsigned, bitness: IntBitness::X16   };
-    pub const U32  : BuiltinInt = BuiltinInt { signedness: Signedness::Unsigned, bitness: IntBitness::X32   };
-    pub const U64  : BuiltinInt = BuiltinInt { signedness: Signedness::Unsigned, bitness: IntBitness::X64   };
-    pub const U128 : BuiltinInt = BuiltinInt { signedness: Signedness::Unsigned, bitness: IntBitness::X128  };
-
-
     pub fn from_suffix(suffix: &str) -> Option<BuiltinInt> {
         let res = match suffix {
-            "isize" => Self::ISIZE,
+            "isize" => Self::Isize,
             "i8"    => Self::I8,
             "i16"   => Self::I16,
             "i32"   => Self::I32,
             "i64"   => Self::I64,
             "i128"  => Self::I128,
 
-            "usize" => Self::USIZE,
+            _ => return None,
+        };
+        Some(res)
+    }
+}
+
+#[rustfmt::skip]
+impl BuiltinUint {
+    pub fn from_suffix(suffix: &str) -> Option<BuiltinUint> {
+        let res = match suffix {
+            "usize" => Self::Usize,
             "u8"    => Self::U8,
             "u16"   => Self::U16,
             "u32"   => Self::U32,
@@ -152,9 +143,6 @@ impl BuiltinInt {
 
 #[rustfmt::skip]
 impl BuiltinFloat {
-    pub const F32: BuiltinFloat = BuiltinFloat { bitness: FloatBitness::X32 };
-    pub const F64: BuiltinFloat = BuiltinFloat { bitness: FloatBitness::X64 };
-
     pub fn from_suffix(suffix: &str) -> Option<BuiltinFloat> {
         let res = match suffix {
             "f32" => BuiltinFloat::F32,

--- a/crates/hir_def/src/expr.rs
+++ b/crates/hir_def/src/expr.rs
@@ -17,7 +17,7 @@ use la_arena::{Idx, RawIdx};
 use syntax::ast::RangeOp;
 
 use crate::{
-    builtin_type::{BuiltinFloat, BuiltinInt},
+    builtin_type::{BuiltinFloat, BuiltinInt, BuiltinUint},
     path::{GenericArgs, Path},
     type_ref::{Mutability, Rawness, TypeRef},
     BlockId,
@@ -43,6 +43,7 @@ pub enum Literal {
     Char(char),
     Bool(bool),
     Int(u64, Option<BuiltinInt>),
+    Uint(u64, Option<BuiltinUint>),
     Float(u64, Option<BuiltinFloat>), // FIXME: f64 is not Eq
 }
 

--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -4,7 +4,8 @@ use std::{borrow::Cow, fmt};
 
 use crate::{
     db::HirDatabase, utils::generics, ApplicationTy, CallableDefId, FnSig, GenericPredicate,
-    Lifetime, Obligation, OpaqueTy, OpaqueTyId, ProjectionTy, Substs, TraitRef, Ty, TypeCtor,
+    Lifetime, Obligation, OpaqueTy, OpaqueTyId, ProjectionTy, Scalar, Substs, TraitRef, Ty,
+    TypeCtor,
 };
 use arrayvec::ArrayVec;
 use hir_def::{
@@ -241,10 +242,11 @@ impl HirDisplay for ApplicationTy {
         }
 
         match self.ctor {
-            TypeCtor::Bool => write!(f, "bool")?,
-            TypeCtor::Char => write!(f, "char")?,
-            TypeCtor::Int(t) => write!(f, "{}", t)?,
-            TypeCtor::Float(t) => write!(f, "{}", t)?,
+            TypeCtor::Scalar(Scalar::Bool) => write!(f, "bool")?,
+            TypeCtor::Scalar(Scalar::Char) => write!(f, "char")?,
+            TypeCtor::Scalar(Scalar::Float(t)) => write!(f, "{}", t)?,
+            TypeCtor::Scalar(Scalar::Int(t)) => write!(f, "{}", t)?,
+            TypeCtor::Scalar(Scalar::Uint(t)) => write!(f, "{}", t)?,
             TypeCtor::Str => write!(f, "str")?,
             TypeCtor::Slice => {
                 let t = self.parameters.as_single();

--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -3,9 +3,9 @@
 use std::{borrow::Cow, fmt};
 
 use crate::{
-    db::HirDatabase, utils::generics, ApplicationTy, CallableDefId, FnSig, GenericPredicate,
-    Lifetime, Obligation, OpaqueTy, OpaqueTyId, ProjectionTy, Scalar, Substs, TraitRef, Ty,
-    TypeCtor,
+    db::HirDatabase, primitive, utils::generics, ApplicationTy, CallableDefId, FnSig,
+    GenericPredicate, Lifetime, Obligation, OpaqueTy, OpaqueTyId, ProjectionTy, Scalar, Substs,
+    TraitRef, Ty, TypeCtor,
 };
 use arrayvec::ArrayVec;
 use hir_def::{
@@ -244,9 +244,11 @@ impl HirDisplay for ApplicationTy {
         match self.ctor {
             TypeCtor::Scalar(Scalar::Bool) => write!(f, "bool")?,
             TypeCtor::Scalar(Scalar::Char) => write!(f, "char")?,
-            TypeCtor::Scalar(Scalar::Float(t)) => write!(f, "{}", t)?,
-            TypeCtor::Scalar(Scalar::Int(t)) => write!(f, "{}", t)?,
-            TypeCtor::Scalar(Scalar::Uint(t)) => write!(f, "{}", t)?,
+            TypeCtor::Scalar(Scalar::Float(t)) => {
+                write!(f, "{}", primitive::float_ty_to_string(t))?
+            }
+            TypeCtor::Scalar(Scalar::Int(t)) => write!(f, "{}", primitive::int_ty_to_string(t))?,
+            TypeCtor::Scalar(Scalar::Uint(t)) => write!(f, "{}", primitive::uint_ty_to_string(t))?,
             TypeCtor::Str => write!(f, "str")?,
             TypeCtor::Slice => {
                 let t = self.parameters.as_single();

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -41,7 +41,7 @@ use super::{
     InEnvironment, ProjectionTy, Substs, TraitEnvironment, TraitRef, Ty, TypeCtor, TypeWalk,
 };
 use crate::{
-    db::HirDatabase, infer::diagnostics::InferenceDiagnostic, lower::ImplTraitLoweringMode,
+    db::HirDatabase, infer::diagnostics::InferenceDiagnostic, lower::ImplTraitLoweringMode, Scalar,
 };
 
 pub(crate) use unify::unify;
@@ -684,8 +684,8 @@ impl InferTy {
     fn fallback_value(self) -> Ty {
         match self {
             InferTy::TypeVar(..) => Ty::Unknown,
-            InferTy::IntVar(..) => Ty::simple(TypeCtor::Int(IntTy::i32())),
-            InferTy::FloatVar(..) => Ty::simple(TypeCtor::Float(FloatTy::f64())),
+            InferTy::IntVar(..) => Ty::simple(TypeCtor::Scalar(Scalar::Int(IntTy::I32))),
+            InferTy::FloatVar(..) => Ty::simple(TypeCtor::Scalar(Scalar::Float(FloatTy::F64))),
             InferTy::MaybeNeverTypeVar(..) => Ty::simple(TypeCtor::Never),
         }
     }

--- a/crates/hir_ty/src/infer/expr.rs
+++ b/crates/hir_ty/src/infer/expr.rs
@@ -15,7 +15,7 @@ use test_utils::mark;
 
 use crate::{
     autoderef, method_resolution, op,
-    primitive::UintTy,
+    primitive::{self, UintTy},
     traits::{FnTrait, InEnvironment},
     utils::{generics, variant_data, Generics},
     ApplicationTy, Binders, CallableDefId, InferTy, Mutability, Obligation, OpaqueTyId, Rawness,
@@ -730,17 +730,21 @@ impl<'a> InferenceContext<'a> {
                 }
                 Literal::Char(..) => Ty::simple(TypeCtor::Scalar(Scalar::Char)),
                 Literal::Int(_v, ty) => match ty {
-                    Some(int_ty) => Ty::simple(TypeCtor::Scalar(Scalar::Int((*int_ty).into()))),
+                    Some(int_ty) => Ty::simple(TypeCtor::Scalar(Scalar::Int(
+                        primitive::int_ty_from_builtin(*int_ty),
+                    ))),
                     None => self.table.new_integer_var(),
                 },
                 Literal::Uint(_v, ty) => match ty {
-                    Some(int_ty) => Ty::simple(TypeCtor::Scalar(Scalar::Uint((*int_ty).into()))),
+                    Some(int_ty) => Ty::simple(TypeCtor::Scalar(Scalar::Uint(
+                        primitive::uint_ty_from_builtin(*int_ty),
+                    ))),
                     None => self.table.new_integer_var(),
                 },
                 Literal::Float(_v, ty) => match ty {
-                    Some(float_ty) => {
-                        Ty::simple(TypeCtor::Scalar(Scalar::Float((*float_ty).into())))
-                    }
+                    Some(float_ty) => Ty::simple(TypeCtor::Scalar(Scalar::Float(
+                        primitive::float_ty_from_builtin(*float_ty),
+                    ))),
                     None => self.table.new_float_var(),
                 },
             },

--- a/crates/hir_ty/src/infer/unify.rs
+++ b/crates/hir_ty/src/infer/unify.rs
@@ -8,8 +8,8 @@ use test_utils::mark;
 
 use super::{InferenceContext, Obligation};
 use crate::{
-    BoundVar, Canonical, DebruijnIndex, GenericPredicate, InEnvironment, InferTy, Substs, Ty,
-    TyKind, TypeCtor, TypeWalk,
+    BoundVar, Canonical, DebruijnIndex, GenericPredicate, InEnvironment, InferTy, Scalar, Substs,
+    Ty, TyKind, TypeCtor, TypeWalk,
 };
 
 impl<'a> InferenceContext<'a> {
@@ -300,10 +300,24 @@ impl InferenceTable {
             | (other, Ty::Infer(InferTy::TypeVar(tv)))
             | (Ty::Infer(InferTy::MaybeNeverTypeVar(tv)), other)
             | (other, Ty::Infer(InferTy::MaybeNeverTypeVar(tv)))
-            | (Ty::Infer(InferTy::IntVar(tv)), other @ ty_app!(TypeCtor::Int(_)))
-            | (other @ ty_app!(TypeCtor::Int(_)), Ty::Infer(InferTy::IntVar(tv)))
-            | (Ty::Infer(InferTy::FloatVar(tv)), other @ ty_app!(TypeCtor::Float(_)))
-            | (other @ ty_app!(TypeCtor::Float(_)), Ty::Infer(InferTy::FloatVar(tv))) => {
+            | (Ty::Infer(InferTy::IntVar(tv)), other @ ty_app!(TypeCtor::Scalar(Scalar::Int(_))))
+            | (other @ ty_app!(TypeCtor::Scalar(Scalar::Int(_))), Ty::Infer(InferTy::IntVar(tv)))
+            | (
+                Ty::Infer(InferTy::IntVar(tv)),
+                other @ ty_app!(TypeCtor::Scalar(Scalar::Uint(_))),
+            )
+            | (
+                other @ ty_app!(TypeCtor::Scalar(Scalar::Uint(_))),
+                Ty::Infer(InferTy::IntVar(tv)),
+            )
+            | (
+                Ty::Infer(InferTy::FloatVar(tv)),
+                other @ ty_app!(TypeCtor::Scalar(Scalar::Float(_))),
+            )
+            | (
+                other @ ty_app!(TypeCtor::Scalar(Scalar::Float(_))),
+                Ty::Infer(InferTy::FloatVar(tv)),
+            ) => {
                 // the type var is unknown since we tried to resolve it
                 self.var_unification_table.union_value(*tv, TypeVarValue::Known(other.clone()));
                 true

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -38,7 +38,6 @@ use itertools::Itertools;
 use crate::{
     db::HirDatabase,
     display::HirDisplay,
-    primitive::{FloatTy, IntTy, UintTy},
     utils::{generics, make_mut_slice, Generics},
 };
 
@@ -50,23 +49,12 @@ pub use lower::{
 };
 pub use traits::{InEnvironment, Obligation, ProjectionPredicate, TraitEnvironment};
 
-pub use chalk_ir::{BoundVar, DebruijnIndex};
+pub use chalk_ir::{BoundVar, DebruijnIndex, Scalar};
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Lifetime {
     Parameter(LifetimeParamId),
     Static,
-}
-
-/// Types of scalar values.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[allow(missing_docs)]
-pub enum Scalar {
-    Bool,
-    Char,
-    Int(IntTy),
-    Uint(UintTy),
-    Float(FloatTy),
 }
 
 /// A type constructor or type name: this might be something like the primitive
@@ -736,9 +724,13 @@ impl Ty {
             BuiltinType::Char => TypeCtor::Scalar(Scalar::Char),
             BuiltinType::Bool => TypeCtor::Scalar(Scalar::Bool),
             BuiltinType::Str => TypeCtor::Str,
-            BuiltinType::Int(t) => TypeCtor::Scalar(Scalar::Int(t.into())),
-            BuiltinType::Uint(t) => TypeCtor::Scalar(Scalar::Uint(t.into())),
-            BuiltinType::Float(t) => TypeCtor::Scalar(Scalar::Float(t.into())),
+            BuiltinType::Int(t) => TypeCtor::Scalar(Scalar::Int(primitive::int_ty_from_builtin(t))),
+            BuiltinType::Uint(t) => {
+                TypeCtor::Scalar(Scalar::Uint(primitive::uint_ty_from_builtin(t)))
+            }
+            BuiltinType::Float(t) => {
+                TypeCtor::Scalar(Scalar::Float(primitive::float_ty_from_builtin(t)))
+            }
         })
     }
 

--- a/crates/hir_ty/src/method_resolution.rs
+++ b/crates/hir_ty/src/method_resolution.rs
@@ -16,7 +16,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use crate::{
     autoderef,
     db::HirDatabase,
-    primitive::{FloatTy, IntTy, UintTy},
+    primitive::{self, FloatTy, IntTy, UintTy},
     utils::all_super_traits,
     ApplicationTy, Canonical, DebruijnIndex, InEnvironment, Scalar, Substs, TraitEnvironment,
     TraitRef, Ty, TyKind, TypeCtor, TypeWalk,
@@ -225,8 +225,12 @@ impl Ty {
                     FloatTy::F32 => lang_item_crate!("f32", "f32_runtime"),
                     FloatTy::F64 => lang_item_crate!("f64", "f64_runtime"),
                 },
-                TypeCtor::Scalar(Scalar::Int(t)) => lang_item_crate!(t.ty_to_string()),
-                TypeCtor::Scalar(Scalar::Uint(t)) => lang_item_crate!(t.ty_to_string()),
+                TypeCtor::Scalar(Scalar::Int(t)) => {
+                    lang_item_crate!(primitive::int_ty_to_string(t))
+                }
+                TypeCtor::Scalar(Scalar::Uint(t)) => {
+                    lang_item_crate!(primitive::uint_ty_to_string(t))
+                }
                 TypeCtor::Str => lang_item_crate!("str_alloc", "str"),
                 TypeCtor::Slice => lang_item_crate!("slice_alloc", "slice"),
                 TypeCtor::RawPtr(Mutability::Shared) => lang_item_crate!("const_ptr"),

--- a/crates/hir_ty/src/op.rs
+++ b/crates/hir_ty/src/op.rs
@@ -2,15 +2,17 @@
 use hir_def::expr::{ArithOp, BinaryOp, CmpOp};
 
 use super::{InferTy, Ty, TypeCtor};
-use crate::ApplicationTy;
+use crate::{ApplicationTy, Scalar};
 
 pub(super) fn binary_op_return_ty(op: BinaryOp, lhs_ty: Ty, rhs_ty: Ty) -> Ty {
     match op {
-        BinaryOp::LogicOp(_) | BinaryOp::CmpOp(_) => Ty::simple(TypeCtor::Bool),
+        BinaryOp::LogicOp(_) | BinaryOp::CmpOp(_) => Ty::simple(TypeCtor::Scalar(Scalar::Bool)),
         BinaryOp::Assignment { .. } => Ty::unit(),
         BinaryOp::ArithOp(ArithOp::Shl) | BinaryOp::ArithOp(ArithOp::Shr) => match lhs_ty {
             Ty::Apply(ApplicationTy { ctor, .. }) => match ctor {
-                TypeCtor::Int(..) | TypeCtor::Float(..) => lhs_ty,
+                TypeCtor::Scalar(Scalar::Int(_))
+                | TypeCtor::Scalar(Scalar::Uint(_))
+                | TypeCtor::Scalar(Scalar::Float(_)) => lhs_ty,
                 _ => Ty::Unknown,
             },
             Ty::Infer(InferTy::IntVar(..)) | Ty::Infer(InferTy::FloatVar(..)) => lhs_ty,
@@ -18,7 +20,9 @@ pub(super) fn binary_op_return_ty(op: BinaryOp, lhs_ty: Ty, rhs_ty: Ty) -> Ty {
         },
         BinaryOp::ArithOp(_) => match rhs_ty {
             Ty::Apply(ApplicationTy { ctor, .. }) => match ctor {
-                TypeCtor::Int(..) | TypeCtor::Float(..) => rhs_ty,
+                TypeCtor::Scalar(Scalar::Int(_))
+                | TypeCtor::Scalar(Scalar::Uint(_))
+                | TypeCtor::Scalar(Scalar::Float(_)) => rhs_ty,
                 _ => Ty::Unknown,
             },
             Ty::Infer(InferTy::IntVar(..)) | Ty::Infer(InferTy::FloatVar(..)) => rhs_ty,
@@ -29,15 +33,11 @@ pub(super) fn binary_op_return_ty(op: BinaryOp, lhs_ty: Ty, rhs_ty: Ty) -> Ty {
 
 pub(super) fn binary_op_rhs_expectation(op: BinaryOp, lhs_ty: Ty) -> Ty {
     match op {
-        BinaryOp::LogicOp(..) => Ty::simple(TypeCtor::Bool),
+        BinaryOp::LogicOp(..) => Ty::simple(TypeCtor::Scalar(Scalar::Bool)),
         BinaryOp::Assignment { op: None } => lhs_ty,
         BinaryOp::CmpOp(CmpOp::Eq { .. }) => match lhs_ty {
             Ty::Apply(ApplicationTy { ctor, .. }) => match ctor {
-                TypeCtor::Int(..)
-                | TypeCtor::Float(..)
-                | TypeCtor::Str
-                | TypeCtor::Char
-                | TypeCtor::Bool => lhs_ty,
+                TypeCtor::Scalar(_) | TypeCtor::Str => lhs_ty,
                 _ => Ty::Unknown,
             },
             Ty::Infer(InferTy::IntVar(..)) | Ty::Infer(InferTy::FloatVar(..)) => lhs_ty,
@@ -48,7 +48,9 @@ pub(super) fn binary_op_rhs_expectation(op: BinaryOp, lhs_ty: Ty) -> Ty {
         | BinaryOp::Assignment { op: Some(_) }
         | BinaryOp::ArithOp(_) => match lhs_ty {
             Ty::Apply(ApplicationTy { ctor, .. }) => match ctor {
-                TypeCtor::Int(..) | TypeCtor::Float(..) => lhs_ty,
+                TypeCtor::Scalar(Scalar::Int(_))
+                | TypeCtor::Scalar(Scalar::Uint(_))
+                | TypeCtor::Scalar(Scalar::Float(_)) => lhs_ty,
                 _ => Ty::Unknown,
             },
             Ty::Infer(InferTy::IntVar(..)) | Ty::Infer(InferTy::FloatVar(..)) => lhs_ty,

--- a/crates/hir_ty/src/primitive.rs
+++ b/crates/hir_ty/src/primitive.rs
@@ -5,18 +5,28 @@
 
 use std::fmt;
 
-pub use hir_def::builtin_type::{BuiltinFloat, BuiltinInt, FloatBitness, IntBitness, Signedness};
+pub use hir_def::builtin_type::{BuiltinFloat, BuiltinInt, BuiltinUint};
 
-#[derive(Copy, Clone, Eq, PartialEq, Hash)]
-pub struct IntTy {
-    pub signedness: Signedness,
-    pub bitness: IntBitness,
+/// Different signed int types.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum IntTy {
+    Isize,
+    I8,
+    I16,
+    I32,
+    I64,
+    I128,
 }
 
-impl fmt::Debug for IntTy {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(self, f)
-    }
+/// Different unsigned int types.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum UintTy {
+    Usize,
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
 }
 
 impl fmt::Display for IntTy {
@@ -26,75 +36,41 @@ impl fmt::Display for IntTy {
 }
 
 impl IntTy {
-    pub fn isize() -> IntTy {
-        IntTy { signedness: Signedness::Signed, bitness: IntBitness::Xsize }
-    }
-
-    pub fn i8() -> IntTy {
-        IntTy { signedness: Signedness::Signed, bitness: IntBitness::X8 }
-    }
-
-    pub fn i16() -> IntTy {
-        IntTy { signedness: Signedness::Signed, bitness: IntBitness::X16 }
-    }
-
-    pub fn i32() -> IntTy {
-        IntTy { signedness: Signedness::Signed, bitness: IntBitness::X32 }
-    }
-
-    pub fn i64() -> IntTy {
-        IntTy { signedness: Signedness::Signed, bitness: IntBitness::X64 }
-    }
-
-    pub fn i128() -> IntTy {
-        IntTy { signedness: Signedness::Signed, bitness: IntBitness::X128 }
-    }
-
-    pub fn usize() -> IntTy {
-        IntTy { signedness: Signedness::Unsigned, bitness: IntBitness::Xsize }
-    }
-
-    pub fn u8() -> IntTy {
-        IntTy { signedness: Signedness::Unsigned, bitness: IntBitness::X8 }
-    }
-
-    pub fn u16() -> IntTy {
-        IntTy { signedness: Signedness::Unsigned, bitness: IntBitness::X16 }
-    }
-
-    pub fn u32() -> IntTy {
-        IntTy { signedness: Signedness::Unsigned, bitness: IntBitness::X32 }
-    }
-
-    pub fn u64() -> IntTy {
-        IntTy { signedness: Signedness::Unsigned, bitness: IntBitness::X64 }
-    }
-
-    pub fn u128() -> IntTy {
-        IntTy { signedness: Signedness::Unsigned, bitness: IntBitness::X128 }
-    }
-
     pub fn ty_to_string(self) -> &'static str {
-        match (self.signedness, self.bitness) {
-            (Signedness::Signed, IntBitness::Xsize) => "isize",
-            (Signedness::Signed, IntBitness::X8) => "i8",
-            (Signedness::Signed, IntBitness::X16) => "i16",
-            (Signedness::Signed, IntBitness::X32) => "i32",
-            (Signedness::Signed, IntBitness::X64) => "i64",
-            (Signedness::Signed, IntBitness::X128) => "i128",
-            (Signedness::Unsigned, IntBitness::Xsize) => "usize",
-            (Signedness::Unsigned, IntBitness::X8) => "u8",
-            (Signedness::Unsigned, IntBitness::X16) => "u16",
-            (Signedness::Unsigned, IntBitness::X32) => "u32",
-            (Signedness::Unsigned, IntBitness::X64) => "u64",
-            (Signedness::Unsigned, IntBitness::X128) => "u128",
+        match self {
+            IntTy::Isize => "isize",
+            IntTy::I8 => "i8",
+            IntTy::I16 => "i16",
+            IntTy::I32 => "i32",
+            IntTy::I64 => "i64",
+            IntTy::I128 => "i128",
         }
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash)]
-pub struct FloatTy {
-    pub bitness: FloatBitness,
+impl fmt::Display for UintTy {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.ty_to_string())
+    }
+}
+
+impl UintTy {
+    pub fn ty_to_string(self) -> &'static str {
+        match self {
+            UintTy::Usize => "usize",
+            UintTy::U8 => "u8",
+            UintTy::U16 => "u16",
+            UintTy::U32 => "u32",
+            UintTy::U64 => "u64",
+            UintTy::U128 => "u128",
+        }
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum FloatTy {
+    F32,
+    F64,
 }
 
 impl fmt::Debug for FloatTy {
@@ -110,30 +86,45 @@ impl fmt::Display for FloatTy {
 }
 
 impl FloatTy {
-    pub fn f32() -> FloatTy {
-        FloatTy { bitness: FloatBitness::X32 }
-    }
-
-    pub fn f64() -> FloatTy {
-        FloatTy { bitness: FloatBitness::X64 }
-    }
-
     pub fn ty_to_string(self) -> &'static str {
-        match self.bitness {
-            FloatBitness::X32 => "f32",
-            FloatBitness::X64 => "f64",
+        match self {
+            FloatTy::F32 => "f32",
+            FloatTy::F64 => "f64",
         }
     }
 }
 
 impl From<BuiltinInt> for IntTy {
     fn from(t: BuiltinInt) -> Self {
-        IntTy { signedness: t.signedness, bitness: t.bitness }
+        match t {
+            BuiltinInt::Isize => Self::Isize,
+            BuiltinInt::I8 => Self::I8,
+            BuiltinInt::I16 => Self::I16,
+            BuiltinInt::I32 => Self::I32,
+            BuiltinInt::I64 => Self::I64,
+            BuiltinInt::I128 => Self::I128,
+        }
+    }
+}
+
+impl From<BuiltinUint> for UintTy {
+    fn from(t: BuiltinUint) -> Self {
+        match t {
+            BuiltinUint::Usize => Self::Usize,
+            BuiltinUint::U8 => Self::U8,
+            BuiltinUint::U16 => Self::U16,
+            BuiltinUint::U32 => Self::U32,
+            BuiltinUint::U64 => Self::U64,
+            BuiltinUint::U128 => Self::U128,
+        }
     }
 }
 
 impl From<BuiltinFloat> for FloatTy {
     fn from(t: BuiltinFloat) -> Self {
-        FloatTy { bitness: t.bitness }
+        match t {
+            BuiltinFloat::F32 => Self::F32,
+            BuiltinFloat::F64 => Self::F64,
+        }
     }
 }

--- a/crates/hir_ty/src/primitive.rs
+++ b/crates/hir_ty/src/primitive.rs
@@ -3,128 +3,63 @@
 //! * during type inference, they can be uncertain (ie, `let x = 92;`)
 //! * they don't belong to any particular crate.
 
-use std::fmt;
-
+pub use chalk_ir::{FloatTy, IntTy, UintTy};
 pub use hir_def::builtin_type::{BuiltinFloat, BuiltinInt, BuiltinUint};
 
-/// Different signed int types.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum IntTy {
-    Isize,
-    I8,
-    I16,
-    I32,
-    I64,
-    I128,
-}
-
-/// Different unsigned int types.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum UintTy {
-    Usize,
-    U8,
-    U16,
-    U32,
-    U64,
-    U128,
-}
-
-impl fmt::Display for IntTy {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.ty_to_string())
+pub fn int_ty_to_string(ty: IntTy) -> &'static str {
+    match ty {
+        IntTy::Isize => "isize",
+        IntTy::I8 => "i8",
+        IntTy::I16 => "i16",
+        IntTy::I32 => "i32",
+        IntTy::I64 => "i64",
+        IntTy::I128 => "i128",
     }
 }
 
-impl IntTy {
-    pub fn ty_to_string(self) -> &'static str {
-        match self {
-            IntTy::Isize => "isize",
-            IntTy::I8 => "i8",
-            IntTy::I16 => "i16",
-            IntTy::I32 => "i32",
-            IntTy::I64 => "i64",
-            IntTy::I128 => "i128",
-        }
+pub fn uint_ty_to_string(ty: UintTy) -> &'static str {
+    match ty {
+        UintTy::Usize => "usize",
+        UintTy::U8 => "u8",
+        UintTy::U16 => "u16",
+        UintTy::U32 => "u32",
+        UintTy::U64 => "u64",
+        UintTy::U128 => "u128",
     }
 }
 
-impl fmt::Display for UintTy {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.ty_to_string())
+pub fn float_ty_to_string(ty: FloatTy) -> &'static str {
+    match ty {
+        FloatTy::F32 => "f32",
+        FloatTy::F64 => "f64",
     }
 }
 
-impl UintTy {
-    pub fn ty_to_string(self) -> &'static str {
-        match self {
-            UintTy::Usize => "usize",
-            UintTy::U8 => "u8",
-            UintTy::U16 => "u16",
-            UintTy::U32 => "u32",
-            UintTy::U64 => "u64",
-            UintTy::U128 => "u128",
-        }
+pub(super) fn int_ty_from_builtin(t: BuiltinInt) -> IntTy {
+    match t {
+        BuiltinInt::Isize => IntTy::Isize,
+        BuiltinInt::I8 => IntTy::I8,
+        BuiltinInt::I16 => IntTy::I16,
+        BuiltinInt::I32 => IntTy::I32,
+        BuiltinInt::I64 => IntTy::I64,
+        BuiltinInt::I128 => IntTy::I128,
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum FloatTy {
-    F32,
-    F64,
-}
-
-impl fmt::Debug for FloatTy {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(self, f)
+pub(super) fn uint_ty_from_builtin(t: BuiltinUint) -> UintTy {
+    match t {
+        BuiltinUint::Usize => UintTy::Usize,
+        BuiltinUint::U8 => UintTy::U8,
+        BuiltinUint::U16 => UintTy::U16,
+        BuiltinUint::U32 => UintTy::U32,
+        BuiltinUint::U64 => UintTy::U64,
+        BuiltinUint::U128 => UintTy::U128,
     }
 }
 
-impl fmt::Display for FloatTy {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.ty_to_string())
-    }
-}
-
-impl FloatTy {
-    pub fn ty_to_string(self) -> &'static str {
-        match self {
-            FloatTy::F32 => "f32",
-            FloatTy::F64 => "f64",
-        }
-    }
-}
-
-impl From<BuiltinInt> for IntTy {
-    fn from(t: BuiltinInt) -> Self {
-        match t {
-            BuiltinInt::Isize => Self::Isize,
-            BuiltinInt::I8 => Self::I8,
-            BuiltinInt::I16 => Self::I16,
-            BuiltinInt::I32 => Self::I32,
-            BuiltinInt::I64 => Self::I64,
-            BuiltinInt::I128 => Self::I128,
-        }
-    }
-}
-
-impl From<BuiltinUint> for UintTy {
-    fn from(t: BuiltinUint) -> Self {
-        match t {
-            BuiltinUint::Usize => Self::Usize,
-            BuiltinUint::U8 => Self::U8,
-            BuiltinUint::U16 => Self::U16,
-            BuiltinUint::U32 => Self::U32,
-            BuiltinUint::U64 => Self::U64,
-            BuiltinUint::U128 => Self::U128,
-        }
-    }
-}
-
-impl From<BuiltinFloat> for FloatTy {
-    fn from(t: BuiltinFloat) -> Self {
-        match t {
-            BuiltinFloat::F32 => Self::F32,
-            BuiltinFloat::F64 => Self::F64,
-        }
+pub(super) fn float_ty_from_builtin(t: BuiltinFloat) -> FloatTy {
+    match t {
+        BuiltinFloat::F32 => FloatTy::F32,
+        BuiltinFloat::F64 => FloatTy::F64,
     }
 }


### PR DESCRIPTION
`TypeCtor::Int(..) | TypeCtor::Float(..) | TypeCtor::Char | TypeCtor::Bool` => `TypeCtor::Scalar(..)`, in this case we can actually just straight up use `chalk_ir::Scalar` already since its just a POD without any IDs or anything.