### PR TITLE
internal: Use more cross-platform utc `date` argument

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -261,7 +261,7 @@ jobs:
       with:
         node-version: 12.x
 
-    - run: echo "TAG=$(date --iso --utc)" >> $GITHUB_ENV
+    - run: echo "TAG=$(date --iso -u)" >> $GITHUB_ENV
       if: github.ref == 'refs/heads/release'
     - run: echo "TAG=nightly" >> $GITHUB_ENV
       if: github.ref != 'refs/heads/release'

--- a/crates/rust-analyzer/build.rs
+++ b/crates/rust-analyzer/build.rs
@@ -55,7 +55,7 @@ fn commit_hash() -> Option<String> {
 }
 
 fn build_date() -> Option<String> {
-    output_to_string("date --utc +%Y-%m-%d")
+    output_to_string("date -u +%Y-%m-%d")
 }
 
 fn output_to_string(command: &str) -> Option<String> {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -108,7 +108,7 @@ fn run_fuzzer() -> Result<()> {
 }
 
 fn date_iso() -> Result<String> {
-    let res = cmd!("date --utc +%Y-%m-%d").read()?;
+    let res = cmd!("date -u +%Y-%m-%d").read()?;
     Ok(res)
 }
 


### PR DESCRIPTION
Part of https://github.com/rust-analyzer/rust-analyzer/issues/8571

```
$ docker run -it --rm ubuntu:20.04 bash
root@7393d1e7bbad:/# date -u +%Y-%m-%d
2021-04-26
```

```
$ date -u +%Y-%m-%d
2021-04-26

$ uname -a
Darwin alaptop.local 20.3.0 Darwin Kernel Version 20.3.0: Thu Jan 21 00:07:06 PST 2021; root:xnu-7195.81.3~1/RELEASE_X86_64 x86_64
```

Some of the places where I've change this do not really require it (since macos bin would have failed with `--iso` param also), but I've changed them for consistency.