### PR TITLE
use references in CompletionItem's builder

### DIFF
--- a/crates/ide_completion/src/completions.rs
+++ b/crates/ide_completion/src/completions.rs
@@ -49,7 +49,7 @@ impl Into<Vec<CompletionItem>> for Completions {
 impl Builder {
     /// Convenience method, which allows to add a freshly created completion into accumulator
     /// without binding it to the variable.
-    pub(crate) fn add_to(self, acc: &mut Completions) {
+    pub(crate) fn add_to(&self, acc: &mut Completions) {
         acc.add(self.build())
     }
 }

--- a/crates/ide_completion/src/completions.rs
+++ b/crates/ide_completion/src/completions.rs
@@ -49,7 +49,7 @@ impl Into<Vec<CompletionItem>> for Completions {
 impl Builder {
     /// Convenience method, which allows to add a freshly created completion into accumulator
     /// without binding it to the variable.
-    pub(crate) fn add_to(&self, acc: &mut Completions) {
+    pub(crate) fn add_to(self, acc: &mut Completions) {
         acc.add(self.build())
     }
 }

--- a/crates/ide_completion/src/completions/attribute.rs
+++ b/crates/ide_completion/src/completions/attribute.rs
@@ -41,12 +41,12 @@ pub(crate) fn complete_attribute(acc: &mut Completions, ctx: &CompletionContext)
 fn complete_attribute_start(acc: &mut Completions, ctx: &CompletionContext, attribute: &ast::Attr) {
     let is_inner = attribute.kind() == ast::AttrKind::Inner;
     for attr_completion in ATTRIBUTES.iter().filter(|compl| is_inner || !compl.prefer_inner) {
-        let mut item = CompletionItem::new(
+        let mut item = &mut CompletionItem::new(
             CompletionKind::Attribute,
             ctx.source_range(),
             attr_completion.label,
-        )
-        .kind(CompletionItemKind::Attribute);
+        );
+        item = item.kind(CompletionItemKind::Attribute);
 
         if let Some(lookup) = attr_completion.lookup {
             item = item.lookup_by(lookup);
@@ -168,16 +168,18 @@ fn complete_derive(acc: &mut Completions, ctx: &CompletionContext, derive_input:
             );
             let lookup = components.join(", ");
             let label = components.iter().rev().join(", ");
-            CompletionItem::new(CompletionKind::Attribute, ctx.source_range(), label)
-                .lookup_by(lookup)
-                .kind(CompletionItemKind::Attribute)
-                .add_to(acc)
+            let builder =
+                &mut CompletionItem::new(CompletionKind::Attribute, ctx.source_range(), label);
+            builder.lookup_by(lookup).kind(CompletionItemKind::Attribute).add_to(acc);
         }
 
         for custom_derive_name in get_derive_names_in_scope(ctx).difference(&existing_derives) {
-            CompletionItem::new(CompletionKind::Attribute, ctx.source_range(), custom_derive_name)
-                .kind(CompletionItemKind::Attribute)
-                .add_to(acc)
+            let builder = &mut CompletionItem::new(
+                CompletionKind::Attribute,
+                ctx.source_range(),
+                custom_derive_name,
+            );
+            builder.kind(CompletionItemKind::Attribute).add_to(acc);
         }
     }
 }

--- a/crates/ide_completion/src/completions/attribute.rs
+++ b/crates/ide_completion/src/completions/attribute.rs
@@ -41,19 +41,19 @@ pub(crate) fn complete_attribute(acc: &mut Completions, ctx: &CompletionContext)
 fn complete_attribute_start(acc: &mut Completions, ctx: &CompletionContext, attribute: &ast::Attr) {
     let is_inner = attribute.kind() == ast::AttrKind::Inner;
     for attr_completion in ATTRIBUTES.iter().filter(|compl| is_inner || !compl.prefer_inner) {
-        let mut item = &mut CompletionItem::new(
+        let mut item = CompletionItem::new(
             CompletionKind::Attribute,
             ctx.source_range(),
             attr_completion.label,
         );
-        item = item.kind(CompletionItemKind::Attribute);
+        item.kind(CompletionItemKind::Attribute);
 
         if let Some(lookup) = attr_completion.lookup {
-            item = item.lookup_by(lookup);
+            item.lookup_by(lookup);
         }
 
         if let Some((snippet, cap)) = attr_completion.snippet.zip(ctx.config.snippet_cap) {
-            item = item.insert_snippet(cap, snippet);
+            item.insert_snippet(cap, snippet);
         }
 
         if attribute.kind() == ast::AttrKind::Inner || !attr_completion.prefer_inner {
@@ -168,18 +168,20 @@ fn complete_derive(acc: &mut Completions, ctx: &CompletionContext, derive_input:
             );
             let lookup = components.join(", ");
             let label = components.iter().rev().join(", ");
-            let builder =
-                &mut CompletionItem::new(CompletionKind::Attribute, ctx.source_range(), label);
-            builder.lookup_by(lookup).kind(CompletionItemKind::Attribute).add_to(acc);
+            let mut builder =
+                CompletionItem::new(CompletionKind::Attribute, ctx.source_range(), label);
+            builder.lookup_by(lookup).kind(CompletionItemKind::Attribute);
+            builder.add_to(acc);
         }
 
         for custom_derive_name in get_derive_names_in_scope(ctx).difference(&existing_derives) {
-            let builder = &mut CompletionItem::new(
+            let mut builder = CompletionItem::new(
                 CompletionKind::Attribute,
                 ctx.source_range(),
                 custom_derive_name,
             );
-            builder.kind(CompletionItemKind::Attribute).add_to(acc);
+            builder.kind(CompletionItemKind::Attribute);
+            builder.add_to(acc);
         }
     }
 }
@@ -195,14 +197,13 @@ fn complete_lint(
             .into_iter()
             .filter(|completion| !existing_lints.contains(completion.label))
         {
-            CompletionItem::new(
+            let mut builder = CompletionItem::new(
                 CompletionKind::Attribute,
                 ctx.source_range(),
                 lint_completion.label,
-            )
-            .kind(CompletionItemKind::Attribute)
-            .detail(lint_completion.description)
-            .add_to(acc)
+            );
+            builder.kind(CompletionItemKind::Attribute).detail(lint_completion.description);
+            builder.add_to(acc)
         }
     }
 }

--- a/crates/ide_completion/src/completions/fn_param.rs
+++ b/crates/ide_completion/src/completions/fn_param.rs
@@ -54,10 +54,9 @@ pub(crate) fn complete_fn_param(acc: &mut Completions, ctx: &CompletionContext) 
     }
 
     params.into_iter().for_each(|(label, lookup)| {
-        CompletionItem::new(CompletionKind::Magic, ctx.source_range(), label)
-            .kind(CompletionItemKind::Binding)
-            .lookup_by(lookup)
-            .add_to(acc)
+        let mut builder = CompletionItem::new(CompletionKind::Magic, ctx.source_range(), label);
+        builder.kind(CompletionItemKind::Binding).lookup_by(lookup);
+        builder.add_to(acc)
     });
 }
 

--- a/crates/ide_completion/src/completions/keyword.rs
+++ b/crates/ide_completion/src/completions/keyword.rs
@@ -165,8 +165,9 @@ pub(crate) fn complete_expr_keyword(acc: &mut Completions, ctx: &CompletionConte
 }
 
 fn add_keyword(ctx: &CompletionContext, acc: &mut Completions, kw: &str, snippet: &str) {
-    let builder = CompletionItem::new(CompletionKind::Keyword, ctx.source_range(), kw)
-        .kind(CompletionItemKind::Keyword);
+    let mut builder = &mut CompletionItem::new(CompletionKind::Keyword, ctx.source_range(), kw);
+    builder = builder.kind(CompletionItemKind::Keyword);
+
     let builder = match ctx.config.snippet_cap {
         Some(cap) => {
             let tmp;

--- a/crates/ide_completion/src/completions/keyword.rs
+++ b/crates/ide_completion/src/completions/keyword.rs
@@ -12,21 +12,21 @@ pub(crate) fn complete_use_tree_keyword(acc: &mut Completions, ctx: &CompletionC
 
     if ctx.use_item_syntax.is_some() {
         if ctx.path_qual.is_none() {
-            CompletionItem::new(CompletionKind::Keyword, source_range, "crate::")
-                .kind(CompletionItemKind::Keyword)
-                .insert_text("crate::")
-                .add_to(acc);
+            let mut crate_builder =
+                CompletionItem::new(CompletionKind::Keyword, source_range, "crate::");
+            crate_builder.kind(CompletionItemKind::Keyword).insert_text("crate::");
+            crate_builder.add_to(acc);
         }
-        CompletionItem::new(CompletionKind::Keyword, source_range, "self")
-            .kind(CompletionItemKind::Keyword)
-            .add_to(acc);
+        let mut self_builder = CompletionItem::new(CompletionKind::Keyword, source_range, "self");
+        self_builder.kind(CompletionItemKind::Keyword);
+        self_builder.add_to(acc);
         if iter::successors(ctx.path_qual.clone(), |p| p.qualifier())
             .all(|p| p.segment().and_then(|s| s.super_token()).is_some())
         {
-            CompletionItem::new(CompletionKind::Keyword, source_range, "super::")
-                .kind(CompletionItemKind::Keyword)
-                .insert_text("super::")
-                .add_to(acc);
+            let mut super_builder =
+                CompletionItem::new(CompletionKind::Keyword, source_range, "super::");
+            super_builder.kind(CompletionItemKind::Keyword).insert_text("super::");
+            super_builder.add_to(acc);
         }
     }
 
@@ -34,11 +34,10 @@ pub(crate) fn complete_use_tree_keyword(acc: &mut Completions, ctx: &CompletionC
     if let Some(receiver) = &ctx.dot_receiver {
         if let Some(ty) = ctx.sema.type_of_expr(receiver) {
             if ty.impls_future(ctx.db) {
-                CompletionItem::new(CompletionKind::Keyword, ctx.source_range(), "await")
-                    .kind(CompletionItemKind::Keyword)
-                    .detail("expr.await")
-                    .insert_text("await")
-                    .add_to(acc);
+                let mut builder =
+                    CompletionItem::new(CompletionKind::Keyword, ctx.source_range(), "await");
+                builder.kind(CompletionItemKind::Keyword).detail("expr.await").insert_text("await");
+                builder.add_to(acc);
             }
         };
     }
@@ -165,10 +164,10 @@ pub(crate) fn complete_expr_keyword(acc: &mut Completions, ctx: &CompletionConte
 }
 
 fn add_keyword(ctx: &CompletionContext, acc: &mut Completions, kw: &str, snippet: &str) {
-    let mut builder = &mut CompletionItem::new(CompletionKind::Keyword, ctx.source_range(), kw);
-    builder = builder.kind(CompletionItemKind::Keyword);
+    let mut builder = CompletionItem::new(CompletionKind::Keyword, ctx.source_range(), kw);
+    builder.kind(CompletionItemKind::Keyword);
 
-    let builder = match ctx.config.snippet_cap {
+    match ctx.config.snippet_cap {
         Some(cap) => {
             let tmp;
             let snippet = if snippet.ends_with('}') && ctx.incomplete_let {
@@ -178,9 +177,11 @@ fn add_keyword(ctx: &CompletionContext, acc: &mut Completions, kw: &str, snippet
             } else {
                 snippet
             };
-            builder.insert_snippet(cap, snippet)
+            builder.insert_snippet(cap, snippet);
         }
-        None => builder.insert_text(if snippet.contains('$') { kw } else { snippet }),
+        None => {
+            builder.insert_text(if snippet.contains('$') { kw } else { snippet });
+        }
     };
     acc.add(builder.build());
 }

--- a/crates/ide_completion/src/completions/mod_.rs
+++ b/crates/ide_completion/src/completions/mod_.rs
@@ -80,9 +80,10 @@ pub(crate) fn complete_mod(acc: &mut Completions, ctx: &CompletionContext) -> Op
             if mod_under_caret.semicolon_token().is_none() {
                 label.push(';');
             }
-            CompletionItem::new(CompletionKind::Magic, ctx.source_range(), &label)
-                .kind(SymbolKind::Module)
-                .add_to(acc)
+            let mut builder =
+                CompletionItem::new(CompletionKind::Magic, ctx.source_range(), &label);
+            builder.kind(SymbolKind::Module);
+            builder.add_to(acc)
         });
 
     Some(())

--- a/crates/ide_completion/src/completions/postfix.rs
+++ b/crates/ide_completion/src/completions/postfix.rs
@@ -301,6 +301,7 @@ fn postfix_snippet(
         .detail(detail)
         .kind(CompletionItemKind::Snippet)
         .snippet_edit(cap, edit)
+        .clone()
 }
 
 #[cfg(test)]

--- a/crates/ide_completion/src/completions/record.rs
+++ b/crates/ide_completion/src/completions/record.rs
@@ -22,16 +22,13 @@ pub(crate) fn complete_record(acc: &mut Completions, ctx: &CompletionContext) ->
                 let completion_text = completion_text
                     .strip_prefix(ctx.token.to_string().as_str())
                     .unwrap_or(completion_text);
-                acc.add(
-                    CompletionItem::new(
-                        CompletionKind::Snippet,
-                        ctx.source_range(),
-                        "..Default::default()",
-                    )
-                    .insert_text(completion_text)
-                    .kind(SymbolKind::Field)
-                    .build(),
+                let mut builder = CompletionItem::new(
+                    CompletionKind::Snippet,
+                    ctx.source_range(),
+                    "..Default::default()",
                 );
+                builder.insert_text(completion_text).kind(SymbolKind::Field);
+                acc.add(builder.build());
             }
 
             missing_fields

--- a/crates/ide_completion/src/completions/snippet.rs
+++ b/crates/ide_completion/src/completions/snippet.rs
@@ -34,7 +34,7 @@ pub(crate) fn complete_item_snippet(acc: &mut Completions, ctx: &CompletionConte
         None => return,
     };
 
-    snippet(
+    let mut test_module_builder = snippet(
         ctx,
         cap,
         "tmod (Test module)",
@@ -48,11 +48,11 @@ mod tests {
         $0
     }
 }",
-    )
-    .lookup_by("tmod")
-    .add_to(acc);
+    );
+    test_module_builder.lookup_by("tmod");
+    test_module_builder.add_to(acc);
 
-    snippet(
+    let mut test_function_builder = snippet(
         ctx,
         cap,
         "tfn (Test function)",
@@ -61,11 +61,13 @@ mod tests {
 fn ${1:feature}() {
     $0
 }",
-    )
-    .lookup_by("tfn")
-    .add_to(acc);
+    );
+    test_function_builder.lookup_by("tfn");
+    test_function_builder.add_to(acc);
 
-    snippet(ctx, cap, "macro_rules", "macro_rules! $1 {\n\t($2) => {\n\t\t$0\n\t};\n}").add_to(acc);
+    let macro_rules_builder =
+        snippet(ctx, cap, "macro_rules", "macro_rules! $1 {\n\t($2) => {\n\t\t$0\n\t};\n}");
+    macro_rules_builder.add_to(acc);
 }
 
 #[cfg(test)]

--- a/crates/ide_completion/src/completions/snippet.rs
+++ b/crates/ide_completion/src/completions/snippet.rs
@@ -8,9 +8,8 @@ use crate::{
 };
 
 fn snippet(ctx: &CompletionContext, cap: SnippetCap, label: &str, snippet: &str) -> Builder {
-    CompletionItem::new(CompletionKind::Snippet, ctx.source_range(), label)
-        .insert_snippet(cap, snippet)
-        .kind(CompletionItemKind::Snippet)
+    let mut builder = CompletionItem::new(CompletionKind::Snippet, ctx.source_range(), label);
+    builder.insert_snippet(cap, snippet).kind(CompletionItemKind::Snippet).clone()
 }
 
 pub(crate) fn complete_expr_snippet(acc: &mut Completions, ctx: &CompletionContext) {

--- a/crates/ide_completion/src/completions/trait_impl.rs
+++ b/crates/ide_completion/src/completions/trait_impl.rs
@@ -145,9 +145,8 @@ fn add_function_impl(
         format!("fn {}(..)", fn_name)
     };
 
-    let builder = CompletionItem::new(CompletionKind::Magic, ctx.source_range(), label)
-        .lookup_by(fn_name)
-        .set_documentation(func.docs(ctx.db));
+    let builder = &mut CompletionItem::new(CompletionKind::Magic, ctx.source_range(), label);
+    builder.lookup_by(fn_name).set_documentation(func.docs(ctx.db));
 
     let completion_kind = if func.self_param(ctx.db).is_some() {
         CompletionItemKind::Method

--- a/crates/ide_completion/src/completions/trait_impl.rs
+++ b/crates/ide_completion/src/completions/trait_impl.rs
@@ -145,7 +145,7 @@ fn add_function_impl(
         format!("fn {}(..)", fn_name)
     };
 
-    let builder = &mut CompletionItem::new(CompletionKind::Magic, ctx.source_range(), label);
+    let mut builder = CompletionItem::new(CompletionKind::Magic, ctx.source_range(), label);
     builder.lookup_by(fn_name).set_documentation(func.docs(ctx.db));
 
     let completion_kind = if func.self_param(ctx.db).is_some() {
@@ -160,15 +160,15 @@ fn add_function_impl(
         match ctx.config.snippet_cap {
             Some(cap) => {
                 let snippet = format!("{} {{\n    $0\n}}", function_decl);
-                builder.snippet_edit(cap, TextEdit::replace(range, snippet))
+                builder.snippet_edit(cap, TextEdit::replace(range, snippet));
             }
             None => {
                 let header = format!("{} {{", function_decl);
-                builder.text_edit(TextEdit::replace(range, header))
+                builder.text_edit(TextEdit::replace(range, header));
             }
-        }
-        .kind(completion_kind)
-        .add_to(acc);
+        };
+        builder.kind(completion_kind);
+        builder.add_to(acc);
     }
 }
 
@@ -184,12 +184,14 @@ fn add_type_alias_impl(
 
     let range = TextRange::new(type_def_node.text_range().start(), ctx.source_range().end());
 
-    CompletionItem::new(CompletionKind::Magic, ctx.source_range(), snippet.clone())
+    let mut builder =
+        CompletionItem::new(CompletionKind::Magic, ctx.source_range(), snippet.clone());
+    builder
         .text_edit(TextEdit::replace(range, snippet))
         .lookup_by(alias_name)
         .kind(SymbolKind::TypeAlias)
-        .set_documentation(type_alias.docs(ctx.db))
-        .add_to(acc);
+        .set_documentation(type_alias.docs(ctx.db));
+    builder.add_to(acc);
 }
 
 fn add_const_impl(
@@ -207,12 +209,14 @@ fn add_const_impl(
             let range =
                 TextRange::new(const_def_node.text_range().start(), ctx.source_range().end());
 
-            CompletionItem::new(CompletionKind::Magic, ctx.source_range(), snippet.clone())
+            let mut builder =
+                CompletionItem::new(CompletionKind::Magic, ctx.source_range(), snippet.clone());
+            builder
                 .text_edit(TextEdit::replace(range, snippet))
                 .lookup_by(const_name)
                 .kind(SymbolKind::Const)
-                .set_documentation(const_.docs(ctx.db))
-                .add_to(acc);
+                .set_documentation(const_.docs(ctx.db));
+            builder.add_to(acc);
         }
     }
 }

--- a/crates/ide_completion/src/item.rs
+++ b/crates/ide_completion/src/item.rs
@@ -355,12 +355,11 @@ pub(crate) struct Builder {
 
 impl Builder {
     pub(crate) fn build(self) -> CompletionItem {
-        let builder = self.clone();
         let _p = profile::span("item::Builder::build");
 
-        let mut label = builder.label;
-        let mut lookup = builder.lookup;
-        let mut insert_text = builder.insert_text;
+        let mut label = self.label;
+        let mut lookup = self.lookup;
+        let mut insert_text = self.insert_text;
 
         if let Some(original_path) = self
             .import_to_add
@@ -378,7 +377,7 @@ impl Builder {
             }
         }
 
-        let text_edit = match builder.text_edit {
+        let text_edit = match self.text_edit {
             Some(it) => it,
             None => {
                 TextEdit::replace(self.source_range, insert_text.unwrap_or_else(|| label.clone()))
@@ -390,8 +389,8 @@ impl Builder {
             label,
             insert_text_format: self.insert_text_format,
             text_edit,
-            detail: builder.detail,
-            documentation: builder.documentation,
+            detail: self.detail,
+            documentation: self.documentation,
             lookup,
             kind: self.kind,
             completion_kind: self.completion_kind,
@@ -399,7 +398,7 @@ impl Builder {
             trigger_call_info: self.trigger_call_info.unwrap_or(false),
             relevance: self.relevance,
             ref_match: self.ref_match,
-            import_to_add: builder.import_to_add,
+            import_to_add: self.import_to_add,
         }
     }
     pub(crate) fn lookup_by(&mut self, lookup: impl Into<String>) -> &mut Builder {

--- a/crates/ide_completion/src/item.rs
+++ b/crates/ide_completion/src/item.rs
@@ -354,12 +354,13 @@ pub(crate) struct Builder {
 }
 
 impl Builder {
-    pub(crate) fn build(self) -> CompletionItem {
+    pub(crate) fn build(&self) -> CompletionItem {
+        let builder = self.clone();
         let _p = profile::span("item::Builder::build");
 
-        let mut label = self.label;
-        let mut lookup = self.lookup;
-        let mut insert_text = self.insert_text;
+        let mut label = builder.label;
+        let mut lookup = builder.lookup;
+        let mut insert_text = builder.insert_text;
 
         if let Some(original_path) = self
             .import_to_add
@@ -377,7 +378,7 @@ impl Builder {
             }
         }
 
-        let text_edit = match self.text_edit {
+        let text_edit = match builder.text_edit {
             Some(it) => it,
             None => {
                 TextEdit::replace(self.source_range, insert_text.unwrap_or_else(|| label.clone()))
@@ -389,8 +390,8 @@ impl Builder {
             label,
             insert_text_format: self.insert_text_format,
             text_edit,
-            detail: self.detail,
-            documentation: self.documentation,
+            detail: builder.detail,
+            documentation: builder.documentation,
             lookup,
             kind: self.kind,
             completion_kind: self.completion_kind,
@@ -398,45 +399,45 @@ impl Builder {
             trigger_call_info: self.trigger_call_info.unwrap_or(false),
             relevance: self.relevance,
             ref_match: self.ref_match,
-            import_to_add: self.import_to_add,
+            import_to_add: builder.import_to_add,
         }
     }
-    pub(crate) fn lookup_by(mut self, lookup: impl Into<String>) -> Builder {
+    pub(crate) fn lookup_by(&mut self, lookup: impl Into<String>) -> &mut Builder {
         self.lookup = Some(lookup.into());
         self
     }
-    pub(crate) fn label(mut self, label: impl Into<String>) -> Builder {
+    pub(crate) fn label(&mut self, label: impl Into<String>) -> &mut Builder {
         self.label = label.into();
         self
     }
-    pub(crate) fn insert_text(mut self, insert_text: impl Into<String>) -> Builder {
+    pub(crate) fn insert_text(&mut self, insert_text: impl Into<String>) -> &mut Builder {
         self.insert_text = Some(insert_text.into());
         self
     }
     pub(crate) fn insert_snippet(
-        mut self,
+        &mut self,
         _cap: SnippetCap,
         snippet: impl Into<String>,
-    ) -> Builder {
+    ) -> &mut Builder {
         self.insert_text_format = InsertTextFormat::Snippet;
         self.insert_text(snippet)
     }
-    pub(crate) fn kind(mut self, kind: impl Into<CompletionItemKind>) -> Builder {
+    pub(crate) fn kind(&mut self, kind: impl Into<CompletionItemKind>) -> &mut Builder {
         self.kind = Some(kind.into());
         self
     }
-    pub(crate) fn text_edit(mut self, edit: TextEdit) -> Builder {
+    pub(crate) fn text_edit(&mut self, edit: TextEdit) -> &mut Builder {
         self.text_edit = Some(edit);
         self
     }
-    pub(crate) fn snippet_edit(mut self, _cap: SnippetCap, edit: TextEdit) -> Builder {
+    pub(crate) fn snippet_edit(&mut self, _cap: SnippetCap, edit: TextEdit) -> &mut Builder {
         self.insert_text_format = InsertTextFormat::Snippet;
         self.text_edit(edit)
     }
-    pub(crate) fn detail(self, detail: impl Into<String>) -> Builder {
+    pub(crate) fn detail(&mut self, detail: impl Into<String>) -> &mut Builder {
         self.set_detail(Some(detail))
     }
-    pub(crate) fn set_detail(mut self, detail: Option<impl Into<String>>) -> Builder {
+    pub(crate) fn set_detail(&mut self, detail: Option<impl Into<String>>) -> &mut Builder {
         self.detail = detail.map(Into::into);
         if let Some(detail) = &self.detail {
             if never!(detail.contains('\n'), "multiline detail:\n{}", detail) {
@@ -446,30 +447,30 @@ impl Builder {
         self
     }
     #[allow(unused)]
-    pub(crate) fn documentation(self, docs: Documentation) -> Builder {
+    pub(crate) fn documentation(&mut self, docs: Documentation) -> &mut Builder {
         self.set_documentation(Some(docs))
     }
-    pub(crate) fn set_documentation(mut self, docs: Option<Documentation>) -> Builder {
+    pub(crate) fn set_documentation(&mut self, docs: Option<Documentation>) -> &mut Builder {
         self.documentation = docs.map(Into::into);
         self
     }
-    pub(crate) fn set_deprecated(mut self, deprecated: bool) -> Builder {
+    pub(crate) fn set_deprecated(&mut self, deprecated: bool) -> &mut Builder {
         self.deprecated = deprecated;
         self
     }
-    pub(crate) fn set_relevance(mut self, relevance: Relevance) -> Builder {
+    pub(crate) fn set_relevance(&mut self, relevance: Relevance) -> &mut Builder {
         self.relevance = relevance;
         self
     }
-    pub(crate) fn trigger_call_info(mut self) -> Builder {
+    pub(crate) fn trigger_call_info(&mut self) -> &mut Builder {
         self.trigger_call_info = Some(true);
         self
     }
-    pub(crate) fn add_import(mut self, import_to_add: Option<ImportEdit>) -> Builder {
+    pub(crate) fn add_import(&mut self, import_to_add: Option<ImportEdit>) -> &mut Builder {
         self.import_to_add = import_to_add;
         self
     }
-    pub(crate) fn ref_match(mut self, mutability: Mutability) -> Builder {
+    pub(crate) fn ref_match(&mut self, mutability: Mutability) -> &mut Builder {
         self.ref_match = Some(mutability);
         self
     }

--- a/crates/ide_completion/src/item.rs
+++ b/crates/ide_completion/src/item.rs
@@ -354,7 +354,7 @@ pub(crate) struct Builder {
 }
 
 impl Builder {
-    pub(crate) fn build(&self) -> CompletionItem {
+    pub(crate) fn build(self) -> CompletionItem {
         let builder = self.clone();
         let _p = profile::span("item::Builder::build");
 

--- a/crates/ide_completion/src/render.rs
+++ b/crates/ide_completion/src/render.rs
@@ -145,15 +145,16 @@ impl<'a> Render<'a> {
     fn add_field(&mut self, field: hir::Field, ty: &Type) -> CompletionItem {
         let is_deprecated = self.ctx.is_deprecated(field);
         let name = field.name(self.ctx.db());
-        let mut item = CompletionItem::new(
+        let mut builder = CompletionItem::new(
             CompletionKind::Reference,
             self.ctx.source_range(),
             name.to_string(),
-        )
-        .kind(SymbolKind::Field)
-        .detail(ty.display(self.ctx.db()).to_string())
-        .set_documentation(field.docs(self.ctx.db()))
-        .set_deprecated(is_deprecated);
+        );
+        let mut item = builder
+            .kind(SymbolKind::Field)
+            .detail(ty.display(self.ctx.db()).to_string())
+            .set_documentation(field.docs(self.ctx.db()))
+            .set_deprecated(is_deprecated);
 
         if let Some(relevance) = compute_relevance(&self.ctx, &ty, &name.to_string()) {
             item = item.set_relevance(relevance);
@@ -238,7 +239,7 @@ impl<'a> Render<'a> {
         };
 
         let mut item =
-            CompletionItem::new(completion_kind, self.ctx.source_range(), local_name.clone());
+            &mut CompletionItem::new(completion_kind, self.ctx.source_range(), local_name.clone());
         if let ScopeDef::Local(local) = resolution {
             let ty = local.ty(self.ctx.db());
             if !ty.is_unknown() {

--- a/crates/ide_completion/src/render.rs
+++ b/crates/ide_completion/src/render.rs
@@ -150,24 +150,29 @@ impl<'a> Render<'a> {
             self.ctx.source_range(),
             name.to_string(),
         );
-        let mut item = builder
+        builder
             .kind(SymbolKind::Field)
             .detail(ty.display(self.ctx.db()).to_string())
             .set_documentation(field.docs(self.ctx.db()))
             .set_deprecated(is_deprecated);
 
         if let Some(relevance) = compute_relevance(&self.ctx, &ty, &name.to_string()) {
-            item = item.set_relevance(relevance);
+            builder.set_relevance(relevance);
         }
 
-        item.build()
+        builder.build()
     }
 
     fn add_tuple_field(&mut self, field: usize, ty: &Type) -> CompletionItem {
-        CompletionItem::new(CompletionKind::Reference, self.ctx.source_range(), field.to_string())
-            .kind(SymbolKind::Field)
-            .detail(ty.display(self.ctx.db()).to_string())
-            .build()
+        let mut builder = CompletionItem::new(
+            CompletionKind::Reference,
+            self.ctx.source_range(),
+            field.to_string(),
+        );
+
+        builder.kind(SymbolKind::Field).detail(ty.display(self.ctx.db()).to_string());
+
+        builder.build()
     }
 
     fn render_resolution(
@@ -226,31 +231,29 @@ impl<'a> Render<'a> {
                 CompletionItemKind::SymbolKind(SymbolKind::SelfParam)
             }
             ScopeDef::Unknown => {
-                let item = CompletionItem::new(
+                let mut item = CompletionItem::new(
                     CompletionKind::Reference,
                     self.ctx.source_range(),
                     local_name,
-                )
-                .kind(CompletionItemKind::UnresolvedReference)
-                .add_import(import_to_add)
-                .build();
-                return Some(item);
+                );
+                item.kind(CompletionItemKind::UnresolvedReference).add_import(import_to_add);
+                return Some(item.build());
             }
         };
 
         let mut item =
-            &mut CompletionItem::new(completion_kind, self.ctx.source_range(), local_name.clone());
+            CompletionItem::new(completion_kind, self.ctx.source_range(), local_name.clone());
         if let ScopeDef::Local(local) = resolution {
             let ty = local.ty(self.ctx.db());
             if !ty.is_unknown() {
-                item = item.detail(ty.display(self.ctx.db()).to_string());
+                item.detail(ty.display(self.ctx.db()).to_string());
             }
         };
 
         if let ScopeDef::Local(local) = resolution {
             let ty = local.ty(self.ctx.db());
             if let Some(relevance) = compute_relevance(&self.ctx, &ty, &local_name) {
-                item = item.set_relevance(relevance)
+                item.set_relevance(relevance);
             }
             if let Some((_expected_name, expected_type)) = self.ctx.expected_name_and_type() {
                 if let Some(ty_without_ref) = expected_type.remove_ref() {
@@ -261,7 +264,7 @@ impl<'a> Render<'a> {
                         } else {
                             Mutability::Shared
                         };
-                        item = item.ref_match(mutability)
+                        item.ref_match(mutability);
                     }
                 }
             }
@@ -282,21 +285,17 @@ impl<'a> Render<'a> {
                 };
                 if has_non_default_type_params {
                     cov_mark::hit!(inserts_angle_brackets_for_generics);
-                    item = item
-                        .lookup_by(local_name.clone())
+                    item.lookup_by(local_name.clone())
                         .label(format!("{}<…>", local_name))
                         .insert_snippet(cap, format!("{}<$0>", local_name));
                 }
             }
         }
-
-        Some(
-            item.kind(kind)
-                .add_import(import_to_add)
-                .set_documentation(self.docs(resolution))
-                .set_deprecated(self.is_deprecated(resolution))
-                .build(),
-        )
+        item.kind(kind)
+            .add_import(import_to_add)
+            .set_documentation(self.docs(resolution))
+            .set_deprecated(self.is_deprecated(resolution));
+        Some(item.build())
     }
 
     fn docs(&self, resolution: &ScopeDef) -> Option<Documentation> {

--- a/crates/ide_completion/src/render/builder_ext.rs
+++ b/crates/ide_completion/src/render/builder_ext.rs
@@ -52,11 +52,11 @@ impl Builder {
     }
 
     pub(super) fn add_call_parens(
-        mut self,
+        &mut self,
         ctx: &CompletionContext,
         name: String,
         params: Params,
-    ) -> Builder {
+    ) -> &mut Builder {
         if !self.should_add_parens(ctx) {
             return self;
         }
@@ -71,7 +71,7 @@ impl Builder {
         let (snippet, label) = if params.is_empty() {
             (format!("{}()$0", name), format!("{}()", name))
         } else {
-            self = self.trigger_call_info();
+            self.trigger_call_info();
             let snippet = match (ctx.config.add_call_argument_snippets, params) {
                 (true, Params::Named(params)) => {
                     let function_params_snippet =

--- a/crates/ide_completion/src/render/const_.rs
+++ b/crates/ide_completion/src/render/const_.rs
@@ -36,17 +36,17 @@ impl<'a> ConstRender<'a> {
         let name = self.name()?;
         let detail = self.detail();
 
-        let item = CompletionItem::new(CompletionKind::Reference, self.ctx.source_range(), name)
-            .kind(SymbolKind::Const)
+        let mut item =
+            CompletionItem::new(CompletionKind::Reference, self.ctx.source_range(), name);
+        item.kind(SymbolKind::Const)
             .set_documentation(self.ctx.docs(self.const_))
             .set_deprecated(
                 self.ctx.is_deprecated(self.const_)
                     || self.ctx.is_deprecated_assoc_item(self.const_),
             )
-            .detail(detail)
-            .build();
+            .detail(detail);
 
-        Some(item)
+        Some(item.build())
     }
 
     fn name(&self) -> Option<String> {

--- a/crates/ide_completion/src/render/enum_variant.rs
+++ b/crates/ide_completion/src/render/enum_variant.rs
@@ -55,16 +55,17 @@ impl<'a> EnumRender<'a> {
     }
 
     fn render(self, import_to_add: Option<ImportEdit>) -> CompletionItem {
-        let mut builder = CompletionItem::new(
+        let mut builder = &mut CompletionItem::new(
             CompletionKind::Reference,
             self.ctx.source_range(),
             self.qualified_name.clone(),
-        )
-        .kind(SymbolKind::Variant)
-        .set_documentation(self.variant.docs(self.ctx.db()))
-        .set_deprecated(self.ctx.is_deprecated(self.variant))
-        .add_import(import_to_add)
-        .detail(self.detail());
+        );
+        builder = builder
+            .kind(SymbolKind::Variant)
+            .set_documentation(self.variant.docs(self.ctx.db()))
+            .set_deprecated(self.ctx.is_deprecated(self.variant))
+            .add_import(import_to_add)
+            .detail(self.detail());
 
         if self.variant_kind == StructKind::Tuple {
             cov_mark::hit!(inserts_parens_for_tuple_enums);

--- a/crates/ide_completion/src/render/enum_variant.rs
+++ b/crates/ide_completion/src/render/enum_variant.rs
@@ -55,12 +55,12 @@ impl<'a> EnumRender<'a> {
     }
 
     fn render(self, import_to_add: Option<ImportEdit>) -> CompletionItem {
-        let mut builder = &mut CompletionItem::new(
+        let mut builder = CompletionItem::new(
             CompletionKind::Reference,
             self.ctx.source_range(),
             self.qualified_name.clone(),
         );
-        builder = builder
+        builder
             .kind(SymbolKind::Variant)
             .set_documentation(self.variant.docs(self.ctx.db()))
             .set_deprecated(self.ctx.is_deprecated(self.variant))
@@ -70,10 +70,9 @@ impl<'a> EnumRender<'a> {
         if self.variant_kind == StructKind::Tuple {
             cov_mark::hit!(inserts_parens_for_tuple_enums);
             let params = Params::Anonymous(self.variant.fields(self.ctx.db()).len());
-            builder =
-                builder.add_call_parens(self.ctx.completion, self.short_qualified_name, params);
+            builder.add_call_parens(self.ctx.completion, self.short_qualified_name, params);
         } else if self.path.is_some() {
-            builder = builder.lookup_by(self.short_qualified_name);
+            builder.lookup_by(self.short_qualified_name);
         }
 
         builder.build()

--- a/crates/ide_completion/src/render/function.rs
+++ b/crates/ide_completion/src/render/function.rs
@@ -41,7 +41,12 @@ impl<'a> FunctionRender<'a> {
 
     fn render(self, import_to_add: Option<ImportEdit>) -> CompletionItem {
         let params = self.params();
-        CompletionItem::new(CompletionKind::Reference, self.ctx.source_range(), self.name.clone())
+        let mut builder = CompletionItem::new(
+            CompletionKind::Reference,
+            self.ctx.source_range(),
+            self.name.clone(),
+        );
+        builder
             .kind(self.kind())
             .set_documentation(self.ctx.docs(self.func))
             .set_deprecated(
@@ -49,8 +54,9 @@ impl<'a> FunctionRender<'a> {
             )
             .detail(self.detail())
             .add_call_parens(self.ctx.completion, self.name, params)
-            .add_import(import_to_add)
-            .build()
+            .add_import(import_to_add);
+
+        builder.build()
     }
 
     fn detail(&self) -> String {

--- a/crates/ide_completion/src/render/macro_.rs
+++ b/crates/ide_completion/src/render/macro_.rs
@@ -39,13 +39,17 @@ impl<'a> MacroRender<'a> {
     }
 
     fn render(&self, import_to_add: Option<ImportEdit>) -> Option<CompletionItem> {
-        let mut builder =
-            CompletionItem::new(CompletionKind::Reference, self.ctx.source_range(), &self.label())
-                .kind(SymbolKind::Macro)
-                .set_documentation(self.docs.clone())
-                .set_deprecated(self.ctx.is_deprecated(self.macro_))
-                .add_import(import_to_add)
-                .set_detail(self.detail());
+        let mut builder = &mut CompletionItem::new(
+            CompletionKind::Reference,
+            self.ctx.source_range(),
+            &self.label(),
+        );
+        builder = builder
+            .kind(SymbolKind::Macro)
+            .set_documentation(self.docs.clone())
+            .set_deprecated(self.ctx.is_deprecated(self.macro_))
+            .add_import(import_to_add)
+            .set_detail(self.detail());
 
         let needs_bang = self.needs_bang();
         builder = match self.ctx.snippet_cap() {

--- a/crates/ide_completion/src/render/macro_.rs
+++ b/crates/ide_completion/src/render/macro_.rs
@@ -39,12 +39,9 @@ impl<'a> MacroRender<'a> {
     }
 
     fn render(&self, import_to_add: Option<ImportEdit>) -> Option<CompletionItem> {
-        let mut builder = &mut CompletionItem::new(
-            CompletionKind::Reference,
-            self.ctx.source_range(),
-            &self.label(),
-        );
-        builder = builder
+        let mut builder =
+            CompletionItem::new(CompletionKind::Reference, self.ctx.source_range(), &self.label());
+        builder
             .kind(SymbolKind::Macro)
             .set_documentation(self.docs.clone())
             .set_deprecated(self.ctx.is_deprecated(self.macro_))
@@ -52,16 +49,18 @@ impl<'a> MacroRender<'a> {
             .set_detail(self.detail());
 
         let needs_bang = self.needs_bang();
-        builder = match self.ctx.snippet_cap() {
+        match self.ctx.snippet_cap() {
             Some(cap) if needs_bang => {
                 let snippet = self.snippet();
                 let lookup = self.lookup();
-                builder.insert_snippet(cap, snippet).lookup_by(lookup)
+                builder.insert_snippet(cap, snippet).lookup_by(lookup);
             }
-            None if needs_bang => builder.insert_text(self.banged_name()),
+            None if needs_bang => {
+                builder.insert_text(self.banged_name());
+            }
             _ => {
                 cov_mark::hit!(dont_insert_macro_call_parens_unncessary);
-                builder.insert_text(&self.name)
+                builder.insert_text(&self.name);
             }
         };
 

--- a/crates/ide_completion/src/render/pattern.rs
+++ b/crates/ide_completion/src/render/pattern.rs
@@ -71,7 +71,9 @@ fn build_completion(
     pat: String,
     item: impl HasAttrs + Copy,
 ) -> CompletionItem {
-    let completion = CompletionItem::new(CompletionKind::Snippet, ctx.source_range(), name)
+    let mut completion =
+        &mut CompletionItem::new(CompletionKind::Snippet, ctx.source_range(), name);
+    completion = completion
         .kind(CompletionItemKind::Binding)
         .set_documentation(ctx.docs(item))
         .set_deprecated(ctx.is_deprecated(item))

--- a/crates/ide_completion/src/render/pattern.rs
+++ b/crates/ide_completion/src/render/pattern.rs
@@ -71,17 +71,16 @@ fn build_completion(
     pat: String,
     item: impl HasAttrs + Copy,
 ) -> CompletionItem {
-    let mut completion =
-        &mut CompletionItem::new(CompletionKind::Snippet, ctx.source_range(), name);
-    completion = completion
+    let mut completion = CompletionItem::new(CompletionKind::Snippet, ctx.source_range(), name);
+    completion
         .kind(CompletionItemKind::Binding)
         .set_documentation(ctx.docs(item))
         .set_deprecated(ctx.is_deprecated(item))
         .detail(&pat);
-    let completion = if let Some(snippet_cap) = ctx.snippet_cap() {
-        completion.insert_snippet(snippet_cap, pat)
+    if let Some(snippet_cap) = ctx.snippet_cap() {
+        completion.insert_snippet(snippet_cap, pat);
     } else {
-        completion.insert_text(pat)
+        completion.insert_text(pat);
     };
     completion.build()
 }

--- a/crates/ide_completion/src/render/type_alias.rs
+++ b/crates/ide_completion/src/render/type_alias.rs
@@ -36,17 +36,17 @@ impl<'a> TypeAliasRender<'a> {
         let name = self.name()?;
         let detail = self.detail();
 
-        let item = CompletionItem::new(CompletionKind::Reference, self.ctx.source_range(), name)
-            .kind(SymbolKind::TypeAlias)
+        let mut item =
+            CompletionItem::new(CompletionKind::Reference, self.ctx.source_range(), name);
+        item.kind(SymbolKind::TypeAlias)
             .set_documentation(self.ctx.docs(self.type_alias))
             .set_deprecated(
                 self.ctx.is_deprecated(self.type_alias)
                     || self.ctx.is_deprecated_assoc_item(self.type_alias),
             )
-            .detail(detail)
-            .build();
+            .detail(detail);
 
-        Some(item)
+        Some(item.build())
     }
 
     fn name(&self) -> Option<String> {


### PR DESCRIPTION
@Veykril @SomeoneToIgnore @matklad
Closing [This issue](https://github.com/rust-analyzer/rust-analyzer/issues/7946).
Came out a bit more verbose due to Rust's borrow checker, and there are some places where I couldn't use references so I `clone`d it. Still, most places use references now which is what we wanted to achieve.

There is one draw back that I'm a bit concerned about:
The `build` function's signature was `pub(crate) fn build(self) -> CompletionItem`, and now it's `pub(crate) fn build(&self) -> CompletionItem`.
Rust's compiler forced me to accept a reference to `self` because the variable I'm calling `build` from is a reference itself and `Builder` doesn't (and can't) implement the `Copy` trait.
I'm preferring the old signature as `build` should take ownership of the `Builder` in my opinion.
(There are a few other similar methods like this)

Please let me know if you have any better solution in mind :smiley: 