### PR TITLE
Switch introduce_named_lifetime assist to use mutable syntax tree 

### DIFF
--- a/crates/syntax/src/ted.rs
+++ b/crates/syntax/src/ted.rs
@@ -165,6 +165,13 @@ fn ws_between(left: &SyntaxElement, right: &SyntaxElement) -> Option<SyntaxToken
     if right.kind() == T![;] || right.kind() == T![,] {
         return None;
     }
+    if left.kind() == T![<] || right.kind() == T![>] {
+        return None;
+    }
+    if left.kind() == T![&] && right.kind() == SyntaxKind::LIFETIME {
+        return None;
+    }
+
     if right.kind() == SyntaxKind::USE {
         let indent = IndentLevel::from_element(left);
         return Some(make::tokens::whitespace(&format!("\n{}", indent)));


### PR DESCRIPTION
This extends `GenericParamsOwnerEdit` trait with `get_or_create_generic_param_list` method