### PR TITLE
Fix crash on syn involving lifetimes returned by Chalk

### DIFF
--- a/crates/hir_ty/src/method_resolution.rs
+++ b/crates/hir_ty/src/method_resolution.rs
@@ -609,6 +609,7 @@ fn iterate_trait_method_candidates(
                 }
             }
             known_implemented = true;
+            // FIXME: we shouldn't be ignoring the binders here
             if callback(&self_ty.value, *item) {
                 return true;
             }

--- a/crates/hir_ty/src/tests/regression.rs
+++ b/crates/hir_ty/src/tests/regression.rs
@@ -974,3 +974,41 @@ fn param_overrides_fn() {
         "#,
     )
 }
+
+#[test]
+fn lifetime_from_chalk_during_deref() {
+    check_types(
+        r#"
+        #[lang = "deref"]
+        pub trait Deref {
+            type Target;
+        }
+
+        struct Box<T: ?Sized> {}
+        impl<T> Deref for Box<T> {
+            type Target = T;
+
+            fn deref(&self) -> &Self::Target {
+                loop {}
+            }
+        }
+
+        trait Iterator {
+            type Item;
+        }
+
+        pub struct Iter<'a, T: 'a> {
+            inner: Box<dyn IterTrait<'a, T, Item = &'a T> + 'a>,
+        }
+
+        trait IterTrait<'a, T: 'a>: Iterator<Item = &'a T> {
+            fn clone_box(&self);
+        }
+
+        fn clone_iter<T>(s: Iter<T>) {
+            s.inner.clone_box();
+          //^^^^^^^^^^^^^^^^^^^ ()
+        }
+        "#,
+    )
+}


### PR DESCRIPTION
If we get lifetime variables back in autoderef, just immediately replace them by static lifetimes for now. Method resolution doesn't really deal correctly with new variables being introduced (this needs to be fixed more properly).

This fixes `rust-analyzer analysis-stats --with-deps` crashing in the RA repo.