### PR TITLE
Handle `#[cfg]` on call arguments

### DIFF
--- a/crates/hir_ty/src/diagnostics/expr.rs
+++ b/crates/hir_ty/src/diagnostics/expr.rs
@@ -690,4 +690,27 @@ fn main() {
 "#,
         )
     }
+
+    #[test]
+    fn cfgd_out_call_arguments() {
+        check_diagnostics(
+            r#"
+struct C(#[cfg(FALSE)] ());
+impl C {
+    fn new() -> Self {
+        Self(
+            #[cfg(FALSE)]
+            (),
+        )
+    }
+
+    fn method(&self) {}
+}
+
+fn main() {
+    C::new().method(#[cfg(FALSE)] 0);
+}
+            "#,
+        );
+    }
 }


### PR DESCRIPTION
This resolved the issue reported in this comment: https://github.com/rust-analyzer/rust-analyzer/issues/5649#issuecomment-789424608

bors r+