### PR TITLE
Fix missing command error with macros

### DIFF
--- a/crates/hir_expand/src/lib.rs
+++ b/crates/hir_expand/src/lib.rs
@@ -207,6 +207,13 @@ impl HirFileId {
         }
         false
     }
+
+    pub fn is_macro_file(&self) -> bool {
+        match self.0 {
+            HirFileIdRepr::MacroFile(_) => true,
+            HirFileIdRepr::FileId(_) => false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/hir_expand/src/lib.rs
+++ b/crates/hir_expand/src/lib.rs
@@ -207,13 +207,6 @@ impl HirFileId {
         }
         false
     }
-
-    pub fn is_macro_file(&self) -> bool {
-        match self.0 {
-            HirFileIdRepr::MacroFile(_) => true,
-            HirFileIdRepr::FileId(_) => false,
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/ide/src/annotations.rs
+++ b/crates/ide/src/annotations.rs
@@ -80,19 +80,19 @@ pub(crate) fn annotations(
         Either::Left(def) => {
             let node = match def {
                 hir::ModuleDef::Const(konst) => {
-                    konst.source(db).and_then(|node| range_and_position_of(&node))
+                    konst.source(db).and_then(|node| range_and_position_of(&node, file_id))
                 }
                 hir::ModuleDef::Trait(trait_) => {
-                    trait_.source(db).and_then(|node| range_and_position_of(&node))
+                    trait_.source(db).and_then(|node| range_and_position_of(&node, file_id))
                 }
                 hir::ModuleDef::Adt(hir::Adt::Struct(strukt)) => {
-                    strukt.source(db).and_then(|node| range_and_position_of(&node))
+                    strukt.source(db).and_then(|node| range_and_position_of(&node, file_id))
                 }
                 hir::ModuleDef::Adt(hir::Adt::Enum(enum_)) => {
-                    enum_.source(db).and_then(|node| range_and_position_of(&node))
+                    enum_.source(db).and_then(|node| range_and_position_of(&node, file_id))
                 }
                 hir::ModuleDef::Adt(hir::Adt::Union(union)) => {
-                    union.source(db).and_then(|node| range_and_position_of(&node))
+                    union.source(db).and_then(|node| range_and_position_of(&node, file_id))
                 }
                 _ => None,
             };
@@ -122,9 +122,10 @@ pub(crate) fn annotations(
 
             fn range_and_position_of<T: NameOwner>(
                 node: &InFile<T>,
+                file_id: FileId,
             ) -> Option<(TextSize, TextRange)> {
-                if node.file_id.is_macro_file() {
-                    // Macro generated files should not contain annotations.
+                if node.file_id != file_id.into() {
+                    // Node is outside the file we are adding annotations to (e.g. macros).
                     None
                 } else {
                     Some((

--- a/crates/ide/src/annotations.rs
+++ b/crates/ide/src/annotations.rs
@@ -1,5 +1,5 @@
 use either::Either;
-use hir::{HasSource, Semantics};
+use hir::{HasSource, InFile, Semantics};
 use ide_db::{
     base_db::{FileId, FilePosition, FileRange},
     helpers::visit_file_defs,
@@ -80,19 +80,19 @@ pub(crate) fn annotations(
         Either::Left(def) => {
             let node = match def {
                 hir::ModuleDef::Const(konst) => {
-                    konst.source(db).and_then(|node| range_and_position_of(&node.value))
+                    konst.source(db).and_then(|node| range_and_position_of(&node))
                 }
                 hir::ModuleDef::Trait(trait_) => {
-                    trait_.source(db).and_then(|node| range_and_position_of(&node.value))
+                    trait_.source(db).and_then(|node| range_and_position_of(&node))
                 }
                 hir::ModuleDef::Adt(hir::Adt::Struct(strukt)) => {
-                    strukt.source(db).and_then(|node| range_and_position_of(&node.value))
+                    strukt.source(db).and_then(|node| range_and_position_of(&node))
                 }
                 hir::ModuleDef::Adt(hir::Adt::Enum(enum_)) => {
-                    enum_.source(db).and_then(|node| range_and_position_of(&node.value))
+                    enum_.source(db).and_then(|node| range_and_position_of(&node))
                 }
                 hir::ModuleDef::Adt(hir::Adt::Union(union)) => {
-                    union.source(db).and_then(|node| range_and_position_of(&node.value))
+                    union.source(db).and_then(|node| range_and_position_of(&node))
                 }
                 _ => None,
             };
@@ -120,8 +120,18 @@ pub(crate) fn annotations(
                 });
             }
 
-            fn range_and_position_of(node: &dyn NameOwner) -> Option<(TextSize, TextRange)> {
-                Some((node.name()?.syntax().text_range().start(), node.syntax().text_range()))
+            fn range_and_position_of<T: NameOwner>(
+                node: &InFile<T>,
+            ) -> Option<(TextSize, TextRange)> {
+                if node.file_id.is_macro_file() {
+                    // Macro generated files should not contain annotations.
+                    None
+                } else {
+                    Some((
+                        node.value.name()?.syntax().text_range().start(),
+                        node.value.syntax().text_range(),
+                    ))
+                }
             }
         }
         Either::Right(_) => (),
@@ -961,6 +971,25 @@ mod tests {
 struct Foo;
 //- /lib.rs
 // this file comes last since `check` checks the first file only
+"#,
+            expect![[r#"
+                []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn test_no_annotations_macro_struct_def() {
+        check(
+            r#"
+//- /lib.rs
+macro_rules! m {
+    () => {
+        struct A {}
+    };
+}
+
+m!();
 "#,
             expect![[r#"
                 []


### PR DESCRIPTION
**Reproduction:**
1. Define a struct through a macro (can be via `macro_rules`, proc macro, or `include!()`).
2. !!MISSING: command!! annotation appears. Clicking on it results in an error message. No matter where the macro is called/defined, the annotation is always at the start of the file.
![image](https://user-images.githubusercontent.com/13722457/112268785-bce14500-8c34-11eb-9a23-bafd63ffd6ef.png)

**Cause:**
- For struct `A`, a `HasImpls` annotation is added just like for struct `B`. Unlike `B`, the file id for `A` is not the file we are adding annotations to but a macro file.
- The resolving step of the code lens does not succeed.

**Fix:**
- Check that the files match before computing offsets and adding `HasImpls`/`HasReferences` annotations.