### PR TITLE
Introduce `GenericArg` like in Chalk

### DIFF
--- a/crates/hir_ty/src/autoderef.rs
+++ b/crates/hir_ty/src/autoderef.rs
@@ -131,7 +131,7 @@ fn deref_by_trait(
             // new variables in that case
 
             for i in 1..vars.0.binders.len(&Interner) {
-                if vars.0.value[i - 1].interned(&Interner)
+                if vars.0.value.at(&Interner, i - 1).assert_ty_ref(&Interner).interned(&Interner)
                     != &TyKind::BoundVar(BoundVar::new(DebruijnIndex::INNERMOST, i - 1))
                 {
                     warn!("complex solution for derefing {:?}: {:?}, ignoring", ty.goal, solution);
@@ -139,7 +139,12 @@ fn deref_by_trait(
                 }
             }
             Some(Canonical {
-                value: vars.0.value[vars.0.value.len() - 1].clone(),
+                value: vars
+                    .0
+                    .value
+                    .at(&Interner, vars.0.value.len(&Interner) - 1)
+                    .assert_ty_ref(&Interner)
+                    .clone(),
                 binders: vars.0.binders.clone(),
             })
         }

--- a/crates/hir_ty/src/chalk_cast.rs
+++ b/crates/hir_ty/src/chalk_cast.rs
@@ -5,7 +5,7 @@ use chalk_ir::{
     interner::HasInterner,
 };
 
-use crate::{AliasEq, DomainGoal, Interner, TraitRef, WhereClause};
+use crate::{AliasEq, DomainGoal, GenericArg, GenericArgData, Interner, TraitRef, Ty, WhereClause};
 
 macro_rules! has_interner {
     ($t:ty) => {
@@ -17,6 +17,8 @@ macro_rules! has_interner {
 
 has_interner!(WhereClause);
 has_interner!(DomainGoal);
+has_interner!(GenericArg);
+has_interner!(Ty);
 
 impl CastTo<WhereClause> for TraitRef {
     fn cast_to(self, _interner: &Interner) -> WhereClause {
@@ -36,6 +38,12 @@ impl CastTo<DomainGoal> for WhereClause {
     }
 }
 
+impl CastTo<GenericArg> for Ty {
+    fn cast_to(self, interner: &Interner) -> GenericArg {
+        GenericArg::new(interner, GenericArgData::Ty(self))
+    }
+}
+
 macro_rules! transitive_impl {
     ($a:ty, $b:ty, $c:ty) => {
         impl CastTo<$c> for $a {
@@ -51,3 +59,15 @@ macro_rules! transitive_impl {
 
 transitive_impl!(TraitRef, WhereClause, DomainGoal);
 transitive_impl!(AliasEq, WhereClause, DomainGoal);
+
+macro_rules! reflexive_impl {
+    ($a:ty) => {
+        impl CastTo<$a> for $a {
+            fn cast_to(self, _interner: &Interner) -> $a {
+                self
+            }
+        }
+    };
+}
+
+reflexive_impl!(GenericArg);

--- a/crates/hir_ty/src/diagnostics/expr.rs
+++ b/crates/hir_ty/src/diagnostics/expr.rs
@@ -392,7 +392,9 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
             _ => return,
         };
 
-        if params.len() > 0 && params[0] == mismatch.actual {
+        if params.len(&Interner) > 0
+            && params.at(&Interner, 0).ty(&Interner) == Some(&mismatch.actual)
+        {
             let (_, source_map) = db.body_with_source_map(self.owner);
 
             if let Ok(source_ptr) = source_map.expr_syntax(id) {

--- a/crates/hir_ty/src/diagnostics/match_check.rs
+++ b/crates/hir_ty/src/diagnostics/match_check.rs
@@ -792,7 +792,10 @@ fn pat_constructor(cx: &MatchCheckCtx, pat: PatIdOrWild) -> MatchCheckResult<Opt
         Pat::Tuple { .. } => {
             let pat_id = pat.as_id().expect("we already know this pattern is not a wild");
             Some(Constructor::Tuple {
-                arity: cx.infer.type_of_pat[pat_id].as_tuple().ok_or(MatchCheckErr::Unknown)?.len(),
+                arity: cx.infer.type_of_pat[pat_id]
+                    .as_tuple()
+                    .ok_or(MatchCheckErr::Unknown)?
+                    .len(&Interner),
             })
         }
         Pat::Lit(lit_expr) => match cx.body.exprs[lit_expr] {

--- a/crates/hir_ty/src/infer/coerce.rs
+++ b/crates/hir_ty/src/infer/coerce.rs
@@ -100,7 +100,7 @@ impl<'a> InferenceContext<'a> {
             },
 
             (TyKind::Closure(.., substs), TyKind::Function { .. }) => {
-                from_ty = substs[0].clone();
+                from_ty = substs.at(&Interner, 0).assert_ty_ref(&Interner).clone();
             }
 
             _ => {}

--- a/crates/hir_ty/src/infer/path.rs
+++ b/crates/hir_ty/src/infer/path.rs
@@ -97,12 +97,12 @@ impl<'a> InferenceContext<'a> {
 
         let ty = self.db.value_ty(typable);
         // self_subst is just for the parent
-        let parent_substs = self_subst.unwrap_or_else(Substitution::empty);
+        let parent_substs = self_subst.unwrap_or_else(|| Substitution::empty(&Interner));
         let ctx = crate::lower::TyLoweringContext::new(self.db, &self.resolver);
         let substs = ctx.substs_from_path(path, typable, true);
-        let full_substs = Substitution::builder(substs.len())
+        let full_substs = Substitution::builder(substs.len(&Interner))
             .use_parent_substs(&parent_substs)
-            .fill(substs.0[parent_substs.len()..].iter().cloned())
+            .fill(substs.interned(&Interner)[parent_substs.len(&Interner)..].iter().cloned())
             .build();
         let ty = ty.subst(&full_substs);
         Some(ty)

--- a/crates/hir_ty/src/method_resolution.rs
+++ b/crates/hir_ty/src/method_resolution.rs
@@ -720,7 +720,7 @@ pub(crate) fn inherent_impl_substs(
             chalk_ir::VariableKind::Ty(chalk_ir::TyVariableKind::General),
             UniverseIndex::ROOT,
         ))
-        .take(vars.len()),
+        .take(vars.len(&Interner)),
     );
     let tys = Canonical {
         binders: CanonicalVarKinds::from_iter(&Interner, kinds),
@@ -732,7 +732,8 @@ pub(crate) fn inherent_impl_substs(
     // Unknown. I think this can only really happen if self_ty contained
     // Unknown, and in that case we want the result to contain Unknown in those
     // places again.
-    substs.map(|s| fallback_bound_vars(s.suffix(vars.len()), self_ty.binders.len(&Interner)))
+    substs
+        .map(|s| fallback_bound_vars(s.suffix(vars.len(&Interner)), self_ty.binders.len(&Interner)))
 }
 
 /// This replaces any 'free' Bound vars in `s` (i.e. those with indices past
@@ -821,7 +822,7 @@ fn generic_implements_goal(
             chalk_ir::VariableKind::Ty(chalk_ir::TyVariableKind::General),
             UniverseIndex::ROOT,
         ))
-        .take(substs.len() - 1),
+        .take(substs.len(&Interner) - 1),
     );
     let trait_ref = TraitRef { trait_id: to_chalk_trait_id(trait_), substitution: substs };
     let obligation = trait_ref.cast(&Interner);

--- a/crates/hir_ty/src/traits.rs
+++ b/crates/hir_ty/src/traits.rs
@@ -138,7 +138,7 @@ pub(crate) fn trait_solve_query(
         ..
     })) = &goal.value.goal
     {
-        if let TyKind::BoundVar(_) = &projection_ty.substitution[0].interned(&Interner) {
+        if let TyKind::BoundVar(_) = projection_ty.self_type_parameter().interned(&Interner) {
             // Hack: don't ask Chalk to normalize with an unknown self type, it'll say that's impossible
             return Some(Solution::Ambig(Guidance::Unknown));
         }

--- a/crates/hir_ty/src/traits/chalk.rs
+++ b/crates/hir_ty/src/traits/chalk.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use log::debug;
 
-use chalk_ir::{fold::shift::Shift, CanonicalVarKinds, GenericArg};
+use chalk_ir::{fold::shift::Shift, CanonicalVarKinds};
 use chalk_solve::rust_ir::{self, OpaqueTyDatumBound, WellKnownTrait};
 
 use base_db::{salsa::InternKey, CrateId};
@@ -80,7 +80,7 @@ impl<'a> chalk_solve::RustIrDatabase<Interner> for ChalkContext<'a> {
     fn impls_for_trait(
         &self,
         trait_id: TraitId,
-        parameters: &[GenericArg<Interner>],
+        parameters: &[chalk_ir::GenericArg<Interner>],
         binders: &CanonicalVarKinds<Interner>,
     ) -> Vec<ImplId> {
         debug!("impls_for_trait {:?}", trait_id);
@@ -308,7 +308,7 @@ impl<'a> chalk_solve::RustIrDatabase<Interner> for ChalkContext<'a> {
         _closure_id: chalk_ir::ClosureId<Interner>,
         _substs: &chalk_ir::Substitution<Interner>,
     ) -> chalk_ir::Substitution<Interner> {
-        Substitution::empty().to_chalk(self.db)
+        Substitution::empty(&Interner).to_chalk(self.db)
     }
 
     fn trait_name(&self, trait_id: chalk_ir::TraitId<Interner>) -> String {
@@ -439,7 +439,7 @@ pub(crate) fn trait_datum_query(
         lang_attr(db.upcast(), trait_).and_then(|name| well_known_trait_from_lang_attr(&name));
     let trait_datum = TraitDatum {
         id: trait_id,
-        binders: make_binders(trait_datum_bound, bound_vars.len()),
+        binders: make_binders(trait_datum_bound, bound_vars.len(&Interner)),
         flags,
         associated_ty_ids,
         well_known,
@@ -577,7 +577,7 @@ fn impl_def_datum(
         .collect();
     debug!("impl_datum: {:?}", impl_datum_bound);
     let impl_datum = ImplDatum {
-        binders: make_binders(impl_datum_bound, bound_vars.len()),
+        binders: make_binders(impl_datum_bound, bound_vars.len(&Interner)),
         impl_type,
         polarity,
         associated_ty_value_ids,


### PR DESCRIPTION
Plus some more adaptations to Substitution.

Lots of `assert_ty_ref` that we should revisit when introducing lifetime/const parameters.