### PR TITLE
some clippy::performance fixes

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -266,8 +266,7 @@ impl ModuleDef {
     }
 
     pub fn canonical_path(&self, db: &dyn HirDatabase) -> Option<String> {
-        let mut segments = Vec::new();
-        segments.push(self.name(db)?.to_string());
+        let mut segments = vec![self.name(db)?.to_string()];
         for m in self.module(db)?.path_to_root(db) {
             segments.extend(m.name(db).map(|it| it.to_string()))
         }

--- a/crates/hir_expand/src/builtin_derive.rs
+++ b/crates/hir_expand/src/builtin_derive.rs
@@ -108,7 +108,7 @@ fn parse_adt(tt: &tt::Subtree) -> Result<BasicAdtInfo, mbe::ExpandError> {
 }
 
 fn make_type_args(n: usize, bound: Vec<tt::TokenTree>) -> Vec<tt::TokenTree> {
-    let mut result = Vec::<tt::TokenTree>::new();
+    let mut result = Vec::<tt::TokenTree>::with_capacity(n * 2);
     result.push(
         tt::Leaf::Punct(tt::Punct {
             char: '<',

--- a/crates/ide/src/join_lines.rs
+++ b/crates/ide/src/join_lines.rs
@@ -218,7 +218,7 @@ mod tests {
         let result = join_lines(&file, range);
 
         let actual = {
-            let mut actual = before.to_string();
+            let mut actual = before;
             result.apply(&mut actual);
             actual
         };
@@ -622,7 +622,7 @@ fn foo() {
         let parse = SourceFile::parse(&before);
         let result = join_lines(&parse.tree(), sel);
         let actual = {
-            let mut actual = before.to_string();
+            let mut actual = before;
             result.apply(&mut actual);
             actual
         };

--- a/crates/ide/src/typing.rs
+++ b/crates/ide/src/typing.rs
@@ -145,9 +145,8 @@ mod tests {
     use super::*;
 
     fn do_type_char(char_typed: char, before: &str) -> Option<String> {
-        let (offset, before) = extract_offset(before);
+        let (offset, mut before) = extract_offset(before);
         let edit = TextEdit::insert(offset, char_typed.to_string());
-        let mut before = before.to_string();
         edit.apply(&mut before);
         let parse = SourceFile::parse(&before);
         on_char_typed_inner(&parse.tree(), offset, char_typed).map(|it| {

--- a/crates/ide_completion/src/completions/postfix/format_like.rs
+++ b/crates/ide_completion/src/completions/postfix/format_like.rs
@@ -59,7 +59,7 @@ pub(crate) fn add_format_like_completions(
 /// Checks whether provided item is a string literal.
 fn string_literal_contents(item: &ast::String) -> Option<String> {
     let item = item.text();
-    if item.len() >= 2 && item.starts_with("\"") && item.ends_with("\"") {
+    if item.len() >= 2 && item.starts_with('\"') && item.ends_with('\"') {
         return Some(item[1..item.len() - 1].to_owned());
     }
 

--- a/crates/mbe/src/syntax_bridge.rs
+++ b/crates/mbe/src/syntax_bridge.rs
@@ -222,14 +222,10 @@ fn convert_doc_comment(token: &syntax::SyntaxToken) -> Option<Vec<tt::TokenTree>
     let doc = comment.kind().doc?;
 
     // Make `doc="\" Comments\""
-    let mut meta_tkns = Vec::new();
-    meta_tkns.push(mk_ident("doc"));
-    meta_tkns.push(mk_punct('='));
-    meta_tkns.push(mk_doc_literal(&comment));
+    let meta_tkns = vec![mk_ident("doc"), mk_punct('='), mk_doc_literal(&comment)];
 
     // Make `#![]`
-    let mut token_trees = Vec::new();
-    token_trees.push(mk_punct('#'));
+    let mut token_trees = vec![mk_punct('#')];
     if let ast::CommentPlacement::Inner = doc {
         token_trees.push(mk_punct('!'));
     }

--- a/crates/proc_macro_api/src/version.rs
+++ b/crates/proc_macro_api/src/version.rs
@@ -33,7 +33,7 @@ pub(crate) fn read_info(dylib_path: &Path) -> io::Result<RustCInfo> {
     }
 
     let version_part = items.next().ok_or(err!("no version string"))?;
-    let mut version_parts = version_part.split("-");
+    let mut version_parts = version_part.split('-');
     let version = version_parts.next().ok_or(err!("no version"))?;
     let channel = version_parts.next().unwrap_or_default().to_string();
 
@@ -51,7 +51,7 @@ pub(crate) fn read_info(dylib_path: &Path) -> io::Result<RustCInfo> {
     let date = date[0..date.len() - 2].to_string();
 
     let version_numbers = version
-        .split(".")
+        .split('.')
         .map(|it| it.parse::<usize>())
         .collect::<Result<Vec<_>, _>>()
         .map_err(|_| err!("version number error"))?;

--- a/crates/project_model/src/rustc_cfg.rs
+++ b/crates/project_model/src/rustc_cfg.rs
@@ -6,7 +6,7 @@ use crate::{cfg_flag::CfgFlag, utf8_stdout};
 
 pub(crate) fn get(target: Option<&str>) -> Vec<CfgFlag> {
     let _p = profile::span("rustc_cfg::get");
-    let mut res = Vec::new();
+    let mut res = Vec::with_capacity(6 * 2 + 1);
 
     // Some nightly-only cfgs, which are required for stdlib
     res.push(CfgFlag::Atom("target_thread_local".into()));

--- a/crates/rust-analyzer/src/lsp_utils.rs
+++ b/crates/rust-analyzer/src/lsp_utils.rs
@@ -360,11 +360,11 @@ mod tests {
             "Completion with disjoint edits is valid"
         );
         assert!(
-            !all_edits_are_disjoint(&completion_with_disjoint_edits, &[joint_edit.clone()]),
+            !all_edits_are_disjoint(&completion_with_disjoint_edits, &[joint_edit]),
             "Completion with disjoint edits and joint extra edit is invalid"
         );
         assert!(
-            all_edits_are_disjoint(&completion_with_disjoint_edits, &[disjoint_edit_2.clone()]),
+            all_edits_are_disjoint(&completion_with_disjoint_edits, &[disjoint_edit_2]),
             "Completion with disjoint edits and joint extra edit is valid"
         );
     }


### PR DESCRIPTION
use vec![] instead of Vec::new() + push()
avoid redundant clones
use chars instead of &str for single char patterns in ends_with() and starts_with()
allocate some Vecs with capacity to avoid unnecessary resizing