### PR TITLE
Error when `rustfmt` component is unavailable

### DIFF
--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -928,7 +928,10 @@ pub(crate) fn handle_formatting(
 
     if !output.status.success() {
         match output.status.code() {
-            Some(1) if !captured_stderr.contains("not installed") => {
+            Some(1)
+                if !captured_stderr.contains("not installed")
+                    && !captured_stderr.contains("not available") =>
+            {
                 // While `rustfmt` doesn't have a specific exit code for parse errors this is the
                 // likely cause exiting with 1. Most Language Servers swallow parse errors on
                 // formatting because otherwise an error is surfaced to the user on top of the


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/8331

When the toolchain has no installable rustfmt component, running `rustfmt` complains with

```
error: the 'rustfmt' component which provides the command 'rustfmt' is not available for the 'nightly-2021-04-04-x86_64-unknown-linux-gnu' toolchain
```

Check for occurrence of "not available" in addition to the existing "not installed" to detect this case and report a user-visible error.

rustfmt and/or rustup should *really* be changed to not use the same exit status here

bors r+