### PR TITLE
fix: Strip delimiter from fn-like macro invocations

### DIFF
--- a/crates/hir_expand/src/lib.rs
+++ b/crates/hir_expand/src/lib.rs
@@ -272,6 +272,10 @@ impl MacroDefId {
         };
         Either::Left(*id)
     }
+
+    pub fn is_proc_macro(&self) -> bool {
+        matches!(self.kind, MacroDefKind::ProcMacro(..))
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]


### PR DESCRIPTION
This broke in https://github.com/rust-analyzer/rust-analyzer/pull/8796 (again), the fix is easy though

bors r+