### PR TITLE
Prefer adding `mod` declaration to lib.rs over file.rs in UnlinkedFile fix

### DIFF
--- a/crates/ide/src/diagnostics/unlinked_file.rs
+++ b/crates/ide/src/diagnostics/unlinked_file.rs
@@ -63,7 +63,7 @@ impl DiagnosticWithFix for UnlinkedFile {
         // - `$dir.rs` in the parent folder, where `$dir` is the directory containing `self.file_id`
         let parent = our_path.parent()?;
         let mut paths =
-            vec![parent.join("mod.rs")?, parent.join("main.rs")?, parent.join("lib.rs")?];
+            vec![parent.join("mod.rs")?, parent.join("lib.rs")?, parent.join("main.rs")?];
 
         // `submod/bla.rs` -> `submod.rs`
         if let Some(newmod) = (|| {


### PR DESCRIPTION
When there is a `lib.rs` and `main.rs` in one crate, one usually wants the `lib.rs` file to declare the modules.
bors r+