### PR TITLE
Allow multiple modules from the same crate in fixtures

### DIFF
--- a/crates/base_db/src/fixture.rs
+++ b/crates/base_db/src/fixture.rs
@@ -177,15 +177,20 @@ impl ChangeFixture {
                 let crate_name = CrateName::normalize_dashes(&krate);
                 match crates.entry(crate_name.clone()) {
                     Entry::Occupied(_) => {
-                        assert_eq!(
-                            crate_deps,
-                            meta.deps
-                                .iter()
-                                .map(|dep| (crate_name.clone(), CrateName::normalize_dashes(dep)))
-                                .collect::<Vec<_>>(),
-                            "Crate {} has two modules with different dependencies in metadata",
-                            krate,
-                        )
+                        if !meta.deps.is_empty() {
+                            assert_eq!(
+                                crate_deps,
+                                meta.deps
+                                    .iter()
+                                    .map(|dep| (
+                                        crate_name.clone(),
+                                        CrateName::normalize_dashes(dep)
+                                    ))
+                                    .collect::<Vec<_>>(),
+                                "Crate {} has two modules with different dependencies in metadata",
+                                krate,
+                            )
+                        }
                     }
                     Entry::Vacant(v) => {
                         let new_crate_id = crate_graph.add_crate_root(

--- a/crates/ide_assists/src/handlers/auto_import.rs
+++ b/crates/ide_assists/src/handlers/auto_import.rs
@@ -920,7 +920,7 @@ fn main() {
 //- /lib.rs crate:dep
 pub mod formatters;
 
-//- /formatters.rs crate:dep
+//- /formatters.rs
 pub struct FMT;
 pub struct fmt;
 

--- a/crates/ide_assists/src/handlers/auto_import.rs
+++ b/crates/ide_assists/src/handlers/auto_import.rs
@@ -918,6 +918,9 @@ fn main() {
             auto_import,
             r"
 //- /lib.rs crate:dep
+pub mod formatters;
+
+//- /formatters.rs crate:dep
 pub struct FMT;
 pub struct fmt;
 
@@ -926,7 +929,7 @@ fn main() {
     FMT$0;
 }
 ",
-            r"use dep::FMT;
+            r"use dep::formatters::FMT;
 
 fn main() {
     FMT;


### PR DESCRIPTION
A tiny step towards https://github.com/rust-analyzer/rust-analyzer/issues/6633

As discussed in [Zulip](https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Fwg-rls-2.2E0/topic/Completion.20benchmarks), we would need to have a generated code for the completions benchmark.
To better represent a real project, we'd better allow to specify multiple modules in a crate within a single fixture.