### PR TITLE
Add no-sysroot flag for analysis-stats

### DIFF
--- a/crates/rust-analyzer/src/bin/flags.rs
+++ b/crates/rust-analyzer/src/bin/flags.rs
@@ -65,6 +65,8 @@ xflags::xflags! {
             optional -o, --only path: String
             /// Also analyze all dependencies.
             optional --with-deps
+            /// Don't load sysroot crates (`std`, `core` & friends).
+            optional --no-sysroot
 
             /// Load OUT_DIR values by running `cargo check` before analysis.
             optional --load-output-dirs
@@ -176,6 +178,7 @@ pub struct AnalysisStats {
     pub memory_usage: bool,
     pub only: Option<String>,
     pub with_deps: bool,
+    pub no_sysroot: bool,
     pub load_output_dirs: bool,
     pub with_proc_macro: bool,
 }

--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -74,6 +74,7 @@ fn try_main() -> Result<()> {
             memory_usage: cmd.memory_usage,
             only: cmd.only,
             with_deps: cmd.with_deps,
+            no_sysroot: cmd.no_sysroot,
             path: cmd.path,
             load_output_dirs: cmd.load_output_dirs,
             with_proc_macro: cmd.with_proc_macro,

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -19,6 +19,7 @@ use ide_db::base_db::{
 };
 use itertools::Itertools;
 use oorandom::Rand32;
+use project_model::CargoConfig;
 use rayon::prelude::*;
 use rustc_hash::FxHashSet;
 use stdx::format_to;
@@ -46,6 +47,7 @@ pub struct AnalysisStatsCmd {
     pub memory_usage: bool,
     pub only: Option<String>,
     pub with_deps: bool,
+    pub no_sysroot: bool,
     pub path: PathBuf,
     pub load_output_dirs: bool,
     pub with_proc_macro: bool,
@@ -59,7 +61,8 @@ impl AnalysisStatsCmd {
         };
 
         let mut db_load_sw = self.stop_watch();
-        let cargo_config = Default::default();
+        let mut cargo_config = CargoConfig::default();
+        cargo_config.no_sysroot = self.no_sysroot;
         let load_cargo_config = LoadCargoConfig {
             load_out_dirs_from_check: self.load_output_dirs,
             with_proc_macro: self.with_proc_macro,


### PR DESCRIPTION
Add `no-sysroot` flag for `rust-analyzer analysis-stats`. It is very useful for debugging propose. 

bors r+