### PR TITLE
feat: Allow viewing the crate graph in a webview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,6 +320,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc4b29f4b9bb94bf267d57269fd0706d343a160937108e9619fe380645428abb"
 
 [[package]]
+name = "dot"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74b6c4d4a1cff5f454164363c16b72fa12463ca6b31f4b5f2035a65fa3d5906"
+
+[[package]]
 name = "drop_bomb"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,6 +594,7 @@ version = "0.0.0"
 dependencies = [
  "cfg",
  "cov-mark",
+ "dot",
  "either",
  "expect-test",
  "hir",

--- a/crates/ide/Cargo.toml
+++ b/crates/ide/Cargo.toml
@@ -20,6 +20,7 @@ oorandom = "11.1.2"
 pulldown-cmark-to-cmark = "6.0.0"
 pulldown-cmark = { version = "0.8.0", default-features = false }
 url = "2.1.1"
+dot = "0.1.4"
 
 stdx = { path = "../stdx", version = "0.0.0" }
 syntax = { path = "../syntax", version = "0.0.0" }

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -49,6 +49,7 @@ mod syntax_tree;
 mod typing;
 mod markdown_remove;
 mod doc_links;
+mod view_crate_graph;
 
 use std::sync::Arc;
 
@@ -285,6 +286,10 @@ impl Analysis {
 
     pub fn view_hir(&self, position: FilePosition) -> Cancelable<String> {
         self.with_db(|db| view_hir::view_hir(&db, position))
+    }
+
+    pub fn view_crate_graph(&self) -> Cancelable<Result<String, String>> {
+        self.with_db(|db| view_crate_graph::view_crate_graph(&db))
     }
 
     pub fn expand_macro(&self, position: FilePosition) -> Cancelable<Option<ExpandedMacro>> {

--- a/crates/ide/src/view_crate_graph.rs
+++ b/crates/ide/src/view_crate_graph.rs
@@ -1,0 +1,81 @@
+use std::{
+    error::Error,
+    io::{Read, Write},
+    process::{Command, Stdio},
+    sync::Arc,
+};
+
+use dot::Id;
+use ide_db::{
+    base_db::{CrateGraph, CrateId, Dependency, SourceDatabase},
+    RootDatabase,
+};
+
+// Feature: View Crate Graph
+//
+// Renders the currently loaded crate graph as an SVG graphic. Requires the `dot` tool to be
+// installed.
+//
+// |===
+// | Editor  | Action Name
+//
+// | VS Code | **Rust Analyzer: View Crate Graph**
+// |===
+pub(crate) fn view_crate_graph(db: &RootDatabase) -> Result<String, String> {
+    let mut dot = Vec::new();
+    let graph = DotCrateGraph(db.crate_graph());
+    dot::render(&graph, &mut dot).unwrap();
+
+    render_svg(&dot).map_err(|e| e.to_string())
+}
+
+fn render_svg(dot: &[u8]) -> Result<String, Box<dyn Error>> {
+    // We shell out to `dot` to render to SVG, as there does not seem to be a pure-Rust renderer.
+    let child = Command::new("dot")
+        .arg("-Tsvg")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .map_err(|err| format!("failed to spawn `dot -Tsvg`: {}", err))?;
+    child.stdin.unwrap().write_all(&dot)?;
+
+    let mut svg = String::new();
+    child.stdout.unwrap().read_to_string(&mut svg)?;
+    Ok(svg)
+}
+
+struct DotCrateGraph(Arc<CrateGraph>);
+
+type Edge<'a> = (CrateId, &'a Dependency);
+
+impl<'a> dot::GraphWalk<'a, CrateId, Edge<'a>> for DotCrateGraph {
+    fn nodes(&'a self) -> dot::Nodes<'a, CrateId> {
+        self.0.iter().collect()
+    }
+
+    fn edges(&'a self) -> dot::Edges<'a, Edge<'a>> {
+        self.0
+            .iter()
+            .flat_map(|krate| self.0[krate].dependencies.iter().map(move |dep| (krate, dep)))
+            .collect()
+    }
+
+    fn source(&'a self, edge: &Edge<'a>) -> CrateId {
+        edge.0
+    }
+
+    fn target(&'a self, edge: &Edge<'a>) -> CrateId {
+        edge.1.crate_id
+    }
+}
+
+impl<'a> dot::Labeller<'a, CrateId, Edge<'a>> for DotCrateGraph {
+    fn graph_id(&'a self) -> Id<'a> {
+        Id::new("rust_analyzer_crate_graph").unwrap()
+    }
+
+    fn node_id(&'a self, n: &CrateId) -> Id<'a> {
+        let name = self.0[*n].display_name.as_ref().map_or("_missing_name_", |name| &*name);
+        Id::new(name).unwrap()
+    }
+}

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -117,6 +117,12 @@ pub(crate) fn handle_view_hir(
     Ok(res)
 }
 
+pub(crate) fn handle_view_crate_graph(snap: GlobalStateSnapshot, (): ()) -> Result<String> {
+    let _p = profile::span("handle_view_crate_graph");
+    let res = snap.analysis.view_crate_graph()??;
+    Ok(res)
+}
+
 pub(crate) fn handle_expand_macro(
     snap: GlobalStateSnapshot,
     params: lsp_ext::ExpandMacroParams,

--- a/crates/rust-analyzer/src/lsp_ext.rs
+++ b/crates/rust-analyzer/src/lsp_ext.rs
@@ -61,6 +61,14 @@ impl Request for ViewHir {
     const METHOD: &'static str = "rust-analyzer/viewHir";
 }
 
+pub enum ViewCrateGraph {}
+
+impl Request for ViewCrateGraph {
+    type Params = ();
+    type Result = String;
+    const METHOD: &'static str = "rust-analyzer/viewCrateGraph";
+}
+
 pub enum ExpandMacro {}
 
 impl Request for ExpandMacro {

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -513,6 +513,7 @@ impl GlobalState {
             .on::<lsp_ext::AnalyzerStatus>(handlers::handle_analyzer_status)
             .on::<lsp_ext::SyntaxTree>(handlers::handle_syntax_tree)
             .on::<lsp_ext::ViewHir>(handlers::handle_view_hir)
+            .on::<lsp_ext::ViewCrateGraph>(handlers::handle_view_crate_graph)
             .on::<lsp_ext::ExpandMacro>(handlers::handle_expand_macro)
             .on::<lsp_ext::ParentModule>(handlers::handle_parent_module)
             .on::<lsp_ext::Runnables>(handlers::handle_runnables)

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -110,6 +110,11 @@
                 "category": "Rust Analyzer"
             },
             {
+                "command": "rust-analyzer.viewCrateGraph",
+                "title": "View Crate Graph",
+                "category": "Rust Analyzer"
+            },
+            {
                 "command": "rust-analyzer.expandMacro",
                 "title": "Expand macro recursively",
                 "category": "Rust Analyzer"

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -429,6 +429,14 @@ export function viewHir(ctx: Ctx): Cmd {
     };
 }
 
+export function viewCrateGraph(ctx: Ctx): Cmd {
+    return async () => {
+        const panel = vscode.window.createWebviewPanel("rust-analyzer.crate-graph", "rust-analyzer crate graph", vscode.ViewColumn.Two);
+        const svg = await ctx.client.sendRequest(ra.viewCrateGraph);
+        panel.webview.html = svg;
+    };
+}
+
 // Opens the virtual file that will show the syntax tree
 //
 // The contents of the file come from the `TextDocumentContentProvider`

--- a/editors/code/src/lsp_ext.ts
+++ b/editors/code/src/lsp_ext.ts
@@ -27,6 +27,8 @@ export const syntaxTree = new lc.RequestType<SyntaxTreeParams, string, void>("ru
 
 export const viewHir = new lc.RequestType<lc.TextDocumentPositionParams, string, void>("rust-analyzer/viewHir");
 
+export const viewCrateGraph = new lc.RequestType0<string, void>("rust-analyzer/viewCrateGraph");
+
 export interface ExpandMacroParams {
     textDocument: lc.TextDocumentIdentifier;
     position: lc.Position;

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -106,6 +106,7 @@ async function tryActivate(context: vscode.ExtensionContext) {
     ctx.registerCommand('parentModule', commands.parentModule);
     ctx.registerCommand('syntaxTree', commands.syntaxTree);
     ctx.registerCommand('viewHir', commands.viewHir);
+    ctx.registerCommand('viewCrateGraph', commands.viewCrateGraph);
     ctx.registerCommand('expandMacro', commands.expandMacro);
     ctx.registerCommand('run', commands.run);
     ctx.registerCommand('copyRunCommandLine', commands.copyRunCommandLine);


### PR DESCRIPTION
It's... a little bit hard to make sense of the resulting graph, but I think that might be mostly because we duplicate dependency edges unnecessarily:

![screenshot-2021-05-11-16:13:06](https://user-images.githubusercontent.com/1786438/117830685-29131900-b274-11eb-9cff-e9029e74528e.png)

Here's a better example on a simple crate graph:

![screenshot-2021-05-11-16:19:32](https://user-images.githubusercontent.com/1786438/117831361-c4a48980-b274-11eb-9276-240cdf6919aa.png)
