### PR TITLE
Exclude nightly tag from git describe to fix version string

### DIFF
--- a/crates/rust-analyzer/build.rs
+++ b/crates/rust-analyzer/build.rs
@@ -39,7 +39,8 @@ fn set_rerun() {
 }
 
 fn rev() -> Option<String> {
-    let output = Command::new("git").args(&["describe", "--tags"]).output().ok()?;
+    let output =
+        Command::new("git").args(&["describe", "--tags", "--exclude", "nightly"]).output().ok()?;
     let stdout = String::from_utf8(output.stdout).ok()?;
     Some(stdout)
 }


### PR DESCRIPTION
Closes #8239

Otherwise if we run `git describe` on the release day we pick up the `nightly` tag from the previous release.

changelog fix

bors r+