### PR TITLE
Trim down IPC json size

### DIFF
--- a/crates/proc_macro_api/src/rpc.rs
+++ b/crates/proc_macro_api/src/rpc.rs
@@ -77,7 +77,11 @@ struct TokenIdDef(u32);
 #[derive(Serialize, Deserialize)]
 #[serde(remote = "Delimiter")]
 struct DelimiterDef {
-    #[serde(with = "TokenIdDef")]
+    #[serde(
+        with = "TokenIdDef",
+        default = "tt::TokenId::unspecified",
+        skip_serializing_if = "token_id_def::skip_if"
+    )]
     id: TokenId,
     #[serde(with = "DelimiterKindDef")]
     kind: DelimiterKind,
@@ -116,7 +120,11 @@ enum LeafDef {
 #[serde(remote = "Literal")]
 struct LiteralDef {
     text: SmolStr,
-    #[serde(with = "TokenIdDef")]
+    #[serde(
+        with = "TokenIdDef",
+        default = "tt::TokenId::unspecified",
+        skip_serializing_if = "token_id_def::skip_if"
+    )]
     id: TokenId,
 }
 
@@ -126,7 +134,11 @@ struct PunctDef {
     char: char,
     #[serde(with = "SpacingDef")]
     spacing: Spacing,
-    #[serde(with = "TokenIdDef")]
+    #[serde(
+        with = "TokenIdDef",
+        default = "tt::TokenId::unspecified",
+        skip_serializing_if = "token_id_def::skip_if"
+    )]
     id: TokenId,
 }
 
@@ -141,8 +153,18 @@ enum SpacingDef {
 #[serde(remote = "Ident")]
 struct IdentDef {
     text: SmolStr,
-    #[serde(with = "TokenIdDef")]
+    #[serde(
+        with = "TokenIdDef",
+        default = "tt::TokenId::unspecified",
+        skip_serializing_if = "token_id_def::skip_if"
+    )]
     id: TokenId,
+}
+
+mod token_id_def {
+    pub(super) fn skip_if(value: &tt::TokenId) -> bool {
+        *value == tt::TokenId::unspecified()
+    }
 }
 
 mod opt_delimiter_def {


### PR DESCRIPTION
This PR try to trim down the json of proc macro IPC by ignoring token id if it equals to `TokenId::unspecifed`. 

Test by following commands:
```bash
$ git clone https://github.com/gluon-lang/lsp-types.git  
$ cd lsp-types
$ export RA_LOG="proc_macro_api=debug"
$ rust-analyzer -q analysis-stats --load-output-dirs --with-proc-macro . 2> debug.log
$ cat debug.log | awk '/^\[DEBUG proc_macro_api::msg\] >/ {print substr($0,31)}' >expand.log
$ stat -c "%s" expand.log
```

Before: 37576726
After: 28551718

So it trimed down 25%.  

bors r+



