### PR TITLE
Create a minimal form of issue reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,13 +10,28 @@ assignees: ''
 <!--
 Troubleshooting guide: https://rust-analyzer.github.io/manual.html#troubleshooting
 Forum for questions: https://users.rust-lang.org/c/ide/14
+-->
 
 Before submitting, please make sure that you're not running into one of these known issues:
 
- 1. on-the-fly diagnostics are mostly unimplemented (`cargo check` diagnostics will be shown when saving a file)
- 2. some platform-specific imports are not resolved: #6038
- 3. attribute proc macros are not supported: #6029
- 4. the version string is misleading (includes the previous week): #8571
+* [ ] on-the-fly diagnostics are mostly unimplemented (`cargo check` diagnostics will be shown when saving a file)
+* [ ] some platform-specific imports are not resolved: #6038
+* [ ] attribute proc macros are not supported: #6029
+* [ ] the version string is misleading (includes the previous week): #8571
 
+<!--
 Otherwise please try to provide information which will help us to fix the issue faster. Minimal reproducible examples with few dependencies are especially lovely <3.
 -->
+
+## System Information
+
+* **Operating System:** ...
+* **IDE/Editor:** ...
+* **rust-analyzer binary version:** ...
+* **Rust version:** ...
+
+## Steps to reproduce
+
+1. ...
+2. ...
+3. ...


### PR DESCRIPTION
When reporting new bugs, I find myself having to provide some information, but forget to provide some essential ones. Having a minimal form to fill would reduce the occurrences of such situations.