### PR TITLE
ProjectJson can now specify the workspace root directory.

### DIFF
--- a/crates/project_model/src/project_json.rs
+++ b/crates/project_model/src/project_json.rs
@@ -45,7 +45,10 @@ impl ProjectJson {
     pub fn new(base: &AbsPath, data: ProjectJsonData) -> ProjectJson {
         ProjectJson {
             sysroot_src: data.sysroot_src.map(|it| base.join(it)),
-            project_root: base.to_path_buf(),
+            project_root: data
+                .project_root
+                .map(|it| base.join(it))
+                .unwrap_or_else(|| base.to_path_buf()),
             crates: data
                 .crates
                 .into_iter()
@@ -113,6 +116,7 @@ impl ProjectJson {
 #[derive(Deserialize, Debug, Clone)]
 pub struct ProjectJsonData {
     sysroot_src: Option<PathBuf>,
+    project_root: Option<PathBuf>,
     crates: Vec<CrateData>,
 }
 

--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -439,6 +439,12 @@ interface JsonProject {
     /// dependencies yourself and, for example, have several different "sysroots" in
     /// one graph of crates.
     sysroot_src?: string;
+    /// Path to the workspace root directory for this project.
+    ///
+    /// Relative paths are treated relative to the directory containing this `rust-project.json`.
+    ///
+    /// If not supplied, this defaults to the directory containing this `rust-project.json`.
+    project_root?: string;
     /// The set of crates comprising the current project.
     /// Must include all transitive dependencies as well as sysroot crate (libstd, libcore and such).
     crates: Crate[];


### PR DESCRIPTION
For cases where `rust-project.json` is generated or otherwise not located in the workspace root, it is now possible to specify the workspace root path, either as an absolute path, or a path relative to the location of `rust-project.json`.