### PR TITLE
Fix handling of `#![cfg]` in outline module file

### DIFF
--- a/crates/hir_def/src/nameres/tests/mod_resolution.rs
+++ b/crates/hir_def/src/nameres/tests/mod_resolution.rs
@@ -819,3 +819,22 @@ pub mod hash { pub trait Hash {} }
         "#]],
     );
 }
+
+#[test]
+fn cfg_in_module_file() {
+    // Inner `#![cfg]` in a module file makes the whole module disappear.
+    check(
+        r#"
+//- /main.rs
+mod module;
+
+//- /module.rs
+#![cfg(NEVER)]
+
+struct AlsoShoulntAppear;
+        "#,
+        expect![[r#"
+            crate
+        "#]],
+    )
+}


### PR DESCRIPTION
bors r+