### PR TITLE
Reexport PrefixKind to remove deps of hir for non-cli part of rust-analzyer crate

### DIFF
--- a/crates/ide_db/src/helpers/insert_use.rs
+++ b/crates/ide_db/src/helpers/insert_use.rs
@@ -14,10 +14,12 @@ use syntax::{
     AstToken, InsertPosition, NodeOrToken, SyntaxElement, SyntaxNode, SyntaxToken,
 };
 
+pub use hir::PrefixKind;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct InsertUseConfig {
     pub merge: Option<MergeBehavior>,
-    pub prefix_kind: hir::PrefixKind,
+    pub prefix_kind: PrefixKind,
     pub group: bool,
 }
 

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -10,10 +10,9 @@
 use std::{ffi::OsString, iter, path::PathBuf};
 
 use flycheck::FlycheckConfig;
-use hir::PrefixKind;
 use ide::{AssistConfig, CompletionConfig, DiagnosticsConfig, HoverConfig, InlayHintsConfig};
 use ide_db::helpers::{
-    insert_use::{InsertUseConfig, MergeBehavior},
+    insert_use::{InsertUseConfig, MergeBehavior, PrefixKind},
     SnippetCap,
 };
 use lsp_types::{ClientCapabilities, MarkupKind};

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -1073,9 +1073,11 @@ pub(crate) fn rename_error(err: RenameError) -> crate::LspError {
 mod tests {
     use std::sync::Arc;
 
-    use hir::PrefixKind;
     use ide::Analysis;
-    use ide_db::helpers::{insert_use::InsertUseConfig, SnippetCap};
+    use ide_db::helpers::{
+        insert_use::{InsertUseConfig, PrefixKind},
+        SnippetCap,
+    };
 
     use super::*;
 


### PR DESCRIPTION
Note that we still need hir for cli.

bors r+