### PR TITLE
Remove dead legacy macro expansion code

### DIFF
--- a/crates/hir_def/src/nameres/collector.rs
+++ b/crates/hir_def/src/nameres/collector.rs
@@ -207,7 +207,7 @@ struct MacroDirective {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 enum MacroDirectiveKind {
-    FnLike { ast_id: AstIdWithPath<ast::MacroCall>, legacy: Option<MacroCallId> },
+    FnLike { ast_id: AstIdWithPath<ast::MacroCall> },
     Derive { ast_id: AstIdWithPath<ast::Item> },
 }
 
@@ -783,13 +783,7 @@ impl DefCollector<'_> {
         let mut res = ReachedFixedPoint::Yes;
         macros.retain(|directive| {
             match &directive.kind {
-                MacroDirectiveKind::FnLike { ast_id, legacy } => {
-                    if let Some(call_id) = legacy {
-                        res = ReachedFixedPoint::No;
-                        resolved.push((directive.module_id, *call_id, directive.depth));
-                        return false;
-                    }
-
+                MacroDirectiveKind::FnLike { ast_id } => {
                     match macro_call_as_call_id(
                         ast_id,
                         self.db,
@@ -1493,7 +1487,7 @@ impl ModCollector<'_, '_> {
         self.def_collector.unexpanded_macros.push(MacroDirective {
             module_id: self.module_id,
             depth: self.macro_depth + 1,
-            kind: MacroDirectiveKind::FnLike { ast_id, legacy: None },
+            kind: MacroDirectiveKind::FnLike { ast_id },
         });
     }
 


### PR DESCRIPTION
I was investigating some unrelated macro issue when I noticed this dead code. This legacy macro expansion logic was changed in https://github.com/rust-analyzer/rust-analyzer/pull/8128.