### PR TITLE
internal: Add more profiling spans into type inference

### DIFF
--- a/crates/hir_ty/src/autoderef.rs
+++ b/crates/hir_ty/src/autoderef.rs
@@ -24,10 +24,8 @@ pub fn autoderef<'a>(
     krate: Option<CrateId>,
     ty: InEnvironment<Canonical<Ty>>,
 ) -> impl Iterator<Item = Canonical<Ty>> + 'a {
-    let _p = profile::span("autoderef");
     let InEnvironment { goal: ty, environment } = ty;
     successors(Some(ty), move |ty| {
-        let _p = profile::span("autoderef.step");
         deref(db, krate?, InEnvironment { goal: ty, environment: environment.clone() })
     })
     .take(AUTODEREF_RECURSION_LIMIT)
@@ -38,6 +36,7 @@ pub(crate) fn deref(
     krate: CrateId,
     ty: InEnvironment<&Canonical<Ty>>,
 ) -> Option<Canonical<Ty>> {
+    let _p = profile::span("deref");
     if let Some(derefed) = builtin_deref(&ty.goal.value) {
         Some(Canonical { value: derefed, binders: ty.goal.binders.clone() })
     } else {

--- a/crates/hir_ty/src/autoderef.rs
+++ b/crates/hir_ty/src/autoderef.rs
@@ -58,6 +58,7 @@ fn deref_by_trait(
     krate: CrateId,
     ty: InEnvironment<&Canonical<Ty>>,
 ) -> Option<Canonical<Ty>> {
+    let _p = profile::span("deref_by_trait");
     let deref_trait = match db.lang_item(krate, "deref".into())? {
         LangItemTarget::TraitId(it) => it,
         _ => return None,
@@ -85,7 +86,10 @@ fn deref_by_trait(
             environment: ty.environment.clone(),
         },
     };
-    if db.trait_solve(krate, implements_goal).is_none() {
+    if {
+        let _p = profile::span("db.trait_solve");
+        db.trait_solve(krate, implements_goal).is_none()
+    } {
         return None;
     }
 

--- a/crates/hir_ty/src/autoderef.rs
+++ b/crates/hir_ty/src/autoderef.rs
@@ -24,8 +24,10 @@ pub fn autoderef<'a>(
     krate: Option<CrateId>,
     ty: InEnvironment<Canonical<Ty>>,
 ) -> impl Iterator<Item = Canonical<Ty>> + 'a {
+    let _p = profile::span("autoderef");
     let InEnvironment { goal: ty, environment } = ty;
     successors(Some(ty), move |ty| {
+        let _p = profile::span("autoderef.step");
         deref(db, krate?, InEnvironment { goal: ty, environment: environment.clone() })
     })
     .take(AUTODEREF_RECURSION_LIMIT)


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/8503

I've added a minimal set of spans to remove `???` and showcase the underlying issue:

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/2690773/114722983-f2181900-9d42-11eb-821d-9e93ded5f81f.png">

`db.trait_solve` reliably produces the same timings for the same input in the same place for me, despite supposedly being cached by Salsa.
In my perception, this is a bit odd, so I've decided to stop at this point and discuss it with people with better knowledge on the topic.