### PR TITLE
improved completion sorting for functions and methods

### DIFF
--- a/crates/ide_completion/src/render.rs
+++ b/crates/ide_completion/src/render.rs
@@ -928,6 +928,66 @@ fn f(foo: &Foo) { f(foo, w$0) }
     }
 
     #[test]
+    fn score_fn_type_and_name_match() {
+        check_relevance(
+            r#"
+struct A { bar: u8 }
+fn baz() -> u8 { 0 }
+fn bar() -> u8 { 0 }
+fn f() { A { bar: b$0 }; }
+"#,
+            expect![[r#"
+                fn baz() [type]
+                st A []
+                fn bar() [type+name]
+                fn f() []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn score_method_type_and_name_match() {
+        check_relevance(
+            r#"
+fn baz(aaa: u32){}
+struct Foo;
+impl Foo {
+fn aaa(&self) -> u32 { 0 }
+fn bbb(&self) -> u32 { 0 }
+fn ccc(&self) -> u64 { 0 }
+}
+fn f() {
+    baz(Foo.$0
+}
+"#,
+            expect![[r#"
+                me aaa() [type+name]
+                me bbb() [type]
+                me ccc() []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn score_method_name_match_only() {
+        check_relevance(
+            r#"
+fn baz(aaa: u32){}
+struct Foo;
+impl Foo {
+fn aaa(&self) -> u64 { 0 }
+}
+fn f() {
+    baz(Foo.$0
+}
+"#,
+            expect![[r#"
+                me aaa() [name]
+            "#]],
+        );
+    }
+
+    #[test]
     fn suggest_ref_mut() {
         cov_mark::check!(suggest_ref);
         check(


### PR DESCRIPTION
This PR improves completion sorting for functions and methods. Related to #7935.

### Before

The methods are being sorted by `coc` by closeness in file. 

![pre-fn-relevance](https://user-images.githubusercontent.com/22216761/111018669-fe3d3f00-836e-11eb-9607-cc05af080a6a.png)

### After

Notice `bbb()` on top (type + name match), followed by `ddd()` (type match).

![image](https://user-images.githubusercontent.com/22216761/111018680-0e551e80-836f-11eb-94b1-c88336ecbc6e.png)
