### PR TITLE
Compute more mathematically well-rounded notion of transitive deps

### DIFF
--- a/crates/base_db/src/input.rs
+++ b/crates/base_db/src/input.rs
@@ -257,7 +257,8 @@ impl CrateGraph {
         self.arena.keys().copied()
     }
 
-    /// Returns an iterator over all transitive dependencies of the given crate.
+    /// Returns an iterator over all transitive dependencies of the given crate,
+    /// including the crate itself.
     pub fn transitive_deps(&self, of: CrateId) -> impl Iterator<Item = CrateId> + '_ {
         let mut worklist = vec![of];
         let mut deps = FxHashSet::default();
@@ -270,7 +271,6 @@ impl CrateGraph {
             worklist.extend(self[krate].dependencies.iter().map(|dep| dep.crate_id));
         }
 
-        deps.remove(&of);
         deps.into_iter()
     }
 

--- a/crates/base_db/src/input.rs
+++ b/crates/base_db/src/input.rs
@@ -276,10 +276,7 @@ impl CrateGraph {
 
     /// Returns all transitive reverse dependencies of the given crate,
     /// including the crate itself.
-    pub fn transitive_reverse_dependencies(
-        &self,
-        of: CrateId,
-    ) -> impl Iterator<Item = CrateId> + '_ {
+    pub fn transitive_rev_deps(&self, of: CrateId) -> impl Iterator<Item = CrateId> + '_ {
         let mut worklist = vec![of];
         let mut rev_deps = FxHashSet::default();
         rev_deps.insert(of);

--- a/crates/base_db/src/input.rs
+++ b/crates/base_db/src/input.rs
@@ -280,6 +280,7 @@ impl CrateGraph {
         let mut worklist = vec![of];
         let mut rev_deps = FxHashSet::default();
         rev_deps.insert(of);
+
         let mut inverted_graph = FxHashMap::<_, Vec<_>>::default();
         self.arena.iter().for_each(|(&krate, data)| {
             data.dependencies

--- a/crates/base_db/src/input.rs
+++ b/crates/base_db/src/input.rs
@@ -274,13 +274,15 @@ impl CrateGraph {
         deps.into_iter()
     }
 
-    /// Returns an iterator over all transitive reverse dependencies of the given crate.
+    /// Returns all transitive reverse dependencies of the given crate,
+    /// including the crate itself.
     pub fn transitive_reverse_dependencies(
         &self,
         of: CrateId,
     ) -> impl Iterator<Item = CrateId> + '_ {
         let mut worklist = vec![of];
         let mut rev_deps = FxHashSet::default();
+        rev_deps.insert(of);
         let mut inverted_graph = FxHashMap::<_, Vec<_>>::default();
         self.arena.iter().for_each(|(&krate, data)| {
             data.dependencies

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -154,11 +154,7 @@ impl Crate {
     }
 
     pub fn transitive_reverse_dependencies(self, db: &dyn HirDatabase) -> Vec<Crate> {
-        db.crate_graph()
-            .transitive_reverse_dependencies(self.id)
-            .into_iter()
-            .map(|id| Crate { id })
-            .collect()
+        db.crate_graph().transitive_rev_deps(self.id).into_iter().map(|id| Crate { id }).collect()
     }
 
     pub fn root_module(self, db: &dyn HirDatabase) -> Module {

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1572,8 +1572,7 @@ impl Impl {
     pub fn all_for_trait(db: &dyn HirDatabase, trait_: Trait) -> Vec<Impl> {
         let krate = trait_.module(db).krate();
         let mut all = Vec::new();
-        for Crate { id } in krate.transitive_reverse_dependencies(db).into_iter().chain(Some(krate))
-        {
+        for Crate { id } in krate.transitive_reverse_dependencies(db).into_iter() {
             let impls = db.trait_impls_in_crate(id);
             all.extend(impls.for_trait(trait_.id).map(Self::from))
         }

--- a/crates/ide_db/src/search.rs
+++ b/crates/ide_db/src/search.rs
@@ -245,9 +245,7 @@ impl Definition {
         }
 
         if let Some(Visibility::Public) = vis {
-            let source_root_id = db.file_source_root(file_id);
-            let source_root = db.source_root(source_root_id);
-            let mut res = source_root.iter().map(|id| (id, None)).collect::<FxHashMap<_, _>>();
+            let mut res = FxHashMap::default();
 
             let krate = module.krate();
             for rev_dep in krate.transitive_reverse_dependencies(db) {


### PR DESCRIPTION
By including the crate itself, we make the resulting set closed with
respect to `transitve_reveres_dependencies` operation, as it becomes a
proper transitive closure. This just feels more proper and mathy.

And, indeed, this actually allows us to simplify call sites somewhat.