### PR TITLE
Make extension respect http proxy settings

### DIFF
--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.4.0-dev",
             "license": "MIT OR Apache-2.0",
             "dependencies": {
+                "https-proxy-agent": "^5.0.0",
                 "node-fetch": "^2.6.1",
                 "vscode-languageclient": "^7.1.0-next.4"
             },
@@ -515,7 +516,6 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
             "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-            "dev": true,
             "dependencies": {
                 "debug": "4"
             },
@@ -830,6 +830,7 @@
             "dependencies": {
                 "anymatch": "~3.1.1",
                 "braces": "~3.0.2",
+                "fsevents": "~2.3.1",
                 "glob-parent": "~5.1.0",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
@@ -959,7 +960,6 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
             "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-            "dev": true,
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -1759,7 +1759,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
             "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-            "dev": true,
             "dependencies": {
                 "agent-base": "6",
                 "debug": "4"
@@ -2236,8 +2235,7 @@
         "node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node_modules/mute-stream": {
             "version": "0.0.8",
@@ -2682,6 +2680,9 @@
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.39.1.tgz",
             "integrity": "sha512-9rfr0Z6j+vE+eayfNVFr1KZ+k+jiUl2+0e4quZafy1x6SFCjzFspfRSO2ZZQeWeX9noeDTUDgg6eCENiEPFvQg==",
             "dev": true,
+            "dependencies": {
+                "fsevents": "~2.3.1"
+            },
             "bin": {
                 "rollup": "dist/bin/rollup"
             },
@@ -3843,7 +3844,6 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
             "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-            "dev": true,
             "requires": {
                 "debug": "4"
             }
@@ -4190,7 +4190,6 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
             "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-            "dev": true,
             "requires": {
                 "ms": "2.1.2"
             }
@@ -4798,7 +4797,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
             "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-            "dev": true,
             "requires": {
                 "agent-base": "6",
                 "debug": "4"
@@ -5175,8 +5173,7 @@
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "mute-stream": {
             "version": "0.0.8",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -35,6 +35,7 @@
         "test": "node ./out/tests/runTests.js"
     },
     "dependencies": {
+        "https-proxy-agent": "^5.0.0",
         "node-fetch": "^2.6.1",
         "vscode-languageclient": "^7.1.0-next.4"
     },

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -100,6 +100,14 @@ export class Config {
     get channel() { return this.get<UpdatesChannel>("updates.channel"); }
     get askBeforeDownload() { return this.get<boolean>("updates.askBeforeDownload"); }
     get traceExtension() { return this.get<boolean>("trace.extension"); }
+    get httpProxy() {
+        const httpProxy = vscode
+            .workspace
+            .getConfiguration('http')
+            .get<null | string>("proxy")!;
+
+        return httpProxy || process.env["https_proxy"] || process.env["HTTPS_PROXY"];
+    }
 
     get inlayHints() {
         return {

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -183,7 +183,7 @@ async function bootstrapExtension(config: Config, state: PersistentState): Promi
     }
 
     const release = await downloadWithRetryDialog(state, async () => {
-        return await fetchRelease("nightly", state.githubToken);
+        return await fetchRelease("nightly", state.githubToken, config.httpProxy);
     }).catch(async (e) => {
         log.error(e);
         if (state.releaseId === undefined) { // Show error only for the initial download
@@ -209,6 +209,7 @@ async function bootstrapExtension(config: Config, state: PersistentState): Promi
             url: artifact.browser_download_url,
             dest,
             progressTitle: "Downloading rust-analyzer extension",
+            httpProxy: config.httpProxy,
         });
     });
 
@@ -331,7 +332,7 @@ async function getServer(config: Config, state: PersistentState): Promise<string
 
     const releaseTag = config.package.releaseTag;
     const release = await downloadWithRetryDialog(state, async () => {
-        return await fetchRelease(releaseTag, state.githubToken);
+        return await fetchRelease(releaseTag, state.githubToken, config.httpProxy);
     });
     const artifact = release.assets.find(artifact => artifact.name === `rust-analyzer-${platform}.gz`);
     assert(!!artifact, `Bad release: ${JSON.stringify(release)}`);
@@ -343,6 +344,7 @@ async function getServer(config: Config, state: PersistentState): Promise<string
             progressTitle: "Downloading rust-analyzer server",
             gunzip: true,
             mode: 0o755,
+            httpProxy: config.httpProxy,
         });
     });
 


### PR DESCRIPTION
This patch makes vscode extension respect proxy settings when fetching release metadata and rust-analyzer binary.