### PR TITLE
Escape characters in builtin macros correctly

### DIFF
--- a/crates/hir_expand/src/builtin_macro.rs
+++ b/crates/hir_expand/src/builtin_macro.rs
@@ -788,9 +788,9 @@ mod tests {
             r##"
             #[rustc_builtin_macro]
             macro_rules! concat {}
-            concat!("foo", "r", 0, r#"bar"#, false);
+            concat!("foo", "r", 0, r#"bar"#, "\n", false);
             "##,
-            expect![[r#""foor0barfalse""#]],
+            expect![[r#""foor0bar\nfalse""#]],
         );
     }
 }

--- a/crates/hir_expand/src/quote.rs
+++ b/crates/hir_expand/src/quote.rs
@@ -196,8 +196,8 @@ impl_to_to_tokentrees! {
     tt::Literal => self { self };
     tt::Ident => self { self };
     tt::Punct => self { self };
-    &str => self { tt::Literal{text: format!("{:?}", self.escape_default().to_string()).into(), id: tt::TokenId::unspecified()}};
-    String => self { tt::Literal{text: format!("{:?}", self.escape_default().to_string()).into(), id: tt::TokenId::unspecified()}}
+    &str => self { tt::Literal{text: format!("\"{}\"", self.escape_debug()).into(), id: tt::TokenId::unspecified()}};
+    String => self { tt::Literal{text: format!("\"{}\"", self.escape_debug()).into(), id: tt::TokenId::unspecified()}}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #8749

It is the same bug in #8560 but in our `quote!` macro. 

Because the "\\" are added exponentially in #8749 case, so the text just eat up all the memory. 

bors r+

