### PR TITLE
temp disable broken ref match completions for struct fields/methods

### DIFF
--- a/crates/ide_completion/src/completions.rs
+++ b/crates/ide_completion/src/completions.rs
@@ -26,7 +26,7 @@ use crate::{
     render::{
         const_::render_const,
         enum_variant::render_variant,
-        function::render_fn,
+        function::{render_fn, render_method},
         macro_::render_macro,
         pattern::{render_struct_pat, render_variant_pat},
         render_field, render_resolution, render_tuple_field,
@@ -119,6 +119,17 @@ impl Completions {
         local_name: Option<String>,
     ) {
         if let Some(item) = render_fn(RenderContext::new(ctx), None, local_name, func) {
+            self.add(item)
+        }
+    }
+
+    pub(crate) fn add_method(
+        &mut self,
+        ctx: &CompletionContext,
+        func: hir::Function,
+        local_name: Option<String>,
+    ) {
+        if let Some(item) = render_method(RenderContext::new(ctx), None, local_name, func) {
             self.add(item)
         }
     }

--- a/crates/ide_completion/src/completions/dot.rs
+++ b/crates/ide_completion/src/completions/dot.rs
@@ -51,7 +51,7 @@ fn complete_methods(acc: &mut Completions, ctx: &CompletionContext, receiver: &T
                 && ctx.scope.module().map_or(true, |m| func.is_visible_from(ctx.db, m))
                 && seen_methods.insert(func.name(ctx.db))
             {
-                acc.add_function(ctx, func, None);
+                acc.add_method(ctx, func, None);
             }
             None::<()>
         });

--- a/crates/ide_completion/src/render.rs
+++ b/crates/ide_completion/src/render.rs
@@ -1315,4 +1315,42 @@ fn main() {
             "#]],
         )
     }
+
+    #[test]
+    fn struct_field_method_ref() {
+        check(
+            r#"
+struct Foo { bar: u32 }
+impl Foo { fn baz(&self) -> u32 { 0 } }
+
+fn foo(f: Foo) { let _: &u32 = f.b$0 }
+"#,
+            // FIXME
+            // Ideally we'd also suggest &f.bar and &f.baz() as exact
+            // type matches. See #8058.
+            expect![[r#"
+                [
+                    CompletionItem {
+                        label: "bar",
+                        source_range: 98..99,
+                        delete: 98..99,
+                        insert: "bar",
+                        kind: SymbolKind(
+                            Field,
+                        ),
+                        detail: "u32",
+                    },
+                    CompletionItem {
+                        label: "baz()",
+                        source_range: 98..99,
+                        delete: 98..99,
+                        insert: "baz()$0",
+                        kind: Method,
+                        lookup: "baz",
+                        detail: "fn(&self) -> u32",
+                    },
+                ]
+            "#]],
+        );
+    }
 }

--- a/crates/ide_completion/src/render.rs
+++ b/crates/ide_completion/src/render.rs
@@ -148,8 +148,10 @@ impl<'a> Render<'a> {
             ..CompletionRelevance::default()
         });
 
-        if let Some(ref_match) = compute_ref_match(self.ctx.completion, ty) {
-            item.ref_match(ref_match);
+        if let Some(_ref_match) = compute_ref_match(self.ctx.completion, ty) {
+            // FIXME
+            // For now we don't properly calculate the edits for ref match
+            // completions on struct fields, so we've disabled them. See #8058.
         }
 
         item.build()


### PR DESCRIPTION
This PR implements a temporary workaround for #8058 by disabling ref match completions for struct fields and methods. Disabling this doesn't break any existing functionality (that I am aware of) since these completions were broken.

I plan to keep working on a real fix for the underlying issue here, but I think a proper fix could take some time, so I'd prefer to quickly fix the bug to buy some more time to implement a better solution (which would ultimately allow re-enabling ref matches for struct fields and methods). 