### PR TITLE
Add more information to VSCode extenstion README

### DIFF
--- a/editors/code/README.md
+++ b/editors/code/README.md
@@ -50,7 +50,7 @@ If you want to sponsor:
 
 ## Quick start
 
-1. Install [rustup] the rust toolchain
+1. Install [rustup]
 2. Install the [rust-analyzer extension]
 
 [rustup]: https://rustup.rs

--- a/editors/code/README.md
+++ b/editors/code/README.md
@@ -2,8 +2,22 @@
 
 Provides support for rust-analyzer: novel LSP server for the Rust programming language.
 
+**Note** the extension may cause conflicts with the official Rust extension. It is recommended to disable the Rust extension when using the rust-analyzer extension.
 
-Features:
+**Note** the project is in alpha status: it is already useful in practice, but can't be considered stable.
+
+## Sponsor
+
+Work on rust-analyzer is sponsored by
+
+[<img src="https://user-images.githubusercontent.com/1711539/58105231-cf306900-7bee-11e9-83d8-9f1102e59d29.png" alt="Ferrous Systems" width="300">](https://ferrous-systems.com/)
+- [Mozilla](https://www.mozilla.org/en-US/)
+- [Embark Studios](https://embark-studios.com/)
+- [freiheit.com](https://www.freiheit.com)
+
+
+
+## Features
 
 * [code completion], [imports insertion]
 * [go to definition], [implementation], [type definition]
@@ -28,6 +42,29 @@ Features:
 [semantic syntax highlighting]: https://rust-analyzer.github.io/manual.html#semantic-syntax-highlighting
 [assist(code actions)]: https://rust-analyzer.github.io/manual.html#assists-code-actions
 
+
+
 [manual]: https://rust-analyzer.github.io/manual.html
+
+## Quick start
+1. Install [rustup] the rust toolchain
+2. Install the [rust-analyzer extension]
+
+[rustup]: https://rustup.rs
+[rust-analyzer extension]: https://marketplace.visualstudio.com/items?itemName=matklad.rust-analyzer
+
+## Configuration
+
+This extension provides configurations through VSCode's configuration settings. All the configurations are under `rust-analyzer.*`.
+
+See https://rust-analyzer.github.io/manual.html#vs-code-2 for more information on VSCode specific configurations.
+
+## Communication
+
+For usage and troubleshooting requests, please use "IDEs and Editors" category of the Rust forum:
+
+https://users.rust-lang.org/c/ide/14
+
+## Documentation
 
 See https://rust-analyzer.github.io/ for more information.

--- a/editors/code/README.md
+++ b/editors/code/README.md
@@ -11,23 +11,27 @@ Provides support for rust-analyzer: novel LSP server for the Rust programming la
 Work on rust-analyzer is sponsored by
 
 [<img src="https://user-images.githubusercontent.com/1711539/58105231-cf306900-7bee-11e9-83d8-9f1102e59d29.png" alt="Ferrous Systems" width="300">](https://ferrous-systems.com/)
+
 - [Mozilla](https://www.mozilla.org/en-US/)
 - [Embark Studios](https://embark-studios.com/)
 - [freiheit.com](https://www.freiheit.com)
 
+If you want to sponsor:
 
+- [OpenCollective](https://opencollective.com/rust-analyzer/)
+- [Github Sponsors](https://github.com/sponsors/rust-analyzer)
 
 ## Features
 
-* [code completion], [imports insertion]
-* [go to definition], [implementation], [type definition]
-* [find all references], [workspace symbol search], [rename]
-* [types and documentation on hover]
-* [inlay hints]
-* [semantic syntax highlighting]
-* a lot of [assist(code actions)]
-* apply suggestions from errors
-* ... and many more, checkout the [manual] to see them all
+- [code completion], [imports insertion]
+- [go to definition], [implementation], [type definition]
+- [find all references], [workspace symbol search], [rename]
+- [types and documentation on hover]
+- [inlay hints]
+- [semantic syntax highlighting]
+- a lot of [assist(code actions)]
+- apply suggestions from errors
+- ... and many more, checkout the [manual] to see them all
 
 [code completion]: https://rust-analyzer.github.io/manual.html#magic-completions
 [imports insertion]: https://rust-analyzer.github.io/manual.html#auto-import
@@ -42,11 +46,10 @@ Work on rust-analyzer is sponsored by
 [semantic syntax highlighting]: https://rust-analyzer.github.io/manual.html#semantic-syntax-highlighting
 [assist(code actions)]: https://rust-analyzer.github.io/manual.html#assists-code-actions
 
-
-
 [manual]: https://rust-analyzer.github.io/manual.html
 
 ## Quick start
+
 1. Install [rustup] the rust toolchain
 2. Install the [rust-analyzer extension]
 
@@ -57,14 +60,14 @@ Work on rust-analyzer is sponsored by
 
 This extension provides configurations through VSCode's configuration settings. All the configurations are under `rust-analyzer.*`.
 
-See https://rust-analyzer.github.io/manual.html#vs-code-2 for more information on VSCode specific configurations.
+See <https://rust-analyzer.github.io/manual.html#vs-code-2> for more information on VSCode specific configurations.
 
 ## Communication
 
 For usage and troubleshooting requests, please use "IDEs and Editors" category of the Rust forum:
 
-https://users.rust-lang.org/c/ide/14
+<https://users.rust-lang.org/c/ide/14>
 
 ## Documentation
 
-See https://rust-analyzer.github.io/ for more information.
+See <https://rust-analyzer.github.io/> for more information.


### PR DESCRIPTION
A lot of these are duplicated from the documentation or main README. While it's unfortunate to have duplicated information, the current VSCode page is very barebones and doesn't offer much confidence. 

This updated README offers a few more links and follows a structure similar to the official rust extension and other popular vscode extensions. The additions are, as much as possible specific to the vscode extension and not rust-analyzer as a LSP.

The note about not using the official extension is also right there at the top because that's a common issue people have when trying it out. 

I added the sponsor section since it's common in other extensions README, but I'm not sure if it's necessary