### PR TITLE
Undo path resolution hack for extern prelude

### DIFF
--- a/crates/hir_def/src/nameres/path_resolution.rs
+++ b/crates/hir_def/src/nameres/path_resolution.rs
@@ -384,15 +384,10 @@ impl DefMap {
                 }
             }
         };
-        // Give precedence to names in outer `DefMap`s over the extern prelude; only check prelude
-        // from the crate DefMap.
-        let from_extern_prelude = match self.block {
-            Some(_) => PerNs::none(),
-            None => self
-                .extern_prelude
-                .get(name)
-                .map_or(PerNs::none(), |&it| PerNs::types(it, Visibility::Public)),
-        };
+        let from_extern_prelude = self
+            .extern_prelude
+            .get(name)
+            .map_or(PerNs::none(), |&it| PerNs::types(it, Visibility::Public));
 
         let from_prelude = self.resolve_in_prelude(db, name);
 


### PR DESCRIPTION
Reverts the change made in https://github.com/rust-analyzer/rust-analyzer/pull/7959

We don't populate the extern prelude for block DefMaps anymore,
so this is unnecessary

bors r+