### PR TITLE
Fix `find_path` when inner items are present

### DIFF
--- a/crates/hir_def/src/item_scope.rs
+++ b/crates/hir_def/src/item_scope.rs
@@ -12,8 +12,8 @@ use stdx::format_to;
 use test_utils::mark;
 
 use crate::{
-    db::DefDatabase, per_ns::PerNs, visibility::Visibility, AdtId, BuiltinType, HasModule, ImplId,
-    LocalModuleId, Lookup, MacroDefId, ModuleDefId, ModuleId, TraitId,
+    db::DefDatabase, per_ns::PerNs, visibility::Visibility, AdtId, BuiltinType, ImplId,
+    LocalModuleId, MacroDefId, ModuleDefId, ModuleId, TraitId,
 };
 
 #[derive(Copy, Clone)]
@@ -375,19 +375,9 @@ impl ItemInNs {
 
     /// Returns the crate defining this item (or `None` if `self` is built-in).
     pub fn krate(&self, db: &dyn DefDatabase) -> Option<CrateId> {
-        Some(match self {
-            ItemInNs::Types(did) | ItemInNs::Values(did) => match did {
-                ModuleDefId::ModuleId(id) => id.krate,
-                ModuleDefId::FunctionId(id) => id.lookup(db).module(db).krate,
-                ModuleDefId::AdtId(id) => id.module(db).krate,
-                ModuleDefId::EnumVariantId(id) => id.parent.lookup(db).container.module(db).krate,
-                ModuleDefId::ConstId(id) => id.lookup(db).container.module(db).krate,
-                ModuleDefId::StaticId(id) => id.lookup(db).container.module(db).krate,
-                ModuleDefId::TraitId(id) => id.lookup(db).container.module(db).krate,
-                ModuleDefId::TypeAliasId(id) => id.lookup(db).module(db).krate,
-                ModuleDefId::BuiltinType(_) => return None,
-            },
-            ItemInNs::Macros(id) => return Some(id.krate),
-        })
+        match self {
+            ItemInNs::Types(did) | ItemInNs::Values(did) => did.module(db).map(|m| m.krate),
+            ItemInNs::Macros(id) => Some(id.krate),
+        }
     }
 }

--- a/crates/hir_def/src/nameres.rs
+++ b/crates/hir_def/src/nameres.rs
@@ -343,6 +343,18 @@ impl DefMap {
         Some(self.block?.parent)
     }
 
+    /// Returns the module containing `local_mod`, either the parent `mod`, or the module containing
+    /// the block, if `self` corresponds to a block expression.
+    pub fn containing_module(&self, local_mod: LocalModuleId) -> Option<ModuleId> {
+        match &self[local_mod].parent {
+            Some(parent) => Some(self.module_id(*parent)),
+            None => match &self.block {
+                Some(block) => Some(block.parent),
+                None => None,
+            },
+        }
+    }
+
     // FIXME: this can use some more human-readable format (ideally, an IR
     // even), as this should be a great debugging aid.
     pub fn dump(&self, db: &dyn DefDatabase) -> String {


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/7750 (but adds a bunch of FIXMEs, because a lot of this code is still wrong in the presence of inner items)

bors r+