### PR TITLE
Support inherent impls in unnamed consts

### DIFF
--- a/crates/hir_def/src/lib.rs
+++ b/crates/hir_def/src/lib.rs
@@ -108,6 +108,18 @@ impl ModuleId {
     pub fn containing_module(&self, db: &dyn db::DefDatabase) -> Option<ModuleId> {
         self.def_map(db).containing_module(self.local_id)
     }
+
+    /// Returns `true` if this module represents a block expression.
+    ///
+    /// Returns `false` if this module is a submodule *inside* a block expression
+    /// (eg. `m` in `{ mod m {} }`).
+    pub fn is_block_root(&self, db: &dyn db::DefDatabase) -> bool {
+        if self.block.is_none() {
+            return false;
+        }
+
+        self.def_map(db)[self.local_id].parent.is_none()
+    }
 }
 
 /// An ID of a module, **local** to a specific crate

--- a/crates/hir_ty/src/tests/method_resolution.rs
+++ b/crates/hir_ty/src/tests/method_resolution.rs
@@ -1294,7 +1294,7 @@ mod b {
 }
 
 #[test]
-fn impl_in_unnamed_const() {
+fn trait_impl_in_unnamed_const() {
     check_types(
         r#"
 struct S;
@@ -1310,6 +1310,41 @@ const _: () = {
 fn f() {
     S.method();
   //^^^^^^^^^^ u16
+}
+    "#,
+    );
+}
+
+#[test]
+fn inherent_impl_in_unnamed_const() {
+    check_types(
+        r#"
+struct S;
+
+const _: () = {
+    impl S {
+        fn method(&self) -> u16 { 0 }
+
+        pub(super) fn super_method(&self) -> u16 { 0 }
+
+        pub(crate) fn crate_method(&self) -> u16 { 0 }
+
+        pub fn pub_method(&self) -> u16 { 0 }
+    }
+};
+
+fn f() {
+    S.method();
+  //^^^^^^^^^^ u16
+
+    S.super_method();
+  //^^^^^^^^^^^^^^^^ u16
+
+    S.crate_method();
+  //^^^^^^^^^^^^^^^^ u16
+
+    S.pub_method();
+  //^^^^^^^^^^^^^^ u16
 }
     "#,
     );


### PR DESCRIPTION
It turns out that some proc. macros not only generate *trait* impls wrapped in `const _: () = { ... };`, but inherent impls too. Even though it is questionable whether *custom derives* should produce non-trait impls, this is useful for procedural attribute macros once we support them.

bors r+