### PR TITLE
Make `ast_to_token_tree` infallible

### DIFF
--- a/crates/cfg/src/tests.rs
+++ b/crates/cfg/src/tests.rs
@@ -8,7 +8,7 @@ fn assert_parse_result(input: &str, expected: CfgExpr) {
     let (tt, _) = {
         let source_file = ast::SourceFile::parse(input).ok().unwrap();
         let tt = source_file.syntax().descendants().find_map(ast::TokenTree::cast).unwrap();
-        ast_to_token_tree(&tt).unwrap()
+        ast_to_token_tree(&tt)
     };
     let cfg = CfgExpr::parse(&tt);
     assert_eq!(cfg, expected);
@@ -18,7 +18,7 @@ fn check_dnf(input: &str, expect: Expect) {
     let (tt, _) = {
         let source_file = ast::SourceFile::parse(input).ok().unwrap();
         let tt = source_file.syntax().descendants().find_map(ast::TokenTree::cast).unwrap();
-        ast_to_token_tree(&tt).unwrap()
+        ast_to_token_tree(&tt)
     };
     let cfg = CfgExpr::parse(&tt);
     let actual = format!("#![cfg({})]", DnfExpr::new(cfg));
@@ -29,7 +29,7 @@ fn check_why_inactive(input: &str, opts: &CfgOptions, expect: Expect) {
     let (tt, _) = {
         let source_file = ast::SourceFile::parse(input).ok().unwrap();
         let tt = source_file.syntax().descendants().find_map(ast::TokenTree::cast).unwrap();
-        ast_to_token_tree(&tt).unwrap()
+        ast_to_token_tree(&tt)
     };
     let cfg = CfgExpr::parse(&tt);
     let dnf = DnfExpr::new(cfg);
@@ -42,7 +42,7 @@ fn check_enable_hints(input: &str, opts: &CfgOptions, expected_hints: &[&str]) {
     let (tt, _) = {
         let source_file = ast::SourceFile::parse(input).ok().unwrap();
         let tt = source_file.syntax().descendants().find_map(ast::TokenTree::cast).unwrap();
-        ast_to_token_tree(&tt).unwrap()
+        ast_to_token_tree(&tt)
     };
     let cfg = CfgExpr::parse(&tt);
     let dnf = DnfExpr::new(cfg);

--- a/crates/hir_def/src/attr.rs
+++ b/crates/hir_def/src/attr.rs
@@ -533,7 +533,7 @@ impl Attr {
             };
             Some(AttrInput::Literal(value))
         } else if let Some(tt) = ast.token_tree() {
-            Some(AttrInput::TokenTree(ast_to_token_tree(&tt)?.0))
+            Some(AttrInput::TokenTree(ast_to_token_tree(&tt).0))
         } else {
             None
         };

--- a/crates/hir_expand/src/builtin_macro.rs
+++ b/crates/hir_expand/src/builtin_macro.rs
@@ -584,7 +584,7 @@ mod tests {
                 };
 
                 let args = macro_call.token_tree().unwrap();
-                let parsed_args = mbe::ast_to_token_tree(&args).unwrap().0;
+                let parsed_args = mbe::ast_to_token_tree(&args).0;
                 let call_id = AstId::new(file_id.into(), ast_id_map.ast_id(&macro_call));
 
                 let arg_id = db.intern_eager_expansion({

--- a/crates/hir_expand/src/db.rs
+++ b/crates/hir_expand/src/db.rs
@@ -119,7 +119,7 @@ pub fn expand_hypothetical(
     token_to_map: syntax::SyntaxToken,
 ) -> Option<(SyntaxNode, syntax::SyntaxToken)> {
     let macro_file = MacroFile { macro_call_id: actual_macro_call };
-    let (tt, tmap_1) = mbe::syntax_node_to_token_tree(hypothetical_args.syntax()).unwrap();
+    let (tt, tmap_1) = mbe::syntax_node_to_token_tree(hypothetical_args.syntax());
     let range =
         token_to_map.text_range().checked_sub(hypothetical_args.syntax().text_range().start())?;
     let token_id = tmap_1.token_by_range(range)?;
@@ -143,10 +143,7 @@ fn macro_def(db: &dyn AstDatabase, id: MacroDefId) -> Option<Arc<(TokenExpander,
         MacroDefKind::Declarative(ast_id) => match ast_id.to_node(db) {
             syntax::ast::Macro::MacroRules(macro_rules) => {
                 let arg = macro_rules.token_tree()?;
-                let (tt, tmap) = mbe::ast_to_token_tree(&arg).or_else(|| {
-                    log::warn!("fail on macro_rules to token tree: {:#?}", arg);
-                    None
-                })?;
+                let (tt, tmap) = mbe::ast_to_token_tree(&arg);
                 let rules = match MacroRules::parse(&tt) {
                     Ok(it) => it,
                     Err(err) => {
@@ -159,10 +156,7 @@ fn macro_def(db: &dyn AstDatabase, id: MacroDefId) -> Option<Arc<(TokenExpander,
             }
             syntax::ast::Macro::MacroDef(macro_def) => {
                 let arg = macro_def.body()?;
-                let (tt, tmap) = mbe::ast_to_token_tree(&arg).or_else(|| {
-                    log::warn!("fail on macro_def to token tree: {:#?}", arg);
-                    None
-                })?;
+                let (tt, tmap) = mbe::ast_to_token_tree(&arg);
                 let rules = match MacroDef::parse(&tt) {
                     Ok(it) => it,
                     Err(err) => {
@@ -202,7 +196,7 @@ fn macro_arg_text(db: &dyn AstDatabase, id: MacroCallId) -> Option<GreenNode> {
 
 fn macro_arg(db: &dyn AstDatabase, id: MacroCallId) -> Option<Arc<(tt::Subtree, mbe::TokenMap)>> {
     let arg = db.macro_arg_text(id)?;
-    let (tt, tmap) = mbe::syntax_node_to_token_tree(&SyntaxNode::new_root(arg))?;
+    let (tt, tmap) = mbe::syntax_node_to_token_tree(&SyntaxNode::new_root(arg));
     Some(Arc::new((tt, tmap)))
 }
 

--- a/crates/hir_expand/src/eager.rs
+++ b/crates/hir_expand/src/eager.rs
@@ -106,7 +106,7 @@ pub fn expand_eager_macro(
     mut diagnostic_sink: &mut dyn FnMut(mbe::ExpandError),
 ) -> Result<EagerMacroId, ErrorEmitted> {
     let parsed_args = diagnostic_sink.option_with(
-        || Some(mbe::ast_to_token_tree(&macro_call.value.token_tree()?)?.0),
+        || Some(mbe::ast_to_token_tree(&macro_call.value.token_tree()?).0),
         || err("malformed macro invocation"),
     )?;
 
@@ -161,7 +161,7 @@ pub fn expand_eager_macro(
 }
 
 fn to_subtree(node: &SyntaxNode) -> Option<tt::Subtree> {
-    let mut subtree = mbe::syntax_node_to_token_tree(node)?.0;
+    let mut subtree = mbe::syntax_node_to_token_tree(node).0;
     subtree.delimiter = None;
     Some(subtree)
 }

--- a/crates/mbe/src/benchmark.rs
+++ b/crates/mbe/src/benchmark.rs
@@ -65,7 +65,7 @@ fn macro_rules_fixtures_tt() -> FxHashMap<String, tt::Subtree> {
         .filter_map(ast::MacroRules::cast)
         .map(|rule| {
             let id = rule.name().unwrap().to_string();
-            let (def_tt, _) = ast_to_token_tree(&rule.token_tree().unwrap()).unwrap();
+            let (def_tt, _) = ast_to_token_tree(&rule.token_tree().unwrap());
             (id, def_tt)
         })
         .collect()

--- a/crates/mbe/src/expander.rs
+++ b/crates/mbe/src/expander.rs
@@ -159,8 +159,7 @@ mod tests {
         let macro_definition =
             source_file.syntax().descendants().find_map(ast::MacroRules::cast).unwrap();
 
-        let (definition_tt, _) =
-            ast_to_token_tree(&macro_definition.token_tree().unwrap()).unwrap();
+        let (definition_tt, _) = ast_to_token_tree(&macro_definition.token_tree().unwrap());
         crate::MacroRules::parse(&definition_tt).unwrap()
     }
 
@@ -169,8 +168,7 @@ mod tests {
         let macro_invocation =
             source_file.syntax().descendants().find_map(ast::MacroCall::cast).unwrap();
 
-        let (invocation_tt, _) =
-            ast_to_token_tree(&macro_invocation.token_tree().unwrap()).unwrap();
+        let (invocation_tt, _) = ast_to_token_tree(&macro_invocation.token_tree().unwrap());
 
         expand_rules(&rules.rules, &invocation_tt)
     }

--- a/crates/mbe/src/tests.rs
+++ b/crates/mbe/src/tests.rs
@@ -29,8 +29,7 @@ macro_rules! impl_fixture {
                 let macro_invocation =
                     source_file.syntax().descendants().find_map(ast::MacroCall::cast).unwrap();
 
-                let (invocation_tt, _) = ast_to_token_tree(&macro_invocation.token_tree().unwrap())
-                    .ok_or_else(|| ExpandError::ConversionError)?;
+                let (invocation_tt, _) = ast_to_token_tree(&macro_invocation.token_tree().unwrap());
 
                 self.rules.expand(&invocation_tt).result()
             }
@@ -101,7 +100,7 @@ macro_rules! impl_fixture {
                         .descendants()
                         .find_map(ast::TokenTree::cast)
                         .unwrap();
-                    let mut wrapped = ast_to_token_tree(&wrapped).unwrap().0;
+                    let mut wrapped = ast_to_token_tree(&wrapped).0;
                     wrapped.delimiter = None;
                     wrapped
                 };
@@ -151,7 +150,7 @@ pub(crate) fn parse_macro_error(ra_fixture: &str) -> ParseError {
 
 pub(crate) fn parse_to_token_tree_by_syntax(ra_fixture: &str) -> tt::Subtree {
     let source_file = ast::SourceFile::parse(ra_fixture).ok().unwrap();
-    let tt = syntax_node_to_token_tree(source_file.syntax()).unwrap().0;
+    let tt = syntax_node_to_token_tree(source_file.syntax()).0;
 
     let parsed = parse_to_token_tree(ra_fixture).unwrap().0;
     assert_eq!(tt, parsed);
@@ -164,7 +163,7 @@ fn parse_macro_rules_to_tt(ra_fixture: &str) -> tt::Subtree {
     let macro_definition =
         source_file.syntax().descendants().find_map(ast::MacroRules::cast).unwrap();
 
-    let (definition_tt, _) = ast_to_token_tree(&macro_definition.token_tree().unwrap()).unwrap();
+    let (definition_tt, _) = ast_to_token_tree(&macro_definition.token_tree().unwrap());
 
     let parsed = parse_to_token_tree(
         &ra_fixture[macro_definition.token_tree().unwrap().syntax().text_range()],
@@ -181,7 +180,7 @@ fn parse_macro_def_to_tt(ra_fixture: &str) -> tt::Subtree {
     let macro_definition =
         source_file.syntax().descendants().find_map(ast::MacroDef::cast).unwrap();
 
-    let (definition_tt, _) = ast_to_token_tree(&macro_definition.body().unwrap()).unwrap();
+    let (definition_tt, _) = ast_to_token_tree(&macro_definition.body().unwrap());
 
     let parsed =
         parse_to_token_tree(&ra_fixture[macro_definition.body().unwrap().syntax().text_range()])

--- a/crates/mbe/src/tests/rule.rs
+++ b/crates/mbe/src/tests/rule.rs
@@ -44,6 +44,6 @@ fn parse_macro_arm(arm_definition: &str) -> Result<crate::MacroRules, ParseError
     let macro_definition =
         source_file.syntax().descendants().find_map(ast::MacroRules::cast).unwrap();
 
-    let (definition_tt, _) = ast_to_token_tree(&macro_definition.token_tree().unwrap()).unwrap();
+    let (definition_tt, _) = ast_to_token_tree(&macro_definition.token_tree().unwrap());
     crate::MacroRules::parse(&definition_tt)
 }

--- a/crates/rust-analyzer/src/cargo_target_spec.rs
+++ b/crates/rust-analyzer/src/cargo_target_spec.rs
@@ -201,7 +201,7 @@ mod tests {
         let cfg_expr = {
             let source_file = ast::SourceFile::parse(cfg).ok().unwrap();
             let tt = source_file.syntax().descendants().find_map(ast::TokenTree::cast).unwrap();
-            let (tt, _) = ast_to_token_tree(&tt).unwrap();
+            let (tt, _) = ast_to_token_tree(&tt);
             CfgExpr::parse(&tt)
         };
 


### PR DESCRIPTION
It could never return `None`, so reflect that in the return type

bors r+