### PR TITLE
Move `Ty` creation methods out of `Ty` (Chalk move preparation)

### DIFF
--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -13,7 +13,7 @@ use syntax::ast::{self, NameOwner};
 
 use crate::{
     Adt, Const, ConstParam, Enum, Field, Function, GenericParam, HasVisibility, LifetimeParam,
-    Module, Static, Struct, Substitution, Trait, Type, TypeAlias, TypeParam, Union, Variant,
+    Module, Static, Struct, Trait, TyBuilder, Type, TypeAlias, TypeParam, Union, Variant,
 };
 
 impl HirDisplay for Function {
@@ -234,7 +234,7 @@ impl HirDisplay for TypeParam {
     fn hir_fmt(&self, f: &mut HirFormatter) -> Result<(), HirDisplayError> {
         write!(f, "{}", self.name(f.db))?;
         let bounds = f.db.generic_predicates_for_param(self.id);
-        let substs = Substitution::type_params(f.db, self.id.parent);
+        let substs = TyBuilder::type_params_subst(f.db, self.id.parent);
         let predicates = bounds.iter().cloned().map(|b| b.subst(&substs)).collect::<Vec<_>>();
         if !(predicates.is_empty() || f.omit_verbose_types()) {
             write_bounds_like_dyn_trait_with_prefix(":", &predicates, f)?;

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1702,10 +1702,9 @@ impl Type {
     fn from_def(
         db: &dyn HirDatabase,
         krate: CrateId,
-        def: impl HasResolver + Into<TyDefId> + Into<GenericDefId>,
+        def: impl HasResolver + Into<TyDefId>,
     ) -> Type {
-        let substs = Substitution::build_for_def(db, def).fill_with_unknown().build();
-        let ty = db.ty(def.into()).subst(&substs);
+        let ty = TyBuilder::def_ty(db, def.into()).fill_with_unknown().build();
         Type::new(db, krate, def, ty)
     }
 

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -514,7 +514,7 @@ impl Field {
             VariantDef::Union(it) => it.id.into(),
             VariantDef::Variant(it) => it.parent.id.into(),
         };
-        let substs = Substitution::type_params(db, generic_def_id);
+        let substs = TyBuilder::type_params_subst(db, generic_def_id);
         let ty = db.field_types(var_id)[self.id].clone().subst(&substs);
         Type::new(db, self.parent.module(db).id.krate(), var_id, ty)
     }
@@ -1501,7 +1501,7 @@ impl TypeParam {
         let resolver = self.id.parent.resolver(db.upcast());
         let krate = self.id.parent.module(db.upcast()).krate();
         let ty = params.get(local_idx)?.clone();
-        let subst = Substitution::type_params(db, self.id.parent);
+        let subst = TyBuilder::type_params_subst(db, self.id.parent);
         let ty = ty.subst(&subst.prefix(local_idx));
         Some(Type::new_with_resolver_inner(db, krate, &resolver, ty))
     }

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -59,7 +59,7 @@ use hir_ty::{
     traits::{FnTrait, Solution, SolutionVariables},
     AliasEq, AliasTy, BoundVar, CallableDefId, CallableSig, Canonical, CanonicalVarKinds, Cast,
     DebruijnIndex, InEnvironment, Interner, ProjectionTy, QuantifiedWhereClause, Scalar,
-    Substitution, TraitEnvironment, Ty, TyDefId, TyKind, TyVariableKind, WhereClause,
+    Substitution, TraitEnvironment, Ty, TyBuilder, TyDefId, TyKind, TyVariableKind, WhereClause,
 };
 use itertools::Itertools;
 use rustc_hash::FxHashSet;
@@ -1129,7 +1129,7 @@ pub struct BuiltinType {
 impl BuiltinType {
     pub fn ty(self, db: &dyn HirDatabase, module: Module) -> Type {
         let resolver = module.id.resolver(db.upcast());
-        Type::new_with_resolver(db, &resolver, Ty::builtin(self.inner))
+        Type::new_with_resolver(db, &resolver, TyBuilder::builtin(self.inner))
             .expect("crate not present in resolver")
     }
 

--- a/crates/hir_ty/src/builder.rs
+++ b/crates/hir_ty/src/builder.rs
@@ -99,6 +99,11 @@ impl TyBuilder<()> {
         }
     }
 
+    pub fn type_params_subst(db: &dyn HirDatabase, def: impl Into<GenericDefId>) -> Substitution {
+        let params = generics(db.upcast(), def.into());
+        params.type_params_subst(db)
+    }
+
     pub fn subst_for_def(db: &dyn HirDatabase, def: impl Into<GenericDefId>) -> TyBuilder<()> {
         let def = def.into();
         let params = generics(db.upcast(), def);

--- a/crates/hir_ty/src/builder.rs
+++ b/crates/hir_ty/src/builder.rs
@@ -16,7 +16,10 @@ use crate::{
     TyDefId, TyKind, TypeWalk, ValueTyDefId,
 };
 
+/// This is a builder for `Ty` or anything that needs a `Substitution`.
 pub struct TyBuilder<D> {
+    /// The `data` field is used to keep track of what we're building (e.g. an
+    /// ADT, a `TraitRef`, ...).
     data: D,
     vec: SmallVec<[GenericArg; 2]>,
     param_count: usize,

--- a/crates/hir_ty/src/builder.rs
+++ b/crates/hir_ty/src/builder.rs
@@ -1,0 +1,211 @@
+//! `TyBuilder`, a helper for building instances of `Ty` and related types.
+
+use std::iter;
+
+use chalk_ir::{
+    cast::{Cast, CastTo, Caster},
+    interner::HasInterner,
+    AdtId, BoundVar, DebruijnIndex, Safety, Scalar,
+};
+use hir_def::{builtin_type::BuiltinType, GenericDefId, TraitId, TypeAliasId};
+use smallvec::SmallVec;
+
+use crate::{
+    db::HirDatabase, primitive, to_assoc_type_id, to_chalk_trait_id, utils::generics, Binders,
+    CallableSig, FnPointer, FnSig, GenericArg, Interner, ProjectionTy, Substitution, TraitRef, Ty,
+    TyDefId, TyKind, TypeWalk, ValueTyDefId,
+};
+
+pub struct TyBuilder<D> {
+    data: D,
+    vec: SmallVec<[GenericArg; 2]>,
+    param_count: usize,
+}
+
+impl<D> TyBuilder<D> {
+    fn new(data: D, param_count: usize) -> TyBuilder<D> {
+        TyBuilder { data, param_count, vec: SmallVec::with_capacity(param_count) }
+    }
+
+    fn build_internal(self) -> (D, Substitution) {
+        assert_eq!(self.vec.len(), self.param_count);
+        // FIXME: would be good to have a way to construct a chalk_ir::Substitution from the interned form
+        let subst = Substitution(self.vec);
+        (self.data, subst)
+    }
+
+    pub fn push(mut self, arg: impl CastTo<GenericArg>) -> Self {
+        self.vec.push(arg.cast(&Interner));
+        self
+    }
+
+    pub fn remaining(&self) -> usize {
+        self.param_count - self.vec.len()
+    }
+
+    pub fn fill_with_bound_vars(self, debruijn: DebruijnIndex, starting_from: usize) -> Self {
+        self.fill(
+            (starting_from..)
+                .map(|idx| TyKind::BoundVar(BoundVar::new(debruijn, idx)).intern(&Interner)),
+        )
+    }
+
+    pub fn fill_with_unknown(self) -> Self {
+        self.fill(iter::repeat(TyKind::Unknown.intern(&Interner)))
+    }
+
+    pub fn fill(mut self, filler: impl Iterator<Item = impl CastTo<GenericArg>>) -> Self {
+        self.vec.extend(filler.take(self.remaining()).casted(&Interner));
+        assert_eq!(self.remaining(), 0);
+        self
+    }
+
+    pub fn use_parent_substs(mut self, parent_substs: &Substitution) -> Self {
+        assert!(self.vec.is_empty());
+        assert!(parent_substs.len(&Interner) <= self.param_count);
+        self.vec.extend(parent_substs.iter(&Interner).cloned());
+        self
+    }
+}
+
+impl TyBuilder<()> {
+    pub fn unit() -> Ty {
+        TyKind::Tuple(0, Substitution::empty(&Interner)).intern(&Interner)
+    }
+
+    pub fn fn_ptr(sig: CallableSig) -> Ty {
+        TyKind::Function(FnPointer {
+            num_args: sig.params().len(),
+            sig: FnSig { abi: (), safety: Safety::Safe, variadic: sig.is_varargs },
+            substs: Substitution::from_iter(&Interner, sig.params_and_return.iter().cloned()),
+        })
+        .intern(&Interner)
+    }
+
+    pub fn builtin(builtin: BuiltinType) -> Ty {
+        match builtin {
+            BuiltinType::Char => TyKind::Scalar(Scalar::Char).intern(&Interner),
+            BuiltinType::Bool => TyKind::Scalar(Scalar::Bool).intern(&Interner),
+            BuiltinType::Str => TyKind::Str.intern(&Interner),
+            BuiltinType::Int(t) => {
+                TyKind::Scalar(Scalar::Int(primitive::int_ty_from_builtin(t))).intern(&Interner)
+            }
+            BuiltinType::Uint(t) => {
+                TyKind::Scalar(Scalar::Uint(primitive::uint_ty_from_builtin(t))).intern(&Interner)
+            }
+            BuiltinType::Float(t) => {
+                TyKind::Scalar(Scalar::Float(primitive::float_ty_from_builtin(t))).intern(&Interner)
+            }
+        }
+    }
+
+    pub fn subst_for_def(db: &dyn HirDatabase, def: impl Into<GenericDefId>) -> TyBuilder<()> {
+        let def = def.into();
+        let params = generics(db.upcast(), def);
+        let param_count = params.len();
+        TyBuilder::new((), param_count)
+    }
+
+    pub fn build(self) -> Substitution {
+        let ((), subst) = self.build_internal();
+        subst
+    }
+}
+
+impl TyBuilder<hir_def::AdtId> {
+    pub fn adt(db: &dyn HirDatabase, adt: hir_def::AdtId) -> TyBuilder<hir_def::AdtId> {
+        let generics = generics(db.upcast(), adt.into());
+        let param_count = generics.len();
+        TyBuilder::new(adt, param_count)
+    }
+
+    pub fn fill_with_defaults(
+        mut self,
+        db: &dyn HirDatabase,
+        mut fallback: impl FnMut() -> Ty,
+    ) -> Self {
+        let defaults = db.generic_defaults(self.data.into());
+        for default_ty in defaults.iter().skip(self.vec.len()) {
+            if default_ty.skip_binders().is_unknown() {
+                self.vec.push(fallback().cast(&Interner));
+            } else {
+                // each default can depend on the previous parameters
+                let subst_so_far = Substitution(self.vec.clone());
+                self.vec.push(default_ty.clone().subst(&subst_so_far).cast(&Interner));
+            }
+        }
+        self
+    }
+
+    pub fn build(self) -> Ty {
+        let (adt, subst) = self.build_internal();
+        TyKind::Adt(AdtId(adt), subst).intern(&Interner)
+    }
+}
+
+pub struct Tuple(usize);
+impl TyBuilder<Tuple> {
+    pub fn tuple(size: usize) -> TyBuilder<Tuple> {
+        TyBuilder::new(Tuple(size), size)
+    }
+
+    pub fn build(self) -> Ty {
+        let (Tuple(size), subst) = self.build_internal();
+        TyKind::Tuple(size, subst).intern(&Interner)
+    }
+}
+
+impl TyBuilder<TraitId> {
+    pub fn trait_ref(db: &dyn HirDatabase, trait_id: TraitId) -> TyBuilder<TraitId> {
+        let generics = generics(db.upcast(), trait_id.into());
+        let param_count = generics.len();
+        TyBuilder::new(trait_id, param_count)
+    }
+
+    pub fn build(self) -> TraitRef {
+        let (trait_id, substitution) = self.build_internal();
+        TraitRef { trait_id: to_chalk_trait_id(trait_id), substitution }
+    }
+}
+
+impl TyBuilder<TypeAliasId> {
+    pub fn assoc_type_projection(
+        db: &dyn HirDatabase,
+        type_alias: TypeAliasId,
+    ) -> TyBuilder<TypeAliasId> {
+        let generics = generics(db.upcast(), type_alias.into());
+        let param_count = generics.len();
+        TyBuilder::new(type_alias, param_count)
+    }
+
+    pub fn build(self) -> ProjectionTy {
+        let (type_alias, substitution) = self.build_internal();
+        ProjectionTy { associated_ty_id: to_assoc_type_id(type_alias), substitution }
+    }
+}
+
+impl<T: TypeWalk + HasInterner<Interner = Interner>> TyBuilder<Binders<T>> {
+    fn subst_binders(b: Binders<T>) -> Self {
+        let param_count = b.num_binders;
+        TyBuilder::new(b, param_count)
+    }
+
+    pub fn build(self) -> T {
+        let (b, subst) = self.build_internal();
+        b.subst(&subst)
+    }
+}
+
+impl TyBuilder<Binders<Ty>> {
+    pub fn def_ty(db: &dyn HirDatabase, def: TyDefId) -> TyBuilder<Binders<Ty>> {
+        TyBuilder::subst_binders(db.ty(def.into()))
+    }
+
+    pub fn impl_self_ty(db: &dyn HirDatabase, def: hir_def::ImplId) -> TyBuilder<Binders<Ty>> {
+        TyBuilder::subst_binders(db.impl_self_ty(def))
+    }
+
+    pub fn value_ty(db: &dyn HirDatabase, def: ValueTyDefId) -> TyBuilder<Binders<Ty>> {
+        TyBuilder::subst_binders(db.value_ty(def))
+    }
+}

--- a/crates/hir_ty/src/chalk_ext.rs
+++ b/crates/hir_ty/src/chalk_ext.rs
@@ -1,0 +1,13 @@
+//! Various extensions traits for Chalk types.
+
+use crate::{Interner, Ty, TyKind};
+
+pub trait TyExt {
+    fn is_unit(&self) -> bool;
+}
+
+impl TyExt for Ty {
+    fn is_unit(&self) -> bool {
+        matches!(self.kind(&Interner), TyKind::Tuple(0, _))
+    }
+}

--- a/crates/hir_ty/src/diagnostics/expr.rs
+++ b/crates/hir_ty/src/diagnostics/expr.rs
@@ -15,7 +15,7 @@ use crate::{
         MissingPatFields, RemoveThisSemicolon,
     },
     utils::variant_data,
-    AdtId, InferenceResult, Interner, Ty, TyKind,
+    AdtId, InferenceResult, Interner, TyExt, TyKind,
 };
 
 pub(crate) use hir_def::{
@@ -423,7 +423,7 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
             None => return,
         };
 
-        if mismatch.actual != Ty::unit() || mismatch.expected != *possible_tail_ty {
+        if !mismatch.actual.is_unit() || mismatch.expected != *possible_tail_ty {
             return;
         }
 

--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -19,8 +19,7 @@ use crate::{
     db::HirDatabase, from_assoc_type_id, from_foreign_def_id, from_placeholder_idx, primitive,
     to_assoc_type_id, traits::chalk::from_chalk, utils::generics, AdtId, AliasEq, AliasTy,
     CallableDefId, CallableSig, DomainGoal, GenericArg, ImplTraitId, Interner, Lifetime, OpaqueTy,
-    ProjectionTy, QuantifiedWhereClause, Scalar, TraitRef, Ty, TyExt, TyKind,
-    WhereClause,
+    ProjectionTy, QuantifiedWhereClause, Scalar, TraitRef, Ty, TyExt, TyKind, WhereClause,
 };
 
 pub struct HirFormatter<'a> {

--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -19,7 +19,7 @@ use crate::{
     db::HirDatabase, from_assoc_type_id, from_foreign_def_id, from_placeholder_idx, primitive,
     to_assoc_type_id, traits::chalk::from_chalk, utils::generics, AdtId, AliasEq, AliasTy,
     CallableDefId, CallableSig, DomainGoal, GenericArg, ImplTraitId, Interner, Lifetime, OpaqueTy,
-    ProjectionTy, QuantifiedWhereClause, Scalar, Substitution, TraitRef, Ty, TyExt, TyKind,
+    ProjectionTy, QuantifiedWhereClause, Scalar, TraitRef, Ty, TyExt, TyKind,
     WhereClause,
 };
 
@@ -592,7 +592,7 @@ impl HirDisplay for Ty {
                         write!(f, "{}", param_data.name.clone().unwrap_or_else(Name::missing))?
                     }
                     TypeParamProvenance::ArgumentImplTrait => {
-                        let substs = Substitution::type_params_for_generics(f.db, &generics);
+                        let substs = generics.type_params_subst(f.db);
                         let bounds = f
                             .db
                             .generic_predicates(id.parent)

--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -19,7 +19,8 @@ use crate::{
     db::HirDatabase, from_assoc_type_id, from_foreign_def_id, from_placeholder_idx, primitive,
     to_assoc_type_id, traits::chalk::from_chalk, utils::generics, AdtId, AliasEq, AliasTy,
     CallableDefId, CallableSig, DomainGoal, GenericArg, ImplTraitId, Interner, Lifetime, OpaqueTy,
-    ProjectionTy, QuantifiedWhereClause, Scalar, Substitution, TraitRef, Ty, TyKind, WhereClause,
+    ProjectionTy, QuantifiedWhereClause, Scalar, Substitution, TraitRef, Ty, TyExt, TyKind,
+    WhereClause,
 };
 
 pub struct HirFormatter<'a> {
@@ -423,7 +424,7 @@ impl HirDisplay for Ty {
                 f.write_joined(sig.params(), ", ")?;
                 write!(f, ")")?;
                 let ret = sig.ret();
-                if *ret != Ty::unit() {
+                if !ret.is_unit() {
                     let ret_display = ret.into_displayable(
                         f.db,
                         f.max_size,
@@ -663,7 +664,7 @@ impl HirDisplay for CallableSig {
         }
         write!(f, ")")?;
         let ret = self.ret();
-        if *ret != Ty::unit() {
+        if !ret.is_unit() {
             let ret_display =
                 ret.into_displayable(f.db, f.max_size, f.omit_verbose_types, f.display_target);
             write!(f, " -> {}", ret_display)?;

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -38,7 +38,7 @@ use syntax::SmolStr;
 
 use super::{
     traits::{DomainGoal, Guidance, Solution},
-    InEnvironment, ProjectionTy, Substitution, TraitEnvironment, TraitRef, Ty, TypeWalk,
+    InEnvironment, ProjectionTy, TraitEnvironment, TraitRef, Ty, TypeWalk,
 };
 use crate::{
     db::HirDatabase, infer::diagnostics::InferenceDiagnostic, lower::ImplTraitLoweringMode,
@@ -487,7 +487,7 @@ impl<'a> InferenceContext<'a> {
             }
             TypeNs::SelfType(impl_id) => {
                 let generics = crate::utils::generics(self.db.upcast(), impl_id.into());
-                let substs = Substitution::type_params_for_generics(self.db, &generics);
+                let substs = generics.type_params_subst(self.db);
                 let ty = self.db.impl_self_ty(impl_id).subst(&substs);
                 match unresolved {
                     None => {

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -42,7 +42,7 @@ use super::{
 };
 use crate::{
     db::HirDatabase, infer::diagnostics::InferenceDiagnostic, lower::ImplTraitLoweringMode,
-    to_assoc_type_id, to_chalk_trait_id, AliasEq, AliasTy, Interner, TyKind,
+    to_assoc_type_id, AliasEq, AliasTy, Interner, TyBuilder, TyKind,
 };
 
 // This lint has a false positive here. See the link below for details.
@@ -409,16 +409,14 @@ impl<'a> InferenceContext<'a> {
                     _ => panic!("resolve_associated_type called with non-associated type"),
                 };
                 let ty = self.table.new_type_var();
-                let substs = Substitution::build_for_def(self.db, res_assoc_ty)
+                let trait_ref = TyBuilder::trait_ref(self.db, trait_)
                     .push(inner_ty)
                     .fill(params.iter().cloned())
                     .build();
-                let trait_ref =
-                    TraitRef { trait_id: to_chalk_trait_id(trait_), substitution: substs.clone() };
                 let alias_eq = AliasEq {
                     alias: AliasTy::Projection(ProjectionTy {
                         associated_ty_id: to_assoc_type_id(res_assoc_ty),
-                        substitution: substs,
+                        substitution: trait_ref.substitution.clone(),
                     }),
                     ty: ty.clone(),
                 };

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -514,10 +514,9 @@ impl<'a> InferenceContext<'a> {
                 }
             }
             TypeNs::TypeAliasId(it) => {
-                let substs = Substitution::build_for_def(self.db, it)
+                let ty = TyBuilder::def_ty(self.db, it.into())
                     .fill(std::iter::repeat_with(|| self.table.new_type_var()))
                     .build();
-                let ty = self.db.ty(it.into()).subst(&substs);
                 let variant = ty_variant(&ty);
                 forbid_unresolved_segments((ty, variant), unresolved)
             }

--- a/crates/hir_ty/src/infer/coerce.rs
+++ b/crates/hir_ty/src/infer/coerce.rs
@@ -8,7 +8,8 @@ use chalk_ir::{cast::Cast, Mutability, TyVariableKind};
 use hir_def::lang_item::LangItemTarget;
 
 use crate::{
-    autoderef, to_chalk_trait_id, traits::Solution, Interner, Substitution, TraitRef, Ty, TyKind,
+    autoderef, to_chalk_trait_id, traits::Solution, Interner, Substitution, TraitRef, Ty,
+    TyBuilder, TyKind,
 };
 
 use super::{InEnvironment, InferenceContext};
@@ -44,8 +45,8 @@ impl<'a> InferenceContext<'a> {
                 // https://github.com/rust-lang/rust/blob/7b805396bf46dce972692a6846ce2ad8481c5f85/src/librustc_typeck/check/coercion.rs#L877-L916
                 let sig1 = ty1.callable_sig(self.db).expect("FnDef without callable sig");
                 let sig2 = ty2.callable_sig(self.db).expect("FnDef without callable sig");
-                let ptr_ty1 = Ty::fn_ptr(sig1);
-                let ptr_ty2 = Ty::fn_ptr(sig2);
+                let ptr_ty1 = TyBuilder::fn_ptr(sig1);
+                let ptr_ty2 = TyBuilder::fn_ptr(sig2);
                 self.coerce_merge_branch(&ptr_ty1, &ptr_ty2)
             } else {
                 cov_mark::hit!(coerce_merge_fail_fallback);
@@ -95,7 +96,7 @@ impl<'a> InferenceContext<'a> {
             (TyKind::FnDef(..), TyKind::Function { .. }) => match from_ty.callable_sig(self.db) {
                 None => return false,
                 Some(sig) => {
-                    from_ty = Ty::fn_ptr(sig);
+                    from_ty = TyBuilder::fn_ptr(sig);
                 }
             },
 

--- a/crates/hir_ty/src/infer/coerce.rs
+++ b/crates/hir_ty/src/infer/coerce.rs
@@ -7,10 +7,7 @@
 use chalk_ir::{cast::Cast, Mutability, TyVariableKind};
 use hir_def::lang_item::LangItemTarget;
 
-use crate::{
-    autoderef, traits::Solution, Interner, Ty,
-    TyBuilder, TyKind,
-};
+use crate::{autoderef, traits::Solution, Interner, Ty, TyBuilder, TyKind};
 
 use super::{InEnvironment, InferenceContext};
 

--- a/crates/hir_ty/src/infer/expr.rs
+++ b/crates/hir_ty/src/infer/expr.rs
@@ -75,14 +75,13 @@ impl<'a> InferenceContext<'a> {
             self.db.trait_data(fn_once_trait).associated_type_by_name(&name![Output])?;
 
         let mut arg_tys = vec![];
-        let parameters = Substitution::builder(num_args)
+        let arg_ty = TyBuilder::tuple(num_args)
             .fill(repeat_with(|| {
                 let arg = self.table.new_type_var();
                 arg_tys.push(arg.clone());
                 arg
             }))
             .build();
-        let arg_ty = TyKind::Tuple(num_args, parameters).intern(&Interner);
 
         let projection = {
             let b = TyBuilder::assoc_type_projection(self.db, output_assoc_type);

--- a/crates/hir_ty/src/infer/path.rs
+++ b/crates/hir_ty/src/infer/path.rs
@@ -93,16 +93,13 @@ impl<'a> InferenceContext<'a> {
             ValueNs::GenericParam(it) => return Some(self.db.const_param_ty(it)),
         };
 
-        let ty = self.db.value_ty(typable);
-        // self_subst is just for the parent
         let parent_substs = self_subst.unwrap_or_else(|| Substitution::empty(&Interner));
         let ctx = crate::lower::TyLoweringContext::new(self.db, &self.resolver);
         let substs = ctx.substs_from_path(path, typable, true);
-        let full_substs = Substitution::builder(substs.len(&Interner))
+        let ty = TyBuilder::value_ty(self.db, typable)
             .use_parent_substs(&parent_substs)
             .fill(substs.interned(&Interner)[parent_substs.len(&Interner)..].iter().cloned())
             .build();
-        let ty = ty.subst(&full_substs);
         Some(ty)
     }
 

--- a/crates/hir_ty/src/infer/path.rs
+++ b/crates/hir_ty/src/infer/path.rs
@@ -80,7 +80,7 @@ impl<'a> InferenceContext<'a> {
             }
             ValueNs::ImplSelf(impl_id) => {
                 let generics = crate::utils::generics(self.db.upcast(), impl_id.into());
-                let substs = Substitution::type_params_for_generics(self.db, &generics);
+                let substs = generics.type_params_subst(self.db);
                 let ty = self.db.impl_self_ty(impl_id).subst(&substs);
                 if let Some((AdtId::StructId(struct_id), substs)) = ty.as_adt() {
                     let ty = self.db.value_ty(struct_id.into()).subst(&substs);

--- a/crates/hir_ty/src/infer/path.rs
+++ b/crates/hir_ty/src/infer/path.rs
@@ -243,7 +243,7 @@ impl<'a> InferenceContext<'a> {
                 };
                 let substs = match container {
                     AssocContainerId::ImplId(impl_id) => {
-                        let impl_substs = Substitution::build_for_def(self.db, impl_id)
+                        let impl_substs = TyBuilder::subst_for_def(self.db, impl_id)
                             .fill(iter::repeat_with(|| self.table.new_type_var()))
                             .build();
                         let impl_self_ty = self.db.impl_self_ty(impl_id).subst(&impl_substs);

--- a/crates/hir_ty/src/infer/unify.rs
+++ b/crates/hir_ty/src/infer/unify.rs
@@ -186,14 +186,11 @@ pub(crate) fn unify(tys: &Canonical<(Ty, Ty)>) -> Option<Substitution> {
             );
         }
     }
-    Some(
-        Substitution::builder(tys.binders.len(&Interner))
-            .fill(
-                vars.iter(&Interner)
-                    .map(|v| table.resolve_ty_completely(v.assert_ty_ref(&Interner).clone())),
-            )
-            .build(),
-    )
+    Some(Substitution::from_iter(
+        &Interner,
+        vars.iter(&Interner)
+            .map(|v| table.resolve_ty_completely(v.assert_ty_ref(&Interner).clone())),
+    ))
 }
 
 #[derive(Clone, Debug)]

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -877,6 +877,23 @@ impl TyBuilder<()> {
         })
         .intern(&Interner)
     }
+
+    pub fn builtin(builtin: BuiltinType) -> Ty {
+        match builtin {
+            BuiltinType::Char => TyKind::Scalar(Scalar::Char).intern(&Interner),
+            BuiltinType::Bool => TyKind::Scalar(Scalar::Bool).intern(&Interner),
+            BuiltinType::Str => TyKind::Str.intern(&Interner),
+            BuiltinType::Int(t) => {
+                TyKind::Scalar(Scalar::Int(primitive::int_ty_from_builtin(t))).intern(&Interner)
+            }
+            BuiltinType::Uint(t) => {
+                TyKind::Scalar(Scalar::Uint(primitive::uint_ty_from_builtin(t))).intern(&Interner)
+            }
+            BuiltinType::Float(t) => {
+                TyKind::Scalar(Scalar::Float(primitive::float_ty_from_builtin(t))).intern(&Interner)
+            }
+        }
+    }
 }
 
 impl TyBuilder<hir_def::AdtId> {
@@ -911,23 +928,6 @@ impl TyBuilder<hir_def::AdtId> {
 }
 
 impl Ty {
-    pub fn builtin(builtin: BuiltinType) -> Self {
-        match builtin {
-            BuiltinType::Char => TyKind::Scalar(Scalar::Char).intern(&Interner),
-            BuiltinType::Bool => TyKind::Scalar(Scalar::Bool).intern(&Interner),
-            BuiltinType::Str => TyKind::Str.intern(&Interner),
-            BuiltinType::Int(t) => {
-                TyKind::Scalar(Scalar::Int(primitive::int_ty_from_builtin(t))).intern(&Interner)
-            }
-            BuiltinType::Uint(t) => {
-                TyKind::Scalar(Scalar::Uint(primitive::uint_ty_from_builtin(t))).intern(&Interner)
-            }
-            BuiltinType::Float(t) => {
-                TyKind::Scalar(Scalar::Float(primitive::float_ty_from_builtin(t))).intern(&Interner)
-            }
-        }
-    }
-
     pub fn as_reference(&self) -> Option<(&Ty, Mutability)> {
         match self.kind(&Interner) {
             TyKind::Ref(mutability, ty) => Some((ty, *mutability)),

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -818,20 +818,20 @@ impl TyBuilder {
     pub fn unit() -> Ty {
         TyKind::Tuple(0, Substitution::empty(&Interner)).intern(&Interner)
     }
-}
 
-impl Ty {
-    pub fn adt_ty(adt: hir_def::AdtId, substs: Substitution) -> Ty {
-        TyKind::Adt(AdtId(adt), substs).intern(&Interner)
-    }
-
-    pub fn fn_ptr(sig: CallableSig) -> Self {
+    pub fn fn_ptr(sig: CallableSig) -> Ty {
         TyKind::Function(FnPointer {
             num_args: sig.params().len(),
             sig: FnSig { abi: (), safety: Safety::Safe, variadic: sig.is_varargs },
             substs: Substitution::from_iter(&Interner, sig.params_and_return.iter().cloned()),
         })
         .intern(&Interner)
+    }
+}
+
+impl Ty {
+    pub fn adt_ty(adt: hir_def::AdtId, substs: Substitution) -> Ty {
+        TyKind::Adt(AdtId(adt), substs).intern(&Interner)
     }
 
     pub fn builtin(builtin: BuiltinType) -> Self {

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -927,6 +927,35 @@ impl TyBuilder<hir_def::AdtId> {
     }
 }
 
+impl TyBuilder<TraitId> {
+    pub fn trait_ref(db: &dyn HirDatabase, trait_id: TraitId) -> TyBuilder<TraitId> {
+        let generics = generics(db.upcast(), trait_id.into());
+        let param_count = generics.len();
+        TyBuilder::new(trait_id, param_count)
+    }
+
+    pub fn build(self) -> TraitRef {
+        let (trait_id, substitution) = self.build_internal();
+        TraitRef { trait_id: to_chalk_trait_id(trait_id), substitution }
+    }
+}
+
+impl TyBuilder<TypeAliasId> {
+    pub fn assoc_type_projection(
+        db: &dyn HirDatabase,
+        type_alias: TypeAliasId,
+    ) -> TyBuilder<TypeAliasId> {
+        let generics = generics(db.upcast(), type_alias.into());
+        let param_count = generics.len();
+        TyBuilder::new(type_alias, param_count)
+    }
+
+    pub fn build(self) -> ProjectionTy {
+        let (type_alias, substitution) = self.build_internal();
+        ProjectionTy { associated_ty_id: to_assoc_type_id(type_alias), substitution }
+    }
+}
+
 impl Ty {
     pub fn as_reference(&self) -> Option<(&Ty, Mutability)> {
         match self.kind(&Interner) {

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -810,6 +810,12 @@ impl TypeWalk for CallableSig {
     }
 }
 
+struct TyBuilder {}
+
+impl TyBuilder {
+
+}
+
 impl Ty {
     pub fn unit() -> Self {
         TyKind::Tuple(0, Substitution::empty(&Interner)).intern(&Interner)

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -23,6 +23,7 @@ pub mod diagnostics;
 mod tests;
 #[cfg(test)]
 mod test_db;
+mod chalk_ext;
 
 use std::{iter, mem, sync::Arc};
 
@@ -42,6 +43,7 @@ use crate::{
 };
 
 pub use autoderef::autoderef;
+pub use chalk_ext::TyExt;
 pub use infer::{could_unify, InferenceResult, InferenceVar};
 pub use lower::{
     associated_type_shorthand_candidates, callable_item_sig, CallableDefId, ImplTraitLoweringMode,
@@ -813,14 +815,12 @@ impl TypeWalk for CallableSig {
 struct TyBuilder {}
 
 impl TyBuilder {
-
+    pub fn unit() -> Ty {
+        TyKind::Tuple(0, Substitution::empty(&Interner)).intern(&Interner)
+    }
 }
 
 impl Ty {
-    pub fn unit() -> Self {
-        TyKind::Tuple(0, Substitution::empty(&Interner)).intern(&Interner)
-    }
-
     pub fn adt_ty(adt: hir_def::AdtId, substs: Substitution) -> Ty {
         TyKind::Adt(AdtId(adt), substs).intern(&Interner)
     }

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -14,6 +14,8 @@ mod lower;
 pub(crate) mod infer;
 pub(crate) mod utils;
 mod chalk_cast;
+mod chalk_ext;
+mod builder;
 
 pub mod display;
 pub mod db;
@@ -23,21 +25,18 @@ pub mod diagnostics;
 mod tests;
 #[cfg(test)]
 mod test_db;
-mod chalk_ext;
 
-use std::{iter, mem, sync::Arc};
+use std::{mem, sync::Arc};
 
-use base_db::salsa;
-use chalk_ir::{
-    cast::{CastTo, Caster},
-    interner::HasInterner,
-};
-use hir_def::{
-    builtin_type::BuiltinType, expr::ExprId, type_ref::Rawness, AssocContainerId, FunctionId,
-    GenericDefId, HasModule, LifetimeParamId, Lookup, TraitId, TypeAliasId, TypeParamId,
-};
+use chalk_ir::cast::{CastTo, Caster};
 use itertools::Itertools;
 use smallvec::SmallVec;
+
+use base_db::salsa;
+use hir_def::{
+    expr::ExprId, type_ref::Rawness, AssocContainerId, FunctionId, GenericDefId, HasModule,
+    LifetimeParamId, Lookup, TraitId, TypeAliasId, TypeParamId,
+};
 
 use crate::{
     db::HirDatabase,
@@ -46,6 +45,7 @@ use crate::{
 };
 
 pub use autoderef::autoderef;
+pub use builder::TyBuilder;
 pub use chalk_ext::TyExt;
 pub use infer::{could_unify, InferenceResult, InferenceVar};
 pub use lower::{
@@ -741,200 +741,6 @@ impl TypeWalk for CallableSig {
         for t in make_mut_slice(&mut self.params_and_return) {
             t.walk_mut_binders(f, binders);
         }
-    }
-}
-
-pub struct TyBuilder<D> {
-    data: D,
-    vec: SmallVec<[GenericArg; 2]>,
-    param_count: usize,
-}
-
-impl<D> TyBuilder<D> {
-    fn new(data: D, param_count: usize) -> TyBuilder<D> {
-        TyBuilder { data, param_count, vec: SmallVec::with_capacity(param_count) }
-    }
-
-    fn build_internal(self) -> (D, Substitution) {
-        assert_eq!(self.vec.len(), self.param_count);
-        // FIXME: would be good to have a way to construct a chalk_ir::Substitution from the interned form
-        let subst = Substitution(self.vec);
-        (self.data, subst)
-    }
-
-    pub fn push(mut self, arg: impl CastTo<GenericArg>) -> Self {
-        self.vec.push(arg.cast(&Interner));
-        self
-    }
-
-    fn remaining(&self) -> usize {
-        self.param_count - self.vec.len()
-    }
-
-    pub fn fill_with_bound_vars(self, debruijn: DebruijnIndex, starting_from: usize) -> Self {
-        self.fill(
-            (starting_from..)
-                .map(|idx| TyKind::BoundVar(BoundVar::new(debruijn, idx)).intern(&Interner)),
-        )
-    }
-
-    pub fn fill_with_unknown(self) -> Self {
-        self.fill(iter::repeat(TyKind::Unknown.intern(&Interner)))
-    }
-
-    pub fn fill(mut self, filler: impl Iterator<Item = impl CastTo<GenericArg>>) -> Self {
-        self.vec.extend(filler.take(self.remaining()).casted(&Interner));
-        assert_eq!(self.remaining(), 0);
-        self
-    }
-
-    pub fn use_parent_substs(mut self, parent_substs: &Substitution) -> Self {
-        assert!(self.vec.is_empty());
-        assert!(parent_substs.len(&Interner) <= self.param_count);
-        self.vec.extend(parent_substs.iter(&Interner).cloned());
-        self
-    }
-}
-
-impl TyBuilder<()> {
-    pub fn unit() -> Ty {
-        TyKind::Tuple(0, Substitution::empty(&Interner)).intern(&Interner)
-    }
-
-    pub fn fn_ptr(sig: CallableSig) -> Ty {
-        TyKind::Function(FnPointer {
-            num_args: sig.params().len(),
-            sig: FnSig { abi: (), safety: Safety::Safe, variadic: sig.is_varargs },
-            substs: Substitution::from_iter(&Interner, sig.params_and_return.iter().cloned()),
-        })
-        .intern(&Interner)
-    }
-
-    pub fn builtin(builtin: BuiltinType) -> Ty {
-        match builtin {
-            BuiltinType::Char => TyKind::Scalar(Scalar::Char).intern(&Interner),
-            BuiltinType::Bool => TyKind::Scalar(Scalar::Bool).intern(&Interner),
-            BuiltinType::Str => TyKind::Str.intern(&Interner),
-            BuiltinType::Int(t) => {
-                TyKind::Scalar(Scalar::Int(primitive::int_ty_from_builtin(t))).intern(&Interner)
-            }
-            BuiltinType::Uint(t) => {
-                TyKind::Scalar(Scalar::Uint(primitive::uint_ty_from_builtin(t))).intern(&Interner)
-            }
-            BuiltinType::Float(t) => {
-                TyKind::Scalar(Scalar::Float(primitive::float_ty_from_builtin(t))).intern(&Interner)
-            }
-        }
-    }
-
-    pub fn subst_for_def(db: &dyn HirDatabase, def: impl Into<GenericDefId>) -> TyBuilder<()> {
-        let def = def.into();
-        let params = generics(db.upcast(), def);
-        let param_count = params.len();
-        TyBuilder::new((), param_count)
-    }
-
-    pub fn build(self) -> Substitution {
-        let ((), subst) = self.build_internal();
-        subst
-    }
-}
-
-impl TyBuilder<hir_def::AdtId> {
-    pub fn adt(db: &dyn HirDatabase, adt: hir_def::AdtId) -> TyBuilder<hir_def::AdtId> {
-        let generics = generics(db.upcast(), adt.into());
-        let param_count = generics.len();
-        TyBuilder::new(adt, param_count)
-    }
-
-    pub fn fill_with_defaults(
-        mut self,
-        db: &dyn HirDatabase,
-        mut fallback: impl FnMut() -> Ty,
-    ) -> Self {
-        let defaults = db.generic_defaults(self.data.into());
-        for default_ty in defaults.iter().skip(self.vec.len()) {
-            if default_ty.skip_binders().is_unknown() {
-                self.vec.push(fallback().cast(&Interner));
-            } else {
-                // each default can depend on the previous parameters
-                let subst_so_far = Substitution(self.vec.clone());
-                self.vec.push(default_ty.clone().subst(&subst_so_far).cast(&Interner));
-            }
-        }
-        self
-    }
-
-    pub fn build(self) -> Ty {
-        let (adt, subst) = self.build_internal();
-        TyKind::Adt(AdtId(adt), subst).intern(&Interner)
-    }
-}
-
-struct Tuple(usize);
-impl TyBuilder<Tuple> {
-    pub fn tuple(size: usize) -> TyBuilder<Tuple> {
-        TyBuilder::new(Tuple(size), size)
-    }
-
-    pub fn build(self) -> Ty {
-        let (Tuple(size), subst) = self.build_internal();
-        TyKind::Tuple(size, subst).intern(&Interner)
-    }
-}
-
-impl TyBuilder<TraitId> {
-    pub fn trait_ref(db: &dyn HirDatabase, trait_id: TraitId) -> TyBuilder<TraitId> {
-        let generics = generics(db.upcast(), trait_id.into());
-        let param_count = generics.len();
-        TyBuilder::new(trait_id, param_count)
-    }
-
-    pub fn build(self) -> TraitRef {
-        let (trait_id, substitution) = self.build_internal();
-        TraitRef { trait_id: to_chalk_trait_id(trait_id), substitution }
-    }
-}
-
-impl TyBuilder<TypeAliasId> {
-    pub fn assoc_type_projection(
-        db: &dyn HirDatabase,
-        type_alias: TypeAliasId,
-    ) -> TyBuilder<TypeAliasId> {
-        let generics = generics(db.upcast(), type_alias.into());
-        let param_count = generics.len();
-        TyBuilder::new(type_alias, param_count)
-    }
-
-    pub fn build(self) -> ProjectionTy {
-        let (type_alias, substitution) = self.build_internal();
-        ProjectionTy { associated_ty_id: to_assoc_type_id(type_alias), substitution }
-    }
-}
-
-impl<T: TypeWalk + HasInterner<Interner = Interner>> TyBuilder<Binders<T>> {
-    fn subst_binders(b: Binders<T>) -> Self {
-        let param_count = b.num_binders;
-        TyBuilder::new(b, param_count)
-    }
-
-    pub fn build(self) -> T {
-        let (b, subst) = self.build_internal();
-        b.subst(&subst)
-    }
-}
-
-impl TyBuilder<Binders<Ty>> {
-    pub fn def_ty(db: &dyn HirDatabase, def: TyDefId) -> TyBuilder<Binders<Ty>> {
-        TyBuilder::subst_binders(db.ty(def.into()))
-    }
-
-    pub fn impl_self_ty(db: &dyn HirDatabase, def: hir_def::ImplId) -> TyBuilder<Binders<Ty>> {
-        TyBuilder::subst_binders(db.impl_self_ty(def))
-    }
-
-    pub fn value_ty(db: &dyn HirDatabase, def: ValueTyDefId) -> TyBuilder<Binders<Ty>> {
-        TyBuilder::subst_binders(db.value_ty(def))
     }
 }
 

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -493,10 +493,6 @@ impl Substitution {
         )
     }
 
-    pub(crate) fn build_for_generics(generic_params: &Generics) -> SubstsBuilder {
-        Substitution::builder(generic_params.len())
-    }
-
     fn builder(param_count: usize) -> SubstsBuilder {
         SubstsBuilder { vec: Vec::with_capacity(param_count), param_count }
     }

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -754,7 +754,7 @@ impl CallableSig {
 
     pub fn from_fn_ptr(fn_ptr: &FnPointer) -> CallableSig {
         CallableSig {
-            // FIXME: what to do about lifetime params?
+            // FIXME: what to do about lifetime params? -> return PolyFnSig
             params_and_return: fn_ptr
                 .substs
                 .clone()
@@ -764,16 +764,6 @@ impl CallableSig {
                 .map(|arg| arg.assert_ty_ref(&Interner).clone())
                 .collect(),
             is_varargs: fn_ptr.sig.variadic,
-        }
-    }
-
-    pub fn from_substs(substs: &Substitution) -> CallableSig {
-        CallableSig {
-            params_and_return: substs
-                .iter(&Interner)
-                .map(|arg| arg.assert_ty_ref(&Interner).clone())
-                .collect(),
-            is_varargs: false,
         }
     }
 

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -41,7 +41,7 @@ use hir_def::{
 use crate::{
     db::HirDatabase,
     display::HirDisplay,
-    utils::{generics, make_mut_slice, Generics},
+    utils::{generics, make_mut_slice},
 };
 
 pub use autoderef::autoderef;
@@ -464,33 +464,9 @@ impl Substitution {
     }
 
     /// Return Substs that replace each parameter by itself (i.e. `Ty::Param`).
-    pub(crate) fn type_params_for_generics(
-        db: &dyn HirDatabase,
-        generic_params: &Generics,
-    ) -> Substitution {
-        Substitution::from_iter(
-            &Interner,
-            generic_params
-                .iter()
-                .map(|(id, _)| TyKind::Placeholder(to_placeholder_idx(db, id)).intern(&Interner)),
-        )
-    }
-
-    /// Return Substs that replace each parameter by itself (i.e. `Ty::Param`).
     pub fn type_params(db: &dyn HirDatabase, def: impl Into<GenericDefId>) -> Substitution {
         let params = generics(db.upcast(), def.into());
-        Substitution::type_params_for_generics(db, &params)
-    }
-
-    /// Return Substs that replace each parameter by a bound variable.
-    pub(crate) fn bound_vars(generic_params: &Generics, debruijn: DebruijnIndex) -> Substitution {
-        Substitution::from_iter(
-            &Interner,
-            generic_params
-                .iter()
-                .enumerate()
-                .map(|(idx, _)| TyKind::BoundVar(BoundVar::new(debruijn, idx)).intern(&Interner)),
-        )
+        params.type_params_subst(db)
     }
 }
 

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -462,12 +462,6 @@ impl Substitution {
     ) -> Self {
         Substitution(elements.into_iter().casted(interner).collect())
     }
-
-    /// Return Substs that replace each parameter by itself (i.e. `Ty::Param`).
-    pub fn type_params(db: &dyn HirDatabase, def: impl Into<GenericDefId>) -> Substitution {
-        let params = generics(db.upcast(), def.into());
-        params.type_params_subst(db)
-    }
 }
 
 /// Return an index of a parameter in the generic type parameter list by it's id.
@@ -944,7 +938,7 @@ impl Ty {
                 let param_data = &generic_params.types[id.local_id];
                 match param_data.provenance {
                     hir_def::generics::TypeParamProvenance::ArgumentImplTrait => {
-                        let substs = Substitution::type_params(db, id.parent);
+                        let substs = TyBuilder::type_params_subst(db, id.parent);
                         let predicates = db
                             .generic_predicates(id.parent)
                             .into_iter()

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -1216,7 +1216,7 @@ impl_from!(FunctionId, StructId, UnionId, EnumVariantId, ConstId, StaticId for V
 /// namespace.
 pub(crate) fn ty_query(db: &dyn HirDatabase, def: TyDefId) -> Binders<Ty> {
     match def {
-        TyDefId::BuiltinType(it) => Binders::new(0, Ty::builtin(it)),
+        TyDefId::BuiltinType(it) => Binders::new(0, TyBuilder::builtin(it)),
         TyDefId::AdtId(it) => type_for_adt(db, it),
         TyDefId::TypeAliasId(it) => type_for_type_alias(db, it),
     }

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -860,10 +860,9 @@ pub fn associated_type_shorthand_candidates<R>(
                 if generics.params.types[param_id.local_id].provenance
                     == TypeParamProvenance::TraitSelf
                 {
-                    let trait_ref = TraitRef {
-                        trait_id: to_chalk_trait_id(trait_id),
-                        substitution: Substitution::bound_vars(&generics, DebruijnIndex::INNERMOST),
-                    };
+                    let trait_ref = TyBuilder::trait_ref(db, trait_id)
+                        .fill_with_bound_vars(DebruijnIndex::INNERMOST, 0)
+                        .build();
                     return search(trait_ref);
                 }
             }

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -36,7 +36,7 @@ use crate::{
     AliasEq, AliasTy, Binders, BoundVar, CallableSig, DebruijnIndex, DynTy, FnPointer, FnSig,
     ImplTraitId, OpaqueTy, PolyFnSig, ProjectionTy, QuantifiedWhereClause, QuantifiedWhereClauses,
     ReturnTypeImplTrait, ReturnTypeImplTraits, Substitution, TraitEnvironment, TraitRef, Ty,
-    TyKind, TypeWalk, WhereClause,
+    TyBuilder, TyKind, TypeWalk, WhereClause,
 };
 
 #[derive(Debug)]
@@ -1141,9 +1141,10 @@ fn type_for_enum_variant_constructor(db: &dyn HirDatabase, def: EnumVariantId) -
 }
 
 fn type_for_adt(db: &dyn HirDatabase, adt: AdtId) -> Binders<Ty> {
-    let generics = generics(db.upcast(), adt.into());
-    let substs = Substitution::bound_vars(&generics, DebruijnIndex::INNERMOST);
-    Binders::new(substs.len(&Interner), Ty::adt_ty(adt, substs))
+    let b = TyBuilder::adt(db, adt);
+    let num_binders = b.remaining();
+    let ty = b.fill_with_bound_vars(DebruijnIndex::INNERMOST, 0).build();
+    Binders::new(num_binders, ty)
 }
 
 fn type_for_type_alias(db: &dyn HirDatabase, t: TypeAliasId) -> Binders<Ty> {

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -470,12 +470,13 @@ impl<'a> TyLoweringContext<'a> {
                             TypeParamLoweringMode::Placeholder => {
                                 // if we're lowering to placeholders, we have to put
                                 // them in now
-                                let s = Substitution::type_params(
-                                    self.db,
+                                let generics = generics(
+                                    self.db.upcast(),
                                     self.resolver.generic_def().expect(
                                         "there should be generics if there's a generic param",
                                     ),
                                 );
+                                let s = generics.type_params_subst(self.db);
                                 t.substitution.clone().subst_bound_vars(&s)
                             }
                             TypeParamLoweringMode::Variable => t.substitution.clone(),
@@ -963,7 +964,7 @@ pub(crate) fn trait_environment_query(
         // function default implementations (and hypothetical code
         // inside consts or type aliases)
         cov_mark::hit!(trait_self_implements_self);
-        let substs = Substitution::type_params(db, trait_id);
+        let substs = TyBuilder::type_params_subst(db, trait_id);
         let trait_ref = TraitRef { trait_id: to_chalk_trait_id(trait_id), substitution: substs };
         let pred = WhereClause::Implemented(trait_ref);
         let program_clause: chalk_ir::ProgramClause<Interner> = pred.to_chalk(db).cast(&Interner);

--- a/crates/hir_ty/src/method_resolution.rs
+++ b/crates/hir_ty/src/method_resolution.rs
@@ -19,10 +19,9 @@ use crate::{
     db::HirDatabase,
     from_foreign_def_id,
     primitive::{self, FloatTy, IntTy, UintTy},
-    to_chalk_trait_id,
     utils::all_super_traits,
     AdtId, Canonical, CanonicalVarKinds, DebruijnIndex, FnPointer, FnSig, ForeignDefId,
-    InEnvironment, Interner, Scalar, Substitution, TraitEnvironment, TraitRef, Ty, TyKind,
+    InEnvironment, Interner, Scalar, Substitution, TraitEnvironment, Ty, TyBuilder, TyKind,
     TypeWalk,
 };
 
@@ -813,7 +812,7 @@ fn generic_implements_goal(
     self_ty: Canonical<Ty>,
 ) -> Canonical<InEnvironment<super::DomainGoal>> {
     let mut kinds = self_ty.binders.interned().to_vec();
-    let substs = super::Substitution::build_for_def(db, trait_)
+    let trait_ref = TyBuilder::trait_ref(db, trait_)
         .push(self_ty.value)
         .fill_with_bound_vars(DebruijnIndex::INNERMOST, kinds.len())
         .build();
@@ -822,9 +821,8 @@ fn generic_implements_goal(
             chalk_ir::VariableKind::Ty(chalk_ir::TyVariableKind::General),
             UniverseIndex::ROOT,
         ))
-        .take(substs.len(&Interner) - 1),
+        .take(trait_ref.substitution.len(&Interner) - 1),
     );
-    let trait_ref = TraitRef { trait_id: to_chalk_trait_id(trait_), substitution: substs };
     let obligation = trait_ref.cast(&Interner);
     Canonical {
         binders: CanonicalVarKinds::from_iter(&Interner, kinds),

--- a/crates/hir_ty/src/method_resolution.rs
+++ b/crates/hir_ty/src/method_resolution.rs
@@ -709,7 +709,7 @@ pub(crate) fn inherent_impl_substs(
 ) -> Option<Substitution> {
     // we create a var for each type parameter of the impl; we need to keep in
     // mind here that `self_ty` might have vars of its own
-    let vars = Substitution::build_for_def(db, impl_id)
+    let vars = TyBuilder::subst_for_def(db, impl_id)
         .fill_with_bound_vars(DebruijnIndex::INNERMOST, self_ty.binders.len(&Interner))
         .build();
     let self_ty_with_vars = db.impl_self_ty(impl_id).subst(&vars);
@@ -760,13 +760,13 @@ fn transform_receiver_ty(
     self_ty: &Canonical<Ty>,
 ) -> Option<Ty> {
     let substs = match function_id.lookup(db.upcast()).container {
-        AssocContainerId::TraitId(_) => Substitution::build_for_def(db, function_id)
+        AssocContainerId::TraitId(_) => TyBuilder::subst_for_def(db, function_id)
             .push(self_ty.value.clone())
             .fill_with_unknown()
             .build(),
         AssocContainerId::ImplId(impl_id) => {
             let impl_substs = inherent_impl_substs(db, impl_id, &self_ty)?;
-            Substitution::build_for_def(db, function_id)
+            TyBuilder::subst_for_def(db, function_id)
                 .use_parent_substs(&impl_substs)
                 .fill_with_unknown()
                 .build()

--- a/crates/hir_ty/src/op.rs
+++ b/crates/hir_ty/src/op.rs
@@ -2,12 +2,12 @@
 use chalk_ir::TyVariableKind;
 use hir_def::expr::{ArithOp, BinaryOp, CmpOp};
 
-use crate::{Interner, Scalar, Ty, TyKind};
+use crate::{Interner, Scalar, Ty, TyBuilder, TyKind};
 
 pub(super) fn binary_op_return_ty(op: BinaryOp, lhs_ty: Ty, rhs_ty: Ty) -> Ty {
     match op {
         BinaryOp::LogicOp(_) | BinaryOp::CmpOp(_) => TyKind::Scalar(Scalar::Bool).intern(&Interner),
-        BinaryOp::Assignment { .. } => Ty::unit(),
+        BinaryOp::Assignment { .. } => TyBuilder::unit(),
         BinaryOp::ArithOp(ArithOp::Shl) | BinaryOp::ArithOp(ArithOp::Shr) => {
             match lhs_ty.kind(&Interner) {
                 TyKind::Scalar(Scalar::Int(_))

--- a/crates/hir_ty/src/traits/chalk.rs
+++ b/crates/hir_ty/src/traits/chalk.rs
@@ -387,7 +387,7 @@ pub(crate) fn associated_ty_data_query(
     // Lower bounds -- we could/should maybe move this to a separate query in `lower`
     let type_alias_data = db.type_alias_data(type_alias);
     let generic_params = generics(db.upcast(), type_alias.into());
-    let bound_vars = Substitution::bound_vars(&generic_params, DebruijnIndex::INNERMOST);
+    let bound_vars = generic_params.bound_vars_subst(DebruijnIndex::INNERMOST);
     let resolver = hir_def::resolver::HasResolver::resolver(type_alias, db.upcast());
     let ctx = crate::TyLoweringContext::new(db, &resolver)
         .with_type_param_mode(crate::lower::TypeParamLoweringMode::Variable);
@@ -421,7 +421,7 @@ pub(crate) fn trait_datum_query(
     let trait_data = db.trait_data(trait_);
     debug!("trait {:?} = {:?}", trait_id, trait_data.name);
     let generic_params = generics(db.upcast(), trait_.into());
-    let bound_vars = Substitution::bound_vars(&generic_params, DebruijnIndex::INNERMOST);
+    let bound_vars = generic_params.bound_vars_subst(DebruijnIndex::INNERMOST);
     let flags = rust_ir::TraitFlags {
         auto: trait_data.is_auto,
         upstream: trait_.lookup(db.upcast()).container.krate() != krate,
@@ -490,7 +490,7 @@ pub(crate) fn struct_datum_query(
     let upstream = adt_id.module(db.upcast()).krate() != krate;
     let where_clauses = {
         let generic_params = generics(db.upcast(), adt_id.into());
-        let bound_vars = Substitution::bound_vars(&generic_params, DebruijnIndex::INNERMOST);
+        let bound_vars = generic_params.bound_vars_subst(DebruijnIndex::INNERMOST);
         convert_where_clauses(db, adt_id.into(), &bound_vars)
     };
     let flags = rust_ir::AdtFlags {
@@ -539,7 +539,7 @@ fn impl_def_datum(
     let impl_data = db.impl_data(impl_id);
 
     let generic_params = generics(db.upcast(), impl_id.into());
-    let bound_vars = Substitution::bound_vars(&generic_params, DebruijnIndex::INNERMOST);
+    let bound_vars = generic_params.bound_vars_subst(DebruijnIndex::INNERMOST);
     let trait_ = trait_ref.hir_trait_id();
     let impl_type = if impl_id.lookup(db.upcast()).container.krate() == krate {
         rust_ir::ImplType::Local
@@ -629,7 +629,7 @@ pub(crate) fn fn_def_datum_query(
     let callable_def: CallableDefId = from_chalk(db, fn_def_id);
     let generic_params = generics(db.upcast(), callable_def.into());
     let sig = db.callable_item_signature(callable_def);
-    let bound_vars = Substitution::bound_vars(&generic_params, DebruijnIndex::INNERMOST);
+    let bound_vars = generic_params.bound_vars_subst(DebruijnIndex::INNERMOST);
     let where_clauses = convert_where_clauses(db, callable_def.into(), &bound_vars);
     let bound = rust_ir::FnDefDatumBound {
         // Note: Chalk doesn't actually use this information yet as far as I am aware, but we provide it anyway

--- a/crates/hir_ty/src/traits/chalk.rs
+++ b/crates/hir_ty/src/traits/chalk.rs
@@ -22,7 +22,7 @@ use crate::{
     to_assoc_type_id, to_chalk_trait_id,
     utils::generics,
     AliasEq, AliasTy, BoundVar, CallableDefId, DebruijnIndex, FnDefId, ProjectionTy, Substitution,
-    TraitRef, Ty, TyKind, WhereClause,
+    TraitRef, Ty, TyBuilder, TyKind, WhereClause,
 };
 use mapping::{
     convert_where_clauses, generic_predicate_to_inline_bound, make_binders, TypeAliasAsValue,
@@ -300,7 +300,7 @@ impl<'a> chalk_solve::RustIrDatabase<Interner> for ChalkContext<'a> {
         _closure_id: chalk_ir::ClosureId<Interner>,
         _substs: &chalk_ir::Substitution<Interner>,
     ) -> chalk_ir::Binders<chalk_ir::Ty<Interner>> {
-        let ty = Ty::unit().to_chalk(self.db);
+        let ty = TyBuilder::unit().to_chalk(self.db);
         make_binders(ty, 0)
     }
     fn closure_fn_substitution(

--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -234,7 +234,7 @@ fn hint_iterator(
             hir::AssocItem::TypeAlias(alias) if alias.name(db) == known::Item => Some(alias),
             _ => None,
         })?;
-        if let Some(ty) = ty.normalize_trait_assoc_type(db, iter_trait, &[], assoc_type_item) {
+        if let Some(ty) = ty.normalize_trait_assoc_type(db, &[], assoc_type_item) {
             const LABEL_START: &str = "impl Iterator<Item = ";
             const LABEL_END: &str = ">";
 


### PR DESCRIPTION
When we'll move to using `chalk_ir::Ty` (#8313), we won't be able to have our own inherent methods on `Ty` anymore, so we need to move the helpers elsewhere.
This adds a `TyBuilder` that allows easily constructing `Ty` and related types (`TraitRef`, `ProjectionTy`, `Substitution`). It also replaces `SubstsBuilder`. `TyBuilder` can construct different things based on its type parameter; e.g. if it has an `AdtId`, we're constructing an ADT type, but if it has a `TraitId`, we're constructing a `TraitRef`. The common thing for all of them is that we need to build a `Substitution`, so the API stays the same for all of them except at the beginning and end.

We also use `TyBuilder` to house various one-shot methods for constructing types, e.g. `TyBuilder::unit()`.