### PR TITLE
Stop using an upgradeable read lock in interning

### DIFF
--- a/crates/hir_def/src/intern.rs
+++ b/crates/hir_def/src/intern.rs
@@ -25,7 +25,7 @@ impl<T: Internable> Interned<T> {
         let storage = T::storage().get();
         let shard_idx = storage.determine_map(&obj);
         let shard = &storage.shards()[shard_idx];
-        let shard = shard.upgradeable_read();
+        let mut shard = shard.write();
 
         // Atomically,
         // - check if `obj` is already in the map
@@ -43,10 +43,7 @@ impl<T: Internable> Interned<T> {
         let arc = Arc::new(obj);
         let arc2 = arc.clone();
 
-        {
-            let mut shard = shard.upgrade();
-            shard.insert(arc2, SharedValue::new(()));
-        }
+        shard.insert(arc2, SharedValue::new(()));
 
         Self { arc }
     }


### PR DESCRIPTION
Only one upgradeable read lock can be handed out at the same time, and
we never acquire a non-upgradeable read lock, so this has no benefit
over just using a write lock in the first place.

bors r+