### PR TITLE
Rewrite `#[derive]` removal code to be based on AST

### DIFF
--- a/crates/hir_def/src/lib.rs
+++ b/crates/hir_def/src/lib.rs
@@ -62,7 +62,7 @@ use hir_expand::{
     ast_id_map::FileAstId,
     eager::{expand_eager_macro, ErrorEmitted, ErrorSink},
     hygiene::Hygiene,
-    AstId, HirFileId, InFile, MacroCallId, MacroCallKind, MacroDefId, MacroDefKind,
+    AstId, AttrId, HirFileId, InFile, MacroCallId, MacroCallKind, MacroDefId, MacroDefKind,
 };
 use la_arena::Idx;
 use nameres::DefMap;
@@ -699,6 +699,7 @@ fn macro_call_as_call_id(
 
 fn derive_macro_as_call_id(
     item_attr: &AstIdWithPath<ast::Item>,
+    derive_attr: AttrId,
     db: &dyn db::DefDatabase,
     krate: CrateId,
     resolver: impl Fn(path::ModPath) -> Option<MacroDefId>,
@@ -712,6 +713,7 @@ fn derive_macro_as_call_id(
             MacroCallKind::Derive {
                 ast_id: item_attr.ast_id,
                 derive_name: last_segment.to_string(),
+                derive_attr,
             },
         )
         .into();

--- a/crates/hir_def/src/nameres.rs
+++ b/crates/hir_def/src/nameres.rs
@@ -617,7 +617,7 @@ mod diagnostics {
                             let node = ast_id.to_node(db.upcast());
                             (ast_id.file_id, SyntaxNodePtr::from(AstPtr::new(&node)), None)
                         }
-                        MacroCallKind::Derive { ast_id, derive_name } => {
+                        MacroCallKind::Derive { ast_id, derive_name, .. } => {
                             let node = ast_id.to_node(db.upcast());
 
                             // Compute the precise location of the macro name's token in the derive

--- a/crates/hir_expand/src/builtin_derive.rs
+++ b/crates/hir_expand/src/builtin_derive.rs
@@ -269,7 +269,7 @@ mod tests {
     use expect_test::{expect, Expect};
     use name::AsName;
 
-    use crate::{test_db::TestDB, AstId, MacroCallId, MacroCallKind, MacroCallLoc};
+    use crate::{test_db::TestDB, AstId, AttrId, MacroCallId, MacroCallKind, MacroCallLoc};
 
     use super::*;
 
@@ -317,7 +317,11 @@ $0
                 local_inner: false,
             },
             krate: CrateId(0),
-            kind: MacroCallKind::Derive { ast_id, derive_name: name.to_string() },
+            kind: MacroCallKind::Derive {
+                ast_id,
+                derive_name: name.to_string(),
+                derive_attr: AttrId(0),
+            },
         };
 
         let id: MacroCallId = db.intern_macro(loc).into();

--- a/crates/hir_expand/src/db.rs
+++ b/crates/hir_expand/src/db.rs
@@ -14,9 +14,9 @@ use syntax::{
 };
 
 use crate::{
-    ast_id_map::AstIdMap, hygiene::HygieneFrame, BuiltinDeriveExpander, BuiltinFnLikeExpander,
-    EagerCallLoc, EagerMacroId, HirFileId, HirFileIdRepr, LazyMacroId, MacroCallId, MacroCallLoc,
-    MacroDefId, MacroDefKind, MacroFile, ProcMacroExpander,
+    ast_id_map::AstIdMap, hygiene::HygieneFrame, input::process_macro_input, BuiltinDeriveExpander,
+    BuiltinFnLikeExpander, EagerCallLoc, EagerMacroId, HirFileId, HirFileIdRepr, LazyMacroId,
+    MacroCallId, MacroCallLoc, MacroDefId, MacroDefKind, MacroFile, ProcMacroExpander,
 };
 
 /// Total limit on the number of tokens produced by any macro invocation.
@@ -191,6 +191,7 @@ fn macro_arg_text(db: &dyn AstDatabase, id: MacroCallId) -> Option<GreenNode> {
     };
     let loc = db.lookup_intern_macro(id);
     let arg = loc.kind.arg(db)?;
+    let arg = process_macro_input(db, arg, id);
     Some(arg.green())
 }
 

--- a/crates/hir_expand/src/input.rs
+++ b/crates/hir_expand/src/input.rs
@@ -1,0 +1,87 @@
+//! Macro input conditioning.
+
+use syntax::{
+    ast::{self, AttrsOwner},
+    AstNode, SyntaxNode,
+};
+
+use crate::{db::AstDatabase, name::AsName, AttrId, LazyMacroId, MacroCallKind, MacroCallLoc};
+
+pub fn process_macro_input(db: &dyn AstDatabase, node: SyntaxNode, id: LazyMacroId) -> SyntaxNode {
+    let loc: MacroCallLoc = db.lookup_intern_macro(id);
+
+    match loc.kind {
+        MacroCallKind::FnLike { .. } => node,
+        MacroCallKind::Derive { derive_attr, .. } => {
+            let item = match ast::Item::cast(node.clone()) {
+                Some(item) => item,
+                None => return node,
+            };
+
+            remove_derives_up_to(item, derive_attr).syntax().clone()
+        }
+    }
+}
+
+/// Removes `#[derive]` attributes from `item`, up to `attr`.
+fn remove_derives_up_to(item: ast::Item, attr: AttrId) -> ast::Item {
+    let item = item.clone_for_update();
+    let idx = attr.0 as usize;
+    for attr in item.attrs().take(idx + 1) {
+        if let Some(name) =
+            attr.path().and_then(|path| path.as_single_segment()).and_then(|seg| seg.name_ref())
+        {
+            if name.as_name().to_string() == "derive" {
+                attr.syntax().detach();
+            }
+        }
+    }
+    item
+}
+
+#[cfg(test)]
+mod tests {
+    use base_db::fixture::WithFixture;
+    use base_db::SourceDatabase;
+    use expect_test::{expect, Expect};
+
+    use crate::test_db::TestDB;
+
+    use super::*;
+
+    fn test_remove_derives_up_to(attr: AttrId, ra_fixture: &str, expect: Expect) {
+        let (db, file_id) = TestDB::with_single_file(&ra_fixture);
+        let parsed = db.parse(file_id);
+
+        let mut items: Vec<_> =
+            parsed.syntax_node().descendants().filter_map(ast::Item::cast).collect();
+        assert_eq!(items.len(), 1);
+
+        let item = remove_derives_up_to(items.pop().unwrap(), attr);
+        expect.assert_eq(&item.to_string());
+    }
+
+    #[test]
+    fn remove_derive() {
+        test_remove_derives_up_to(
+            AttrId(2),
+            r#"
+#[allow(unused)]
+#[derive(Copy)]
+#[derive(Hello)]
+#[derive(Clone)]
+struct A {
+    bar: u32
+}
+        "#,
+            expect![[r#"
+#[allow(unused)]
+
+
+#[derive(Clone)]
+struct A {
+    bar: u32
+}"#]],
+        );
+    }
+}

--- a/crates/hir_expand/src/input.rs
+++ b/crates/hir_expand/src/input.rs
@@ -7,7 +7,11 @@ use syntax::{
 
 use crate::{db::AstDatabase, name::AsName, AttrId, LazyMacroId, MacroCallKind, MacroCallLoc};
 
-pub fn process_macro_input(db: &dyn AstDatabase, node: SyntaxNode, id: LazyMacroId) -> SyntaxNode {
+pub(crate) fn process_macro_input(
+    db: &dyn AstDatabase,
+    node: SyntaxNode,
+    id: LazyMacroId,
+) -> SyntaxNode {
     let loc: MacroCallLoc = db.lookup_intern_macro(id);
 
     match loc.kind {

--- a/crates/hir_expand/src/input.rs
+++ b/crates/hir_expand/src/input.rs
@@ -5,7 +5,11 @@ use syntax::{
     AstNode, SyntaxNode,
 };
 
-use crate::{db::AstDatabase, name::AsName, AttrId, LazyMacroId, MacroCallKind, MacroCallLoc};
+use crate::{
+    db::AstDatabase,
+    name::{name, AsName},
+    AttrId, LazyMacroId, MacroCallKind, MacroCallLoc,
+};
 
 pub(crate) fn process_macro_input(
     db: &dyn AstDatabase,
@@ -35,7 +39,7 @@ fn remove_derives_up_to(item: ast::Item, attr: AttrId) -> ast::Item {
         if let Some(name) =
             attr.path().and_then(|path| path.as_single_segment()).and_then(|seg| seg.name_ref())
         {
-            if name.as_name().to_string() == "derive" {
+            if name.as_name() == name![derive] {
                 attr.syntax().detach();
             }
         }

--- a/crates/hir_expand/src/lib.rs
+++ b/crates/hir_expand/src/lib.rs
@@ -14,6 +14,7 @@ pub mod builtin_macro;
 pub mod proc_macro;
 pub mod quote;
 pub mod eager;
+mod input;
 
 use either::Either;
 pub use mbe::{ExpandError, ExpandResult};

--- a/crates/hir_expand/src/lib.rs
+++ b/crates/hir_expand/src/lib.rs
@@ -294,6 +294,9 @@ pub enum MacroCallKind {
     Derive { ast_id: AstId<ast::Item>, derive_name: String },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AttrId(pub u32);
+
 impl MacroCallKind {
     fn file_id(&self) -> HirFileId {
         match self {

--- a/crates/hir_expand/src/lib.rs
+++ b/crates/hir_expand/src/lib.rs
@@ -291,7 +291,7 @@ pub struct MacroCallLoc {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum MacroCallKind {
     FnLike { ast_id: AstId<ast::MacroCall> },
-    Derive { ast_id: AstId<ast::Item>, derive_name: String },
+    Derive { ast_id: AstId<ast::Item>, derive_name: String, derive_attr: AttrId },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/hir_expand/src/proc_macro.rs
+++ b/crates/hir_expand/src/proc_macro.rs
@@ -2,7 +2,6 @@
 
 use crate::db::AstDatabase;
 use base_db::{CrateId, ProcMacroId};
-use tt::buffer::{Cursor, TokenBuffer};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct ProcMacroExpander {
@@ -44,9 +43,6 @@ impl ProcMacroExpander {
                     .clone()
                     .ok_or_else(|| err!("No derive macro found."))?;
 
-                let tt = remove_derive_attrs(tt)
-                    .ok_or_else(|| err!("Fail to remove derive for custom derive"))?;
-
                 // Proc macros have access to the environment variables of the invoking crate.
                 let env = &krate_graph[calling_crate].env;
 
@@ -54,103 +50,5 @@ impl ProcMacroExpander {
             }
             None => Err(mbe::ExpandError::UnresolvedProcMacro),
         }
-    }
-}
-
-fn eat_punct(cursor: &mut Cursor, c: char) -> bool {
-    if let Some(tt::buffer::TokenTreeRef::Leaf(tt::Leaf::Punct(punct), _)) = cursor.token_tree() {
-        if punct.char == c {
-            *cursor = cursor.bump();
-            return true;
-        }
-    }
-    false
-}
-
-fn eat_subtree(cursor: &mut Cursor, kind: tt::DelimiterKind) -> bool {
-    if let Some(tt::buffer::TokenTreeRef::Subtree(subtree, _)) = cursor.token_tree() {
-        if Some(kind) == subtree.delimiter_kind() {
-            *cursor = cursor.bump_subtree();
-            return true;
-        }
-    }
-    false
-}
-
-fn eat_ident(cursor: &mut Cursor, t: &str) -> bool {
-    if let Some(tt::buffer::TokenTreeRef::Leaf(tt::Leaf::Ident(ident), _)) = cursor.token_tree() {
-        if t == ident.text.as_str() {
-            *cursor = cursor.bump();
-            return true;
-        }
-    }
-    false
-}
-
-fn remove_derive_attrs(tt: &tt::Subtree) -> Option<tt::Subtree> {
-    let buffer = TokenBuffer::from_tokens(&tt.token_trees);
-    let mut p = buffer.begin();
-    let mut result = tt::Subtree::default();
-
-    while !p.eof() {
-        let curr = p;
-
-        if eat_punct(&mut p, '#') {
-            eat_punct(&mut p, '!');
-            let parent = p;
-            if eat_subtree(&mut p, tt::DelimiterKind::Bracket) {
-                if eat_ident(&mut p, "derive") {
-                    p = parent.bump();
-                    continue;
-                }
-            }
-        }
-
-        result.token_trees.push(curr.token_tree()?.cloned());
-        p = curr.bump();
-    }
-
-    Some(result)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use test_utils::assert_eq_text;
-
-    #[test]
-    fn test_remove_derive_attrs() {
-        let tt = mbe::parse_to_token_tree(
-            r#"
-    #[allow(unused)]
-    #[derive(Copy)]
-    #[derive(Hello)]
-    struct A {
-        bar: u32
-    }
-"#,
-        )
-        .unwrap()
-        .0;
-        let result = format!("{:#?}", remove_derive_attrs(&tt).unwrap());
-
-        assert_eq_text!(
-            r#"
-SUBTREE $
-  PUNCH   # [alone] 0
-  SUBTREE [] 1
-    IDENT   allow 2
-    SUBTREE () 3
-      IDENT   unused 4
-  IDENT   struct 15
-  IDENT   A 16
-  SUBTREE {} 17
-    IDENT   bar 18
-    PUNCH   : [alone] 19
-    IDENT   u32 20
-"#
-            .trim(),
-            &result
-        );
     }
 }


### PR DESCRIPTION
We now remove any `#[derive]` before and including the one we want to expand, in the `macro_arg` query.

The same infra will be needed by attribute macros (except we only remove the attribute we're expanding, not any preceding ones).

Part of https://github.com/rust-analyzer/rust-analyzer/issues/8434 (doesn't implement the cfg-expansion yet, because that's more difficult)