### PR TITLE
Add assist to convert for_each into for loops

### DIFF
--- a/crates/ide_assists/src/handlers/convert_iter_for_each_to_for.rs
+++ b/crates/ide_assists/src/handlers/convert_iter_for_each_to_for.rs
@@ -10,7 +10,7 @@ use crate::{AssistContext, AssistId, AssistKind, Assists};
 //
 // Converts an Iterator::for_each function into a for loop.
 //
-// ```rust
+// ```
 // fn main() {
 //     let vec = vec![(1, 2), (2, 3), (3, 4)];
 //     x.iter().for_each(|(x, y)| {
@@ -19,7 +19,7 @@ use crate::{AssistContext, AssistId, AssistKind, Assists};
 // }
 // ```
 // ->
-// ```rust
+// ```
 // fn main() {
 //     let vec = vec![(1, 2), (2, 3), (3, 4)];
 //     for (x, y) in x.iter() {

--- a/crates/ide_assists/src/handlers/convert_iter_for_each_to_for.rs
+++ b/crates/ide_assists/src/handlers/convert_iter_for_each_to_for.rs
@@ -1,5 +1,8 @@
 use ide_db::helpers::FamousDefs;
-use syntax::{AstNode, ast::{self, make, ArgListOwner, edit::AstNodeEdit}};
+use syntax::{
+    ast::{self, edit::AstNodeEdit, make, ArgListOwner},
+    AstNode,
+};
 
 use crate::{AssistContext, AssistId, AssistKind, Assists};
 
@@ -31,16 +34,20 @@ pub(crate) fn convert_iter_for_each_to_for(acc: &mut Assists, ctx: &AssistContex
         ast::Expr::MethodCallExpr(expr) => {
             closure = match expr.arg_list()?.args().next()? {
                 ast::Expr::ClosureExpr(expr) => expr,
-                _ => { return None; }
+                _ => {
+                    return None;
+                }
             };
-            
+
             expr
-        },
+        }
         ast::Expr::ClosureExpr(expr) => {
             closure = expr;
             ast::MethodCallExpr::cast(closure.syntax().ancestors().nth(2)?)?
-        },
-        _ => { return None; }
+        }
+        _ => {
+            return None;
+        }
     };
 
     let (total_expr, parent) = validate_method_call_expr(&ctx.sema, total_expr)?;
@@ -58,8 +65,10 @@ pub(crate) fn convert_iter_for_each_to_for(acc: &mut Assists, ctx: &AssistContex
 
             let block = match body {
                 ast::Expr::BlockExpr(block) => block,
-                _ => make::block_expr(Vec::new(), Some(body))
-            }.reset_indent().indent(original_indentation);
+                _ => make::block_expr(Vec::new(), Some(body)),
+            }
+            .reset_indent()
+            .indent(original_indentation);
 
             let expr_for_loop = make::expr_for_loop(param, parent, block);
             builder.replace_ast(total_expr, expr_for_loop)
@@ -187,6 +196,7 @@ fn main() {
             r#"
 fn main() {
     value.$0for_each(|x| println!("{}", x));
-}"#)
+}"#,
+        )
     }
 }

--- a/crates/ide_assists/src/handlers/convert_iter_for_each_to_for.rs
+++ b/crates/ide_assists/src/handlers/convert_iter_for_each_to_for.rs
@@ -1,0 +1,138 @@
+use ide_db::helpers::FamousDefs;
+use stdx::format_to;
+use syntax::{AstNode, ast::{self, ArgListOwner}};
+
+use crate::{AssistContext, AssistId, AssistKind, Assists};
+
+/// Assist: convert_iter_for_each_to_for
+//
+/// Converts an Iterator::for_each function into a for loop.
+///
+/// ```rust
+/// fn main() {
+///     let vec = vec![(1, 2), (2, 3), (3, 4)];
+///     x.iter().for_each(|(x, y)| {
+///         println!("x: {}, y: {}", x, y);
+///    })
+/// }
+/// ```
+/// ->
+/// ```rust
+/// fn main() {
+///     let vec = vec![(1, 2), (2, 3), (3, 4)];
+///     for (x, y) in x.iter() {
+///         println!("x: {}, y: {}", x, y);
+///     });
+/// }
+/// ```
+pub(crate) fn convert_iter_for_each_to_for(acc: &mut Assists, ctx: &AssistContext) -> Option<()> {
+    let closure;
+
+    let total_expr = match ctx.find_node_at_offset::<ast::Expr>()? {
+        ast::Expr::MethodCallExpr(expr) => {
+            closure = match expr.arg_list()?.args().next()? {
+                ast::Expr::ClosureExpr(expr) => expr,
+                _ => { return None; }
+            };
+            
+            expr
+        },
+        ast::Expr::ClosureExpr(expr) => {
+            closure = expr;
+            ast::MethodCallExpr::cast(closure.syntax().ancestors().nth(2)?)?
+        },
+        _ => { return None; }
+    };
+
+    let (total_expr, parent) = validate_method_call_expr(&ctx.sema, total_expr)?;
+
+    let param_list = closure.param_list()?;
+    let param = param_list.params().next()?;
+    let body = closure.body()?;
+
+    acc.add(
+        AssistId("convert_iter_for_each_to_for", AssistKind::RefactorRewrite),
+        "Replace this `Iterator::for_each` with a for loop",
+        total_expr.syntax().text_range(),
+        |builder| {
+            let mut buf = String::new();
+
+            format_to!(buf, "for {} in {} ", param, parent);
+
+            match body {
+                ast::Expr::BlockExpr(body) => format_to!(buf, "{}", body),
+                _ => format_to!(buf, "{{\n{}\n}}", body)
+            }
+
+            builder.replace(total_expr.syntax().text_range(), buf)
+        },
+    )
+}
+
+fn validate_method_call_expr(
+    sema: &hir::Semantics<ide_db::RootDatabase>,
+    expr: ast::MethodCallExpr,
+) -> Option<(ast::Expr, ast::Expr)> {
+    if expr.name_ref()?.text() != "for_each" {
+        return None;
+    }
+
+    let expr = ast::Expr::MethodCallExpr(expr);
+    let parent = ast::Expr::cast(expr.syntax().first_child()?)?;
+
+    let it_type = sema.type_of_expr(&parent)?;
+    let module = sema.scope(parent.syntax()).module()?;
+    let krate = module.krate();
+
+    let iter_trait = FamousDefs(sema, Some(krate)).core_iter_Iterator()?;
+    it_type.impls_trait(sema.db, iter_trait, &[]).then(|| (expr, parent))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::check_assist;
+
+    use super::*;
+
+    #[test]
+    fn test_for_each_in_method() {
+        check_assist(
+            convert_iter_for_each_to_for,
+            r"
+fn main() {
+    let x = vec![(1, 1), (2, 2), (3, 3), (4, 4)];
+    x.iter().$0for_each(|(x, y)| {
+        dbg!(x, y)
+    });
+}",
+            r"
+fn main() {
+    let x = vec![(1, 1), (2, 2), (3, 3), (4, 4)];
+    for (x, y) in x.iter() {
+        dbg!(x, y)
+    };
+}",
+        )
+    }
+
+    #[test]
+    fn test_for_each_in_closure() {
+        check_assist(
+            convert_iter_for_each_to_for,
+            r"
+fn main() {
+    let x = vec![(1, 1), (2, 2), (3, 3), (4, 4)];
+    x.iter().for_each($0|(x, y)| {
+        dbg!(x, y)
+    });
+}",
+            r"
+fn main() {
+    let x = vec![(1, 1), (2, 2), (3, 3), (4, 4)];
+    for (x, y) in x.iter() {
+        dbg!(x, y)
+    };
+}",
+        )
+    }
+}

--- a/crates/ide_assists/src/handlers/convert_iter_for_each_to_for.rs
+++ b/crates/ide_assists/src/handlers/convert_iter_for_each_to_for.rs
@@ -6,27 +6,27 @@ use syntax::{
 
 use crate::{AssistContext, AssistId, AssistKind, Assists};
 
-/// Assist: convert_iter_for_each_to_for
+// Assist: convert_iter_for_each_to_for
 //
-/// Converts an Iterator::for_each function into a for loop.
-///
-/// ```rust
-/// fn main() {
-///     let vec = vec![(1, 2), (2, 3), (3, 4)];
-///     x.iter().for_each(|(x, y)| {
-///         println!("x: {}, y: {}", x, y);
-///    })
-/// }
-/// ```
-/// ->
-/// ```rust
-/// fn main() {
-///     let vec = vec![(1, 2), (2, 3), (3, 4)];
-///     for (x, y) in x.iter() {
-///         println!("x: {}, y: {}", x, y);
-///     });
-/// }
-/// ```
+// Converts an Iterator::for_each function into a for loop.
+//
+// ```rust
+// fn main() {
+//     let vec = vec![(1, 2), (2, 3), (3, 4)];
+//     x.iter().for_each(|(x, y)| {
+//         println!("x: {}, y: {}", x, y);
+//     });
+// }
+// ```
+// ->
+// ```rust
+// fn main() {
+//     let vec = vec![(1, 2), (2, 3), (3, 4)];
+//     for (x, y) in x.iter() {
+//         println!("x: {}, y: {}", x, y);
+//     }
+// }
+// ```
 pub(crate) fn convert_iter_for_each_to_for(acc: &mut Assists, ctx: &AssistContext) -> Option<()> {
     let method = ctx.find_node_at_offset::<ast::MethodCallExpr>()?;
     let stmt = method.syntax().parent().and_then(ast::ExprStmt::cast);

--- a/crates/ide_assists/src/lib.rs
+++ b/crates/ide_assists/src/lib.rs
@@ -116,6 +116,7 @@ mod handlers {
     mod change_visibility;
     mod convert_integer_literal;
     mod convert_comment_block;
+    mod convert_iter_for_each_to_for;
     mod early_return;
     mod expand_glob_import;
     mod extract_function;
@@ -181,6 +182,7 @@ mod handlers {
             change_visibility::change_visibility,
             convert_integer_literal::convert_integer_literal,
             convert_comment_block::convert_comment_block,
+            convert_iter_for_each_to_for::convert_iter_for_each_to_for,
             early_return::convert_to_guarded_return,
             expand_glob_import::expand_glob_import,
             extract_struct_from_enum_variant::extract_struct_from_enum_variant,

--- a/crates/ide_assists/src/tests/generated.rs
+++ b/crates/ide_assists/src/tests/generated.rs
@@ -210,17 +210,24 @@ fn doctest_convert_iter_for_each_to_for() {
     check_doc_test(
         "convert_iter_for_each_to_for",
         r#####"
+//- /lib.rs crate:core
+pub mod iter { pub mod traits { pub mod iterator { pub trait Iterator {} } } }
+pub struct SomeIter;
+impl self::iter::traits::iterator::Iterator for SomeIter {}
+//- /lib.rs crate:main deps:core
+use core::SomeIter;
 fn main() {
-    let vec = vec![(1, 2), (2, 3), (3, 4)];
-    x.iter().for_each(|(x, y)| {
+    let iter = SomeIter;
+    iter.for_each$0(|(x, y)| {
         println!("x: {}, y: {}", x, y);
     });
 }
 "#####,
         r#####"
+use core::SomeIter;
 fn main() {
-    let vec = vec![(1, 2), (2, 3), (3, 4)];
-    for (x, y) in x.iter() {
+    let iter = SomeIter;
+    for (x, y) in iter {
         println!("x: {}, y: {}", x, y);
     }
 }

--- a/crates/ide_assists/src/tests/generated.rs
+++ b/crates/ide_assists/src/tests/generated.rs
@@ -206,6 +206,29 @@ const _: i32 = 0b1010;
 }
 
 #[test]
+fn doctest_convert_iter_for_each_to_for() {
+    check_doc_test(
+        "convert_iter_for_each_to_for",
+        r#####"
+fn main() {
+    let vec = vec![(1, 2), (2, 3), (3, 4)];
+    x.iter().for_each(|(x, y)| {
+        println!("x: {}, y: {}", x, y);
+    });
+}
+"#####,
+        r#####"
+fn main() {
+    let vec = vec![(1, 2), (2, 3), (3, 4)];
+    for (x, y) in x.iter() {
+        println!("x: {}, y: {}", x, y);
+    }
+}
+"#####,
+    )
+}
+
+#[test]
 fn doctest_convert_to_guarded_return() {
     check_doc_test(
         "convert_to_guarded_return",

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -222,6 +222,9 @@ pub fn expr_if(
     };
     expr_from_text(&format!("if {} {} {}", condition, then_branch, else_branch))
 }
+pub fn expr_for_loop(pat: ast::Pat, expr: ast::Expr, block: ast::BlockExpr) -> ast::Expr {
+    expr_from_text(&format!("for {} in {} {}", pat, expr, block))
+}
 pub fn expr_prefix(op: SyntaxKind, expr: ast::Expr) -> ast::Expr {
     let token = token(op);
     expr_from_text(&format!("{}{}", token, expr))


### PR DESCRIPTION
This PR resolves #7821.
Adds an assist to that converts an `Iterator::for_each` into a for loop: 

```rust
fn main() {
    let vec = vec![(1, 2), (2, 3), (3, 4)];
    x.iter().for_each(|(x, y)| {
        println!("x: {}, y: {}", x, y);
    })
}
```
becomes
```rust
fn main() {
    let vec = vec![(1, 2), (2, 3), (3, 4)];
    for (x, y) in x.iter() {
        println!("x: {}, y: {}", x, y);
    });
}
```