### PR TITLE
increase completion relevance for items in local scope

### DIFF
--- a/crates/ide_completion/src/item.rs
+++ b/crates/ide_completion/src/item.rs
@@ -144,6 +144,21 @@ pub struct CompletionRelevance {
     /// }
     /// ```
     pub exact_type_match: bool,
+    /// This is set in cases like these:
+    ///
+    /// ```
+    /// fn foo(bar: u32) {
+    ///     $0 // `bar` is local
+    /// }
+    /// ```
+    ///
+    /// ```
+    /// fn foo() {
+    ///     let bar = 0;
+    ///     $0 // `bar` is local
+    /// }
+    /// ```
+    pub is_local: bool,
 }
 
 impl CompletionRelevance {
@@ -163,6 +178,9 @@ impl CompletionRelevance {
             score += 1;
         }
         if self.exact_type_match {
+            score += 3;
+        }
+        if self.is_local {
             score += 1;
         }
 
@@ -551,9 +569,24 @@ mod tests {
             vec![CompletionRelevance::default()],
             vec![
                 CompletionRelevance { exact_name_match: true, ..CompletionRelevance::default() },
-                CompletionRelevance { exact_type_match: true, ..CompletionRelevance::default() },
+                CompletionRelevance { is_local: true, ..CompletionRelevance::default() },
             ],
-            vec![CompletionRelevance { exact_name_match: true, exact_type_match: true }],
+            vec![CompletionRelevance {
+                exact_name_match: true,
+                is_local: true,
+                ..CompletionRelevance::default()
+            }],
+            vec![CompletionRelevance { exact_type_match: true, ..CompletionRelevance::default() }],
+            vec![CompletionRelevance {
+                exact_name_match: true,
+                exact_type_match: true,
+                ..CompletionRelevance::default()
+            }],
+            vec![CompletionRelevance {
+                exact_name_match: true,
+                exact_type_match: true,
+                is_local: true,
+            }],
         ];
 
         check_relevance_score_ordered(expected_relevance_order);

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -1117,13 +1117,13 @@ mod tests {
                 (
                     "&arg",
                     Some(
-                        "fffffffd",
+                        "fffffffa",
                     ),
                 ),
                 (
                     "arg",
                     Some(
-                        "fffffffe",
+                        "fffffffd",
                     ),
                 ),
             ]


### PR DESCRIPTION
This PR provides a small completion relevance score bonus for items in local scope. The changes here are relatively minimal, since `coc` by default pre-sorts by position in file. But as we move toward fully server side sorting #7935 I think we'll want some relevance score bump for items in local scope. 

### Before

Note `let~` and `syntax` are both ahead of locals. Ultimately we may decide that `let~` is a high relevance completion given my cursor position here, but that should be done with some explicit scoring on the server side, rather than being caused by (I think) `coc` preferring shorter completions. 

![pre-local-score](https://user-images.githubusercontent.com/22216761/111073414-c97ad600-849b-11eb-84e7-fcee130536f0.png)

### After

![post-local-score](https://user-images.githubusercontent.com/22216761/111073422-d0094d80-849b-11eb-92ec-7ae5ec3b190d.png)
