### PR TITLE
Make `Binders` more like Chalk

### DIFF
--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -9,6 +9,7 @@ use hir_ty::display::{
     write_bounds_like_dyn_trait_with_prefix, write_visibility, HirDisplay, HirDisplayError,
     HirFormatter,
 };
+use hir_ty::Interner;
 use syntax::ast::{self, NameOwner};
 
 use crate::{
@@ -235,7 +236,8 @@ impl HirDisplay for TypeParam {
         write!(f, "{}", self.name(f.db))?;
         let bounds = f.db.generic_predicates_for_param(self.id);
         let substs = TyBuilder::type_params_subst(f.db, self.id.parent);
-        let predicates = bounds.iter().cloned().map(|b| b.substitute(&substs)).collect::<Vec<_>>();
+        let predicates =
+            bounds.iter().cloned().map(|b| b.substitute(&Interner, &substs)).collect::<Vec<_>>();
         if !(predicates.is_empty() || f.omit_verbose_types()) {
             write_bounds_like_dyn_trait_with_prefix(":", &predicates, f)?;
         }

--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -235,7 +235,7 @@ impl HirDisplay for TypeParam {
         write!(f, "{}", self.name(f.db))?;
         let bounds = f.db.generic_predicates_for_param(self.id);
         let substs = TyBuilder::type_params_subst(f.db, self.id.parent);
-        let predicates = bounds.iter().cloned().map(|b| b.subst(&substs)).collect::<Vec<_>>();
+        let predicates = bounds.iter().cloned().map(|b| b.substitute(&substs)).collect::<Vec<_>>();
         if !(predicates.is_empty() || f.omit_verbose_types()) {
             write_bounds_like_dyn_trait_with_prefix(":", &predicates, f)?;
         }

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -702,7 +702,7 @@ impl_from!(Struct, Union, Enum for Adt);
 impl Adt {
     pub fn has_non_default_type_params(self, db: &dyn HirDatabase) -> bool {
         let subst = db.generic_defaults(self.into());
-        subst.iter().any(|ty| ty.value.is_unknown())
+        subst.iter().any(|ty| ty.skip_binders().is_unknown())
     }
 
     /// Turns this ADT into a type. Any type parameters of the ADT will be
@@ -1089,7 +1089,7 @@ pub struct TypeAlias {
 impl TypeAlias {
     pub fn has_non_default_type_params(self, db: &dyn HirDatabase) -> bool {
         let subst = db.generic_defaults(self.id.into());
-        subst.iter().any(|ty| ty.value.is_unknown())
+        subst.iter().any(|ty| ty.skip_binders().is_unknown())
     }
 
     pub fn module(self, db: &dyn HirDatabase) -> Module {

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -516,7 +516,7 @@ impl Field {
             VariantDef::Variant(it) => it.parent.id.into(),
         };
         let substs = TyBuilder::type_params_subst(db, generic_def_id);
-        let ty = db.field_types(var_id)[self.id].clone().substitute(&substs);
+        let ty = db.field_types(var_id)[self.id].clone().substitute(&Interner, &substs);
         Type::new(db, self.parent.module(db).id.krate(), var_id, ty)
     }
 
@@ -1503,7 +1503,7 @@ impl TypeParam {
         let krate = self.id.parent.module(db.upcast()).krate();
         let ty = params.get(local_idx)?.clone();
         let subst = TyBuilder::type_params_subst(db, self.id.parent);
-        let ty = ty.substitute(&subst.prefix(local_idx));
+        let ty = ty.substitute(&Interner, &subst.prefix(local_idx));
         Some(Type::new_with_resolver_inner(db, krate, &resolver, ty))
     }
 }
@@ -1916,7 +1916,7 @@ impl Type {
             .iter()
             .map(|(local_id, ty)| {
                 let def = Field { parent: variant_id.into(), id: local_id };
-                let ty = ty.clone().substitute(substs);
+                let ty = ty.clone().substitute(&Interner, substs);
                 (def, self.derived(ty))
             })
             .collect()

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -516,7 +516,7 @@ impl Field {
             VariantDef::Variant(it) => it.parent.id.into(),
         };
         let substs = TyBuilder::type_params_subst(db, generic_def_id);
-        let ty = db.field_types(var_id)[self.id].clone().subst(&substs);
+        let ty = db.field_types(var_id)[self.id].clone().substitute(&substs);
         Type::new(db, self.parent.module(db).id.krate(), var_id, ty)
     }
 
@@ -1503,7 +1503,7 @@ impl TypeParam {
         let krate = self.id.parent.module(db.upcast()).krate();
         let ty = params.get(local_idx)?.clone();
         let subst = TyBuilder::type_params_subst(db, self.id.parent);
-        let ty = ty.subst(&subst.prefix(local_idx));
+        let ty = ty.substitute(&subst.prefix(local_idx));
         Some(Type::new_with_resolver_inner(db, krate, &resolver, ty))
     }
 }
@@ -1916,7 +1916,7 @@ impl Type {
             .iter()
             .map(|(local_id, ty)| {
                 let def = Field { parent: variant_id.into(), id: local_id };
-                let ty = ty.clone().subst(substs);
+                let ty = ty.clone().substitute(substs);
                 (def, self.derived(ty))
             })
             .collect()

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -494,9 +494,9 @@ impl<'db> SemanticsImpl<'db> {
     fn resolve_method_call_as_callable(&self, call: &ast::MethodCallExpr) -> Option<Callable> {
         // FIXME: this erases Substs
         let func = self.resolve_method_call(call)?;
-        let ty = self.db.value_ty(func.into());
+        let (ty, _) = self.db.value_ty(func.into()).into_value_and_skipped_binders();
         let resolver = self.analyze(call.syntax()).resolver;
-        let ty = Type::new_with_resolver(self.db, &resolver, ty.value)?;
+        let ty = Type::new_with_resolver(self.db, &resolver, ty)?;
         let mut res = ty.as_callable(self.db)?;
         res.is_bound_method = true;
         Some(res)

--- a/crates/hir/src/source_analyzer.rs
+++ b/crates/hir/src/source_analyzer.rs
@@ -339,7 +339,7 @@ impl SourceAnalyzer {
             .into_iter()
             .map(|local_id| {
                 let field = FieldId { parent: variant, local_id };
-                let ty = field_types[local_id].clone().subst(substs);
+                let ty = field_types[local_id].clone().substitute(substs);
                 (field.into(), Type::new_with_resolver_inner(db, krate, &self.resolver, ty))
             })
             .collect()

--- a/crates/hir/src/source_analyzer.rs
+++ b/crates/hir/src/source_analyzer.rs
@@ -20,7 +20,7 @@ use hir_def::{
 use hir_expand::{hygiene::Hygiene, name::AsName, HirFileId, InFile};
 use hir_ty::{
     diagnostics::{record_literal_missing_fields, record_pattern_missing_fields},
-    InferenceResult, Substitution, TyLoweringContext,
+    InferenceResult, Interner, Substitution, TyLoweringContext,
 };
 use syntax::{
     ast::{self, AstNode},
@@ -339,7 +339,7 @@ impl SourceAnalyzer {
             .into_iter()
             .map(|local_id| {
                 let field = FieldId { parent: variant, local_id };
-                let ty = field_types[local_id].clone().substitute(substs);
+                let ty = field_types[local_id].clone().substitute(&Interner, substs);
                 (field.into(), Type::new_with_resolver_inner(db, krate, &self.resolver, ty))
             })
             .collect()

--- a/crates/hir_ty/src/builder.rs
+++ b/crates/hir_ty/src/builder.rs
@@ -194,7 +194,7 @@ impl TyBuilder<TypeAliasId> {
 
 impl<T: TypeWalk + HasInterner<Interner = Interner>> TyBuilder<Binders<T>> {
     fn subst_binders(b: Binders<T>) -> Self {
-        let param_count = b.num_binders;
+        let param_count = b.binders.len(&Interner);
         TyBuilder::new(b, param_count)
     }
 

--- a/crates/hir_ty/src/builder.rs
+++ b/crates/hir_ty/src/builder.rs
@@ -139,7 +139,7 @@ impl TyBuilder<hir_def::AdtId> {
             } else {
                 // each default can depend on the previous parameters
                 let subst_so_far = Substitution::intern(self.vec.clone());
-                self.vec.push(default_ty.clone().subst(&subst_so_far).cast(&Interner));
+                self.vec.push(default_ty.clone().substitute(&subst_so_far).cast(&Interner));
             }
         }
         self
@@ -200,7 +200,7 @@ impl<T: TypeWalk + HasInterner<Interner = Interner>> TyBuilder<Binders<T>> {
 
     pub fn build(self) -> T {
         let (b, subst) = self.build_internal();
-        b.subst(&subst)
+        b.substitute(&subst)
     }
 }
 

--- a/crates/hir_ty/src/builder.rs
+++ b/crates/hir_ty/src/builder.rs
@@ -139,7 +139,8 @@ impl TyBuilder<hir_def::AdtId> {
             } else {
                 // each default can depend on the previous parameters
                 let subst_so_far = Substitution::intern(self.vec.clone());
-                self.vec.push(default_ty.clone().substitute(&subst_so_far).cast(&Interner));
+                self.vec
+                    .push(default_ty.clone().substitute(&Interner, &subst_so_far).cast(&Interner));
             }
         }
         self
@@ -200,7 +201,7 @@ impl<T: TypeWalk + HasInterner<Interner = Interner>> TyBuilder<Binders<T>> {
 
     pub fn build(self) -> T {
         let (b, subst) = self.build_internal();
-        b.substitute(&subst)
+        b.substitute(&Interner, &subst)
     }
 }
 

--- a/crates/hir_ty/src/diagnostics/expr.rs
+++ b/crates/hir_ty/src/diagnostics/expr.rs
@@ -245,7 +245,8 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
                     Some(callee) => callee,
                     None => return,
                 };
-                let sig = db.callable_item_signature(callee.into()).value;
+                let sig =
+                    db.callable_item_signature(callee.into()).into_value_and_skipped_binders().0;
 
                 (sig, args)
             }

--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -353,7 +353,7 @@ impl HirDisplay for Ty {
                                 .as_ref()
                                 .map(|rpit| rpit.impl_traits[idx as usize].bounds.clone());
                             let bounds = data.subst(parameters);
-                            bounds.value
+                            bounds.into_value_and_skipped_binders().0
                         } else {
                             Vec::new()
                         }
@@ -543,7 +543,7 @@ impl HirDisplay for Ty {
                             .as_ref()
                             .map(|rpit| rpit.impl_traits[idx as usize].bounds.clone());
                         let bounds = data.subst(&parameters);
-                        write_bounds_like_dyn_trait_with_prefix("impl", &bounds.value, f)?;
+                        write_bounds_like_dyn_trait_with_prefix("impl", bounds.skip_binders(), f)?;
                         // FIXME: it would maybe be good to distinguish this from the alias type (when debug printing), and to show the substitution
                     }
                     ImplTraitId::AsyncBlockTypeImplTrait(..) => {
@@ -630,7 +630,7 @@ impl HirDisplay for Ty {
                             .as_ref()
                             .map(|rpit| rpit.impl_traits[idx as usize].bounds.clone());
                         let bounds = data.subst(&opaque_ty.substitution);
-                        write_bounds_like_dyn_trait_with_prefix("impl", &bounds.value, f)?;
+                        write_bounds_like_dyn_trait_with_prefix("impl", bounds.skip_binders(), f)?;
                     }
                     ImplTraitId::AsyncBlockTypeImplTrait(..) => {
                         write!(f, "{{async block}}")?;

--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -352,7 +352,7 @@ impl HirDisplay for Ty {
                             let data = (*datas)
                                 .as_ref()
                                 .map(|rpit| rpit.impl_traits[idx as usize].bounds.clone());
-                            let bounds = data.subst(parameters);
+                            let bounds = data.substitute(parameters);
                             bounds.into_value_and_skipped_binders().0
                         } else {
                             Vec::new()
@@ -397,7 +397,7 @@ impl HirDisplay for Ty {
             }
             TyKind::FnDef(def, parameters) => {
                 let def = from_chalk(f.db, *def);
-                let sig = f.db.callable_item_signature(def).subst(parameters);
+                let sig = f.db.callable_item_signature(def).substitute(parameters);
                 match def {
                     CallableDefId::FunctionId(ff) => {
                         write!(f, "fn {}", f.db.function_data(ff).name)?
@@ -482,7 +482,7 @@ impl HirDisplay for Ty {
                                         (_, Some(default_parameter)) => {
                                             let actual_default = default_parameter
                                                 .clone()
-                                                .subst(&parameters.prefix(i));
+                                                .substitute(&parameters.prefix(i));
                                             if parameter.assert_ty_ref(&Interner) != &actual_default
                                             {
                                                 default_from = i + 1;
@@ -542,7 +542,7 @@ impl HirDisplay for Ty {
                         let data = (*datas)
                             .as_ref()
                             .map(|rpit| rpit.impl_traits[idx as usize].bounds.clone());
-                        let bounds = data.subst(&parameters);
+                        let bounds = data.substitute(&parameters);
                         write_bounds_like_dyn_trait_with_prefix("impl", bounds.skip_binders(), f)?;
                         // FIXME: it would maybe be good to distinguish this from the alias type (when debug printing), and to show the substitution
                     }
@@ -595,7 +595,7 @@ impl HirDisplay for Ty {
                         let bounds =
                             f.db.generic_predicates(id.parent)
                                 .into_iter()
-                                .map(|pred| pred.clone().subst(&substs))
+                                .map(|pred| pred.clone().substitute(&substs))
                                 .filter(|wc| match &wc.skip_binders() {
                                     WhereClause::Implemented(tr) => {
                                         tr.self_type_parameter(&Interner) == self
@@ -629,7 +629,7 @@ impl HirDisplay for Ty {
                         let data = (*datas)
                             .as_ref()
                             .map(|rpit| rpit.impl_traits[idx as usize].bounds.clone());
-                        let bounds = data.subst(&opaque_ty.substitution);
+                        let bounds = data.substitute(&opaque_ty.substitution);
                         write_bounds_like_dyn_trait_with_prefix("impl", bounds.skip_binders(), f)?;
                     }
                     ImplTraitId::AsyncBlockTypeImplTrait(..) => {

--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -352,7 +352,7 @@ impl HirDisplay for Ty {
                             let data = (*datas)
                                 .as_ref()
                                 .map(|rpit| rpit.impl_traits[idx as usize].bounds.clone());
-                            let bounds = data.substitute(parameters);
+                            let bounds = data.substitute(&Interner, parameters);
                             bounds.into_value_and_skipped_binders().0
                         } else {
                             Vec::new()
@@ -397,7 +397,7 @@ impl HirDisplay for Ty {
             }
             TyKind::FnDef(def, parameters) => {
                 let def = from_chalk(f.db, *def);
-                let sig = f.db.callable_item_signature(def).substitute(parameters);
+                let sig = f.db.callable_item_signature(def).substitute(&Interner, parameters);
                 match def {
                     CallableDefId::FunctionId(ff) => {
                         write!(f, "fn {}", f.db.function_data(ff).name)?
@@ -482,7 +482,7 @@ impl HirDisplay for Ty {
                                         (_, Some(default_parameter)) => {
                                             let actual_default = default_parameter
                                                 .clone()
-                                                .substitute(&parameters.prefix(i));
+                                                .substitute(&Interner, &parameters.prefix(i));
                                             if parameter.assert_ty_ref(&Interner) != &actual_default
                                             {
                                                 default_from = i + 1;
@@ -542,7 +542,7 @@ impl HirDisplay for Ty {
                         let data = (*datas)
                             .as_ref()
                             .map(|rpit| rpit.impl_traits[idx as usize].bounds.clone());
-                        let bounds = data.substitute(&parameters);
+                        let bounds = data.substitute(&Interner, &parameters);
                         write_bounds_like_dyn_trait_with_prefix("impl", bounds.skip_binders(), f)?;
                         // FIXME: it would maybe be good to distinguish this from the alias type (when debug printing), and to show the substitution
                     }
@@ -595,7 +595,7 @@ impl HirDisplay for Ty {
                         let bounds =
                             f.db.generic_predicates(id.parent)
                                 .into_iter()
-                                .map(|pred| pred.clone().substitute(&substs))
+                                .map(|pred| pred.clone().substitute(&Interner, &substs))
                                 .filter(|wc| match &wc.skip_binders() {
                                     WhereClause::Implemented(tr) => {
                                         tr.self_type_parameter(&Interner) == self
@@ -629,7 +629,7 @@ impl HirDisplay for Ty {
                         let data = (*datas)
                             .as_ref()
                             .map(|rpit| rpit.impl_traits[idx as usize].bounds.clone());
-                        let bounds = data.substitute(&opaque_ty.substitution);
+                        let bounds = data.substitute(&Interner, &opaque_ty.substitution);
                         write_bounds_like_dyn_trait_with_prefix("impl", bounds.skip_binders(), f)?;
                     }
                     ImplTraitId::AsyncBlockTypeImplTrait(..) => {

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -470,25 +470,25 @@ impl<'a> InferenceContext<'a> {
             TypeNs::AdtId(AdtId::StructId(strukt)) => {
                 let substs = ctx.substs_from_path(path, strukt.into(), true);
                 let ty = self.db.ty(strukt.into());
-                let ty = self.insert_type_vars(ty.substitute(&substs));
+                let ty = self.insert_type_vars(ty.substitute(&Interner, &substs));
                 forbid_unresolved_segments((ty, Some(strukt.into())), unresolved)
             }
             TypeNs::AdtId(AdtId::UnionId(u)) => {
                 let substs = ctx.substs_from_path(path, u.into(), true);
                 let ty = self.db.ty(u.into());
-                let ty = self.insert_type_vars(ty.substitute(&substs));
+                let ty = self.insert_type_vars(ty.substitute(&Interner, &substs));
                 forbid_unresolved_segments((ty, Some(u.into())), unresolved)
             }
             TypeNs::EnumVariantId(var) => {
                 let substs = ctx.substs_from_path(path, var.into(), true);
                 let ty = self.db.ty(var.parent.into());
-                let ty = self.insert_type_vars(ty.substitute(&substs));
+                let ty = self.insert_type_vars(ty.substitute(&Interner, &substs));
                 forbid_unresolved_segments((ty, Some(var.into())), unresolved)
             }
             TypeNs::SelfType(impl_id) => {
                 let generics = crate::utils::generics(self.db.upcast(), impl_id.into());
                 let substs = generics.type_params_subst(self.db);
-                let ty = self.db.impl_self_ty(impl_id).substitute(&substs);
+                let ty = self.db.impl_self_ty(impl_id).substitute(&Interner, &substs);
                 match unresolved {
                     None => {
                         let variant = ty_variant(&ty);

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -470,25 +470,25 @@ impl<'a> InferenceContext<'a> {
             TypeNs::AdtId(AdtId::StructId(strukt)) => {
                 let substs = ctx.substs_from_path(path, strukt.into(), true);
                 let ty = self.db.ty(strukt.into());
-                let ty = self.insert_type_vars(ty.subst(&substs));
+                let ty = self.insert_type_vars(ty.substitute(&substs));
                 forbid_unresolved_segments((ty, Some(strukt.into())), unresolved)
             }
             TypeNs::AdtId(AdtId::UnionId(u)) => {
                 let substs = ctx.substs_from_path(path, u.into(), true);
                 let ty = self.db.ty(u.into());
-                let ty = self.insert_type_vars(ty.subst(&substs));
+                let ty = self.insert_type_vars(ty.substitute(&substs));
                 forbid_unresolved_segments((ty, Some(u.into())), unresolved)
             }
             TypeNs::EnumVariantId(var) => {
                 let substs = ctx.substs_from_path(path, var.into(), true);
                 let ty = self.db.ty(var.parent.into());
-                let ty = self.insert_type_vars(ty.subst(&substs));
+                let ty = self.insert_type_vars(ty.substitute(&substs));
                 forbid_unresolved_segments((ty, Some(var.into())), unresolved)
             }
             TypeNs::SelfType(impl_id) => {
                 let generics = crate::utils::generics(self.db.upcast(), impl_id.into());
                 let substs = generics.type_params_subst(self.db);
-                let ty = self.db.impl_self_ty(impl_id).subst(&substs);
+                let ty = self.db.impl_self_ty(impl_id).substitute(&substs);
                 match unresolved {
                     None => {
                         let variant = ty_variant(&ty);

--- a/crates/hir_ty/src/infer/expr.rs
+++ b/crates/hir_ty/src/infer/expr.rs
@@ -419,7 +419,7 @@ impl<'a> InferenceContext<'a> {
                         self.result.record_field_resolutions.insert(field.expr, field_def);
                     }
                     let field_ty = field_def.map_or(self.err_ty(), |it| {
-                        field_types[it.local_id].clone().subst(&substs)
+                        field_types[it.local_id].clone().substitute(&substs)
                     });
                     self.infer_expr_coerce(field.expr, &Expectation::has_type(field_ty));
                 }
@@ -462,7 +462,7 @@ impl<'a> InferenceContext<'a> {
                                 Some(
                                     self.db.field_types((*s).into())[field.local_id]
                                         .clone()
-                                        .subst(&parameters),
+                                        .substitute(&parameters),
                                 )
                             } else {
                                 None
@@ -476,7 +476,7 @@ impl<'a> InferenceContext<'a> {
                                 Some(
                                     self.db.field_types((*u).into())[field.local_id]
                                         .clone()
-                                        .subst(&parameters),
+                                        .substitute(&parameters),
                                 )
                             } else {
                                 None
@@ -852,7 +852,7 @@ impl<'a> InferenceContext<'a> {
             None => (receiver_ty, Binders::empty(&Interner, self.err_ty()), None),
         };
         let substs = self.substs_for_method_call(def_generics, generic_args, &derefed_receiver_ty);
-        let method_ty = method_ty.subst(&substs);
+        let method_ty = method_ty.substitute(&substs);
         let method_ty = self.insert_type_vars(method_ty);
         self.register_obligations_for_call(&method_ty);
         let (expected_receiver_ty, param_tys, ret_ty) = match method_ty.callable_sig(self.db) {
@@ -950,7 +950,7 @@ impl<'a> InferenceContext<'a> {
             let generic_predicates = self.db.generic_predicates(def.into());
             for predicate in generic_predicates.iter() {
                 let (predicate, binders) =
-                    predicate.clone().subst(parameters).into_value_and_skipped_binders();
+                    predicate.clone().substitute(parameters).into_value_and_skipped_binders();
                 always!(binders.len(&Interner) == 0); // quantified where clauses not yet handled
                 self.push_obligation(predicate.cast(&Interner));
             }

--- a/crates/hir_ty/src/infer/expr.rs
+++ b/crates/hir_ty/src/infer/expr.rs
@@ -419,7 +419,7 @@ impl<'a> InferenceContext<'a> {
                         self.result.record_field_resolutions.insert(field.expr, field_def);
                     }
                     let field_ty = field_def.map_or(self.err_ty(), |it| {
-                        field_types[it.local_id].clone().substitute(&substs)
+                        field_types[it.local_id].clone().substitute(&Interner, &substs)
                     });
                     self.infer_expr_coerce(field.expr, &Expectation::has_type(field_ty));
                 }
@@ -462,7 +462,7 @@ impl<'a> InferenceContext<'a> {
                                 Some(
                                     self.db.field_types((*s).into())[field.local_id]
                                         .clone()
-                                        .substitute(&parameters),
+                                        .substitute(&Interner, &parameters),
                                 )
                             } else {
                                 None
@@ -476,7 +476,7 @@ impl<'a> InferenceContext<'a> {
                                 Some(
                                     self.db.field_types((*u).into())[field.local_id]
                                         .clone()
-                                        .substitute(&parameters),
+                                        .substitute(&Interner, &parameters),
                                 )
                             } else {
                                 None
@@ -852,7 +852,7 @@ impl<'a> InferenceContext<'a> {
             None => (receiver_ty, Binders::empty(&Interner, self.err_ty()), None),
         };
         let substs = self.substs_for_method_call(def_generics, generic_args, &derefed_receiver_ty);
-        let method_ty = method_ty.substitute(&substs);
+        let method_ty = method_ty.substitute(&Interner, &substs);
         let method_ty = self.insert_type_vars(method_ty);
         self.register_obligations_for_call(&method_ty);
         let (expected_receiver_ty, param_tys, ret_ty) = match method_ty.callable_sig(self.db) {
@@ -949,8 +949,10 @@ impl<'a> InferenceContext<'a> {
             let def: CallableDefId = from_chalk(self.db, *fn_def);
             let generic_predicates = self.db.generic_predicates(def.into());
             for predicate in generic_predicates.iter() {
-                let (predicate, binders) =
-                    predicate.clone().substitute(parameters).into_value_and_skipped_binders();
+                let (predicate, binders) = predicate
+                    .clone()
+                    .substitute(&Interner, parameters)
+                    .into_value_and_skipped_binders();
                 always!(binders.len(&Interner) == 0); // quantified where clauses not yet handled
                 self.push_obligation(predicate.cast(&Interner));
             }

--- a/crates/hir_ty/src/infer/expr.rs
+++ b/crates/hir_ty/src/infer/expr.rs
@@ -849,7 +849,7 @@ impl<'a> InferenceContext<'a> {
                 self.write_method_resolution(tgt_expr, func);
                 (ty, self.db.value_ty(func.into()), Some(generics(self.db.upcast(), func.into())))
             }
-            None => (receiver_ty, Binders::new(0, self.err_ty()), None),
+            None => (receiver_ty, Binders::empty(&Interner, self.err_ty()), None),
         };
         let substs = self.substs_for_method_call(def_generics, generic_args, &derefed_receiver_ty);
         let method_ty = method_ty.subst(&substs);
@@ -951,7 +951,7 @@ impl<'a> InferenceContext<'a> {
             for predicate in generic_predicates.iter() {
                 let (predicate, binders) =
                     predicate.clone().subst(parameters).into_value_and_skipped_binders();
-                always!(binders == 0); // quantified where clauses not yet handled
+                always!(binders.len(&Interner) == 0); // quantified where clauses not yet handled
                 self.push_obligation(predicate.cast(&Interner));
             }
             // add obligation for trait implementation, if this is a trait method

--- a/crates/hir_ty/src/infer/pat.rs
+++ b/crates/hir_ty/src/infer/pat.rs
@@ -49,7 +49,7 @@ impl<'a> InferenceContext<'a> {
             let expected_ty = var_data
                 .as_ref()
                 .and_then(|d| d.field(&Name::new_tuple_field(i)))
-                .map_or(self.err_ty(), |field| field_tys[field].clone().subst(&substs));
+                .map_or(self.err_ty(), |field| field_tys[field].clone().substitute(&substs));
             let expected_ty = self.normalize_associated_types_in(expected_ty);
             self.infer_pat(subpat, &expected_ty, default_bm);
         }
@@ -84,7 +84,7 @@ impl<'a> InferenceContext<'a> {
             }
 
             let expected_ty = matching_field
-                .map_or(self.err_ty(), |field| field_tys[field].clone().subst(&substs));
+                .map_or(self.err_ty(), |field| field_tys[field].clone().substitute(&substs));
             let expected_ty = self.normalize_associated_types_in(expected_ty);
             self.infer_pat(subpat.pat, &expected_ty, default_bm);
         }

--- a/crates/hir_ty/src/infer/pat.rs
+++ b/crates/hir_ty/src/infer/pat.rs
@@ -49,7 +49,9 @@ impl<'a> InferenceContext<'a> {
             let expected_ty = var_data
                 .as_ref()
                 .and_then(|d| d.field(&Name::new_tuple_field(i)))
-                .map_or(self.err_ty(), |field| field_tys[field].clone().substitute(&substs));
+                .map_or(self.err_ty(), |field| {
+                    field_tys[field].clone().substitute(&Interner, &substs)
+                });
             let expected_ty = self.normalize_associated_types_in(expected_ty);
             self.infer_pat(subpat, &expected_ty, default_bm);
         }
@@ -83,8 +85,9 @@ impl<'a> InferenceContext<'a> {
                 self.result.record_pat_field_resolutions.insert(subpat.pat, field_def);
             }
 
-            let expected_ty = matching_field
-                .map_or(self.err_ty(), |field| field_tys[field].clone().substitute(&substs));
+            let expected_ty = matching_field.map_or(self.err_ty(), |field| {
+                field_tys[field].clone().substitute(&Interner, &substs)
+            });
             let expected_ty = self.normalize_associated_types_in(expected_ty);
             self.infer_pat(subpat.pat, &expected_ty, default_bm);
         }

--- a/crates/hir_ty/src/infer/path.rs
+++ b/crates/hir_ty/src/infer/path.rs
@@ -81,9 +81,9 @@ impl<'a> InferenceContext<'a> {
             ValueNs::ImplSelf(impl_id) => {
                 let generics = crate::utils::generics(self.db.upcast(), impl_id.into());
                 let substs = generics.type_params_subst(self.db);
-                let ty = self.db.impl_self_ty(impl_id).subst(&substs);
+                let ty = self.db.impl_self_ty(impl_id).substitute(&substs);
                 if let Some((AdtId::StructId(struct_id), substs)) = ty.as_adt() {
-                    let ty = self.db.value_ty(struct_id.into()).subst(&substs);
+                    let ty = self.db.value_ty(struct_id.into()).substitute(&substs);
                     return Some(ty);
                 } else {
                     // FIXME: diagnostic, invalid Self reference
@@ -243,7 +243,7 @@ impl<'a> InferenceContext<'a> {
                         let impl_substs = TyBuilder::subst_for_def(self.db, impl_id)
                             .fill(iter::repeat_with(|| self.table.new_type_var()))
                             .build();
-                        let impl_self_ty = self.db.impl_self_ty(impl_id).subst(&impl_substs);
+                        let impl_self_ty = self.db.impl_self_ty(impl_id).substitute(&impl_substs);
                         self.unify(&impl_self_ty, &ty);
                         Some(impl_substs)
                     }

--- a/crates/hir_ty/src/infer/path.rs
+++ b/crates/hir_ty/src/infer/path.rs
@@ -81,9 +81,9 @@ impl<'a> InferenceContext<'a> {
             ValueNs::ImplSelf(impl_id) => {
                 let generics = crate::utils::generics(self.db.upcast(), impl_id.into());
                 let substs = generics.type_params_subst(self.db);
-                let ty = self.db.impl_self_ty(impl_id).substitute(&substs);
+                let ty = self.db.impl_self_ty(impl_id).substitute(&Interner, &substs);
                 if let Some((AdtId::StructId(struct_id), substs)) = ty.as_adt() {
-                    let ty = self.db.value_ty(struct_id.into()).substitute(&substs);
+                    let ty = self.db.value_ty(struct_id.into()).substitute(&Interner, &substs);
                     return Some(ty);
                 } else {
                     // FIXME: diagnostic, invalid Self reference
@@ -243,7 +243,8 @@ impl<'a> InferenceContext<'a> {
                         let impl_substs = TyBuilder::subst_for_def(self.db, impl_id)
                             .fill(iter::repeat_with(|| self.table.new_type_var()))
                             .build();
-                        let impl_self_ty = self.db.impl_self_ty(impl_id).substitute(&impl_substs);
+                        let impl_self_ty =
+                            self.db.impl_self_ty(impl_id).substitute(&Interner, &impl_substs);
                         self.unify(&impl_self_ty, &ty);
                         Some(impl_substs)
                     }

--- a/crates/hir_ty/src/infer/unify.rs
+++ b/crates/hir_ty/src/infer/unify.rs
@@ -152,7 +152,7 @@ impl<T> Canonicalized<T> {
             // eagerly replace projections in the type; we may be getting types
             // e.g. from where clauses where this hasn't happened yet
             let ty = ctx.normalize_associated_types_in(
-                ty.assert_ty_ref(&Interner).clone().subst_bound_vars(&new_vars),
+                new_vars.apply(ty.assert_ty_ref(&Interner).clone(), &Interner),
             );
             ctx.table.unify(&TyKind::InferenceVar(v, k).intern(&Interner), &ty);
         }
@@ -173,8 +173,8 @@ pub(crate) fn unify(tys: &Canonical<(Ty, Ty)>) -> Option<Substitution> {
             // fallback to Unknown in the end (kind of hacky, as below)
             .map(|_| table.new_type_var()),
     );
-    let ty1_with_vars = tys.value.0.clone().subst_bound_vars(&vars);
-    let ty2_with_vars = tys.value.1.clone().subst_bound_vars(&vars);
+    let ty1_with_vars = vars.apply(tys.value.0.clone(), &Interner);
+    let ty2_with_vars = vars.apply(tys.value.1.clone(), &Interner);
     if !table.unify(&ty1_with_vars, &ty2_with_vars) {
         return None;
     }

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -124,7 +124,7 @@ impl<T> Binders<T> {
     where
         T: TypeWalk,
     {
-        Binders::empty(&Interner, value.shift_bound_vars(DebruijnIndex::ONE))
+        Binders::empty(&Interner, value.shifted_in_from(DebruijnIndex::ONE))
     }
 }
 
@@ -209,7 +209,8 @@ impl CallableSig {
             params_and_return: fn_ptr
                 .substs
                 .clone()
-                .shift_bound_vars_out(DebruijnIndex::ONE)
+                .shifted_out_to(DebruijnIndex::ONE)
+                .expect("unexpected lifetime vars in fn ptr")
                 .interned()
                 .iter()
                 .map(|arg| arg.assert_ty_ref(&Interner).clone())

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -130,7 +130,7 @@ impl<T> Binders<T> {
 
 impl<T: TypeWalk> Binders<T> {
     /// Substitutes all variables.
-    pub fn subst(self, subst: &Substitution) -> T {
+    pub fn substitute(self, subst: &Substitution) -> T {
         let (value, binders) = self.into_value_and_skipped_binders();
         assert_eq!(subst.len(&Interner), binders.len(&Interner));
         value.subst_bound_vars(subst)
@@ -362,7 +362,7 @@ impl Ty {
             TyKind::FnDef(def, parameters) => {
                 let callable_def = db.lookup_intern_callable_def((*def).into());
                 let sig = db.callable_item_signature(callable_def);
-                Some(sig.subst(&parameters))
+                Some(sig.substitute(&parameters))
             }
             TyKind::Closure(.., substs) => {
                 let sig_param = substs.at(&Interner, 0).assert_ty_ref(&Interner);
@@ -436,7 +436,7 @@ impl Ty {
                             let data = (*it)
                                 .as_ref()
                                 .map(|rpit| rpit.impl_traits[idx as usize].bounds.clone());
-                            data.subst(&opaque_ty.substitution)
+                            data.substitute(&opaque_ty.substitution)
                         })
                     }
                     // It always has an parameter for Future::Output type.
@@ -455,7 +455,7 @@ impl Ty {
                         let predicates = db
                             .generic_predicates(id.parent)
                             .into_iter()
-                            .map(|pred| pred.clone().subst(&substs))
+                            .map(|pred| pred.clone().substitute(&substs))
                             .filter(|wc| match &wc.skip_binders() {
                                 WhereClause::Implemented(tr) => {
                                     tr.self_type_parameter(&Interner) == self

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -414,7 +414,7 @@ impl<'a> TyLoweringContext<'a> {
                     TypeParamLoweringMode::Placeholder => generics.type_params_subst(self.db),
                     TypeParamLoweringMode::Variable => generics.bound_vars_subst(self.in_binders),
                 };
-                self.db.impl_self_ty(impl_id).substitute(&substs)
+                self.db.impl_self_ty(impl_id).substitute(&Interner, &substs)
             }
             TypeNs::AdtSelfType(adt) => {
                 let generics = generics(self.db.upcast(), adt.into());
@@ -422,7 +422,7 @@ impl<'a> TyLoweringContext<'a> {
                     TypeParamLoweringMode::Placeholder => generics.type_params_subst(self.db),
                     TypeParamLoweringMode::Variable => generics.bound_vars_subst(self.in_binders),
                 };
-                self.db.ty(adt.into()).substitute(&substs)
+                self.db.ty(adt.into()).substitute(&Interner, &substs)
             }
 
             TypeNs::AdtId(it) => self.lower_path_inner(resolved_segment, it.into(), infer_args),
@@ -516,7 +516,7 @@ impl<'a> TyLoweringContext<'a> {
             TyDefId::TypeAliasId(it) => Some(it.into()),
         };
         let substs = self.substs_from_path_segment(segment, generic_def, infer_args, None);
-        self.db.ty(typeable).substitute(&substs)
+        self.db.ty(typeable).substitute(&Interner, &substs)
     }
 
     /// Collect generic arguments from a path into a `Substs`. See also
@@ -620,7 +620,7 @@ impl<'a> TyLoweringContext<'a> {
                 for default_ty in defaults.iter().skip(substs.len()) {
                     // each default can depend on the previous parameters
                     let substs_so_far = Substitution::from_iter(&Interner, substs.clone());
-                    substs.push(default_ty.clone().substitute(&substs_so_far));
+                    substs.push(default_ty.clone().substitute(&Interner, &substs_so_far));
                 }
             }
         }

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -414,7 +414,7 @@ impl<'a> TyLoweringContext<'a> {
                     TypeParamLoweringMode::Placeholder => generics.type_params_subst(self.db),
                     TypeParamLoweringMode::Variable => generics.bound_vars_subst(self.in_binders),
                 };
-                self.db.impl_self_ty(impl_id).subst(&substs)
+                self.db.impl_self_ty(impl_id).substitute(&substs)
             }
             TypeNs::AdtSelfType(adt) => {
                 let generics = generics(self.db.upcast(), adt.into());
@@ -422,7 +422,7 @@ impl<'a> TyLoweringContext<'a> {
                     TypeParamLoweringMode::Placeholder => generics.type_params_subst(self.db),
                     TypeParamLoweringMode::Variable => generics.bound_vars_subst(self.in_binders),
                 };
-                self.db.ty(adt.into()).subst(&substs)
+                self.db.ty(adt.into()).substitute(&substs)
             }
 
             TypeNs::AdtId(it) => self.lower_path_inner(resolved_segment, it.into(), infer_args),
@@ -516,7 +516,7 @@ impl<'a> TyLoweringContext<'a> {
             TyDefId::TypeAliasId(it) => Some(it.into()),
         };
         let substs = self.substs_from_path_segment(segment, generic_def, infer_args, None);
-        self.db.ty(typeable).subst(&substs)
+        self.db.ty(typeable).substitute(&substs)
     }
 
     /// Collect generic arguments from a path into a `Substs`. See also
@@ -620,7 +620,7 @@ impl<'a> TyLoweringContext<'a> {
                 for default_ty in defaults.iter().skip(substs.len()) {
                     // each default can depend on the previous parameters
                     let substs_so_far = Substitution::from_iter(&Interner, substs.clone());
-                    substs.push(default_ty.clone().subst(&substs_so_far));
+                    substs.push(default_ty.clone().substitute(&substs_so_far));
                 }
             }
         }

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -477,7 +477,7 @@ impl<'a> TyLoweringContext<'a> {
                                     ),
                                 );
                                 let s = generics.type_params_subst(self.db);
-                                t.substitution.clone().subst_bound_vars(&s)
+                                s.apply(t.substitution.clone(), &Interner)
                             }
                             TypeParamLoweringMode::Variable => t.substitution.clone(),
                         };

--- a/crates/hir_ty/src/method_resolution.rs
+++ b/crates/hir_ty/src/method_resolution.rs
@@ -102,11 +102,11 @@ impl TraitImpls {
         for (_module_id, module_data) in crate_def_map.modules() {
             for impl_id in module_data.scope.impls() {
                 let target_trait = match db.impl_trait(impl_id) {
-                    Some(tr) => tr.value.hir_trait_id(),
+                    Some(tr) => tr.skip_binders().hir_trait_id(),
                     None => continue,
                 };
                 let self_ty = db.impl_self_ty(impl_id);
-                let self_ty_fp = TyFingerprint::for_impl(&self_ty.value);
+                let self_ty_fp = TyFingerprint::for_impl(self_ty.skip_binders());
                 impls
                     .map
                     .entry(target_trait)
@@ -201,7 +201,7 @@ impl InherentImpls {
                 }
 
                 let self_ty = db.impl_self_ty(impl_id);
-                if let Some(fp) = TyFingerprint::for_impl(&self_ty.value) {
+                if let Some(fp) = TyFingerprint::for_impl(self_ty.skip_binders()) {
                     map.entry(fp).or_default().push(impl_id);
                 }
             }
@@ -774,7 +774,7 @@ fn transform_receiver_ty(
         AssocContainerId::ModuleId(_) => unreachable!(),
     };
     let sig = db.callable_item_signature(function_id.into());
-    Some(sig.value.params()[0].clone().subst_bound_vars(&substs))
+    Some(sig.map(|s| s.params()[0].clone()).subst(&substs))
 }
 
 pub fn implements_trait(

--- a/crates/hir_ty/src/method_resolution.rs
+++ b/crates/hir_ty/src/method_resolution.rs
@@ -712,7 +712,7 @@ pub(crate) fn inherent_impl_substs(
     let vars = TyBuilder::subst_for_def(db, impl_id)
         .fill_with_bound_vars(DebruijnIndex::INNERMOST, self_ty.binders.len(&Interner))
         .build();
-    let self_ty_with_vars = db.impl_self_ty(impl_id).substitute(&vars);
+    let self_ty_with_vars = db.impl_self_ty(impl_id).substitute(&Interner, &vars);
     let mut kinds = self_ty.binders.interned().to_vec();
     kinds.extend(
         iter::repeat(chalk_ir::WithKind::new(
@@ -774,7 +774,7 @@ fn transform_receiver_ty(
         AssocContainerId::ModuleId(_) => unreachable!(),
     };
     let sig = db.callable_item_signature(function_id.into());
-    Some(sig.map(|s| s.params()[0].clone()).substitute(&substs))
+    Some(sig.map(|s| s.params()[0].clone()).substitute(&Interner, &substs))
 }
 
 pub fn implements_trait(

--- a/crates/hir_ty/src/method_resolution.rs
+++ b/crates/hir_ty/src/method_resolution.rs
@@ -712,7 +712,7 @@ pub(crate) fn inherent_impl_substs(
     let vars = TyBuilder::subst_for_def(db, impl_id)
         .fill_with_bound_vars(DebruijnIndex::INNERMOST, self_ty.binders.len(&Interner))
         .build();
-    let self_ty_with_vars = db.impl_self_ty(impl_id).subst(&vars);
+    let self_ty_with_vars = db.impl_self_ty(impl_id).substitute(&vars);
     let mut kinds = self_ty.binders.interned().to_vec();
     kinds.extend(
         iter::repeat(chalk_ir::WithKind::new(
@@ -774,7 +774,7 @@ fn transform_receiver_ty(
         AssocContainerId::ModuleId(_) => unreachable!(),
     };
     let sig = db.callable_item_signature(function_id.into());
-    Some(sig.map(|s| s.params()[0].clone()).subst(&substs))
+    Some(sig.map(|s| s.params()[0].clone()).substitute(&substs))
 }
 
 pub fn implements_trait(

--- a/crates/hir_ty/src/traits/chalk.rs
+++ b/crates/hir_ty/src/traits/chalk.rs
@@ -184,10 +184,15 @@ impl<'a> chalk_solve::RustIrDatabase<Interner> for ChalkContext<'a> {
                     .db
                     .return_type_impl_traits(func)
                     .expect("impl trait id without impl traits");
-                let data = &datas.value.impl_traits[idx as usize];
+                let data = &datas.skip_binders().impl_traits[idx as usize];
                 let bound = OpaqueTyDatumBound {
                     bounds: make_binders(
-                        data.bounds.value.iter().cloned().map(|b| b.to_chalk(self.db)).collect(),
+                        data.bounds
+                            .skip_binders()
+                            .iter()
+                            .cloned()
+                            .map(|b| b.to_chalk(self.db))
+                            .collect(),
                         1,
                     ),
                     where_clauses: make_binders(vec![], 0),
@@ -535,7 +540,8 @@ fn impl_def_datum(
         .impl_trait(impl_id)
         // ImplIds for impls where the trait ref can't be resolved should never reach Chalk
         .expect("invalid impl passed to Chalk")
-        .value;
+        .into_value_and_skipped_binders()
+        .0;
     let impl_data = db.impl_data(impl_id);
 
     let generic_params = generics(db.upcast(), impl_id.into());
@@ -605,18 +611,22 @@ fn type_alias_associated_ty_value(
         _ => panic!("assoc ty value should be in impl"),
     };
 
-    let trait_ref = db.impl_trait(impl_id).expect("assoc ty value should not exist").value; // we don't return any assoc ty values if the impl'd trait can't be resolved
+    let trait_ref = db
+        .impl_trait(impl_id)
+        .expect("assoc ty value should not exist")
+        .into_value_and_skipped_binders()
+        .0; // we don't return any assoc ty values if the impl'd trait can't be resolved
 
     let assoc_ty = db
         .trait_data(trait_ref.hir_trait_id())
         .associated_type_by_name(&type_alias_data.name)
         .expect("assoc ty value should not exist"); // validated when building the impl data as well
-    let ty = db.ty(type_alias.into());
-    let value_bound = rust_ir::AssociatedTyValueBound { ty: ty.value.to_chalk(db) };
+    let (ty, binders) = db.ty(type_alias.into()).into_value_and_skipped_binders();
+    let value_bound = rust_ir::AssociatedTyValueBound { ty: ty.to_chalk(db) };
     let value = rust_ir::AssociatedTyValue {
         impl_id: impl_id.to_chalk(db),
         associated_ty_id: to_assoc_type_id(assoc_ty),
-        value: make_binders(value_bound, ty.num_binders),
+        value: make_binders(value_bound, binders),
     };
     Arc::new(value)
 }
@@ -628,20 +638,15 @@ pub(crate) fn fn_def_datum_query(
 ) -> Arc<FnDefDatum> {
     let callable_def: CallableDefId = from_chalk(db, fn_def_id);
     let generic_params = generics(db.upcast(), callable_def.into());
-    let sig = db.callable_item_signature(callable_def);
+    let (sig, binders) = db.callable_item_signature(callable_def).into_value_and_skipped_binders();
     let bound_vars = generic_params.bound_vars_subst(DebruijnIndex::INNERMOST);
     let where_clauses = convert_where_clauses(db, callable_def.into(), &bound_vars);
     let bound = rust_ir::FnDefDatumBound {
         // Note: Chalk doesn't actually use this information yet as far as I am aware, but we provide it anyway
         inputs_and_output: make_binders(
             rust_ir::FnDefInputsAndOutputDatum {
-                argument_types: sig
-                    .value
-                    .params()
-                    .iter()
-                    .map(|ty| ty.clone().to_chalk(db))
-                    .collect(),
-                return_type: sig.value.ret().clone().to_chalk(db),
+                argument_types: sig.params().iter().map(|ty| ty.clone().to_chalk(db)).collect(),
+                return_type: sig.ret().clone().to_chalk(db),
             }
             .shifted_in(&Interner),
             0,
@@ -650,12 +655,8 @@ pub(crate) fn fn_def_datum_query(
     };
     let datum = FnDefDatum {
         id: fn_def_id,
-        sig: chalk_ir::FnSig {
-            abi: (),
-            safety: chalk_ir::Safety::Safe,
-            variadic: sig.value.is_varargs,
-        },
-        binders: make_binders(bound, sig.num_binders),
+        sig: chalk_ir::FnSig { abi: (), safety: chalk_ir::Safety::Safe, variadic: sig.is_varargs },
+        binders: make_binders(bound, binders),
     };
     Arc::new(datum)
 }

--- a/crates/hir_ty/src/traits/chalk/mapping.rs
+++ b/crates/hir_ty/src/traits/chalk/mapping.rs
@@ -531,7 +531,7 @@ pub(super) fn generic_predicate_to_inline_bound(
 ) -> Option<chalk_ir::Binders<rust_ir::InlineBound<Interner>>> {
     // An InlineBound is like a GenericPredicate, except the self type is left out.
     // We don't have a special type for this, but Chalk does.
-    let self_ty_shifted_in = self_ty.clone().shift_bound_vars(DebruijnIndex::ONE);
+    let self_ty_shifted_in = self_ty.clone().shifted_in_from(DebruijnIndex::ONE);
     let (pred, binders) = pred.as_ref().into_value_and_skipped_binders();
     match pred {
         WhereClause::Implemented(trait_ref) => {

--- a/crates/hir_ty/src/traits/chalk/mapping.rs
+++ b/crates/hir_ty/src/traits/chalk/mapping.rs
@@ -519,7 +519,7 @@ pub(super) fn convert_where_clauses(
     let generic_predicates = db.generic_predicates(def);
     let mut result = Vec::with_capacity(generic_predicates.len());
     for pred in generic_predicates.iter() {
-        result.push(pred.clone().substitute(substs).to_chalk(db));
+        result.push(pred.clone().substitute(&Interner, substs).to_chalk(db));
     }
     result
 }

--- a/crates/hir_ty/src/traits/chalk/mapping.rs
+++ b/crates/hir_ty/src/traits/chalk/mapping.rs
@@ -519,7 +519,7 @@ pub(super) fn convert_where_clauses(
     let generic_predicates = db.generic_predicates(def);
     let mut result = Vec::with_capacity(generic_predicates.len());
     for pred in generic_predicates.iter() {
-        result.push(pred.clone().subst(substs).to_chalk(db));
+        result.push(pred.clone().substitute(substs).to_chalk(db));
     }
     result
 }

--- a/crates/hir_ty/src/types.rs
+++ b/crates/hir_ty/src/types.rs
@@ -299,7 +299,41 @@ impl Substitution {
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub struct Binders<T> {
     pub num_binders: usize,
-    pub value: T,
+    value: T,
+}
+
+impl<T> Binders<T> {
+    pub fn new(num_binders: usize, value: T) -> Self {
+        Self { num_binders, value }
+    }
+
+    pub fn empty(_interner: &Interner, value: T) -> Self {
+        Self { num_binders: 0, value }
+    }
+
+    pub fn as_ref(&self) -> Binders<&T> {
+        Binders { num_binders: self.num_binders, value: &self.value }
+    }
+
+    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> Binders<U> {
+        Binders { num_binders: self.num_binders, value: f(self.value) }
+    }
+
+    pub fn filter_map<U>(self, f: impl FnOnce(T) -> Option<U>) -> Option<Binders<U>> {
+        Some(Binders { num_binders: self.num_binders, value: f(self.value)? })
+    }
+
+    pub fn skip_binders(&self) -> &T {
+        &self.value
+    }
+
+    pub fn into_value_and_skipped_binders(self) -> (T, usize) {
+        (self.value, self.num_binders)
+    }
+
+    pub fn skip_binders_mut(&mut self) -> &mut T {
+        &mut self.value
+    }
 }
 
 /// A trait with type parameters. This includes the `Self`, so this represents a concrete type implementing the trait.

--- a/crates/hir_ty/src/types.rs
+++ b/crates/hir_ty/src/types.rs
@@ -12,7 +12,7 @@ use smallvec::SmallVec;
 
 use crate::{
     AssocTypeId, CanonicalVarKinds, ChalkTraitId, ClosureId, FnDefId, FnSig, ForeignDefId,
-    InferenceVar, Interner, OpaqueTyId, PlaceholderIndex, VariableKinds,
+    InferenceVar, Interner, OpaqueTyId, PlaceholderIndex, TypeWalk, VariableKinds,
 };
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
@@ -284,6 +284,10 @@ impl Substitution {
         elements: impl IntoIterator<Item = impl CastTo<GenericArg>>,
     ) -> Self {
         Substitution(elements.into_iter().casted(interner).collect())
+    }
+
+    pub fn apply<T: TypeWalk>(&self, value: T, _interner: &Interner) -> T {
+        value.subst_bound_vars(self)
     }
 
     // Temporary helper functions, to be removed

--- a/crates/hir_ty/src/utils.rs
+++ b/crates/hir_ty/src/utils.rs
@@ -72,7 +72,7 @@ fn direct_super_trait_refs(db: &dyn HirDatabase, trait_ref: &TraitRef) -> Vec<Tr
                 _ => None,
             })
         })
-        .map(|pred| pred.subst(&trait_ref.substitution))
+        .map(|pred| pred.substitute(&trait_ref.substitution))
         .collect()
 }
 

--- a/crates/hir_ty/src/utils.rs
+++ b/crates/hir_ty/src/utils.rs
@@ -66,9 +66,11 @@ fn direct_super_trait_refs(db: &dyn HirDatabase, trait_ref: &TraitRef) -> Vec<Tr
         .filter_map(|pred| {
             pred.as_ref().filter_map(|pred| match pred.skip_binders() {
                 // FIXME: how to correctly handle higher-ranked bounds here?
-                WhereClause::Implemented(tr) => {
-                    Some(tr.clone().shift_bound_vars_out(DebruijnIndex::ONE))
-                }
+                WhereClause::Implemented(tr) => Some(
+                    tr.clone()
+                        .shifted_out_to(DebruijnIndex::ONE)
+                        .expect("FIXME unexpected higher-ranked trait bound"),
+                ),
                 _ => None,
             })
         })
@@ -103,6 +105,8 @@ pub(super) fn all_super_traits(db: &dyn DefDatabase, trait_: TraitId) -> Vec<Tra
 /// we have `Self: Trait<u32, i32>` and `Trait<T, U>: OtherTrait<U>` we'll get
 /// `Self: OtherTrait<i32>`.
 pub(super) fn all_super_trait_refs(db: &dyn HirDatabase, trait_ref: TraitRef) -> Vec<TraitRef> {
+    // FIXME: replace by Chalk's `super_traits`, maybe make this a query
+
     // we need to take care a bit here to avoid infinite loops in case of cycles
     // (i.e. if we have `trait A: B; trait B: A;`)
     let mut result = vec![trait_ref];

--- a/crates/hir_ty/src/utils.rs
+++ b/crates/hir_ty/src/utils.rs
@@ -72,7 +72,7 @@ fn direct_super_trait_refs(db: &dyn HirDatabase, trait_ref: &TraitRef) -> Vec<Tr
                 _ => None,
             })
         })
-        .map(|pred| pred.substitute(&trait_ref.substitution))
+        .map(|pred| pred.substitute(&Interner, &trait_ref.substitution))
         .collect()
 }
 

--- a/crates/hir_ty/src/walk.rs
+++ b/crates/hir_ty/src/walk.rs
@@ -139,7 +139,7 @@ impl TypeWalk for Ty {
                 }
             }
             TyKind::Dyn(dyn_ty) => {
-                for p in dyn_ty.bounds.value.interned().iter() {
+                for p in dyn_ty.bounds.skip_binders().interned().iter() {
                     p.walk(f);
                 }
             }
@@ -167,7 +167,7 @@ impl TypeWalk for Ty {
                 p_ty.substitution.walk_mut_binders(f, binders);
             }
             TyKind::Dyn(dyn_ty) => {
-                for p in make_mut_slice(dyn_ty.bounds.value.interned_mut()) {
+                for p in make_mut_slice(dyn_ty.bounds.skip_binders_mut().interned_mut()) {
                     p.walk_mut_binders(f, binders.shifted_in());
                 }
             }
@@ -294,7 +294,7 @@ impl TypeWalk for Substitution {
 
 impl<T: TypeWalk> TypeWalk for Binders<T> {
     fn walk(&self, f: &mut impl FnMut(&Ty)) {
-        self.value.walk(f);
+        self.skip_binders().walk(f);
     }
 
     fn walk_mut_binders(
@@ -302,7 +302,7 @@ impl<T: TypeWalk> TypeWalk for Binders<T> {
         f: &mut impl FnMut(&mut Ty, DebruijnIndex),
         binders: DebruijnIndex,
     ) {
-        self.value.walk_mut_binders(f, binders.shifted_in())
+        self.skip_binders_mut().walk_mut_binders(f, binders.shifted_in())
     }
 }
 


### PR DESCRIPTION
Working towards #8313.
 - hide `value`
 - use `VariableKinds`
 - adjust `subst` to be like Chalk's `substitute`
 - also clean up some other `TypeWalk` stuff to prepare for it being replaced by Chalk's `Fold`