### PR TITLE
Rename Ty::interned to Ty::kind

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1711,22 +1711,22 @@ impl Type {
     }
 
     pub fn is_unit(&self) -> bool {
-        matches!(self.ty.interned(&Interner), TyKind::Tuple(0, ..))
+        matches!(self.ty.kind(&Interner), TyKind::Tuple(0, ..))
     }
     pub fn is_bool(&self) -> bool {
-        matches!(self.ty.interned(&Interner), TyKind::Scalar(Scalar::Bool))
+        matches!(self.ty.kind(&Interner), TyKind::Scalar(Scalar::Bool))
     }
 
     pub fn is_mutable_reference(&self) -> bool {
-        matches!(self.ty.interned(&Interner), TyKind::Ref(hir_ty::Mutability::Mut, ..))
+        matches!(self.ty.kind(&Interner), TyKind::Ref(hir_ty::Mutability::Mut, ..))
     }
 
     pub fn is_usize(&self) -> bool {
-        matches!(self.ty.interned(&Interner), TyKind::Scalar(Scalar::Uint(UintTy::Usize)))
+        matches!(self.ty.kind(&Interner), TyKind::Scalar(Scalar::Uint(UintTy::Usize)))
     }
 
     pub fn remove_ref(&self) -> Option<Type> {
-        match &self.ty.interned(&Interner) {
+        match &self.ty.kind(&Interner) {
             TyKind::Ref(.., ty) => Some(self.derived(ty.clone())),
             _ => None,
         }
@@ -1855,15 +1855,15 @@ impl Type {
     }
 
     pub fn is_closure(&self) -> bool {
-        matches!(&self.ty.interned(&Interner), TyKind::Closure { .. })
+        matches!(&self.ty.kind(&Interner), TyKind::Closure { .. })
     }
 
     pub fn is_fn(&self) -> bool {
-        matches!(&self.ty.interned(&Interner), TyKind::FnDef(..) | TyKind::Function { .. })
+        matches!(&self.ty.kind(&Interner), TyKind::FnDef(..) | TyKind::Function { .. })
     }
 
     pub fn is_packed(&self, db: &dyn HirDatabase) -> bool {
-        let adt_id = match self.ty.interned(&Interner) {
+        let adt_id = match self.ty.kind(&Interner) {
             &TyKind::Adt(hir_ty::AdtId(adt_id), ..) => adt_id,
             _ => return false,
         };
@@ -1876,14 +1876,14 @@ impl Type {
     }
 
     pub fn is_raw_ptr(&self) -> bool {
-        matches!(&self.ty.interned(&Interner), TyKind::Raw(..))
+        matches!(&self.ty.kind(&Interner), TyKind::Raw(..))
     }
 
     pub fn contains_unknown(&self) -> bool {
         return go(&self.ty);
 
         fn go(ty: &Ty) -> bool {
-            match ty.interned(&Interner) {
+            match ty.kind(&Interner) {
                 TyKind::Unknown => true,
 
                 TyKind::Adt(_, substs)
@@ -1914,7 +1914,7 @@ impl Type {
     }
 
     pub fn fields(&self, db: &dyn HirDatabase) -> Vec<(Field, Type)> {
-        let (variant_id, substs) = match self.ty.interned(&Interner) {
+        let (variant_id, substs) = match self.ty.kind(&Interner) {
             &TyKind::Adt(hir_ty::AdtId(AdtId::StructId(s)), ref substs) => (s.into(), substs),
             &TyKind::Adt(hir_ty::AdtId(AdtId::UnionId(u)), ref substs) => (u.into(), substs),
             _ => return Vec::new(),
@@ -1931,7 +1931,7 @@ impl Type {
     }
 
     pub fn tuple_fields(&self, _db: &dyn HirDatabase) -> Vec<Type> {
-        if let TyKind::Tuple(_, substs) = &self.ty.interned(&Interner) {
+        if let TyKind::Tuple(_, substs) = &self.ty.kind(&Interner) {
             substs
                 .iter(&Interner)
                 .map(|ty| self.derived(ty.assert_ty_ref(&Interner).clone()))
@@ -2120,7 +2120,7 @@ impl Type {
 
         fn walk_type(db: &dyn HirDatabase, type_: &Type, cb: &mut impl FnMut(Type)) {
             let ty = type_.ty.strip_references();
-            match ty.interned(&Interner) {
+            match ty.kind(&Interner) {
                 TyKind::Adt(..) => {
                     cb(type_.derived(ty.clone()));
                 }

--- a/crates/hir_ty/src/autoderef.rs
+++ b/crates/hir_ty/src/autoderef.rs
@@ -131,7 +131,7 @@ fn deref_by_trait(
             // new variables in that case
 
             for i in 1..vars.0.binders.len(&Interner) {
-                if vars.0.value.at(&Interner, i - 1).assert_ty_ref(&Interner).interned(&Interner)
+                if vars.0.value.at(&Interner, i - 1).assert_ty_ref(&Interner).kind(&Interner)
                     != &TyKind::BoundVar(BoundVar::new(DebruijnIndex::INNERMOST, i - 1))
                 {
                     warn!("complex solution for derefing {:?}: {:?}, ignoring", ty.goal, solution);

--- a/crates/hir_ty/src/diagnostics/expr.rs
+++ b/crates/hir_ty/src/diagnostics/expr.rs
@@ -378,7 +378,7 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
             _ => return,
         };
 
-        let (params, required) = match mismatch.expected.interned(&Interner) {
+        let (params, required) = match mismatch.expected.kind(&Interner) {
             TyKind::Adt(AdtId(hir_def::AdtId::EnumId(enum_id)), ref parameters)
                 if *enum_id == core_result_enum =>
             {

--- a/crates/hir_ty/src/diagnostics/match_check.rs
+++ b/crates/hir_ty/src/diagnostics/match_check.rs
@@ -626,7 +626,7 @@ pub(super) fn is_useful(
     // - enum with no variants
     // - `!` type
     // In those cases, no match arm is useful.
-    match cx.infer[cx.match_expr].strip_references().interned(&Interner) {
+    match cx.infer[cx.match_expr].strip_references().kind(&Interner) {
         TyKind::Adt(AdtId(hir_def::AdtId::EnumId(enum_id)), ..) => {
             if cx.db.enum_data(*enum_id).variants.is_empty() {
                 return Ok(Usefulness::NotUseful);

--- a/crates/hir_ty/src/diagnostics/unsafe_check.rs
+++ b/crates/hir_ty/src/diagnostics/unsafe_check.rs
@@ -110,7 +110,7 @@ fn walk_unsafe(
             }
         }
         Expr::UnaryOp { expr, op: UnaryOp::Deref } => {
-            if let TyKind::Raw(..) = &infer[*expr].interned(&Interner) {
+            if let TyKind::Raw(..) = &infer[*expr].kind(&Interner) {
                 unsafe_exprs.push(UnsafeExpr { expr: current, inside_unsafe_block });
             }
         }

--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -292,7 +292,7 @@ impl HirDisplay for Ty {
             return write!(f, "{}", TYPE_HINT_TRUNCATION);
         }
 
-        match self.interned(&Interner) {
+        match self.kind(&Interner) {
             TyKind::Never => write!(f, "!")?,
             TyKind::Str => write!(f, "str")?,
             TyKind::Scalar(Scalar::Bool) => write!(f, "bool")?,
@@ -314,7 +314,7 @@ impl HirDisplay for Ty {
                 let ty_display =
                     t.into_displayable(f.db, f.max_size, f.omit_verbose_types, f.display_target);
 
-                if matches!(self.interned(&Interner), TyKind::Raw(..)) {
+                if matches!(self.kind(&Interner), TyKind::Raw(..)) {
                     write!(
                         f,
                         "*{}",
@@ -336,7 +336,7 @@ impl HirDisplay for Ty {
 
                 // FIXME: all this just to decide whether to use parentheses...
                 let datas;
-                let predicates: Vec<_> = match t.interned(&Interner) {
+                let predicates: Vec<_> = match t.kind(&Interner) {
                     TyKind::Dyn(dyn_ty) if dyn_ty.bounds.skip_binders().interned().len() > 1 => {
                         dyn_ty.bounds.skip_binders().interned().iter().cloned().collect()
                     }
@@ -473,7 +473,7 @@ impl HirDisplay for Ty {
                                 let mut default_from = 0;
                                 for (i, parameter) in parameters.iter(&Interner).enumerate() {
                                     match (
-                                        parameter.assert_ty_ref(&Interner).interned(&Interner),
+                                        parameter.assert_ty_ref(&Interner).kind(&Interner),
                                         default_parameters.get(i),
                                     ) {
                                         (&TyKind::Unknown, _) | (_, None) => {

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -325,7 +325,7 @@ impl<'a> InferenceContext<'a> {
 
     /// Replaces Ty::Unknown by a new type var, so we can maybe still infer it.
     fn insert_type_vars_shallow(&mut self, ty: Ty) -> Ty {
-        match ty.interned(&Interner) {
+        match ty.kind(&Interner) {
             TyKind::Unknown => self.table.new_type_var(),
             _ => ty,
         }
@@ -438,7 +438,7 @@ impl<'a> InferenceContext<'a> {
     /// to do it as well.
     fn normalize_associated_types_in(&mut self, ty: Ty) -> Ty {
         let ty = self.resolve_ty_as_possible(ty);
-        ty.fold(&mut |ty| match ty.interned(&Interner) {
+        ty.fold(&mut |ty| match ty.kind(&Interner) {
             TyKind::Alias(AliasTy::Projection(proj_ty)) => {
                 self.normalize_projection_ty(proj_ty.clone())
             }

--- a/crates/hir_ty/src/infer/coerce.rs
+++ b/crates/hir_ty/src/infer/coerce.rs
@@ -36,7 +36,7 @@ impl<'a> InferenceContext<'a> {
             ty1.clone()
         } else {
             if let (TyKind::FnDef(..), TyKind::FnDef(..)) =
-                (ty1.interned(&Interner), ty2.interned(&Interner))
+                (ty1.kind(&Interner), ty2.kind(&Interner))
             {
                 cov_mark::hit!(coerce_fn_reification);
                 // Special case: two function types. Try to coerce both to
@@ -55,7 +55,7 @@ impl<'a> InferenceContext<'a> {
     }
 
     fn coerce_inner(&mut self, mut from_ty: Ty, to_ty: &Ty) -> bool {
-        match (from_ty.interned(&Interner), to_ty.interned(&Interner)) {
+        match (from_ty.kind(&Interner), to_ty.kind(&Interner)) {
             // Never type will make type variable to fallback to Never Type instead of Unknown.
             (TyKind::Never, TyKind::InferenceVar(tv, TyVariableKind::General)) => {
                 self.table.type_variable_table.set_diverging(*tv, true);
@@ -73,7 +73,7 @@ impl<'a> InferenceContext<'a> {
         }
 
         // Pointer weakening and function to pointer
-        match (from_ty.interned_mut(), to_ty.interned(&Interner)) {
+        match (from_ty.interned_mut(), to_ty.kind(&Interner)) {
             // `*mut T` -> `*const T`
             // `&mut T` -> `&T`
             (TyKind::Raw(m1, ..), TyKind::Raw(m2 @ Mutability::Not, ..))
@@ -111,7 +111,7 @@ impl<'a> InferenceContext<'a> {
         }
 
         // Auto Deref if cannot coerce
-        match (from_ty.interned(&Interner), to_ty.interned(&Interner)) {
+        match (from_ty.kind(&Interner), to_ty.kind(&Interner)) {
             // FIXME: DerefMut
             (TyKind::Ref(_, st1), TyKind::Ref(_, st2)) => self.unify_autoderef_behind_ref(st1, st2),
 

--- a/crates/hir_ty/src/infer/expr.rs
+++ b/crates/hir_ty/src/infer/expr.rs
@@ -455,7 +455,7 @@ impl<'a> InferenceContext<'a> {
                             })
                             .unwrap_or(true)
                     };
-                    match canonicalized.decanonicalize_ty(derefed_ty.value).interned(&Interner) {
+                    match canonicalized.decanonicalize_ty(derefed_ty.value).kind(&Interner) {
                         TyKind::Tuple(_, substs) => name.as_tuple_index().and_then(|idx| {
                             substs
                                 .interned(&Interner)
@@ -577,7 +577,7 @@ impl<'a> InferenceContext<'a> {
                         None => self.err_ty(),
                     },
                     UnaryOp::Neg => {
-                        match inner_ty.interned(&Interner) {
+                        match inner_ty.kind(&Interner) {
                             // Fast path for builtins
                             TyKind::Scalar(Scalar::Int(_))
                             | TyKind::Scalar(Scalar::Uint(_))
@@ -590,7 +590,7 @@ impl<'a> InferenceContext<'a> {
                         }
                     }
                     UnaryOp::Not => {
-                        match inner_ty.interned(&Interner) {
+                        match inner_ty.kind(&Interner) {
                             // Fast path for builtins
                             TyKind::Scalar(Scalar::Bool)
                             | TyKind::Scalar(Scalar::Int(_))
@@ -696,7 +696,7 @@ impl<'a> InferenceContext<'a> {
                 }
             }
             Expr::Tuple { exprs } => {
-                let mut tys = match expected.ty.interned(&Interner) {
+                let mut tys = match expected.ty.kind(&Interner) {
                     TyKind::Tuple(_, substs) => substs
                         .iter(&Interner)
                         .map(|a| a.assert_ty_ref(&Interner).clone())
@@ -713,7 +713,7 @@ impl<'a> InferenceContext<'a> {
                 TyKind::Tuple(tys.len(), Substitution::from_iter(&Interner, tys)).intern(&Interner)
             }
             Expr::Array(array) => {
-                let elem_ty = match expected.ty.interned(&Interner) {
+                let elem_ty = match expected.ty.kind(&Interner) {
                     TyKind::Array(st) | TyKind::Slice(st) => st.clone(),
                     _ => self.table.new_type_var(),
                 };
@@ -961,7 +961,7 @@ impl<'a> InferenceContext<'a> {
     }
 
     fn register_obligations_for_call(&mut self, callable_ty: &Ty) {
-        if let TyKind::FnDef(fn_def, parameters) = callable_ty.interned(&Interner) {
+        if let TyKind::FnDef(fn_def, parameters) = callable_ty.kind(&Interner) {
             let def: CallableDefId = from_chalk(self.db, *fn_def);
             let generic_predicates = self.db.generic_predicates(def.into());
             for predicate in generic_predicates.iter() {

--- a/crates/hir_ty/src/infer/pat.rs
+++ b/crates/hir_ty/src/infer/pat.rs
@@ -211,7 +211,7 @@ impl<'a> InferenceContext<'a> {
                 return inner_ty;
             }
             Pat::Slice { prefix, slice, suffix } => {
-                let (container_ty, elem_ty): (fn(_) -> _, _) = match expected.interned(&Interner) {
+                let (container_ty, elem_ty): (fn(_) -> _, _) = match expected.kind(&Interner) {
                     TyKind::Array(st) => (TyKind::Array, st.clone()),
                     TyKind::Slice(st) => (TyKind::Slice, st.clone()),
                     _ => (TyKind::Slice, self.err_ty()),

--- a/crates/hir_ty/src/infer/path.rs
+++ b/crates/hir_ty/src/infer/path.rs
@@ -147,7 +147,7 @@ impl<'a> InferenceContext<'a> {
                     remaining_segments_for_ty,
                     true,
                 );
-                if let TyKind::Unknown = ty.interned(&Interner) {
+                if let TyKind::Unknown = ty.kind(&Interner) {
                     return None;
                 }
 
@@ -212,7 +212,7 @@ impl<'a> InferenceContext<'a> {
         name: &Name,
         id: ExprOrPatId,
     ) -> Option<(ValueNs, Option<Substitution>)> {
-        if let TyKind::Unknown = ty.interned(&Interner) {
+        if let TyKind::Unknown = ty.kind(&Interner) {
             return None;
         }
 

--- a/crates/hir_ty/src/op.rs
+++ b/crates/hir_ty/src/op.rs
@@ -9,7 +9,7 @@ pub(super) fn binary_op_return_ty(op: BinaryOp, lhs_ty: Ty, rhs_ty: Ty) -> Ty {
         BinaryOp::LogicOp(_) | BinaryOp::CmpOp(_) => TyKind::Scalar(Scalar::Bool).intern(&Interner),
         BinaryOp::Assignment { .. } => Ty::unit(),
         BinaryOp::ArithOp(ArithOp::Shl) | BinaryOp::ArithOp(ArithOp::Shr) => {
-            match lhs_ty.interned(&Interner) {
+            match lhs_ty.kind(&Interner) {
                 TyKind::Scalar(Scalar::Int(_))
                 | TyKind::Scalar(Scalar::Uint(_))
                 | TyKind::Scalar(Scalar::Float(_)) => lhs_ty,
@@ -18,7 +18,7 @@ pub(super) fn binary_op_return_ty(op: BinaryOp, lhs_ty: Ty, rhs_ty: Ty) -> Ty {
                 _ => TyKind::Unknown.intern(&Interner),
             }
         }
-        BinaryOp::ArithOp(_) => match rhs_ty.interned(&Interner) {
+        BinaryOp::ArithOp(_) => match rhs_ty.kind(&Interner) {
             TyKind::Scalar(Scalar::Int(_))
             | TyKind::Scalar(Scalar::Uint(_))
             | TyKind::Scalar(Scalar::Float(_)) => rhs_ty,
@@ -33,7 +33,7 @@ pub(super) fn binary_op_rhs_expectation(op: BinaryOp, lhs_ty: Ty) -> Ty {
     match op {
         BinaryOp::LogicOp(..) => TyKind::Scalar(Scalar::Bool).intern(&Interner),
         BinaryOp::Assignment { op: None } => lhs_ty,
-        BinaryOp::CmpOp(CmpOp::Eq { .. }) => match lhs_ty.interned(&Interner) {
+        BinaryOp::CmpOp(CmpOp::Eq { .. }) => match lhs_ty.kind(&Interner) {
             TyKind::Scalar(_) | TyKind::Str => lhs_ty,
             TyKind::InferenceVar(_, TyVariableKind::Integer)
             | TyKind::InferenceVar(_, TyVariableKind::Float) => lhs_ty,
@@ -44,7 +44,7 @@ pub(super) fn binary_op_rhs_expectation(op: BinaryOp, lhs_ty: Ty) -> Ty {
         }
         BinaryOp::CmpOp(CmpOp::Ord { .. })
         | BinaryOp::Assignment { op: Some(_) }
-        | BinaryOp::ArithOp(_) => match lhs_ty.interned(&Interner) {
+        | BinaryOp::ArithOp(_) => match lhs_ty.kind(&Interner) {
             TyKind::Scalar(Scalar::Int(_))
             | TyKind::Scalar(Scalar::Uint(_))
             | TyKind::Scalar(Scalar::Float(_)) => lhs_ty,

--- a/crates/hir_ty/src/traits.rs
+++ b/crates/hir_ty/src/traits.rs
@@ -138,7 +138,7 @@ pub(crate) fn trait_solve_query(
         ..
     })) = &goal.value.goal
     {
-        if let TyKind::BoundVar(_) = projection_ty.self_type_parameter().interned(&Interner) {
+        if let TyKind::BoundVar(_) = projection_ty.self_type_parameter().kind(&Interner) {
             // Hack: don't ask Chalk to normalize with an unknown self type, it'll say that's impossible
             return Some(Solution::Ambig(Guidance::Unknown));
         }

--- a/crates/hir_ty/src/traits/chalk.rs
+++ b/crates/hir_ty/src/traits/chalk.rs
@@ -92,7 +92,7 @@ impl<'a> chalk_solve::RustIrDatabase<Interner> for ChalkContext<'a> {
             ty: &Ty,
             binders: &CanonicalVarKinds<Interner>,
         ) -> Option<chalk_ir::TyVariableKind> {
-            if let TyKind::BoundVar(bv) = ty.interned(&Interner) {
+            if let TyKind::BoundVar(bv) = ty.kind(&Interner) {
                 let binders = binders.as_slice(&Interner);
                 if bv.debruijn == DebruijnIndex::INNERMOST {
                     if let chalk_ir::VariableKind::Ty(tk) = binders[bv.index].kind {


### PR DESCRIPTION
... since that's the actual method on Chalk side that matches the signature.