### PR TITLE
Add `:` and `=` to pattern parser recovery

### DIFF
--- a/crates/parser/src/grammar/patterns.rs
+++ b/crates/parser/src/grammar/patterns.rs
@@ -83,7 +83,7 @@ fn pattern_single_r(p: &mut Parser, recovery_set: TokenSet) {
 }
 
 const PAT_RECOVERY_SET: TokenSet =
-    TokenSet::new(&[T![let], T![if], T![while], T![loop], T![match], T![')'], T![,]]);
+    TokenSet::new(&[T![let], T![if], T![while], T![loop], T![match], T![')'], T![,], T![:], T![=]]);
 
 fn atom_pat(p: &mut Parser, recovery_set: TokenSet) -> Option<CompletedMarker> {
     let m = match p.nth(0) {


### PR DESCRIPTION
I noticed that malformed let statements result in rather odd trees, namely ones that are missing the pattern like
`let = 3;`:
```
LET_STMT@1393..1398
  LET_KW@1393..1396 "let"
  WHITESPACE@1396..1397 " "
  ERROR@1397..1398
    EQ@1397..1398 "="
WHITESPACE@1398..1399 " "
EXPR_STMT@1399..1401
  LITERAL@1399..1400
    INT_NUMBER@1399..1400 "3"
  SEMICOLON@1400..1401 ";"
```
and `let : usize;`
```
LET_STMT@1393..1398
  LET_KW@1393..1396 "let"
  WHITESPACE@1396..1397 " "
  ERROR@1397..1398
    COLON@1397..1398 ":"
EXPR_STMT@1398..1404
  PATH_EXPR@1398..1403
    PATH@1398..1403
      PATH_SEGMENT@1398..1403
        NAME_REF@1398..1403
          IDENT@1398..1403 "usize"
  SEMICOLON@1403..1404 ";"
```
These errors cause the initializer/type ascription to disconnect.

With this let statements and function parameters recover properly, I don't think this should have any problematic side effects?

I noticed this when trying to enhance the `expected_type` logic in completions which can't really work with these broken trees to extract out the type info.