### PR TITLE
 fix: Do not propose inherent traits in flyimports and import assists

### DIFF
--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -56,6 +56,7 @@ pub use mapping::{
     to_foreign_def_id, to_placeholder_idx,
 };
 pub use traits::TraitEnvironment;
+pub use utils::all_super_traits;
 pub use walk::TypeWalk;
 
 pub use chalk_ir::{

--- a/crates/hir_ty/src/utils.rs
+++ b/crates/hir_ty/src/utils.rs
@@ -78,7 +78,7 @@ fn direct_super_trait_refs(db: &dyn HirDatabase, trait_ref: &TraitRef) -> Vec<Tr
 
 /// Returns an iterator over the whole super trait hierarchy (including the
 /// trait itself).
-pub(super) fn all_super_traits(db: &dyn DefDatabase, trait_: TraitId) -> Vec<TraitId> {
+pub fn all_super_traits(db: &dyn DefDatabase, trait_: TraitId) -> Vec<TraitId> {
     // we need to take care a bit here to avoid infinite loops in case of cycles
     // (i.e. if we have `trait A: B; trait B: A;`)
     let mut result = vec![trait_];

--- a/crates/ide_completion/src/completions/flyimport.rs
+++ b/crates/ide_completion/src/completions/flyimport.rs
@@ -1127,4 +1127,27 @@ impl Bar for Foo {
             expect![[r#""#]],
         );
     }
+
+    #[test]
+    fn no_inherent_candidates_proposed() {
+        check(
+            r#"
+mod baz {
+    pub trait DefDatabase {
+        fn method1(&self);
+    }
+    pub trait HirDatabase: DefDatabase {
+        fn method2(&self);
+    }
+}
+
+mod bar {
+    fn test(db: &dyn crate::baz::HirDatabase) {
+        db.metho$0
+    }
+}
+            "#,
+            expect![[r#""#]],
+        );
+    }
 }


### PR DESCRIPTION
Closes https://github.com/rust-analyzer/rust-analyzer/issues/8520

I've went with a separate method approach, since the [highlighted code](https://github.com/rust-analyzer/rust-analyzer/issues/8520#issuecomment-819856337) has not`Type` and uses `Ty` to get his data, but the code I had to change has no access to `Ty` and has `Type` only.