### PR TITLE
minor: notify 5.0.0.pre7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -971,9 +971,9 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "5.0.0-pre.6"
+version = "5.0.0-pre.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5fd82b93434edb9c00ae65ee741e0e081cdc8c63346ab9f687935a629aaf4c3"
+checksum = "1ebe7699a0f8c5759450716ee03d231685c22b4fe8f406c42c22e0ad94d40ce7"
 dependencies = [
  "anymap",
  "bitflags",

--- a/xtask/src/tidy.rs
+++ b/xtask/src/tidy.rs
@@ -224,7 +224,7 @@ Apache-2.0 OR BSL-1.0
 Apache-2.0 OR MIT
 Apache-2.0/MIT
 BSD-3-Clause
-CC0-1.0
+CC0-1.0 OR Artistic-2.0
 ISC
 MIT
 MIT / Apache-2.0


### PR DESCRIPTION
Fixes windows leak: https://github.com/notify-rs/notify/pull/298