### PR TITLE
Add pub mod option for UnlinkedFile

### DIFF
--- a/crates/ide/src/diagnostics/field_shorthand.rs
+++ b/crates/ide/src/diagnostics/field_shorthand.rs
@@ -46,14 +46,13 @@ fn check_expr_field_shorthand(
 
         let field_range = record_field.syntax().text_range();
         acc.push(
-            Diagnostic::hint(field_range, "Shorthand struct initialization".to_string()).with_fix(
-                Some(fix(
+            Diagnostic::hint(field_range, "Shorthand struct initialization".to_string())
+                .with_fixes(Some(vec![fix(
                     "use_expr_field_shorthand",
                     "Use struct shorthand initialization",
                     SourceChange::from_text_edit(file_id, edit),
                     field_range,
-                )),
-            ),
+                )])),
         );
     }
 }
@@ -86,13 +85,13 @@ fn check_pat_field_shorthand(
         let edit = edit_builder.finish();
 
         let field_range = record_pat_field.syntax().text_range();
-        acc.push(Diagnostic::hint(field_range, "Shorthand struct pattern".to_string()).with_fix(
-            Some(fix(
+        acc.push(Diagnostic::hint(field_range, "Shorthand struct pattern".to_string()).with_fixes(
+            Some(vec![fix(
                 "use_pat_field_shorthand",
                 "Use struct field shorthand",
                 SourceChange::from_text_edit(file_id, edit),
                 field_range,
-            )),
+            )]),
         ));
     }
 }

--- a/crates/ide/src/diagnostics/fixes.rs
+++ b/crates/ide/src/diagnostics/fixes.rs
@@ -14,18 +14,18 @@ use ide_db::RootDatabase;
 
 use crate::Assist;
 
-/// A [Diagnostic] that potentially has a fix available.
+/// A [Diagnostic] that potentially has some fixes available.
 ///
 /// [Diagnostic]: hir::diagnostics::Diagnostic
-pub(crate) trait DiagnosticWithFix: Diagnostic {
+pub(crate) trait DiagnosticWithFixes: Diagnostic {
     /// `resolve` determines if the diagnostic should fill in the `edit` field
     /// of the assist.
     ///
     /// If `resolve` is false, the edit will be computed later, on demand, and
     /// can be omitted.
-    fn fix(
+    fn fixes(
         &self,
         sema: &Semantics<RootDatabase>,
         _resolve: &AssistResolveStrategy,
-    ) -> Option<Assist>;
+    ) -> Option<Vec<Assist>>;
 }

--- a/crates/ide/src/diagnostics/fixes/change_case.rs
+++ b/crates/ide/src/diagnostics/fixes/change_case.rs
@@ -4,16 +4,16 @@ use ide_db::{base_db::FilePosition, RootDatabase};
 use syntax::AstNode;
 
 use crate::{
-    diagnostics::{unresolved_fix, DiagnosticWithFix},
+    diagnostics::{unresolved_fix, DiagnosticWithFixes},
     references::rename::rename_with_semantics,
 };
 
-impl DiagnosticWithFix for IncorrectCase {
-    fn fix(
+impl DiagnosticWithFixes for IncorrectCase {
+    fn fixes(
         &self,
         sema: &Semantics<RootDatabase>,
         resolve: &AssistResolveStrategy,
-    ) -> Option<Assist> {
+    ) -> Option<Vec<Assist>> {
         let root = sema.db.parse_or_expand(self.file)?;
         let name_node = self.ident.to_node(&root);
 
@@ -28,7 +28,7 @@ impl DiagnosticWithFix for IncorrectCase {
             res.source_change = Some(source_change.ok().unwrap_or_default());
         }
 
-        Some(res)
+        Some(vec![res])
     }
 }
 

--- a/crates/ide/src/diagnostics/fixes/fill_missing_fields.rs
+++ b/crates/ide/src/diagnostics/fixes/fill_missing_fields.rs
@@ -5,16 +5,16 @@ use syntax::{algo, ast::make, AstNode};
 use text_edit::TextEdit;
 
 use crate::{
-    diagnostics::{fix, fixes::DiagnosticWithFix},
+    diagnostics::{fix, fixes::DiagnosticWithFixes},
     Assist,
 };
 
-impl DiagnosticWithFix for MissingFields {
-    fn fix(
+impl DiagnosticWithFixes for MissingFields {
+    fn fixes(
         &self,
         sema: &Semantics<RootDatabase>,
         _resolve: &AssistResolveStrategy,
-    ) -> Option<Assist> {
+    ) -> Option<Vec<Assist>> {
         // Note that although we could add a diagnostics to
         // fill the missing tuple field, e.g :
         // `struct A(usize);`
@@ -41,12 +41,12 @@ impl DiagnosticWithFix for MissingFields {
                 .into_text_edit(&mut builder);
             builder.finish()
         };
-        Some(fix(
+        Some(vec![fix(
             "fill_missing_fields",
             "Fill struct fields",
             SourceChange::from_text_edit(self.file.original_file(sema.db), edit),
             sema.original_range(&field_list_parent.syntax()).range,
-        ))
+        )])
     }
 }
 

--- a/crates/ide/src/diagnostics/fixes/remove_semicolon.rs
+++ b/crates/ide/src/diagnostics/fixes/remove_semicolon.rs
@@ -4,14 +4,14 @@ use ide_db::{source_change::SourceChange, RootDatabase};
 use syntax::{ast, AstNode};
 use text_edit::TextEdit;
 
-use crate::diagnostics::{fix, DiagnosticWithFix};
+use crate::diagnostics::{fix, DiagnosticWithFixes};
 
-impl DiagnosticWithFix for RemoveThisSemicolon {
-    fn fix(
+impl DiagnosticWithFixes for RemoveThisSemicolon {
+    fn fixes(
         &self,
         sema: &Semantics<RootDatabase>,
         _resolve: &AssistResolveStrategy,
-    ) -> Option<Assist> {
+    ) -> Option<Vec<Assist>> {
         let root = sema.db.parse_or_expand(self.file)?;
 
         let semicolon = self
@@ -26,7 +26,7 @@ impl DiagnosticWithFix for RemoveThisSemicolon {
         let edit = TextEdit::delete(semicolon);
         let source_change = SourceChange::from_text_edit(self.file.original_file(sema.db), edit);
 
-        Some(fix("remove_semicolon", "Remove this semicolon", source_change, semicolon))
+        Some(vec![fix("remove_semicolon", "Remove this semicolon", source_change, semicolon)])
     }
 }
 

--- a/crates/ide/src/diagnostics/fixes/replace_with_find_map.rs
+++ b/crates/ide/src/diagnostics/fixes/replace_with_find_map.rs
@@ -7,14 +7,14 @@ use syntax::{
 };
 use text_edit::TextEdit;
 
-use crate::diagnostics::{fix, DiagnosticWithFix};
+use crate::diagnostics::{fix, DiagnosticWithFixes};
 
-impl DiagnosticWithFix for ReplaceFilterMapNextWithFindMap {
-    fn fix(
+impl DiagnosticWithFixes for ReplaceFilterMapNextWithFindMap {
+    fn fixes(
         &self,
         sema: &Semantics<RootDatabase>,
         _resolve: &AssistResolveStrategy,
-    ) -> Option<Assist> {
+    ) -> Option<Vec<Assist>> {
         let root = sema.db.parse_or_expand(self.file)?;
         let next_expr = self.next_expr.to_node(&root);
         let next_call = ast::MethodCallExpr::cast(next_expr.syntax().clone())?;
@@ -32,12 +32,12 @@ impl DiagnosticWithFix for ReplaceFilterMapNextWithFindMap {
 
         let source_change = SourceChange::from_text_edit(self.file.original_file(sema.db), edit);
 
-        Some(fix(
+        Some(vec![fix(
             "replace_with_find_map",
             "Replace filter_map(..).next() with find_map()",
             source_change,
             trigger_range,
-        ))
+        )])
     }
 }
 

--- a/crates/ide/src/diagnostics/fixes/wrap_tail_expr.rs
+++ b/crates/ide/src/diagnostics/fixes/wrap_tail_expr.rs
@@ -4,14 +4,14 @@ use ide_db::{source_change::SourceChange, RootDatabase};
 use syntax::AstNode;
 use text_edit::TextEdit;
 
-use crate::diagnostics::{fix, DiagnosticWithFix};
+use crate::diagnostics::{fix, DiagnosticWithFixes};
 
-impl DiagnosticWithFix for MissingOkOrSomeInTailExpr {
-    fn fix(
+impl DiagnosticWithFixes for MissingOkOrSomeInTailExpr {
+    fn fixes(
         &self,
         sema: &Semantics<RootDatabase>,
         _resolve: &AssistResolveStrategy,
-    ) -> Option<Assist> {
+    ) -> Option<Vec<Assist>> {
         let root = sema.db.parse_or_expand(self.file)?;
         let tail_expr = self.expr.to_node(&root);
         let tail_expr_range = tail_expr.syntax().text_range();
@@ -19,7 +19,7 @@ impl DiagnosticWithFix for MissingOkOrSomeInTailExpr {
         let edit = TextEdit::replace(tail_expr_range, replacement);
         let source_change = SourceChange::from_text_edit(self.file.original_file(sema.db), edit);
         let name = if self.required == "Ok" { "Wrap with Ok" } else { "Wrap with Some" };
-        Some(fix("wrap_tail_expr", name, source_change, tail_expr_range))
+        Some(vec![fix("wrap_tail_expr", name, source_change, tail_expr_range)])
     }
 }
 

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -565,7 +565,7 @@ impl Analysis {
             let diagnostic_assists = if include_fixes {
                 diagnostics::diagnostics(db, diagnostics_config, &resolve, frange.file_id)
                     .into_iter()
-                    .filter_map(|it| it.fix)
+                    .flat_map(|it| it.fixes.unwrap_or_default())
                     .filter(|it| it.target.intersect(frange.range).is_some())
                     .collect()
             } else {


### PR DESCRIPTION
close #8228

This is a draft that changes `Diagnostic` to contain multiple fixes. Pre analysis is in https://github.com/rust-analyzer/rust-analyzer/issues/8228#issuecomment-812887085 Because this solution is straightforward so I decided to type it out for discussion.

Currently the `check_fix` is not able to test the situation when multiple fixes available. <del>Also because `Insert 'mod x;'` and  `Insert 'pub mod x;'` are so similar, I don't know how to test them correctly and want some suggestions.</del>. I added 
 `check_fixes` to allow checking mutiple possible fixes.

In additional, instead of append after possible existing `mod y`, I think it's possible to Insert `pub mod x;` after `pub mod y`. Should I implement this too?