### PR TITLE
Make Ty wrap TyKind in an Arc

### DIFF
--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -276,20 +276,17 @@ impl HirDisplay for Ty {
             &TyKind::Scalar(Scalar::Float(t)) => write!(f, "{}", primitive::float_ty_to_string(t))?,
             &TyKind::Scalar(Scalar::Int(t)) => write!(f, "{}", primitive::int_ty_to_string(t))?,
             &TyKind::Scalar(Scalar::Uint(t)) => write!(f, "{}", primitive::uint_ty_to_string(t))?,
-            TyKind::Slice(parameters) => {
-                let t = parameters.as_single();
+            TyKind::Slice(t) => {
                 write!(f, "[")?;
                 t.hir_fmt(f)?;
                 write!(f, "]")?;
             }
-            TyKind::Array(parameters) => {
-                let t = parameters.as_single();
+            TyKind::Array(t) => {
                 write!(f, "[")?;
                 t.hir_fmt(f)?;
                 write!(f, "; _]")?;
             }
-            TyKind::Raw(m, parameters) | TyKind::Ref(m, parameters) => {
-                let t = parameters.as_single();
+            TyKind::Raw(m, t) | TyKind::Ref(m, t) => {
                 let ty_display =
                     t.into_displayable(f.db, f.max_size, f.omit_verbose_types, f.display_target);
 

--- a/crates/hir_ty/src/infer/coerce.rs
+++ b/crates/hir_ty/src/infer/coerce.rs
@@ -111,9 +111,7 @@ impl<'a> InferenceContext<'a> {
         // Auto Deref if cannot coerce
         match (from_ty.interned(&Interner), to_ty.interned(&Interner)) {
             // FIXME: DerefMut
-            (TyKind::Ref(_, st1), TyKind::Ref(_, st2)) => {
-                self.unify_autoderef_behind_ref(&st1[0], &st2[0])
-            }
+            (TyKind::Ref(_, st1), TyKind::Ref(_, st2)) => self.unify_autoderef_behind_ref(st1, st2),
 
             // Otherwise, normal unify
             _ => self.unify(&from_ty, to_ty),
@@ -178,11 +176,7 @@ impl<'a> InferenceContext<'a> {
             // Stop when constructor matches.
             if from_ty.equals_ctor(&to_ty) {
                 // It will not recurse to `coerce`.
-                return match (from_ty.substs(), to_ty.substs()) {
-                    (Some(st1), Some(st2)) => self.table.unify_substs(st1, st2, 0),
-                    (None, None) => true,
-                    _ => false,
-                };
+                return self.table.unify(&from_ty, &to_ty);
             } else if self.table.unify_inner_trivial(&derefed_ty, &to_ty, 0) {
                 return true;
             }

--- a/crates/hir_ty/src/infer/coerce.rs
+++ b/crates/hir_ty/src/infer/coerce.rs
@@ -71,7 +71,7 @@ impl<'a> InferenceContext<'a> {
         }
 
         // Pointer weakening and function to pointer
-        match (&mut from_ty.0, to_ty.interned(&Interner)) {
+        match (from_ty.interned_mut(), to_ty.interned(&Interner)) {
             // `*mut T` -> `*const T`
             // `&mut T` -> `&T`
             (TyKind::Raw(m1, ..), TyKind::Raw(m2 @ Mutability::Not, ..))

--- a/crates/hir_ty/src/infer/expr.rs
+++ b/crates/hir_ty/src/infer/expr.rs
@@ -800,7 +800,7 @@ impl<'a> InferenceContext<'a> {
                 // we don't even make an attempt at coercion
                 self.table.new_maybe_never_var()
             } else {
-                self.coerce(&Ty::unit(), expected.coercion_target());
+                self.coerce(&Ty::unit(), &expected.coercion_target());
                 Ty::unit()
             }
         };

--- a/crates/hir_ty/src/infer/expr.rs
+++ b/crates/hir_ty/src/infer/expr.rs
@@ -504,8 +504,8 @@ impl<'a> InferenceContext<'a> {
                 };
                 let inner_ty = self.infer_expr_inner(*expr, &expectation);
                 match rawness {
-                    Rawness::RawPtr => TyKind::Raw(mutability, Substs::single(inner_ty)),
-                    Rawness::Ref => TyKind::Ref(mutability, Substs::single(inner_ty)),
+                    Rawness::RawPtr => TyKind::Raw(mutability, inner_ty),
+                    Rawness::Ref => TyKind::Ref(mutability, inner_ty),
                 }
                 .intern(&Interner)
             }
@@ -686,7 +686,7 @@ impl<'a> InferenceContext<'a> {
             }
             Expr::Array(array) => {
                 let elem_ty = match expected.ty.interned(&Interner) {
-                    TyKind::Array(st) | TyKind::Slice(st) => st.as_single().clone(),
+                    TyKind::Array(st) | TyKind::Slice(st) => st.clone(),
                     _ => self.table.new_type_var(),
                 };
 
@@ -710,18 +710,17 @@ impl<'a> InferenceContext<'a> {
                     }
                 }
 
-                TyKind::Array(Substs::single(elem_ty)).intern(&Interner)
+                TyKind::Array(elem_ty).intern(&Interner)
             }
             Expr::Literal(lit) => match lit {
                 Literal::Bool(..) => TyKind::Scalar(Scalar::Bool).intern(&Interner),
                 Literal::String(..) => {
-                    TyKind::Ref(Mutability::Not, Substs::single(TyKind::Str.intern(&Interner)))
-                        .intern(&Interner)
+                    TyKind::Ref(Mutability::Not, TyKind::Str.intern(&Interner)).intern(&Interner)
                 }
                 Literal::ByteString(..) => {
                     let byte_type = TyKind::Scalar(Scalar::Uint(UintTy::U8)).intern(&Interner);
-                    let array_type = TyKind::Array(Substs::single(byte_type)).intern(&Interner);
-                    TyKind::Ref(Mutability::Not, Substs::single(array_type)).intern(&Interner)
+                    let array_type = TyKind::Array(byte_type).intern(&Interner);
+                    TyKind::Ref(Mutability::Not, array_type).intern(&Interner)
                 }
                 Literal::Char(..) => TyKind::Scalar(Scalar::Char).intern(&Interner),
                 Literal::Int(_v, ty) => match ty {
@@ -855,9 +854,7 @@ impl<'a> InferenceContext<'a> {
         // Apply autoref so the below unification works correctly
         // FIXME: return correct autorefs from lookup_method
         let actual_receiver_ty = match expected_receiver_ty.as_reference() {
-            Some((_, mutability)) => {
-                TyKind::Ref(mutability, Substs::single(derefed_receiver_ty)).intern(&Interner)
-            }
+            Some((_, mutability)) => TyKind::Ref(mutability, derefed_receiver_ty).intern(&Interner),
             _ => derefed_receiver_ty,
         };
         self.unify(&expected_receiver_ty, &actual_receiver_ty);

--- a/crates/hir_ty/src/infer/pat.rs
+++ b/crates/hir_ty/src/infer/pat.rs
@@ -163,7 +163,7 @@ impl<'a> InferenceContext<'a> {
                     _ => self.result.standard_types.unknown.clone(),
                 };
                 let subty = self.infer_pat(*pat, &expectation, default_bm);
-                TyKind::Ref(mutability, Substs::single(subty)).intern(&Interner)
+                TyKind::Ref(mutability, subty).intern(&Interner)
             }
             Pat::TupleStruct { path: p, args: subpats, ellipsis } => self.infer_tuple_struct_pat(
                 p.as_ref(),
@@ -196,7 +196,7 @@ impl<'a> InferenceContext<'a> {
 
                 let bound_ty = match mode {
                     BindingMode::Ref(mutability) => {
-                        TyKind::Ref(mutability, Substs::single(inner_ty.clone())).intern(&Interner)
+                        TyKind::Ref(mutability, inner_ty.clone()).intern(&Interner)
                     }
                     BindingMode::Move => inner_ty.clone(),
                 };
@@ -206,8 +206,8 @@ impl<'a> InferenceContext<'a> {
             }
             Pat::Slice { prefix, slice, suffix } => {
                 let (container_ty, elem_ty): (fn(_) -> _, _) = match expected.interned(&Interner) {
-                    TyKind::Array(st) => (TyKind::Array, st.as_single().clone()),
-                    TyKind::Slice(st) => (TyKind::Slice, st.as_single().clone()),
+                    TyKind::Array(st) => (TyKind::Array, st.clone()),
+                    TyKind::Slice(st) => (TyKind::Slice, st.clone()),
                     _ => (TyKind::Slice, self.err_ty()),
                 };
 
@@ -215,7 +215,7 @@ impl<'a> InferenceContext<'a> {
                     self.infer_pat(*pat_id, &elem_ty, default_bm);
                 }
 
-                let pat_ty = container_ty(Substs::single(elem_ty)).intern(&Interner);
+                let pat_ty = container_ty(elem_ty).intern(&Interner);
                 if let Some(slice_pat_id) = slice {
                     self.infer_pat(*slice_pat_id, &pat_ty, default_bm);
                 }

--- a/crates/hir_ty/src/infer/pat.rs
+++ b/crates/hir_ty/src/infer/pat.rs
@@ -158,11 +158,11 @@ impl<'a> InferenceContext<'a> {
                         if mutability != exp_mut {
                             // FIXME: emit type error?
                         }
-                        inner_ty
+                        inner_ty.clone()
                     }
-                    _ => &Ty(TyKind::Unknown),
+                    _ => self.result.standard_types.unknown.clone(),
                 };
-                let subty = self.infer_pat(*pat, expectation, default_bm);
+                let subty = self.infer_pat(*pat, &expectation, default_bm);
                 TyKind::Ref(mutability, Substs::single(subty)).intern(&Interner)
             }
             Pat::TupleStruct { path: p, args: subpats, ellipsis } => self.infer_tuple_struct_pat(
@@ -232,11 +232,11 @@ impl<'a> InferenceContext<'a> {
             Pat::Box { inner } => match self.resolve_boxed_box() {
                 Some(box_adt) => {
                     let inner_expected = match expected.as_adt() {
-                        Some((adt, substs)) if adt == box_adt => substs.as_single(),
-                        _ => &Ty(TyKind::Unknown),
+                        Some((adt, substs)) if adt == box_adt => substs.as_single().clone(),
+                        _ => self.result.standard_types.unknown.clone(),
                     };
 
-                    let inner_ty = self.infer_pat(*inner, inner_expected, default_bm);
+                    let inner_ty = self.infer_pat(*inner, &inner_expected, default_bm);
                     Ty::adt_ty(box_adt, Substs::single(inner_ty))
                 }
                 None => self.err_ty(),

--- a/crates/hir_ty/src/infer/unify.rs
+++ b/crates/hir_ty/src/infer/unify.rs
@@ -7,8 +7,8 @@ use ena::unify::{InPlaceUnificationTable, NoError, UnifyKey, UnifyValue};
 
 use super::{InferenceContext, Obligation};
 use crate::{
-    BoundVar, Canonical, DebruijnIndex, GenericPredicate, InEnvironment, InferenceVar, Interner,
-    Scalar, Substs, Ty, TyKind, TypeWalk,
+    BoundVar, Canonical, DebruijnIndex, FnPointer, GenericPredicate, InEnvironment, InferenceVar,
+    Interner, Scalar, Substs, Ty, TyKind, TypeWalk,
 };
 
 impl<'a> InferenceContext<'a> {
@@ -283,9 +283,23 @@ impl InferenceTable {
         let ty1 = self.resolve_ty_shallow(ty1);
         let ty2 = self.resolve_ty_shallow(ty2);
         if ty1.equals_ctor(&ty2) {
-            match (ty1.substs(), ty2.substs()) {
-                (Some(st1), Some(st2)) => self.unify_substs(st1, st2, depth + 1),
-                (None, None) => true,
+            match (ty1.interned(&Interner), ty2.interned(&Interner)) {
+                (TyKind::Adt(_, substs1), TyKind::Adt(_, substs2))
+                | (TyKind::FnDef(_, substs1), TyKind::FnDef(_, substs2))
+                | (
+                    TyKind::Function(FnPointer { substs: substs1, .. }),
+                    TyKind::Function(FnPointer { substs: substs2, .. }),
+                )
+                | (TyKind::Tuple(_, substs1), TyKind::Tuple(_, substs2))
+                | (TyKind::OpaqueType(_, substs1), TyKind::OpaqueType(_, substs2))
+                | (TyKind::AssociatedType(_, substs1), TyKind::AssociatedType(_, substs2))
+                | (TyKind::Closure(.., substs1), TyKind::Closure(.., substs2)) => {
+                    self.unify_substs(substs1, substs2, depth + 1)
+                }
+                (TyKind::Ref(_, ty1), TyKind::Ref(_, ty2))
+                | (TyKind::Raw(_, ty1), TyKind::Raw(_, ty2))
+                | (TyKind::Array(ty1), TyKind::Array(ty2))
+                | (TyKind::Slice(ty1), TyKind::Slice(ty2)) => self.unify_inner(ty1, ty2, depth + 1),
                 _ => false,
             }
         } else {

--- a/crates/hir_ty/src/infer/unify.rs
+++ b/crates/hir_ty/src/infer/unify.rs
@@ -108,7 +108,7 @@ impl<T> Canonicalized<T> {
     pub(super) fn decanonicalize_ty(&self, mut ty: Ty) -> Ty {
         ty.walk_mut_binders(
             &mut |ty, binders| {
-                if let &mut TyKind::BoundVar(bound) = &mut ty.0 {
+                if let &mut TyKind::BoundVar(bound) = ty.interned_mut() {
                     if bound.debruijn >= binders {
                         let (v, k) = self.free_vars[bound.index];
                         *ty = TyKind::InferenceVar(v, k).intern(&Interner);
@@ -404,7 +404,7 @@ impl InferenceTable {
             if i > 0 {
                 cov_mark::hit!(type_var_resolves_to_int_var);
             }
-            match &ty.0 {
+            match ty.interned(&Interner) {
                 TyKind::InferenceVar(tv, _) => {
                     let inner = tv.to_inner();
                     match self.var_unification_table.inlined_probe_value(inner).known() {

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -160,21 +160,19 @@ impl<'a> TyLoweringContext<'a> {
             }
             TypeRef::RawPtr(inner, mutability) => {
                 let inner_ty = self.lower_ty(inner);
-                TyKind::Raw(lower_to_chalk_mutability(*mutability), Substs::single(inner_ty))
-                    .intern(&Interner)
+                TyKind::Raw(lower_to_chalk_mutability(*mutability), inner_ty).intern(&Interner)
             }
             TypeRef::Array(inner) => {
                 let inner_ty = self.lower_ty(inner);
-                TyKind::Array(Substs::single(inner_ty)).intern(&Interner)
+                TyKind::Array(inner_ty).intern(&Interner)
             }
             TypeRef::Slice(inner) => {
                 let inner_ty = self.lower_ty(inner);
-                TyKind::Slice(Substs::single(inner_ty)).intern(&Interner)
+                TyKind::Slice(inner_ty).intern(&Interner)
             }
             TypeRef::Reference(inner, _, mutability) => {
                 let inner_ty = self.lower_ty(inner);
-                TyKind::Ref(lower_to_chalk_mutability(*mutability), Substs::single(inner_ty))
-                    .intern(&Interner)
+                TyKind::Ref(lower_to_chalk_mutability(*mutability), inner_ty).intern(&Interner)
             }
             TypeRef::Placeholder => TyKind::Unknown.intern(&Interner),
             TypeRef::Fn(params, is_varargs) => {

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -993,7 +993,7 @@ pub(crate) fn generic_defaults_query(
 
             // Each default can only refer to previous parameters.
             ty.walk_mut_binders(
-                &mut |ty, binders| match &mut ty.0 {
+                &mut |ty, binders| match ty.interned_mut() {
                     TyKind::BoundVar(BoundVar { debruijn, index }) if *debruijn == binders => {
                         if *index >= idx {
                             // type variable default referring to parameter coming

--- a/crates/hir_ty/src/method_resolution.rs
+++ b/crates/hir_ty/src/method_resolution.rs
@@ -435,8 +435,7 @@ fn iterate_method_candidates_with_autoref(
     }
     let refed = Canonical {
         kinds: deref_chain[0].kinds.clone(),
-        value: TyKind::Ref(Mutability::Not, Substs::single(deref_chain[0].value.clone()))
-            .intern(&Interner),
+        value: TyKind::Ref(Mutability::Not, deref_chain[0].value.clone()).intern(&Interner),
     };
     if iterate_method_candidates_by_receiver(
         &refed,
@@ -452,8 +451,7 @@ fn iterate_method_candidates_with_autoref(
     }
     let ref_muted = Canonical {
         kinds: deref_chain[0].kinds.clone(),
-        value: TyKind::Ref(Mutability::Mut, Substs::single(deref_chain[0].value.clone()))
-            .intern(&Interner),
+        value: TyKind::Ref(Mutability::Mut, deref_chain[0].value.clone()).intern(&Interner),
     };
     if iterate_method_candidates_by_receiver(
         &ref_muted,

--- a/crates/hir_ty/src/traits/chalk/mapping.rs
+++ b/crates/hir_ty/src/traits/chalk/mapping.rs
@@ -24,7 +24,7 @@ use super::*;
 impl ToChalk for Ty {
     type Chalk = chalk_ir::Ty<Interner>;
     fn to_chalk(self, db: &dyn HirDatabase) -> chalk_ir::Ty<Interner> {
-        match self.0 {
+        match self.into_inner() {
             TyKind::Ref(m, parameters) => ref_to_chalk(db, m, parameters),
             TyKind::Array(parameters) => array_to_chalk(db, parameters),
             TyKind::Function(FnPointer { sig, substs, .. }) => {


### PR DESCRIPTION
... to further move towards Chalk.

This is a bit of a slowdown (218ginstr vs 213ginstr for inference on RA), even though it allows us to unwrap the Substs in `TyKind::Ref` etc..