### PR TITLE
xtask: replace "lint" command by a simply cargo alias

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -3,6 +3,7 @@ xtask = "run --package xtask --bin xtask --"
 install-ra = "run --package xtask --bin xtask -- install" # for backwards compat
 tq = "test -- -q"
 qt = "tq"
+lint = "clippy --all-targets -- -Aclippy::collapsible_if -Aclippy::needless_pass_by_value -Aclippy::nonminimal_bool -Aclippy::redundant_pattern_matching --cap-lints warn"
 
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld"

--- a/xtask/src/flags.rs
+++ b/xtask/src/flags.rs
@@ -27,7 +27,6 @@ xflags::xflags! {
             optional --jemalloc
         }
 
-        cmd lint {}
         cmd fuzz-tests {}
         cmd pre-cache {}
 
@@ -63,7 +62,6 @@ pub struct Xtask {
 pub enum XtaskCmd {
     Help(Help),
     Install(Install),
-    Lint(Lint),
     FuzzTests(FuzzTests),
     PreCache(PreCache),
     Release(Release),

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -40,7 +40,6 @@ fn main() -> Result<()> {
             return Ok(());
         }
         flags::XtaskCmd::Install(cmd) => cmd.run(),
-        flags::XtaskCmd::Lint(_) => run_clippy(),
         flags::XtaskCmd::FuzzTests(_) => run_fuzzer(),
         flags::XtaskCmd::PreCache(cmd) => cmd.run(),
         flags::XtaskCmd::Release(cmd) => cmd.run(),
@@ -92,25 +91,6 @@ fn ensure_rustfmt() -> Result<()> {
              Please run `rustup component add rustfmt --toolchain stable` to install it.",
         )
     }
-    Ok(())
-}
-
-fn run_clippy() -> Result<()> {
-    if cmd!("cargo clippy --version").read().is_err() {
-        bail!(
-            "Failed run cargo clippy. \
-            Please run `rustup component add clippy` to install it.",
-        )
-    }
-
-    let allowed_lints = "
-        -A clippy::collapsible_if
-        -A clippy::needless_pass_by_value
-        -A clippy::nonminimal_bool
-        -A clippy::redundant_pattern_matching
-    "
-    .split_ascii_whitespace();
-    cmd!("cargo clippy --all-features --all-targets -- {allowed_lints...}").run()?;
     Ok(())
 }
 


### PR DESCRIPTION
This strips the run_clippy implementation out of xtask and replaces it by
a simple "cargo lint" alias which runs clippy with the corresponding flags.

Unfortunately  I could not name the alias "clippy" because that would lead to infinite recursion. :sweat_smile: 