### PR TITLE
More accurately classify assoc. types in paths

### DIFF
--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -918,6 +918,21 @@ fn f() -> impl Iterator<Item$0 = u8> {}
     }
 
     #[test]
+    #[should_panic = "unresolved reference"]
+    fn unknown_assoc_ty() {
+        check(
+            r#"
+trait Iterator {
+    type Item;
+       //^^^^
+}
+
+fn f() -> impl Iterator<Invalid$0 = u8> {}
+            "#,
+        )
+    }
+
+    #[test]
     fn goto_def_for_assoc_ty_in_path_multiple() {
         check(
             r#"


### PR DESCRIPTION
Previously `Iterator<Whoops$0 = ()>` would go to the `Iterator` trait. This fixes that and correctly marks `Whoops` as unresolved.

bors r+