### PR TITLE
Enable searching for builtin types

### DIFF
--- a/crates/ide/src/references/rename.rs
+++ b/crates/ide/src/references/rename.rs
@@ -510,7 +510,8 @@ fn source_edit_from_def(
     def: Definition,
     new_name: &str,
 ) -> RenameResult<(FileId, TextEdit)> {
-    let nav = def.try_to_nav(sema.db).unwrap();
+    let nav =
+        def.try_to_nav(sema.db).ok_or_else(|| format_err!("No references found at position"))?;
 
     let mut replacement_text = String::new();
     let mut repl_range = nav.focus_or_full_range();

--- a/crates/ide_db/src/defs.rs
+++ b/crates/ide_db/src/defs.rs
@@ -70,7 +70,7 @@ impl Definition {
                 hir::ModuleDef::Static(it) => it.name(db)?,
                 hir::ModuleDef::Trait(it) => it.name(db),
                 hir::ModuleDef::TypeAlias(it) => it.name(db),
-                hir::ModuleDef::BuiltinType(_) => return None,
+                hir::ModuleDef::BuiltinType(it) => it.name(),
             },
             Definition::SelfType(_) => return None,
             Definition::Local(it) => it.name(db)?,

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -828,9 +828,9 @@ pub(crate) fn handle_references(
     };
 
     let decl = if params.context.include_declaration {
-        Some(FileRange {
-            file_id: refs.declaration.nav.file_id,
-            range: refs.declaration.nav.focus_or_full_range(),
+        refs.declaration.map(|decl| FileRange {
+            file_id: decl.nav.file_id,
+            range: decl.nav.focus_or_full_range(),
         })
     } else {
         None
@@ -1135,14 +1135,12 @@ pub(crate) fn handle_document_highlight(
         Some(refs) => refs,
     };
 
-    let decl = if refs.declaration.nav.file_id == position.file_id {
-        Some(DocumentHighlight {
-            range: to_proto::range(&line_index, refs.declaration.nav.focus_or_full_range()),
-            kind: refs.declaration.access.map(to_proto::document_highlight_kind),
-        })
-    } else {
-        None
-    };
+    let decl = refs.declaration.filter(|decl| decl.nav.file_id == position.file_id).map(|decl| {
+        DocumentHighlight {
+            range: to_proto::range(&line_index, decl.nav.focus_or_full_range()),
+            kind: decl.access.map(to_proto::document_highlight_kind),
+        }
+    });
 
     let file_refs = refs.references.get(&position.file_id).map_or(&[][..], Vec::as_slice);
     let mut res = Vec::with_capacity(file_refs.len() + 1);


### PR DESCRIPTION
Not too sure how useful this is for reference search overall, but for completeness sake it should be there 
![image](https://user-images.githubusercontent.com/3757771/111132711-f69db600-8579-11eb-8c90-22fd6862d11f.png)

Also enables document highlighting for them.
