### PR TITLE
Separate `Ty` and `TyKind` like in Chalk

### DIFF
--- a/crates/hir_ty/src/autoderef.rs
+++ b/crates/hir_ty/src/autoderef.rs
@@ -14,7 +14,7 @@ use crate::{
     db::HirDatabase,
     traits::{InEnvironment, Solution},
     utils::generics,
-    BoundVar, Canonical, DebruijnIndex, Obligation, Substs, TraitRef, Ty,
+    BoundVar, Canonical, DebruijnIndex, Interner, Obligation, Substs, TraitRef, Ty, TyKind,
 };
 
 const AUTODEREF_RECURSION_LIMIT: usize = 10;
@@ -81,7 +81,8 @@ fn deref_by_trait(
 
     // Now do the assoc type projection
     let projection = super::traits::ProjectionPredicate {
-        ty: Ty::BoundVar(BoundVar::new(DebruijnIndex::INNERMOST, ty.value.kinds.len())),
+        ty: TyKind::BoundVar(BoundVar::new(DebruijnIndex::INNERMOST, ty.value.kinds.len()))
+            .intern(&Interner),
         projection_ty: super::ProjectionTy { associated_ty: target, parameters },
     };
 
@@ -114,8 +115,8 @@ fn deref_by_trait(
             // new variables in that case
 
             for i in 1..vars.0.kinds.len() {
-                if vars.0.value[i - 1]
-                    != Ty::BoundVar(BoundVar::new(DebruijnIndex::INNERMOST, i - 1))
+                if vars.0.value[i - 1].interned(&Interner)
+                    != &TyKind::BoundVar(BoundVar::new(DebruijnIndex::INNERMOST, i - 1))
                 {
                     warn!("complex solution for derefing {:?}: {:?}, ignoring", ty.value, solution);
                     return None;

--- a/crates/hir_ty/src/diagnostics/match_check.rs
+++ b/crates/hir_ty/src/diagnostics/match_check.rs
@@ -227,7 +227,7 @@ use hir_def::{
 use la_arena::Idx;
 use smallvec::{smallvec, SmallVec};
 
-use crate::{db::HirDatabase, AdtId, InferenceResult, Ty};
+use crate::{db::HirDatabase, AdtId, InferenceResult, Interner, TyKind};
 
 #[derive(Debug, Clone, Copy)]
 /// Either a pattern from the source code being analyzed, represented as
@@ -626,13 +626,13 @@ pub(super) fn is_useful(
     // - enum with no variants
     // - `!` type
     // In those cases, no match arm is useful.
-    match cx.infer[cx.match_expr].strip_references() {
-        Ty::Adt(AdtId(hir_def::AdtId::EnumId(enum_id)), ..) => {
+    match cx.infer[cx.match_expr].strip_references().interned(&Interner) {
+        TyKind::Adt(AdtId(hir_def::AdtId::EnumId(enum_id)), ..) => {
             if cx.db.enum_data(*enum_id).variants.is_empty() {
                 return Ok(Usefulness::NotUseful);
             }
         }
-        Ty::Never => return Ok(Usefulness::NotUseful),
+        TyKind::Never => return Ok(Usefulness::NotUseful),
         _ => (),
     }
 

--- a/crates/hir_ty/src/diagnostics/unsafe_check.rs
+++ b/crates/hir_ty/src/diagnostics/unsafe_check.rs
@@ -11,7 +11,7 @@ use hir_def::{
 };
 use hir_expand::diagnostics::DiagnosticSink;
 
-use crate::{db::HirDatabase, diagnostics::MissingUnsafe, InferenceResult, Ty};
+use crate::{db::HirDatabase, diagnostics::MissingUnsafe, InferenceResult, Interner, TyKind};
 
 pub(super) struct UnsafeValidator<'a, 'b: 'a> {
     owner: DefWithBodyId,
@@ -110,7 +110,7 @@ fn walk_unsafe(
             }
         }
         Expr::UnaryOp { expr, op: UnaryOp::Deref } => {
-            if let Ty::Raw(..) = &infer[*expr] {
+            if let TyKind::Raw(..) = &infer[*expr].interned(&Interner) {
                 unsafe_exprs.push(UnsafeExpr { expr: current, inside_unsafe_block });
             }
         }

--- a/crates/hir_ty/src/infer/path.rs
+++ b/crates/hir_ty/src/infer/path.rs
@@ -9,7 +9,7 @@ use hir_def::{
 };
 use hir_expand::name::Name;
 
-use crate::{method_resolution, Substs, Ty, ValueTyDefId};
+use crate::{method_resolution, Interner, Substs, Ty, TyKind, ValueTyDefId};
 
 use super::{ExprOrPatId, InferenceContext, TraitRef};
 
@@ -144,7 +144,7 @@ impl<'a> InferenceContext<'a> {
                     remaining_segments_for_ty,
                     true,
                 );
-                if let Ty::Unknown = ty {
+                if let TyKind::Unknown = ty.interned(&Interner) {
                     return None;
                 }
 
@@ -209,7 +209,7 @@ impl<'a> InferenceContext<'a> {
         name: &Name,
         id: ExprOrPatId,
     ) -> Option<(ValueNs, Option<Substs>)> {
-        if let Ty::Unknown = ty {
+        if let TyKind::Unknown = ty.interned(&Interner) {
             return None;
         }
 

--- a/crates/hir_ty/src/op.rs
+++ b/crates/hir_ty/src/op.rs
@@ -2,51 +2,55 @@
 use chalk_ir::TyVariableKind;
 use hir_def::expr::{ArithOp, BinaryOp, CmpOp};
 
-use crate::{Scalar, Ty};
+use crate::{Interner, Scalar, Ty, TyKind};
 
 pub(super) fn binary_op_return_ty(op: BinaryOp, lhs_ty: Ty, rhs_ty: Ty) -> Ty {
     match op {
-        BinaryOp::LogicOp(_) | BinaryOp::CmpOp(_) => Ty::Scalar(Scalar::Bool),
+        BinaryOp::LogicOp(_) | BinaryOp::CmpOp(_) => TyKind::Scalar(Scalar::Bool).intern(&Interner),
         BinaryOp::Assignment { .. } => Ty::unit(),
-        BinaryOp::ArithOp(ArithOp::Shl) | BinaryOp::ArithOp(ArithOp::Shr) => match lhs_ty {
-            Ty::Scalar(Scalar::Int(_))
-            | Ty::Scalar(Scalar::Uint(_))
-            | Ty::Scalar(Scalar::Float(_)) => lhs_ty,
-            Ty::InferenceVar(_, TyVariableKind::Integer)
-            | Ty::InferenceVar(_, TyVariableKind::Float) => lhs_ty,
-            _ => Ty::Unknown,
-        },
-        BinaryOp::ArithOp(_) => match rhs_ty {
-            Ty::Scalar(Scalar::Int(_))
-            | Ty::Scalar(Scalar::Uint(_))
-            | Ty::Scalar(Scalar::Float(_)) => rhs_ty,
-            Ty::InferenceVar(_, TyVariableKind::Integer)
-            | Ty::InferenceVar(_, TyVariableKind::Float) => rhs_ty,
-            _ => Ty::Unknown,
+        BinaryOp::ArithOp(ArithOp::Shl) | BinaryOp::ArithOp(ArithOp::Shr) => {
+            match lhs_ty.interned(&Interner) {
+                TyKind::Scalar(Scalar::Int(_))
+                | TyKind::Scalar(Scalar::Uint(_))
+                | TyKind::Scalar(Scalar::Float(_)) => lhs_ty,
+                TyKind::InferenceVar(_, TyVariableKind::Integer)
+                | TyKind::InferenceVar(_, TyVariableKind::Float) => lhs_ty,
+                _ => TyKind::Unknown.intern(&Interner),
+            }
+        }
+        BinaryOp::ArithOp(_) => match rhs_ty.interned(&Interner) {
+            TyKind::Scalar(Scalar::Int(_))
+            | TyKind::Scalar(Scalar::Uint(_))
+            | TyKind::Scalar(Scalar::Float(_)) => rhs_ty,
+            TyKind::InferenceVar(_, TyVariableKind::Integer)
+            | TyKind::InferenceVar(_, TyVariableKind::Float) => rhs_ty,
+            _ => TyKind::Unknown.intern(&Interner),
         },
     }
 }
 
 pub(super) fn binary_op_rhs_expectation(op: BinaryOp, lhs_ty: Ty) -> Ty {
     match op {
-        BinaryOp::LogicOp(..) => Ty::Scalar(Scalar::Bool),
+        BinaryOp::LogicOp(..) => TyKind::Scalar(Scalar::Bool).intern(&Interner),
         BinaryOp::Assignment { op: None } => lhs_ty,
-        BinaryOp::CmpOp(CmpOp::Eq { .. }) => match lhs_ty {
-            Ty::Scalar(_) | Ty::Str => lhs_ty,
-            Ty::InferenceVar(_, TyVariableKind::Integer)
-            | Ty::InferenceVar(_, TyVariableKind::Float) => lhs_ty,
-            _ => Ty::Unknown,
+        BinaryOp::CmpOp(CmpOp::Eq { .. }) => match lhs_ty.interned(&Interner) {
+            TyKind::Scalar(_) | TyKind::Str => lhs_ty,
+            TyKind::InferenceVar(_, TyVariableKind::Integer)
+            | TyKind::InferenceVar(_, TyVariableKind::Float) => lhs_ty,
+            _ => TyKind::Unknown.intern(&Interner),
         },
-        BinaryOp::ArithOp(ArithOp::Shl) | BinaryOp::ArithOp(ArithOp::Shr) => Ty::Unknown,
+        BinaryOp::ArithOp(ArithOp::Shl) | BinaryOp::ArithOp(ArithOp::Shr) => {
+            TyKind::Unknown.intern(&Interner)
+        }
         BinaryOp::CmpOp(CmpOp::Ord { .. })
         | BinaryOp::Assignment { op: Some(_) }
-        | BinaryOp::ArithOp(_) => match lhs_ty {
-            Ty::Scalar(Scalar::Int(_))
-            | Ty::Scalar(Scalar::Uint(_))
-            | Ty::Scalar(Scalar::Float(_)) => lhs_ty,
-            Ty::InferenceVar(_, TyVariableKind::Integer)
-            | Ty::InferenceVar(_, TyVariableKind::Float) => lhs_ty,
-            _ => Ty::Unknown,
+        | BinaryOp::ArithOp(_) => match lhs_ty.interned(&Interner) {
+            TyKind::Scalar(Scalar::Int(_))
+            | TyKind::Scalar(Scalar::Uint(_))
+            | TyKind::Scalar(Scalar::Float(_)) => lhs_ty,
+            TyKind::InferenceVar(_, TyVariableKind::Integer)
+            | TyKind::InferenceVar(_, TyVariableKind::Float) => lhs_ty,
+            _ => TyKind::Unknown.intern(&Interner),
         },
     }
 }

--- a/crates/hir_ty/src/traits.rs
+++ b/crates/hir_ty/src/traits.rs
@@ -10,7 +10,9 @@ use stdx::panic_context;
 
 use crate::{db::HirDatabase, DebruijnIndex, Substs};
 
-use super::{Canonical, GenericPredicate, HirDisplay, ProjectionTy, TraitRef, Ty, TypeWalk};
+use super::{
+    Canonical, GenericPredicate, HirDisplay, ProjectionTy, TraitRef, Ty, TyKind, TypeWalk,
+};
 
 use self::chalk::{from_chalk, Interner, ToChalk};
 
@@ -132,7 +134,7 @@ pub(crate) fn trait_solve_query(
     log::info!("trait_solve_query({})", goal.value.value.display(db));
 
     if let Obligation::Projection(pred) = &goal.value.value {
-        if let Ty::BoundVar(_) = &pred.projection_ty.parameters[0] {
+        if let TyKind::BoundVar(_) = &pred.projection_ty.parameters[0].interned(&Interner) {
             // Hack: don't ask Chalk to normalize with an unknown self type, it'll say that's impossible
             return Some(Solution::Ambig(Guidance::Unknown));
         }

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -12,7 +12,7 @@ use hir::{
     AssocItem, Crate, HasSource, HirDisplay, ModuleDef,
 };
 use hir_def::FunctionId;
-use hir_ty::{Ty, TypeWalk};
+use hir_ty::TypeWalk;
 use ide_db::base_db::{
     salsa::{self, ParallelDatabase},
     SourceDatabaseExt,
@@ -187,12 +187,12 @@ impl AnalysisStatsCmd {
             for (expr_id, _) in body.exprs.iter() {
                 let ty = &inference_result[expr_id];
                 num_exprs += 1;
-                if let Ty::Unknown = ty {
+                if ty.is_unknown() {
                     num_exprs_unknown += 1;
                 } else {
                     let mut is_partially_unknown = false;
                     ty.walk(&mut |ty| {
-                        if let Ty::Unknown = ty {
+                        if ty.is_unknown() {
                             is_partially_unknown = true;
                         }
                     });


### PR DESCRIPTION
Currently `Ty` just wraps `TyKind`, but this allows us to change most
places to already use `intern` / `interned`.