### PR TITLE
Add option to opt out of smaller font size for inlay hints.

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -145,6 +145,8 @@ config_data! {
         inlayHints_parameterHints: bool     = "true",
         /// Whether to show inlay type hints for variables.
         inlayHints_typeHints: bool          = "true",
+        /// Whether inlay hints font size should be smaller than editor's font size.
+        inlayHints_smallerHints: bool       = "true",
 
         /// Whether to show `Debug` lens. Only applies when
         /// `#rust-analyzer.lens.enable#` is set.

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -234,6 +234,11 @@ site.
 --
 Whether to show inlay type hints for variables.
 --
+[[rust-analyzer.inlayHints.smallerHints]]rust-analyzer.inlayHints.smallerHints (default: `true`)::
++
+--
+Whether inlay hints font size should be smaller than editor's font size.
+--
 [[rust-analyzer.lens.debug]]rust-analyzer.lens.debug (default: `true`)::
 +
 --

--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -830,7 +830,6 @@
             "dependencies": {
                 "anymatch": "~3.1.1",
                 "braces": "~3.0.2",
-                "fsevents": "~2.3.1",
                 "glob-parent": "~5.1.0",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
@@ -2680,9 +2679,6 @@
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.39.1.tgz",
             "integrity": "sha512-9rfr0Z6j+vE+eayfNVFr1KZ+k+jiUl2+0e4quZafy1x6SFCjzFspfRSO2ZZQeWeX9noeDTUDgg6eCENiEPFvQg==",
             "dev": true,
-            "dependencies": {
-                "fsevents": "~2.3.1"
-            },
             "bin": {
                 "rollup": "dist/bin/rollup"
             },

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -653,6 +653,11 @@
                     "default": true,
                     "type": "boolean"
                 },
+                "rust-analyzer.inlayHints.smallerHints": {
+                    "markdownDescription": "Whether inlay hints font size should be smaller than editor's font size.",
+                    "default": true,
+                    "type": "boolean"
+                },
                 "rust-analyzer.lens.debug": {
                     "markdownDescription": "Whether to show `Debug` lens. Only applies when\n`#rust-analyzer.lens.enable#` is set.",
                     "default": true,

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -115,6 +115,7 @@ export class Config {
             typeHints: this.get<boolean>("inlayHints.typeHints"),
             parameterHints: this.get<boolean>("inlayHints.parameterHints"),
             chainingHints: this.get<boolean>("inlayHints.chainingHints"),
+            smallerHints: this.get<boolean>("inlayHints.smallerHints"),
             maxLength: this.get<null | number>("inlayHints.maxLength"),
         };
     }

--- a/editors/code/src/inlay_hints.ts
+++ b/editors/code/src/inlay_hints.ts
@@ -5,6 +5,11 @@ import * as ra from './lsp_ext';
 import { Ctx, Disposable } from './ctx';
 import { sendRequestWithRetry, isRustDocument, RustDocument, RustEditor, sleep } from './util';
 
+interface InlayHintStyle {
+    decorationType: vscode.TextEditorDecorationType;
+    toDecoration(hint: ra.InlayHint, conv: lc.Protocol2CodeConverter): vscode.DecorationOptions;
+};
+
 
 export function activateInlayHints(ctx: Ctx) {
     const maybeUpdater = {
@@ -19,6 +24,7 @@ export function activateInlayHints(ctx: Ctx) {
 
             await sleep(100);
             if (this.updater) {
+                this.updater.updateInlayHintsStyles();
                 this.updater.syncCacheAndRenderHints();
             } else {
                 this.updater = new HintsUpdater(ctx);
@@ -39,11 +45,7 @@ export function activateInlayHints(ctx: Ctx) {
     maybeUpdater.onConfigChange().catch(console.error);
 }
 
-const typeHints = createHintStyle("type");
-const paramHints = createHintStyle("parameter");
-const chainingHints = createHintStyle("chaining");
-
-function createHintStyle(hintKind: "type" | "parameter" | "chaining") {
+function createHintStyle(ctx: Ctx, hintKind: "type" | "parameter" | "chaining"): InlayHintStyle {
     // U+200C is a zero-width non-joiner to prevent the editor from forming a ligature
     // between code and type hints
     const [pos, render] = ({
@@ -51,6 +53,8 @@ function createHintStyle(hintKind: "type" | "parameter" | "chaining") {
         parameter: ["before", (label: string) => `${label}: `],
         chaining: ["after", (label: string) => `\u{200c}: ${label}`],
     } as const)[hintKind];
+
+    const smallerHints = ctx.config.inlayHints.smallerHints;
 
     const fg = new vscode.ThemeColor(`rust_analyzer.inlayHints.foreground.${hintKind}Hints`);
     const bg = new vscode.ThemeColor(`rust_analyzer.inlayHints.background.${hintKind}Hints`);
@@ -61,7 +65,7 @@ function createHintStyle(hintKind: "type" | "parameter" | "chaining") {
                 backgroundColor: bg,
                 fontStyle: "normal",
                 fontWeight: "normal",
-                textDecoration: ";font-size:smaller",
+                textDecoration: smallerHints ? ";font-size:smaller" : "none",
             },
         }),
         toDecoration(hint: ra.InlayHint, conv: lc.Protocol2CodeConverter): vscode.DecorationOptions {
@@ -76,6 +80,11 @@ function createHintStyle(hintKind: "type" | "parameter" | "chaining") {
 class HintsUpdater implements Disposable {
     private sourceFiles = new Map<string, RustSourceFile>(); // map Uri -> RustSourceFile
     private readonly disposables: Disposable[] = [];
+    private inlayHintsStyles!: {
+        typeHints: InlayHintStyle;
+        paramHints: InlayHintStyle;
+        chainingHints: InlayHintStyle;
+    };
 
     constructor(private readonly ctx: Ctx) {
         vscode.window.onDidChangeVisibleTextEditors(
@@ -100,6 +109,7 @@ class HintsUpdater implements Disposable {
             }
         ));
 
+        this.updateInlayHintsStyles();
         this.syncCacheAndRenderHints();
     }
 
@@ -112,6 +122,17 @@ class HintsUpdater implements Disposable {
     onDidChangeTextDocument({ contentChanges, document }: vscode.TextDocumentChangeEvent) {
         if (contentChanges.length === 0 || !isRustDocument(document)) return;
         this.syncCacheAndRenderHints();
+    }
+
+    updateInlayHintsStyles() {
+        this.inlayHintsStyles?.typeHints.decorationType.dispose();
+        this.inlayHintsStyles?.paramHints.decorationType.dispose();
+        this.inlayHintsStyles?.chainingHints.decorationType.dispose();
+        this.inlayHintsStyles = {
+            typeHints: createHintStyle(this.ctx, "type"),
+            paramHints: createHintStyle(this.ctx, "parameter"),
+            chainingHints: createHintStyle(this.ctx, "chaining"),
+        };
     }
 
     syncCacheAndRenderHints() {
@@ -161,12 +182,14 @@ class HintsUpdater implements Disposable {
     }
 
     private renderDecorations(editor: RustEditor, decorations: InlaysDecorations) {
+        const { typeHints, paramHints, chainingHints } = this.inlayHintsStyles;
         editor.setDecorations(typeHints.decorationType, decorations.type);
         editor.setDecorations(paramHints.decorationType, decorations.param);
         editor.setDecorations(chainingHints.decorationType, decorations.chaining);
     }
 
     private hintsToDecorations(hints: ra.InlayHint[]): InlaysDecorations {
+        const { typeHints, paramHints, chainingHints } = this.inlayHintsStyles;
         const decorations: InlaysDecorations = { type: [], param: [], chaining: [] };
         const conv = this.ctx.client.protocol2CodeConverter;
 


### PR DESCRIPTION
As requested on issue #6883 this PR provides an option for users to opt out of the smaller font size for inlay hints. Part of #6883.