### PR TITLE
Don't mark unlinked file diagnostic as unused

### DIFF
--- a/crates/ide/src/diagnostics.rs
+++ b/crates/ide/src/diagnostics.rs
@@ -165,7 +165,6 @@ pub(crate) fn diagnostics(
                     sema.diagnostics_display_range(d.display_source()).range,
                     d.message(),
                 )
-                .with_unused(true)
                 .with_fix(d.fix(&sema))
                 .with_code(Some(d.code())),
             );


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/8215, at least on VS Code