### PR TITLE
Don't store call-site text offsets in hygiene info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,5 @@ debug = 0 # Set this to 1 or 2 to get more useful backtraces in debugger.
 # chalk-recursive = { path = "../chalk/chalk-recursive" }
 
 # ungrammar = { path = "../ungrammar" }
+
+# salsa = { path = "../salsa" }

--- a/crates/hir/src/attrs.rs
+++ b/crates/hir/src/attrs.rs
@@ -112,7 +112,7 @@ fn resolve_doc_path(
         AttrDefId::MacroDefId(_) => return None,
     };
     let path = ast::Path::parse(link).ok()?;
-    let modpath = ModPath::from_src(path, &Hygiene::new_unhygienic()).unwrap();
+    let modpath = ModPath::from_src(db.upcast(), path, &Hygiene::new_unhygienic()).unwrap();
     let resolved = resolver.resolve_module_path_in_items(db.upcast(), &modpath);
     if resolved == PerNs::none() {
         if let Some(trait_id) = resolver.resolve_module_path_in_trait_items(db.upcast(), &modpath) {

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1666,7 +1666,7 @@ impl Impl {
             .value
             .attrs()
             .filter_map(|it| {
-                let path = ModPath::from_src(it.path()?, &hygenic)?;
+                let path = ModPath::from_src(db.upcast(), it.path()?, &hygenic)?;
                 if path.as_ident()?.to_string() == "derive" {
                     Some(it)
                 } else {

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -855,7 +855,7 @@ impl<'a> SemanticsScope<'a> {
     /// necessary a heuristic, as it doesn't take hygiene into account.
     pub fn speculative_resolve(&self, path: &ast::Path) -> Option<PathResolution> {
         let ctx = body::LowerCtx::new(self.db.upcast(), self.file_id);
-        let path = Path::from_src(self.db.upcast(), path.clone(), &ctx)?;
+        let path = Path::from_src(path.clone(), &ctx)?;
         resolve_hir_path(self.db, &self.resolver, &path)
     }
 }

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -855,7 +855,7 @@ impl<'a> SemanticsScope<'a> {
     /// necessary a heuristic, as it doesn't take hygiene into account.
     pub fn speculative_resolve(&self, path: &ast::Path) -> Option<PathResolution> {
         let ctx = body::LowerCtx::new(self.db.upcast(), self.file_id);
-        let path = Path::from_src(path.clone(), &ctx)?;
+        let path = Path::from_src(self.db.upcast(), path.clone(), &ctx)?;
         resolve_hir_path(self.db, &self.resolver, &path)
     }
 }

--- a/crates/hir/src/source_analyzer.rs
+++ b/crates/hir/src/source_analyzer.rs
@@ -204,7 +204,8 @@ impl SourceAnalyzer {
         macro_call: InFile<&ast::MacroCall>,
     ) -> Option<MacroDef> {
         let ctx = body::LowerCtx::new(db.upcast(), macro_call.file_id);
-        let path = macro_call.value.path().and_then(|ast| Path::from_src(ast, &ctx))?;
+        let path =
+            macro_call.value.path().and_then(|ast| Path::from_src(db.upcast(), ast, &ctx))?;
         self.resolver.resolve_path_as_macro(db.upcast(), path.mod_path()).map(|it| it.into())
     }
 
@@ -283,8 +284,8 @@ impl SourceAnalyzer {
 
         // This must be a normal source file rather than macro file.
         let hygiene = Hygiene::new(db.upcast(), self.file_id);
-        let ctx = body::LowerCtx::with_hygiene(&hygiene);
-        let hir_path = Path::from_src(path.clone(), &ctx)?;
+        let ctx = body::LowerCtx::with_hygiene(db.upcast(), &hygiene);
+        let hir_path = Path::from_src(db.upcast(), path.clone(), &ctx)?;
 
         // Case where path is a qualifier of another path, e.g. foo::bar::Baz where we
         // trying to resolve foo::bar.

--- a/crates/hir/src/source_analyzer.rs
+++ b/crates/hir/src/source_analyzer.rs
@@ -204,8 +204,7 @@ impl SourceAnalyzer {
         macro_call: InFile<&ast::MacroCall>,
     ) -> Option<MacroDef> {
         let ctx = body::LowerCtx::new(db.upcast(), macro_call.file_id);
-        let path =
-            macro_call.value.path().and_then(|ast| Path::from_src(db.upcast(), ast, &ctx))?;
+        let path = macro_call.value.path().and_then(|ast| Path::from_src(ast, &ctx))?;
         self.resolver.resolve_path_as_macro(db.upcast(), path.mod_path()).map(|it| it.into())
     }
 
@@ -285,7 +284,7 @@ impl SourceAnalyzer {
         // This must be a normal source file rather than macro file.
         let hygiene = Hygiene::new(db.upcast(), self.file_id);
         let ctx = body::LowerCtx::with_hygiene(db.upcast(), &hygiene);
-        let hir_path = Path::from_src(db.upcast(), path.clone(), &ctx)?;
+        let hir_path = Path::from_src(path.clone(), &ctx)?;
 
         // Case where path is a qualifier of another path, e.g. foo::bar::Baz where we
         // trying to resolve foo::bar.

--- a/crates/hir_def/src/body.rs
+++ b/crates/hir_def/src/body.rs
@@ -72,7 +72,7 @@ impl CfgExpander {
     }
 
     pub(crate) fn parse_attrs(&self, db: &dyn DefDatabase, owner: &dyn ast::AttrsOwner) -> Attrs {
-        RawAttrs::new(owner, &self.hygiene).filter(db, self.krate)
+        RawAttrs::new(db, owner, &self.hygiene).filter(db, self.krate)
     }
 
     pub(crate) fn is_cfg_enabled(&self, db: &dyn DefDatabase, owner: &dyn ast::AttrsOwner) -> bool {
@@ -192,9 +192,9 @@ impl Expander {
         self.current_file_id
     }
 
-    fn parse_path(&mut self, path: ast::Path) -> Option<Path> {
-        let ctx = LowerCtx::with_hygiene(&self.cfg_expander.hygiene);
-        Path::from_src(path, &ctx)
+    fn parse_path(&mut self, db: &dyn DefDatabase, path: ast::Path) -> Option<Path> {
+        let ctx = LowerCtx::with_hygiene(db, &self.cfg_expander.hygiene);
+        Path::from_src(db, path, &ctx)
     }
 
     fn resolve_path_as_macro(&self, db: &dyn DefDatabase, path: &ModPath) -> Option<MacroDefId> {

--- a/crates/hir_def/src/body.rs
+++ b/crates/hir_def/src/body.rs
@@ -194,7 +194,7 @@ impl Expander {
 
     fn parse_path(&mut self, db: &dyn DefDatabase, path: ast::Path) -> Option<Path> {
         let ctx = LowerCtx::with_hygiene(db, &self.cfg_expander.hygiene);
-        Path::from_src(db, path, &ctx)
+        Path::from_src(path, &ctx)
     }
 
     fn resolve_path_as_macro(&self, db: &dyn DefDatabase, path: &ModPath) -> Option<MacroDefId> {

--- a/crates/hir_def/src/body/lower.rs
+++ b/crates/hir_def/src/body/lower.rs
@@ -41,7 +41,7 @@ use crate::{
 use super::{diagnostics::BodyDiagnostic, ExprSource, PatSource};
 
 pub struct LowerCtx<'a> {
-    db: &'a dyn DefDatabase,
+    pub db: &'a dyn DefDatabase,
     hygiene: Hygiene,
     file_id: Option<HirFileId>,
     source_ast_id_map: Option<Arc<AstIdMap>>,
@@ -70,7 +70,7 @@ impl<'a> LowerCtx<'a> {
     }
 
     pub(crate) fn lower_path(&self, ast: ast::Path) -> Option<Path> {
-        Path::from_src(self.db, ast, self)
+        Path::from_src(ast, self)
     }
 
     pub(crate) fn ast_id<N: AstNode>(&self, item: &N) -> Option<FileAstId<N>> {

--- a/crates/hir_def/src/find_path.rs
+++ b/crates/hir_def/src/find_path.rs
@@ -386,7 +386,7 @@ mod tests {
         let parsed_path_file = syntax::SourceFile::parse(&format!("use {};", path));
         let ast_path =
             parsed_path_file.syntax_node().descendants().find_map(syntax::ast::Path::cast).unwrap();
-        let mod_path = ModPath::from_src(ast_path, &Hygiene::new_unhygienic()).unwrap();
+        let mod_path = ModPath::from_src(&db, ast_path, &Hygiene::new_unhygienic()).unwrap();
 
         let def_map = module.def_map(&db);
         let resolved = def_map

--- a/crates/hir_def/src/item_tree.rs
+++ b/crates/hir_def/src/item_tree.rs
@@ -88,7 +88,7 @@ impl ItemTree {
         let mut item_tree = match_ast! {
             match syntax {
                 ast::SourceFile(file) => {
-                    top_attrs = Some(RawAttrs::new(&file, &hygiene));
+                    top_attrs = Some(RawAttrs::new(db, &file, &hygiene));
                     ctx.lower_module_items(&file)
                 },
                 ast::MacroItems(items) => {

--- a/crates/hir_def/src/lib.rs
+++ b/crates/hir_def/src/lib.rs
@@ -654,7 +654,7 @@ impl AsMacroCall for InFile<&ast::MacroCall> {
     ) -> Result<Result<MacroCallId, ErrorEmitted>, UnresolvedMacro> {
         let ast_id = AstId::new(self.file_id, db.ast_id_map(self.file_id).ast_id(self.value));
         let h = Hygiene::new(db.upcast(), self.file_id);
-        let path = self.value.path().and_then(|path| path::ModPath::from_src(path, &h));
+        let path = self.value.path().and_then(|path| path::ModPath::from_src(db, path, &h));
 
         let path = match error_sink
             .option(path, || mbe::ExpandError::Other("malformed macro invocation".into()))
@@ -712,7 +712,7 @@ fn macro_call_as_call_id(
             krate,
             macro_call,
             def,
-            &|path: ast::Path| resolver(path::ModPath::from_src(path, &hygiene)?),
+            &|path: ast::Path| resolver(path::ModPath::from_src(db, path, &hygiene)?),
             error_sink,
         )
         .map(MacroCallId::from)

--- a/crates/hir_def/src/nameres.rs
+++ b/crates/hir_def/src/nameres.rs
@@ -599,6 +599,7 @@ mod diagnostics {
                     let mut cur = 0;
                     let mut tree = None;
                     ModPath::expand_use_item(
+                        db,
                         InFile::new(ast.file_id, use_item),
                         &hygiene,
                         |_mod_path, use_tree, _is_glob, _alias| {

--- a/crates/hir_def/src/nameres/tests/incremental.rs
+++ b/crates/hir_def/src/nameres/tests/incremental.rs
@@ -107,7 +107,7 @@ fn typing_inside_a_macro_should_not_invalidate_def_map() {
 }
 
 #[test]
-fn typing_inside_a_function_doe_should_not_invalidate_expansions() {
+fn typing_inside_a_function_should_not_invalidate_expansions() {
     let (mut db, pos) = TestDB::with_position(
         r#"
 //- /lib.rs

--- a/crates/hir_def/src/path.rs
+++ b/crates/hir_def/src/path.rs
@@ -49,7 +49,7 @@ pub enum ImportAlias {
 impl ModPath {
     pub fn from_src(db: &dyn DefDatabase, path: ast::Path, hygiene: &Hygiene) -> Option<ModPath> {
         let ctx = LowerCtx::with_hygiene(db, hygiene);
-        lower::lower_path(db, path, &ctx).map(|it| (*it.mod_path).clone())
+        lower::lower_path(path, &ctx).map(|it| (*it.mod_path).clone())
     }
 
     pub fn from_segments(kind: PathKind, segments: impl IntoIterator<Item = Name>) -> ModPath {
@@ -169,8 +169,8 @@ pub enum GenericArg {
 impl Path {
     /// Converts an `ast::Path` to `Path`. Works with use trees.
     /// It correctly handles `$crate` based path from macro call.
-    pub fn from_src(db: &dyn DefDatabase, path: ast::Path, ctx: &LowerCtx) -> Option<Path> {
-        lower::lower_path(db, path, ctx)
+    pub fn from_src(path: ast::Path, ctx: &LowerCtx) -> Option<Path> {
+        lower::lower_path(path, ctx)
     }
 
     /// Converts a known mod path to `Path`.

--- a/crates/hir_def/src/path.rs
+++ b/crates/hir_def/src/path.rs
@@ -7,7 +7,7 @@ use std::{
     sync::Arc,
 };
 
-use crate::{body::LowerCtx, intern::Interned, type_ref::LifetimeRef};
+use crate::{body::LowerCtx, db::DefDatabase, intern::Interned, type_ref::LifetimeRef};
 use base_db::CrateId;
 use hir_expand::{
     hygiene::Hygiene,
@@ -47,9 +47,9 @@ pub enum ImportAlias {
 }
 
 impl ModPath {
-    pub fn from_src(path: ast::Path, hygiene: &Hygiene) -> Option<ModPath> {
-        let ctx = LowerCtx::with_hygiene(hygiene);
-        lower::lower_path(path, &ctx).map(|it| (*it.mod_path).clone())
+    pub fn from_src(db: &dyn DefDatabase, path: ast::Path, hygiene: &Hygiene) -> Option<ModPath> {
+        let ctx = LowerCtx::with_hygiene(db, hygiene);
+        lower::lower_path(db, path, &ctx).map(|it| (*it.mod_path).clone())
     }
 
     pub fn from_segments(kind: PathKind, segments: impl IntoIterator<Item = Name>) -> ModPath {
@@ -64,12 +64,13 @@ impl ModPath {
 
     /// Calls `cb` with all paths, represented by this use item.
     pub(crate) fn expand_use_item(
+        db: &dyn DefDatabase,
         item_src: InFile<ast::Use>,
         hygiene: &Hygiene,
         mut cb: impl FnMut(ModPath, &ast::UseTree, /* is_glob */ bool, Option<ImportAlias>),
     ) {
         if let Some(tree) = item_src.value.use_tree() {
-            lower::lower_use_tree(None, tree, hygiene, &mut cb);
+            lower::lower_use_tree(db, None, tree, hygiene, &mut cb);
         }
     }
 
@@ -168,8 +169,8 @@ pub enum GenericArg {
 impl Path {
     /// Converts an `ast::Path` to `Path`. Works with use trees.
     /// It correctly handles `$crate` based path from macro call.
-    pub fn from_src(path: ast::Path, ctx: &LowerCtx) -> Option<Path> {
-        lower::lower_path(path, ctx)
+    pub fn from_src(db: &dyn DefDatabase, path: ast::Path, ctx: &LowerCtx) -> Option<Path> {
+        lower::lower_path(db, path, ctx)
     }
 
     /// Converts a known mod path to `Path`.

--- a/crates/hir_def/src/path/lower.rs
+++ b/crates/hir_def/src/path/lower.rs
@@ -2,7 +2,7 @@
 
 mod lower_use;
 
-use crate::{db::DefDatabase, intern::Interned};
+use crate::intern::Interned;
 use std::sync::Arc;
 
 use either::Either;
@@ -20,11 +20,7 @@ pub(super) use lower_use::lower_use_tree;
 
 /// Converts an `ast::Path` to `Path`. Works with use trees.
 /// It correctly handles `$crate` based path from macro call.
-pub(super) fn lower_path(
-    db: &dyn DefDatabase,
-    mut path: ast::Path,
-    ctx: &LowerCtx,
-) -> Option<Path> {
+pub(super) fn lower_path(mut path: ast::Path, ctx: &LowerCtx) -> Option<Path> {
     let mut kind = PathKind::Plain;
     let mut type_anchor = None;
     let mut segments = Vec::new();
@@ -40,7 +36,7 @@ pub(super) fn lower_path(
         match segment.kind()? {
             ast::PathSegmentKind::Name(name_ref) => {
                 // FIXME: this should just return name
-                match hygiene.name_ref_to_name(db.upcast(), name_ref) {
+                match hygiene.name_ref_to_name(ctx.db.upcast(), name_ref) {
                     Either::Left(name) => {
                         let args = segment
                             .generic_arg_list()
@@ -75,7 +71,7 @@ pub(super) fn lower_path(
                     }
                     // <T as Trait<A>>::Foo desugars to Trait<Self=T, A>::Foo
                     Some(trait_ref) => {
-                        let path = Path::from_src(db, trait_ref.path()?, ctx)?;
+                        let path = Path::from_src(trait_ref.path()?, ctx)?;
                         let mod_path = (*path.mod_path).clone();
                         let num_segments = path.mod_path.segments.len();
                         kind = mod_path.kind;
@@ -137,7 +133,7 @@ pub(super) fn lower_path(
     // We follow what it did anyway :)
     if segments.len() == 1 && kind == PathKind::Plain {
         if let Some(_macro_call) = path.syntax().parent().and_then(ast::MacroCall::cast) {
-            if let Some(crate_id) = hygiene.local_inner_macros(db.upcast(), path) {
+            if let Some(crate_id) = hygiene.local_inner_macros(ctx.db.upcast(), path) {
                 kind = PathKind::DollarCrate(crate_id);
             }
         }

--- a/crates/hir_def/src/visibility.rs
+++ b/crates/hir_def/src/visibility.rs
@@ -33,17 +33,19 @@ impl RawVisibility {
         db: &dyn DefDatabase,
         node: InFile<Option<ast::Visibility>>,
     ) -> RawVisibility {
-        Self::from_ast_with_hygiene(node.value, &Hygiene::new(db.upcast(), node.file_id))
+        Self::from_ast_with_hygiene(db, node.value, &Hygiene::new(db.upcast(), node.file_id))
     }
 
     pub(crate) fn from_ast_with_hygiene(
+        db: &dyn DefDatabase,
         node: Option<ast::Visibility>,
         hygiene: &Hygiene,
     ) -> RawVisibility {
-        Self::from_ast_with_hygiene_and_default(node, RawVisibility::private(), hygiene)
+        Self::from_ast_with_hygiene_and_default(db, node, RawVisibility::private(), hygiene)
     }
 
     pub(crate) fn from_ast_with_hygiene_and_default(
+        db: &dyn DefDatabase,
         node: Option<ast::Visibility>,
         default: RawVisibility,
         hygiene: &Hygiene,
@@ -54,7 +56,7 @@ impl RawVisibility {
         };
         match node.kind() {
             ast::VisibilityKind::In(path) => {
-                let path = ModPath::from_src(path, hygiene);
+                let path = ModPath::from_src(db, path, hygiene);
                 let path = match path {
                     None => return RawVisibility::private(),
                     Some(path) => path,

--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -1002,7 +1002,7 @@ impl HirDisplay for TypeRef {
                 let macro_call = macro_call.to_node(f.db.upcast());
                 let ctx = body::LowerCtx::with_hygiene(f.db.upcast(), &Hygiene::new_unhygienic());
                 match macro_call.path() {
-                    Some(path) => match Path::from_src(f.db.upcast(), path, &ctx) {
+                    Some(path) => match Path::from_src(path, &ctx) {
                         Some(path) => path.hir_fmt(f)?,
                         None => write!(f, "{{macro}}")?,
                     },

--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -1000,9 +1000,9 @@ impl HirDisplay for TypeRef {
             }
             TypeRef::Macro(macro_call) => {
                 let macro_call = macro_call.to_node(f.db.upcast());
-                let ctx = body::LowerCtx::with_hygiene(&Hygiene::new_unhygienic());
+                let ctx = body::LowerCtx::with_hygiene(f.db.upcast(), &Hygiene::new_unhygienic());
                 match macro_call.path() {
-                    Some(path) => match Path::from_src(path, &ctx) {
+                    Some(path) => match Path::from_src(f.db.upcast(), path, &ctx) {
                         Some(path) => path.hir_fmt(f)?,
                         None => write!(f, "{{macro}}")?,
                     },


### PR DESCRIPTION
This threads a lot more database references around in order to avoid storing a bare `TextOffset` in the hygiene info. This `TextOffset` made hygiene info and `ItemTree`s more volatile than they should be, leading to excessive recomputation of `ItemTree`s.

The incremental test added in https://github.com/rust-analyzer/rust-analyzer/pull/8721 is now passing with these changes.

closes https://github.com/rust-analyzer/rust-analyzer/pull/8721