### PR TITLE
Delete `ContainerId`

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -535,7 +535,7 @@ pub struct Struct {
 
 impl Struct {
     pub fn module(self, db: &dyn HirDatabase) -> Module {
-        Module { id: self.id.lookup(db.upcast()).container.module(db.upcast()) }
+        Module { id: self.id.lookup(db.upcast()).container }
     }
 
     pub fn krate(self, db: &dyn HirDatabase) -> Option<Crate> {
@@ -556,11 +556,7 @@ impl Struct {
     }
 
     pub fn ty(self, db: &dyn HirDatabase) -> Type {
-        Type::from_def(
-            db,
-            self.id.lookup(db.upcast()).container.module(db.upcast()).krate(),
-            self.id,
-        )
+        Type::from_def(db, self.id.lookup(db.upcast()).container.krate(), self.id)
     }
 
     pub fn repr(self, db: &dyn HirDatabase) -> Option<ReprKind> {
@@ -587,15 +583,11 @@ impl Union {
     }
 
     pub fn module(self, db: &dyn HirDatabase) -> Module {
-        Module { id: self.id.lookup(db.upcast()).container.module(db.upcast()) }
+        Module { id: self.id.lookup(db.upcast()).container }
     }
 
     pub fn ty(self, db: &dyn HirDatabase) -> Type {
-        Type::from_def(
-            db,
-            self.id.lookup(db.upcast()).container.module(db.upcast()).krate(),
-            self.id,
-        )
+        Type::from_def(db, self.id.lookup(db.upcast()).container.krate(), self.id)
     }
 
     pub fn fields(self, db: &dyn HirDatabase) -> Vec<Field> {
@@ -619,7 +611,7 @@ pub struct Enum {
 
 impl Enum {
     pub fn module(self, db: &dyn HirDatabase) -> Module {
-        Module { id: self.id.lookup(db.upcast()).container.module(db.upcast()) }
+        Module { id: self.id.lookup(db.upcast()).container }
     }
 
     pub fn krate(self, db: &dyn HirDatabase) -> Option<Crate> {
@@ -635,11 +627,7 @@ impl Enum {
     }
 
     pub fn ty(self, db: &dyn HirDatabase) -> Type {
-        Type::from_def(
-            db,
-            self.id.lookup(db.upcast()).container.module(db.upcast()).krate(),
-            self.id,
-        )
+        Type::from_def(db, self.id.lookup(db.upcast()).container.krate(), self.id)
     }
 }
 
@@ -1001,7 +989,7 @@ pub struct Trait {
 
 impl Trait {
     pub fn module(self, db: &dyn HirDatabase) -> Module {
-        Module { id: self.id.lookup(db.upcast()).container.module(db.upcast()) }
+        Module { id: self.id.lookup(db.upcast()).container }
     }
 
     pub fn name(self, db: &dyn HirDatabase) -> Name {
@@ -1510,7 +1498,7 @@ impl Impl {
     pub fn target_ty(self, db: &dyn HirDatabase) -> Type {
         let impl_data = db.impl_data(self.id);
         let resolver = self.id.resolver(db.upcast());
-        let krate = self.id.lookup(db.upcast()).container.module(db.upcast()).krate();
+        let krate = self.id.lookup(db.upcast()).container.krate();
         let ctx = hir_ty::TyLoweringContext::new(db, &resolver);
         let ty = Ty::from_hir(&ctx, &impl_data.target_type);
         Type::new_with_resolver_inner(db, krate, &resolver, ty)
@@ -1525,7 +1513,7 @@ impl Impl {
     }
 
     pub fn module(self, db: &dyn HirDatabase) -> Module {
-        self.id.lookup(db.upcast()).container.module(db.upcast()).into()
+        self.id.lookup(db.upcast()).container.into()
     }
 
     pub fn krate(self, db: &dyn HirDatabase) -> Crate {

--- a/crates/hir_def/src/attr.rs
+++ b/crates/hir_def/src/attr.rs
@@ -267,7 +267,7 @@ impl Attrs {
         db: &dyn DefDatabase,
         e: EnumId,
     ) -> Arc<ArenaMap<LocalEnumVariantId, Attrs>> {
-        let krate = e.lookup(db).container.module(db).krate;
+        let krate = e.lookup(db).container.krate;
         let src = e.child_source(db);
         let mut res = ArenaMap::default();
 

--- a/crates/hir_def/src/data.rs
+++ b/crates/hir_def/src/data.rs
@@ -97,7 +97,7 @@ impl TraitData {
         let tr_def = &item_tree[tr_loc.id.value];
         let name = tr_def.name.clone();
         let auto = tr_def.auto;
-        let module_id = tr_loc.container.module(db);
+        let module_id = tr_loc.container;
         let container = AssocContainerId::TraitId(tr);
         let mut expander = Expander::new(db, tr_loc.id.file_id, module_id);
 
@@ -147,7 +147,7 @@ impl ImplData {
         let target_trait = impl_def.target_trait.map(|id| item_tree[id].clone());
         let target_type = item_tree[impl_def.target_type].clone();
         let is_negative = impl_def.is_negative;
-        let module_id = impl_loc.container.module(db);
+        let module_id = impl_loc.container;
         let container = AssocContainerId::ImplId(id);
         let mut expander = Expander::new(db, impl_loc.id.file_id, module_id);
 

--- a/crates/hir_def/src/nameres/collector.rs
+++ b/crates/hir_def/src/nameres/collector.rs
@@ -37,9 +37,9 @@ use crate::{
     path::{ImportAlias, ModPath, PathKind},
     per_ns::PerNs,
     visibility::{RawVisibility, Visibility},
-    AdtId, AstId, AstIdWithPath, ConstLoc, ContainerId, EnumLoc, EnumVariantId, FunctionLoc,
-    ImplLoc, Intern, LocalModuleId, ModuleDefId, StaticLoc, StructLoc, TraitLoc, TypeAliasLoc,
-    UnionLoc, UnresolvedMacro,
+    AdtId, AstId, AstIdWithPath, ConstLoc, EnumLoc, EnumVariantId, FunctionLoc, ImplLoc, Intern,
+    LocalModuleId, ModuleDefId, StaticLoc, StructLoc, TraitLoc, TypeAliasLoc, UnionLoc,
+    UnresolvedMacro,
 };
 
 const GLOB_RECURSION_LIMIT: usize = 100;
@@ -1042,7 +1042,6 @@ impl ModCollector<'_, '_> {
                 }
             }
             let module = self.def_collector.def_map.module_id(self.module_id);
-            let container = ContainerId::ModuleId(module);
 
             let mut def = None;
             match item {
@@ -1109,9 +1108,9 @@ impl ModCollector<'_, '_> {
                 }
                 ModItem::Impl(imp) => {
                     let module = self.def_collector.def_map.module_id(self.module_id);
-                    let container = ContainerId::ModuleId(module);
-                    let impl_id = ImplLoc { container, id: ItemTreeId::new(self.file_id, imp) }
-                        .intern(self.def_collector.db);
+                    let impl_id =
+                        ImplLoc { container: module, id: ItemTreeId::new(self.file_id, imp) }
+                            .intern(self.def_collector.db);
                     self.def_collector.def_map.modules[self.module_id].scope.define_impl(impl_id)
                 }
                 ModItem::Function(id) => {
@@ -1140,7 +1139,7 @@ impl ModCollector<'_, '_> {
                     self.collect_derives(&attrs, it.ast_id.upcast());
 
                     def = Some(DefData {
-                        id: StructLoc { container, id: ItemTreeId::new(self.file_id, id) }
+                        id: StructLoc { container: module, id: ItemTreeId::new(self.file_id, id) }
                             .intern(self.def_collector.db)
                             .into(),
                         name: &it.name,
@@ -1157,7 +1156,7 @@ impl ModCollector<'_, '_> {
                     self.collect_derives(&attrs, it.ast_id.upcast());
 
                     def = Some(DefData {
-                        id: UnionLoc { container, id: ItemTreeId::new(self.file_id, id) }
+                        id: UnionLoc { container: module, id: ItemTreeId::new(self.file_id, id) }
                             .intern(self.def_collector.db)
                             .into(),
                         name: &it.name,
@@ -1174,7 +1173,7 @@ impl ModCollector<'_, '_> {
                     self.collect_derives(&attrs, it.ast_id.upcast());
 
                     def = Some(DefData {
-                        id: EnumLoc { container, id: ItemTreeId::new(self.file_id, id) }
+                        id: EnumLoc { container: module, id: ItemTreeId::new(self.file_id, id) }
                             .intern(self.def_collector.db)
                             .into(),
                         name: &it.name,
@@ -1203,7 +1202,7 @@ impl ModCollector<'_, '_> {
                     let it = &self.item_tree[id];
 
                     def = Some(DefData {
-                        id: StaticLoc { container, id: ItemTreeId::new(self.file_id, id) }
+                        id: StaticLoc { container: module, id: ItemTreeId::new(self.file_id, id) }
                             .intern(self.def_collector.db)
                             .into(),
                         name: &it.name,
@@ -1215,7 +1214,7 @@ impl ModCollector<'_, '_> {
                     let it = &self.item_tree[id];
 
                     def = Some(DefData {
-                        id: TraitLoc { container, id: ItemTreeId::new(self.file_id, id) }
+                        id: TraitLoc { container: module, id: ItemTreeId::new(self.file_id, id) }
                             .intern(self.def_collector.db)
                             .into(),
                         name: &it.name,

--- a/crates/hir_def/src/resolver.rs
+++ b/crates/hir_def/src/resolver.rs
@@ -19,10 +19,10 @@ use crate::{
     path::{ModPath, PathKind},
     per_ns::PerNs,
     visibility::{RawVisibility, Visibility},
-    AdtId, AssocContainerId, ConstId, ConstParamId, ContainerId, DefWithBodyId, EnumId,
-    EnumVariantId, FunctionId, GenericDefId, GenericParamId, HasModule, ImplId, LifetimeParamId,
-    LocalModuleId, Lookup, ModuleDefId, ModuleId, StaticId, StructId, TraitId, TypeAliasId,
-    TypeParamId, VariantId,
+    AdtId, AssocContainerId, ConstId, ConstParamId, DefWithBodyId, EnumId, EnumVariantId,
+    FunctionId, GenericDefId, GenericParamId, HasModule, ImplId, LifetimeParamId, LocalModuleId,
+    Lookup, ModuleDefId, ModuleId, StaticId, StructId, TraitId, TypeAliasId, TypeParamId,
+    VariantId,
 };
 
 #[derive(Debug, Clone, Default)]
@@ -684,15 +684,6 @@ impl HasResolver for DefWithBodyId {
             DefWithBodyId::ConstId(c) => c.resolver(db),
             DefWithBodyId::FunctionId(f) => f.resolver(db),
             DefWithBodyId::StaticId(s) => s.resolver(db),
-        }
-    }
-}
-
-impl HasResolver for ContainerId {
-    fn resolver(self, db: &dyn DefDatabase) -> Resolver {
-        match self {
-            ContainerId::ModuleId(it) => it.resolver(db),
-            ContainerId::DefWithBodyId(it) => it.module(db).resolver(db),
         }
     }
 }

--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -6,7 +6,7 @@ use arrayvec::ArrayVec;
 use chalk_ir::Mutability;
 use hir_def::{
     db::DefDatabase, find_path, generics::TypeParamProvenance, item_scope::ItemInNs,
-    AssocContainerId, HasModule, Lookup, ModuleId, TraitId,
+    AssocContainerId, Lookup, ModuleId, TraitId,
 };
 use hir_expand::name::Name;
 
@@ -611,7 +611,7 @@ impl HirDisplay for CallableSig {
 }
 
 fn fn_traits(db: &dyn DefDatabase, trait_: TraitId) -> impl Iterator<Item = TraitId> {
-    let krate = trait_.lookup(db).container.module(db).krate();
+    let krate = trait_.lookup(db).container.krate();
     let fn_traits = [
         db.lang_item(krate, "fn".into()),
         db.lang_item(krate, "fn_mut".into()),

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -1130,8 +1130,8 @@ impl CallableDefId {
         let db = db.upcast();
         match self {
             CallableDefId::FunctionId(f) => f.lookup(db).module(db),
-            CallableDefId::StructId(s) => s.lookup(db).container.module(db),
-            CallableDefId::EnumVariantId(e) => e.parent.lookup(db).container.module(db),
+            CallableDefId::StructId(s) => s.lookup(db).container,
+            CallableDefId::EnumVariantId(e) => e.parent.lookup(db).container,
         }
         .krate()
     }

--- a/crates/hir_ty/src/method_resolution.rs
+++ b/crates/hir_ty/src/method_resolution.rs
@@ -267,7 +267,7 @@ impl Ty {
                 LangItemTarget::ImplDefId(it) => Some(it),
                 _ => None,
             })
-            .map(|it| it.lookup(db.upcast()).container.module(db.upcast()).krate())
+            .map(|it| it.lookup(db.upcast()).container.krate())
             .collect();
         Some(res)
     }

--- a/crates/hir_ty/src/traits/chalk.rs
+++ b/crates/hir_ty/src/traits/chalk.rs
@@ -424,7 +424,7 @@ pub(crate) fn trait_datum_query(
     let bound_vars = Substs::bound_vars(&generic_params, DebruijnIndex::INNERMOST);
     let flags = rust_ir::TraitFlags {
         auto: trait_data.auto,
-        upstream: trait_.lookup(db.upcast()).container.module(db.upcast()).krate() != krate,
+        upstream: trait_.lookup(db.upcast()).container.krate() != krate,
         non_enumerable: true,
         coinductive: false, // only relevant for Chalk testing
         // FIXME: set these flags correctly
@@ -548,7 +548,7 @@ fn impl_def_datum(
     let generic_params = generics(db.upcast(), impl_id.into());
     let bound_vars = Substs::bound_vars(&generic_params, DebruijnIndex::INNERMOST);
     let trait_ = trait_ref.trait_;
-    let impl_type = if impl_id.lookup(db.upcast()).container.module(db.upcast()).krate() == krate {
+    let impl_type = if impl_id.lookup(db.upcast()).container.krate() == krate {
         rust_ir::ImplType::Local
     } else {
         rust_ir::ImplType::External


### PR DESCRIPTION
Since block expressions containing items now have a `ModuleId`, there's no need to also treat `DefWithBodyId` as a potential item container. Since https://github.com/rust-analyzer/rust-analyzer/pull/7878, only the `ModuleId` variant of `ContainerId` was ever created, so just delete the thing and use `ModuleId` everywhere.

bors r+