### PR TITLE
Use chalk_ir::AdtId

### DIFF
--- a/crates/hir/src/code_model.rs
+++ b/crates/hir/src/code_model.rs
@@ -1700,7 +1700,7 @@ impl Type {
 
     pub fn is_packed(&self, db: &dyn HirDatabase) -> bool {
         let adt_id = match self.ty.value {
-            Ty::Adt(adt_id, ..) => adt_id,
+            Ty::Adt(hir_ty::AdtId(adt_id), ..) => adt_id,
             _ => return false,
         };
 
@@ -1728,8 +1728,8 @@ impl Type {
 
     pub fn fields(&self, db: &dyn HirDatabase) -> Vec<(Field, Type)> {
         let (variant_id, substs) = match self.ty.value {
-            Ty::Adt(AdtId::StructId(s), ref substs) => (s.into(), substs),
-            Ty::Adt(AdtId::UnionId(u), ref substs) => (u.into(), substs),
+            Ty::Adt(hir_ty::AdtId(AdtId::StructId(s)), ref substs) => (s.into(), substs),
+            Ty::Adt(hir_ty::AdtId(AdtId::UnionId(u)), ref substs) => (u.into(), substs),
             _ => return Vec::new(),
         };
 

--- a/crates/hir_ty/src/diagnostics/expr.rs
+++ b/crates/hir_ty/src/diagnostics/expr.rs
@@ -2,9 +2,7 @@
 
 use std::sync::Arc;
 
-use hir_def::{
-    expr::Statement, path::path, resolver::HasResolver, AdtId, AssocItemId, DefWithBodyId,
-};
+use hir_def::{expr::Statement, path::path, resolver::HasResolver, AssocItemId, DefWithBodyId};
 use hir_expand::{diagnostics::DiagnosticSink, name};
 use rustc_hash::FxHashSet;
 use syntax::{ast, AstPtr};
@@ -17,7 +15,7 @@ use crate::{
         MissingPatFields, RemoveThisSemicolon,
     },
     utils::variant_data,
-    InferenceResult, Ty,
+    AdtId, InferenceResult, Ty,
 };
 
 pub(crate) use hir_def::{
@@ -382,10 +380,14 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
         };
 
         let (params, required) = match mismatch.expected {
-            Ty::Adt(AdtId::EnumId(enum_id), ref parameters) if enum_id == core_result_enum => {
+            Ty::Adt(AdtId(hir_def::AdtId::EnumId(enum_id)), ref parameters)
+                if enum_id == core_result_enum =>
+            {
                 (parameters, "Ok".to_string())
             }
-            Ty::Adt(AdtId::EnumId(enum_id), ref parameters) if enum_id == core_option_enum => {
+            Ty::Adt(AdtId(hir_def::AdtId::EnumId(enum_id)), ref parameters)
+                if enum_id == core_option_enum =>
+            {
                 (parameters, "Some".to_string())
             }
             _ => return,

--- a/crates/hir_ty/src/diagnostics/match_check.rs
+++ b/crates/hir_ty/src/diagnostics/match_check.rs
@@ -222,12 +222,12 @@ use hir_def::{
     adt::VariantData,
     body::Body,
     expr::{Expr, Literal, Pat, PatId},
-    AdtId, EnumVariantId, StructId, VariantId,
+    EnumVariantId, StructId, VariantId,
 };
 use la_arena::Idx;
 use smallvec::{smallvec, SmallVec};
 
-use crate::{db::HirDatabase, InferenceResult, Ty};
+use crate::{db::HirDatabase, AdtId, InferenceResult, Ty};
 
 #[derive(Debug, Clone, Copy)]
 /// Either a pattern from the source code being analyzed, represented as
@@ -627,7 +627,7 @@ pub(super) fn is_useful(
     // - `!` type
     // In those cases, no match arm is useful.
     match cx.infer[cx.match_expr].strip_references() {
-        Ty::Adt(AdtId::EnumId(enum_id), ..) => {
+        Ty::Adt(AdtId(hir_def::AdtId::EnumId(enum_id)), ..) => {
             if cx.db.enum_data(*enum_id).variants.is_empty() {
                 return Ok(Usefulness::NotUseful);
             }

--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -2,18 +2,19 @@
 
 use std::{borrow::Cow, fmt};
 
-use crate::{
-    db::HirDatabase, primitive, utils::generics, AliasTy, CallableDefId, CallableSig,
-    GenericPredicate, Lifetime, Obligation, OpaqueTy, OpaqueTyId, ProjectionTy, Scalar, Substs,
-    TraitRef, Ty,
-};
 use arrayvec::ArrayVec;
 use chalk_ir::Mutability;
 use hir_def::{
-    db::DefDatabase, find_path, generics::TypeParamProvenance, item_scope::ItemInNs, AdtId,
+    db::DefDatabase, find_path, generics::TypeParamProvenance, item_scope::ItemInNs,
     AssocContainerId, HasModule, Lookup, ModuleId, TraitId,
 };
 use hir_expand::name::Name;
+
+use crate::{
+    db::HirDatabase, primitive, utils::generics, AdtId, AliasTy, CallableDefId, CallableSig,
+    GenericPredicate, Lifetime, Obligation, OpaqueTy, OpaqueTyId, ProjectionTy, Scalar, Substs,
+    TraitRef, Ty,
+};
 
 pub struct HirFormatter<'a> {
     pub db: &'a dyn HirDatabase,
@@ -400,13 +401,13 @@ impl HirDisplay for Ty {
                     write!(f, " -> {}", ret_display)?;
                 }
             }
-            Ty::Adt(def_id, parameters) => {
+            Ty::Adt(AdtId(def_id), parameters) => {
                 match f.display_target {
                     DisplayTarget::Diagnostics | DisplayTarget::Test => {
                         let name = match *def_id {
-                            AdtId::StructId(it) => f.db.struct_data(it).name.clone(),
-                            AdtId::UnionId(it) => f.db.union_data(it).name.clone(),
-                            AdtId::EnumId(it) => f.db.enum_data(it).name.clone(),
+                            hir_def::AdtId::StructId(it) => f.db.struct_data(it).name.clone(),
+                            hir_def::AdtId::UnionId(it) => f.db.union_data(it).name.clone(),
+                            hir_def::AdtId::EnumId(it) => f.db.enum_data(it).name.clone(),
                         };
                         write!(f, "{}", name)?;
                     }

--- a/crates/hir_ty/src/infer/pat.rs
+++ b/crates/hir_ty/src/infer/pat.rs
@@ -237,7 +237,7 @@ impl<'a> InferenceContext<'a> {
                     };
 
                     let inner_ty = self.infer_pat(*inner, inner_expected, default_bm);
-                    Ty::Adt(box_adt, Substs::single(inner_ty))
+                    Ty::adt_ty(box_adt, Substs::single(inner_ty))
                 }
                 None => Ty::Unknown,
             },

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -1100,7 +1100,7 @@ fn type_for_enum_variant_constructor(db: &dyn HirDatabase, def: EnumVariantId) -
 fn type_for_adt(db: &dyn HirDatabase, adt: AdtId) -> Binders<Ty> {
     let generics = generics(db.upcast(), adt.into());
     let substs = Substs::bound_vars(&generics, DebruijnIndex::INNERMOST);
-    Binders::new(substs.len(), Ty::Adt(adt, substs))
+    Binders::new(substs.len(), Ty::adt_ty(adt, substs))
 }
 
 fn type_for_type_alias(db: &dyn HirDatabase, t: TypeAliasId) -> Binders<Ty> {

--- a/crates/hir_ty/src/traits/chalk.rs
+++ b/crates/hir_ty/src/traits/chalk.rs
@@ -315,9 +315,8 @@ impl<'a> chalk_solve::RustIrDatabase<Interner> for ChalkContext<'a> {
         let id = from_chalk(self.db, trait_id);
         self.db.trait_data(id).name.to_string()
     }
-    fn adt_name(&self, adt_id: chalk_ir::AdtId<Interner>) -> String {
-        let id = from_chalk(self.db, adt_id);
-        match id {
+    fn adt_name(&self, chalk_ir::AdtId(adt_id): AdtId) -> String {
+        match adt_id {
             hir_def::AdtId::StructId(id) => self.db.struct_data(id).name.to_string(),
             hir_def::AdtId::EnumId(id) => self.db.enum_data(id).name.to_string(),
             hir_def::AdtId::UnionId(id) => self.db.union_data(id).name.to_string(),
@@ -488,8 +487,8 @@ pub(crate) fn struct_datum_query(
     struct_id: AdtId,
 ) -> Arc<StructDatum> {
     debug!("struct_datum {:?}", struct_id);
-    let adt_id = from_chalk(db, struct_id);
-    let type_ctor = Ty::Adt(adt_id, Substs::empty());
+    let type_ctor = Ty::Adt(struct_id, Substs::empty());
+    let chalk_ir::AdtId(adt_id) = struct_id;
     debug!("struct {:?} = {:?}", struct_id, type_ctor);
     let num_params = generics(db.upcast(), adt_id.into()).len();
     let upstream = adt_id.module(db.upcast()).krate() != krate;
@@ -684,10 +683,9 @@ pub(crate) fn fn_def_variance_query(
 pub(crate) fn adt_variance_query(
     db: &dyn HirDatabase,
     _krate: CrateId,
-    adt_id: AdtId,
+    chalk_ir::AdtId(adt_id): AdtId,
 ) -> Variances {
-    let adt: crate::AdtId = from_chalk(db, adt_id);
-    let generic_params = generics(db.upcast(), adt.into());
+    let generic_params = generics(db.upcast(), adt_id.into());
     Variances::from_iter(
         &Interner,
         std::iter::repeat(chalk_ir::Variance::Invariant).take(generic_params.len()),

--- a/crates/hir_ty/src/traits/chalk/mapping.rs
+++ b/crates/hir_ty/src/traits/chalk/mapping.rs
@@ -86,7 +86,7 @@ impl ToChalk for Ty {
 
             Ty::Adt(adt_id, substs) => {
                 let substitution = substs.to_chalk(db);
-                chalk_ir::TyKind::Adt(chalk_ir::AdtId(adt_id), substitution).intern(&Interner)
+                chalk_ir::TyKind::Adt(adt_id, substitution).intern(&Interner)
             }
             Ty::Alias(AliasTy::Projection(proj_ty)) => {
                 let associated_ty_id = TypeAliasAsAssocType(proj_ty.associated_ty).to_chalk(db);
@@ -183,7 +183,7 @@ impl ToChalk for Ty {
                 Ty::Dyn(predicates)
             }
 
-            chalk_ir::TyKind::Adt(struct_id, subst) => Ty::Adt(struct_id.0, from_chalk(db, subst)),
+            chalk_ir::TyKind::Adt(adt_id, subst) => Ty::Adt(adt_id, from_chalk(db, subst)),
             chalk_ir::TyKind::AssociatedType(type_id, subst) => Ty::AssociatedType(
                 from_chalk::<TypeAliasAsAssocType, _>(db, type_id).0,
                 from_chalk(db, subst),
@@ -322,18 +322,6 @@ impl ToChalk for hir_def::ImplId {
 
     fn from_chalk(_db: &dyn HirDatabase, impl_id: ImplId) -> hir_def::ImplId {
         InternKey::from_intern_id(impl_id.0)
-    }
-}
-
-impl ToChalk for hir_def::AdtId {
-    type Chalk = AdtId;
-
-    fn to_chalk(self, _db: &dyn HirDatabase) -> Self::Chalk {
-        chalk_ir::AdtId(self.into())
-    }
-
-    fn from_chalk(_db: &dyn HirDatabase, id: AdtId) -> Self {
-        id.0
     }
 }
 


### PR DESCRIPTION
It's a bit unfortunate that we got two AdtId's now(technically 3 with the alias in the chalk module but that one won't allow pattern matching), one from hir_def and one from chalk_ir(hir_ty). But the hir_ty/chalk one doesn't leave hir so it shouldn't be that bad I suppose. Though if I see this right this will happen for almost all IDs.

I imagine most of the intermediate changes to using chalk ids will turn out not too nice until the refactor is over.