### PR TITLE
Add in-place edit methods to Impl

### DIFF
--- a/crates/syntax/src/ast/edit_in_place.rs
+++ b/crates/syntax/src/ast/edit_in_place.rs
@@ -164,3 +164,29 @@ impl ast::Use {
         ted::remove(self.syntax())
     }
 }
+
+impl ast::Impl {
+    /// Add a node to at the start of the impl block.
+    pub fn push_front(&self, item: ast::AssocItem) {
+        let l_curly = self.get_or_create_assoc_item_list().l_curly_token().unwrap();
+        let position = Position::after(l_curly);
+        ted::insert(position, item.syntax());
+    }
+
+    /// Add a node at the end of the impl block.
+    pub fn push_back(&self, item: ast::AssocItem) {
+        let r_curly = self.get_or_create_assoc_item_list().r_curly_token().unwrap();
+        let position = Position::before(r_curly);
+        ted::insert(position, item.syntax());
+    }
+
+    /// Get the associated item list of this impl, or create one if none exists.
+    pub fn get_or_create_assoc_item_list(&self) -> ast::AssocItemList {
+        self.assoc_item_list().unwrap_or_else(|| {
+            let list = make::assoc_item_list();
+            let position = Position::after(self.syntax());
+            ted::insert(position, list.syntax());
+            list
+        })
+    }
+}


### PR DESCRIPTION
Making progress towards https://github.com/rust-analyzer/rust-analyzer/issues/8555, so gradually writing out assists to help familiarize myself with the new in-place edit system. Next step after this is to author a similar in-place edit method but to "create or get an impl block" for a struct, which we can then use together with these methods to rewrite some of the "generate" assists. Thanks!