### PR TITLE
Use Chalk for unification

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2223,8 +2223,8 @@ impl Type {
         walk_type(db, self, &mut cb);
     }
 
-    pub fn could_unify_with(&self, other: &Type) -> bool {
-        could_unify(&self.ty, &other.ty)
+    pub fn could_unify_with(&self, db: &dyn HirDatabase, other: &Type) -> bool {
+        could_unify(db, self.env.clone(), &self.ty, &other.ty)
     }
 }
 

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2051,11 +2051,7 @@ impl Type {
         name: Option<&Name>,
         mut callback: impl FnMut(&Ty, AssocItem) -> Option<T>,
     ) -> Option<T> {
-        // There should be no inference vars in types passed here
-        // FIXME check that?
-        // FIXME replace Unknown by bound vars here
-        let canonical =
-            Canonical { value: self.ty.clone(), binders: CanonicalVarKinds::empty(&Interner) };
+        let canonical = hir_ty::replace_errors_with_variables(self.ty.clone());
 
         let env = self.env.clone();
         let krate = krate.id;
@@ -2224,7 +2220,8 @@ impl Type {
     }
 
     pub fn could_unify_with(&self, db: &dyn HirDatabase, other: &Type) -> bool {
-        could_unify(db, self.env.clone(), &self.ty, &other.ty)
+        let tys = hir_ty::replace_errors_with_variables((self.ty.clone(), other.ty.clone()));
+        could_unify(db, self.env.clone(), &tys)
     }
 }
 

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1712,15 +1712,17 @@ impl Type {
         resolver: &Resolver,
         ty: Ty,
     ) -> Type {
-        let environment =
-            resolver.generic_def().map_or_else(Default::default, |d| db.trait_environment(d));
+        let environment = resolver
+            .generic_def()
+            .map_or_else(|| Arc::new(TraitEnvironment::empty(krate)), |d| db.trait_environment(d));
         Type { krate, env: environment, ty }
     }
 
     fn new(db: &dyn HirDatabase, krate: CrateId, lexical_env: impl HasResolver, ty: Ty) -> Type {
         let resolver = lexical_env.resolver(db.upcast());
-        let environment =
-            resolver.generic_def().map_or_else(Default::default, |d| db.trait_environment(d));
+        let environment = resolver
+            .generic_def()
+            .map_or_else(|| Arc::new(TraitEnvironment::empty(krate)), |d| db.trait_environment(d));
         Type { krate, env: environment, ty }
     }
 

--- a/crates/hir_ty/src/builder.rs
+++ b/crates/hir_ty/src/builder.rs
@@ -6,15 +6,15 @@ use chalk_ir::{
     cast::{Cast, CastTo, Caster},
     fold::Fold,
     interner::HasInterner,
-    AdtId, BoundVar, DebruijnIndex, Safety, Scalar,
+    AdtId, BoundVar, DebruijnIndex, Scalar,
 };
 use hir_def::{builtin_type::BuiltinType, GenericDefId, TraitId, TypeAliasId};
 use smallvec::SmallVec;
 
 use crate::{
     db::HirDatabase, primitive, to_assoc_type_id, to_chalk_trait_id, utils::generics, Binders,
-    CallableSig, FnPointer, FnSig, FnSubst, GenericArg, Interner, ProjectionTy, Substitution,
-    TraitRef, Ty, TyDefId, TyExt, TyKind, ValueTyDefId,
+    CallableSig, GenericArg, Interner, ProjectionTy, Substitution, TraitRef, Ty, TyDefId, TyExt,
+    TyKind, ValueTyDefId,
 };
 
 /// This is a builder for `Ty` or anything that needs a `Substitution`.

--- a/crates/hir_ty/src/builder.rs
+++ b/crates/hir_ty/src/builder.rs
@@ -77,15 +77,7 @@ impl TyBuilder<()> {
     }
 
     pub fn fn_ptr(sig: CallableSig) -> Ty {
-        TyKind::Function(FnPointer {
-            num_binders: 0,
-            sig: FnSig { abi: (), safety: Safety::Safe, variadic: sig.is_varargs },
-            substitution: FnSubst(Substitution::from_iter(
-                &Interner,
-                sig.params_and_return.iter().cloned(),
-            )),
-        })
-        .intern(&Interner)
+        TyKind::Function(sig.to_fn_ptr()).intern(&Interner)
     }
 
     pub fn builtin(builtin: BuiltinType) -> Ty {

--- a/crates/hir_ty/src/chalk_ext.rs
+++ b/crates/hir_ty/src/chalk_ext.rs
@@ -18,6 +18,7 @@ pub trait TyExt {
     fn is_unit(&self) -> bool;
     fn is_never(&self) -> bool;
     fn is_unknown(&self) -> bool;
+    fn is_ty_var(&self) -> bool;
 
     fn as_adt(&self) -> Option<(hir_def::AdtId, &Substitution)>;
     fn as_builtin(&self) -> Option<BuiltinType>;
@@ -53,6 +54,10 @@ impl TyExt for Ty {
 
     fn is_unknown(&self) -> bool {
         matches!(self.kind(&Interner), TyKind::Error)
+    }
+
+    fn is_ty_var(&self) -> bool {
+        matches!(self.kind(&Interner), TyKind::InferenceVar(_, _))
     }
 
     fn as_adt(&self) -> Option<(hir_def::AdtId, &Substitution)> {

--- a/crates/hir_ty/src/db.rs
+++ b/crates/hir_ty/src/db.rs
@@ -134,14 +134,14 @@ pub trait HirDatabase: DefDatabase + Upcast<dyn DefDatabase> {
     fn trait_solve(
         &self,
         krate: CrateId,
-        goal: crate::Canonical<crate::InEnvironment<crate::DomainGoal>>,
+        goal: crate::Canonical<crate::InEnvironment<crate::Goal>>,
     ) -> Option<crate::Solution>;
 
     #[salsa::invoke(crate::traits::trait_solve_query)]
     fn trait_solve_query(
         &self,
         krate: CrateId,
-        goal: crate::Canonical<crate::InEnvironment<crate::DomainGoal>>,
+        goal: crate::Canonical<crate::InEnvironment<crate::Goal>>,
     ) -> Option<crate::Solution>;
 
     #[salsa::invoke(chalk_db::program_clauses_for_chalk_env_query)]
@@ -168,7 +168,7 @@ fn infer_wait(db: &dyn HirDatabase, def: DefWithBodyId) -> Arc<InferenceResult> 
 fn trait_solve_wait(
     db: &dyn HirDatabase,
     krate: CrateId,
-    goal: crate::Canonical<crate::InEnvironment<crate::DomainGoal>>,
+    goal: crate::Canonical<crate::InEnvironment<crate::Goal>>,
 ) -> Option<crate::Solution> {
     let _p = profile::span("trait_solve::wait");
     db.trait_solve_query(krate, goal)

--- a/crates/hir_ty/src/db.rs
+++ b/crates/hir_ty/src/db.rs
@@ -117,10 +117,10 @@ pub trait HirDatabase: DefDatabase + Upcast<dyn DefDatabase> {
     fn fn_def_datum(&self, krate: CrateId, fn_def_id: FnDefId) -> Arc<chalk_db::FnDefDatum>;
 
     #[salsa::invoke(chalk_db::fn_def_variance_query)]
-    fn fn_def_variance(&self, krate: CrateId, fn_def_id: FnDefId) -> chalk_db::Variances;
+    fn fn_def_variance(&self, fn_def_id: FnDefId) -> chalk_db::Variances;
 
     #[salsa::invoke(chalk_db::adt_variance_query)]
-    fn adt_variance(&self, krate: CrateId, adt_id: chalk_db::AdtId) -> chalk_db::Variances;
+    fn adt_variance(&self, adt_id: chalk_db::AdtId) -> chalk_db::Variances;
 
     #[salsa::invoke(chalk_db::associated_ty_value_query)]
     fn associated_ty_value(

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -37,8 +37,8 @@ use syntax::SmolStr;
 use super::{DomainGoal, InEnvironment, ProjectionTy, TraitEnvironment, TraitRef, Ty};
 use crate::{
     db::HirDatabase, fold_tys, infer::diagnostics::InferenceDiagnostic,
-    lower::ImplTraitLoweringMode, to_assoc_type_id, AliasEq, AliasTy, Interner, TyBuilder, TyExt,
-    TyKind,
+    lower::ImplTraitLoweringMode, to_assoc_type_id, AliasEq, AliasTy, Goal, Interner, TyBuilder,
+    TyExt, TyKind,
 };
 
 // This lint has a false positive here. See the link below for details.
@@ -104,7 +104,7 @@ impl Default for BindingMode {
 
 #[derive(Debug)]
 pub(crate) struct InferOk {
-    // obligations
+    goals: Vec<InEnvironment<Goal>>,
 }
 #[derive(Debug)]
 pub(crate) struct TypeError;

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -106,6 +106,14 @@ impl Default for BindingMode {
     }
 }
 
+#[derive(Debug)]
+pub(crate) struct InferOk {
+    // obligations
+}
+#[derive(Debug)]
+pub(crate) struct TypeError;
+pub(crate) type InferResult = Result<InferOk, TypeError>;
+
 /// A mismatch between an expected and an inferred type.
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub struct TypeMismatch {
@@ -388,6 +396,10 @@ impl<'a> InferenceContext<'a> {
 
     fn unify(&mut self, ty1: &Ty, ty2: &Ty) -> bool {
         self.table.unify(ty1, ty2)
+    }
+
+    fn unify_inner(&mut self, ty1: &Ty, ty2: &Ty) -> InferResult {
+        self.table.unify_inner(ty1, ty2)
     }
 
     // FIXME get rid of this, instead resolve shallowly where necessary

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -373,10 +373,6 @@ impl<'a> InferenceContext<'a> {
         self.table.unify(ty1, ty2)
     }
 
-    fn unify_inner(&mut self, ty1: &Ty, ty2: &Ty) -> InferResult {
-        self.table.unify_inner(ty1, ty2)
-    }
-
     fn resolve_ty_shallow(&mut self, ty: &Ty) -> Ty {
         self.resolve_obligations_as_possible();
         self.table.resolve_ty_shallow(ty)

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -284,6 +284,9 @@ impl<'a> InferenceContext<'a> {
 
     fn resolve_all(mut self) -> InferenceResult {
         // FIXME resolve obligations as well (use Guidance if necessary)
+
+        // make sure diverging type variables are marked as such
+        self.table.propagate_diverging_flag();
         let mut result = std::mem::take(&mut self.result);
         for ty in result.type_of_expr.values_mut() {
             let resolved = self.table.resolve_ty_completely(ty.clone());

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -13,8 +13,6 @@
 //! to certain types. To record this, we use the union-find implementation from
 //! the `ena` crate, which is extracted from rustc.
 
-use std::borrow::Cow;
-
 use std::ops::Index;
 use std::sync::Arc;
 
@@ -384,7 +382,7 @@ impl<'a> InferenceContext<'a> {
         self.table.resolve_ty_as_possible(ty)
     }
 
-    fn resolve_ty_shallow<'b>(&mut self, ty: &'b Ty) -> Cow<'b, Ty> {
+    fn resolve_ty_shallow(&mut self, ty: &Ty) -> Ty {
         self.table.resolve_ty_shallow(ty)
     }
 

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -395,6 +395,10 @@ impl<'a> InferenceContext<'a> {
     }
 
     fn unify(&mut self, ty1: &Ty, ty2: &Ty) -> bool {
+        // TODO handle expectations properly
+        if ty2.is_unknown() {
+            return true;
+        }
         self.table.unify(ty1, ty2)
     }
 

--- a/crates/hir_ty/src/infer/coerce.rs
+++ b/crates/hir_ty/src/infer/coerce.rs
@@ -21,10 +21,6 @@ impl<'a> InferenceContext<'a> {
     pub(super) fn coerce(&mut self, from_ty: &Ty, to_ty: &Ty) -> bool {
         let from_ty = self.resolve_ty_shallow(from_ty);
         let to_ty = self.resolve_ty_shallow(to_ty);
-        // TODO handle expectations properly
-        if to_ty.is_unknown() {
-            return true;
-        }
         match self.coerce_inner(from_ty, &to_ty) {
             Ok(result) => {
                 self.table.register_infer_ok(result);

--- a/crates/hir_ty/src/infer/coerce.rs
+++ b/crates/hir_ty/src/infer/coerce.rs
@@ -402,12 +402,15 @@ impl<'a> InferenceContext<'a> {
         // solve `CoerceUnsized` and `Unsize` goals at this point and leaves the
         // rest for later. Also, there's some logic about sized type variables.
         // Need to find out in what cases this is necessary
-        let solution = self.db.trait_solve(krate, canonicalized.value.clone()).ok_or(TypeError)?;
+        let solution = self
+            .db
+            .trait_solve(krate, canonicalized.value.clone().cast(&Interner))
+            .ok_or(TypeError)?;
 
         match solution {
             Solution::Unique(v) => {
                 canonicalized.apply_solution(
-                    self,
+                    &mut self.table,
                     Canonical {
                         binders: v.binders,
                         // FIXME handle constraints

--- a/crates/hir_ty/src/infer/coerce.rs
+++ b/crates/hir_ty/src/infer/coerce.rs
@@ -101,7 +101,7 @@ impl<'a> InferenceContext<'a> {
             // here, we would coerce from `!` to `?T`.
             match to_ty.kind(&Interner) {
                 TyKind::InferenceVar(tv, TyVariableKind::General) => {
-                    self.table.type_variable_table.set_diverging(*tv, true);
+                    self.table.set_diverging(*tv, true);
                 }
                 _ => {}
             }

--- a/crates/hir_ty/src/infer/coerce.rs
+++ b/crates/hir_ty/src/infer/coerce.rs
@@ -23,7 +23,7 @@ impl<'a> InferenceContext<'a> {
         if to_ty.is_unknown() {
             return true;
         }
-        let from_ty = self.resolve_ty_shallow(from_ty).into_owned();
+        let from_ty = self.resolve_ty_shallow(from_ty);
         let to_ty = self.resolve_ty_shallow(to_ty);
         match self.coerce_inner(from_ty, &to_ty) {
             Ok(_result) => {
@@ -46,9 +46,7 @@ impl<'a> InferenceContext<'a> {
     ///    least upper bound.
     pub(super) fn coerce_merge_branch(&mut self, ty1: &Ty, ty2: &Ty) -> Ty {
         let ty1 = self.resolve_ty_shallow(ty1);
-        let ty1 = ty1.as_ref();
         let ty2 = self.resolve_ty_shallow(ty2);
-        let ty2 = ty2.as_ref();
         // Special case: two function types. Try to coerce both to
         // pointers to have a chance at getting a match. See
         // https://github.com/rust-lang/rust/blob/7b805396bf46dce972692a6846ce2ad8481c5f85/src/librustc_typeck/check/coercion.rs#L877-L916
@@ -80,9 +78,9 @@ impl<'a> InferenceContext<'a> {
         // type is a type variable and the new one is `!`, trying it the other
         // way around first would mean we make the type variable `!`, instead of
         // just marking it as possibly diverging.
-        if self.coerce(ty2, ty1) {
+        if self.coerce(&ty2, &ty1) {
             ty1.clone()
-        } else if self.coerce(ty1, ty2) {
+        } else if self.coerce(&ty1, &ty2) {
             ty2.clone()
         } else {
             // TODO record a type mismatch

--- a/crates/hir_ty/src/infer/coerce.rs
+++ b/crates/hir_ty/src/infer/coerce.rs
@@ -19,12 +19,12 @@ impl<'a> InferenceContext<'a> {
     /// Unify two types, but may coerce the first one to the second one
     /// using "implicit coercion rules" if needed.
     pub(super) fn coerce(&mut self, from_ty: &Ty, to_ty: &Ty) -> bool {
+        let from_ty = self.resolve_ty_shallow(from_ty);
+        let to_ty = self.resolve_ty_shallow(to_ty);
         // TODO handle expectations properly
         if to_ty.is_unknown() {
             return true;
         }
-        let from_ty = self.resolve_ty_shallow(from_ty);
-        let to_ty = self.resolve_ty_shallow(to_ty);
         match self.coerce_inner(from_ty, &to_ty) {
             Ok(_result) => {
                 // TODO deal with goals

--- a/crates/hir_ty/src/infer/coerce.rs
+++ b/crates/hir_ty/src/infer/coerce.rs
@@ -19,6 +19,10 @@ impl<'a> InferenceContext<'a> {
     /// Unify two types, but may coerce the first one to the second one
     /// using "implicit coercion rules" if needed.
     pub(super) fn coerce(&mut self, from_ty: &Ty, to_ty: &Ty) -> bool {
+        // TODO handle expectations properly
+        if to_ty.is_unknown() {
+            return true;
+        }
         let from_ty = self.resolve_ty_shallow(from_ty).into_owned();
         let to_ty = self.resolve_ty_shallow(to_ty);
         match self.coerce_inner(from_ty, &to_ty) {

--- a/crates/hir_ty/src/infer/expr.rs
+++ b/crates/hir_ty/src/infer/expr.rs
@@ -99,9 +99,9 @@ impl<'a> InferenceContext<'a> {
             environment: trait_env,
         };
         let canonical = self.canonicalize(obligation.clone());
-        if self.db.trait_solve(krate, canonical.value).is_some() {
+        if self.db.trait_solve(krate, canonical.value.cast(&Interner)).is_some() {
             self.push_obligation(obligation.goal);
-            let return_ty = self.normalize_projection_ty(projection);
+            let return_ty = self.table.normalize_projection_ty(projection);
             Some((arg_tys, return_ty))
         } else {
             None
@@ -306,7 +306,7 @@ impl<'a> InferenceContext<'a> {
                     self.resolver.krate(),
                     InEnvironment {
                         goal: canonicalized.value.clone(),
-                        environment: self.trait_env.env.clone(),
+                        environment: self.table.trait_env.env.clone(),
                     },
                 );
                 let (param_tys, ret_ty): (Vec<Ty>, Ty) = derefs

--- a/crates/hir_ty/src/infer/expr.rs
+++ b/crates/hir_ty/src/infer/expr.rs
@@ -98,7 +98,7 @@ impl<'a> InferenceContext<'a> {
             goal: projection.trait_ref(self.db).cast(&Interner),
             environment: trait_env,
         };
-        let canonical = self.canonicalizer().canonicalize_obligation(obligation.clone());
+        let canonical = self.canonicalize(obligation.clone());
         if self.db.trait_solve(krate, canonical.value).is_some() {
             self.push_obligation(obligation.goal);
             let return_ty = self.normalize_projection_ty(projection);
@@ -297,7 +297,7 @@ impl<'a> InferenceContext<'a> {
             }
             Expr::Call { callee, args } => {
                 let callee_ty = self.infer_expr(*callee, &Expectation::none());
-                let canonicalized = self.canonicalizer().canonicalize_ty(callee_ty.clone());
+                let canonicalized = self.canonicalize(callee_ty.clone());
                 let mut derefs = autoderef(
                     self.db,
                     self.resolver.krate(),
@@ -442,7 +442,7 @@ impl<'a> InferenceContext<'a> {
             }
             Expr::Field { expr, name } => {
                 let receiver_ty = self.infer_expr_inner(*expr, &Expectation::none());
-                let canonicalized = self.canonicalizer().canonicalize_ty(receiver_ty);
+                let canonicalized = self.canonicalize(receiver_ty);
                 let ty = autoderef::autoderef(
                     self.db,
                     self.resolver.krate(),
@@ -559,7 +559,7 @@ impl<'a> InferenceContext<'a> {
                 match op {
                     UnaryOp::Deref => match self.resolver.krate() {
                         Some(krate) => {
-                            let canonicalized = self.canonicalizer().canonicalize_ty(inner_ty);
+                            let canonicalized = self.canonicalize(inner_ty);
                             match autoderef::deref(
                                 self.db,
                                 krate,
@@ -676,7 +676,7 @@ impl<'a> InferenceContext<'a> {
                 if let (Some(index_trait), Some(krate)) =
                     (self.resolve_ops_index(), self.resolver.krate())
                 {
-                    let canonicalized = self.canonicalizer().canonicalize_ty(base_ty);
+                    let canonicalized = self.canonicalize(base_ty);
                     let self_ty = method_resolution::resolve_indexing_op(
                         self.db,
                         &canonicalized.value,
@@ -852,7 +852,7 @@ impl<'a> InferenceContext<'a> {
         generic_args: Option<&GenericArgs>,
     ) -> Ty {
         let receiver_ty = self.infer_expr(receiver, &Expectation::none());
-        let canonicalized_receiver = self.canonicalizer().canonicalize_ty(receiver_ty.clone());
+        let canonicalized_receiver = self.canonicalize(receiver_ty.clone());
 
         let traits_in_scope = self.resolver.traits_in_scope(self.db.upcast());
 

--- a/crates/hir_ty/src/infer/path.rs
+++ b/crates/hir_ty/src/infer/path.rs
@@ -65,7 +65,6 @@ impl<'a> InferenceContext<'a> {
         let typable: ValueTyDefId = match value {
             ValueNs::LocalBinding(pat) => {
                 let ty = self.result.type_of_pat.get(pat)?.clone();
-                let ty = self.resolve_ty_as_possible(ty);
                 return Some(ty);
             }
             ValueNs::FunctionId(it) => it.into(),
@@ -275,6 +274,7 @@ impl<'a> InferenceContext<'a> {
         name: &Name,
         id: ExprOrPatId,
     ) -> Option<(ValueNs, Option<Substitution>)> {
+        let ty = self.resolve_ty_shallow(ty);
         let (enum_id, subst) = match ty.as_adt() {
             Some((AdtId::EnumId(e), subst)) => (e, subst),
             _ => return None,

--- a/crates/hir_ty/src/infer/path.rs
+++ b/crates/hir_ty/src/infer/path.rs
@@ -218,7 +218,7 @@ impl<'a> InferenceContext<'a> {
             return Some(result);
         }
 
-        let canonical_ty = self.canonicalizer().canonicalize_ty(ty.clone());
+        let canonical_ty = self.canonicalize(ty.clone());
         let krate = self.resolver.krate()?;
         let traits_in_scope = self.resolver.traits_in_scope(self.db.upcast());
 

--- a/crates/hir_ty/src/infer/path.rs
+++ b/crates/hir_ty/src/infer/path.rs
@@ -225,7 +225,7 @@ impl<'a> InferenceContext<'a> {
         method_resolution::iterate_method_candidates(
             &canonical_ty.value,
             self.db,
-            self.trait_env.clone(),
+            self.table.trait_env.clone(),
             krate,
             &traits_in_scope,
             None,

--- a/crates/hir_ty/src/infer/unify.rs
+++ b/crates/hir_ty/src/infer/unify.rs
@@ -70,7 +70,7 @@ impl<T: HasInterner<Interner = Interner>> Canonicalized<T> {
                 let ty = ctx.normalize_associated_types_in(new_vars.apply(ty.clone(), &Interner));
                 ctx.unify(var.assert_ty_ref(&Interner), &ty);
             } else {
-                let _ = ctx.unify_inner(&var, &new_vars.apply(v.clone(), &Interner));
+                let _ = ctx.try_unify(&var, &new_vars.apply(v.clone(), &Interner));
             }
         }
     }
@@ -300,9 +300,8 @@ impl<'a> InferenceTable<'a> {
     }
 
     /// Unify two types and register new trait goals that arise from that.
-    // TODO give these two functions better names
     pub(crate) fn unify(&mut self, ty1: &Ty, ty2: &Ty) -> bool {
-        let result = if let Ok(r) = self.unify_inner(ty1, ty2) {
+        let result = if let Ok(r) = self.try_unify(ty1, ty2) {
             r
         } else {
             return false;
@@ -313,7 +312,7 @@ impl<'a> InferenceTable<'a> {
 
     /// Unify two types and return new trait goals arising from it, so the
     /// caller needs to deal with them.
-    pub(crate) fn unify_inner<T: Zip<Interner>>(&mut self, t1: &T, t2: &T) -> InferResult {
+    pub(crate) fn try_unify<T: Zip<Interner>>(&mut self, t1: &T, t2: &T) -> InferResult {
         match self.var_unification_table.relate(
             &Interner,
             &self.db,

--- a/crates/hir_ty/src/infer/unify.rs
+++ b/crates/hir_ty/src/infer/unify.rs
@@ -149,7 +149,9 @@ impl TypeVariableTable {
 
     fn fallback_value(&self, iv: InferenceVar, kind: TyVariableKind) -> Ty {
         match kind {
-            _ if self.inner[iv.index() as usize].diverging => TyKind::Never,
+            _ if self.inner.get(iv.index() as usize).map_or(false, |data| data.diverging) => {
+                TyKind::Never
+            }
             TyVariableKind::General => TyKind::Error,
             TyVariableKind::Integer => TyKind::Scalar(Scalar::Int(IntTy::I32)),
             TyVariableKind::Float => TyKind::Scalar(Scalar::Float(FloatTy::F64)),
@@ -205,6 +207,7 @@ impl<'a> InferenceTable<'a> {
     fn new_var(&mut self, kind: TyVariableKind, diverging: bool) -> Ty {
         let var = self.var_unification_table.new_variable(UniverseIndex::ROOT);
         // Chalk might have created some type variables for its own purposes that we don't know about...
+        // TODO refactor this?
         self.type_variable_table.inner.extend(
             (0..1 + var.index() as usize - self.type_variable_table.inner.len())
                 .map(|_| TypeVariableData { diverging: false }),

--- a/crates/hir_ty/src/infer/unify.rs
+++ b/crates/hir_ty/src/infer/unify.rs
@@ -1,6 +1,6 @@
 //! Unification and canonicalization logic.
 
-use std::{borrow::Cow, fmt, mem, sync::Arc};
+use std::{fmt, mem, sync::Arc};
 
 use chalk_ir::{
     cast::Cast, fold::Fold, interner::HasInterner, zip::Zip, FloatTy, IntTy, TyVariableKind,
@@ -340,11 +340,8 @@ impl<'a> InferenceTable<'a> {
 
     /// If `ty` is a type variable with known type, returns that type;
     /// otherwise, return ty.
-    // FIXME this could probably just return Ty
-    pub(crate) fn resolve_ty_shallow<'b>(&mut self, ty: &'b Ty) -> Cow<'b, Ty> {
-        self.var_unification_table
-            .normalize_ty_shallow(&Interner, ty)
-            .map_or(Cow::Borrowed(ty), Cow::Owned)
+    pub(crate) fn resolve_ty_shallow(&mut self, ty: &Ty) -> Ty {
+        self.var_unification_table.normalize_ty_shallow(&Interner, ty).unwrap_or_else(|| ty.clone())
     }
 
     /// Resolves the type as far as currently possible, replacing type variables

--- a/crates/hir_ty/src/infer/unify.rs
+++ b/crates/hir_ty/src/infer/unify.rs
@@ -134,16 +134,8 @@ pub(super) struct TypeVariableTable {
 }
 
 impl TypeVariableTable {
-    fn push(&mut self, data: TypeVariableData) {
-        self.inner.push(data);
-    }
-
     pub(super) fn set_diverging(&mut self, iv: InferenceVar, diverging: bool) {
         self.inner[iv.index() as usize].diverging = diverging;
-    }
-
-    fn is_diverging(&mut self, iv: InferenceVar) -> bool {
-        self.inner[iv.index() as usize].diverging
     }
 
     fn fallback_value(&self, iv: InferenceVar, kind: TyVariableKind) -> Ty {
@@ -221,7 +213,7 @@ impl<'a> InferenceTable<'a> {
     /// Unify two types and register new trait goals that arise from that.
     // TODO give these two functions better names
     pub(crate) fn unify(&mut self, ty1: &Ty, ty2: &Ty) -> bool {
-        let result = if let Ok(r) = self.unify_inner(ty1, ty2) {
+        let _result = if let Ok(r) = self.unify_inner(ty1, ty2) {
             r
         } else {
             return false;
@@ -241,11 +233,11 @@ impl<'a> InferenceTable<'a> {
             ty1,
             ty2,
         ) {
-            Ok(result) => {
+            Ok(_result) => {
                 // TODO deal with new goals
                 Ok(InferOk {})
             }
-            Err(NoSolution) => Err(TypeError),
+            Err(chalk_ir::NoSolution) => Err(TypeError),
         }
     }
 

--- a/crates/hir_ty/src/infer/unify.rs
+++ b/crates/hir_ty/src/infer/unify.rs
@@ -136,10 +136,10 @@ type ChalkInferenceTable = chalk_solve::infer::InferenceTable<Interner>;
 
 #[derive(Clone)]
 pub(crate) struct InferenceTable<'a> {
-    pub db: &'a dyn HirDatabase,
-    pub trait_env: Arc<TraitEnvironment>,
-    pub(super) var_unification_table: ChalkInferenceTable,
-    pub(super) type_variable_table: Vec<TypeVariableData>,
+    pub(crate) db: &'a dyn HirDatabase,
+    pub(crate) trait_env: Arc<TraitEnvironment>,
+    var_unification_table: ChalkInferenceTable,
+    type_variable_table: Vec<TypeVariableData>,
     pending_obligations: Vec<Canonicalized<InEnvironment<Goal>>>,
 }
 
@@ -332,7 +332,7 @@ impl<'a> InferenceTable<'a> {
         self.var_unification_table.normalize_ty_shallow(&Interner, ty).unwrap_or_else(|| ty.clone())
     }
 
-    pub fn register_obligation(&mut self, goal: Goal) {
+    pub(crate) fn register_obligation(&mut self, goal: Goal) {
         let in_env = InEnvironment::new(&self.trait_env.env, goal);
         self.register_obligation_in_env(in_env)
     }
@@ -344,11 +344,11 @@ impl<'a> InferenceTable<'a> {
         }
     }
 
-    pub fn register_infer_ok(&mut self, infer_ok: InferOk) {
+    pub(crate) fn register_infer_ok(&mut self, infer_ok: InferOk) {
         infer_ok.goals.into_iter().for_each(|goal| self.register_obligation_in_env(goal));
     }
 
-    pub fn resolve_obligations_as_possible(&mut self) {
+    pub(crate) fn resolve_obligations_as_possible(&mut self) {
         let _span = profile::span("resolve_obligations_as_possible");
         let mut changed = true;
         let mut obligations = Vec::new();
@@ -445,9 +445,9 @@ mod resolve {
     use hir_def::type_ref::ConstScalar;
 
     pub(super) struct Resolver<'a, 'b, F> {
-        pub table: &'a mut InferenceTable<'b>,
-        pub var_stack: &'a mut Vec<InferenceVar>,
-        pub fallback: F,
+        pub(super) table: &'a mut InferenceTable<'b>,
+        pub(super) var_stack: &'a mut Vec<InferenceVar>,
+        pub(super) fallback: F,
     }
     impl<'a, 'b, 'i, F> Folder<'i, Interner> for Resolver<'a, 'b, F>
     where

--- a/crates/hir_ty/src/infer/unify.rs
+++ b/crates/hir_ty/src/infer/unify.rs
@@ -295,7 +295,6 @@ impl<'a> InferenceTable<'a> {
             |ty, _| match ty.kind(&Interner) {
                 &TyKind::InferenceVar(tv, kind) => {
                     if tv_stack.contains(&tv) {
-                        cov_mark::hit!(type_var_cycles_resolve_as_possible);
                         // recursive type
                         return self.type_variable_table.fallback_value(tv, kind);
                     }
@@ -366,7 +365,6 @@ mod resolve {
         ) -> Fallible<Ty> {
             let var = self.var_unification_table.inference_var_root(var);
             if self.var_stack.contains(&var) {
-                cov_mark::hit!(type_var_cycles_resolve_as_possible);
                 // recursive type
                 let default = self.type_variable_table.fallback_value(var, kind).cast(&Interner);
                 return Ok((self.fallback)(var, VariableKind::Ty(kind), default, outer_binder)
@@ -403,7 +401,6 @@ mod resolve {
             .intern(&Interner)
             .cast(&Interner);
             if self.var_stack.contains(&var) {
-                cov_mark::hit!(type_var_cycles_resolve_as_possible);
                 // recursive
                 return Ok((self.fallback)(var, VariableKind::Const(ty), default, outer_binder)
                     .assert_const_ref(&Interner)

--- a/crates/hir_ty/src/infer/unify.rs
+++ b/crates/hir_ty/src/infer/unify.rs
@@ -1,39 +1,36 @@
 //! Unification and canonicalization logic.
 
-use std::borrow::Cow;
+use std::{borrow::Cow, fmt, sync::Arc};
 
 use chalk_ir::{
     cast::Cast, fold::Fold, interner::HasInterner, FloatTy, IntTy, TyVariableKind, UniverseIndex,
     VariableKind,
 };
-use ena::unify::{InPlaceUnificationTable, NoError, UnifyKey, UnifyValue};
+use chalk_solve::infer::ParameterEnaVariableExt;
+use ena::unify::UnifyKey;
 
-use super::{DomainGoal, InferenceContext};
+use super::InferenceContext;
 use crate::{
-    fold_tys, static_lifetime, AliasEq, AliasTy, BoundVar, Canonical, CanonicalVarKinds,
-    DebruijnIndex, FnPointer, FnSubst, InEnvironment, InferenceVar, Interner, Scalar, Substitution,
-    Ty, TyExt, TyKind, WhereClause,
+    db::HirDatabase, fold_tys, static_lifetime, BoundVar, Canonical, DebruijnIndex, GenericArg,
+    InferenceVar, Interner, Scalar, Substitution, TraitEnvironment, Ty, TyKind,
 };
 
 impl<'a> InferenceContext<'a> {
-    pub(super) fn canonicalizer<'b>(&'b mut self) -> Canonicalizer<'a, 'b>
+    pub(super) fn canonicalize<T: Fold<Interner> + HasInterner<Interner = Interner>>(
+        &mut self,
+        t: T,
+    ) -> Canonicalized<T::Result>
     where
-        'a: 'b,
+        T::Result: HasInterner<Interner = Interner>,
     {
-        Canonicalizer { ctx: self, free_vars: Vec::new(), var_stack: Vec::new() }
+        let result = self.table.var_unification_table.canonicalize(&Interner, t);
+        let free_vars = result
+            .free_vars
+            .into_iter()
+            .map(|free_var| free_var.to_generic_arg(&Interner))
+            .collect();
+        Canonicalized { value: result.quantified, free_vars }
     }
-}
-
-pub(super) struct Canonicalizer<'a, 'b>
-where
-    'a: 'b,
-{
-    ctx: &'b mut InferenceContext<'a>,
-    free_vars: Vec<(InferenceVar, TyVariableKind)>,
-    /// A stack of type variables that is used to detect recursive types (which
-    /// are an error, but we need to protect against them to avoid stack
-    /// overflows).
-    var_stack: Vec<TypeVarId>,
 }
 
 #[derive(Debug)]
@@ -42,92 +39,14 @@ where
     T: HasInterner<Interner = Interner>,
 {
     pub(super) value: Canonical<T>,
-    free_vars: Vec<(InferenceVar, TyVariableKind)>,
-}
-
-impl<'a, 'b> Canonicalizer<'a, 'b> {
-    fn add(&mut self, free_var: InferenceVar, kind: TyVariableKind) -> usize {
-        self.free_vars.iter().position(|&(v, _)| v == free_var).unwrap_or_else(|| {
-            let next_index = self.free_vars.len();
-            self.free_vars.push((free_var, kind));
-            next_index
-        })
-    }
-
-    fn do_canonicalize<T: Fold<Interner, Result = T> + HasInterner<Interner = Interner>>(
-        &mut self,
-        t: T,
-        binders: DebruijnIndex,
-    ) -> T {
-        fold_tys(
-            t,
-            |ty, binders| match ty.kind(&Interner) {
-                &TyKind::InferenceVar(var, kind) => {
-                    let inner = from_inference_var(var);
-                    if self.var_stack.contains(&inner) {
-                        // recursive type
-                        return self.ctx.table.type_variable_table.fallback_value(var, kind);
-                    }
-                    if let Some(known_ty) =
-                        self.ctx.table.var_unification_table.inlined_probe_value(inner).known()
-                    {
-                        self.var_stack.push(inner);
-                        let result = self.do_canonicalize(known_ty.clone(), binders);
-                        self.var_stack.pop();
-                        result
-                    } else {
-                        let root = self.ctx.table.var_unification_table.find(inner);
-                        let position = self.add(to_inference_var(root), kind);
-                        TyKind::BoundVar(BoundVar::new(binders, position)).intern(&Interner)
-                    }
-                }
-                _ => ty,
-            },
-            binders,
-        )
-    }
-
-    fn into_canonicalized<T: HasInterner<Interner = Interner>>(
-        self,
-        result: T,
-    ) -> Canonicalized<T> {
-        let kinds = self
-            .free_vars
-            .iter()
-            .map(|&(_, k)| chalk_ir::WithKind::new(VariableKind::Ty(k), UniverseIndex::ROOT));
-        Canonicalized {
-            value: Canonical {
-                value: result,
-                binders: CanonicalVarKinds::from_iter(&Interner, kinds),
-            },
-            free_vars: self.free_vars,
-        }
-    }
-
-    pub(crate) fn canonicalize_ty(mut self, ty: Ty) -> Canonicalized<Ty> {
-        let result = self.do_canonicalize(ty, DebruijnIndex::INNERMOST);
-        self.into_canonicalized(result)
-    }
-
-    pub(crate) fn canonicalize_obligation(
-        mut self,
-        obligation: InEnvironment<DomainGoal>,
-    ) -> Canonicalized<InEnvironment<DomainGoal>> {
-        let result = match obligation.goal {
-            DomainGoal::Holds(wc) => {
-                DomainGoal::Holds(self.do_canonicalize(wc, DebruijnIndex::INNERMOST))
-            }
-            _ => unimplemented!(),
-        };
-        self.into_canonicalized(InEnvironment { goal: result, environment: obligation.environment })
-    }
+    free_vars: Vec<GenericArg>,
 }
 
 impl<T: HasInterner<Interner = Interner>> Canonicalized<T> {
     pub(super) fn decanonicalize_ty(&self, ty: Ty) -> Ty {
         crate::fold_free_vars(ty, |bound, _binders| {
-            let (v, k) = self.free_vars[bound.index];
-            TyKind::InferenceVar(v, k).intern(&Interner)
+            let var = self.free_vars[bound.index];
+            var.assert_ty_ref(&Interner).clone()
         })
     }
 
@@ -155,23 +74,29 @@ impl<T: HasInterner<Interner = Interner>> Canonicalized<T> {
             }),
         );
         for (i, ty) in solution.value.iter(&Interner).enumerate() {
-            let (v, k) = self.free_vars[i];
+            // FIXME: deal with non-type vars here -- the only problematic part is the normalization
+            // and maybe we don't need that with lazy normalization?
+            let var = self.free_vars[i];
             // eagerly replace projections in the type; we may be getting types
             // e.g. from where clauses where this hasn't happened yet
             let ty = ctx.normalize_associated_types_in(
                 new_vars.apply(ty.assert_ty_ref(&Interner).clone(), &Interner),
             );
-            ctx.table.unify(&TyKind::InferenceVar(v, k).intern(&Interner), &ty);
+            ctx.table.unify(var.assert_ty_ref(&Interner), &ty);
         }
     }
 }
 
-pub fn could_unify(t1: &Ty, t2: &Ty) -> bool {
-    InferenceTable::new().unify(t1, t2)
+pub fn could_unify(db: &dyn HirDatabase, env: Arc<TraitEnvironment>, t1: &Ty, t2: &Ty) -> bool {
+    InferenceTable::new(db, env).unify(t1, t2)
 }
 
-pub(crate) fn unify(tys: &Canonical<(Ty, Ty)>) -> Option<Substitution> {
-    let mut table = InferenceTable::new();
+pub(crate) fn unify(
+    db: &dyn HirDatabase,
+    env: Arc<TraitEnvironment>,
+    tys: &Canonical<(Ty, Ty)>,
+) -> Option<Substitution> {
+    let mut table = InferenceTable::new(db, env);
     let vars = Substitution::from_iter(
         &Interner,
         tys.binders
@@ -214,16 +139,16 @@ impl TypeVariableTable {
     }
 
     pub(super) fn set_diverging(&mut self, iv: InferenceVar, diverging: bool) {
-        self.inner[from_inference_var(iv).0 as usize].diverging = diverging;
+        self.inner[iv.index() as usize].diverging = diverging;
     }
 
     fn is_diverging(&mut self, iv: InferenceVar) -> bool {
-        self.inner[from_inference_var(iv).0 as usize].diverging
+        self.inner[iv.index() as usize].diverging
     }
 
     fn fallback_value(&self, iv: InferenceVar, kind: TyVariableKind) -> Ty {
         match kind {
-            _ if self.inner[from_inference_var(iv).0 as usize].diverging => TyKind::Never,
+            _ if self.inner[iv.index() as usize].diverging => TyKind::Never,
             TyVariableKind::General => TyKind::Error,
             TyVariableKind::Integer => TyKind::Scalar(Scalar::Int(IntTy::I32)),
             TyVariableKind::Float => TyKind::Scalar(Scalar::Float(FloatTy::F64)),
@@ -237,27 +162,35 @@ pub(crate) struct TypeVariableData {
     diverging: bool,
 }
 
-#[derive(Clone, Debug)]
-pub(crate) struct InferenceTable {
-    pub(super) var_unification_table: InPlaceUnificationTable<TypeVarId>,
+type ChalkInferenceTable = chalk_solve::infer::InferenceTable<Interner>;
+
+#[derive(Clone)]
+pub(crate) struct InferenceTable<'a> {
+    db: &'a dyn HirDatabase,
+    trait_env: Arc<TraitEnvironment>,
+    pub(super) var_unification_table: ChalkInferenceTable,
     pub(super) type_variable_table: TypeVariableTable,
-    pub(super) revision: u32,
 }
 
-impl InferenceTable {
-    pub(crate) fn new() -> Self {
+impl<'a> InferenceTable<'a> {
+    pub(crate) fn new(db: &'a dyn HirDatabase, trait_env: Arc<TraitEnvironment>) -> Self {
         InferenceTable {
-            var_unification_table: InPlaceUnificationTable::new(),
+            db,
+            trait_env,
+            var_unification_table: ChalkInferenceTable::new(),
             type_variable_table: TypeVariableTable { inner: Vec::new() },
-            revision: 0,
         }
     }
 
     fn new_var(&mut self, kind: TyVariableKind, diverging: bool) -> Ty {
-        self.type_variable_table.push(TypeVariableData { diverging });
-        let key = self.var_unification_table.new_key(TypeVarValue::Unknown);
-        assert_eq!(key.0 as usize, self.type_variable_table.inner.len() - 1);
-        TyKind::InferenceVar(to_inference_var(key), kind).intern(&Interner)
+        let var = self.var_unification_table.new_variable(UniverseIndex::ROOT);
+        self.type_variable_table.inner.extend(
+            (0..1 + var.index() as usize - self.type_variable_table.inner.len())
+                .map(|_| TypeVariableData { diverging: false }),
+        );
+        assert_eq!(var.index() as usize, self.type_variable_table.inner.len() - 1);
+        self.type_variable_table.inner[var.index() as usize].diverging = diverging;
+        var.to_ty_with_kind(&Interner, kind)
     }
 
     pub(crate) fn new_type_var(&mut self) -> Ty {
@@ -280,240 +213,59 @@ impl InferenceTable {
         self.resolve_ty_completely_inner(&mut Vec::new(), ty)
     }
 
+    // FIXME get rid of this, instead resolve shallowly where necessary
     pub(crate) fn resolve_ty_as_possible(&mut self, ty: Ty) -> Ty {
         self.resolve_ty_as_possible_inner(&mut Vec::new(), ty)
     }
 
     pub(crate) fn unify(&mut self, ty1: &Ty, ty2: &Ty) -> bool {
-        self.unify_inner(ty1, ty2, 0)
-    }
-
-    pub(crate) fn unify_substs(
-        &mut self,
-        substs1: &Substitution,
-        substs2: &Substitution,
-        depth: usize,
-    ) -> bool {
-        substs1.iter(&Interner).zip(substs2.iter(&Interner)).all(|(t1, t2)| {
-            self.unify_inner(t1.assert_ty_ref(&Interner), t2.assert_ty_ref(&Interner), depth)
-        })
-    }
-
-    fn unify_inner(&mut self, ty1: &Ty, ty2: &Ty, depth: usize) -> bool {
-        if depth > 1000 {
-            // prevent stackoverflows
-            panic!("infinite recursion in unification");
-        }
-        if ty1 == ty2 {
-            return true;
-        }
-        // try to resolve type vars first
-        let ty1 = self.resolve_ty_shallow(ty1);
-        let ty2 = self.resolve_ty_shallow(ty2);
-        if ty1.equals_ctor(&ty2) {
-            match (ty1.kind(&Interner), ty2.kind(&Interner)) {
-                (TyKind::Adt(_, substs1), TyKind::Adt(_, substs2))
-                | (TyKind::FnDef(_, substs1), TyKind::FnDef(_, substs2))
-                | (
-                    TyKind::Function(FnPointer { substitution: FnSubst(substs1), .. }),
-                    TyKind::Function(FnPointer { substitution: FnSubst(substs2), .. }),
-                )
-                | (TyKind::Tuple(_, substs1), TyKind::Tuple(_, substs2))
-                | (TyKind::OpaqueType(_, substs1), TyKind::OpaqueType(_, substs2))
-                | (TyKind::AssociatedType(_, substs1), TyKind::AssociatedType(_, substs2))
-                | (TyKind::Closure(.., substs1), TyKind::Closure(.., substs2)) => {
-                    self.unify_substs(substs1, substs2, depth + 1)
-                }
-                (TyKind::Array(ty1, c1), TyKind::Array(ty2, c2)) if c1 == c2 => {
-                    self.unify_inner(ty1, ty2, depth + 1)
-                }
-                (TyKind::Ref(_, _, ty1), TyKind::Ref(_, _, ty2))
-                | (TyKind::Raw(_, ty1), TyKind::Raw(_, ty2))
-                | (TyKind::Slice(ty1), TyKind::Slice(ty2)) => self.unify_inner(ty1, ty2, depth + 1),
-                _ => true, /* we checked equals_ctor already */
-            }
-        } else if let (TyKind::Closure(.., substs1), TyKind::Closure(.., substs2)) =
-            (ty1.kind(&Interner), ty2.kind(&Interner))
-        {
-            self.unify_substs(substs1, substs2, depth + 1)
+        let result = self.var_unification_table.relate(
+            &Interner,
+            &self.db,
+            &self.trait_env.env,
+            chalk_ir::Variance::Invariant,
+            ty1,
+            ty2,
+        );
+        let result = if let Ok(r) = result {
+            r
         } else {
-            self.unify_inner_trivial(&ty1, &ty2, depth)
-        }
-    }
-
-    pub(super) fn unify_inner_trivial(&mut self, ty1: &Ty, ty2: &Ty, depth: usize) -> bool {
-        match (ty1.kind(&Interner), ty2.kind(&Interner)) {
-            (TyKind::Error, _) | (_, TyKind::Error) => true,
-
-            (TyKind::Placeholder(p1), TyKind::Placeholder(p2)) if *p1 == *p2 => true,
-
-            (TyKind::Dyn(dyn1), TyKind::Dyn(dyn2))
-                if dyn1.bounds.skip_binders().interned().len()
-                    == dyn2.bounds.skip_binders().interned().len() =>
-            {
-                for (pred1, pred2) in dyn1
-                    .bounds
-                    .skip_binders()
-                    .interned()
-                    .iter()
-                    .zip(dyn2.bounds.skip_binders().interned().iter())
-                {
-                    if !self.unify_preds(pred1.skip_binders(), pred2.skip_binders(), depth + 1) {
-                        return false;
-                    }
-                }
-                true
-            }
-
-            (
-                TyKind::InferenceVar(tv1, TyVariableKind::General),
-                TyKind::InferenceVar(tv2, TyVariableKind::General),
-            )
-            | (
-                TyKind::InferenceVar(tv1, TyVariableKind::Integer),
-                TyKind::InferenceVar(tv2, TyVariableKind::Integer),
-            )
-            | (
-                TyKind::InferenceVar(tv1, TyVariableKind::Float),
-                TyKind::InferenceVar(tv2, TyVariableKind::Float),
-            ) if self.type_variable_table.is_diverging(*tv1)
-                == self.type_variable_table.is_diverging(*tv2) =>
-            {
-                // both type vars are unknown since we tried to resolve them
-                if !self
-                    .var_unification_table
-                    .unioned(from_inference_var(*tv1), from_inference_var(*tv2))
-                {
-                    self.var_unification_table
-                        .union(from_inference_var(*tv1), from_inference_var(*tv2));
-                    self.revision += 1;
-                }
-                true
-            }
-
-            // The order of MaybeNeverTypeVar matters here.
-            // Unifying MaybeNeverTypeVar and TypeVar will let the latter become MaybeNeverTypeVar.
-            // Unifying MaybeNeverTypeVar and other concrete type will let the former become it.
-            (TyKind::InferenceVar(tv, TyVariableKind::General), other)
-            | (other, TyKind::InferenceVar(tv, TyVariableKind::General))
-            | (
-                TyKind::InferenceVar(tv, TyVariableKind::Integer),
-                other @ TyKind::Scalar(Scalar::Int(_)),
-            )
-            | (
-                other @ TyKind::Scalar(Scalar::Int(_)),
-                TyKind::InferenceVar(tv, TyVariableKind::Integer),
-            )
-            | (
-                TyKind::InferenceVar(tv, TyVariableKind::Integer),
-                other @ TyKind::Scalar(Scalar::Uint(_)),
-            )
-            | (
-                other @ TyKind::Scalar(Scalar::Uint(_)),
-                TyKind::InferenceVar(tv, TyVariableKind::Integer),
-            )
-            | (
-                TyKind::InferenceVar(tv, TyVariableKind::Float),
-                other @ TyKind::Scalar(Scalar::Float(_)),
-            )
-            | (
-                other @ TyKind::Scalar(Scalar::Float(_)),
-                TyKind::InferenceVar(tv, TyVariableKind::Float),
-            ) => {
-                // the type var is unknown since we tried to resolve it
-                self.var_unification_table.union_value(
-                    from_inference_var(*tv),
-                    TypeVarValue::Known(other.clone().intern(&Interner)),
-                );
-                self.revision += 1;
-                true
-            }
-
-            _ => false,
-        }
-    }
-
-    fn unify_preds(&mut self, pred1: &WhereClause, pred2: &WhereClause, depth: usize) -> bool {
-        match (pred1, pred2) {
-            (WhereClause::Implemented(tr1), WhereClause::Implemented(tr2))
-                if tr1.trait_id == tr2.trait_id =>
-            {
-                self.unify_substs(&tr1.substitution, &tr2.substitution, depth + 1)
-            }
-            (
-                WhereClause::AliasEq(AliasEq { alias: alias1, ty: ty1 }),
-                WhereClause::AliasEq(AliasEq { alias: alias2, ty: ty2 }),
-            ) => {
-                let (substitution1, substitution2) = match (alias1, alias2) {
-                    (AliasTy::Projection(projection_ty1), AliasTy::Projection(projection_ty2))
-                        if projection_ty1.associated_ty_id == projection_ty2.associated_ty_id =>
-                    {
-                        (&projection_ty1.substitution, &projection_ty2.substitution)
-                    }
-                    (AliasTy::Opaque(opaque1), AliasTy::Opaque(opaque2))
-                        if opaque1.opaque_ty_id == opaque2.opaque_ty_id =>
-                    {
-                        (&opaque1.substitution, &opaque2.substitution)
-                    }
-                    _ => return false,
-                };
-                self.unify_substs(&substitution1, &substitution2, depth + 1)
-                    && self.unify_inner(&ty1, &ty2, depth + 1)
-            }
-            _ => false,
-        }
+            return false;
+        };
+        // TODO deal with new goals
+        true
     }
 
     /// If `ty` is a type variable with known type, returns that type;
     /// otherwise, return ty.
+    // FIXME this could probably just return Ty
     pub(crate) fn resolve_ty_shallow<'b>(&mut self, ty: &'b Ty) -> Cow<'b, Ty> {
-        let mut ty = Cow::Borrowed(ty);
-        // The type variable could resolve to a int/float variable. Hence try
-        // resolving up to three times; each type of variable shouldn't occur
-        // more than once
-        for i in 0..3 {
-            if i > 0 {
-                cov_mark::hit!(type_var_resolves_to_int_var);
-            }
-            match ty.kind(&Interner) {
-                TyKind::InferenceVar(tv, _) => {
-                    let inner = from_inference_var(*tv);
-                    match self.var_unification_table.inlined_probe_value(inner).known() {
-                        Some(known_ty) => {
-                            // The known_ty can't be a type var itself
-                            ty = Cow::Owned(known_ty.clone());
-                        }
-                        _ => return ty,
-                    }
-                }
-                _ => return ty,
-            }
-        }
-        log::error!("Inference variable still not resolved: {:?}", ty);
-        ty
+        self.var_unification_table
+            .normalize_ty_shallow(&Interner, ty)
+            .map_or(Cow::Borrowed(ty), Cow::Owned)
     }
 
     /// Resolves the type as far as currently possible, replacing type variables
     /// by their known types. All types returned by the infer_* functions should
     /// be resolved as far as possible, i.e. contain no type variables with
     /// known type.
-    fn resolve_ty_as_possible_inner(&mut self, tv_stack: &mut Vec<TypeVarId>, ty: Ty) -> Ty {
+    fn resolve_ty_as_possible_inner(&mut self, tv_stack: &mut Vec<InferenceVar>, ty: Ty) -> Ty {
         fold_tys(
             ty,
             |ty, _| match ty.kind(&Interner) {
                 &TyKind::InferenceVar(tv, kind) => {
-                    let inner = from_inference_var(tv);
-                    if tv_stack.contains(&inner) {
+                    if tv_stack.contains(&tv) {
                         cov_mark::hit!(type_var_cycles_resolve_as_possible);
                         // recursive type
                         return self.type_variable_table.fallback_value(tv, kind);
                     }
-                    if let Some(known_ty) =
-                        self.var_unification_table.inlined_probe_value(inner).known()
-                    {
+                    if let Some(known_ty) = self.var_unification_table.probe_var(tv) {
                         // known_ty may contain other variables that are known by now
-                        tv_stack.push(inner);
-                        let result = self.resolve_ty_as_possible_inner(tv_stack, known_ty.clone());
+                        tv_stack.push(tv);
+                        let result = self.resolve_ty_as_possible_inner(
+                            tv_stack,
+                            known_ty.assert_ty_ref(&Interner).clone(),
+                        );
                         tv_stack.pop();
                         result
                     } else {
@@ -528,23 +280,24 @@ impl InferenceTable {
 
     /// Resolves the type completely; type variables without known type are
     /// replaced by TyKind::Unknown.
-    fn resolve_ty_completely_inner(&mut self, tv_stack: &mut Vec<TypeVarId>, ty: Ty) -> Ty {
+    fn resolve_ty_completely_inner(&mut self, tv_stack: &mut Vec<InferenceVar>, ty: Ty) -> Ty {
+        // FIXME implement as a proper Folder, handle lifetimes and consts as well
         fold_tys(
             ty,
             |ty, _| match ty.kind(&Interner) {
                 &TyKind::InferenceVar(tv, kind) => {
-                    let inner = from_inference_var(tv);
-                    if tv_stack.contains(&inner) {
+                    if tv_stack.contains(&tv) {
                         cov_mark::hit!(type_var_cycles_resolve_completely);
                         // recursive type
                         return self.type_variable_table.fallback_value(tv, kind);
                     }
-                    if let Some(known_ty) =
-                        self.var_unification_table.inlined_probe_value(inner).known()
-                    {
+                    if let Some(known_ty) = self.var_unification_table.probe_var(tv) {
                         // known_ty may contain other variables that are known by now
-                        tv_stack.push(inner);
-                        let result = self.resolve_ty_completely_inner(tv_stack, known_ty.clone());
+                        tv_stack.push(tv);
+                        let result = self.resolve_ty_completely_inner(
+                            tv_stack,
+                            known_ty.assert_ty_ref(&Interner).clone(),
+                        );
                         tv_stack.pop();
                         result
                     } else {
@@ -558,68 +311,10 @@ impl InferenceTable {
     }
 }
 
-/// The ID of a type variable.
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
-pub(super) struct TypeVarId(pub(super) u32);
-
-impl UnifyKey for TypeVarId {
-    type Value = TypeVarValue;
-
-    fn index(&self) -> u32 {
-        self.0
-    }
-
-    fn from_index(i: u32) -> Self {
-        TypeVarId(i)
-    }
-
-    fn tag() -> &'static str {
-        "TypeVarId"
-    }
-}
-
-fn from_inference_var(var: InferenceVar) -> TypeVarId {
-    TypeVarId(var.index())
-}
-
-fn to_inference_var(TypeVarId(index): TypeVarId) -> InferenceVar {
-    index.into()
-}
-
-/// The value of a type variable: either we already know the type, or we don't
-/// know it yet.
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub(super) enum TypeVarValue {
-    Known(Ty),
-    Unknown,
-}
-
-impl TypeVarValue {
-    fn known(&self) -> Option<&Ty> {
-        match self {
-            TypeVarValue::Known(ty) => Some(ty),
-            TypeVarValue::Unknown => None,
-        }
-    }
-}
-
-impl UnifyValue for TypeVarValue {
-    type Error = NoError;
-
-    fn unify_values(value1: &Self, value2: &Self) -> Result<Self, NoError> {
-        match (value1, value2) {
-            // We should never equate two type variables, both of which have
-            // known types. Instead, we recursively equate those types.
-            (TypeVarValue::Known(t1), TypeVarValue::Known(t2)) => panic!(
-                "equating two type variables, both of which have known types: {:?} and {:?}",
-                t1, t2
-            ),
-
-            // If one side is known, prefer that one.
-            (TypeVarValue::Known(..), TypeVarValue::Unknown) => Ok(value1.clone()),
-            (TypeVarValue::Unknown, TypeVarValue::Known(..)) => Ok(value2.clone()),
-
-            (TypeVarValue::Unknown, TypeVarValue::Unknown) => Ok(TypeVarValue::Unknown),
-        }
+impl<'a> fmt::Debug for InferenceTable<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InferenceTable")
+            .field("num_vars", &self.type_variable_table.inner.len())
+            .finish()
     }
 }

--- a/crates/hir_ty/src/infer/unify.rs
+++ b/crates/hir_ty/src/infer/unify.rs
@@ -86,8 +86,12 @@ impl<T: HasInterner<Interner = Interner>> Canonicalized<T> {
     }
 }
 
-pub fn could_unify(db: &dyn HirDatabase, env: Arc<TraitEnvironment>, t1: &Ty, t2: &Ty) -> bool {
-    InferenceTable::new(db, env).unify(t1, t2)
+pub fn could_unify(
+    db: &dyn HirDatabase,
+    env: Arc<TraitEnvironment>,
+    tys: &Canonical<(Ty, Ty)>,
+) -> bool {
+    unify(db, env, tys).is_some()
 }
 
 pub(crate) fn unify(

--- a/crates/hir_ty/src/interner.rs
+++ b/crates/hir_ty/src/interner.rs
@@ -107,66 +107,65 @@ impl chalk_ir::interner::Interner for Interner {
         opaque_ty: &chalk_ir::OpaqueTy<Interner>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Option<fmt::Result> {
-        tls::with_current_program(|prog| Some(prog?.debug_opaque_ty(opaque_ty, fmt)))
+        Some(write!(fmt, "{:?}", opaque_ty.opaque_ty_id))
     }
 
     fn debug_opaque_ty_id(
         opaque_ty_id: chalk_ir::OpaqueTyId<Self>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Option<fmt::Result> {
-        tls::with_current_program(|prog| Some(prog?.debug_opaque_ty_id(opaque_ty_id, fmt)))
+        Some(fmt.debug_struct("OpaqueTyId").field("index", &opaque_ty_id.0).finish())
     }
 
     fn debug_ty(ty: &chalk_ir::Ty<Interner>, fmt: &mut fmt::Formatter<'_>) -> Option<fmt::Result> {
-        tls::with_current_program(|prog| Some(prog?.debug_ty(ty, fmt)))
+        Some(write!(fmt, "{:?}", ty.data(&Interner)))
     }
 
     fn debug_lifetime(
         lifetime: &chalk_ir::Lifetime<Interner>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Option<fmt::Result> {
-        tls::with_current_program(|prog| Some(prog?.debug_lifetime(lifetime, fmt)))
+        Some(write!(fmt, "{:?}", lifetime.data(&Interner)))
     }
 
     fn debug_generic_arg(
         parameter: &GenericArg,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Option<fmt::Result> {
-        tls::with_current_program(|prog| Some(prog?.debug_generic_arg(parameter, fmt)))
+        Some(write!(fmt, "{:?}", parameter.data(&Interner).inner_debug()))
     }
 
     fn debug_goal(goal: &Goal<Interner>, fmt: &mut fmt::Formatter<'_>) -> Option<fmt::Result> {
-        tls::with_current_program(|prog| Some(prog?.debug_goal(goal, fmt)))
+        let goal_data = goal.data(&Interner);
+        Some(write!(fmt, "{:?}", goal_data))
     }
 
     fn debug_goals(
         goals: &chalk_ir::Goals<Interner>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Option<fmt::Result> {
-        tls::with_current_program(|prog| Some(prog?.debug_goals(goals, fmt)))
+        Some(write!(fmt, "{:?}", goals.debug(&Interner)))
     }
 
     fn debug_program_clause_implication(
         pci: &chalk_ir::ProgramClauseImplication<Interner>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Option<fmt::Result> {
-        tls::with_current_program(|prog| Some(prog?.debug_program_clause_implication(pci, fmt)))
+        Some(write!(fmt, "{:?}", pci.debug(&Interner)))
     }
 
     fn debug_substitution(
         substitution: &chalk_ir::Substitution<Interner>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Option<fmt::Result> {
-        tls::with_current_program(|prog| Some(prog?.debug_substitution(substitution, fmt)))
+        Some(write!(fmt, "{:?}", substitution.debug(&Interner)))
     }
 
     fn debug_separator_trait_ref(
         separator_trait_ref: &chalk_ir::SeparatorTraitRef<Interner>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Option<fmt::Result> {
-        tls::with_current_program(|prog| {
-            Some(prog?.debug_separator_trait_ref(separator_trait_ref, fmt))
-        })
+        Some(write!(fmt, "{:?}", separator_trait_ref.debug(&Interner)))
     }
 
     fn debug_fn_def_id(
@@ -179,47 +178,43 @@ impl chalk_ir::interner::Interner for Interner {
         constant: &chalk_ir::Const<Self>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Option<fmt::Result> {
-        tls::with_current_program(|prog| Some(prog?.debug_const(constant, fmt)))
+        Some(write!(fmt, "{:?}", constant.data(&Interner)))
     }
     fn debug_variable_kinds(
         variable_kinds: &chalk_ir::VariableKinds<Self>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Option<fmt::Result> {
-        tls::with_current_program(|prog| Some(prog?.debug_variable_kinds(variable_kinds, fmt)))
+        Some(write!(fmt, "{:?}", variable_kinds.as_slice(&Interner)))
     }
     fn debug_variable_kinds_with_angles(
         variable_kinds: &chalk_ir::VariableKinds<Self>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Option<fmt::Result> {
-        tls::with_current_program(|prog| {
-            Some(prog?.debug_variable_kinds_with_angles(variable_kinds, fmt))
-        })
+        Some(write!(fmt, "{:?}", variable_kinds.inner_debug(&Interner)))
     }
     fn debug_canonical_var_kinds(
         canonical_var_kinds: &chalk_ir::CanonicalVarKinds<Self>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Option<fmt::Result> {
-        tls::with_current_program(|prog| {
-            Some(prog?.debug_canonical_var_kinds(canonical_var_kinds, fmt))
-        })
+        Some(write!(fmt, "{:?}", canonical_var_kinds.as_slice(&Interner)))
     }
     fn debug_program_clause(
         clause: &chalk_ir::ProgramClause<Self>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Option<fmt::Result> {
-        tls::with_current_program(|prog| Some(prog?.debug_program_clause(clause, fmt)))
+        Some(write!(fmt, "{:?}", clause.data(&Interner)))
     }
     fn debug_program_clauses(
         clauses: &chalk_ir::ProgramClauses<Self>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Option<fmt::Result> {
-        tls::with_current_program(|prog| Some(prog?.debug_program_clauses(clauses, fmt)))
+        Some(write!(fmt, "{:?}", clauses.as_slice(&Interner)))
     }
     fn debug_quantified_where_clauses(
         clauses: &chalk_ir::QuantifiedWhereClauses<Self>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Option<fmt::Result> {
-        tls::with_current_program(|prog| Some(prog?.debug_quantified_where_clauses(clauses, fmt)))
+        Some(write!(fmt, "{:?}", clauses.as_slice(&Interner)))
     }
 
     fn intern_ty(&self, kind: chalk_ir::TyKind<Self>) -> Self::InternedType {

--- a/crates/hir_ty/src/interner.rs
+++ b/crates/hir_ty/src/interner.rs
@@ -15,8 +15,14 @@ use std::{fmt, sync::Arc};
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct Interner;
 
-#[derive(PartialEq, Eq, Hash, Debug)]
+#[derive(PartialEq, Eq, Hash)]
 pub struct InternedWrapper<T>(T);
+
+impl<T: fmt::Debug> fmt::Debug for InternedWrapper<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, f)
+    }
+}
 
 impl<T> std::ops::Deref for InternedWrapper<T> {
     type Target = T;

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -167,6 +167,7 @@ pub fn make_canonical<T: HasInterner<Interner = Interner>>(
     Canonical { value, binders: chalk_ir::CanonicalVarKinds::from_iter(&Interner, kinds) }
 }
 
+// FIXME: get rid of this, just replace it by FnPointer
 /// A function signature as seen by type inference: Several parameter types and
 /// one return type.
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -203,6 +203,17 @@ impl CallableSig {
         }
     }
 
+    pub fn to_fn_ptr(&self) -> FnPointer {
+        FnPointer {
+            num_binders: 0,
+            sig: FnSig { abi: (), safety: Safety::Safe, variadic: self.is_varargs },
+            substitution: FnSubst(Substitution::from_iter(
+                &Interner,
+                self.params_and_return.iter().cloned(),
+            )),
+        }
+    }
+
     pub fn params(&self) -> &[Ty] {
         &self.params_and_return[0..self.params_and_return.len() - 1]
     }

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -45,7 +45,7 @@ use hir_def::{
 };
 use stdx::always;
 
-use crate::{db::HirDatabase, display::HirDisplay, utils::generics};
+use crate::{db::HirDatabase, utils::generics};
 
 pub use autoderef::autoderef;
 pub use builder::TyBuilder;
@@ -114,6 +114,7 @@ pub type FnSig = chalk_ir::FnSig<Interner>;
 
 pub type InEnvironment<T> = chalk_ir::InEnvironment<T>;
 pub type DomainGoal = chalk_ir::DomainGoal<Interner>;
+pub type Goal = chalk_ir::Goal<Interner>;
 pub type AliasEq = chalk_ir::AliasEq<Interner>;
 pub type Solution = chalk_solve::Solution<Interner>;
 pub type ConstrainedSubst = chalk_ir::ConstrainedSubst<Interner>;

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -1035,9 +1035,11 @@ pub(crate) fn trait_environment_query(
         clauses.push(program_clause.into_from_env_clause(&Interner));
     }
 
+    let krate = def.module(db.upcast()).krate();
+
     let env = chalk_ir::Environment::new(&Interner).add_clauses(&Interner, clauses);
 
-    Arc::new(TraitEnvironment { traits_from_clauses: traits_in_scope, env })
+    Arc::new(TraitEnvironment { krate, traits_from_clauses: traits_in_scope, env })
 }
 
 /// Resolve the where clause(s) of an item with generics.

--- a/crates/hir_ty/src/method_resolution.rs
+++ b/crates/hir_ty/src/method_resolution.rs
@@ -577,6 +577,7 @@ fn iterate_method_candidates_by_receiver(
         if iterate_inherent_methods(
             self_ty,
             db,
+            env.clone(),
             name,
             Some(receiver_ty),
             krate,
@@ -613,8 +614,16 @@ fn iterate_method_candidates_for_self_ty(
     name: Option<&Name>,
     mut callback: &mut dyn FnMut(&Ty, AssocItemId) -> bool,
 ) -> bool {
-    if iterate_inherent_methods(self_ty, db, name, None, krate, visible_from_module, &mut callback)
-    {
+    if iterate_inherent_methods(
+        self_ty,
+        db,
+        env.clone(),
+        name,
+        None,
+        krate,
+        visible_from_module,
+        &mut callback,
+    ) {
         return true;
     }
     iterate_trait_method_candidates(self_ty, db, env, krate, traits_in_scope, name, None, callback)
@@ -653,12 +662,12 @@ fn iterate_trait_method_candidates(
         for (_name, item) in data.items.iter() {
             // Don't pass a `visible_from_module` down to `is_valid_candidate`,
             // since only inherent methods should be included into visibility checking.
-            if !is_valid_candidate(db, name, receiver_ty, *item, self_ty, None) {
+            if !is_valid_candidate(db, env.clone(), name, receiver_ty, *item, self_ty, None) {
                 continue;
             }
             if !known_implemented {
                 let goal = generic_implements_goal(db, env.clone(), t, self_ty.clone());
-                if db.trait_solve(krate, goal).is_none() {
+                if db.trait_solve(krate, goal.cast(&Interner)).is_none() {
                     continue 'traits;
                 }
             }
@@ -675,6 +684,7 @@ fn iterate_trait_method_candidates(
 fn iterate_inherent_methods(
     self_ty: &Canonical<Ty>,
     db: &dyn HirDatabase,
+    env: Arc<TraitEnvironment>,
     name: Option<&Name>,
     receiver_ty: Option<&Canonical<Ty>>,
     krate: CrateId,
@@ -690,14 +700,24 @@ fn iterate_inherent_methods(
 
         for &impl_def in impls.for_self_ty(&self_ty.value) {
             for &item in db.impl_data(impl_def).items.iter() {
-                if !is_valid_candidate(db, name, receiver_ty, item, self_ty, visible_from_module) {
+                if !is_valid_candidate(
+                    db,
+                    env.clone(),
+                    name,
+                    receiver_ty,
+                    item,
+                    self_ty,
+                    visible_from_module,
+                ) {
                     continue;
                 }
                 // we have to check whether the self type unifies with the type
                 // that the impl is for. If we have a receiver type, this
                 // already happens in `is_valid_candidate` above; if not, we
                 // check it here
-                if receiver_ty.is_none() && inherent_impl_substs(db, impl_def, self_ty).is_none() {
+                if receiver_ty.is_none()
+                    && inherent_impl_substs(db, env.clone(), impl_def, self_ty).is_none()
+                {
                     cov_mark::hit!(impl_self_type_match_without_receiver);
                     continue;
                 }
@@ -722,7 +742,7 @@ pub fn resolve_indexing_op(
     let deref_chain = autoderef_method_receiver(db, krate, ty);
     for ty in deref_chain {
         let goal = generic_implements_goal(db, env.clone(), index_trait, ty.clone());
-        if db.trait_solve(krate, goal).is_some() {
+        if db.trait_solve(krate, goal.cast(&Interner)).is_some() {
             return Some(ty);
         }
     }
@@ -731,6 +751,7 @@ pub fn resolve_indexing_op(
 
 fn is_valid_candidate(
     db: &dyn HirDatabase,
+    env: Arc<TraitEnvironment>,
     name: Option<&Name>,
     receiver_ty: Option<&Canonical<Ty>>,
     item: AssocItemId,
@@ -749,7 +770,7 @@ fn is_valid_candidate(
                 if !data.has_self_param() {
                     return false;
                 }
-                let transformed_receiver_ty = match transform_receiver_ty(db, m, self_ty) {
+                let transformed_receiver_ty = match transform_receiver_ty(db, env, m, self_ty) {
                     Some(ty) => ty,
                     None => return false,
                 };
@@ -776,6 +797,7 @@ fn is_valid_candidate(
 
 pub(crate) fn inherent_impl_substs(
     db: &dyn HirDatabase,
+    env: Arc<TraitEnvironment>,
     impl_id: ImplId,
     self_ty: &Canonical<Ty>,
 ) -> Option<Substitution> {
@@ -798,8 +820,7 @@ pub(crate) fn inherent_impl_substs(
         binders: CanonicalVarKinds::from_iter(&Interner, kinds),
         value: (self_ty_with_vars, self_ty.value.clone()),
     };
-    let trait_env = Arc::new(TraitEnvironment::default()); // FIXME
-    let substs = super::infer::unify(db, trait_env, &tys)?;
+    let substs = super::infer::unify(db, env, &tys)?;
     // We only want the substs for the vars we added, not the ones from self_ty.
     // Also, if any of the vars we added are still in there, we replace them by
     // Unknown. I think this can only really happen if self_ty contained
@@ -824,6 +845,7 @@ fn fallback_bound_vars(s: Substitution, num_vars_to_keep: usize) -> Substitution
 
 fn transform_receiver_ty(
     db: &dyn HirDatabase,
+    env: Arc<TraitEnvironment>,
     function_id: FunctionId,
     self_ty: &Canonical<Ty>,
 ) -> Option<Ty> {
@@ -833,7 +855,7 @@ fn transform_receiver_ty(
             .fill_with_unknown()
             .build(),
         AssocContainerId::ImplId(impl_id) => {
-            let impl_substs = inherent_impl_substs(db, impl_id, &self_ty)?;
+            let impl_substs = inherent_impl_substs(db, env, impl_id, &self_ty)?;
             TyBuilder::subst_for_def(db, function_id)
                 .use_parent_substs(&impl_substs)
                 .fill_with_unknown()
@@ -853,7 +875,7 @@ pub fn implements_trait(
     trait_: TraitId,
 ) -> bool {
     let goal = generic_implements_goal(db, env, trait_, ty.clone());
-    let solution = db.trait_solve(krate, goal);
+    let solution = db.trait_solve(krate, goal.cast(&Interner));
 
     solution.is_some()
 }
@@ -866,7 +888,7 @@ pub fn implements_trait_unique(
     trait_: TraitId,
 ) -> bool {
     let goal = generic_implements_goal(db, env, trait_, ty.clone());
-    let solution = db.trait_solve(krate, goal);
+    let solution = db.trait_solve(krate, goal.cast(&Interner));
 
     matches!(solution, Some(crate::Solution::Unique(_)))
 }

--- a/crates/hir_ty/src/method_resolution.rs
+++ b/crates/hir_ty/src/method_resolution.rs
@@ -798,7 +798,8 @@ pub(crate) fn inherent_impl_substs(
         binders: CanonicalVarKinds::from_iter(&Interner, kinds),
         value: (self_ty_with_vars, self_ty.value.clone()),
     };
-    let substs = super::infer::unify(&tys)?;
+    let trait_env = Arc::new(TraitEnvironment::default()); // FIXME
+    let substs = super::infer::unify(db, trait_env, &tys)?;
     // We only want the substs for the vars we added, not the ones from self_ty.
     // Also, if any of the vars we added are still in there, we replace them by
     // Unknown. I think this can only really happen if self_ty contained

--- a/crates/hir_ty/src/tests/coercion.rs
+++ b/crates/hir_ty/src/tests/coercion.rs
@@ -1,6 +1,6 @@
 use expect_test::expect;
 
-use super::{check_infer, check_infer_with_mismatches};
+use super::{check_infer, check_infer_with_mismatches, check_types};
 
 #[test]
 fn infer_block_expr_type_mismatch() {
@@ -857,4 +857,19 @@ fn coerce_unsize_generic() {
         expect![[r"
         "]],
     );
+}
+
+#[test]
+fn infer_two_closures_lub() {
+    check_types(
+        r#"
+fn foo(c: i32) {
+    let add = |a: i32, b: i32| a + b;
+    let sub = |a, b| a - b;
+            //^ |i32, i32| -> i32
+    if c > 42 { add } else { sub };
+  //^ fn(i32, i32) -> i32
+}
+        "#,
+    )
 }

--- a/crates/hir_ty/src/tests/coercion.rs
+++ b/crates/hir_ty/src/tests/coercion.rs
@@ -873,3 +873,42 @@ fn foo(c: i32) {
         "#,
     )
 }
+
+#[test]
+fn infer_match_diverging_branch_1() {
+    check_types(
+        r#"
+enum Result<T> { Ok(T), Err }
+fn parse<T>() -> T { loop {} }
+
+fn test() -> i32 {
+    let a = match parse() {
+        Ok(val) => val,
+        Err => return 0,
+    };
+    a
+  //^ i32
+}
+        "#,
+    )
+}
+
+#[test]
+fn infer_match_diverging_branch_2() {
+    // same as 1 except for order of branches
+    check_types(
+        r#"
+enum Result<T> { Ok(T), Err }
+fn parse<T>() -> T { loop {} }
+
+fn test() -> i32 {
+    let a = match parse() {
+        Err => return 0,
+        Ok(val) => val,
+    };
+    a
+  //^ i32
+}
+        "#,
+    )
+}

--- a/crates/hir_ty/src/tests/patterns.rs
+++ b/crates/hir_ty/src/tests/patterns.rs
@@ -747,7 +747,7 @@ fn foo(tuple: (u8, i16, f32)) {
             209..210 '_': (u8, i16, f32)
             214..216 '{}': ()
             136..142: expected (u8, i16, f32), got (u8, i16)
-            170..182: expected (u8, i16, f32), got (u8, i16, f32, _)
+            170..182: expected (u8, i16, f32), got (u8, i16, f32, {unknown})
         "#]],
     );
 }

--- a/crates/hir_ty/src/tests/regression.rs
+++ b/crates/hir_ty/src/tests/regression.rs
@@ -758,7 +758,7 @@ fn issue_4885() {
         "#,
         expect![[r#"
             136..139 'key': &K
-            198..214 '{     ...key) }': {unknown}
+            198..214 '{     ...key) }': impl Future<Output = <K as Foo<R>>::Bar>
             204..207 'bar': fn bar<R, K>(&K) -> impl Future<Output = <K as Foo<R>>::Bar>
             204..212 'bar(key)': impl Future<Output = <K as Foo<R>>::Bar>
             208..211 'key': &K

--- a/crates/hir_ty/src/tests/regression.rs
+++ b/crates/hir_ty/src/tests/regression.rs
@@ -117,19 +117,19 @@ fn recursive_vars_2() {
         "#,
         expect![[r#"
             10..79 '{     ...x)]; }': ()
-            20..21 'x': {unknown}
-            24..31 'unknown': {unknown}
+            20..21 'x': &{unknown}
+            24..31 'unknown': &{unknown}
             41..42 'y': {unknown}
             45..52 'unknown': {unknown}
-            58..76 '[(x, y..., &x)]': [({unknown}, {unknown}); 2]
-            59..65 '(x, y)': ({unknown}, {unknown})
-            60..61 'x': {unknown}
+            58..76 '[(x, y..., &x)]': [(&{unknown}, {unknown}); 2]
+            59..65 '(x, y)': (&{unknown}, {unknown})
+            60..61 'x': &{unknown}
             63..64 'y': {unknown}
-            67..75 '(&y, &x)': (&{unknown}, &{unknown})
+            67..75 '(&y, &x)': (&{unknown}, {unknown})
             68..70 '&y': &{unknown}
             69..70 'y': {unknown}
-            72..74 '&x': &{unknown}
-            73..74 'x': {unknown}
+            72..74 '&x': &&{unknown}
+            73..74 'x': &{unknown}
         "#]],
     );
 }

--- a/crates/hir_ty/src/tests/regression.rs
+++ b/crates/hir_ty/src/tests/regression.rs
@@ -86,8 +86,6 @@ fn bug_651() {
 
 #[test]
 fn recursive_vars() {
-    cov_mark::check!(type_var_cycles_resolve_completely);
-    cov_mark::check!(type_var_cycles_resolve_as_possible);
     check_infer(
         r#"
         fn test() {
@@ -97,12 +95,12 @@ fn recursive_vars() {
         "#,
         expect![[r#"
             10..47 '{     ...&y]; }': ()
-            20..21 'y': &{unknown}
-            24..31 'unknown': &{unknown}
-            37..44 '[y, &y]': [&&{unknown}; 2]
-            38..39 'y': &{unknown}
-            41..43 '&y': &&{unknown}
-            42..43 'y': &{unknown}
+            20..21 'y': {unknown}
+            24..31 'unknown': {unknown}
+            37..44 '[y, &y]': [{unknown}; 2]
+            38..39 'y': {unknown}
+            41..43 '&y': &{unknown}
+            42..43 'y': {unknown}
         "#]],
     );
 }
@@ -119,19 +117,19 @@ fn recursive_vars_2() {
         "#,
         expect![[r#"
             10..79 '{     ...x)]; }': ()
-            20..21 'x': &&{unknown}
-            24..31 'unknown': &&{unknown}
-            41..42 'y': &&{unknown}
-            45..52 'unknown': &&{unknown}
-            58..76 '[(x, y..., &x)]': [(&&&{unknown}, &&&{unknown}); 2]
-            59..65 '(x, y)': (&&&{unknown}, &&&{unknown})
-            60..61 'x': &&{unknown}
-            63..64 'y': &&{unknown}
-            67..75 '(&y, &x)': (&&&{unknown}, &&&{unknown})
-            68..70 '&y': &&&{unknown}
-            69..70 'y': &&{unknown}
-            72..74 '&x': &&&{unknown}
-            73..74 'x': &&{unknown}
+            20..21 'x': {unknown}
+            24..31 'unknown': {unknown}
+            41..42 'y': {unknown}
+            45..52 'unknown': {unknown}
+            58..76 '[(x, y..., &x)]': [({unknown}, {unknown}); 2]
+            59..65 '(x, y)': ({unknown}, {unknown})
+            60..61 'x': {unknown}
+            63..64 'y': {unknown}
+            67..75 '(&y, &x)': (&{unknown}, &{unknown})
+            68..70 '&y': &{unknown}
+            69..70 'y': {unknown}
+            72..74 '&x': &{unknown}
+            73..74 'x': {unknown}
         "#]],
     );
 }
@@ -165,7 +163,6 @@ fn infer_std_crash_1() {
 
 #[test]
 fn infer_std_crash_2() {
-    cov_mark::check!(type_var_resolves_to_int_var);
     // caused "equating two type variables, ...", taken from std
     check_infer(
         r#"
@@ -257,27 +254,27 @@ fn infer_std_crash_5() {
         expect![[r#"
             26..322 '{     ...   } }': ()
             32..320 'for co...     }': ()
-            36..43 'content': &{unknown}
+            36..43 'content': {unknown}
             47..60 'doesnt_matter': {unknown}
             61..320 '{     ...     }': ()
-            75..79 'name': &&{unknown}
-            82..166 'if doe...     }': &&{unknown}
+            75..79 'name': &{unknown}
+            82..166 'if doe...     }': &{unknown}
             85..98 'doesnt_matter': bool
-            99..128 '{     ...     }': &&{unknown}
-            113..118 'first': &&{unknown}
-            134..166 '{     ...     }': &&{unknown}
-            148..156 '&content': &&{unknown}
-            149..156 'content': &{unknown}
+            99..128 '{     ...     }': &{unknown}
+            113..118 'first': &{unknown}
+            134..166 '{     ...     }': &{unknown}
+            148..156 '&content': &{unknown}
+            149..156 'content': {unknown}
             181..188 'content': &{unknown}
             191..313 'if ICE...     }': &{unknown}
             194..231 'ICE_RE..._VALUE': {unknown}
             194..247 'ICE_RE...&name)': bool
-            241..246 '&name': &&&{unknown}
-            242..246 'name': &&{unknown}
-            248..276 '{     ...     }': &&{unknown}
-            262..266 'name': &&{unknown}
-            282..313 '{     ...     }': &{unknown}
-            296..303 'content': &{unknown}
+            241..246 '&name': &&{unknown}
+            242..246 'name': &{unknown}
+            248..276 '{     ...     }': &{unknown}
+            262..266 'name': &{unknown}
+            282..313 '{     ...     }': {unknown}
+            296..303 'content': {unknown}
         "#]],
     );
 }
@@ -761,7 +758,7 @@ fn issue_4885() {
         "#,
         expect![[r#"
             136..139 'key': &K
-            198..214 '{     ...key) }': impl Future<Output = <K as Foo<R>>::Bar>
+            198..214 '{     ...key) }': {unknown}
             204..207 'bar': fn bar<R, K>(&K) -> impl Future<Output = <K as Foo<R>>::Bar>
             204..212 'bar(key)': impl Future<Output = <K as Foo<R>>::Bar>
             208..211 'key': &K

--- a/crates/hir_ty/src/tests/simple.rs
+++ b/crates/hir_ty/src/tests/simple.rs
@@ -1040,42 +1040,6 @@ fn infer_in_elseif() {
 }
 
 #[test]
-fn infer_closure_unify() {
-    check_infer(
-        r#"
-        fn foo(f: bool) {
-            let a = |x| x;
-            let b = |x| x;
-            let id = if f { a } else { b };
-            id(123);
-        }
-        "#,
-        expect![[r#"
-            7..8 'f': bool
-            16..106 '{     ...23); }': ()
-            26..27 'a': |i32| -> i32
-            30..35 '|x| x': |i32| -> i32
-            31..32 'x': i32
-            34..35 'x': i32
-            45..46 'b': |i32| -> i32
-            49..54 '|x| x': |i32| -> i32
-            50..51 'x': i32
-            53..54 'x': i32
-            64..66 'id': |i32| -> i32
-            69..90 'if f {... { b }': |i32| -> i32
-            72..73 'f': bool
-            74..79 '{ a }': |i32| -> i32
-            76..77 'a': |i32| -> i32
-            85..90 '{ b }': |i32| -> i32
-            87..88 'b': |i32| -> i32
-            96..98 'id': |i32| -> i32
-            96..103 'id(123)': i32
-            99..102 '123': i32
-        "#]],
-    )
-}
-
-#[test]
 fn infer_if_match_with_return() {
     check_infer(
         r#"

--- a/crates/hir_ty/src/tests/traits.rs
+++ b/crates/hir_ty/src/tests/traits.rs
@@ -3104,7 +3104,7 @@ fn foo() {
             568..573 'f(&s)': FnOnce::Output<dyn FnOnce(&Option<i32>), (&Option<i32>,)>
             570..572 '&s': &Option<i32>
             571..572 's': Option<i32>
-            549..562: expected Box<dyn FnOnce(&Option<i32>)>, got Box<|_| -> ()>
+            549..562: expected Box<dyn FnOnce(&Option<i32>)>, got Box<|{unknown}| -> ()>
         "#]],
     );
 }

--- a/crates/hir_ty/src/tls.rs
+++ b/crates/hir_ty/src/tls.rs
@@ -1,7 +1,7 @@
 //! Implementation of Chalk debug helper functions using TLS.
-use std::fmt;
+use std::fmt::{self, Debug};
 
-use chalk_ir::{AliasTy, GenericArg, Goal, Goals, Lifetime, ProgramClauseImplication};
+use chalk_ir::AliasTy;
 use itertools::Itertools;
 
 use crate::{
@@ -53,14 +53,6 @@ impl DebugContext<'_> {
         write!(fmt, "{}::{}", trait_data.name, type_alias_data.name)
     }
 
-    pub(crate) fn debug_opaque_ty_id(
-        &self,
-        opaque_ty_id: chalk_ir::OpaqueTyId<Interner>,
-        fmt: &mut fmt::Formatter<'_>,
-    ) -> Result<(), fmt::Error> {
-        fmt.debug_struct("OpaqueTyId").field("index", &opaque_ty_id.0).finish()
-    }
-
     pub(crate) fn debug_alias(
         &self,
         alias_ty: &AliasTy<Interner>,
@@ -68,7 +60,7 @@ impl DebugContext<'_> {
     ) -> Result<(), fmt::Error> {
         match alias_ty {
             AliasTy::Projection(projection_ty) => self.debug_projection_ty(projection_ty, fmt),
-            AliasTy::Opaque(opaque_ty) => self.debug_opaque_ty(opaque_ty, fmt),
+            AliasTy::Opaque(opaque_ty) => opaque_ty.fmt(fmt),
         }
     }
 
@@ -96,79 +88,6 @@ impl DebugContext<'_> {
         write!(fmt, ">::{}", type_alias_data.name)
     }
 
-    pub(crate) fn debug_opaque_ty(
-        &self,
-        opaque_ty: &chalk_ir::OpaqueTy<Interner>,
-        fmt: &mut fmt::Formatter<'_>,
-    ) -> Result<(), fmt::Error> {
-        write!(fmt, "{:?}", opaque_ty.opaque_ty_id)
-    }
-
-    pub(crate) fn debug_ty(
-        &self,
-        ty: &chalk_ir::Ty<Interner>,
-        fmt: &mut fmt::Formatter<'_>,
-    ) -> Result<(), fmt::Error> {
-        write!(fmt, "{:?}", ty.data(&Interner))
-    }
-
-    pub(crate) fn debug_lifetime(
-        &self,
-        lifetime: &Lifetime<Interner>,
-        fmt: &mut fmt::Formatter<'_>,
-    ) -> Result<(), fmt::Error> {
-        write!(fmt, "{:?}", lifetime.data(&Interner))
-    }
-
-    pub(crate) fn debug_generic_arg(
-        &self,
-        parameter: &GenericArg<Interner>,
-        fmt: &mut fmt::Formatter<'_>,
-    ) -> Result<(), fmt::Error> {
-        write!(fmt, "{:?}", parameter.data(&Interner).inner_debug())
-    }
-
-    pub(crate) fn debug_goal(
-        &self,
-        goal: &Goal<Interner>,
-        fmt: &mut fmt::Formatter<'_>,
-    ) -> Result<(), fmt::Error> {
-        let goal_data = goal.data(&Interner);
-        write!(fmt, "{:?}", goal_data)
-    }
-
-    pub(crate) fn debug_goals(
-        &self,
-        goals: &Goals<Interner>,
-        fmt: &mut fmt::Formatter<'_>,
-    ) -> Result<(), fmt::Error> {
-        write!(fmt, "{:?}", goals.debug(&Interner))
-    }
-
-    pub(crate) fn debug_program_clause_implication(
-        &self,
-        pci: &ProgramClauseImplication<Interner>,
-        fmt: &mut fmt::Formatter<'_>,
-    ) -> Result<(), fmt::Error> {
-        write!(fmt, "{:?}", pci.debug(&Interner))
-    }
-
-    pub(crate) fn debug_substitution(
-        &self,
-        substitution: &chalk_ir::Substitution<Interner>,
-        fmt: &mut fmt::Formatter<'_>,
-    ) -> Result<(), fmt::Error> {
-        write!(fmt, "{:?}", substitution.debug(&Interner))
-    }
-
-    pub(crate) fn debug_separator_trait_ref(
-        &self,
-        separator_trait_ref: &chalk_ir::SeparatorTraitRef<Interner>,
-        fmt: &mut fmt::Formatter<'_>,
-    ) -> Result<(), fmt::Error> {
-        write!(fmt, "{:?}", separator_trait_ref.debug(&Interner))
-    }
-
     pub(crate) fn debug_fn_def_id(
         &self,
         fn_def_id: chalk_ir::FnDefId<Interner>,
@@ -189,57 +108,6 @@ impl DebugContext<'_> {
                 write!(fmt, "{{ctor {}}}", name)
             }
         }
-    }
-
-    pub(crate) fn debug_const(
-        &self,
-        _constant: &chalk_ir::Const<Interner>,
-        fmt: &mut fmt::Formatter<'_>,
-    ) -> fmt::Result {
-        write!(fmt, "const")
-    }
-
-    pub(crate) fn debug_variable_kinds(
-        &self,
-        variable_kinds: &chalk_ir::VariableKinds<Interner>,
-        fmt: &mut fmt::Formatter<'_>,
-    ) -> fmt::Result {
-        write!(fmt, "{:?}", variable_kinds.as_slice(&Interner))
-    }
-    pub(crate) fn debug_variable_kinds_with_angles(
-        &self,
-        variable_kinds: &chalk_ir::VariableKinds<Interner>,
-        fmt: &mut fmt::Formatter<'_>,
-    ) -> fmt::Result {
-        write!(fmt, "{:?}", variable_kinds.inner_debug(&Interner))
-    }
-    pub(crate) fn debug_canonical_var_kinds(
-        &self,
-        canonical_var_kinds: &chalk_ir::CanonicalVarKinds<Interner>,
-        fmt: &mut fmt::Formatter<'_>,
-    ) -> fmt::Result {
-        write!(fmt, "{:?}", canonical_var_kinds.as_slice(&Interner))
-    }
-    pub(crate) fn debug_program_clause(
-        &self,
-        clause: &chalk_ir::ProgramClause<Interner>,
-        fmt: &mut fmt::Formatter<'_>,
-    ) -> fmt::Result {
-        write!(fmt, "{:?}", clause.data(&Interner))
-    }
-    pub(crate) fn debug_program_clauses(
-        &self,
-        clauses: &chalk_ir::ProgramClauses<Interner>,
-        fmt: &mut fmt::Formatter<'_>,
-    ) -> fmt::Result {
-        write!(fmt, "{:?}", clauses.as_slice(&Interner))
-    }
-    pub(crate) fn debug_quantified_where_clauses(
-        &self,
-        clauses: &chalk_ir::QuantifiedWhereClauses<Interner>,
-        fmt: &mut fmt::Formatter<'_>,
-    ) -> fmt::Result {
-        write!(fmt, "{:?}", clauses.as_slice(&Interner))
     }
 }
 

--- a/crates/ide_completion/src/render.rs
+++ b/crates/ide_completion/src/render.rs
@@ -323,7 +323,7 @@ fn compute_type_match(
 
     if completion_ty == expected_type {
         Some(CompletionRelevanceTypeMatch::Exact)
-    } else if expected_type.could_unify_with(completion_ty) {
+    } else if expected_type.could_unify_with(ctx.db, completion_ty) {
         Some(CompletionRelevanceTypeMatch::CouldUnify)
     } else {
         None


### PR DESCRIPTION
 - use Chalk's unification, get rid of our own `unify`
 - rewrite coercion to not use unification internals and to be more analogous to rustc
 - fix various coercion bugs
 - rewrite handling of obligations, since the old hacky optimization where we noted when an inference variable changes wasn't possible anymore
 - stop trying to deeply resolve types all the time during inference, instead only do it shallowly where necessary