### PR TITLE
fix: use raw idents in `make::{name, name_ref}` when used with a keyword

### DIFF
--- a/crates/ide/src/diagnostics.rs
+++ b/crates/ide/src/diagnostics.rs
@@ -654,6 +654,26 @@ fn test_fn() {
     }
 
     #[test]
+    fn test_fill_struct_fields_raw_ident() {
+        check_fix(
+            r#"
+struct TestStruct { r#type: u8 }
+
+fn test_fn() {
+    TestStruct { $0 };
+}
+"#,
+            r"
+struct TestStruct { r#type: u8 }
+
+fn test_fn() {
+    TestStruct { r#type: ()  };
+}
+",
+        );
+    }
+
+    #[test]
     fn test_fill_struct_fields_no_diagnostic() {
         check_no_diagnostics(
             r"

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -15,12 +15,22 @@ use stdx::format_to;
 use crate::{ast, AstNode, SourceFile, SyntaxKind, SyntaxNode, SyntaxToken};
 
 pub fn name(text: &str) -> ast::Name {
-    ast_from_text(&format!("mod {};", text))
+    ast_from_text(&format!("mod {}{};", raw_ident_esc(text), text))
 }
 
 pub fn name_ref(text: &str) -> ast::NameRef {
-    ast_from_text(&format!("fn f() {{ {}; }}", text))
+    ast_from_text(&format!("fn f() {{ {}{}; }}", raw_ident_esc(text), text))
 }
+
+fn raw_ident_esc(ident: &str) -> &'static str {
+    let is_keyword = parser::SyntaxKind::from_keyword(ident).is_some();
+    if is_keyword && !matches!(ident, "self" | "crate" | "super" | "Self") {
+        "r#"
+    } else {
+        ""
+    }
+}
+
 // FIXME: replace stringly-typed constructor with a family of typed ctors, a-la
 // `expr_xxx`.
 pub fn ty(text: &str) -> ast::Type {


### PR DESCRIPTION
fixes https://github.com/rust-analyzer/rust-analyzer/issues/8680

bors r+