### PR TITLE
Replace `memmap` with `memmap2` in `proc_macro_api`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,16 +903,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
-name = "memmap"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "memmap2"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1174,7 +1164,7 @@ dependencies = [
  "crossbeam-channel",
  "jod-thread",
  "log",
- "memmap",
+ "memmap2",
  "object",
  "profile",
  "serde",

--- a/crates/proc_macro_api/Cargo.toml
+++ b/crates/proc_macro_api/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { version = "1.0", features = ["unbounded_depth"] }
 log = "0.4.8"
 crossbeam-channel = "0.5.0"
 jod-thread = "0.1.1"
-memmap = "0.7.0"
+memmap2 = "0.2.0"
 object = { version = "0.23.0", default-features = false, features = ["std", "read_core", "elf", "macho", "pe", "unaligned"] }
 snap = "1.0"
 

--- a/crates/proc_macro_api/src/version.rs
+++ b/crates/proc_macro_api/src/version.rs
@@ -6,7 +6,7 @@ use std::{
     path::Path,
 };
 
-use memmap::Mmap;
+use memmap2::Mmap;
 use object::read::{File as BinaryFile, Object, ObjectSection};
 use snap::read::FrameDecoder as SnapDecoder;
 


### PR DESCRIPTION
#7522 did the same for `proc_macro_srv` before this usage of `memmap` was introduced to `proc_macro_api` in #6822 .

Something like [`cargo-deny`](https://github.com/EmbarkStudios/cargo-deny-action) could help prevent specific crates (and versions, licenses, etc) from being introduced into the crate tree, but that's unrelated to this pull request.

