### PR TITLE
Support goto_type_definition for types

### DIFF
--- a/crates/ide/src/goto_type_definition.rs
+++ b/crates/ide/src/goto_type_definition.rs
@@ -30,6 +30,7 @@ pub(crate) fn goto_type_definition(
                 ast::Expr(it) => sema.type_of_expr(&it)?,
                 ast::Pat(it) => sema.type_of_pat(&it)?,
                 ast::SelfParam(it) => sema.type_of_self(&it)?,
+                ast::Type(it) => sema.resolve_type(&it)?,
                 _ => return None,
             }
         };
@@ -146,6 +147,17 @@ struct Foo;
 impl Foo {
     fn f(&self$0) {}
 }
+"#,
+        )
+    }
+
+    #[test]
+    fn goto_def_for_type_fallback() {
+        check(
+            r#"
+struct Foo;
+     //^^^
+impl Foo$0 {}
 "#,
         )
     }


### PR DESCRIPTION
I'm unsure if the approach of lowering an `ast::Type` to a `hir::Type` is a good idea, it seems fine to me at least.
Fixes #2882