### PR TITLE
Intern lots of things

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1825,7 +1825,7 @@ impl Type {
             Solution::Unique(s) => s
                 .value
                 .subst
-                .interned()
+                .as_slice(&Interner)
                 .first()
                 .map(|ty| self.derived(ty.assert_ty_ref(&Interner).clone())),
             Solution::Ambig(_) => None,

--- a/crates/hir_ty/src/chalk_ext.rs
+++ b/crates/hir_ty/src/chalk_ext.rs
@@ -75,7 +75,7 @@ impl TyExt for Ty {
     }
     fn as_reference(&self) -> Option<(&Ty, Lifetime, Mutability)> {
         match self.kind(&Interner) {
-            TyKind::Ref(mutability, lifetime, ty) => Some((ty, *lifetime, *mutability)),
+            TyKind::Ref(mutability, lifetime, ty) => Some((ty, lifetime.clone(), *mutability)),
             _ => None,
         }
     }

--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -265,7 +265,7 @@ impl HirDisplay for ProjectionTy {
         write!(f, " as {}", trait_.name)?;
         if self.substitution.len(&Interner) > 1 {
             write!(f, "<")?;
-            f.write_joined(&self.substitution.interned()[1..], ", ")?;
+            f.write_joined(&self.substitution.as_slice(&Interner)[1..], ", ")?;
             write!(f, ">")?;
         }
         write!(f, ">::{}", f.db.type_alias_data(from_assoc_type_id(self.associated_ty_id)).name)?;
@@ -416,7 +416,7 @@ impl HirDisplay for Ty {
                     write!(f, ",)")?;
                 } else {
                     write!(f, "(")?;
-                    f.write_joined(&*substs.interned(), ", ")?;
+                    f.write_joined(&*substs.as_slice(&Interner), ", ")?;
                     write!(f, ")")?;
                 }
             }
@@ -444,7 +444,7 @@ impl HirDisplay for Ty {
                     // We print all params except implicit impl Trait params. Still a bit weird; should we leave out parent and self?
                     if total_len > 0 {
                         write!(f, "<")?;
-                        f.write_joined(&parameters.interned()[..total_len], ", ")?;
+                        f.write_joined(&parameters.as_slice(&Interner)[..total_len], ", ")?;
                         write!(f, ">")?;
                     }
                 }
@@ -491,7 +491,7 @@ impl HirDisplay for Ty {
                             .map(|generic_def_id| f.db.generic_defaults(generic_def_id))
                             .filter(|defaults| !defaults.is_empty())
                         {
-                            None => parameters.interned().as_ref(),
+                            None => parameters.as_slice(&Interner),
                             Some(default_parameters) => {
                                 let mut default_from = 0;
                                 for (i, parameter) in parameters.iter(&Interner).enumerate() {
@@ -515,11 +515,11 @@ impl HirDisplay for Ty {
                                         }
                                     }
                                 }
-                                &parameters.interned()[0..default_from]
+                                &parameters.as_slice(&Interner)[0..default_from]
                             }
                         }
                     } else {
-                        parameters.interned().as_ref()
+                        parameters.as_slice(&Interner)
                     };
                     if !parameters_to_write.is_empty() {
                         write!(f, "<")?;
@@ -542,7 +542,7 @@ impl HirDisplay for Ty {
                     write!(f, "{}::{}", trait_.name, type_alias_data.name)?;
                     if parameters.len(&Interner) > 0 {
                         write!(f, "<")?;
-                        f.write_joined(&*parameters.interned(), ", ")?;
+                        f.write_joined(&*parameters.as_slice(&Interner), ", ")?;
                         write!(f, ">")?;
                     }
                 } else {
@@ -749,13 +749,13 @@ fn write_bounds_like_dyn_trait(
                 // existential) here, which is the only thing that's
                 // possible in actual Rust, and hence don't print it
                 write!(f, "{}", f.db.trait_data(trait_).name)?;
-                if let [_, params @ ..] = &*trait_ref.substitution.interned().as_slice() {
+                if let [_, params @ ..] = &*trait_ref.substitution.as_slice(&Interner) {
                     if is_fn_trait {
                         if let Some(args) =
                             params.first().and_then(|it| it.assert_ty_ref(&Interner).as_tuple())
                         {
                             write!(f, "(")?;
-                            f.write_joined(&*args.interned(), ", ")?;
+                            f.write_joined(args.as_slice(&Interner), ", ")?;
                             write!(f, ")")?;
                         }
                     } else if !params.is_empty() {
@@ -814,7 +814,7 @@ fn fmt_trait_ref(tr: &TraitRef, f: &mut HirFormatter, use_as: bool) -> Result<()
     write!(f, "{}", f.db.trait_data(tr.hir_trait_id()).name)?;
     if tr.substitution.len(&Interner) > 1 {
         write!(f, "<")?;
-        f.write_joined(&tr.substitution.interned()[1..], ", ")?;
+        f.write_joined(&tr.substitution.as_slice(&Interner)[1..], ", ")?;
         write!(f, ">")?;
     }
     Ok(())

--- a/crates/hir_ty/src/infer/expr.rs
+++ b/crates/hir_ty/src/infer/expr.rs
@@ -462,7 +462,7 @@ impl<'a> InferenceContext<'a> {
                     };
                     match canonicalized.decanonicalize_ty(derefed_ty.value).kind(&Interner) {
                         TyKind::Tuple(_, substs) => name.as_tuple_index().and_then(|idx| {
-                            substs.interned().get(idx).map(|a| a.assert_ty_ref(&Interner)).cloned()
+                            substs.as_slice(&Interner).get(idx).map(|a| a.assert_ty_ref(&Interner)).cloned()
                         }),
                         TyKind::Adt(AdtId(hir_def::AdtId::StructId(s)), parameters) => {
                             let local_id = self.db.struct_data(*s).variant_data.field(name)?;

--- a/crates/hir_ty/src/infer/expr.rs
+++ b/crates/hir_ty/src/infer/expr.rs
@@ -462,7 +462,11 @@ impl<'a> InferenceContext<'a> {
                     };
                     match canonicalized.decanonicalize_ty(derefed_ty.value).kind(&Interner) {
                         TyKind::Tuple(_, substs) => name.as_tuple_index().and_then(|idx| {
-                            substs.as_slice(&Interner).get(idx).map(|a| a.assert_ty_ref(&Interner)).cloned()
+                            substs
+                                .as_slice(&Interner)
+                                .get(idx)
+                                .map(|a| a.assert_ty_ref(&Interner))
+                                .cloned()
                         }),
                         TyKind::Adt(AdtId(hir_def::AdtId::StructId(s)), parameters) => {
                             let local_id = self.db.struct_data(*s).variant_data.field(name)?;

--- a/crates/hir_ty/src/infer/pat.rs
+++ b/crates/hir_ty/src/infer/pat.rs
@@ -122,7 +122,7 @@ impl<'a> InferenceContext<'a> {
         let ty = match &body[pat] {
             &Pat::Tuple { ref args, ellipsis } => {
                 let expectations = match expected.as_tuple() {
-                    Some(parameters) => &*parameters.interned().as_slice(),
+                    Some(parameters) => &*parameters.as_slice(&Interner),
                     _ => &[],
                 };
 
@@ -242,7 +242,7 @@ impl<'a> InferenceContext<'a> {
                     let (inner_ty, alloc_ty) = match expected.as_adt() {
                         Some((adt, subst)) if adt == box_adt => (
                             subst.at(&Interner, 0).assert_ty_ref(&Interner).clone(),
-                            subst.interned().get(1).and_then(|a| a.ty(&Interner).cloned()),
+                            subst.as_slice(&Interner).get(1).and_then(|a| a.ty(&Interner).cloned()),
                         ),
                         _ => (self.result.standard_types.unknown.clone(), None),
                     };

--- a/crates/hir_ty/src/infer/path.rs
+++ b/crates/hir_ty/src/infer/path.rs
@@ -101,7 +101,7 @@ impl<'a> InferenceContext<'a> {
         let substs = ctx.substs_from_path(path, typable, true);
         let ty = TyBuilder::value_ty(self.db, typable)
             .use_parent_substs(&parent_substs)
-            .fill(substs.interned()[parent_substs.len(&Interner)..].iter().cloned())
+            .fill(substs.as_slice(&Interner)[parent_substs.len(&Interner)..].iter().cloned())
             .build();
         Some(ty)
     }

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -109,7 +109,7 @@ pub type WhereClause = chalk_ir::WhereClause<Interner>;
 pub fn subst_prefix(s: &Substitution, n: usize) -> Substitution {
     Substitution::from_iter(
         &Interner,
-        s.interned()[..std::cmp::min(s.len(&Interner), n)].iter().cloned(),
+        s.as_slice(&Interner)[..std::cmp::min(s.len(&Interner), n)].iter().cloned(),
     )
 }
 
@@ -187,7 +187,7 @@ impl CallableSig {
                 .shifted_out_to(&Interner, DebruijnIndex::ONE)
                 .expect("unexpected lifetime vars in fn ptr")
                 .0
-                .interned()
+                .as_slice(&Interner)
                 .iter()
                 .map(|arg| arg.assert_ty_ref(&Interner).clone())
                 .collect(),

--- a/crates/hir_ty/src/traits/chalk/interner.rs
+++ b/crates/hir_ty/src/traits/chalk/interner.rs
@@ -57,6 +57,7 @@ impl_internable!(
     InternedWrapper<chalk_ir::LifetimeData<Interner>>,
     InternedWrapper<chalk_ir::ConstData<Interner>>,
     InternedWrapper<Vec<chalk_ir::CanonicalVarKind<Interner>>>,
+    InternedWrapper<Vec<chalk_ir::ProgramClause<Interner>>>,
 );
 
 impl chalk_ir::interner::Interner for Interner {
@@ -69,7 +70,7 @@ impl chalk_ir::interner::Interner for Interner {
     type InternedGoals = Vec<Goal<Self>>;
     type InternedSubstitution = Interned<InternedSubstitutionInner>;
     type InternedProgramClause = Arc<chalk_ir::ProgramClauseData<Self>>;
-    type InternedProgramClauses = Arc<[chalk_ir::ProgramClause<Self>]>;
+    type InternedProgramClauses = Interned<InternedWrapper<Vec<chalk_ir::ProgramClause<Self>>>>;
     type InternedQuantifiedWhereClauses = Vec<chalk_ir::QuantifiedWhereClause<Self>>;
     type InternedVariableKinds = Interned<InternedVariableKindsInner>;
     type InternedCanonicalVarKinds = Interned<InternedWrapper<Vec<chalk_ir::CanonicalVarKind<Self>>>>;
@@ -327,7 +328,7 @@ impl chalk_ir::interner::Interner for Interner {
         &self,
         data: impl IntoIterator<Item = Result<chalk_ir::ProgramClause<Self>, E>>,
     ) -> Result<Self::InternedProgramClauses, E> {
-        data.into_iter().collect()
+        Ok(Interned::new(InternedWrapper(data.into_iter().collect::<Result<_, _>>()?)))
     }
 
     fn program_clauses_data<'a>(

--- a/crates/hir_ty/src/traits/chalk/interner.rs
+++ b/crates/hir_ty/src/traits/chalk/interner.rs
@@ -70,7 +70,7 @@ impl chalk_ir::interner::Interner for Interner {
     type InternedGoal = Arc<GoalData<Self>>;
     type InternedGoals = Vec<Goal<Self>>;
     type InternedSubstitution = Interned<InternedSubstitutionInner>;
-    type InternedProgramClause = Arc<chalk_ir::ProgramClauseData<Self>>;
+    type InternedProgramClause = chalk_ir::ProgramClauseData<Self>;
     type InternedProgramClauses = Interned<InternedWrapper<Vec<chalk_ir::ProgramClause<Self>>>>;
     type InternedQuantifiedWhereClauses = Interned<InternedWrapper<Vec<chalk_ir::QuantifiedWhereClause<Self>>>>;
     type InternedVariableKinds = Interned<InternedVariableKindsInner>;
@@ -315,7 +315,7 @@ impl chalk_ir::interner::Interner for Interner {
         &self,
         data: chalk_ir::ProgramClauseData<Self>,
     ) -> Self::InternedProgramClause {
-        Arc::new(data)
+        data
     }
 
     fn program_clause_data<'a>(

--- a/crates/hir_ty/src/traits/chalk/interner.rs
+++ b/crates/hir_ty/src/traits/chalk/interner.rs
@@ -58,6 +58,7 @@ impl_internable!(
     InternedWrapper<chalk_ir::ConstData<Interner>>,
     InternedWrapper<Vec<chalk_ir::CanonicalVarKind<Interner>>>,
     InternedWrapper<Vec<chalk_ir::ProgramClause<Interner>>>,
+    InternedWrapper<Vec<chalk_ir::QuantifiedWhereClause<Interner>>>,
 );
 
 impl chalk_ir::interner::Interner for Interner {
@@ -71,7 +72,7 @@ impl chalk_ir::interner::Interner for Interner {
     type InternedSubstitution = Interned<InternedSubstitutionInner>;
     type InternedProgramClause = Arc<chalk_ir::ProgramClauseData<Self>>;
     type InternedProgramClauses = Interned<InternedWrapper<Vec<chalk_ir::ProgramClause<Self>>>>;
-    type InternedQuantifiedWhereClauses = Vec<chalk_ir::QuantifiedWhereClause<Self>>;
+    type InternedQuantifiedWhereClauses = Interned<InternedWrapper<Vec<chalk_ir::QuantifiedWhereClause<Self>>>>;
     type InternedVariableKinds = Interned<InternedVariableKindsInner>;
     type InternedCanonicalVarKinds = Interned<InternedWrapper<Vec<chalk_ir::CanonicalVarKind<Self>>>>;
     type InternedConstraints = Vec<chalk_ir::InEnvironment<chalk_ir::Constraint<Self>>>;
@@ -342,7 +343,7 @@ impl chalk_ir::interner::Interner for Interner {
         &self,
         data: impl IntoIterator<Item = Result<chalk_ir::QuantifiedWhereClause<Self>, E>>,
     ) -> Result<Self::InternedQuantifiedWhereClauses, E> {
-        data.into_iter().collect()
+        Ok(Interned::new(InternedWrapper(data.into_iter().collect::<Result<_, _>>()?)))
     }
 
     fn quantified_where_clauses_data<'a>(

--- a/crates/hir_ty/src/traits/chalk/interner.rs
+++ b/crates/hir_ty/src/traits/chalk/interner.rs
@@ -56,6 +56,7 @@ impl_internable!(
     InternedTypeInner,
     InternedWrapper<chalk_ir::LifetimeData<Interner>>,
     InternedWrapper<chalk_ir::ConstData<Interner>>,
+    InternedWrapper<Vec<chalk_ir::CanonicalVarKind<Interner>>>,
 );
 
 impl chalk_ir::interner::Interner for Interner {
@@ -71,7 +72,7 @@ impl chalk_ir::interner::Interner for Interner {
     type InternedProgramClauses = Arc<[chalk_ir::ProgramClause<Self>]>;
     type InternedQuantifiedWhereClauses = Vec<chalk_ir::QuantifiedWhereClause<Self>>;
     type InternedVariableKinds = Interned<InternedVariableKindsInner>;
-    type InternedCanonicalVarKinds = Vec<chalk_ir::CanonicalVarKind<Self>>;
+    type InternedCanonicalVarKinds = Interned<InternedWrapper<Vec<chalk_ir::CanonicalVarKind<Self>>>>;
     type InternedConstraints = Vec<chalk_ir::InEnvironment<chalk_ir::Constraint<Self>>>;
     type InternedVariances = Arc<[chalk_ir::Variance]>;
     type DefId = InternId;
@@ -370,7 +371,7 @@ impl chalk_ir::interner::Interner for Interner {
         &self,
         data: impl IntoIterator<Item = Result<chalk_ir::CanonicalVarKind<Self>, E>>,
     ) -> Result<Self::InternedCanonicalVarKinds, E> {
-        data.into_iter().collect()
+        Ok(Interned::new(InternedWrapper(data.into_iter().collect::<Result<_, _>>()?)))
     }
 
     fn canonical_var_kinds_data<'a>(

--- a/crates/hir_ty/src/traits/chalk/interner.rs
+++ b/crates/hir_ty/src/traits/chalk/interner.rs
@@ -59,6 +59,7 @@ impl_internable!(
     InternedWrapper<Vec<chalk_ir::CanonicalVarKind<Interner>>>,
     InternedWrapper<Vec<chalk_ir::ProgramClause<Interner>>>,
     InternedWrapper<Vec<chalk_ir::QuantifiedWhereClause<Interner>>>,
+    InternedWrapper<Vec<chalk_ir::Variance>>,
 );
 
 impl chalk_ir::interner::Interner for Interner {
@@ -76,7 +77,7 @@ impl chalk_ir::interner::Interner for Interner {
     type InternedVariableKinds = Interned<InternedVariableKindsInner>;
     type InternedCanonicalVarKinds = Interned<InternedWrapper<Vec<chalk_ir::CanonicalVarKind<Self>>>>;
     type InternedConstraints = Vec<chalk_ir::InEnvironment<chalk_ir::Constraint<Self>>>;
-    type InternedVariances = Arc<[chalk_ir::Variance]>;
+    type InternedVariances = Interned<InternedWrapper<Vec<chalk_ir::Variance>>>;
     type DefId = InternId;
     type InternedAdtId = hir_def::AdtId;
     type Identifier = TypeAliasId;
@@ -413,7 +414,7 @@ impl chalk_ir::interner::Interner for Interner {
         &self,
         data: impl IntoIterator<Item = Result<chalk_ir::Variance, E>>,
     ) -> Result<Self::InternedVariances, E> {
-        data.into_iter().collect()
+        Ok(Interned::new(InternedWrapper(data.into_iter().collect::<Result<_, _>>()?)))
     }
 
     fn variances_data<'a>(

--- a/crates/hir_ty/src/traits/chalk/interner.rs
+++ b/crates/hir_ty/src/traits/chalk/interner.rs
@@ -36,13 +36,17 @@ pub struct InternedVariableKindsInner(Vec<chalk_ir::VariableKind<Interner>>);
 #[derive(PartialEq, Eq, Hash, Debug)]
 pub struct InternedSubstitutionInner(SmallVec<[GenericArg; 2]>);
 
+#[derive(PartialEq, Eq, Hash, Debug)]
+pub struct InternedTypeInner(chalk_ir::TyData<Interner>);
+
 impl_internable!(
     InternedVariableKindsInner,
     InternedSubstitutionInner,
+    InternedTypeInner,
 );
 
 impl chalk_ir::interner::Interner for Interner {
-    type InternedType = Arc<chalk_ir::TyData<Self>>;
+    type InternedType = Interned<InternedTypeInner>;
     type InternedLifetime = chalk_ir::LifetimeData<Self>;
     type InternedConst = Arc<chalk_ir::ConstData<Self>>;
     type InternedConcreteConst = ();
@@ -209,11 +213,11 @@ impl chalk_ir::interner::Interner for Interner {
 
     fn intern_ty(&self, kind: chalk_ir::TyKind<Self>) -> Self::InternedType {
         let flags = kind.compute_flags(self);
-        Arc::new(chalk_ir::TyData { kind, flags })
+        Interned::new(InternedTypeInner(chalk_ir::TyData { kind, flags }))
     }
 
     fn ty_data<'a>(&self, ty: &'a Self::InternedType) -> &'a chalk_ir::TyData<Self> {
-        ty
+        &ty.0
     }
 
     fn intern_lifetime(&self, lifetime: chalk_ir::LifetimeData<Self>) -> Self::InternedLifetime {

--- a/crates/hir_ty/src/traits/chalk/mapping.rs
+++ b/crates/hir_ty/src/traits/chalk/mapping.rs
@@ -99,7 +99,7 @@ pub(super) fn generic_predicate_to_inline_bound(
                 // have the expected self type
                 return None;
             }
-            let args_no_self = trait_ref.substitution.interned()[1..]
+            let args_no_self = trait_ref.substitution.as_slice(&Interner)[1..]
                 .iter()
                 .map(|ty| ty.clone().cast(&Interner))
                 .collect();
@@ -111,7 +111,7 @@ pub(super) fn generic_predicate_to_inline_bound(
                 return None;
             }
             let trait_ = projection_ty.trait_(db);
-            let args_no_self = projection_ty.substitution.interned()[1..]
+            let args_no_self = projection_ty.substitution.as_slice(&Interner)[1..]
                 .iter()
                 .map(|ty| ty.clone().cast(&Interner))
                 .collect();


### PR DESCRIPTION
This uses the new interning infrastructure for most type-related things, where it had a positive effect on memory usage and performance. In total, this gives a slight performance improvement and a quite good memory reduction (1119MB->885MB on RA, 1774MB->1188MB on Diesel).