### PR TITLE
Do smart case fuzzy search during flyimports

### DIFF
--- a/crates/ide_assists/src/handlers/replace_derive_with_manual_impl.rs
+++ b/crates/ide_assists/src/handlers/replace_derive_with_manual_impl.rs
@@ -72,7 +72,6 @@ pub(crate) fn replace_derive_with_manual_impl(
         items_locator::AssocItemSearch::Exclude,
         Some(items_locator::DEFAULT_QUERY_SEARCH_LIMIT),
     )
-    .into_iter()
     .filter_map(|item| match ModuleDef::from(item.as_module_def_id()?) {
         ModuleDef::Trait(trait_) => Some(trait_),
         _ => None,

--- a/crates/ide_completion/src/lib.rs
+++ b/crates/ide_completion/src/lib.rs
@@ -161,7 +161,6 @@ pub fn resolve_completion_edits(
         items_locator::AssocItemSearch::Include,
         Some(items_locator::DEFAULT_QUERY_SEARCH_LIMIT),
     )
-    .into_iter()
     .filter_map(|candidate| {
         current_module
             .find_use_path_prefixed(db, candidate, config.insert_use.prefix_kind)

--- a/crates/ide_db/src/helpers/import_assets.rs
+++ b/crates/ide_db/src/helpers/import_assets.rs
@@ -267,7 +267,6 @@ fn path_applicable_imports(
                 AssocItemSearch::Exclude,
                 Some(DEFAULT_QUERY_SEARCH_LIMIT),
             )
-            .into_iter()
             .filter_map(|item| {
                 let mod_path = mod_path(item)?;
                 Some(LocatedImport::new(mod_path.clone(), item, item, Some(mod_path)))
@@ -285,7 +284,6 @@ fn path_applicable_imports(
                 AssocItemSearch::Include,
                 Some(DEFAULT_QUERY_SEARCH_LIMIT),
             )
-            .into_iter()
             .filter_map(|item| {
                 import_for_item(
                     sema.db,
@@ -430,7 +428,6 @@ fn trait_applicable_items(
         AssocItemSearch::AssocItemsOnly,
         Some(DEFAULT_QUERY_SEARCH_LIMIT),
     )
-    .into_iter()
     .filter_map(|input| item_as_assoc(db, input))
     .filter_map(|assoc| {
         let assoc_item_trait = assoc.containing_trait(db)?;

--- a/crates/ide_db/src/items_locator.rs
+++ b/crates/ide_db/src/items_locator.rs
@@ -40,7 +40,7 @@ pub fn items_with_name<'a>(
 ) -> impl Iterator<Item = ItemInNs> + 'a {
     let _p = profile::span("items_with_name").detail(|| {
         format!(
-            "Name: {} ({:?}), crate: {:?}, limit: {:?}",
+            "Name: {}, crate: {:?}, assoc items: {:?}, limit: {:?}",
             name.text(),
             assoc_item_search,
             krate.display_name(sema.db).map(|name| name.to_string()),

--- a/crates/ide_db/src/items_locator.rs
+++ b/crates/ide_db/src/items_locator.rs
@@ -15,7 +15,6 @@ use crate::{
     symbol_index::{self, FileSymbol},
     RootDatabase,
 };
-use rustc_hash::FxHashSet;
 
 /// A value to use, when uncertain which limit to pick.
 pub const DEFAULT_QUERY_SEARCH_LIMIT: usize = 40;
@@ -32,13 +31,13 @@ pub enum AssocItemSearch {
 }
 
 /// Searches for importable items with the given name in the crate and its dependencies.
-pub fn items_with_name(
-    sema: &Semantics<'_, RootDatabase>,
+pub fn items_with_name<'a>(
+    sema: &'a Semantics<'_, RootDatabase>,
     krate: Crate,
     name: NameToImport,
     assoc_item_search: AssocItemSearch,
     limit: Option<usize>,
-) -> FxHashSet<ItemInNs> {
+) -> impl Iterator<Item = ItemInNs> + 'a {
     let _p = profile::span("items_with_name").detail(|| {
         format!(
             "Name: {} ({:?}), crate: {:?}, limit: {:?}",
@@ -94,13 +93,13 @@ pub fn items_with_name(
     find_items(sema, krate, assoc_item_search, local_query, external_query)
 }
 
-fn find_items(
-    sema: &Semantics<'_, RootDatabase>,
+fn find_items<'a>(
+    sema: &'a Semantics<'_, RootDatabase>,
     krate: Crate,
     assoc_item_search: AssocItemSearch,
     local_query: symbol_index::Query,
     external_query: import_map::Query,
-) -> FxHashSet<ItemInNs> {
+) -> impl Iterator<Item = ItemInNs> + 'a {
     let _p = profile::span("find_items");
     let db = sema.db;
 
@@ -115,21 +114,18 @@ fn find_items(
     // Query the local crate using the symbol index.
     let local_results = symbol_index::crate_symbols(db, krate.into(), local_query)
         .into_iter()
-        .filter_map(|local_candidate| get_name_definition(sema, &local_candidate))
+        .filter_map(move |local_candidate| get_name_definition(sema, &local_candidate))
         .filter_map(|name_definition_to_import| match name_definition_to_import {
             Definition::ModuleDef(module_def) => Some(ItemInNs::from(module_def)),
             Definition::Macro(macro_def) => Some(ItemInNs::from(macro_def)),
             _ => None,
         });
 
-    external_importables
-        .chain(local_results)
-        .filter(move |&item| match assoc_item_search {
-            AssocItemSearch::Include => true,
-            AssocItemSearch::Exclude => !is_assoc_item(item, sema.db),
-            AssocItemSearch::AssocItemsOnly => is_assoc_item(item, sema.db),
-        })
-        .collect()
+    external_importables.chain(local_results).filter(move |&item| match assoc_item_search {
+        AssocItemSearch::Include => true,
+        AssocItemSearch::Exclude => !is_assoc_item(item, sema.db),
+        AssocItemSearch::AssocItemsOnly => is_assoc_item(item, sema.db),
+    })
 }
 
 fn get_name_definition(

--- a/crates/ide_db/src/items_locator.rs
+++ b/crates/ide_db/src/items_locator.rs
@@ -62,6 +62,8 @@ pub fn items_with_name(
             (local_query, external_query)
         }
         NameToImport::Fuzzy(fuzzy_search_string) => {
+            let mut local_query = symbol_index::Query::new(fuzzy_search_string.clone());
+
             let mut external_query = import_map::Query::new(fuzzy_search_string.clone())
                 .search_mode(import_map::SearchMode::Fuzzy)
                 .name_only();
@@ -75,7 +77,12 @@ pub fn items_with_name(
                 }
             }
 
-            (symbol_index::Query::new(fuzzy_search_string), external_query)
+            if fuzzy_search_string.to_lowercase() != fuzzy_search_string {
+                local_query.case_sensitive();
+                external_query = external_query.case_sensitive();
+            }
+
+            (local_query, external_query)
         }
     };
 

--- a/crates/ide_db/src/symbol_index.rs
+++ b/crates/ide_db/src/symbol_index.rs
@@ -52,6 +52,7 @@ pub struct Query {
     only_types: bool,
     libs: bool,
     exact: bool,
+    case_sensitive: bool,
     limit: usize,
 }
 
@@ -64,6 +65,7 @@ impl Query {
             only_types: false,
             libs: false,
             exact: false,
+            case_sensitive: false,
             limit: usize::max_value(),
         }
     }
@@ -78,6 +80,10 @@ impl Query {
 
     pub fn exact(&mut self) {
         self.exact = true;
+    }
+
+    pub fn case_sensitive(&mut self) {
+        self.case_sensitive = true;
     }
 
     pub fn limit(&mut self, limit: usize) {
@@ -326,8 +332,14 @@ impl Query {
                     if self.only_types && !symbol.kind.is_type() {
                         continue;
                     }
-                    if self.exact && symbol.name != self.query {
-                        continue;
+                    if self.exact {
+                        if symbol.name != self.query {
+                            continue;
+                        }
+                    } else if self.case_sensitive {
+                        if self.query.chars().any(|c| !symbol.name.contains(c)) {
+                            continue;
+                        }
                     }
 
                     res.push(symbol.clone());


### PR DESCRIPTION
For now, last actionable part of https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Fwg-rls-2.2E0/topic/autoimport.20weirdness

Should help https://github.com/rust-analyzer/rust-analyzer/issues/7902

Now during the flyimport completion, if the input is searched case-sensitively, if the input contains any non-lowercase letters; otherwise the lookup done as before, case-insensitively.