### PR TITLE
Check if bitflags deps pulls its weight

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,7 +498,6 @@ version = "0.0.0"
 dependencies = [
  "anymap",
  "base_db",
- "bitflags",
  "cfg",
  "cov-mark",
  "dashmap",

--- a/crates/hir_def/Cargo.toml
+++ b/crates/hir_def/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2018"
 doctest = false
 
 [dependencies]
-bitflags = "1.2.1"
 cov-mark = { version = "1.1", features = ["thread-local"] }
 dashmap = { version = "4.0.2", features = ["raw-api"] }
 log = "0.4.8"

--- a/crates/hir_def/src/data.rs
+++ b/crates/hir_def/src/data.rs
@@ -50,7 +50,7 @@ impl FunctionData {
 
         let mut flags = func.flags;
         if is_varargs {
-            flags |= FnFlags::IS_VARARGS;
+            flags.bits |= FnFlags::IS_VARARGS;
         }
 
         Arc::new(FunctionData {
@@ -71,37 +71,37 @@ impl FunctionData {
     }
 
     pub fn has_body(&self) -> bool {
-        self.flags.contains(FnFlags::HAS_BODY)
+        self.flags.bits & FnFlags::HAS_BODY != 0
     }
 
     /// True if the first param is `self`. This is relevant to decide whether this
     /// can be called as a method.
     pub fn has_self_param(&self) -> bool {
-        self.flags.contains(FnFlags::HAS_SELF_PARAM)
+        self.flags.bits & FnFlags::HAS_SELF_PARAM != 0
     }
 
     pub fn is_default(&self) -> bool {
-        self.flags.contains(FnFlags::IS_DEFAULT)
+        self.flags.bits & FnFlags::IS_DEFAULT != 0
     }
 
     pub fn is_const(&self) -> bool {
-        self.flags.contains(FnFlags::IS_CONST)
+        self.flags.bits & FnFlags::IS_CONST != 0
     }
 
     pub fn is_async(&self) -> bool {
-        self.flags.contains(FnFlags::IS_ASYNC)
+        self.flags.bits & FnFlags::IS_ASYNC != 0
     }
 
     pub fn is_unsafe(&self) -> bool {
-        self.flags.contains(FnFlags::IS_UNSAFE)
+        self.flags.bits & FnFlags::IS_UNSAFE != 0
     }
 
     pub fn is_in_extern_block(&self) -> bool {
-        self.flags.contains(FnFlags::IS_IN_EXTERN_BLOCK)
+        self.flags.bits & FnFlags::IS_IN_EXTERN_BLOCK != 0
     }
 
     pub fn is_varargs(&self) -> bool {
-        self.flags.contains(FnFlags::IS_VARARGS)
+        self.flags.bits & FnFlags::IS_VARARGS != 0
     }
 }
 

--- a/crates/hir_def/src/item_tree.rs
+++ b/crates/hir_def/src/item_tree.rs
@@ -569,20 +569,21 @@ pub enum Param {
     Varargs,
 }
 
-bitflags::bitflags! {
-    /// NOTE: Shared with `FunctionData`
-    pub(crate) struct FnFlags: u8 {
-        const HAS_SELF_PARAM = 1 << 0;
-        const HAS_BODY = 1 << 1;
-        const IS_DEFAULT = 1 << 2;
-        const IS_CONST = 1 << 3;
-        const IS_ASYNC = 1 << 4;
-        const IS_UNSAFE = 1 << 5;
-        /// Whether the function is located in an `extern` block (*not* whether it is an
-        /// `extern "abi" fn`).
-        const IS_IN_EXTERN_BLOCK = 1 << 6;
-        const IS_VARARGS = 1 << 7;
-    }
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+pub(crate) struct FnFlags {
+    pub(crate) bits: u8,
+}
+impl FnFlags {
+    pub(crate) const HAS_SELF_PARAM: u8 = 1 << 0;
+    pub(crate) const HAS_BODY: u8 = 1 << 1;
+    pub(crate) const IS_DEFAULT: u8 = 1 << 2;
+    pub(crate) const IS_CONST: u8 = 1 << 3;
+    pub(crate) const IS_ASYNC: u8 = 1 << 4;
+    pub(crate) const IS_UNSAFE: u8 = 1 << 5;
+    /// Whether the function is located in an `extern` block (*not* whether it is an
+    /// `extern "abi" fn`).
+    pub(crate) const IS_IN_EXTERN_BLOCK: u8 = 1 << 6;
+    pub(crate) const IS_VARARGS: u8 = 1 << 7;
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/crates/hir_def/src/item_tree/lower.rs
+++ b/crates/hir_def/src/item_tree/lower.rs
@@ -411,24 +411,24 @@ impl Ctx {
 
         let ast_id = self.source_ast_id_map.ast_id(func);
 
-        let mut flags = FnFlags::empty();
+        let mut flags = FnFlags::default();
         if func.body().is_some() {
-            flags |= FnFlags::HAS_BODY;
+            flags.bits |= FnFlags::HAS_BODY;
         }
         if has_self_param {
-            flags |= FnFlags::HAS_SELF_PARAM;
+            flags.bits |= FnFlags::HAS_SELF_PARAM;
         }
         if func.default_token().is_some() {
-            flags |= FnFlags::IS_DEFAULT;
+            flags.bits |= FnFlags::IS_DEFAULT;
         }
         if func.const_token().is_some() {
-            flags |= FnFlags::IS_CONST;
+            flags.bits |= FnFlags::IS_CONST;
         }
         if func.async_token().is_some() {
-            flags |= FnFlags::IS_ASYNC;
+            flags.bits |= FnFlags::IS_ASYNC;
         }
         if func.unsafe_token().is_some() {
-            flags |= FnFlags::IS_UNSAFE;
+            flags.bits |= FnFlags::IS_UNSAFE;
         }
 
         let mut res = Function {
@@ -653,9 +653,9 @@ impl Ctx {
                             let func_id = self.lower_function(&ast)?;
                             let func = &mut self.data().functions[func_id.index];
                             if is_intrinsic_fn_unsafe(&func.name) {
-                                func.flags |= FnFlags::IS_UNSAFE;
+                                func.flags.bits |= FnFlags::IS_UNSAFE;
                             }
-                            func.flags |= FnFlags::IS_IN_EXTERN_BLOCK;
+                            func.flags.bits |= FnFlags::IS_IN_EXTERN_BLOCK;
                             func_id.into()
                         }
                         ast::ExternItem::Static(ast) => {


### PR DESCRIPTION
Bitflags is generally a good dependency -- it's lightweight, well
maintained and embraced by the ecosystem.

I wonder, however, do we really need it? Doesn't feel like it adds much
to be honest.