### PR TITLE
Move cursor position when using item movers

### DIFF
--- a/crates/rust-analyzer/src/lsp_ext.rs
+++ b/crates/rust-analyzer/src/lsp_ext.rs
@@ -407,7 +407,7 @@ pub enum MoveItem {}
 
 impl Request for MoveItem {
     type Params = MoveItemParams;
-    type Result = Option<lsp_types::TextDocumentEdit>;
+    type Result = Vec<SnippetTextEdit>;
     const METHOD: &'static str = "experimental/moveItem";
 }
 

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -688,18 +688,6 @@ pub(crate) fn goto_definition_response(
     }
 }
 
-pub(crate) fn text_document_edit(
-    snap: &GlobalStateSnapshot,
-    file_id: FileId,
-    edit: TextEdit,
-) -> Result<lsp_types::TextDocumentEdit> {
-    let text_document = optional_versioned_text_document_identifier(snap, file_id);
-    let line_index = snap.file_line_index(file_id)?;
-    let edits =
-        edit.into_iter().map(|it| lsp_types::OneOf::Left(text_edit(&line_index, it))).collect();
-    Ok(lsp_types::TextDocumentEdit { text_document, edits })
-}
-
 pub(crate) fn snippet_text_document_edit(
     snap: &GlobalStateSnapshot,
     is_snippet: bool,

--- a/docs/dev/lsp-extensions.md
+++ b/docs/dev/lsp-extensions.md
@@ -1,8 +1,8 @@
 <!---
-lsp_ext.rs hash: faae991334a151d0
+lsp_ext.rs hash: b19ddc3ab8767af9
 
 If you need to change the above hash to make the test pass, please check if you
-need to adjust this doc as well and ping this  issue:
+need to adjust this doc as well and ping this issue:
 
   https://github.com/rust-analyzer/rust-analyzer/issues/4604
 
@@ -620,7 +620,7 @@ This request is sent from client to server to move item under cursor or selectio
 
 **Request:** `MoveItemParams`
 
-**Response:** `TextDocumentEdit | null`
+**Response:** `SnippetTextEdit[]`
 
 ```typescript
 export interface MoveItemParams {

--- a/editors/code/src/lsp_ext.ts
+++ b/editors/code/src/lsp_ext.ts
@@ -129,7 +129,7 @@ export interface OpenCargoTomlParams {
     textDocument: lc.TextDocumentIdentifier;
 }
 
-export const moveItem = new lc.RequestType<MoveItemParams, lc.TextDocumentEdit | void, void>("experimental/moveItem");
+export const moveItem = new lc.RequestType<MoveItemParams, lc.TextEdit[], void>("experimental/moveItem");
 
 export interface MoveItemParams {
     textDocument: lc.TextDocumentIdentifier;


### PR DESCRIPTION
This updates the cursor position when moving items around to stay in the same location within the moved node.

I changed the `moveItem` response to `SnippetTextEdit[]`, since that made more sense to me (the file was ignored by the client anyways, since the edits always apply to the current document). It also matches `onEnter`, which seems logical to me, but please let me know if this doesn't make sense.

There's still a bug in the client-side snippet code that will cause the cursor position to be slightly off when moving parameters in the same line (presumably we don't track the column correctly after deleting `$0`). Not really sure how to fix that immediately, but this PR should already be an improvement despite that bug.