### PR TITLE
Integrate imports into public `hir_def` API

### DIFF
--- a/crates/hir/src/attrs.rs
+++ b/crates/hir/src/attrs.rs
@@ -103,6 +103,7 @@ fn resolve_doc_path(
         AttrDefId::TraitId(it) => it.resolver(db.upcast()),
         AttrDefId::TypeAliasId(it) => it.resolver(db.upcast()),
         AttrDefId::ImplId(it) => it.resolver(db.upcast()),
+        AttrDefId::ImportId(it) => it.resolver(db.upcast()),
         AttrDefId::GenericParamId(it) => match it {
             GenericParamId::TypeParamId(it) => it.parent,
             GenericParamId::LifetimeParamId(it) => it.parent,

--- a/crates/hir_def/src/attr.rs
+++ b/crates/hir_def/src/attr.rs
@@ -336,6 +336,7 @@ impl AttrsWithOwner {
             AttrDefId::StaticId(it) => attrs_from_item_tree(it.lookup(db).id, db),
             AttrDefId::FunctionId(it) => attrs_from_item_tree(it.lookup(db).id, db),
             AttrDefId::TypeAliasId(it) => attrs_from_item_tree(it.lookup(db).id, db),
+            AttrDefId::ImportId(it) => attrs_from_item_tree(it.lookup(db).id, db),
             AttrDefId::GenericParamId(it) => match it {
                 GenericParamId::TypeParamId(it) => {
                     let src = it.parent.child_source(db);
@@ -428,6 +429,7 @@ impl AttrsWithOwner {
             AttrDefId::ConstId(id) => id.lookup(db).source(db).map(ast::AttrsOwnerNode::new),
             AttrDefId::TraitId(id) => id.lookup(db).source(db).map(ast::AttrsOwnerNode::new),
             AttrDefId::TypeAliasId(id) => id.lookup(db).source(db).map(ast::AttrsOwnerNode::new),
+            AttrDefId::ImportId(id) => id.lookup(db).source(db).map(ast::AttrsOwnerNode::new),
             AttrDefId::MacroDefId(id) => match id.ast_id() {
                 Either::Left(it) => {
                     it.with_value(ast::AttrsOwnerNode::new(it.to_node(db.upcast())))

--- a/crates/hir_def/src/attr.rs
+++ b/crates/hir_def/src/attr.rs
@@ -336,7 +336,10 @@ impl AttrsWithOwner {
             AttrDefId::StaticId(it) => attrs_from_item_tree(it.lookup(db).id, db),
             AttrDefId::FunctionId(it) => attrs_from_item_tree(it.lookup(db).id, db),
             AttrDefId::TypeAliasId(it) => attrs_from_item_tree(it.lookup(db).id, db),
-            AttrDefId::ImportId(it) => attrs_from_item_tree(it.lookup(db).id, db),
+            AttrDefId::ImportId(it) => match it.lookup(db) {
+                Either::Left(it) => attrs_from_item_tree(it.id, db),
+                Either::Right(it) => attrs_from_item_tree(it.id, db),
+            },
             AttrDefId::GenericParamId(it) => match it {
                 GenericParamId::TypeParamId(it) => {
                     let src = it.parent.child_source(db);
@@ -429,7 +432,10 @@ impl AttrsWithOwner {
             AttrDefId::ConstId(id) => id.lookup(db).source(db).map(ast::AttrsOwnerNode::new),
             AttrDefId::TraitId(id) => id.lookup(db).source(db).map(ast::AttrsOwnerNode::new),
             AttrDefId::TypeAliasId(id) => id.lookup(db).source(db).map(ast::AttrsOwnerNode::new),
-            AttrDefId::ImportId(id) => id.lookup(db).source(db).map(ast::AttrsOwnerNode::new),
+            AttrDefId::ImportId(id) => match id.lookup(db) {
+                Either::Left(it) => it.source(db).map(ast::AttrsOwnerNode::new),
+                Either::Right(it) => it.source(db).map(ast::AttrsOwnerNode::new),
+            },
             AttrDefId::MacroDefId(id) => match id.ast_id() {
                 Either::Left(it) => {
                     it.with_value(ast::AttrsOwnerNode::new(it.to_node(db.upcast())))

--- a/crates/hir_def/src/db.rs
+++ b/crates/hir_def/src/db.rs
@@ -20,13 +20,15 @@ use crate::{
     nameres::DefMap,
     visibility::{self, Visibility},
     AttrDefId, BlockId, BlockLoc, ConstId, ConstLoc, DefWithBodyId, EnumId, EnumLoc, FunctionId,
-    FunctionLoc, GenericDefId, ImplId, ImplLoc, LocalEnumVariantId, LocalFieldId, StaticId,
-    StaticLoc, StructId, StructLoc, TraitId, TraitLoc, TypeAliasId, TypeAliasLoc, UnionId,
-    UnionLoc, VariantId,
+    FunctionLoc, GenericDefId, ImplId, ImplLoc, ImportId, ImportLoc, LocalEnumVariantId,
+    LocalFieldId, StaticId, StaticLoc, StructId, StructLoc, TraitId, TraitLoc, TypeAliasId,
+    TypeAliasLoc, UnionId, UnionLoc, VariantId,
 };
 
 #[salsa::query_group(InternDatabaseStorage)]
 pub trait InternDatabase: SourceDatabase {
+    #[salsa::interned]
+    fn intern_import(&self, loc: ImportLoc) -> ImportId;
     #[salsa::interned]
     fn intern_function(&self, loc: FunctionLoc) -> FunctionId;
     #[salsa::interned]

--- a/crates/hir_def/src/lib.rs
+++ b/crates/hir_def/src/lib.rs
@@ -70,7 +70,7 @@ use syntax::ast;
 
 use crate::builtin_type::BuiltinType;
 use item_tree::{
-    Const, Enum, Function, Impl, ItemTreeId, ItemTreeNode, ModItem, Static, Struct, Trait,
+    Const, Enum, Function, Impl, Import, ItemTreeId, ItemTreeNode, ModItem, Static, Struct, Trait,
     TypeAlias, Union,
 };
 use stdx::impl_from;
@@ -189,6 +189,11 @@ macro_rules! impl_intern {
         }
     };
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ImportId(salsa::InternId);
+type ImportLoc = AssocItemLoc<Import>;
+impl_intern!(ImportId, ImportLoc, intern_import, lookup_intern_import);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct FunctionId(salsa::InternId);
@@ -417,6 +422,7 @@ pub enum AttrDefId {
     MacroDefId(MacroDefId),
     ImplId(ImplId),
     GenericParamId(GenericParamId),
+    ImportId(ImportId),
 }
 
 impl_from!(
@@ -431,7 +437,8 @@ impl_from!(
     TypeAliasId,
     MacroDefId,
     ImplId,
-    GenericParamId
+    GenericParamId,
+    ImportId
     for AttrDefId
 );
 
@@ -585,6 +592,7 @@ impl AttrDefId {
             AttrDefId::TraitId(it) => it.lookup(db).container.krate,
             AttrDefId::TypeAliasId(it) => it.lookup(db).module(db).krate,
             AttrDefId::ImplId(it) => it.lookup(db).container.krate,
+            AttrDefId::ImportId(it) => it.lookup(db).module(db).krate,
             AttrDefId::GenericParamId(it) => {
                 match it {
                     GenericParamId::TypeParamId(it) => it.parent,

--- a/crates/hir_def/src/resolver.rs
+++ b/crates/hir_def/src/resolver.rs
@@ -2,6 +2,7 @@
 use std::sync::Arc;
 
 use base_db::CrateId;
+use either::Either;
 use hir_expand::{
     name::{name, Name},
     MacroDefId,
@@ -667,7 +668,10 @@ impl HasResolver for FunctionId {
 
 impl HasResolver for ImportId {
     fn resolver(self, db: &dyn DefDatabase) -> Resolver {
-        self.lookup(db).container.resolver(db)
+        match self.lookup(db) {
+            Either::Left(it) => it.container.resolver(db),
+            Either::Right(it) => it.container.resolver(db),
+        }
     }
 }
 

--- a/crates/hir_def/src/resolver.rs
+++ b/crates/hir_def/src/resolver.rs
@@ -21,9 +21,9 @@ use crate::{
     per_ns::PerNs,
     visibility::{RawVisibility, Visibility},
     AdtId, AssocContainerId, ConstId, ConstParamId, DefWithBodyId, EnumId, EnumVariantId,
-    FunctionId, GenericDefId, GenericParamId, HasModule, ImplId, LifetimeParamId, LocalModuleId,
-    Lookup, ModuleDefId, ModuleId, StaticId, StructId, TraitId, TypeAliasId, TypeParamId,
-    VariantId,
+    FunctionId, GenericDefId, GenericParamId, HasModule, ImplId, ImportId, LifetimeParamId,
+    LocalModuleId, Lookup, ModuleDefId, ModuleId, StaticId, StructId, TraitId, TypeAliasId,
+    TypeParamId, VariantId,
 };
 
 #[derive(Debug, Clone, Default)]
@@ -662,6 +662,12 @@ impl<T: Into<AdtId> + Copy> HasResolver for T {
 impl HasResolver for FunctionId {
     fn resolver(self, db: &dyn DefDatabase) -> Resolver {
         self.lookup(db).container.resolver(db).push_generic_params_scope(db, self.into())
+    }
+}
+
+impl HasResolver for ImportId {
+    fn resolver(self, db: &dyn DefDatabase) -> Resolver {
+        self.lookup(db).container.resolver(db)
     }
 }
 

--- a/crates/ide_db/src/apply_change.rs
+++ b/crates/ide_db/src/apply_change.rs
@@ -225,6 +225,7 @@ impl RootDatabase {
             hir::db::InternEagerExpansionQuery
 
             // InternDatabase
+            hir::db::InternImportQuery
             hir::db::InternFunctionQuery
             hir::db::InternStructQuery
             hir::db::InternUnionQuery
@@ -234,6 +235,7 @@ impl RootDatabase {
             hir::db::InternTraitQuery
             hir::db::InternTypeAliasQuery
             hir::db::InternImplQuery
+            hir::db::InternBlockQuery
 
             // HirDatabase
             hir::db::InternTypeParamIdQuery


### PR DESCRIPTION
This adds `ImportId`/`ImportLoc` and a corresponding interning query, and adds `AttrDefId::ImportId`, which lets the IDE query attributes and doc comments on imports.

Imports are flattened during `ItemTree` lowering, so `use m::{a, b};` generates 2 `ImportId`s that share the same attributes.

We probably want to have this in order to process doc comments on reexports. It should also let us more easily attach diagnostics to attributes during name resolution.