### PR TITLE
Add space after lifetime in expand macro

### DIFF
--- a/crates/ide/src/expand_macro.rs
+++ b/crates/ide/src/expand_macro.rs
@@ -103,6 +103,9 @@ fn insert_whitespaces(syn: SyntaxNode) -> String {
                 format!("\n{}}}", "  ".repeat(indent))
             }
             R_CURLY => format!("}}\n{}", "  ".repeat(indent)),
+            LIFETIME_IDENT if is_next(|it| it == IDENT, true) => {
+                format!("{} ", token.text().to_string())
+            }
             T![;] => format!(";\n{}", "  ".repeat(indent)),
             T![->] => " -> ".to_string(),
             T![=] => " = ".to_string(),


### PR DESCRIPTION
When a lifetime is followed by an ident, this lead to invalid syntax. This adds a whitespace between the lifetime and the identifier.

Noticed this here: https://github.com/simrat39/rust-tools.nvim/issues/2#issuecomment-814551847