### PR TITLE
Improve rustc diagnostic mapping

### DIFF
--- a/crates/rust-analyzer/src/diagnostics/test_data/handles_macro_location.txt
+++ b/crates/rust-analyzer/src/diagnostics/test_data/handles_macro_location.txt
@@ -22,6 +22,94 @@
                 },
             },
             severity: Some(
+                Hint,
+            ),
+            code: Some(
+                String(
+                    "E0277",
+                ),
+            ),
+            code_description: Some(
+                CodeDescription {
+                    href: Url {
+                        scheme: "https",
+                        username: "",
+                        password: None,
+                        host: Some(
+                            Domain(
+                                "doc.rust-lang.org",
+                            ),
+                        ),
+                        port: None,
+                        path: "/error-index.html",
+                        query: None,
+                        fragment: Some(
+                            "E0277",
+                        ),
+                    },
+                },
+            ),
+            source: Some(
+                "rustc",
+            ),
+            message: "can\'t compare `{integer}` with `&str`\nthe trait `std::cmp::PartialEq<&str>` is not implemented for `{integer}`",
+            related_information: Some(
+                [
+                    DiagnosticRelatedInformation {
+                        location: Location {
+                            uri: Url {
+                                scheme: "file",
+                                username: "",
+                                password: None,
+                                host: None,
+                                port: None,
+                                path: "/test/%3C::core::macros::assert_eq%20macros%3E",
+                                query: None,
+                                fragment: None,
+                            },
+                            range: Range {
+                                start: Position {
+                                    line: 6,
+                                    character: 30,
+                                },
+                                end: Position {
+                                    line: 6,
+                                    character: 32,
+                                },
+                            },
+                        },
+                        message: "Exact error occurred here",
+                    },
+                ],
+            ),
+            tags: None,
+            data: None,
+        },
+        fixes: [],
+    },
+    MappedRustDiagnostic {
+        url: Url {
+            scheme: "file",
+            username: "",
+            password: None,
+            host: None,
+            port: None,
+            path: "/test/%3C::core::macros::assert_eq%20macros%3E",
+            query: None,
+            fragment: None,
+        },
+        diagnostic: Diagnostic {
+            range: Range {
+                start: Position {
+                    line: 6,
+                    character: 30,
+                },
+                end: Position {
+                    line: 6,
+                    character: 32,
+                },
+            },
+            severity: Some(
                 Error,
             ),
             code: Some(
@@ -53,7 +141,35 @@
                 "rustc",
             ),
             message: "can\'t compare `{integer}` with `&str`\nthe trait `std::cmp::PartialEq<&str>` is not implemented for `{integer}`",
-            related_information: None,
+            related_information: Some(
+                [
+                    DiagnosticRelatedInformation {
+                        location: Location {
+                            uri: Url {
+                                scheme: "file",
+                                username: "",
+                                password: None,
+                                host: None,
+                                port: None,
+                                path: "/test/src/main.rs",
+                                query: None,
+                                fragment: None,
+                            },
+                            range: Range {
+                                start: Position {
+                                    line: 1,
+                                    character: 4,
+                                },
+                                end: Position {
+                                    line: 1,
+                                    character: 26,
+                                },
+                            },
+                        },
+                        message: "Error originated from macro call here",
+                    },
+                ],
+            ),
             tags: None,
             data: None,
         },

--- a/crates/rust-analyzer/src/diagnostics/test_data/handles_macro_location.txt
+++ b/crates/rust-analyzer/src/diagnostics/test_data/handles_macro_location.txt
@@ -22,94 +22,6 @@
                 },
             },
             severity: Some(
-                Hint,
-            ),
-            code: Some(
-                String(
-                    "E0277",
-                ),
-            ),
-            code_description: Some(
-                CodeDescription {
-                    href: Url {
-                        scheme: "https",
-                        username: "",
-                        password: None,
-                        host: Some(
-                            Domain(
-                                "doc.rust-lang.org",
-                            ),
-                        ),
-                        port: None,
-                        path: "/error-index.html",
-                        query: None,
-                        fragment: Some(
-                            "E0277",
-                        ),
-                    },
-                },
-            ),
-            source: Some(
-                "rustc",
-            ),
-            message: "can\'t compare `{integer}` with `&str`\nthe trait `std::cmp::PartialEq<&str>` is not implemented for `{integer}`",
-            related_information: Some(
-                [
-                    DiagnosticRelatedInformation {
-                        location: Location {
-                            uri: Url {
-                                scheme: "file",
-                                username: "",
-                                password: None,
-                                host: None,
-                                port: None,
-                                path: "/test/%3C::core::macros::assert_eq%20macros%3E",
-                                query: None,
-                                fragment: None,
-                            },
-                            range: Range {
-                                start: Position {
-                                    line: 6,
-                                    character: 30,
-                                },
-                                end: Position {
-                                    line: 6,
-                                    character: 32,
-                                },
-                            },
-                        },
-                        message: "Exact error occurred here",
-                    },
-                ],
-            ),
-            tags: None,
-            data: None,
-        },
-        fixes: [],
-    },
-    MappedRustDiagnostic {
-        url: Url {
-            scheme: "file",
-            username: "",
-            password: None,
-            host: None,
-            port: None,
-            path: "/test/%3C::core::macros::assert_eq%20macros%3E",
-            query: None,
-            fragment: None,
-        },
-        diagnostic: Diagnostic {
-            range: Range {
-                start: Position {
-                    line: 6,
-                    character: 30,
-                },
-                end: Position {
-                    line: 6,
-                    character: 32,
-                },
-            },
-            severity: Some(
                 Error,
             ),
             code: Some(
@@ -141,35 +53,7 @@
                 "rustc",
             ),
             message: "can\'t compare `{integer}` with `&str`\nthe trait `std::cmp::PartialEq<&str>` is not implemented for `{integer}`",
-            related_information: Some(
-                [
-                    DiagnosticRelatedInformation {
-                        location: Location {
-                            uri: Url {
-                                scheme: "file",
-                                username: "",
-                                password: None,
-                                host: None,
-                                port: None,
-                                path: "/test/src/main.rs",
-                                query: None,
-                                fragment: None,
-                            },
-                            range: Range {
-                                start: Position {
-                                    line: 1,
-                                    character: 4,
-                                },
-                                end: Position {
-                                    line: 1,
-                                    character: 26,
-                                },
-                            },
-                        },
-                        message: "Error originated from macro call here",
-                    },
-                ],
-            ),
+            related_information: None,
             tags: None,
             data: None,
         },

--- a/crates/rust-analyzer/src/diagnostics/test_data/macro_compiler_error.txt
+++ b/crates/rust-analyzer/src/diagnostics/test_data/macro_compiler_error.txt
@@ -13,16 +13,16 @@
         diagnostic: Diagnostic {
             range: Range {
                 start: Position {
-                    line: 264,
+                    line: 271,
                     character: 8,
                 },
                 end: Position {
-                    line: 264,
-                    character: 76,
+                    line: 271,
+                    character: 50,
                 },
             },
             severity: Some(
-                Error,
+                Hint,
             ),
             code: None,
             code_description: None,
@@ -40,18 +40,18 @@
                                 password: None,
                                 host: None,
                                 port: None,
-                                path: "/test/crates/hir_def/src/data.rs",
+                                path: "/test/crates/hir_def/src/path.rs",
                                 query: None,
                                 fragment: None,
                             },
                             range: Range {
                                 start: Position {
-                                    line: 79,
-                                    character: 15,
+                                    line: 264,
+                                    character: 8,
                                 },
                                 end: Position {
-                                    line: 79,
-                                    character: 41,
+                                    line: 264,
+                                    character: 76,
                                 },
                             },
                         },
@@ -87,6 +87,71 @@
                 },
             },
             severity: Some(
+                Hint,
+            ),
+            code: None,
+            code_description: None,
+            source: Some(
+                "rustc",
+            ),
+            message: "Please register your known path in the path module",
+            related_information: Some(
+                [
+                    DiagnosticRelatedInformation {
+                        location: Location {
+                            uri: Url {
+                                scheme: "file",
+                                username: "",
+                                password: None,
+                                host: None,
+                                port: None,
+                                path: "/test/crates/hir_def/src/path.rs",
+                                query: None,
+                                fragment: None,
+                            },
+                            range: Range {
+                                start: Position {
+                                    line: 264,
+                                    character: 8,
+                                },
+                                end: Position {
+                                    line: 264,
+                                    character: 76,
+                                },
+                            },
+                        },
+                        message: "Exact error occurred here",
+                    },
+                ],
+            ),
+            tags: None,
+            data: None,
+        },
+        fixes: [],
+    },
+    MappedRustDiagnostic {
+        url: Url {
+            scheme: "file",
+            username: "",
+            password: None,
+            host: None,
+            port: None,
+            path: "/test/crates/hir_def/src/path.rs",
+            query: None,
+            fragment: None,
+        },
+        diagnostic: Diagnostic {
+            range: Range {
+                start: Position {
+                    line: 264,
+                    character: 8,
+                },
+                end: Position {
+                    line: 264,
+                    character: 76,
+                },
+            },
+            severity: Some(
                 Error,
             ),
             code: None,
@@ -95,7 +160,60 @@
                 "rustc",
             ),
             message: "Please register your known path in the path module",
-            related_information: None,
+            related_information: Some(
+                [
+                    DiagnosticRelatedInformation {
+                        location: Location {
+                            uri: Url {
+                                scheme: "file",
+                                username: "",
+                                password: None,
+                                host: None,
+                                port: None,
+                                path: "/test/crates/hir_def/src/path.rs",
+                                query: None,
+                                fragment: None,
+                            },
+                            range: Range {
+                                start: Position {
+                                    line: 271,
+                                    character: 8,
+                                },
+                                end: Position {
+                                    line: 271,
+                                    character: 50,
+                                },
+                            },
+                        },
+                        message: "Error originated from macro call here",
+                    },
+                    DiagnosticRelatedInformation {
+                        location: Location {
+                            uri: Url {
+                                scheme: "file",
+                                username: "",
+                                password: None,
+                                host: None,
+                                port: None,
+                                path: "/test/crates/hir_def/src/data.rs",
+                                query: None,
+                                fragment: None,
+                            },
+                            range: Range {
+                                start: Position {
+                                    line: 79,
+                                    character: 15,
+                                },
+                                end: Position {
+                                    line: 79,
+                                    character: 41,
+                                },
+                            },
+                        },
+                        message: "Error originated from macro call here",
+                    },
+                ],
+            ),
             tags: None,
             data: None,
         },


### PR DESCRIPTION
Try to mirror rustc diagnostics more closely by:

* Emitting hint-level diagnostics at *all* macro invocation sites that caused the diagnostic
  * Previously we emitted a copy of the diagnostic (not at hint level) at the last macro invocation site only
* Emitting the original diagnostic inside the macro, if it was caused by a macro
* Always including related information pointing to the invocation site or the macro, respectively (the old code contained a bug that would sometimes omit it)

Fixes https://github.com/rust-analyzer/rust-analyzer/issues/8260


![screenshot-2021-03-30-19:34:56](https://user-images.githubusercontent.com/1786438/113031484-1266a600-918f-11eb-9164-fed01c8ba37e.png)
![screenshot-2021-03-30-19:35:10](https://user-images.githubusercontent.com/1786438/113031486-12ff3c80-918f-11eb-8f15-9d7f23b69653.png)
