### PR TITLE
minor: Add failing local items test

### DIFF
--- a/crates/hir_def/src/body/tests.rs
+++ b/crates/hir_def/src/body/tests.rs
@@ -40,6 +40,14 @@ fn block_def_map_at(ra_fixture: &str) -> String {
     module.def_map(&db).dump(&db)
 }
 
+fn check_block_scopes_at(ra_fixture: &str, expect: Expect) {
+    let (db, position) = crate::test_db::TestDB::with_position(ra_fixture);
+
+    let module = db.module_at_position(position);
+    let actual = module.def_map(&db).dump_block_scopes(&db);
+    expect.assert_eq(&actual);
+}
+
 fn check_at(ra_fixture: &str, expect: Expect) {
     let actual = block_def_map_at(ra_fixture);
     expect.assert_eq(&actual);

--- a/crates/hir_def/src/body/tests/block.rs
+++ b/crates/hir_def/src/body/tests/block.rs
@@ -134,6 +134,30 @@ struct Struct {}
 }
 
 #[test]
+fn nested_module_scoping() {
+    check_block_scopes_at(
+        r#"
+fn f() {
+    mod module {
+        struct Struct {}
+        fn f() {
+            use self::Struct;
+            $0
+        }
+    }
+}
+    "#,
+        expect![[r#"
+            BlockId(1) in ModuleId { krate: CrateId(0), block: Some(BlockId(0)), local_id: Idx::<ModuleData>(0) }
+            BlockId(0) in ModuleId { krate: CrateId(0), block: None, local_id: Idx::<ModuleData>(0) }
+            crate scope
+        "#]],
+    );
+    // FIXME: The module nesting here is wrong!
+    // The first block map should be located in module #1 (`mod module`), not #0 (BlockId(0) root module)
+}
+
+#[test]
 fn legacy_macro_items() {
     // Checks that legacy-scoped `macro_rules!` from parent namespaces are resolved and expanded
     // correctly.

--- a/crates/hir_def/src/nameres.rs
+++ b/crates/hir_def/src/nameres.rs
@@ -410,6 +410,20 @@ impl DefMap {
         }
     }
 
+    pub fn dump_block_scopes(&self, db: &dyn DefDatabase) -> String {
+        let mut buf = String::new();
+        let mut arc;
+        let mut current_map = self;
+        while let Some(block) = &current_map.block {
+            format_to!(buf, "{:?} in {:?}\n", block.block, block.parent);
+            arc = block.parent.def_map(db);
+            current_map = &*arc;
+        }
+
+        format_to!(buf, "crate scope\n");
+        buf
+    }
+
     fn shrink_to_fit(&mut self) {
         // Exhaustive match to require handling new fields.
         let Self {


### PR DESCRIPTION
This is currently broken due to the way ItemTree stores inner items. This test serves as a reminder until this gets fixed.

bors r+