### PR TITLE
Remove SyntaxRewriter usage in insert_use in favor of mutable syntax trees

### DIFF
--- a/crates/ide_assists/src/handlers/auto_import.rs
+++ b/crates/ide_assists/src/handlers/auto_import.rs
@@ -93,7 +93,7 @@ pub(crate) fn auto_import(acc: &mut Assists, ctx: &AssistContext) -> Option<()> 
 
     let range = ctx.sema.original_range(&syntax_under_caret).range;
     let group_label = group_label(import_assets.import_candidate());
-    let scope = ImportScope::find_insert_use_container(&syntax_under_caret, &ctx.sema)?;
+    let scope = ImportScope::find_insert_use_container_with_macros(&syntax_under_caret, &ctx.sema)?;
     for import in proposed_imports {
         acc.add_group(
             &group_label,

--- a/crates/ide_assists/src/handlers/auto_import.rs
+++ b/crates/ide_assists/src/handlers/auto_import.rs
@@ -101,9 +101,11 @@ pub(crate) fn auto_import(acc: &mut Assists, ctx: &AssistContext) -> Option<()> 
             format!("Import `{}`", import.import_path),
             range,
             |builder| {
-                let rewriter =
-                    insert_use(&scope, mod_path_to_ast(&import.import_path), ctx.config.insert_use);
-                builder.rewrite(rewriter);
+                let scope = match scope.clone() {
+                    ImportScope::File(it) => ImportScope::File(builder.make_ast_mut(it)),
+                    ImportScope::Module(it) => ImportScope::Module(builder.make_ast_mut(it)),
+                };
+                insert_use(&scope, mod_path_to_ast(&import.import_path), ctx.config.insert_use);
             },
         );
     }

--- a/crates/ide_assists/src/handlers/reorder_fields.rs
+++ b/crates/ide_assists/src/handlers/reorder_fields.rs
@@ -83,11 +83,9 @@ fn replace<T: AstNode + PartialEq>(
     fields: impl Iterator<Item = T>,
     sorted_fields: impl IntoIterator<Item = T>,
 ) {
-    fields.zip(sorted_fields).filter(|(field, sorted)| field != sorted).for_each(
-        |(field, sorted_field)| {
-            ted::replace(field.syntax(), sorted_field.syntax().clone_for_update());
-        },
-    );
+    fields.zip(sorted_fields).for_each(|(field, sorted_field)| {
+        ted::replace(field.syntax(), sorted_field.syntax().clone_for_update())
+    });
 }
 
 fn compute_fields_ranks(path: &ast::Path, ctx: &AssistContext) -> Option<FxHashMap<String, usize>> {

--- a/crates/ide_assists/src/handlers/reorder_impl.rs
+++ b/crates/ide_assists/src/handlers/reorder_impl.rs
@@ -79,11 +79,9 @@ pub(crate) fn reorder_impl(acc: &mut Assists, ctx: &AssistContext) -> Option<()>
         "Sort methods",
         target,
         |builder| {
-            for (old, new) in
-                methods.into_iter().zip(sorted).filter(|(field, sorted)| field != sorted)
-            {
-                ted::replace(builder.make_ast_mut(old).syntax(), new.clone_for_update().syntax());
-            }
+            methods.into_iter().zip(sorted).for_each(|(old, new)| {
+                ted::replace(builder.make_ast_mut(old).syntax(), new.clone_for_update().syntax())
+            });
         },
     )
 }

--- a/crates/ide_assists/src/handlers/reorder_impl.rs
+++ b/crates/ide_assists/src/handlers/reorder_impl.rs
@@ -4,9 +4,8 @@ use rustc_hash::FxHashMap;
 use hir::{PathResolution, Semantics};
 use ide_db::RootDatabase;
 use syntax::{
-    algo,
     ast::{self, NameOwner},
-    AstNode,
+    ted, AstNode,
 };
 
 use crate::{AssistContext, AssistId, AssistKind, Assists};
@@ -75,13 +74,18 @@ pub(crate) fn reorder_impl(acc: &mut Assists, ctx: &AssistContext) -> Option<()>
     }
 
     let target = items.syntax().text_range();
-    acc.add(AssistId("reorder_impl", AssistKind::RefactorRewrite), "Sort methods", target, |edit| {
-        let mut rewriter = algo::SyntaxRewriter::default();
-        for (old, new) in methods.iter().zip(&sorted) {
-            rewriter.replace(old.syntax(), new.syntax());
-        }
-        edit.rewrite(rewriter);
-    })
+    acc.add(
+        AssistId("reorder_impl", AssistKind::RefactorRewrite),
+        "Sort methods",
+        target,
+        |builder| {
+            for (old, new) in
+                methods.into_iter().zip(sorted).filter(|(field, sorted)| field != sorted)
+            {
+                ted::replace(builder.make_ast_mut(old).syntax(), new.clone_for_update().syntax());
+            }
+        },
+    )
 }
 
 fn compute_method_ranks(path: &ast::Path, ctx: &AssistContext) -> Option<FxHashMap<String, usize>> {

--- a/crates/ide_assists/src/handlers/replace_qualified_name_with_use.rs
+++ b/crates/ide_assists/src/handlers/replace_qualified_name_with_use.rs
@@ -1,5 +1,5 @@
 use ide_db::helpers::insert_use::{insert_use, ImportScope};
-use syntax::{algo::SyntaxRewriter, ast, match_ast, AstNode, SyntaxNode};
+use syntax::{ast, match_ast, ted, AstNode, SyntaxNode};
 
 use crate::{AssistContext, AssistId, AssistKind, Assists};
 
@@ -40,18 +40,17 @@ pub(crate) fn replace_qualified_name_with_use(
         |builder| {
             // Now that we've brought the name into scope, re-qualify all paths that could be
             // affected (that is, all paths inside the node we added the `use` to).
-            let mut rewriter = SyntaxRewriter::default();
-            shorten_paths(&mut rewriter, syntax.clone(), &path);
+            let syntax = builder.make_mut(syntax.clone());
             if let Some(ref import_scope) = ImportScope::from(syntax.clone()) {
-                rewriter += insert_use(import_scope, path, ctx.config.insert_use);
-                builder.rewrite(rewriter);
+                insert_use(import_scope, path.clone(), ctx.config.insert_use);
             }
+            shorten_paths(syntax.clone(), &path.clone_for_update());
         },
     )
 }
 
 /// Adds replacements to `re` that shorten `path` in all descendants of `node`.
-fn shorten_paths(rewriter: &mut SyntaxRewriter<'static>, node: SyntaxNode, path: &ast::Path) {
+fn shorten_paths(node: SyntaxNode, path: &ast::Path) {
     for child in node.children() {
         match_ast! {
             match child {
@@ -62,32 +61,28 @@ fn shorten_paths(rewriter: &mut SyntaxRewriter<'static>, node: SyntaxNode, path:
                 ast::Module(_it) => continue,
 
                 ast::Path(p) => {
-                    match maybe_replace_path(rewriter, p.clone(), path.clone()) {
+                    match maybe_replace_path(p.clone(), path.clone()) {
                         Some(()) => {},
-                        None => shorten_paths(rewriter, p.syntax().clone(), path),
+                        None => shorten_paths(p.syntax().clone(), path),
                     }
                 },
-                _ => shorten_paths(rewriter, child, path),
+                _ => shorten_paths(child, path),
             }
         }
     }
 }
 
-fn maybe_replace_path(
-    rewriter: &mut SyntaxRewriter<'static>,
-    path: ast::Path,
-    target: ast::Path,
-) -> Option<()> {
+fn maybe_replace_path(path: ast::Path, target: ast::Path) -> Option<()> {
     if !path_eq(path.clone(), target) {
         return None;
     }
 
     // Shorten `path`, leaving only its last segment.
     if let Some(parent) = path.qualifier() {
-        rewriter.delete(parent.syntax());
+        ted::remove(parent.syntax());
     }
     if let Some(double_colon) = path.coloncolon_token() {
-        rewriter.delete(&double_colon);
+        ted::remove(&double_colon);
     }
 
     Some(())
@@ -150,6 +145,7 @@ Debug
     ",
         );
     }
+
     #[test]
     fn test_replace_add_use_no_anchor_with_item_below() {
         check_assist(

--- a/crates/ide_completion/src/completions/flyimport.rs
+++ b/crates/ide_completion/src/completions/flyimport.rs
@@ -132,7 +132,7 @@ pub(crate) fn import_on_the_fly(acc: &mut Completions, ctx: &CompletionContext) 
 
     let user_input_lowercased = potential_import_name.to_lowercase();
     let import_assets = import_assets(ctx, potential_import_name)?;
-    let import_scope = ImportScope::find_insert_use_container(
+    let import_scope = ImportScope::find_insert_use_container_with_macros(
         position_for_import(ctx, Some(import_assets.import_candidate()))?,
         &ctx.sema,
     )?;

--- a/crates/ide_completion/src/item.rs
+++ b/crates/ide_completion/src/item.rs
@@ -377,11 +377,11 @@ impl ImportEdit {
     pub fn to_text_edit(&self, cfg: InsertUseConfig) -> Option<TextEdit> {
         let _p = profile::span("ImportEdit::to_text_edit");
 
-        let rewriter =
-            insert_use::insert_use(&self.scope, mod_path_to_ast(&self.import.import_path), cfg);
-        let old_ast = rewriter.rewrite_root()?;
+        let new_ast = self.scope.clone_for_update();
+        insert_use::insert_use(&new_ast, mod_path_to_ast(&self.import.import_path), cfg);
         let mut import_insert = TextEdit::builder();
-        algo::diff(&old_ast, &rewriter.rewrite(&old_ast)).into_text_edit(&mut import_insert);
+        algo::diff(self.scope.as_syntax_node(), new_ast.as_syntax_node())
+            .into_text_edit(&mut import_insert);
 
         Some(import_insert.finish())
     }

--- a/crates/ide_completion/src/lib.rs
+++ b/crates/ide_completion/src/lib.rs
@@ -179,7 +179,7 @@ pub fn resolve_completion_edits(
 ) -> Option<Vec<TextEdit>> {
     let ctx = CompletionContext::new(db, position, config)?;
     let position_for_import = position_for_import(&ctx, None)?;
-    let scope = ImportScope::find_insert_use_container(position_for_import, &ctx.sema)?;
+    let scope = ImportScope::find_insert_use_container_with_macros(position_for_import, &ctx.sema)?;
 
     let current_module = ctx.sema.scope(position_for_import).module()?;
     let current_crate = current_module.krate();

--- a/crates/ide_db/src/helpers/insert_use.rs
+++ b/crates/ide_db/src/helpers/insert_use.rs
@@ -4,13 +4,9 @@ use std::{cmp::Ordering, iter::successors};
 use hir::Semantics;
 use itertools::{EitherOrBoth, Itertools};
 use syntax::{
-    algo::SyntaxRewriter,
-    ast::{
-        self,
-        edit::{AstNodeEdit, IndentLevel},
-        make, AstNode, AttrsOwner, PathSegmentKind, VisibilityOwner,
-    },
-    AstToken, InsertPosition, NodeOrToken, SyntaxElement, SyntaxNode, SyntaxToken,
+    algo,
+    ast::{self, edit::AstNodeEdit, make, AstNode, AttrsOwner, PathSegmentKind, VisibilityOwner},
+    ted, AstToken, Direction, NodeOrToken, SyntaxNode, SyntaxToken,
 };
 
 use crate::RootDatabase;
@@ -56,127 +52,32 @@ impl ImportScope {
         }
     }
 
-    fn indent_level(&self) -> IndentLevel {
+    pub fn clone_for_update(&self) -> Self {
         match self {
-            ImportScope::File(file) => file.indent_level(),
-            ImportScope::Module(item_list) => item_list.indent_level() + 1,
+            ImportScope::File(file) => ImportScope::File(file.clone_for_update()),
+            ImportScope::Module(item_list) => ImportScope::Module(item_list.clone_for_update()),
         }
     }
-
-    fn first_insert_pos(&self) -> (InsertPosition<SyntaxElement>, AddBlankLine) {
-        match self {
-            ImportScope::File(_) => (InsertPosition::First, AddBlankLine::AfterTwice),
-            // don't insert the imports before the item list's opening curly brace
-            ImportScope::Module(item_list) => item_list
-                .l_curly_token()
-                .map(|b| (InsertPosition::After(b.into()), AddBlankLine::Around))
-                .unwrap_or((InsertPosition::First, AddBlankLine::AfterTwice)),
-        }
-    }
-
-    fn insert_pos_after_last_inner_element(&self) -> (InsertPosition<SyntaxElement>, AddBlankLine) {
-        self.as_syntax_node()
-            .children_with_tokens()
-            .filter(|child| match child {
-                NodeOrToken::Node(node) => is_inner_attribute(node.clone()),
-                NodeOrToken::Token(token) => is_inner_comment(token.clone()),
-            })
-            .last()
-            .map(|last_inner_element| {
-                (InsertPosition::After(last_inner_element), AddBlankLine::BeforeTwice)
-            })
-            .unwrap_or_else(|| self.first_insert_pos())
-    }
-}
-
-fn is_inner_attribute(node: SyntaxNode) -> bool {
-    ast::Attr::cast(node).map(|attr| attr.kind()) == Some(ast::AttrKind::Inner)
-}
-
-fn is_inner_comment(token: SyntaxToken) -> bool {
-    ast::Comment::cast(token).and_then(|comment| comment.kind().doc)
-        == Some(ast::CommentPlacement::Inner)
 }
 
 /// Insert an import path into the given file/node. A `merge` value of none indicates that no import merging is allowed to occur.
-pub fn insert_use<'a>(
-    scope: &ImportScope,
-    path: ast::Path,
-    cfg: InsertUseConfig,
-) -> SyntaxRewriter<'a> {
+pub fn insert_use<'a>(scope: &ImportScope, path: ast::Path, cfg: InsertUseConfig) {
     let _p = profile::span("insert_use");
-    let mut rewriter = SyntaxRewriter::default();
-    let use_item = make::use_(None, make::use_tree(path.clone(), None, None, false));
+    let use_item =
+        make::use_(None, make::use_tree(path.clone(), None, None, false)).clone_for_update();
     // merge into existing imports if possible
     if let Some(mb) = cfg.merge {
         for existing_use in scope.as_syntax_node().children().filter_map(ast::Use::cast) {
             if let Some(merged) = try_merge_imports(&existing_use, &use_item, mb) {
-                rewriter.replace(existing_use.syntax(), merged.syntax());
-                return rewriter;
+                ted::replace(existing_use.syntax(), merged.syntax());
+                return;
             }
         }
     }
 
     // either we weren't allowed to merge or there is no import that fits the merge conditions
     // so look for the place we have to insert to
-    let (insert_position, add_blank) = find_insert_position(scope, path, cfg.group);
-
-    let indent = if let ident_level @ 1..=usize::MAX = scope.indent_level().0 as usize {
-        Some(make::tokens::whitespace(&" ".repeat(4 * ident_level)).into())
-    } else {
-        None
-    };
-
-    let to_insert: Vec<SyntaxElement> = {
-        let mut buf = Vec::new();
-
-        match add_blank {
-            AddBlankLine::Before | AddBlankLine::Around => {
-                buf.push(make::tokens::single_newline().into())
-            }
-            AddBlankLine::BeforeTwice => buf.push(make::tokens::blank_line().into()),
-            _ => (),
-        }
-
-        if add_blank.has_before() {
-            if let Some(indent) = indent.clone() {
-                cov_mark::hit!(insert_use_indent_before);
-                buf.push(indent);
-            }
-        }
-
-        buf.push(use_item.syntax().clone().into());
-
-        match add_blank {
-            AddBlankLine::After | AddBlankLine::Around => {
-                buf.push(make::tokens::single_newline().into())
-            }
-            AddBlankLine::AfterTwice => buf.push(make::tokens::blank_line().into()),
-            _ => (),
-        }
-
-        // only add indentation *after* our stuff if there's another node directly after it
-        if add_blank.has_after() && matches!(insert_position, InsertPosition::Before(_)) {
-            if let Some(indent) = indent {
-                cov_mark::hit!(insert_use_indent_after);
-                buf.push(indent);
-            }
-        } else if add_blank.has_after() && matches!(insert_position, InsertPosition::After(_)) {
-            cov_mark::hit!(insert_use_no_indent_after);
-        }
-
-        buf
-    };
-
-    match insert_position {
-        InsertPosition::First => {
-            rewriter.insert_many_as_first_children(scope.as_syntax_node(), to_insert)
-        }
-        InsertPosition::Last => return rewriter, // actually unreachable
-        InsertPosition::Before(anchor) => rewriter.insert_many_before(&anchor, to_insert),
-        InsertPosition::After(anchor) => rewriter.insert_many_after(&anchor, to_insert),
-    }
-    rewriter
+    insert_use_(scope, path, cfg.group, use_item);
 }
 
 fn eq_visibility(vis0: Option<ast::Visibility>, vis1: Option<ast::Visibility>) -> bool {
@@ -235,7 +136,7 @@ pub fn try_merge_trees(
     } else {
         (lhs.split_prefix(&lhs_prefix), rhs.split_prefix(&rhs_prefix))
     };
-    recursive_merge(&lhs, &rhs, merge).map(|it| it.clone_for_update())
+    recursive_merge(&lhs, &rhs, merge)
 }
 
 /// Recursively "zips" together lhs and rhs.
@@ -334,7 +235,12 @@ fn recursive_merge(
             }
         }
     }
-    Some(lhs.with_use_tree_list(make::use_tree_list(use_trees)))
+
+    Some(if let Some(old) = lhs.use_tree_list() {
+        lhs.replace_descendant(old, make::use_tree_list(use_trees)).clone_for_update()
+    } else {
+        lhs.clone()
+    })
 }
 
 /// Traverses both paths until they differ, returning the common prefix of both.
@@ -520,32 +426,15 @@ impl ImportGroup {
     }
 }
 
-#[derive(PartialEq, Eq)]
-enum AddBlankLine {
-    Before,
-    BeforeTwice,
-    Around,
-    After,
-    AfterTwice,
-}
-
-impl AddBlankLine {
-    fn has_before(&self) -> bool {
-        matches!(self, AddBlankLine::Before | AddBlankLine::BeforeTwice | AddBlankLine::Around)
-    }
-    fn has_after(&self) -> bool {
-        matches!(self, AddBlankLine::After | AddBlankLine::AfterTwice | AddBlankLine::Around)
-    }
-}
-
-fn find_insert_position(
+fn insert_use_(
     scope: &ImportScope,
     insert_path: ast::Path,
     group_imports: bool,
-) -> (InsertPosition<SyntaxElement>, AddBlankLine) {
+    use_item: ast::Use,
+) {
+    let scope_syntax = scope.as_syntax_node();
     let group = ImportGroup::new(&insert_path);
-    let path_node_iter = scope
-        .as_syntax_node()
+    let path_node_iter = scope_syntax
         .children()
         .filter_map(|node| ast::Use::cast(node.clone()).zip(Some(node)))
         .flat_map(|(use_, node)| {
@@ -557,9 +446,12 @@ fn find_insert_position(
 
     if !group_imports {
         if let Some((_, _, node)) = path_node_iter.last() {
-            return (InsertPosition::After(node.into()), AddBlankLine::Before);
+            ted::insert(ted::Position::after(node), use_item.syntax());
+        } else {
+            ted::insert(ted::Position::first_child_of(scope_syntax), make::tokens::blank_line());
+            ted::insert(ted::Position::first_child_of(scope_syntax), use_item.syntax());
         }
-        return (InsertPosition::First, AddBlankLine::AfterTwice);
+        return;
     }
 
     // Iterator that discards anything thats not in the required grouping
@@ -572,43 +464,83 @@ fn find_insert_position(
     // track the last element we iterated over, if this is still None after the iteration then that means we never iterated in the first place
     let mut last = None;
     // find the element that would come directly after our new import
-    let post_insert = group_iter.inspect(|(.., node)| last = Some(node.clone())).find(
-        |&(ref path, has_tl, _)| {
+    let post_insert: Option<(_, _, SyntaxNode)> = group_iter
+        .inspect(|(.., node)| last = Some(node.clone()))
+        .find(|&(ref path, has_tl, _)| {
             use_tree_path_cmp(&insert_path, false, path, has_tl) != Ordering::Greater
-        },
-    );
+        });
 
-    match post_insert {
+    if let Some((.., node)) = post_insert {
         // insert our import before that element
-        Some((.., node)) => (InsertPosition::Before(node.into()), AddBlankLine::After),
+        return ted::insert(ted::Position::before(node), use_item.syntax());
+    }
+    if let Some(node) = last {
         // there is no element after our new import, so append it to the end of the group
-        None => match last {
-            Some(node) => (InsertPosition::After(node.into()), AddBlankLine::Before),
-            // the group we were looking for actually doesnt exist, so insert
+        return ted::insert(ted::Position::after(node), use_item.syntax());
+    }
+
+    // the group we were looking for actually doesn't exist, so insert
+
+    let mut last = None;
+    // find the group that comes after where we want to insert
+    let post_group = path_node_iter
+        .inspect(|(.., node)| last = Some(node.clone()))
+        .find(|(p, ..)| ImportGroup::new(p) > group);
+    if let Some((.., node)) = post_group {
+        ted::insert(ted::Position::before(&node), use_item.syntax());
+        if let Some(node) = algo::non_trivia_sibling(node.into(), Direction::Prev) {
+            ted::insert(ted::Position::after(node), make::tokens::single_newline());
+        }
+        return;
+    }
+    // there is no such group, so append after the last one
+    if let Some(node) = last {
+        ted::insert(ted::Position::after(&node), use_item.syntax());
+        ted::insert(ted::Position::after(node), make::tokens::single_newline());
+        return;
+    }
+    // there are no imports in this file at all
+    if let Some(last_inner_element) = scope_syntax
+        .children_with_tokens()
+        .filter(|child| match child {
+            NodeOrToken::Node(node) => is_inner_attribute(node.clone()),
+            NodeOrToken::Token(token) => is_inner_comment(token.clone()),
+        })
+        .last()
+    {
+        ted::insert(ted::Position::after(&last_inner_element), use_item.syntax());
+        ted::insert(ted::Position::after(last_inner_element), make::tokens::single_newline());
+        return;
+    }
+    match scope {
+        ImportScope::File(_) => {
+            ted::insert(ted::Position::first_child_of(scope_syntax), make::tokens::blank_line());
+            ted::insert(ted::Position::first_child_of(scope_syntax), use_item.syntax())
+        }
+        // don't insert the imports before the item list's opening curly brace
+        ImportScope::Module(item_list) => match item_list.l_curly_token() {
+            Some(b) => {
+                ted::insert(ted::Position::after(&b), make::tokens::single_newline());
+                ted::insert(ted::Position::after(&b), use_item.syntax());
+            }
             None => {
-                // similar concept here to the `last` from above
-                let mut last = None;
-                // find the group that comes after where we want to insert
-                let post_group = path_node_iter
-                    .inspect(|(.., node)| last = Some(node.clone()))
-                    .find(|(p, ..)| ImportGroup::new(p) > group);
-                match post_group {
-                    Some((.., node)) => {
-                        (InsertPosition::Before(node.into()), AddBlankLine::AfterTwice)
-                    }
-                    // there is no such group, so append after the last one
-                    None => match last {
-                        Some(node) => {
-                            (InsertPosition::After(node.into()), AddBlankLine::BeforeTwice)
-                        }
-                        // there are no imports in this file at all
-                        None => scope.insert_pos_after_last_inner_element(),
-                    },
-                }
+                ted::insert(
+                    ted::Position::first_child_of(scope_syntax),
+                    make::tokens::blank_line(),
+                );
+                ted::insert(ted::Position::first_child_of(scope_syntax), use_item.syntax());
             }
         },
     }
 }
 
+fn is_inner_attribute(node: SyntaxNode) -> bool {
+    ast::Attr::cast(node).map(|attr| attr.kind()) == Some(ast::AttrKind::Inner)
+}
+
+fn is_inner_comment(token: SyntaxToken) -> bool {
+    ast::Comment::cast(token).and_then(|comment| comment.kind().doc)
+        == Some(ast::CommentPlacement::Inner)
+}
 #[cfg(test)]
 mod tests;

--- a/crates/ide_db/src/helpers/insert_use/tests.rs
+++ b/crates/ide_db/src/helpers/insert_use/tests.rs
@@ -5,6 +5,7 @@ use test_utils::assert_eq_text;
 
 #[test]
 fn insert_not_group() {
+    cov_mark::check!(insert_no_grouping_last);
     check(
         "use external_crate2::bar::A",
         r"
@@ -20,6 +21,21 @@ use crate::bar::A;
 use self::bar::A;
 use super::bar::A;
 use external_crate2::bar::A;",
+        None,
+        false,
+        false,
+    );
+}
+
+#[test]
+fn insert_not_group_empty() {
+    cov_mark::check!(insert_no_grouping_last2);
+    check(
+        "use external_crate2::bar::A",
+        r"",
+        r"use external_crate2::bar::A;
+
+",
         None,
         false,
         false,
@@ -65,6 +81,7 @@ fn insert_start_indent() {
 
 #[test]
 fn insert_middle() {
+    cov_mark::check!(insert_group);
     check_none(
         "std::bar::EE",
         r"
@@ -101,6 +118,7 @@ fn insert_middle_indent() {
 
 #[test]
 fn insert_end() {
+    cov_mark::check!(insert_group_last);
     check_none(
         "std::bar::ZZ",
         r"
@@ -199,6 +217,7 @@ fn insert_first_matching_group() {
 
 #[test]
 fn insert_missing_group_std() {
+    cov_mark::check!(insert_group_new_group);
     check_none(
         "std::fmt",
         r"
@@ -214,6 +233,7 @@ fn insert_missing_group_std() {
 
 #[test]
 fn insert_missing_group_self() {
+    cov_mark::check!(insert_group_no_group);
     check_none(
         "self::fmt",
         r"
@@ -240,6 +260,7 @@ fn main() {}",
 
 #[test]
 fn insert_empty_file() {
+    cov_mark::check!(insert_group_empty_file);
     // empty files will get two trailing newlines
     // this is due to the test case insert_no_imports above
     check_full(
@@ -253,6 +274,7 @@ fn insert_empty_file() {
 
 #[test]
 fn insert_empty_module() {
+    cov_mark::check!(insert_group_empty_module);
     check(
         "foo::bar",
         "mod x {}",
@@ -267,6 +289,7 @@ fn insert_empty_module() {
 
 #[test]
 fn insert_after_inner_attr() {
+    cov_mark::check!(insert_group_empty_inner_attr);
     check_full(
         "foo::bar",
         r"#![allow(unused_imports)]",

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -598,6 +598,7 @@ pub mod tokens {
         SOURCE_FILE
             .tree()
             .syntax()
+            .clone_for_update()
             .descendants_with_tokens()
             .filter_map(|it| it.into_token())
             .find(|it| it.kind() == WHITESPACE && it.text() == "\n\n")


### PR DESCRIPTION
Unfortunately changing `insert_use` to not use `SyntaxRewriter` creates a lot of changes since so much relies on that. But on the other hand this should be the biggest usage of `SyntaxRewriter` I believe.