### PR TITLE
fix: false positive "Missing match arm" when an or-pattern has mismatched types

### DIFF
--- a/crates/hir_ty/src/diagnostics/expr.rs
+++ b/crates/hir_ty/src/diagnostics/expr.rs
@@ -211,7 +211,7 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
 
         // FIXME: Due to shortcomings in the current type system implementation, only emit this
         // diagnostic if there are no type mismatches in the containing function.
-        if self.infer.type_mismatches.iter().next().is_some() {
+        if self.infer.expr_type_mismatches().next().is_some() {
             return;
         }
 

--- a/crates/hir_ty/src/diagnostics/match_check.rs
+++ b/crates/hir_ty/src/diagnostics/match_check.rs
@@ -1128,6 +1128,18 @@ fn main() {
     }
 
     #[test]
+    fn mismatched_types_in_or_patterns() {
+        check_diagnostics(
+            r#"
+fn main() {
+    match false { true | () => {} }
+    match (false,) { (true | (),) => {} }
+}
+"#,
+        );
+    }
+
+    #[test]
     fn malformed_match_arm_tuple_enum_missing_pattern() {
         // We are testing to be sure we don't panic here when the match
         // arm `Either::B` is missing its pattern.

--- a/crates/hir_ty/src/infer/expr.rs
+++ b/crates/hir_ty/src/infer/expr.rs
@@ -42,7 +42,7 @@ impl<'a> InferenceContext<'a> {
         let could_unify = self.unify(&ty, &expected.ty);
         if !could_unify {
             self.result.type_mismatches.insert(
-                tgt_expr,
+                tgt_expr.into(),
                 TypeMismatch { expected: expected.ty.clone(), actual: ty.clone() },
             );
         }
@@ -54,9 +54,10 @@ impl<'a> InferenceContext<'a> {
     pub(super) fn infer_expr_coerce(&mut self, expr: ExprId, expected: &Expectation) -> Ty {
         let ty = self.infer_expr_inner(expr, &expected);
         let ty = if !self.coerce(&ty, &expected.coercion_target()) {
-            self.result
-                .type_mismatches
-                .insert(expr, TypeMismatch { expected: expected.ty.clone(), actual: ty.clone() });
+            self.result.type_mismatches.insert(
+                expr.into(),
+                TypeMismatch { expected: expected.ty.clone(), actual: ty.clone() },
+            );
             // Return actual type when type mismatch.
             // This is needed for diagnostic when return type mismatch.
             ty

--- a/crates/hir_ty/src/infer/pat.rs
+++ b/crates/hir_ty/src/infer/pat.rs
@@ -10,7 +10,7 @@ use hir_def::{
 };
 use hir_expand::name::Name;
 
-use super::{BindingMode, Expectation, InferenceContext};
+use super::{BindingMode, Expectation, InferenceContext, TypeMismatch};
 use crate::{
     lower::lower_to_chalk_mutability, static_lifetime, Interner, Substitution, Ty, TyBuilder,
     TyExt, TyKind,
@@ -266,7 +266,10 @@ impl<'a> InferenceContext<'a> {
         // use a new type variable if we got error type here
         let ty = self.insert_type_vars_shallow(ty);
         if !self.unify(&ty, expected) {
-            // FIXME record mismatch, we need to change the type of self.type_mismatches for that
+            self.result.type_mismatches.insert(
+                pat.into(),
+                TypeMismatch { expected: expected.clone(), actual: ty.clone() },
+            );
         }
         let ty = self.resolve_ty_as_possible(ty);
         self.write_pat_ty(pat, ty.clone());

--- a/crates/hir_ty/src/tests.rs
+++ b/crates/hir_ty/src/tests.rs
@@ -130,7 +130,10 @@ fn infer_with_mismatches(content: &str, include_mismatches: bool) -> String {
                 }
                 Err(SyntheticSyntax) => continue,
             };
-            types.push((syntax_ptr, ty));
+            types.push((syntax_ptr.clone(), ty));
+            if let Some(mismatch) = inference_result.type_mismatch_for_pat(pat) {
+                mismatches.push((syntax_ptr, mismatch));
+            }
         }
 
         for (expr, ty) in inference_result.type_of_expr.iter() {


### PR DESCRIPTION
![Screenshot_20210519_114510](https://user-images.githubusercontent.com/7803845/118768935-19e12c00-b86f-11eb-90c4-1eed3f2bf57f.jpg)
`InferenceResult` now records pattern type mismatches.