### PR TITLE
analysis-stats: allow skipping type inference

### DIFF
--- a/crates/rust-analyzer/src/bin/flags.rs
+++ b/crates/rust-analyzer/src/bin/flags.rs
@@ -71,6 +71,8 @@ xflags::xflags! {
             optional --load-output-dirs
             /// Use proc-macro-srv for proc-macro expanding.
             optional --with-proc-macro
+            /// Only resolve names, don't run type inference.
+            optional --skip-inference
         }
 
         cmd diagnostics
@@ -158,6 +160,7 @@ pub struct AnalysisStats {
     pub no_sysroot: bool,
     pub load_output_dirs: bool,
     pub with_proc_macro: bool,
+    pub skip_inference: bool,
 }
 
 #[derive(Debug)]

--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -78,6 +78,7 @@ fn try_main() -> Result<()> {
             path: cmd.path,
             load_output_dirs: cmd.load_output_dirs,
             with_proc_macro: cmd.with_proc_macro,
+            skip_inference: cmd.skip_inference,
         }
         .run(verbosity)?,
 


### PR DESCRIPTION
This removes "noise" from memory profiles since it avoids lowering
function bodies and types

bors r+