### PR TITLE
Assist fix: Fill match arms for a tuple of a single enum.

### DIFF
--- a/crates/ide_assists/src/handlers/fill_match_arms.rs
+++ b/crates/ide_assists/src/handlers/fill_match_arms.rs
@@ -71,12 +71,6 @@ pub(crate) fn fill_match_arms(acc: &mut Assists, ctx: &AssistContext) -> Option<
             return None;
         }
 
-        // We do not currently support filling match arms for a tuple
-        // containing a single enum.
-        if enum_defs.len() < 2 {
-            return None;
-        }
-
         // When calculating the match arms for a tuple of enums, we want
         // to create a match arm for each possible combination of enum
         // values. The `multi_cartesian_product` method transforms
@@ -514,10 +508,7 @@ fn main() {
 
     #[test]
     fn fill_match_arms_single_element_tuple_of_enum() {
-        // For now we don't hande the case of a single element tuple, but
-        // we could handle this in the future if `make::tuple_pat` allowed
-        // creating a tuple with a single pattern.
-        check_assist_not_applicable(
+        check_assist(
             fill_match_arms,
             r#"
             enum A { One, Two }
@@ -525,6 +516,17 @@ fn main() {
             fn main() {
                 let a = A::One;
                 match (a$0, ) {
+                }
+            }
+            "#,
+            r#"
+            enum A { One, Two }
+
+            fn main() {
+                let a = A::One;
+                match (a, ) {
+                    $0(A::One,) => {}
+                    (A::Two,) => {}
                 }
             }
             "#,

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -29,9 +29,13 @@ pub fn ty(text: &str) -> ast::Type {
 pub fn ty_unit() -> ast::Type {
     ty("()")
 }
-// FIXME: handle types of length == 1
 pub fn ty_tuple(types: impl IntoIterator<Item = ast::Type>) -> ast::Type {
-    let contents = types.into_iter().join(", ");
+    let mut count: usize = 0;
+    let mut contents = types.into_iter().inspect(|_| count += 1).join(", ");
+    if count == 1 {
+        contents.push(',');
+    }
+
     ty(&format!("({})", contents))
 }
 // FIXME: handle path to type
@@ -292,11 +296,13 @@ pub fn wildcard_pat() -> ast::WildcardPat {
 
 /// Creates a tuple of patterns from an iterator of patterns.
 ///
-/// Invariant: `pats` must be length > 1
-///
-/// FIXME handle `pats` length == 1
+/// Invariant: `pats` must be length > 0
 pub fn tuple_pat(pats: impl IntoIterator<Item = ast::Pat>) -> ast::TuplePat {
-    let pats_str = pats.into_iter().map(|p| p.to_string()).join(", ");
+    let mut count: usize = 0;
+    let mut pats_str = pats.into_iter().inspect(|_| count += 1).join(", ");
+    if count == 1 {
+        pats_str.push(',');
+    }
     return from_text(&format!("({})", pats_str));
 
     fn from_text(text: &str) -> ast::TuplePat {


### PR DESCRIPTION
This is rather a small fix addressing an issue mentioned in https://github.com/rust-analyzer/rust-analyzer/issues/8493#issuecomment-818770670
