### PR TITLE
Use shrink_to_fit to reduce DefMap sizes

### DIFF
--- a/crates/hir_def/src/item_scope.rs
+++ b/crates/hir_def/src/item_scope.rs
@@ -285,6 +285,17 @@ impl ItemScope {
             buf.push('\n');
         }
     }
+
+    pub(crate) fn shrink_to_fit(&mut self) {
+        self.types.shrink_to_fit();
+        self.values.shrink_to_fit();
+        self.macros.shrink_to_fit();
+        self.unresolved.shrink_to_fit();
+        self.defs.shrink_to_fit();
+        self.impls.shrink_to_fit();
+        self.unnamed_trait_imports.shrink_to_fit();
+        self.legacy_macros.shrink_to_fit();
+    }
 }
 
 impl PerNs {

--- a/crates/hir_def/src/nameres.rs
+++ b/crates/hir_def/src/nameres.rs
@@ -409,6 +409,17 @@ impl DefMap {
             }
         }
     }
+
+    fn shrink_to_fit(&mut self) {
+        self.extern_prelude.shrink_to_fit();
+        self.exported_proc_macros.shrink_to_fit();
+        self.diagnostics.shrink_to_fit();
+        self.modules.shrink_to_fit();
+        for (_, module) in self.modules.iter_mut() {
+            module.children.shrink_to_fit();
+            module.scope.shrink_to_fit();
+        }
+    }
 }
 
 impl ModuleData {

--- a/crates/hir_def/src/nameres/collector.rs
+++ b/crates/hir_def/src/nameres/collector.rs
@@ -109,7 +109,9 @@ pub(super) fn collect_defs(
         }
     }
     collector.collect();
-    collector.finish()
+    let mut def_map = collector.finish();
+    def_map.shrink_to_fit();
+    def_map
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/lib/arena/src/lib.rs
+++ b/lib/arena/src/lib.rs
@@ -194,6 +194,29 @@ impl<T> Arena<T> {
         self.data.iter().enumerate().map(|(idx, value)| (Idx::from_raw(RawIdx(idx as u32)), value))
     }
 
+    /// Returns an iterator over the arena’s mutable elements.
+    ///
+    /// ```
+    /// let mut arena = la_arena::Arena::new();
+    /// let idx1 = arena.alloc(20);
+    ///
+    /// assert_eq!(arena[idx1], 20);
+    ///
+    /// let mut iterator = arena.iter_mut();
+    /// *iterator.next().unwrap().1 = 10;
+    /// drop(iterator);
+    ///
+    /// assert_eq!(arena[idx1], 10);
+    /// ```
+    pub fn iter_mut(
+        &mut self,
+    ) -> impl Iterator<Item = (Idx<T>, &mut T)> + ExactSizeIterator + DoubleEndedIterator {
+        self.data
+            .iter_mut()
+            .enumerate()
+            .map(|(idx, value)| (Idx::from_raw(RawIdx(idx as u32)), value))
+    }
+
     /// Reallocates the arena to make it take up as little space as possible.
     pub fn shrink_to_fit(&mut self) {
         self.data.shrink_to_fit();


### PR DESCRIPTION
Especially `block_def_map` can overallocate when there's not a lot of items in the `DefMap`. This saves around 10 MB during analysis-stats. Not too much, but a cheap win.

bors r+