### PR TITLE
Don't use HirDisplayWrapper when displaying SourceCode

### DIFF
--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -51,6 +51,10 @@ pub trait HirDisplay {
     where
         Self: Sized,
     {
+        assert!(
+            !matches!(display_target, DisplayTarget::SourceCode { .. }),
+            "HirDisplayWrapper cannot fail with DisplaySourceCodeError, use HirDisplay::hir_fmt directly instead"
+        );
         HirDisplayWrapper { db, t: self, max_size, omit_verbose_types, display_target }
     }
 
@@ -235,7 +239,7 @@ where
             Err(HirDisplayError::FmtError) => Err(fmt::Error),
             Err(HirDisplayError::DisplaySourceCodeError(_)) => {
                 // This should never happen
-                panic!("HirDisplay failed when calling Display::fmt!")
+                panic!("HirDisplay::hir_fmt failed with DisplaySourceCodeError when calling Display::fmt!")
             }
         }
     }

--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -256,13 +256,9 @@ impl HirDisplay for ProjectionTy {
         }
 
         let trait_ = f.db.trait_data(self.trait_(f.db));
-        let first_parameter = self.self_type_parameter(&Interner).into_displayable(
-            f.db,
-            f.max_size,
-            f.omit_verbose_types,
-            f.display_target,
-        );
-        write!(f, "<{} as {}", first_parameter, trait_.name)?;
+        write!(f, "<")?;
+        self.self_type_parameter(&Interner).hir_fmt(f)?;
+        write!(f, " as {}", trait_.name)?;
         if self.substitution.len(&Interner) > 1 {
             write!(f, "<")?;
             f.write_joined(&self.substitution.interned()[1..], ", ")?;
@@ -341,9 +337,6 @@ impl HirDisplay for Ty {
                 write!(f, "]")?;
             }
             TyKind::Raw(m, t) | TyKind::Ref(m, _, t) => {
-                let ty_display =
-                    t.into_displayable(f.db, f.max_size, f.omit_verbose_types, f.display_target);
-
                 if matches!(self.kind(&Interner), TyKind::Raw(..)) {
                     write!(
                         f,
@@ -398,16 +391,16 @@ impl HirDisplay for Ty {
                     if fn_traits(f.db.upcast(), trait_).any(|it| it == trait_)
                         && predicates.len() <= 2
                     {
-                        return write!(f, "{}", ty_display);
+                        return t.hir_fmt(f);
                     }
                 }
 
                 if predicates.len() > 1 {
                     write!(f, "(")?;
-                    write!(f, "{}", ty_display)?;
+                    t.hir_fmt(f)?;
                     write!(f, ")")?;
                 } else {
-                    write!(f, "{}", ty_display)?;
+                    t.hir_fmt(f)?;
                 }
             }
             TyKind::Tuple(_, substs) => {
@@ -454,14 +447,8 @@ impl HirDisplay for Ty {
                 write!(f, ")")?;
                 let ret = sig.ret();
                 if !ret.is_unit() {
-                    let ret_display = ret.into_displayable(
-                        f.db,
-                        f.max_size,
-                        f.omit_verbose_types,
-                        f.display_target,
-                    );
-
-                    write!(f, " -> {}", ret_display)?;
+                    write!(f, " -> ")?;
+                    ret.hir_fmt(f)?;
                 }
             }
             TyKind::Adt(AdtId(def_id), parameters) => {
@@ -603,13 +590,8 @@ impl HirDisplay for Ty {
                         write!(f, "|")?;
                     };
 
-                    let ret_display = sig.ret().into_displayable(
-                        f.db,
-                        f.max_size,
-                        f.omit_verbose_types,
-                        f.display_target,
-                    );
-                    write!(f, " -> {}", ret_display)?;
+                    write!(f, " -> ")?;
+                    sig.ret().hir_fmt(f)?;
                 } else {
                     write!(f, "{{closure}}")?;
                 }
@@ -697,9 +679,8 @@ impl HirDisplay for CallableSig {
         write!(f, ")")?;
         let ret = self.ret();
         if !ret.is_unit() {
-            let ret_display =
-                ret.into_displayable(f.db, f.max_size, f.omit_verbose_types, f.display_target);
-            write!(f, " -> {}", ret_display)?;
+            write!(f, " -> ")?;
+            ret.hir_fmt(f)?;
         }
         Ok(())
     }


### PR DESCRIPTION
The issue was basically that when displaying for `DisplayTarget::SourceCode` some `hir_fmt` functions would create `HirDisplayWrapper`s which would then `fmt` these triggering the Display panic since `fmt::Display` can't fail the same way as `HirDisplay`. Simple fix is to just use `hir_fmt` directly. Should probably write that down somewhere in source, looking for a good spot to put that right now.

Fixes #8077, Fixes #8370
