### PR TITLE
Use an unversioned profile dependency in mbe

### DIFF
--- a/crates/mbe/Cargo.toml
+++ b/crates/mbe/Cargo.toml
@@ -19,8 +19,5 @@ parser = { path = "../parser", version = "0.0.0" }
 tt = { path = "../tt", version = "0.0.0" }
 test_utils = { path = "../test_utils", version = "0.0.0" }
 
-# FIXME: Paper over a bug in cargo-worspaces which block publishing
-# https://github.com/pksunkara/cargo-workspaces/issues/39
-# [dev-dependencies]
-profile = { path = "../profile", version = "0.0.0" }
-
+[dev-dependencies]
+profile = { path = "../profile" }


### PR DESCRIPTION
Apparently, dev dependencies shouldn't be versioned. This hopefully fixes publishing to crates.io.