### PR TITLE
Return proper error code when server is loading

### DIFF
--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -484,7 +484,7 @@ impl GlobalState {
                 req.id,
                 // FIXME: i32 should impl From<ErrorCode> (from() guarantees lossless conversion)
                 lsp_server::ErrorCode::ContentModified as i32,
-                "Rust Analyzer is still loading...".to_owned(),
+                "waiting for cargo metadata or cargo check".to_owned(),
             ));
             return Ok(());
         }


### PR DESCRIPTION
When requests are made to rust-analyzer and the server is still loading, a response error is returned with the code `ContentModified` and text `"Rust Analyzer is still loading..."`. This error code doesn't seem to be the more appropriate for this situation. Using `ServerNotInitialized` seems better.

As this is such a small change, I have not created an issue for it.