### PR TITLE
Remove ref_match from CompletionItem

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1721,6 +1721,10 @@ impl Type {
         matches!(self.ty.kind(&Interner), TyKind::Ref(hir_ty::Mutability::Mut, ..))
     }
 
+    pub fn is_shared_reference(&self) -> bool {
+        matches!(self.ty.kind(&Interner), TyKind::Ref(hir_ty::Mutability::Not, ..))
+    }
+
     pub fn is_usize(&self) -> bool {
         matches!(self.ty.kind(&Interner), TyKind::Scalar(Scalar::Uint(UintTy::Usize)))
     }
@@ -1730,6 +1734,12 @@ impl Type {
             TyKind::Ref(.., ty) => Some(self.derived(ty.clone())),
             _ => None,
         }
+    }
+
+    pub fn add_ref(mut self, ref_mutability: Mutability) -> Type {
+        self.ty = self.ty.add_ref(ref_mutability);
+
+        self
     }
 
     pub fn is_unknown(&self) -> bool {

--- a/crates/hir_ty/src/types.rs
+++ b/crates/hir_ty/src/types.rs
@@ -229,6 +229,16 @@ impl Ty {
     pub fn into_inner(self) -> TyKind {
         Arc::try_unwrap(self.0).unwrap_or_else(|a| (*a).clone())
     }
+
+    pub fn add_ref(self, ref_mutability: hir_def::type_ref::Mutability) -> Ty {
+        let mutability = match ref_mutability {
+            hir_def::type_ref::Mutability::Shared => Mutability::Not,
+            hir_def::type_ref::Mutability::Mut => Mutability::Mut,
+        };
+
+        let kind = TyKind::Ref(mutability, self);
+        Ty(Arc::new(kind))
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]

--- a/crates/ide_completion/src/completions.rs
+++ b/crates/ide_completion/src/completions.rs
@@ -121,7 +121,7 @@ impl Completions {
         func: hir::Function,
         local_name: Option<String>,
     ) {
-        if let Some(item) = render_fn(RenderContext::new(ctx), None, local_name, func) {
+        if let Some(item) = render_fn(RenderContext::new(ctx), None, local_name, func, None) {
             self.add(item)
         }
     }
@@ -132,7 +132,7 @@ impl Completions {
         func: hir::Function,
         local_name: Option<String>,
     ) {
-        if let Some(item) = render_fn(RenderContext::new(ctx), None, local_name, func) {
+        if let Some(item) = render_fn(RenderContext::new(ctx), None, local_name, func, None) {
             self.add(item)
         }
     }

--- a/crates/ide_completion/src/completions.rs
+++ b/crates/ide_completion/src/completions.rs
@@ -187,8 +187,9 @@ impl Completions {
         ctx: &CompletionContext,
         variant: hir::Variant,
         path: ModPath,
+        is_ref: Option<Mutability>,
     ) {
-        let item = render_variant(RenderContext::new(ctx), None, None, variant, Some(path));
+        let item = render_variant(RenderContext::new(ctx), None, None, variant, Some(path), is_ref);
         self.add(item);
     }
 
@@ -197,8 +198,9 @@ impl Completions {
         ctx: &CompletionContext,
         variant: hir::Variant,
         local_name: Option<String>,
+        is_ref: Option<Mutability>,
     ) {
-        let item = render_variant(RenderContext::new(ctx), None, local_name, variant, None);
+        let item = render_variant(RenderContext::new(ctx), None, local_name, variant, None, is_ref);
         self.add(item);
     }
 }

--- a/crates/ide_completion/src/completions.rs
+++ b/crates/ide_completion/src/completions.rs
@@ -91,8 +91,11 @@ impl Completions {
         ctx: &CompletionContext,
         local_name: String,
         resolution: &ScopeDef,
+        is_ref: Option<Mutability>,
     ) {
-        if let Some(item) = render_resolution(RenderContext::new(ctx), local_name, resolution) {
+        if let Some(item) =
+            render_resolution(RenderContext::new(ctx), local_name, resolution, is_ref)
+        {
             self.add(item);
         }
     }

--- a/crates/ide_completion/src/completions.rs
+++ b/crates/ide_completion/src/completions.rs
@@ -26,7 +26,7 @@ use crate::{
     render::{
         const_::render_const,
         enum_variant::render_variant,
-        function::{render_fn, render_method},
+        function::render_fn,
         macro_::render_macro,
         pattern::{render_struct_pat, render_variant_pat},
         render_field, render_resolution, render_tuple_field,
@@ -132,7 +132,7 @@ impl Completions {
         func: hir::Function,
         local_name: Option<String>,
     ) {
-        if let Some(item) = render_method(RenderContext::new(ctx), None, local_name, func) {
+        if let Some(item) = render_fn(RenderContext::new(ctx), None, local_name, func) {
             self.add(item)
         }
     }

--- a/crates/ide_completion/src/completions/lifetime.rs
+++ b/crates/ide_completion/src/completions/lifetime.rs
@@ -20,7 +20,7 @@ pub(crate) fn complete_lifetime(acc: &mut Completions, ctx: &CompletionContext) 
     ctx.scope.process_all_names(&mut |name, res| {
         if let ScopeDef::GenericParam(hir::GenericParam::LifetimeParam(_)) = res {
             if param_lifetime != Some(name.to_string()) {
-                acc.add_resolution(ctx, name.to_string(), &res);
+                acc.add_resolution(ctx, name.to_string(), &res, None);
             }
         }
     });
@@ -36,7 +36,7 @@ pub(crate) fn complete_label(acc: &mut Completions, ctx: &CompletionContext) {
     }
     ctx.scope.process_all_names(&mut |name, res| {
         if let ScopeDef::Label(_) = res {
-            acc.add_resolution(ctx, name.to_string(), &res);
+            acc.add_resolution(ctx, name.to_string(), &res, None);
         }
     });
 }

--- a/crates/ide_completion/src/completions/pattern.rs
+++ b/crates/ide_completion/src/completions/pattern.rs
@@ -15,7 +15,7 @@ pub(crate) fn complete_pattern(acc: &mut Completions, ctx: &CompletionContext) {
         if let Some(ty) = ctx.expected_type.as_ref() {
             super::complete_enum_variants(acc, ctx, ty, |acc, ctx, variant, path| {
                 acc.add_qualified_variant_pat(ctx, variant, path.clone());
-                acc.add_qualified_enum_variant(ctx, variant, path);
+                acc.add_qualified_enum_variant(ctx, variant, path, None);
             });
         }
     }

--- a/crates/ide_completion/src/completions/pattern.rs
+++ b/crates/ide_completion/src/completions/pattern.rs
@@ -51,7 +51,7 @@ pub(crate) fn complete_pattern(acc: &mut Completions, ctx: &CompletionContext) {
             _ => false,
         };
         if add_resolution {
-            acc.add_resolution(ctx, name.to_string(), &res);
+            acc.add_resolution(ctx, name.to_string(), &res, None);
         }
     });
 }

--- a/crates/ide_completion/src/completions/qualified_path.rs
+++ b/crates/ide_completion/src/completions/qualified_path.rs
@@ -53,7 +53,7 @@ pub(crate) fn complete_qualified_path(acc: &mut Completions, ctx: &CompletionCon
         | PathResolution::Def(def @ hir::ModuleDef::BuiltinType(_)) => {
             if let hir::ModuleDef::Adt(Adt::Enum(e)) = def {
                 for variant in e.variants(ctx.db) {
-                    acc.add_enum_variant(ctx, variant, None);
+                    acc.add_enum_variant(ctx, variant, None, None);
                 }
             }
             let ty = match def {
@@ -123,7 +123,7 @@ pub(crate) fn complete_qualified_path(acc: &mut Completions, ctx: &CompletionCon
 
                 if let Some(Adt::Enum(e)) = ty.as_adt() {
                     for variant in e.variants(ctx.db) {
-                        acc.add_enum_variant(ctx, variant, None);
+                        acc.add_enum_variant(ctx, variant, None, None);
                     }
                 }
 

--- a/crates/ide_completion/src/completions/qualified_path.rs
+++ b/crates/ide_completion/src/completions/qualified_path.rs
@@ -45,7 +45,7 @@ pub(crate) fn complete_qualified_path(acc: &mut Completions, ctx: &CompletionCon
                     }
                 }
 
-                acc.add_resolution(ctx, name.to_string(), &def);
+                acc.add_resolution(ctx, name.to_string(), &def, None);
             }
         }
         PathResolution::Def(def @ hir::ModuleDef::Adt(_))

--- a/crates/ide_completion/src/completions/unqualified_path.rs
+++ b/crates/ide_completion/src/completions/unqualified_path.rs
@@ -5,6 +5,8 @@ use syntax::AstNode;
 
 use crate::{CompletionContext, Completions};
 
+use super::compute_ref_match;
+
 pub(crate) fn complete_unqualified_path(acc: &mut Completions, ctx: &CompletionContext) {
     if !ctx.is_trivial_path {
         return;
@@ -36,7 +38,14 @@ pub(crate) fn complete_unqualified_path(acc: &mut Completions, ctx: &CompletionC
                 }
             }
         }
-        acc.add_resolution(ctx, name.to_string(), &res);
+        acc.add_resolution(ctx, name.to_string(), &res, None);
+
+        if let ScopeDef::Local(local) = res {
+            let ty = local.ty(ctx.db);
+            if let Some(mutability) = compute_ref_match(ctx, &ty) {
+                acc.add_resolution(ctx, name.to_string(), &res, Some(mutability));
+            }
+        };
     });
 }
 

--- a/crates/ide_completion/src/completions/unqualified_path.rs
+++ b/crates/ide_completion/src/completions/unqualified_path.rs
@@ -21,7 +21,11 @@ pub(crate) fn complete_unqualified_path(acc: &mut Completions, ctx: &CompletionC
 
     if let Some(ty) = &ctx.expected_type {
         super::complete_enum_variants(acc, ctx, ty, |acc, ctx, variant, path| {
-            acc.add_qualified_enum_variant(ctx, variant, path)
+            acc.add_qualified_enum_variant(ctx, variant, path.clone(), None);
+            let ty = variant.parent_enum(ctx.db).ty(ctx.db);
+            if let Some(mutability) = super::compute_ref_match(ctx, &ty) {
+                acc.add_qualified_enum_variant(ctx, variant, path, Some(mutability));
+            }
         });
     }
 

--- a/crates/ide_completion/src/render.rs
+++ b/crates/ide_completion/src/render.rs
@@ -190,7 +190,8 @@ impl<'a> Render<'a> {
                 CompletionItemKind::SymbolKind(SymbolKind::Variant)
             }
             ScopeDef::ModuleDef(Variant(var)) => {
-                let item = render_variant(self.ctx, import_to_add, Some(local_name), *var, None);
+                let item =
+                    render_variant(self.ctx, import_to_add, Some(local_name), *var, None, None);
                 return Some(item);
             }
             ScopeDef::MacroDef(mac) => {

--- a/crates/ide_completion/src/render.rs
+++ b/crates/ide_completion/src/render.rs
@@ -181,7 +181,7 @@ impl<'a> Render<'a> {
 
         let kind = match resolution {
             ScopeDef::ModuleDef(Function(func)) => {
-                return render_fn(self.ctx, import_to_add, Some(local_name), *func);
+                return render_fn(self.ctx, import_to_add, Some(local_name), *func, is_ref);
             }
             ScopeDef::ModuleDef(Variant(_))
                 if self.ctx.completion.is_pat_binding_or_const

--- a/crates/ide_completion/src/render/enum_variant.rs
+++ b/crates/ide_completion/src/render/enum_variant.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 
 use crate::{
     item::{CompletionItem, CompletionKind, ImportEdit},
-    render::{builder_ext::Params, compute_ref_match, compute_type_match, RenderContext},
+    render::{builder_ext::Params, compute_type_match, RenderContext},
     CompletionRelevance,
 };
 
@@ -80,10 +80,6 @@ impl<'a> EnumRender<'a> {
             type_match: compute_type_match(self.ctx.completion, &ty),
             ..CompletionRelevance::default()
         });
-
-        if let Some(ref_match) = compute_ref_match(self.ctx.completion, &ty) {
-            item.ref_match(ref_match);
-        }
 
         item.build()
     }

--- a/crates/ide_completion/src/render/function.rs
+++ b/crates/ide_completion/src/render/function.rs
@@ -17,17 +17,7 @@ pub(crate) fn render_fn<'a>(
     fn_: hir::Function,
 ) -> Option<CompletionItem> {
     let _p = profile::span("render_fn");
-    Some(FunctionRender::new(ctx, local_name, fn_, false)?.render(import_to_add))
-}
-
-pub(crate) fn render_method<'a>(
-    ctx: RenderContext<'a>,
-    import_to_add: Option<ImportEdit>,
-    local_name: Option<String>,
-    fn_: hir::Function,
-) -> Option<CompletionItem> {
-    let _p = profile::span("render_method");
-    Some(FunctionRender::new(ctx, local_name, fn_, true)?.render(import_to_add))
+    Some(FunctionRender::new(ctx, local_name, fn_)?.render(import_to_add))
 }
 
 #[derive(Debug)]
@@ -36,7 +26,6 @@ struct FunctionRender<'a> {
     name: String,
     func: hir::Function,
     ast_node: Fn,
-    is_method: bool,
 }
 
 impl<'a> FunctionRender<'a> {
@@ -44,12 +33,11 @@ impl<'a> FunctionRender<'a> {
         ctx: RenderContext<'a>,
         local_name: Option<String>,
         fn_: hir::Function,
-        is_method: bool,
     ) -> Option<FunctionRender<'a>> {
         let name = local_name.unwrap_or_else(|| fn_.name(ctx.db()).to_string());
         let ast_node = fn_.source(ctx.db())?.value;
 
-        Some(FunctionRender { ctx, name, func: fn_, ast_node, is_method })
+        Some(FunctionRender { ctx, name, func: fn_, ast_node })
     }
 
     fn render(self, import_to_add: Option<ImportEdit>) -> CompletionItem {

--- a/crates/ide_completion/src/render/function.rs
+++ b/crates/ide_completion/src/render/function.rs
@@ -7,10 +7,7 @@ use syntax::ast::Fn;
 
 use crate::{
     item::{CompletionItem, CompletionItemKind, CompletionKind, CompletionRelevance, ImportEdit},
-    render::{
-        builder_ext::Params, compute_exact_name_match, compute_ref_match, compute_type_match,
-        RenderContext,
-    },
+    render::{builder_ext::Params, compute_exact_name_match, compute_type_match, RenderContext},
 };
 
 pub(crate) fn render_fn<'a>(
@@ -77,15 +74,6 @@ impl<'a> FunctionRender<'a> {
             exact_name_match: compute_exact_name_match(self.ctx.completion, self.name.clone()),
             ..CompletionRelevance::default()
         });
-
-        if let Some(ref_match) = compute_ref_match(self.ctx.completion, &ret_type) {
-            // FIXME
-            // For now we don't properly calculate the edits for ref match
-            // completions on methods, so we've disabled them. See #8058.
-            if !self.is_method {
-                item.ref_match(ref_match);
-            }
-        }
 
         item.build()
     }

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -667,16 +667,14 @@ pub(crate) fn handle_completion(
 
     let items: Vec<CompletionItem> = items
         .into_iter()
-        .flat_map(|item| {
-            let mut new_completion_items = to_proto::completion_item(&line_index, item.clone());
+        .map(|item| {
+            let mut new_completion_item = to_proto::completion_item(&line_index, item.clone());
 
             if completion_config.enable_imports_on_the_fly {
-                for new_item in &mut new_completion_items {
-                    fill_resolve_data(&mut new_item.data, &item, &text_document_position);
-                }
+                fill_resolve_data(&mut new_completion_item.data, &item, &text_document_position);
             }
 
-            new_completion_items
+            new_completion_item
         })
         .collect();
 

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -1099,7 +1099,7 @@ mod tests {
             encoding: OffsetEncoding::Utf16,
         };
         let (analysis, file_id) = Analysis::from_single_file(text);
-        let completions: Vec<(String, Option<String>)> = analysis
+        let mut completions: Vec<(String, Option<String>)> = analysis
             .completions(
                 &ide::CompletionConfig {
                     enable_postfix_completions: true,
@@ -1122,6 +1122,10 @@ mod tests {
             .map(|c| completion_item(&line_index, c))
             .map(|c| (c.label, c.sort_text))
             .collect();
+
+        // Sort by increasing sort_text, as the LSP clients will do.
+        completions.sort_by_key(|c| c.1.clone());
+
         expect_test::expect![[r#"
             [
                 (


### PR DESCRIPTION
This PR makes two changes:

1. Remove the ref_match field from CompletionItem
2. Move the responsibility for finding reference completions from render to completion

I discussed doing this in #8058, as a step toward fixing the problem where we put the reference completion in the wrong place for struct fields. 

However, after implementing this, I'm not sure it improves on the existing code. I'm concerned that this implementation spreads the responsibility for reference completion around to too many places. Instead of this, next I want to try adding some kind of marker for where the reference would go in the `ref_match` field. I don't intend to merge this PR, just wanted to open it as a draft in case there was any question about what this might look like. 