### PR TITLE
fix for #8664: Emit folding ranges for multi-line where clauses

### DIFF
--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -524,6 +524,7 @@ pub(crate) fn folding_range(
         | FoldKind::ArgList
         | FoldKind::Consts
         | FoldKind::Statics
+        | FoldKind::WhereClause
         | FoldKind::Array => None,
     };
 


### PR DESCRIPTION
#8664 

I added a test that assert folding multi-line where clauses while leaving single lined one. Please, let me know if the code needs further improvements.