### PR TITLE
More Chalk adaptations

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1979,7 +1979,7 @@ impl Type {
                         walk_bounds(db, &type_.derived(ty.clone()), &bounds, cb);
                     }
 
-                    walk_substs(db, type_, &opaque_ty.parameters, cb);
+                    walk_substs(db, type_, &opaque_ty.substitution, cb);
                 }
                 TyKind::Placeholder(_) => {
                     if let Some(bounds) = ty.impl_trait_bounds(db) {

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1686,8 +1686,8 @@ impl Type {
             .build();
         let predicate = ProjectionPredicate {
             projection_ty: ProjectionTy {
-                associated_ty: to_assoc_type_id(alias.id),
-                parameters: subst,
+                associated_ty_id: to_assoc_type_id(alias.id),
+                substitution: subst,
             },
             ty: TyKind::BoundVar(BoundVar::new(DebruijnIndex::INNERMOST, 0)).intern(&Interner),
         };

--- a/crates/hir_ty/src/autoderef.rs
+++ b/crates/hir_ty/src/autoderef.rs
@@ -84,7 +84,10 @@ fn deref_by_trait(
     let projection = super::traits::ProjectionPredicate {
         ty: TyKind::BoundVar(BoundVar::new(DebruijnIndex::INNERMOST, ty.value.kinds.len()))
             .intern(&Interner),
-        projection_ty: super::ProjectionTy { associated_ty_id: to_assoc_type_id(target), substitution: parameters },
+        projection_ty: super::ProjectionTy {
+            associated_ty_id: to_assoc_type_id(target),
+            substitution: parameters,
+        },
     };
 
     let obligation = super::Obligation::Projection(projection);

--- a/crates/hir_ty/src/autoderef.rs
+++ b/crates/hir_ty/src/autoderef.rs
@@ -84,7 +84,7 @@ fn deref_by_trait(
     let projection = super::traits::ProjectionPredicate {
         ty: TyKind::BoundVar(BoundVar::new(DebruijnIndex::INNERMOST, ty.value.kinds.len()))
             .intern(&Interner),
-        projection_ty: super::ProjectionTy { associated_ty: to_assoc_type_id(target), parameters },
+        projection_ty: super::ProjectionTy { associated_ty_id: to_assoc_type_id(target), substitution: parameters },
     };
 
     let obligation = super::Obligation::Projection(projection);

--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -245,19 +245,19 @@ impl HirDisplay for ProjectionTy {
         }
 
         let trait_ = f.db.trait_data(self.trait_(f.db));
-        let first_parameter = self.parameters[0].into_displayable(
+        let first_parameter = self.substitution[0].into_displayable(
             f.db,
             f.max_size,
             f.omit_verbose_types,
             f.display_target,
         );
         write!(f, "<{} as {}", first_parameter, trait_.name)?;
-        if self.parameters.len() > 1 {
+        if self.substitution.len() > 1 {
             write!(f, "<")?;
-            f.write_joined(&self.parameters[1..], ", ")?;
+            f.write_joined(&self.substitution[1..], ", ")?;
             write!(f, ">")?;
         }
-        write!(f, ">::{}", f.db.type_alias_data(from_assoc_type_id(self.associated_ty)).name)?;
+        write!(f, ">::{}", f.db.type_alias_data(from_assoc_type_id(self.associated_ty_id)).name)?;
         Ok(())
     }
 }
@@ -491,8 +491,8 @@ impl HirDisplay for Ty {
                     }
                 } else {
                     let projection_ty = ProjectionTy {
-                        associated_ty: to_assoc_type_id(type_alias),
-                        parameters: parameters.clone(),
+                        associated_ty_id: to_assoc_type_id(type_alias),
+                        substitution: parameters.clone(),
                     };
 
                     projection_ty.hir_fmt(f)?;
@@ -709,7 +709,7 @@ fn write_bounds_like_dyn_trait(
                     angle_open = true;
                 }
                 let type_alias = f.db.type_alias_data(from_assoc_type_id(
-                    projection_pred.projection_ty.associated_ty,
+                    projection_pred.projection_ty.associated_ty_id,
                 ));
                 write!(f, "{} = ", type_alias.name)?;
                 projection_pred.ty.hir_fmt(f)?;
@@ -782,7 +782,7 @@ impl HirDisplay for GenericPredicate {
                     f,
                     ">::{} = ",
                     f.db.type_alias_data(from_assoc_type_id(
-                        projection_pred.projection_ty.associated_ty
+                        projection_pred.projection_ty.associated_ty_id
                     ))
                     .name,
                 )?;

--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -319,7 +319,10 @@ impl HirDisplay for Ty {
                     TyKind::Dyn(predicates) if predicates.len() > 1 => {
                         Cow::Borrowed(predicates.as_ref())
                     }
-                    &TyKind::Alias(AliasTy::Opaque(OpaqueTy { opaque_ty_id, ref parameters })) => {
+                    &TyKind::Alias(AliasTy::Opaque(OpaqueTy {
+                        opaque_ty_id,
+                        substitution: ref parameters,
+                    })) => {
                         let impl_trait_id = f.db.lookup_intern_impl_trait_id(opaque_ty_id.into());
                         if let ImplTraitId::ReturnTypeImplTrait(func, idx) = impl_trait_id {
                             datas =
@@ -579,7 +582,7 @@ impl HirDisplay for Ty {
                         let data = (*datas)
                             .as_ref()
                             .map(|rpit| rpit.impl_traits[idx as usize].bounds.clone());
-                        let bounds = data.subst(&opaque_ty.parameters);
+                        let bounds = data.subst(&opaque_ty.substitution);
                         write_bounds_like_dyn_trait_with_prefix("impl", &bounds.value, f)?;
                     }
                     ImplTraitId::AsyncBlockTypeImplTrait(..) => {

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -385,8 +385,8 @@ impl<'a> InferenceContext<'a> {
                 let projection = ProjectionPredicate {
                     ty: ty.clone(),
                     projection_ty: ProjectionTy {
-                        associated_ty: to_assoc_type_id(res_assoc_ty),
-                        parameters: substs,
+                        associated_ty_id: to_assoc_type_id(res_assoc_ty),
+                        substitution: substs,
                     },
                 };
                 self.obligations.push(Obligation::Trait(trait_ref));

--- a/crates/hir_ty/src/infer/expr.rs
+++ b/crates/hir_ty/src/infer/expr.rs
@@ -261,7 +261,7 @@ impl<'a> InferenceContext<'a> {
                 sig_tys.push(ret_ty.clone());
                 let sig_ty = TyKind::Function(FnPointer {
                     num_args: sig_tys.len() - 1,
-                    sig: FnSig { variadic: false },
+                    sig: FnSig { abi: (), safety: chalk_ir::Safety::Safe, variadic: false },
                     substs: Substs(sig_tys.clone().into()),
                 })
                 .intern(&Interner);

--- a/crates/hir_ty/src/infer/expr.rs
+++ b/crates/hir_ty/src/infer/expr.rs
@@ -99,8 +99,8 @@ impl<'a> InferenceContext<'a> {
         if self.db.trait_solve(krate, goal.value).is_some() {
             self.obligations.push(implements_fn_trait);
             let output_proj_ty = crate::ProjectionTy {
-                associated_ty: to_assoc_type_id(output_assoc_type),
-                parameters: substs,
+                associated_ty_id: to_assoc_type_id(output_assoc_type),
+                substitution: substs,
             };
             let return_ty = self.normalize_projection_ty(output_proj_ty);
             Some((arg_tys, return_ty))

--- a/crates/hir_ty/src/infer/unify.rs
+++ b/crates/hir_ty/src/infer/unify.rs
@@ -381,11 +381,11 @@ impl InferenceTable {
                 self.unify_substs(&tr1.substs, &tr2.substs, depth + 1)
             }
             (GenericPredicate::Projection(proj1), GenericPredicate::Projection(proj2))
-                if proj1.projection_ty.associated_ty == proj2.projection_ty.associated_ty =>
+                if proj1.projection_ty.associated_ty_id == proj2.projection_ty.associated_ty_id =>
             {
                 self.unify_substs(
-                    &proj1.projection_ty.parameters,
-                    &proj2.projection_ty.parameters,
+                    &proj1.projection_ty.substitution,
+                    &proj2.projection_ty.substitution,
                     depth + 1,
                 ) && self.unify_inner(&proj1.ty, &proj2.ty, depth + 1)
             }

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -66,7 +66,7 @@ pub enum Lifetime {
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub struct OpaqueTy {
     pub opaque_ty_id: OpaqueTyId,
-    pub parameters: Substs,
+    pub substitution: Substs,
 }
 
 /// A "projection" type corresponds to an (unnormalized)
@@ -903,7 +903,7 @@ impl Ty {
                             let data = (*it)
                                 .as_ref()
                                 .map(|rpit| rpit.impl_traits[idx as usize].bounds.clone());
-                            data.subst(&opaque_ty.parameters)
+                            data.subst(&opaque_ty.substitution)
                         })
                     }
                     // It always has an parameter for Future::Output type.
@@ -1059,7 +1059,7 @@ impl TypeWalk for Ty {
                 }
             }
             TyKind::Alias(AliasTy::Opaque(o_ty)) => {
-                for t in o_ty.parameters.iter() {
+                for t in o_ty.substitution.iter() {
                     t.walk(f);
                 }
             }
@@ -1094,7 +1094,7 @@ impl TypeWalk for Ty {
                 }
             }
             TyKind::Alias(AliasTy::Opaque(o_ty)) => {
-                o_ty.parameters.walk_mut_binders(f, binders);
+                o_ty.substitution.walk_mut_binders(f, binders);
             }
             _ => {
                 if let Some(substs) = self.substs_mut() {

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -8,7 +8,7 @@
 use std::{iter, sync::Arc};
 
 use base_db::CrateId;
-use chalk_ir::{cast::Cast, Mutability};
+use chalk_ir::{cast::Cast, Mutability, Safety};
 use hir_def::{
     adt::StructKind,
     builtin_type::BuiltinType,
@@ -181,7 +181,7 @@ impl<'a> TyLoweringContext<'a> {
                 let substs = Substs(params.iter().map(|tr| self.lower_ty(tr)).collect());
                 TyKind::Function(FnPointer {
                     num_args: substs.len() - 1,
-                    sig: FnSig { variadic: *is_varargs },
+                    sig: FnSig { abi: (), safety: Safety::Safe, variadic: *is_varargs },
                     substs,
                 })
                 .intern(&Interner)

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -230,8 +230,11 @@ impl<'a> TyLoweringContext<'a> {
                         let opaque_ty_id = self.db.intern_impl_trait_id(impl_trait_id).into();
                         let generics = generics(self.db.upcast(), func.into());
                         let parameters = Substs::bound_vars(&generics, self.in_binders);
-                        TyKind::Alias(AliasTy::Opaque(OpaqueTy { opaque_ty_id, parameters }))
-                            .intern(&Interner)
+                        TyKind::Alias(AliasTy::Opaque(OpaqueTy {
+                            opaque_ty_id,
+                            substitution: parameters,
+                        }))
+                        .intern(&Interner)
                     }
                     ImplTraitLoweringMode::Param => {
                         let idx = self.impl_trait_counter.get();

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -357,8 +357,8 @@ impl<'a> TyLoweringContext<'a> {
                         Some((super_trait_ref, associated_ty)) => {
                             // FIXME handle type parameters on the segment
                             TyKind::Alias(AliasTy::Projection(ProjectionTy {
-                                associated_ty: to_assoc_type_id(associated_ty),
-                                parameters: super_trait_ref.substs,
+                                associated_ty_id: to_assoc_type_id(associated_ty),
+                                substitution: super_trait_ref.substs,
                             }))
                             .intern(&Interner)
                         }
@@ -478,8 +478,8 @@ impl<'a> TyLoweringContext<'a> {
                         // FIXME handle type parameters on the segment
                         return Some(
                             TyKind::Alias(AliasTy::Projection(ProjectionTy {
-                                associated_ty: to_assoc_type_id(associated_ty),
-                                parameters: substs,
+                                associated_ty_id: to_assoc_type_id(associated_ty),
+                                substitution: substs,
                             }))
                             .intern(&Interner),
                         );
@@ -736,8 +736,8 @@ impl<'a> TyLoweringContext<'a> {
                     Some(t) => t,
                 };
                 let projection_ty = ProjectionTy {
-                    associated_ty: to_assoc_type_id(associated_ty),
-                    parameters: super_trait_ref.substs,
+                    associated_ty_id: to_assoc_type_id(associated_ty),
+                    substitution: super_trait_ref.substs,
                 };
                 let mut preds = SmallVec::with_capacity(
                     binding.type_ref.as_ref().map_or(0, |_| 1) + binding.bounds.len(),

--- a/crates/hir_ty/src/traits.rs
+++ b/crates/hir_ty/src/traits.rs
@@ -143,7 +143,7 @@ pub(crate) fn trait_solve_query(
     log::info!("trait_solve_query({})", goal.value.value.display(db));
 
     if let Obligation::Projection(pred) = &goal.value.value {
-        if let TyKind::BoundVar(_) = &pred.projection_ty.parameters[0].interned(&Interner) {
+        if let TyKind::BoundVar(_) = &pred.projection_ty.substitution[0].interned(&Interner) {
             // Hack: don't ask Chalk to normalize with an unknown self type, it'll say that's impossible
             return Some(Solution::Ambig(Guidance::Unknown));
         }

--- a/crates/hir_ty/src/traits/chalk.rs
+++ b/crates/hir_ty/src/traits/chalk.rs
@@ -234,9 +234,9 @@ impl<'a> chalk_solve::RustIrDatabase<Interner> for ChalkContext<'a> {
                         ty: TyKind::BoundVar(BoundVar { debruijn: DebruijnIndex::ONE, index: 0 })
                             .intern(&Interner),
                         projection_ty: ProjectionTy {
-                            associated_ty: to_assoc_type_id(future_output),
+                            associated_ty_id: to_assoc_type_id(future_output),
                             // Self type as the first parameter.
-                            parameters: Substs::single(
+                            substitution: Substs::single(
                                 TyKind::BoundVar(BoundVar::new(DebruijnIndex::INNERMOST, 0))
                                     .intern(&Interner),
                             ),

--- a/crates/hir_ty/src/traits/chalk/mapping.rs
+++ b/crates/hir_ty/src/traits/chalk/mapping.rs
@@ -78,8 +78,8 @@ impl ToChalk for Ty {
                 chalk_ir::TyKind::Adt(adt_id, substitution).intern(&Interner)
             }
             TyKind::Alias(AliasTy::Projection(proj_ty)) => {
-                let associated_ty_id = proj_ty.associated_ty;
-                let substitution = proj_ty.parameters.to_chalk(db);
+                let associated_ty_id = proj_ty.associated_ty_id;
+                let substitution = proj_ty.substitution.to_chalk(db);
                 chalk_ir::AliasTy::Projection(chalk_ir::ProjectionTy {
                     associated_ty_id,
                     substitution,
@@ -121,7 +121,7 @@ impl ToChalk for Ty {
             chalk_ir::TyKind::Alias(chalk_ir::AliasTy::Projection(proj)) => {
                 let associated_ty = proj.associated_ty_id;
                 let parameters = from_chalk(db, proj.substitution);
-                TyKind::Alias(AliasTy::Projection(ProjectionTy { associated_ty, parameters }))
+                TyKind::Alias(AliasTy::Projection(ProjectionTy { associated_ty_id: associated_ty, substitution: parameters }))
             }
             chalk_ir::TyKind::Alias(chalk_ir::AliasTy::Opaque(opaque_ty)) => {
                 let opaque_ty_id = opaque_ty.opaque_ty_id;
@@ -372,8 +372,8 @@ impl ToChalk for ProjectionTy {
 
     fn to_chalk(self, db: &dyn HirDatabase) -> chalk_ir::ProjectionTy<Interner> {
         chalk_ir::ProjectionTy {
-            associated_ty_id: self.associated_ty,
-            substitution: self.parameters.to_chalk(db),
+            associated_ty_id: self.associated_ty_id,
+            substitution: self.substitution.to_chalk(db),
         }
     }
 
@@ -382,8 +382,8 @@ impl ToChalk for ProjectionTy {
         projection_ty: chalk_ir::ProjectionTy<Interner>,
     ) -> ProjectionTy {
         ProjectionTy {
-            associated_ty: projection_ty.associated_ty_id,
-            parameters: from_chalk(db, projection_ty.substitution),
+            associated_ty_id: projection_ty.associated_ty_id,
+            substitution: from_chalk(db, projection_ty.substitution),
         }
     }
 }
@@ -533,24 +533,24 @@ pub(super) fn generic_predicate_to_inline_bound(
             Some(rust_ir::InlineBound::TraitBound(trait_bound))
         }
         GenericPredicate::Projection(proj) => {
-            if &proj.projection_ty.parameters[0] != self_ty {
+            if &proj.projection_ty.substitution[0] != self_ty {
                 return None;
             }
-            let trait_ = match from_assoc_type_id(proj.projection_ty.associated_ty)
+            let trait_ = match from_assoc_type_id(proj.projection_ty.associated_ty_id)
                 .lookup(db.upcast())
                 .container
             {
                 AssocContainerId::TraitId(t) => t,
                 _ => panic!("associated type not in trait"),
             };
-            let args_no_self = proj.projection_ty.parameters[1..]
+            let args_no_self = proj.projection_ty.substitution[1..]
                 .iter()
                 .map(|ty| ty.clone().to_chalk(db).cast(&Interner))
                 .collect();
             let alias_eq_bound = rust_ir::AliasEqBound {
                 value: proj.ty.clone().to_chalk(db),
                 trait_bound: rust_ir::TraitBound { trait_id: trait_.to_chalk(db), args_no_self },
-                associated_ty_id: proj.projection_ty.associated_ty,
+                associated_ty_id: proj.projection_ty.associated_ty_id,
                 parameters: Vec::new(), // FIXME we don't support generic associated types yet
             };
             Some(rust_ir::InlineBound::AliasEqBound(alias_eq_bound))

--- a/crates/hir_ty/src/traits/chalk/mapping.rs
+++ b/crates/hir_ty/src/traits/chalk/mapping.rs
@@ -87,6 +87,13 @@ impl ToChalk for Ty {
                 .cast(&Interner)
                 .intern(&Interner)
             }
+            TyKind::Alias(AliasTy::Opaque(opaque_ty)) => {
+                let opaque_ty_id = opaque_ty.opaque_ty_id;
+                let substitution = opaque_ty.substitution.to_chalk(db);
+                chalk_ir::AliasTy::Opaque(chalk_ir::OpaqueTy { opaque_ty_id, substitution })
+                    .cast(&Interner)
+                    .intern(&Interner)
+            }
             TyKind::Placeholder(idx) => idx.to_ty::<Interner>(&Interner),
             TyKind::BoundVar(idx) => chalk_ir::TyKind::BoundVar(idx).intern(&Interner),
             TyKind::InferenceVar(..) => panic!("uncanonicalized infer ty"),
@@ -100,15 +107,6 @@ impl ToChalk for Ty {
                     lifetime: LifetimeData::Static.intern(&Interner),
                 };
                 chalk_ir::TyKind::Dyn(bounded_ty).intern(&Interner)
-            }
-            TyKind::Alias(AliasTy::Opaque(opaque_ty)) => {
-                let opaque_ty_id = opaque_ty.opaque_ty_id;
-                let substitution = opaque_ty.parameters.to_chalk(db);
-                chalk_ir::TyKind::Alias(chalk_ir::AliasTy::Opaque(chalk_ir::OpaqueTy {
-                    opaque_ty_id,
-                    substitution,
-                }))
-                .intern(&Interner)
             }
             TyKind::Unknown => chalk_ir::TyKind::Error.intern(&Interner),
         }
@@ -129,7 +127,7 @@ impl ToChalk for Ty {
             chalk_ir::TyKind::Alias(chalk_ir::AliasTy::Opaque(opaque_ty)) => {
                 let opaque_ty_id = opaque_ty.opaque_ty_id;
                 let parameters = from_chalk(db, opaque_ty.substitution);
-                TyKind::Alias(AliasTy::Opaque(OpaqueTy { opaque_ty_id, parameters }))
+                TyKind::Alias(AliasTy::Opaque(OpaqueTy { opaque_ty_id, substitution: parameters }))
             }
             chalk_ir::TyKind::Function(chalk_ir::FnPointer {
                 num_binders,


### PR DESCRIPTION
 - rename a bunch of fields
 - use `chalk_ir::FnSig`