### PR TITLE
Improve version display

### DIFF
--- a/crates/rust-analyzer/build.rs
+++ b/crates/rust-analyzer/build.rs
@@ -39,8 +39,7 @@ fn set_rerun() {
 }
 
 fn rev() -> Option<String> {
-    let output = Command::new("git").args(&["rev-parse", "HEAD"]).output().ok()?;
+    let output = Command::new("git").args(&["describe", "--tags"]).output().ok()?;
     let stdout = String::from_utf8(output.stdout).ok()?;
-    let short_hash = stdout.get(0..7)?;
-    Some(short_hash.to_owned())
+    Some(stdout)
 }

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -253,11 +253,10 @@ export function ssr(ctx: Ctx): Cmd {
 export function serverVersion(ctx: Ctx): Cmd {
     return async () => {
         const { stdout } = spawnSync(ctx.serverPath, ["--version"], { encoding: "utf8" });
-        const commitHash = stdout.slice(`rust-analyzer `.length).trim();
-        const { releaseTag } = ctx.config.package;
+        const versionString = stdout.slice(`rust-analyzer `.length).trim();
 
         void vscode.window.showInformationMessage(
-            `rust-analyzer version: ${releaseTag ?? "unreleased"} (${commitHash})`
+            `rust-analyzer version: ${versionString}`
         );
     };
 }


### PR DESCRIPTION
Maybe closes #7854

The version string for unreleased builds looks like this now:

```
$ rust-analyzer --version
rust-analyzer 2021-03-08-159-gc0459c535
```

Release builds should only have the tag name (`2021-03-15`).