### PR TITLE
internal: ensure that runaway type-inference doesn't block the main loop

### DIFF
--- a/crates/hir_ty/src/infer/expr.rs
+++ b/crates/hir_ty/src/infer/expr.rs
@@ -119,6 +119,8 @@ impl<'a> InferenceContext<'a> {
     }
 
     fn infer_expr_inner(&mut self, tgt_expr: ExprId, expected: &Expectation) -> Ty {
+        self.db.check_canceled();
+
         let body = Arc::clone(&self.body); // avoid borrow checker problem
         let ty = match &body[tgt_expr] {
             Expr::Missing => self.err_ty(),


### PR DESCRIPTION
We have a bug where type-checking `per_query_memory_usage` takes a
couple of seconds. It also reveals another bug: our type inference is
not cancellable.