### PR TITLE
internal: resolve attributes in name resolution (minimal version)

### DIFF
--- a/crates/hir_def/src/intern.rs
+++ b/crates/hir_def/src/intern.rs
@@ -4,7 +4,7 @@
 
 use std::{
     collections::HashMap,
-    fmt::{self, Debug},
+    fmt::{self, Debug, Display},
     hash::{BuildHasherDefault, Hash, Hasher},
     ops::Deref,
     sync::Arc,
@@ -166,6 +166,12 @@ impl<T: Internable + ?Sized> Clone for Interned<T> {
 }
 
 impl<T: Debug + Internable + ?Sized> Debug for Interned<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (*self.arc).fmt(f)
+    }
+}
+
+impl<T: Display + Internable + ?Sized> Display for Interned<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         (*self.arc).fmt(f)
     }


### PR DESCRIPTION
Closes https://github.com/rust-analyzer/rust-analyzer/pull/7049

This should not have any observable effect, since we don't attempt to expand attribute macros yet, and I have implemented a fallback that treats items with unresolved attributes as if the attribute wasn't there.

Derive helpers are not yet resolved. `#![register_{attr,tool}]` are not yet supported.