### PR TITLE
Bump deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,9 +158,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chalk-derive"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e625b7c688272783140509a0de8f7aa9000217cb0982c9b10606a12b0b747ba8"
+checksum = "4b9000fbcb67353dc8973ab9fd136277d321d85b79bd36b8756bb3ae0979a94a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "chalk-ir"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c220d870128959d7d56667060d556ffdebd490f32ee0fc9f4060a76c1193f206"
+checksum = "b23528d61b3557c676eccf508fa0771a38453b379f0b780154eaa7f70afe8dfc"
 dependencies = [
  "bitflags",
  "chalk-derive",
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "chalk-recursive"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8cd81a15aa936215378e695a8907b9f1af8626a27a32ee22e97a50984960da"
+checksum = "a8bdd37afc666b771de8b4429fe014363d0e74aae5cc26f320f60a3eab34d744"
 dependencies = [
  "chalk-derive",
  "chalk-ir",
@@ -194,14 +194,14 @@ dependencies = [
 
 [[package]]
 name = "chalk-solve"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55571250dfe096a4c899be88c81418284c952ce1c8a06aa16afb5781b298e9c9"
+checksum = "4182c42ca319cb71c89898ebc3d2671d1fa7d928123b171b66f1797a2000b9c8"
 dependencies = [
  "chalk-derive",
  "chalk-ir",
  "ena",
- "itertools 0.9.0",
+ "itertools",
  "petgraph",
  "rustc-hash",
  "tracing",
@@ -475,7 +475,7 @@ dependencies = [
  "hir_def",
  "hir_expand",
  "hir_ty",
- "itertools 0.10.0",
+ "itertools",
  "log",
  "profile",
  "rustc-hash",
@@ -497,7 +497,7 @@ dependencies = [
  "fst",
  "hir_expand",
  "indexmap",
- "itertools 0.10.0",
+ "itertools",
  "la-arena",
  "log",
  "mbe",
@@ -541,7 +541,7 @@ dependencies = [
  "expect-test",
  "hir_def",
  "hir_expand",
- "itertools 0.10.0",
+ "itertools",
  "la-arena",
  "log",
  "once_cell",
@@ -579,7 +579,7 @@ dependencies = [
  "ide_db",
  "ide_ssr",
  "indexmap",
- "itertools 0.10.0",
+ "itertools",
  "log",
  "oorandom",
  "profile",
@@ -601,7 +601,7 @@ dependencies = [
  "expect-test",
  "hir",
  "ide_db",
- "itertools 0.10.0",
+ "itertools",
  "profile",
  "rustc-hash",
  "stdx",
@@ -619,7 +619,7 @@ dependencies = [
  "expect-test",
  "hir",
  "ide_db",
- "itertools 0.10.0",
+ "itertools",
  "log",
  "profile",
  "rustc-hash",
@@ -638,7 +638,7 @@ dependencies = [
  "expect-test",
  "fst",
  "hir",
- "itertools 0.10.0",
+ "itertools",
  "log",
  "once_cell",
  "profile",
@@ -657,7 +657,7 @@ dependencies = [
  "expect-test",
  "hir",
  "ide_db",
- "itertools 0.10.0",
+ "itertools",
  "rustc-hash",
  "syntax",
  "test_utils",
@@ -712,15 +712,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -1206,7 +1197,7 @@ dependencies = [
  "base_db",
  "cargo_metadata",
  "cfg",
- "itertools 0.10.0",
+ "itertools",
  "la-arena",
  "log",
  "paths",
@@ -1338,7 +1329,7 @@ dependencies = [
  "ide",
  "ide_db",
  "ide_ssr",
- "itertools 0.10.0",
+ "itertools",
  "jemallocator",
  "jod-thread",
  "log",
@@ -1593,7 +1584,7 @@ dependencies = [
  "arrayvec",
  "expect-test",
  "indexmap",
- "itertools 0.10.0",
+ "itertools",
  "once_cell",
  "parser",
  "profile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "adler"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bedc89c5c7b5550ffb9372eb5c5ffc7f9f705cc3f4a128bd4669b9745f555093"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "always-assert"
@@ -1490,9 +1490,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.62"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1923,18 +1923,18 @@ checksum = "06069a848f95fceae3e5e03c0ddc8cb78452b56654ee0c8e68f938cf790fb9e3"
 
 [[package]]
 name = "xshell"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed373ede30cea03e8c0af22f48ee1ba80efbf06fec8b4746977e6ee703878de0"
+checksum = "6f18102278453c8f70ea5c514ac78cb4c73a0ef72a8273d17094b52f9584c0c1"
 dependencies = [
  "xshell-macros",
 ]
 
 [[package]]
 name = "xshell-macros"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6af9f8119104697b0105989a73c578ce33f922d9d6f3dae0e8ae3d538db321"
+checksum = "6093c460064572007f885facc70bb0ca5e40a83ea7ff8b16c1abbee56fd2e767"
 
 [[package]]
 name = "xtask"

--- a/crates/hir_ty/Cargo.toml
+++ b/crates/hir_ty/Cargo.toml
@@ -17,9 +17,9 @@ ena = "0.14.0"
 log = "0.4.8"
 rustc-hash = "1.1.0"
 scoped-tls = "1"
-chalk-solve = { version = "0.58", default-features = false }
-chalk-ir = "0.58"
-chalk-recursive = "0.58"
+chalk-solve = { version = "0.59", default-features = false }
+chalk-ir = "0.59"
+chalk-recursive = "0.59"
 la-arena = { version = "0.2.0", path = "../../lib/arena" }
 
 stdx = { path = "../stdx", version = "0.0.0" }


### PR DESCRIPTION
Unfortunately, this brings a bunch of proc macros dep because `cargo-metadata` went full-in on `derive-builder`. I'm not sure what we can do here..