### PR TITLE
Add an error message to fixture errors

### DIFF
--- a/crates/base_db/src/fixture.rs
+++ b/crates/base_db/src/fixture.rs
@@ -54,7 +54,9 @@ pub trait WithFixture: Default + SourceDatabaseExt + 'static {
         let fixture = ChangeFixture::parse(ra_fixture);
         let mut db = Self::default();
         fixture.change.apply(&mut db);
-        let (file_id, range_or_offset) = fixture.file_position.unwrap();
+        let (file_id, range_or_offset) = fixture
+            .file_position
+            .expect("Could not find file position in fixture. Did you forget to add an `$0`?");
         (db, file_id, range_or_offset)
     }
 


### PR DESCRIPTION
Improve the error message when folks forget to add an `$0` in one of the fixtures. Figuring this one out was 20 minutes down the drain for me, so figured I might as well make sure nobody else has to go through the same thing in the future. Thanks!