### PR TITLE
Selecting `&mut foo` completion now actually inserts `&mut`

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1614,10 +1614,9 @@ impl Type {
     }
 
     pub fn remove_ref(&self) -> Option<Type> {
-        if let Ty::Ref(.., substs) = &self.ty.value {
-            Some(self.derived(substs[0].clone()))
-        } else {
-            None
+        match &self.ty.value {
+            Ty::Ref(.., substs) => Some(self.derived(substs[0].clone())),
+            _ => None,
         }
     }
 

--- a/crates/ide_completion/src/item.rs
+++ b/crates/ide_completion/src/item.rs
@@ -68,7 +68,7 @@ pub struct CompletionItem {
 
     /// Indicates that a reference or mutable reference to this variable is a
     /// possible match.
-    ref_match: Option<(Mutability, CompletionScore)>,
+    ref_match: Option<Mutability>,
 
     /// The import data to add to completion's edits.
     import_to_add: Option<ImportEdit>,
@@ -103,6 +103,9 @@ impl fmt::Debug for CompletionItem {
         }
         if let Some(score) = &self.score {
             s.field("score", score);
+        }
+        if let Some(mutability) = &self.ref_match {
+            s.field("ref_match", &format!("&{}", mutability.as_keyword_for_ref()));
         }
         if self.trigger_call_info {
             s.field("trigger_call_info", &true);
@@ -261,7 +264,7 @@ impl CompletionItem {
         self.trigger_call_info
     }
 
-    pub fn ref_match(&self) -> Option<(Mutability, CompletionScore)> {
+    pub fn ref_match(&self) -> Option<Mutability> {
         self.ref_match
     }
 
@@ -311,7 +314,7 @@ pub(crate) struct Builder {
     deprecated: bool,
     trigger_call_info: Option<bool>,
     score: Option<CompletionScore>,
-    ref_match: Option<(Mutability, CompletionScore)>,
+    ref_match: Option<Mutability>,
 }
 
 impl Builder {
@@ -430,8 +433,8 @@ impl Builder {
         self.import_to_add = import_to_add;
         self
     }
-    pub(crate) fn ref_match(mut self, ref_match: (Mutability, CompletionScore)) -> Builder {
-        self.ref_match = Some(ref_match);
+    pub(crate) fn ref_match(mut self, mutability: Mutability) -> Builder {
+        self.ref_match = Some(mutability);
         self
     }
 }

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -232,9 +232,8 @@ pub(crate) fn completion_item(
     }
 
     let mut res = match item.ref_match() {
-        Some(ref_match) => {
+        Some(mutability) => {
             let mut refed = lsp_item.clone();
-            let (mutability, _score) = ref_match;
             let label = format!("&{}{}", mutability.as_keyword_for_ref(), refed.label);
             set_score(&mut refed, &label);
             refed.label = label;
@@ -243,8 +242,8 @@ pub(crate) fn completion_item(
         None => vec![lsp_item],
     };
 
-    for mut r in res.iter_mut() {
-        r.insert_text_format = Some(insert_text_format(item.insert_text_format()));
+    for lsp_item in res.iter_mut() {
+        lsp_item.insert_text_format = Some(insert_text_format(item.insert_text_format()));
     }
     res
 }

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -175,12 +175,6 @@ pub(crate) fn completion_item(
     line_index: &LineIndex,
     item: CompletionItem,
 ) -> Vec<lsp_types::CompletionItem> {
-    fn set_score(lsp_item: &mut lsp_types::CompletionItem, label: &str) {
-        lsp_item.preselect = Some(true);
-        // HACK: sort preselect items first
-        lsp_item.sort_text = Some(format!(" {}", label));
-    }
-
     let mut additional_text_edits = Vec::new();
     let mut text_edit = None;
     // LSP does not allow arbitrary edits in completion, so we have to do a
@@ -220,7 +214,9 @@ pub(crate) fn completion_item(
     };
 
     if item.score().is_some() {
-        set_score(&mut lsp_item, item.label());
+        lsp_item.preselect = Some(true);
+        // HACK: sort preselect items first
+        lsp_item.sort_text = Some(format!(" {}", item.label()));
     }
 
     if item.deprecated() {
@@ -233,11 +229,16 @@ pub(crate) fn completion_item(
 
     let mut res = match item.ref_match() {
         Some(mutability) => {
-            let mut refed = lsp_item.clone();
-            let label = format!("&{}{}", mutability.as_keyword_for_ref(), refed.label);
-            set_score(&mut refed, &label);
-            refed.label = label;
-            vec![lsp_item, refed]
+            let mut lsp_item_with_ref = lsp_item.clone();
+            lsp_item.preselect = Some(true);
+            lsp_item.sort_text = Some(format!(" {}", item.label()));
+            lsp_item_with_ref.label =
+                format!("&{}{}", mutability.as_keyword_for_ref(), lsp_item_with_ref.label);
+            if let Some(lsp_types::CompletionTextEdit::Edit(it)) = &mut lsp_item_with_ref.text_edit
+            {
+                it.new_text = format!("&{}{}", mutability.as_keyword_for_ref(), it.new_text);
+            }
+            vec![lsp_item_with_ref, lsp_item]
         }
         None => vec![lsp_item],
     };
@@ -1104,13 +1105,13 @@ mod tests {
         expect_test::expect![[r#"
             [
                 (
-                    "arg",
+                    "&arg",
                     None,
                 ),
                 (
-                    "&arg",
+                    "arg",
                     Some(
-                        " &arg",
+                        " arg",
                     ),
                 ),
             ]


### PR DESCRIPTION
bors r+
🤖