### PR TITLE
Add `'` to trigger_characters, allowing more direct lifetime completions

### DIFF
--- a/crates/ide_completion/src/completions/lifetime.rs
+++ b/crates/ide_completion/src/completions/lifetime.rs
@@ -70,6 +70,16 @@ fn func<'lifetime>(foo: &'li$0) {}
 fn func<'lifetime>(foo: &'lifetime) {}
 "#,
         );
+        cov_mark::check!(completes_if_lifetime_without_idents);
+        check_edit(
+            "'lifetime",
+            r#"
+fn func<'lifetime>(foo: &'$0) {}
+"#,
+            r#"
+fn func<'lifetime>(foo: &'lifetime) {}
+"#,
+        );
     }
 
     #[test]
@@ -188,6 +198,27 @@ fn foo<'footime, 'lifetime: 'a$0>() {}
             expect![[r#"
                 lt 'footime
             "#]],
+        );
+    }
+
+    #[test]
+    fn check_label_edit() {
+        check_edit(
+            "'label",
+            r#"
+fn foo() {
+    'label: loop {
+        break '$0
+    }
+}
+"#,
+            r#"
+fn foo() {
+    'label: loop {
+        break 'label
+    }
+}
+"#,
         );
     }
 

--- a/crates/ide_completion/src/context.rs
+++ b/crates/ide_completion/src/context.rs
@@ -255,6 +255,10 @@ impl<'a> CompletionContext<'a> {
         if kind == IDENT || kind == LIFETIME_IDENT || kind == UNDERSCORE || kind.is_keyword() {
             cov_mark::hit!(completes_if_prefix_is_keyword);
             self.original_token.text_range()
+        } else if kind == CHAR {
+            // assume we are completing a lifetime but the user has only typed the '
+            cov_mark::hit!(completes_if_lifetime_without_idents);
+            TextRange::at(self.original_token.text_range().start(), TextSize::from(1))
         } else {
             TextRange::empty(self.position.offset)
         }
@@ -471,7 +475,7 @@ impl<'a> CompletionContext<'a> {
         self.lifetime_syntax =
             find_node_at_offset(original_file, lifetime.syntax().text_range().start());
         if let Some(parent) = lifetime.syntax().parent() {
-            if parent.kind() == syntax::SyntaxKind::ERROR {
+            if parent.kind() == ERROR {
                 return;
             }
 

--- a/crates/rust-analyzer/src/caps.rs
+++ b/crates/rust-analyzer/src/caps.rs
@@ -33,7 +33,7 @@ pub fn server_capabilities(client_caps: &ClientCapabilities) -> ServerCapabiliti
         hover_provider: Some(HoverProviderCapability::Simple(true)),
         completion_provider: Some(CompletionOptions {
             resolve_provider: completions_resolve_provider(client_caps),
-            trigger_characters: Some(vec![":".to_string(), ".".to_string()]),
+            trigger_characters: Some(vec![":".to_string(), ".".to_string(), "'".to_string()]),
             all_commit_characters: None,
             completion_item: None,
             work_done_progress_options: WorkDoneProgressOptions { work_done_progress: None },


### PR DESCRIPTION
Fixes having to type a character after `'` to complete lifetimes and labels