### PR TITLE
decl_check: consider outer scopes' allows

### DIFF
--- a/crates/hir_def/src/lib.rs
+++ b/crates/hir_def/src/lib.rs
@@ -435,6 +435,16 @@ impl_from!(
     for AttrDefId
 );
 
+impl From<AssocContainerId> for AttrDefId {
+    fn from(acid: AssocContainerId) -> Self {
+        match acid {
+            AssocContainerId::ModuleId(mid) => AttrDefId::ModuleId(mid),
+            AssocContainerId::ImplId(iid) => AttrDefId::ImplId(iid),
+            AssocContainerId::TraitId(tid) => AttrDefId::TraitId(tid),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum VariantId {
     EnumVariantId(EnumVariantId),

--- a/crates/hir_ty/src/diagnostics/decl_check.rs
+++ b/crates/hir_ty/src/diagnostics/decl_check.rs
@@ -926,11 +926,6 @@ fn main() {
         fn CheckItWorksWithModAttr(BAD_NAME_HI: u8) {}
     }
 
-    trait BAD_TRAIT {
-        fn BAD_FUNCTION();
-        fn BadFunction();
-    }
-
     #[allow(non_snake_case, non_camel_case_types)]
     pub struct some_type {
         SOME_FIELD: u8,
@@ -981,22 +976,41 @@ fn main() {
 
         check_diagnostics(
             r#"
-trait T { fn a(); }
-struct U {}
-impl T for U {
-    fn a() {
-        // this comes out of bitflags, mostly
-        #[allow(non_snake_case)]
-        trait __BitFlags {
-            const HiImAlsoBad: u8 = 2;
-            #[inline]
-            fn Dirty(&self) -> bool {
-                false
+    trait T { fn a(); }
+    struct U {}
+    impl T for U {
+        fn a() {
+            // this comes out of bitflags, mostly
+            #[allow(non_snake_case)]
+            trait __BitFlags {
+                const HiImAlsoBad: u8 = 2;
+                #[inline]
+                fn Dirty(&self) -> bool {
+                    false
+                }
             }
-        }
 
+        }
     }
-}"#,
+    "#,
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn bug_traits_arent_checked() {
+        // FIXME: Traits and functions in traits aren't currently checked by
+        // r-a, even though rustc will complain about them.
+        check_diagnostics(
+            r#"
+    trait BAD_TRAIT {
+       // ^^^^^^^^^ Trait `BAD_TRAIT` should have CamelCase name, e.g. `BadTrait`
+        fn BAD_FUNCTION();
+        // ^^^^^^^^^^^^ Function `BAD_FUNCTION` should have snake_case name, e.g. `bad_function`
+        fn BadFunction();
+        // ^^^^^^^^^^^^ Function `BadFunction` should have snake_case name, e.g. `bad_function`
+    }
+    "#,
         );
     }
 
@@ -1006,10 +1020,10 @@ impl T for U {
         cov_mark::check!(extern_static_incorrect_case_ignored);
         check_diagnostics(
             r#"
-extern {
-    fn NonSnakeCaseName(SOME_VAR: u8) -> u8;
-    pub static SomeStatic: u8 = 10;
-}
+    extern {
+        fn NonSnakeCaseName(SOME_VAR: u8) -> u8;
+        pub static SomeStatic: u8 = 10;
+    }
             "#,
         );
     }

--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -541,7 +541,7 @@ include::./generated_assists.adoc[]
 == Diagnostics
 
 While most errors and warnings provided by rust-analyzer come from the `cargo check` integration, there's a growing number of diagnostics implemented using rust-analyzer's own analysis.
-These diagnostics don't respect `#[allow]` or `#[deny]` attributes yet, but can be turned off using the `rust-analyzer.diagnostics.enable`, `rust-analyzer.diagnostics.enableExperimental` or `rust-analyzer.diagnostics.disabled` settings.
+Some of these diagnostics don't respect `\#[allow]` or `\#[deny]` attributes yet, but can be turned off using the `rust-analyzer.diagnostics.enable`, `rust-analyzer.diagnostics.enableExperimental` or `rust-analyzer.diagnostics.disabled` settings.
 
 include::./generated_diagnostic.adoc[]
 


### PR DESCRIPTION
Fix #8417. Also makes it less noisy about no_mangle annotated stuff the
user can do nothing about.

Note: this still is broken with bitfield! macros. A repro in an ignore
test is included here. I believe this bug is elsewhere, and I don't
think I can work around it here.

I would like help filing the remaining bug, as it does actually affect
users, but I don't know how to describe the behaviour (or even if it
is unintended).