### PR TITLE
completion relevance consider if types can be unified

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -51,7 +51,7 @@ use hir_def::{
 };
 use hir_expand::{diagnostics::DiagnosticSink, name::name, MacroDefKind};
 use hir_ty::{
-    autoderef,
+    autoderef, could_unify,
     method_resolution::{self, TyFingerprint},
     primitive::UintTy,
     to_assoc_type_id,
@@ -2153,6 +2153,10 @@ impl Type {
         }
 
         walk_type(db, self, &mut cb);
+    }
+
+    pub fn could_unify_with(&self, other: &Type) -> bool {
+        could_unify(&self.ty, &other.ty)
     }
 }
 

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -45,6 +45,11 @@ use crate::{
     to_assoc_type_id, to_chalk_trait_id, AliasEq, AliasTy, Interner, TyKind,
 };
 
+// This lint has a false positive here. See the link below for details.
+//
+// https://github.com/rust-lang/rust/issues/57411
+#[allow(unreachable_pub)]
+pub use unify::could_unify;
 pub(crate) use unify::unify;
 
 mod unify;

--- a/crates/hir_ty/src/infer/unify.rs
+++ b/crates/hir_ty/src/infer/unify.rs
@@ -157,6 +157,10 @@ impl<T> Canonicalized<T> {
     }
 }
 
+pub fn could_unify(t1: &Ty, t2: &Ty) -> bool {
+    InferenceTable::new().unify(t1, t2)
+}
+
 pub(crate) fn unify(tys: &Canonical<(Ty, Ty)>) -> Option<Substitution> {
     let mut table = InferenceTable::new();
     let vars = Substitution(

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -41,7 +41,7 @@ use crate::{
 };
 
 pub use autoderef::autoderef;
-pub use infer::{InferenceResult, InferenceVar};
+pub use infer::{could_unify, InferenceResult, InferenceVar};
 pub use lower::{
     associated_type_shorthand_candidates, callable_item_sig, CallableDefId, ImplTraitLoweringMode,
     TyDefId, TyLoweringContext, ValueTyDefId,

--- a/crates/ide_completion/src/render.rs
+++ b/crates/ide_completion/src/render.rs
@@ -20,8 +20,8 @@ use ide_db::{
 use syntax::TextRange;
 
 use crate::{
-    item::ImportEdit, CompletionContext, CompletionItem, CompletionItemKind, CompletionKind,
-    CompletionRelevance,
+    item::{CompletionRelevanceTypeMatch, ImportEdit},
+    CompletionContext, CompletionItem, CompletionItemKind, CompletionKind, CompletionRelevance,
 };
 
 use crate::render::{enum_variant::render_variant, function::render_fn, macro_::render_macro};
@@ -143,7 +143,7 @@ impl<'a> Render<'a> {
             .set_deprecated(is_deprecated);
 
         item.set_relevance(CompletionRelevance {
-            exact_type_match: compute_exact_type_match(self.ctx.completion, ty),
+            type_match: compute_type_match(self.ctx.completion, ty),
             exact_name_match: compute_exact_name_match(self.ctx.completion, name.to_string()),
             ..CompletionRelevance::default()
         });
@@ -245,7 +245,7 @@ impl<'a> Render<'a> {
             }
 
             item.set_relevance(CompletionRelevance {
-                exact_type_match: compute_exact_type_match(self.ctx.completion, &ty),
+                type_match: compute_type_match(self.ctx.completion, &ty),
                 exact_name_match: compute_exact_name_match(self.ctx.completion, &local_name),
                 is_local: true,
                 ..CompletionRelevance::default()
@@ -309,15 +309,24 @@ impl<'a> Render<'a> {
     }
 }
 
-fn compute_exact_type_match(ctx: &CompletionContext, completion_ty: &hir::Type) -> bool {
-    match ctx.expected_type.as_ref() {
-        Some(expected_type) => {
-            // We don't ever consider unit type to be an exact type match, since
-            // nearly always this is not meaningful to the user.
-            (completion_ty == expected_type || expected_type.could_unify_with(completion_ty))
-                && !expected_type.is_unit()
-        }
-        None => false,
+fn compute_type_match(
+    ctx: &CompletionContext,
+    completion_ty: &hir::Type,
+) -> Option<CompletionRelevanceTypeMatch> {
+    let expected_type = ctx.expected_type.as_ref()?;
+
+    // We don't ever consider unit type to be an exact type match, since
+    // nearly always this is not meaningful to the user.
+    if expected_type.is_unit() {
+        return None;
+    }
+
+    if completion_ty == expected_type {
+        Some(CompletionRelevanceTypeMatch::Exact)
+    } else if expected_type.could_unify_with(completion_ty) {
+        Some(CompletionRelevanceTypeMatch::CouldUnify)
+    } else {
+        None
     }
 }
 
@@ -349,6 +358,7 @@ mod tests {
     use itertools::Itertools;
 
     use crate::{
+        item::CompletionRelevanceTypeMatch,
         test_utils::{check_edit, do_completion, get_all_items, TEST_CONFIG},
         CompletionKind, CompletionRelevance,
     };
@@ -361,7 +371,11 @@ mod tests {
     fn check_relevance(ra_fixture: &str, expect: Expect) {
         fn display_relevance(relevance: CompletionRelevance) -> String {
             let relevance_factors = vec![
-                (relevance.exact_type_match, "type"),
+                (relevance.type_match == Some(CompletionRelevanceTypeMatch::Exact), "type"),
+                (
+                    relevance.type_match == Some(CompletionRelevanceTypeMatch::CouldUnify),
+                    "type_could_unify",
+                ),
                 (relevance.exact_name_match, "name"),
                 (relevance.is_local, "local"),
             ]
@@ -534,7 +548,9 @@ fn main() { let _: m::Spam = S$0 }
                         detail: "(i32)",
                         relevance: CompletionRelevance {
                             exact_name_match: false,
-                            exact_type_match: true,
+                            type_match: Some(
+                                Exact,
+                            ),
                             is_local: false,
                         },
                         trigger_call_info: true,
@@ -560,7 +576,9 @@ fn main() { let _: m::Spam = S$0 }
                         detail: "()",
                         relevance: CompletionRelevance {
                             exact_name_match: false,
-                            exact_type_match: true,
+                            type_match: Some(
+                                Exact,
+                            ),
                             is_local: false,
                         },
                     },
@@ -1109,7 +1127,7 @@ fn main() {
                         detail: "S",
                         relevance: CompletionRelevance {
                             exact_name_match: true,
-                            exact_type_match: false,
+                            type_match: None,
                             is_local: true,
                         },
                         ref_match: "&mut ",
@@ -1374,8 +1392,8 @@ fn foo() {
 }
 "#,
             expect![[r#"
-                ev Foo::A(…) [type]
-                ev Foo::B [type]
+                ev Foo::A(…) [type_could_unify]
+                ev Foo::B [type_could_unify]
                 lc foo [type+local]
                 en Foo []
                 fn baz() []

--- a/crates/ide_completion/src/render/enum_variant.rs
+++ b/crates/ide_completion/src/render/enum_variant.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 
 use crate::{
     item::{CompletionItem, CompletionKind, ImportEdit},
-    render::{builder_ext::Params, compute_exact_type_match, compute_ref_match, RenderContext},
+    render::{builder_ext::Params, compute_ref_match, compute_type_match, RenderContext},
     CompletionRelevance,
 };
 
@@ -77,7 +77,7 @@ impl<'a> EnumRender<'a> {
 
         let ty = self.variant.parent_enum(self.ctx.completion.db).ty(self.ctx.completion.db);
         item.set_relevance(CompletionRelevance {
-            exact_type_match: compute_exact_type_match(self.ctx.completion, &ty),
+            type_match: compute_type_match(self.ctx.completion, &ty),
             ..CompletionRelevance::default()
         });
 

--- a/crates/ide_completion/src/render/function.rs
+++ b/crates/ide_completion/src/render/function.rs
@@ -8,7 +8,7 @@ use syntax::ast::Fn;
 use crate::{
     item::{CompletionItem, CompletionItemKind, CompletionKind, CompletionRelevance, ImportEdit},
     render::{
-        builder_ext::Params, compute_exact_name_match, compute_exact_type_match, compute_ref_match,
+        builder_ext::Params, compute_exact_name_match, compute_ref_match, compute_type_match,
         RenderContext,
     },
 };
@@ -73,7 +73,7 @@ impl<'a> FunctionRender<'a> {
 
         let ret_type = self.func.ret_type(self.ctx.db());
         item.set_relevance(CompletionRelevance {
-            exact_type_match: compute_exact_type_match(self.ctx.completion, &ret_type),
+            type_match: compute_type_match(self.ctx.completion, &ret_type),
             exact_name_match: compute_exact_name_match(self.ctx.completion, self.name.clone()),
             ..CompletionRelevance::default()
         });

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -1138,7 +1138,7 @@ mod tests {
                 (
                     "&arg",
                     Some(
-                        "fffffffa",
+                        "fffffff9",
                     ),
                 ),
                 (


### PR DESCRIPTION
This PR improves completion relevance scoring for generic types, in cases where the types could unify. 

### Before

![pre-could-unify](https://user-images.githubusercontent.com/22216761/111338556-46d94e80-8634-11eb-9936-2b20eb9e6756.png)

### After

![post-could-unify](https://user-images.githubusercontent.com/22216761/111338598-4e005c80-8634-11eb-92e0-69c2c1cda6fc.png)

changelog feature improve completions