### PR TITLE
Adding a few more gifs and screenshots for features in manual

### DIFF
--- a/crates/ide/src/syntax_highlighting.rs
+++ b/crates/ide/src/syntax_highlighting.rs
@@ -48,6 +48,8 @@ pub struct HlRange {
 //
 // The general rule is that a reference to an entity gets colored the same way as the entity itself.
 // We also give special modifier for `mut` and `&mut` local variables.
+//
+// image::https://user-images.githubusercontent.com/48062697/113164457-06cfb980-9239-11eb-819b-0f93e646acf8.png[]
 pub(crate) fn highlight(
     db: &RootDatabase,
     file_id: FileId,

--- a/crates/ide/src/syntax_highlighting.rs
+++ b/crates/ide/src/syntax_highlighting.rs
@@ -50,6 +50,7 @@ pub struct HlRange {
 // We also give special modifier for `mut` and `&mut` local variables.
 //
 // image::https://user-images.githubusercontent.com/48062697/113164457-06cfb980-9239-11eb-819b-0f93e646acf8.png[]
+// image::https://user-images.githubusercontent.com/48062697/113187625-f7f50100-9250-11eb-825e-91c58f236071.png[]
 pub(crate) fn highlight(
     db: &RootDatabase,
     file_id: FileId,

--- a/crates/ide/src/typing.rs
+++ b/crates/ide/src/typing.rs
@@ -51,6 +51,7 @@ pub(crate) const TRIGGER_CHARS: &str = ".=>";
 // ----
 //
 // image::https://user-images.githubusercontent.com/48062697/113166163-69758500-923a-11eb-81ee-eb33ec380399.gif[]
+// image::https://user-images.githubusercontent.com/48062697/113171066-105c2000-923f-11eb-87ab-f4a263346567.gif[]
 pub(crate) fn on_char_typed(
     db: &RootDatabase,
     position: FilePosition,

--- a/crates/ide/src/typing.rs
+++ b/crates/ide/src/typing.rs
@@ -49,6 +49,8 @@ pub(crate) const TRIGGER_CHARS: &str = ".=>";
 // ----
 // "editor.formatOnType": true,
 // ----
+//
+// image::https://user-images.githubusercontent.com/48062697/113166163-69758500-923a-11eb-81ee-eb33ec380399.gif[]
 pub(crate) fn on_char_typed(
     db: &RootDatabase,
     position: FilePosition,


### PR DESCRIPTION
Related  #8267,#6539. Gifs are [here](https://github.com/rust-analyzer/rust-analyzer/issues/6539#issuecomment-809574840)

Finishing up the last PR,  for the last two features that didn't have a visual example. 

For syntax highlighting, I wasn't able to find a theme that displayed the difference between an enum and struct, but I only tried a few apart from the default so there could be one out there! 

e.g., with the default light theme, `Ord` and `Ordering` in `use std::cmp::{Ord, Ordering}` had the same highlight colour. So I just went with displaying `mut` items being underlined.
