### PR TITLE
Completion context expected type

### DIFF
--- a/crates/ide_completion/src/render.rs
+++ b/crates/ide_completion/src/render.rs
@@ -119,17 +119,10 @@ impl<'a> RenderContext<'a> {
         node.docs(self.db())
     }
 
+    // FIXME delete this method in favor of directly using the fields
+    // on CompletionContext
     fn expected_name_and_type(&self) -> Option<(String, Type)> {
-        if let Some(record_field) = &self.completion.record_field_syntax {
-            cov_mark::hit!(record_field_type_match);
-            let (struct_field, _local) = self.completion.sema.resolve_record_field(record_field)?;
-            Some((struct_field.name(self.db()).to_string(), struct_field.signature_ty(self.db())))
-        } else if let Some(active_parameter) = &self.completion.active_parameter {
-            cov_mark::hit!(active_param_type_match);
-            Some((active_parameter.name.clone(), active_parameter.ty.clone()))
-        } else {
-            None
-        }
+        Some((self.completion.expected_name.clone()?, self.completion.expected_type.clone()?))
     }
 }
 
@@ -852,7 +845,6 @@ fn foo(xs: Vec<i128>)
 
     #[test]
     fn active_param_relevance() {
-        cov_mark::check!(active_param_type_match);
         check_relevance(
             r#"
 struct S { foo: i64, bar: u32, baz: u32 }
@@ -869,7 +861,6 @@ fn foo(s: S) { test(s.$0) }
 
     #[test]
     fn record_field_relevances() {
-        cov_mark::check!(record_field_type_match);
         check_relevance(
             r#"
 struct A { foo: i64, bar: u32, baz: u32 }


### PR DESCRIPTION
Currently there are two ways completions use to determine the expected type. There is the `expected_type` field on the `CompletionContext`, as well as the `expected_name_and_type` method on the `RenderContext`. These two things returned slightly different results, and their results were only valid if you had pre-checked some (undocumented) invariants. A simple combination of the two approaches doesn't work because they are both too willing to go far up the syntax tree to find something that fits what they are looking for.

This PR makes the following changes:

1. Updates the algorithm that sets `expected_type` on `CompletionContext`
2. Adds `expected_name` field to `CompletionContext`
3. Re-writes the `expected_name_and_type` method to simply return the underlying fields from `CompletionContext` (I'd like to save actually removing this method for a follow up PR just to keep the scope of the changes down)
4. Adds unit tests for the `expected_type`/`expected_name` fields

All the existing unit tests still pass (unmodified), but this new algorithm certainly has some gaps (although I believe all the `FIXME` introduced in this PR are also flaws in the current code). I wanted to stop here and get some feedback though - is this approach fundamentally sound? 