### PR TITLE
Use arrayvec 0.7 to avoid perf regression in 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,9 +49,9 @@ checksum = "33954243bd79057c2de7338850b85983a44588021f8a5fee574a8888c6de4344"
 
 [[package]]
 name = "arrayvec"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "269d0f5e68353a7cab87f81e7c736adc008d279a36ebc6a05dfe01193a89f0c9"
+checksum = "5a2f58b0bb10c380af2b26e57212856b8c9a59e0925b4c20f4a174a49734eaf7"
 
 [[package]]
 name = "atty"

--- a/crates/hir/Cargo.toml
+++ b/crates/hir/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 log = "0.4.8"
 rustc-hash = "1.1.0"
 either = "1.5.3"
-arrayvec = "0.6"
+arrayvec = "0.7"
 itertools = "0.10.0"
 smallvec = "1.4.0"
 

--- a/crates/hir_ty/Cargo.toml
+++ b/crates/hir_ty/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 [dependencies]
 cov-mark = { version = "1.1", features = ["thread-local"] }
 itertools = "0.10.0"
-arrayvec = "0.6"
+arrayvec = "0.7"
 smallvec = "1.2.0"
 ena = "0.14.0"
 log = "0.4.8"

--- a/crates/syntax/Cargo.toml
+++ b/crates/syntax/Cargo.toml
@@ -16,7 +16,7 @@ itertools = "0.10.0"
 rowan = "0.13.0-pre.3"
 rustc_lexer = { version = "710.0.0", package = "rustc-ap-rustc_lexer" }
 rustc-hash = "1.1.0"
-arrayvec = "0.6"
+arrayvec = "0.7"
 once_cell = "1.3.1"
 indexmap = "1.4.0"
 smol_str = { version = "0.1.15", features = ["serde"] }


### PR DESCRIPTION
See: https://github.com/bluss/arrayvec/issues/182