### PR TITLE
Store an `AstId` for procedural macros

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1144,12 +1144,15 @@ impl MacroDef {
 
     /// XXX: this parses the file
     pub fn name(self, db: &dyn HirDatabase) -> Option<Name> {
-        self.source(db)?.value.name().map(|it| it.as_name())
+        match self.source(db)?.value {
+            Either::Left(it) => it.name().map(|it| it.as_name()),
+            Either::Right(it) => it.name().map(|it| it.as_name()),
+        }
     }
 
     /// Indicate it is a proc-macro
     pub fn is_proc_macro(&self) -> bool {
-        matches!(self.id.kind, MacroDefKind::ProcMacro(_))
+        matches!(self.id.kind, MacroDefKind::ProcMacro(..))
     }
 
     /// Indicate it is a derive macro

--- a/crates/hir_def/src/item_scope.rs
+++ b/crates/hir_def/src/item_scope.rs
@@ -252,7 +252,7 @@ impl ItemScope {
             .for_each(|vis| *vis = Visibility::Module(this_module));
 
         for (mac, vis) in self.macros.values_mut() {
-            if let MacroDefKind::ProcMacro(_) = mac.kind {
+            if let MacroDefKind::ProcMacro(..) = mac.kind {
                 // FIXME: Technically this is insufficient since reexports of proc macros are also
                 // forbidden. Practically nobody does that.
                 continue;

--- a/crates/hir_expand/src/db.rs
+++ b/crates/hir_expand/src/db.rs
@@ -157,7 +157,7 @@ fn macro_def(db: &dyn AstDatabase, id: MacroDefId) -> Option<Arc<(TokenExpander,
             Some(Arc::new((TokenExpander::BuiltinDerive(expander), mbe::TokenMap::default())))
         }
         MacroDefKind::BuiltInEager(..) => None,
-        MacroDefKind::ProcMacro(expander) => {
+        MacroDefKind::ProcMacro(expander, ..) => {
             Some(Arc::new((TokenExpander::ProcMacro(expander), mbe::TokenMap::default())))
         }
     }
@@ -269,7 +269,7 @@ fn expand_proc_macro(
     };
 
     let expander = match loc.def.kind {
-        MacroDefKind::ProcMacro(expander) => expander,
+        MacroDefKind::ProcMacro(expander, ..) => expander,
         _ => unreachable!(),
     };
 

--- a/crates/hir_expand/src/eager.rs
+++ b/crates/hir_expand/src/eager.rs
@@ -209,7 +209,7 @@ fn eager_macro_recur(
             MacroDefKind::Declarative(_)
             | MacroDefKind::BuiltIn(..)
             | MacroDefKind::BuiltInDerive(..)
-            | MacroDefKind::ProcMacro(_) => {
+            | MacroDefKind::ProcMacro(..) => {
                 let res = lazy_expand(db, &def, curr.with_value(child.clone()), krate);
                 let val = diagnostic_sink.expand_result_option(res)?;
 

--- a/crates/hir_expand/src/hygiene.rs
+++ b/crates/hir_expand/src/hygiene.rs
@@ -182,7 +182,7 @@ impl HygieneFrame {
                         MacroDefKind::BuiltIn(..) => (info, Some(loc.def.krate), false),
                         MacroDefKind::BuiltInDerive(..) => (info, None, false),
                         MacroDefKind::BuiltInEager(..) => (info, None, false),
-                        MacroDefKind::ProcMacro(_) => (info, None, false),
+                        MacroDefKind::ProcMacro(..) => (info, None, false),
                     }
                 }
             },

--- a/crates/hir_expand/src/lib.rs
+++ b/crates/hir_expand/src/lib.rs
@@ -245,7 +245,7 @@ impl MacroDefId {
             MacroDefKind::BuiltIn(_, id) => id,
             MacroDefKind::BuiltInDerive(_, id) => id,
             MacroDefKind::BuiltInEager(_, id) => id,
-            MacroDefKind::ProcMacro(_) => return None,
+            MacroDefKind::ProcMacro(..) => return None,
         };
         Some(*id)
     }
@@ -258,7 +258,7 @@ pub enum MacroDefKind {
     // FIXME: maybe just Builtin and rename BuiltinFnLikeExpander to BuiltinExpander
     BuiltInDerive(BuiltinDeriveExpander, AstId<ast::Macro>),
     BuiltInEager(EagerExpander, AstId<ast::Macro>),
-    ProcMacro(ProcMacroExpander),
+    ProcMacro(ProcMacroExpander, AstId<ast::Fn>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/ide/src/display/navigation_target.rs
+++ b/crates/ide/src/display/navigation_target.rs
@@ -339,10 +339,14 @@ impl TryToNav for hir::Field {
 impl TryToNav for hir::MacroDef {
     fn try_to_nav(&self, db: &RootDatabase) -> Option<NavigationTarget> {
         let src = self.source(db)?;
-        log::debug!("nav target {:#?}", src.value.syntax());
+        let name_owner: &dyn ast::NameOwner = match &src.value {
+            Either::Left(it) => it,
+            Either::Right(it) => it,
+        };
+        log::debug!("nav target {:#?}", name_owner.syntax());
         let mut res = NavigationTarget::from_named(
             db,
-            src.as_ref().map(|it| it as &dyn ast::NameOwner),
+            src.as_ref().with_value(name_owner),
             SymbolKind::Macro,
         );
         res.docs = self.docs(db);

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -331,10 +331,16 @@ fn hover_for_definition(
 ) -> Option<Markup> {
     let mod_path = definition_mod_path(db, &def);
     return match def {
-        Definition::Macro(it) => {
-            let label = macro_label(&it.source(db)?.value);
-            from_def_source_labeled(db, it, Some(label), mod_path)
-        }
+        Definition::Macro(it) => match &it.source(db)?.value {
+            Either::Left(mac) => {
+                let label = macro_label(&mac);
+                from_def_source_labeled(db, it, Some(label), mod_path)
+            }
+            Either::Right(_) => {
+                // FIXME
+                None
+            }
+        },
         Definition::Field(def) => from_hir_fmt(db, def, mod_path),
         Definition::ModuleDef(it) => match it {
             ModuleDef::Module(it) => from_hir_fmt(db, it, mod_path),

--- a/crates/ide_completion/src/render/macro_.rs
+++ b/crates/ide_completion/src/render/macro_.rs
@@ -91,7 +91,7 @@ impl<'a> MacroRender<'a> {
     }
 
     fn detail(&self) -> Option<String> {
-        let ast_node = self.macro_.source(self.ctx.db())?.value;
+        let ast_node = self.macro_.source(self.ctx.db())?.value.left()?;
         Some(macro_label(&ast_node))
     }
 }


### PR DESCRIPTION
Point `HasSource` to the `ast::Fn`, and go to it in `TryToNav`.

bors r+