### PR TITLE
Remove WhereClause::Error

### DIFF
--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -731,16 +731,6 @@ fn write_bounds_like_dyn_trait(
                 }
                 ty.hir_fmt(f)?;
             }
-            WhereClause::Error => {
-                if angle_open {
-                    // impl Trait<X, {error}>
-                    write!(f, ", ")?;
-                } else if !first {
-                    // impl Trait + {error}
-                    write!(f, " + ")?;
-                }
-                p.hir_fmt(f)?;
-            }
         }
         first = false;
     }
@@ -796,7 +786,7 @@ impl HirDisplay for WhereClause {
                 )?;
                 ty.hir_fmt(f)?;
             }
-            WhereClause::AliasEq(_) | WhereClause::Error => write!(f, "{{error}}")?,
+            WhereClause::AliasEq(_) => write!(f, "{{error}}")?,
         }
         Ok(())
     }

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -569,16 +569,9 @@ pub enum WhereClause {
     Implemented(TraitRef),
     /// An associated type bindings like in `Iterator<Item = T>`.
     AliasEq(AliasEq),
-    /// We couldn't resolve the trait reference. (If some type parameters can't
-    /// be resolved, they will just be Unknown).
-    Error,
 }
 
 impl WhereClause {
-    pub fn is_error(&self) -> bool {
-        matches!(self, WhereClause::Error)
-    }
-
     pub fn is_implemented(&self) -> bool {
         matches!(self, WhereClause::Implemented(_))
     }
@@ -589,7 +582,7 @@ impl WhereClause {
             WhereClause::AliasEq(AliasEq { alias: AliasTy::Projection(proj), .. }) => {
                 Some(proj.trait_ref(db))
             }
-            WhereClause::AliasEq(_) | WhereClause::Error => None,
+            WhereClause::AliasEq(_) => None,
         }
     }
 }
@@ -599,7 +592,6 @@ impl TypeWalk for WhereClause {
         match self {
             WhereClause::Implemented(trait_ref) => trait_ref.walk(f),
             WhereClause::AliasEq(alias_eq) => alias_eq.walk(f),
-            WhereClause::Error => {}
         }
     }
 
@@ -611,7 +603,6 @@ impl TypeWalk for WhereClause {
         match self {
             WhereClause::Implemented(trait_ref) => trait_ref.walk_mut_binders(f, binders),
             WhereClause::AliasEq(alias_eq) => alias_eq.walk_mut_binders(f, binders),
-            WhereClause::Error => {}
         }
     }
 }

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -703,10 +703,10 @@ impl<'a> TyLoweringContext<'a> {
         let trait_ref = match bound {
             TypeBound::Path(path) => {
                 bindings = self.lower_trait_ref_from_path(path, Some(self_ty));
-                Some(bindings.clone().map_or(WhereClause::Error, WhereClause::Implemented))
+                bindings.clone().map(WhereClause::Implemented)
             }
             TypeBound::Lifetime(_) => None,
-            TypeBound::Error => Some(WhereClause::Error),
+            TypeBound::Error => None,
         };
         trait_ref.into_iter().chain(
             bindings
@@ -919,9 +919,6 @@ pub(crate) fn trait_environment_query(
     let mut clauses = Vec::new();
     for pred in resolver.where_predicates_in_scope() {
         for pred in ctx.lower_where_predicate(pred) {
-            if pred.is_error() {
-                continue;
-            }
             if let WhereClause::Implemented(tr) = &pred {
                 traits_in_scope.push((tr.self_type_parameter().clone(), tr.hir_trait_id()));
             }

--- a/crates/hir_ty/src/tests/traits.rs
+++ b/crates/hir_ty/src/tests/traits.rs
@@ -1412,8 +1412,8 @@ fn weird_bounds() {
             50..51 'b': impl
             69..70 'c': impl Trait
             86..87 'd': impl
-            107..108 'e': impl {error}
-            123..124 'f': impl Trait + {error}
+            107..108 'e': impl
+            123..124 'f': impl Trait
             147..149 '{}': ()
         "#]],
     );

--- a/crates/hir_ty/src/traits.rs
+++ b/crates/hir_ty/src/traits.rs
@@ -100,7 +100,6 @@ impl Obligation {
         match predicate {
             WhereClause::Implemented(trait_ref) => Some(Obligation::Trait(trait_ref)),
             WhereClause::AliasEq(alias_eq) => Some(Obligation::AliasEq(alias_eq)),
-            WhereClause::Error => None,
         }
     }
 }

--- a/crates/hir_ty/src/traits/chalk.rs
+++ b/crates/hir_ty/src/traits/chalk.rs
@@ -187,13 +187,7 @@ impl<'a> chalk_solve::RustIrDatabase<Interner> for ChalkContext<'a> {
                 let data = &datas.value.impl_traits[idx as usize];
                 let bound = OpaqueTyDatumBound {
                     bounds: make_binders(
-                        data.bounds
-                            .value
-                            .iter()
-                            .cloned()
-                            .filter(|b| !b.is_error())
-                            .map(|b| b.to_chalk(self.db))
-                            .collect(),
+                        data.bounds.value.iter().cloned().map(|b| b.to_chalk(self.db)).collect(),
                         1,
                     ),
                     where_clauses: make_binders(vec![], 0),

--- a/crates/hir_ty/src/traits/chalk/mapping.rs
+++ b/crates/hir_ty/src/traits/chalk/mapping.rs
@@ -98,7 +98,7 @@ impl ToChalk for Ty {
             TyKind::Dyn(predicates) => {
                 let where_clauses = chalk_ir::QuantifiedWhereClauses::from_iter(
                     &Interner,
-                    predicates.iter().filter(|p| !p.is_error()).cloned().map(|p| p.to_chalk(db)),
+                    predicates.iter().cloned().map(|p| p.to_chalk(db)),
                 );
                 let bounded_ty = chalk_ir::DynTy {
                     bounds: make_binders(where_clauses, 1),
@@ -318,7 +318,6 @@ impl ToChalk for WhereClause {
                 chalk_ir::WhereClause::AliasEq(alias_eq.to_chalk(db).shifted_in(&Interner)),
                 0,
             ),
-            WhereClause::Error => panic!("tried passing GenericPredicate::Error to Chalk"),
         }
     }
 
@@ -521,10 +520,6 @@ pub(super) fn convert_where_clauses(
     let generic_predicates = db.generic_predicates(def);
     let mut result = Vec::with_capacity(generic_predicates.len());
     for pred in generic_predicates.iter() {
-        if pred.value.is_error() {
-            // skip errored predicates completely
-            continue;
-        }
         result.push(pred.clone().subst(substs).to_chalk(db));
     }
     result


### PR DESCRIPTION
Chalk doesn't have it, and judging from the removed code, it wasn't useful anyway.