### PR TITLE
Diagnostic paths support specifying `remapPrefix`

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -99,9 +99,9 @@ config_data! {
         diagnostics_enableExperimental: bool    = "true",
         /// List of rust-analyzer diagnostics to disable.
         diagnostics_disabled: FxHashSet<String> = "[]",
-        /// Map of path prefixes to be substituted when parsing diagnostic file paths.
+        /// Map of prefixes to be substituted when parsing diagnostic file paths.
         /// This should be the reverse mapping of what is passed to `rustc` as `--remap-path-prefix`.
-        diagnostics_remapPathPrefixes: FxHashMap<String, String> = "{}",
+        diagnostics_remapPrefix: FxHashMap<String, String> = "{}",
         /// List of warnings that should be displayed with info severity.
         ///
         /// The warnings will be indicated by a blue squiggly underline in code
@@ -477,7 +477,7 @@ impl Config {
     }
     pub fn diagnostics_map(&self) -> DiagnosticsMapConfig {
         DiagnosticsMapConfig {
-            remap_path_prefixes: self.data.diagnostics_remapPathPrefixes.clone(),
+            remap_prefix: self.data.diagnostics_remapPrefix.clone(),
             warnings_as_info: self.data.diagnostics_warningsAsInfo.clone(),
             warnings_as_hint: self.data.diagnostics_warningsAsHint.clone(),
         }

--- a/crates/rust-analyzer/src/diagnostics.rs
+++ b/crates/rust-analyzer/src/diagnostics.rs
@@ -12,7 +12,7 @@ pub(crate) type CheckFixes = Arc<FxHashMap<FileId, Vec<Fix>>>;
 
 #[derive(Debug, Default, Clone)]
 pub struct DiagnosticsMapConfig {
-    pub remap_path_prefixes: FxHashMap<String, String>,
+    pub remap_prefix: FxHashMap<String, String>,
     pub warnings_as_info: Vec<String>,
     pub warnings_as_hint: Vec<String>,
 }

--- a/crates/rust-analyzer/src/diagnostics.rs
+++ b/crates/rust-analyzer/src/diagnostics.rs
@@ -12,6 +12,7 @@ pub(crate) type CheckFixes = Arc<FxHashMap<FileId, Vec<Fix>>>;
 
 #[derive(Debug, Default, Clone)]
 pub struct DiagnosticsMapConfig {
+    pub remap_path_prefixes: FxHashMap<String, String>,
     pub warnings_as_info: Vec<String>,
     pub warnings_as_hint: Vec<String>,
 }

--- a/crates/rust-analyzer/src/diagnostics/to_proto.rs
+++ b/crates/rust-analyzer/src/diagnostics/to_proto.rs
@@ -99,10 +99,12 @@ fn diagnostic_related_information(
 /// Resolves paths applying any matching path prefix remappings, and then
 /// joining the path to the workspace root.
 fn resolve_path(config: &DiagnosticsMapConfig, workspace_root: &Path, file_name: &str) -> PathBuf {
-    match config.remap_path_prefixes.iter().find(|(from, _)| file_name.starts_with(*from)) {
-        Some((from, to)) => {
-            workspace_root.join(format!("{}{}", to, file_name.strip_prefix(from).unwrap()))
-        }
+    match config
+        .remap_prefix
+        .iter()
+        .find_map(|(from, to)| file_name.strip_prefix(from).map(|file_name| (to, file_name)))
+    {
+        Some((to, file_name)) => workspace_root.join(format!("{}{}", to, file_name)),
         None => workspace_root.join(file_name),
     }
 }

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -147,10 +147,10 @@ have more false positives than usual.
 --
 List of rust-analyzer diagnostics to disable.
 --
-[[rust-analyzer.diagnostics.remapPathPrefixes]]rust-analyzer.diagnostics.remapPathPrefixes (default: `{}`)::
+[[rust-analyzer.diagnostics.remapPrefix]]rust-analyzer.diagnostics.remapPrefix (default: `{}`)::
 +
 --
-Map of path prefixes to be substituted when parsing diagnostic file paths.
+Map of prefixes to be substituted when parsing diagnostic file paths.
 This should be the reverse mapping of what is passed to `rustc` as `--remap-path-prefix`.
 --
 [[rust-analyzer.diagnostics.warningsAsHint]]rust-analyzer.diagnostics.warningsAsHint (default: `[]`)::

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -147,6 +147,12 @@ have more false positives than usual.
 --
 List of rust-analyzer diagnostics to disable.
 --
+[[rust-analyzer.diagnostics.remapPathPrefixes]]rust-analyzer.diagnostics.remapPathPrefixes (default: `{}`)::
++
+--
+Map of path prefixes to be substituted when parsing diagnostic file paths.
+This should be the reverse mapping of what is passed to `rustc` as `--remap-path-prefix`.
+--
 [[rust-analyzer.diagnostics.warningsAsHint]]rust-analyzer.diagnostics.warningsAsHint (default: `[]`)::
 +
 --

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -565,8 +565,8 @@
                     },
                     "uniqueItems": true
                 },
-                "rust-analyzer.diagnostics.remapPathPrefixes": {
-                    "markdownDescription": "Map of path prefixes to be substituted when parsing diagnostic file paths.\nThis should be the reverse mapping of what is passed to `rustc` as `--remap-path-prefix`.",
+                "rust-analyzer.diagnostics.remapPrefix": {
+                    "markdownDescription": "Map of prefixes to be substituted when parsing diagnostic file paths.\nThis should be the reverse mapping of what is passed to `rustc` as `--remap-path-prefix`.",
                     "default": {},
                     "type": "object"
                 },

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -565,6 +565,11 @@
                     },
                     "uniqueItems": true
                 },
+                "rust-analyzer.diagnostics.remapPathPrefixes": {
+                    "markdownDescription": "Map of path prefixes to be substituted when parsing diagnostic file paths.\nThis should be the reverse mapping of what is passed to `rustc` as `--remap-path-prefix`.",
+                    "default": {},
+                    "type": "object"
+                },
                 "rust-analyzer.diagnostics.warningsAsHint": {
                     "markdownDescription": "List of warnings that should be displayed with info severity.\n\nThe warnings will be indicated by a blue squiggly underline in code\nand a blue icon in the `Problems Panel`.",
                     "default": [],


### PR DESCRIPTION
Currently VSCode Problem Matchers will resolve a path like `//foo_crate/src/main.rs` if `${workspaceFolder}/foo_crate/src/main.rs` exists.  Presumably their behavior is functionally a string concatenation that would produce `${workspaceFolder///foo_crate/src/main.rs` and repeated path separators get ignored.

This PR attempts to mimic this behavior by stripping any `Component::RootDir` from `file_name` before joining it to `workspace_root`, and then checking if the file exists.  If it does, this path is used, and if not, the behavior falls through to the existing Rust path join behavior.