### PR TITLE
Improved completion sorting

### DIFF
--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -87,8 +87,8 @@ pub use crate::{
 pub use hir::{Documentation, Semantics};
 pub use ide_assists::{Assist, AssistConfig, AssistId, AssistKind};
 pub use ide_completion::{
-    CompletionConfig, CompletionItem, CompletionItemKind, CompletionScore, ImportEdit,
-    InsertTextFormat,
+    CompletionConfig, CompletionItem, CompletionItemKind, CompletionRelevance, CompletionScore,
+    ImportEdit, InsertTextFormat,
 };
 pub use ide_db::{
     base_db::{

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -87,8 +87,8 @@ pub use crate::{
 pub use hir::{Documentation, Semantics};
 pub use ide_assists::{Assist, AssistConfig, AssistId, AssistKind};
 pub use ide_completion::{
-    CompletionConfig, CompletionItem, CompletionItemKind, CompletionRelevance, CompletionScore,
-    ImportEdit, InsertTextFormat,
+    CompletionConfig, CompletionItem, CompletionItemKind, CompletionRelevance, ImportEdit,
+    InsertTextFormat,
 };
 pub use ide_db::{
     base_db::{

--- a/crates/ide_completion/src/item.rs
+++ b/crates/ide_completion/src/item.rs
@@ -156,7 +156,7 @@ impl CompletionRelevance {
     ///
     /// See is_relevant if you need to make some judgement about score
     /// in an absolute sense.
-    pub fn score(&self) -> u8 {
+    pub fn score(&self) -> u32 {
         let mut score = 0;
 
         if self.exact_name_match {
@@ -525,7 +525,7 @@ mod tests {
             .map(|r| (r.score(), r))
             .sorted_by_key(|(score, _r)| *score)
             .fold(
-                (u8::MIN, vec![vec![]]),
+                (u32::MIN, vec![vec![]]),
                 |(mut currently_collecting_score, mut out), (score, r)| {
                     if currently_collecting_score == score {
                         out.last_mut().unwrap().push(r);

--- a/crates/ide_completion/src/item.rs
+++ b/crates/ide_completion/src/item.rs
@@ -122,14 +122,6 @@ impl fmt::Debug for CompletionItem {
     }
 }
 
-#[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
-pub enum CompletionScore {
-    /// If only type match
-    TypeMatch,
-    /// If type and name match
-    TypeAndNameMatch,
-}
-
 #[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Default)]
 pub struct CompletionRelevance {
     /// This is set in cases like these:

--- a/crates/ide_completion/src/lib.rs
+++ b/crates/ide_completion/src/lib.rs
@@ -23,10 +23,7 @@ use crate::{completions::Completions, context::CompletionContext, item::Completi
 
 pub use crate::{
     config::CompletionConfig,
-    item::{
-        CompletionItem, CompletionItemKind, CompletionRelevance, CompletionScore, ImportEdit,
-        InsertTextFormat,
-    },
+    item::{CompletionItem, CompletionItemKind, CompletionRelevance, ImportEdit, InsertTextFormat},
 };
 
 //FIXME: split the following feature into fine-grained features.

--- a/crates/ide_completion/src/lib.rs
+++ b/crates/ide_completion/src/lib.rs
@@ -24,8 +24,8 @@ use crate::{completions::Completions, context::CompletionContext, item::Completi
 pub use crate::{
     config::CompletionConfig,
     item::{
-        CompletionItem, CompletionItemKind, CompletionScore, ImportEdit, InsertTextFormat,
-        Relevance,
+        CompletionItem, CompletionItemKind, CompletionRelevance, CompletionScore, ImportEdit,
+        InsertTextFormat,
     },
 };
 

--- a/crates/ide_completion/src/render.rs
+++ b/crates/ide_completion/src/render.rs
@@ -20,7 +20,7 @@ use ide_db::{
 use syntax::TextRange;
 
 use crate::{
-    item::{ImportEdit, Relevance},
+    item::{CompletionRelevance, ImportEdit},
     CompletionContext, CompletionItem, CompletionItemKind, CompletionKind,
 };
 
@@ -322,9 +322,9 @@ impl<'a> Render<'a> {
     }
 }
 
-fn compute_relevance(ctx: &RenderContext, ty: &Type, name: &str) -> Option<Relevance> {
+fn compute_relevance(ctx: &RenderContext, ty: &Type, name: &str) -> Option<CompletionRelevance> {
     let (expected_name, expected_type) = ctx.expected_name_and_type()?;
-    let mut res = Relevance::default();
+    let mut res = CompletionRelevance::default();
     res.exact_type_match = ty == &expected_type;
     res.exact_name_match = name == &expected_name;
     Some(res)
@@ -338,7 +338,7 @@ mod tests {
 
     use crate::{
         test_utils::{check_edit, do_completion, get_all_items, TEST_CONFIG},
-        CompletionKind, Relevance,
+        CompletionKind, CompletionRelevance,
     };
 
     fn check(ra_fixture: &str, expect: Expect) {
@@ -347,12 +347,14 @@ mod tests {
     }
 
     fn check_relevance(ra_fixture: &str, expect: Expect) {
-        fn display_relevance(relevance: Relevance) -> &'static str {
+        fn display_relevance(relevance: CompletionRelevance) -> &'static str {
             match relevance {
-                Relevance { exact_type_match: true, exact_name_match: true } => "[type+name]",
-                Relevance { exact_type_match: true, exact_name_match: false } => "[type]",
-                Relevance { exact_type_match: false, exact_name_match: true } => "[name]",
-                Relevance { exact_type_match: false, exact_name_match: false } => "[]",
+                CompletionRelevance { exact_type_match: true, exact_name_match: true } => {
+                    "[type+name]"
+                }
+                CompletionRelevance { exact_type_match: true, exact_name_match: false } => "[type]",
+                CompletionRelevance { exact_type_match: false, exact_name_match: true } => "[name]",
+                CompletionRelevance { exact_type_match: false, exact_name_match: false } => "[]",
             }
         }
 
@@ -975,7 +977,7 @@ fn main() {
                             Local,
                         ),
                         detail: "S",
-                        relevance: Relevance {
+                        relevance: CompletionRelevance {
                             exact_name_match: true,
                             exact_type_match: false,
                         },

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -220,12 +220,12 @@ pub(crate) fn completion_item(
         }
         // The relevance needs to be inverted to come up with a sort score
         // because the client will sort ascending.
-        let sort_score = relevance.score() ^ 0xFF;
-        // Zero pad the string to ensure values are sorted numerically
-        // even though the client is sorting alphabetically. Three
-        // characters is enough to fit the largest u8, which is the
-        // type of the relevance score.
-        res.sort_text = Some(format!("{:03}", sort_score));
+        let sort_score = relevance.score() ^ 0xFF_FF_FF_FF;
+        // Zero pad the string to ensure values can be properly sorted
+        // by the client. Hex format is used because it is easier to
+        // visually compare very large values, which the sort text
+        // tends to be since it is the opposite of the score.
+        res.sort_text = Some(format!("{:08x}", sort_score));
     }
 
     set_score(&mut lsp_item, item.relevance());
@@ -1117,13 +1117,13 @@ mod tests {
                 (
                     "&arg",
                     Some(
-                        "253",
+                        "fffffffd",
                     ),
                 ),
                 (
                     "arg",
                     Some(
-                        "254",
+                        "fffffffe",
                     ),
                 ),
             ]

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -6,9 +6,10 @@ use std::{
 
 use ide::{
     Annotation, AnnotationKind, Assist, AssistKind, CallInfo, CompletionItem, CompletionItemKind,
-    Documentation, FileId, FileRange, FileSystemEdit, Fold, FoldKind, Highlight, HlMod, HlPunct,
-    HlRange, HlTag, Indel, InlayHint, InlayKind, InsertTextFormat, Markup, NavigationTarget,
-    ReferenceAccess, RenameError, Runnable, Severity, SourceChange, TextEdit, TextRange, TextSize,
+    CompletionRelevance, Documentation, FileId, FileRange, FileSystemEdit, Fold, FoldKind,
+    Highlight, HlMod, HlPunct, HlRange, HlTag, Indel, InlayHint, InlayKind, InsertTextFormat,
+    Markup, NavigationTarget, ReferenceAccess, RenameError, Runnable, Severity, SourceChange,
+    TextEdit, TextRange, TextSize,
 };
 use ide_db::SymbolKind;
 use itertools::Itertools;
@@ -213,11 +214,21 @@ pub(crate) fn completion_item(
         ..Default::default()
     };
 
-    if item.relevance().is_relevant() {
-        lsp_item.preselect = Some(true);
-        // HACK: sort preselect items first
-        lsp_item.sort_text = Some(format!(" {}", item.label()));
+    fn set_score(res: &mut lsp_types::CompletionItem, relevance: CompletionRelevance) {
+        if relevance.is_relevant() {
+            res.preselect = Some(true);
+        }
+        // The relevance needs to be inverted to come up with a sort score
+        // because the client will sort ascending.
+        let sort_score = relevance.score() ^ 0xFF;
+        // Zero pad the string to ensure values are sorted numerically
+        // even though the client is sorting alphabetically. Three
+        // characters is enough to fit the largest u8, which is the
+        // type of the relevance score.
+        res.sort_text = Some(format!("{:03}", sort_score));
     }
+
+    set_score(&mut lsp_item, item.relevance());
 
     if item.deprecated() {
         lsp_item.tags = Some(vec![lsp_types::CompletionItemTag::Deprecated])
@@ -228,10 +239,9 @@ pub(crate) fn completion_item(
     }
 
     let mut res = match item.ref_match() {
-        Some(mutability) => {
+        Some((mutability, relevance)) => {
             let mut lsp_item_with_ref = lsp_item.clone();
-            lsp_item.preselect = Some(true);
-            lsp_item.sort_text = Some(format!(" {}", item.label()));
+            set_score(&mut lsp_item_with_ref, relevance);
             lsp_item_with_ref.label =
                 format!("&{}{}", mutability.as_keyword_for_ref(), lsp_item_with_ref.label);
             if let Some(lsp_types::CompletionTextEdit::Edit(it)) = &mut lsp_item_with_ref.text_edit
@@ -1107,13 +1117,13 @@ mod tests {
                 (
                     "&arg",
                     Some(
-                        " arg",
+                        "253",
                     ),
                 ),
                 (
                     "arg",
                     Some(
-                        " arg",
+                        "254",
                     ),
                 ),
             ]


### PR DESCRIPTION
I was working on extending #3954 to apply completion scores in more places (I'll have another PR open for that soon) when I discovered that actually completion sorting was not working for me at all in `coc.nvim`. This led me down a bit of a rabbit hole of how coc and vs code each sort completion items.

Before this PR, rust-analyzer was setting the `sortText` field on completion items to `None` if we hadn't applied any completion score for that item, or to the label of the item with a leading whitespace character if we had applied any completion score. Completion score is defined in rust-analyzer as an enum with two variants, `TypeMatch` and `TypeAndNameMatch`. 

In vs code the above strategy works, because if `sortText` isn't set [they default it to the label](https://github.com/microsoft/vscode/commit/b4ead4ed665e1ce2e58d8329c682f78da2d4e89d). However, coc [does not do this](https://github.com/neoclide/coc.nvim/blob/e211e361475a38b146a903b9b02343551c6cd372/src/completion/complete.ts#L245).

I was going to file a bug report against coc, but I read the [LSP spec for the `sortText` field](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_completion) and I feel like it is ambiguous and coc could claim what they do is a valid interpretation of the spec.

Further, the existing rust-analyzer behavior of prepending a leading whitespace character for completion items with any completion score does not handle sorting `TypeAndNameMatch` completions above `TypeMatch` completions. They were both being treated the same.

The first change this PR makes is to set the `sortText` field to either "1" for `TypeAndNameMatch` completions, "2" for `TypeMatch` completions, or "3" for completions which are neither of those. This change works around the potential ambiguity in the LSP spec and fixes completion sorting for users of coc. It also allows `TypeAndNameMatch` items to be sorted above just `TypeMatch` items (of course both of these will be sorted above completion items without a score). 

The second change this PR makes is to use the actual completion scores for ref matches. The existing code ignored the actual score and always assumed these would be a high priority completion item.

#### Before

Here coc just sorts based on how close the items are in the file.

![image](https://user-images.githubusercontent.com/22216761/110249880-46063580-7f2d-11eb-9233-91a2bbd48238.png)

#### After

Here we correctly get `zzz` first, since that is both a type and name match. Then we get `ccc` which is just a type match.

![image](https://user-images.githubusercontent.com/22216761/110249883-4e5e7080-7f2d-11eb-9269-a3bc133fdee7.png)
