### PR TITLE
Properly resolve intra doc links in hover and goto_definition

### DIFF
--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -1,5 +1,5 @@
 use either::Either;
-use hir::Semantics;
+use hir::{InFile, Semantics};
 use ide_db::{
     defs::{NameClass, NameRefClass},
     RootDatabase,
@@ -8,7 +8,7 @@ use syntax::{ast, match_ast, AstNode, AstToken, SyntaxKind::*, SyntaxToken, Toke
 
 use crate::{
     display::TryToNav,
-    doc_links::{doc_owner_to_def, extract_positioned_link_from_comment, resolve_doc_path_for_def},
+    doc_links::{doc_attributes, extract_definitions_from_markdown, resolve_doc_path_for_def},
     FilePosition, NavigationTarget, RangeInfo,
 };
 
@@ -30,11 +30,16 @@ pub(crate) fn goto_definition(
     let original_token = pick_best(file.token_at_offset(position.offset))?;
     let token = sema.descend_into_macros(original_token.clone());
     let parent = token.parent()?;
-    if let Some(comment) = ast::Comment::cast(token) {
-        let docs = doc_owner_to_def(&sema, &parent)?.docs(db)?;
+    if let Some(_) = ast::Comment::cast(token) {
+        let (attributes, def) = doc_attributes(&sema, &parent)?;
 
-        let (_, link, ns) = extract_positioned_link_from_comment(position.offset, &comment, docs)?;
-        let def = doc_owner_to_def(&sema, &parent)?;
+        let (docs, doc_mapping) = attributes.docs_with_rangemap(db)?;
+        let (_, link, ns) =
+            extract_definitions_from_markdown(docs.as_str()).into_iter().find(|(range, ..)| {
+                doc_mapping.map(range.clone()).map_or(false, |InFile { file_id, value: range }| {
+                    file_id == position.file_id.into() && range.contains(position.offset)
+                })
+            })?;
         let nav = resolve_doc_path_for_def(db, def, &link, ns)?.try_to_nav(db)?;
         return Some(RangeInfo::new(original_token.text_range(), vec![nav]));
     }

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -32,6 +32,7 @@ pub(crate) fn goto_definition(
     let parent = token.parent()?;
     if let Some(comment) = ast::Comment::cast(token) {
         let docs = doc_owner_to_def(&sema, &parent)?.docs(db)?;
+
         let (_, link, ns) = extract_positioned_link_from_comment(position.offset, &comment, docs)?;
         let def = doc_owner_to_def(&sema, &parent)?;
         let nav = resolve_doc_path_for_def(db, def, &link, ns)?.try_to_nav(db)?;

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_doctest.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_doctest.html
@@ -100,9 +100,17 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 <span class="brace">}</span>
 
 <span class="comment documentation">/// </span><span class="struct documentation intra_doc_link injected">[`Foo`](Foo)</span><span class="comment documentation"> is a struct</span>
-<span class="comment documentation">/// </span><span class="function documentation intra_doc_link injected">[`all_the_links`](all_the_links)</span><span class="comment documentation"> is this function</span>
+<span class="comment documentation">/// This function is &gt; </span><span class="function documentation intra_doc_link injected">[`all_the_links`](all_the_links)</span><span class="comment documentation"> &lt;</span>
 <span class="comment documentation">/// [`noop`](noop) is a macro below</span>
+<span class="comment documentation">/// </span><span class="struct documentation intra_doc_link injected">[`Item`]</span><span class="comment documentation"> is a struct in the module </span><span class="module documentation intra_doc_link injected">[`module`]</span>
+<span class="comment documentation">///</span>
+<span class="comment documentation">/// [`Item`]: module::Item</span>
+<span class="comment documentation">/// [mix_and_match]: ThisShouldntResolve</span>
 <span class="keyword">pub</span> <span class="keyword">fn</span> <span class="function declaration">all_the_links</span><span class="parenthesis">(</span><span class="parenthesis">)</span> <span class="brace">{</span><span class="brace">}</span>
+
+<span class="keyword">pub</span> <span class="keyword">mod</span> <span class="module declaration">module</span> <span class="brace">{</span>
+    <span class="keyword">pub</span> <span class="keyword">struct</span> <span class="struct declaration">Item</span><span class="semicolon">;</span>
+<span class="brace">}</span>
 
 <span class="comment documentation">/// ```</span>
 <span class="comment documentation">/// </span><span class="macro injected">noop!</span><span class="parenthesis injected">(</span><span class="numeric_literal injected">1</span><span class="parenthesis injected">)</span><span class="semicolon injected">;</span>

--- a/crates/ide/src/syntax_highlighting/tests.rs
+++ b/crates/ide/src/syntax_highlighting/tests.rs
@@ -544,9 +544,17 @@ impl Foo {
 }
 
 /// [`Foo`](Foo) is a struct
-/// [`all_the_links`](all_the_links) is this function
+/// This function is > [`all_the_links`](all_the_links) <
 /// [`noop`](noop) is a macro below
+/// [`Item`] is a struct in the module [`module`]
+///
+/// [`Item`]: module::Item
+/// [mix_and_match]: ThisShouldntResolve
 pub fn all_the_links() {}
+
+pub mod module {
+    pub struct Item;
+}
 
 /// ```
 /// noop!(1);

--- a/crates/ide_db/src/defs.rs
+++ b/crates/ide_db/src/defs.rs
@@ -79,6 +79,29 @@ impl Definition {
         };
         Some(name)
     }
+
+    pub fn docs(&self, db: &RootDatabase) -> Option<hir::Documentation> {
+        match self {
+            Definition::Macro(it) => it.docs(db),
+            Definition::Field(it) => it.docs(db),
+            Definition::ModuleDef(def) => match def {
+                hir::ModuleDef::Module(it) => it.docs(db),
+                hir::ModuleDef::Function(it) => it.docs(db),
+                hir::ModuleDef::Adt(def) => match def {
+                    hir::Adt::Struct(it) => it.docs(db),
+                    hir::Adt::Union(it) => it.docs(db),
+                    hir::Adt::Enum(it) => it.docs(db),
+                },
+                hir::ModuleDef::Variant(it) => it.docs(db),
+                hir::ModuleDef::Const(it) => it.docs(db),
+                hir::ModuleDef::Static(it) => it.docs(db),
+                hir::ModuleDef::Trait(it) => it.docs(db),
+                hir::ModuleDef::TypeAlias(it) => it.docs(db),
+                hir::ModuleDef::BuiltinType(_) => None,
+            },
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/crates/ide_db/src/defs.rs
+++ b/crates/ide_db/src/defs.rs
@@ -79,29 +79,6 @@ impl Definition {
         };
         Some(name)
     }
-
-    pub fn docs(&self, db: &RootDatabase) -> Option<hir::Documentation> {
-        match self {
-            Definition::Macro(it) => it.docs(db),
-            Definition::Field(it) => it.docs(db),
-            Definition::ModuleDef(def) => match def {
-                hir::ModuleDef::Module(it) => it.docs(db),
-                hir::ModuleDef::Function(it) => it.docs(db),
-                hir::ModuleDef::Adt(def) => match def {
-                    hir::Adt::Struct(it) => it.docs(db),
-                    hir::Adt::Union(it) => it.docs(db),
-                    hir::Adt::Enum(it) => it.docs(db),
-                },
-                hir::ModuleDef::Variant(it) => it.docs(db),
-                hir::ModuleDef::Const(it) => it.docs(db),
-                hir::ModuleDef::Static(it) => it.docs(db),
-                hir::ModuleDef::Trait(it) => it.docs(db),
-                hir::ModuleDef::TypeAlias(it) => it.docs(db),
-                hir::ModuleDef::BuiltinType(_) => None,
-            },
-            _ => None,
-        }
-    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Unfortunately involves a bit of weird workarounds due to pulldown_cmark's incorrect lifetimes on `BrokenLinkCallback`... I should probably open an issue there asking for the fixes to be pushed to a release since they already exist in the repo for quite some time it seems.

Fixes #8258, Fixes #8238