### PR TITLE
Fill match arms assist: add remaining arms for tuple of enums

### DIFF
--- a/crates/ide_assists/src/handlers/fill_match_arms.rs
+++ b/crates/ide_assists/src/handlers/fill_match_arms.rs
@@ -481,32 +481,32 @@ fn main() {
         check_assist(
             fill_match_arms,
             r#"
-            enum A { One, Two }
-            enum B { One, Two }
+enum A { One, Two }
+enum B { One, Two }
 
-            fn main() {
-                let a = A::One;
-                let b = B::One;
-                match (a$0, b) {
-                    (A::Two, B::One) => {}
-                }
-            }
-            "#,
+fn main() {
+    let a = A::One;
+    let b = B::One;
+    match (a$0, b) {
+        (A::Two, B::One) => {}
+    }
+}
+"#,
             r#"
-            enum A { One, Two }
-            enum B { One, Two }
+enum A { One, Two }
+enum B { One, Two }
 
-            fn main() {
-                let a = A::One;
-                let b = B::One;
-                match (a, b) {
-                    (A::Two, B::One) => {}
-                    $0(A::One, B::One) => {}
-                    (A::One, B::Two) => {}
-                    (A::Two, B::Two) => {}
-                }
-            }
-            "#,
+fn main() {
+    let a = A::One;
+    let b = B::One;
+    match (a, b) {
+        (A::Two, B::One) => {}
+        $0(A::One, B::One) => {}
+        (A::One, B::Two) => {}
+        (A::Two, B::Two) => {}
+    }
+}
+"#,
         );
     }
 

--- a/crates/ide_assists/src/handlers/fill_match_arms.rs
+++ b/crates/ide_assists/src/handlers/fill_match_arms.rs
@@ -504,6 +504,40 @@ fn main() {
         );
     }
 
+    // Fixme: This fails with extra useless match arms added.
+    // To fix, it needs full fledged match exhaustiveness checking from
+    // hir_ty::diagnostics::match_check
+    // see https://github.com/rust-analyzer/rust-analyzer/issues/8493
+    #[ignore]
+    #[test]
+    fn fill_match_arms_tuple_of_enum_partial_with_wildcards() {
+        let ra_fixture = r#"
+fn main() {
+    let a = Some(1);
+    let b = Some(());
+    match (a$0, b) {
+        (Some(_), _) => {}
+        (None, Some(_)) => {}
+    }
+}
+"#;
+        check_assist(
+            fill_match_arms,
+            &format!("//- /main.rs crate:main deps:core{}{}", ra_fixture, FamousDefs::FIXTURE),
+            r#"
+fn main() {
+    let a = Some(1);
+    let b = Some(());
+    match (a, b) {
+        (Some(_), _) => {}
+        (None, Some(_)) => {}
+        $0(None, None) => {}
+    }
+}
+"#,
+        );
+    }
+
     #[test]
     fn fill_match_arms_tuple_of_enum_not_applicable() {
         check_assist_not_applicable(

--- a/crates/ide_assists/src/handlers/fill_match_arms.rs
+++ b/crates/ide_assists/src/handlers/fill_match_arms.rs
@@ -57,6 +57,8 @@ pub(crate) fn fill_match_arms(acc: &mut Assists, ctx: &AssistContext) -> Option<
             Pat::OrPat(or_pat) => Either::Left(or_pat.pats()),
             _ => Either::Right(iter::once(pat)),
         })
+        // Exclude top level wildcards so that they are expanded by this assist, retains status quo in #8129.
+        .filter(|pat| !matches!(pat, Pat::WildcardPat(_)))
         .collect();
 
     let module = ctx.sema.scope(expr.syntax()).module()?;


### PR DESCRIPTION
Fix for #8493

However, the assist is still flaky and does not use `hir_ty::diagnostics::match_check`