### PR TITLE
Fix "unset `OUT_DIR`" diagnostic when using it in item position

### DIFF
--- a/crates/hir_def/src/nameres/collector.rs
+++ b/crates/hir_def/src/nameres/collector.rs
@@ -1469,7 +1469,9 @@ impl ModCollector<'_, '_> {
                     )
                 })
             },
-            &mut |err| error = Some(err),
+            &mut |err| {
+                error.get_or_insert(err);
+            },
         ) {
             Ok(Ok(macro_call_id)) => {
                 self.def_collector.unexpanded_macros.push(MacroDirective {

--- a/crates/hir_def/src/nameres/tests/diagnostics.rs
+++ b/crates/hir_def/src/nameres/tests/diagnostics.rs
@@ -200,3 +200,20 @@ fn builtin_macro_fails_expansion() {
         "#,
     );
 }
+
+#[test]
+fn good_out_dir_diagnostic() {
+    check_diagnostics(
+        r#"
+        #[rustc_builtin_macro]
+        macro_rules! include { () => {} }
+        #[rustc_builtin_macro]
+        macro_rules! env { () => {} }
+        #[rustc_builtin_macro]
+        macro_rules! concat { () => {} }
+
+        include!(concat!(env!("OUT_DIR"), "/out.rs"));
+      //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `OUT_DIR` not set, enable "load out dirs from check" to fix
+        "#,
+    );
+}


### PR DESCRIPTION
"load out dirs from check" is enabled by default now, but better late than never I guess.

bors r+