### PR TITLE
Track recursion limit when expanding custom derive

### DIFF
--- a/crates/hir_def/src/nameres/collector.rs
+++ b/crates/hir_def/src/nameres/collector.rs
@@ -836,7 +836,7 @@ impl DefCollector<'_> {
                         self.resolve_derive_macro(directive.module_id, &path)
                     }) {
                         Ok(call_id) => {
-                            resolved.push((directive.module_id, call_id, 0));
+                            resolved.push((directive.module_id, call_id, directive.depth));
                             res = ReachedFixedPoint::No;
                             return false;
                         }


### PR DESCRIPTION
You can write a custom derive that expands to itself:

```rust
#[proc_macro_derive(Derive)]
pub fn derive(item: TokenStream) -> TokenStream {
    let mut out: TokenStream = "#[derive(Derive)]".parse().unwrap();

    out.extend(item);
    out
}
```

rustc reports a recursion limit error, but rust-analyzer used to spin in name resolution and eventually fail with "name resolution is stuck". This makes it fail fast by respecting the recursion depth of the invocation.

bors r+