### PR TITLE
nail rowan version down

### DIFF
--- a/crates/syntax/Cargo.toml
+++ b/crates/syntax/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 [dependencies]
 cov-mark = { version = "1.1", features = ["thread-local"] }
 itertools = "0.10.0"
-rowan = "0.13.0-pre.3"
+rowan = "=0.13.0-pre.3"
 rustc_lexer = { version = "714.0.0", package = "rustc-ap-rustc_lexer" }
 rustc-hash = "1.1.0"
 arrayvec = "0.7"


### PR DESCRIPTION
The different pre versions include breaking changes, which cause build failures for the users.