### PR TITLE
internal: greatly simplify eager macro representation

### DIFF
--- a/crates/hir/src/db.rs
+++ b/crates/hir/src/db.rs
@@ -2,8 +2,8 @@
 
 pub use hir_def::db::*;
 pub use hir_expand::db::{
-    AstDatabase, AstDatabaseStorage, AstIdMapQuery, HygieneFrameQuery, InternEagerExpansionQuery,
-    InternMacroQuery, MacroArgTextQuery, MacroDefQuery, MacroExpandQuery, ParseMacroExpansionQuery,
+    AstDatabase, AstDatabaseStorage, AstIdMapQuery, HygieneFrameQuery, InternMacroQuery,
+    MacroArgTextQuery, MacroDefQuery, MacroExpandQuery, ParseMacroExpansionQuery,
 };
 pub use hir_ty::db::*;
 

--- a/crates/hir_def/src/nameres/collector.rs
+++ b/crates/hir_def/src/nameres/collector.rs
@@ -948,20 +948,17 @@ impl DefCollector<'_> {
         // incrementality).
         let err = self.db.macro_expand_error(macro_call_id);
         if let Some(err) = err {
-            if let MacroCallId::LazyMacro(id) = macro_call_id {
-                let loc: MacroCallLoc = self.db.lookup_intern_macro(id);
+            let loc: MacroCallLoc = self.db.lookup_intern_macro(macro_call_id);
 
-                let diag = match err {
-                    hir_expand::ExpandError::UnresolvedProcMacro => {
-                        // Missing proc macros are non-fatal, so they are handled specially.
-                        DefDiagnostic::unresolved_proc_macro(module_id, loc.kind)
-                    }
-                    _ => DefDiagnostic::macro_error(module_id, loc.kind, err.to_string()),
-                };
+            let diag = match err {
+                hir_expand::ExpandError::UnresolvedProcMacro => {
+                    // Missing proc macros are non-fatal, so they are handled specially.
+                    DefDiagnostic::unresolved_proc_macro(module_id, loc.kind)
+                }
+                _ => DefDiagnostic::macro_error(module_id, loc.kind, err.to_string()),
+            };
 
-                self.def_map.diagnostics.push(diag);
-            }
-            // FIXME: Handle eager macros.
+            self.def_map.diagnostics.push(diag);
         }
 
         // Then, fetch and process the item tree. This will reuse the expansion result from above.

--- a/crates/hir_expand/src/builtin_derive.rs
+++ b/crates/hir_expand/src/builtin_derive.rs
@@ -8,7 +8,7 @@ use syntax::{
     match_ast,
 };
 
-use crate::{db::AstDatabase, name, quote, AstId, CrateId, LazyMacroId, MacroDefId, MacroDefKind};
+use crate::{db::AstDatabase, name, quote, AstId, CrateId, MacroCallId, MacroDefId, MacroDefKind};
 
 macro_rules! register_builtin {
     ( $($trait:ident => $expand:ident),* ) => {
@@ -21,7 +21,7 @@ macro_rules! register_builtin {
             pub fn expand(
                 &self,
                 db: &dyn AstDatabase,
-                id: LazyMacroId,
+                id: MacroCallId,
                 tt: &tt::Subtree,
             ) -> Result<tt::Subtree, mbe::ExpandError> {
                 let expander = match *self {
@@ -164,7 +164,7 @@ fn expand_simple_derive(
     Ok(expanded)
 }
 
-fn find_builtin_crate(db: &dyn AstDatabase, id: LazyMacroId) -> tt::TokenTree {
+fn find_builtin_crate(db: &dyn AstDatabase, id: MacroCallId) -> tt::TokenTree {
     // FIXME: make hygiene works for builtin derive macro
     // such that $crate can be used here.
     let cg = db.crate_graph();
@@ -184,7 +184,7 @@ fn find_builtin_crate(db: &dyn AstDatabase, id: LazyMacroId) -> tt::TokenTree {
 
 fn copy_expand(
     db: &dyn AstDatabase,
-    id: LazyMacroId,
+    id: MacroCallId,
     tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     let krate = find_builtin_crate(db, id);
@@ -193,7 +193,7 @@ fn copy_expand(
 
 fn clone_expand(
     db: &dyn AstDatabase,
-    id: LazyMacroId,
+    id: MacroCallId,
     tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     let krate = find_builtin_crate(db, id);
@@ -202,7 +202,7 @@ fn clone_expand(
 
 fn default_expand(
     db: &dyn AstDatabase,
-    id: LazyMacroId,
+    id: MacroCallId,
     tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     let krate = find_builtin_crate(db, id);
@@ -211,7 +211,7 @@ fn default_expand(
 
 fn debug_expand(
     db: &dyn AstDatabase,
-    id: LazyMacroId,
+    id: MacroCallId,
     tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     let krate = find_builtin_crate(db, id);
@@ -220,7 +220,7 @@ fn debug_expand(
 
 fn hash_expand(
     db: &dyn AstDatabase,
-    id: LazyMacroId,
+    id: MacroCallId,
     tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     let krate = find_builtin_crate(db, id);
@@ -229,7 +229,7 @@ fn hash_expand(
 
 fn eq_expand(
     db: &dyn AstDatabase,
-    id: LazyMacroId,
+    id: MacroCallId,
     tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     let krate = find_builtin_crate(db, id);
@@ -238,7 +238,7 @@ fn eq_expand(
 
 fn partial_eq_expand(
     db: &dyn AstDatabase,
-    id: LazyMacroId,
+    id: MacroCallId,
     tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     let krate = find_builtin_crate(db, id);
@@ -247,7 +247,7 @@ fn partial_eq_expand(
 
 fn ord_expand(
     db: &dyn AstDatabase,
-    id: LazyMacroId,
+    id: MacroCallId,
     tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     let krate = find_builtin_crate(db, id);
@@ -256,7 +256,7 @@ fn ord_expand(
 
 fn partial_ord_expand(
     db: &dyn AstDatabase,
-    id: LazyMacroId,
+    id: MacroCallId,
     tt: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
     let krate = find_builtin_crate(db, id);
@@ -317,6 +317,7 @@ $0
                 local_inner: false,
             },
             krate: CrateId(0),
+            eager: None,
             kind: MacroCallKind::Derive {
                 ast_id,
                 derive_name: name.to_string(),

--- a/crates/hir_expand/src/builtin_macro.rs
+++ b/crates/hir_expand/src/builtin_macro.rs
@@ -625,7 +625,7 @@ mod tests {
                     def,
                     krate,
                     eager: Some(EagerCallInfo {
-                        expansion: Arc::new(parsed_args.clone()),
+                        arg_or_expansion: Arc::new(parsed_args.clone()),
                         included_file: None,
                     }),
                     kind: MacroCallKind::FnLike { ast_id: call_id, fragment: FragmentKind::Expr },
@@ -636,7 +636,7 @@ mod tests {
                     def,
                     krate,
                     eager: Some(EagerCallInfo {
-                        expansion: Arc::new(expanded.subtree),
+                        arg_or_expansion: Arc::new(expanded.subtree),
                         included_file: expanded.included_file,
                     }),
                     kind: MacroCallKind::FnLike { ast_id: call_id, fragment: expanded.fragment },

--- a/crates/hir_expand/src/builtin_macro.rs
+++ b/crates/hir_expand/src/builtin_macro.rs
@@ -1,7 +1,7 @@
 //! Builtin macro
 use crate::{
-    db::AstDatabase, name, quote, AstId, CrateId, EagerMacroId, LazyMacroId, MacroCallId,
-    MacroCallLoc, MacroDefId, MacroDefKind, TextSize,
+    db::AstDatabase, name, quote, AstId, CrateId, MacroCallId, MacroCallLoc, MacroDefId,
+    MacroDefKind, TextSize,
 };
 
 use base_db::{AnchoredPath, Edition, FileId};
@@ -27,7 +27,7 @@ macro_rules! register_builtin {
             pub fn expand(
                 &self,
                 db: &dyn AstDatabase,
-                id: LazyMacroId,
+                id: MacroCallId,
                 tt: &tt::Subtree,
             ) -> ExpandResult<tt::Subtree> {
                 let expander = match *self {
@@ -41,7 +41,7 @@ macro_rules! register_builtin {
             pub fn expand(
                 &self,
                 db: &dyn AstDatabase,
-                arg_id: EagerMacroId,
+                arg_id: MacroCallId,
                 tt: &tt::Subtree,
             ) -> ExpandResult<Option<ExpandedEager>> {
                 let expander = match *self {
@@ -128,7 +128,7 @@ register_builtin! {
 
 fn module_path_expand(
     _db: &dyn AstDatabase,
-    _id: LazyMacroId,
+    _id: MacroCallId,
     _tt: &tt::Subtree,
 ) -> ExpandResult<tt::Subtree> {
     // Just return a dummy result.
@@ -137,7 +137,7 @@ fn module_path_expand(
 
 fn line_expand(
     _db: &dyn AstDatabase,
-    _id: LazyMacroId,
+    _id: MacroCallId,
     _tt: &tt::Subtree,
 ) -> ExpandResult<tt::Subtree> {
     // dummy implementation for type-checking purposes
@@ -151,7 +151,7 @@ fn line_expand(
 
 fn stringify_expand(
     db: &dyn AstDatabase,
-    id: LazyMacroId,
+    id: MacroCallId,
     _tt: &tt::Subtree,
 ) -> ExpandResult<tt::Subtree> {
     let loc = db.lookup_intern_macro(id);
@@ -176,7 +176,7 @@ fn stringify_expand(
 
 fn column_expand(
     _db: &dyn AstDatabase,
-    _id: LazyMacroId,
+    _id: MacroCallId,
     _tt: &tt::Subtree,
 ) -> ExpandResult<tt::Subtree> {
     // dummy implementation for type-checking purposes
@@ -190,7 +190,7 @@ fn column_expand(
 
 fn assert_expand(
     _db: &dyn AstDatabase,
-    _id: LazyMacroId,
+    _id: MacroCallId,
     tt: &tt::Subtree,
 ) -> ExpandResult<tt::Subtree> {
     // A hacky implementation for goto def and hover
@@ -214,7 +214,7 @@ fn assert_expand(
 
 fn file_expand(
     _db: &dyn AstDatabase,
-    _id: LazyMacroId,
+    _id: MacroCallId,
     _tt: &tt::Subtree,
 ) -> ExpandResult<tt::Subtree> {
     // FIXME: RA purposefully lacks knowledge of absolute file names
@@ -230,7 +230,7 @@ fn file_expand(
 
 fn format_args_expand(
     _db: &dyn AstDatabase,
-    _id: LazyMacroId,
+    _id: MacroCallId,
     tt: &tt::Subtree,
 ) -> ExpandResult<tt::Subtree> {
     // We expand `format_args!("", a1, a2)` to
@@ -265,7 +265,7 @@ fn format_args_expand(
 
 fn asm_expand(
     _db: &dyn AstDatabase,
-    _id: LazyMacroId,
+    _id: MacroCallId,
     _tt: &tt::Subtree,
 ) -> ExpandResult<tt::Subtree> {
     // both asm and llvm_asm don't return anything, so we can expand them to nothing,
@@ -278,7 +278,7 @@ fn asm_expand(
 
 fn global_asm_expand(
     _db: &dyn AstDatabase,
-    _id: LazyMacroId,
+    _id: MacroCallId,
     _tt: &tt::Subtree,
 ) -> ExpandResult<tt::Subtree> {
     // Expand to nothing (at item-level)
@@ -287,7 +287,7 @@ fn global_asm_expand(
 
 fn cfg_expand(
     db: &dyn AstDatabase,
-    id: LazyMacroId,
+    id: MacroCallId,
     tt: &tt::Subtree,
 ) -> ExpandResult<tt::Subtree> {
     let loc = db.lookup_intern_macro(id);
@@ -299,7 +299,7 @@ fn cfg_expand(
 
 fn panic_expand(
     db: &dyn AstDatabase,
-    id: LazyMacroId,
+    id: MacroCallId,
     tt: &tt::Subtree,
 ) -> ExpandResult<tt::Subtree> {
     let loc: MacroCallLoc = db.lookup_intern_macro(id);
@@ -324,7 +324,7 @@ fn unquote_str(lit: &tt::Literal) -> Option<String> {
 
 fn compile_error_expand(
     _db: &dyn AstDatabase,
-    _id: EagerMacroId,
+    _id: MacroCallId,
     tt: &tt::Subtree,
 ) -> ExpandResult<Option<ExpandedEager>> {
     let err = match &*tt.token_trees {
@@ -345,7 +345,7 @@ fn compile_error_expand(
 
 fn concat_expand(
     _db: &dyn AstDatabase,
-    _arg_id: EagerMacroId,
+    _arg_id: MacroCallId,
     tt: &tt::Subtree,
 ) -> ExpandResult<Option<ExpandedEager>> {
     let mut err = None;
@@ -376,7 +376,7 @@ fn concat_expand(
 
 fn concat_idents_expand(
     _db: &dyn AstDatabase,
-    _arg_id: EagerMacroId,
+    _arg_id: MacroCallId,
     tt: &tt::Subtree,
 ) -> ExpandResult<Option<ExpandedEager>> {
     let mut err = None;
@@ -427,7 +427,7 @@ fn parse_string(tt: &tt::Subtree) -> Result<String, mbe::ExpandError> {
 
 fn include_expand(
     db: &dyn AstDatabase,
-    arg_id: EagerMacroId,
+    arg_id: MacroCallId,
     tt: &tt::Subtree,
 ) -> ExpandResult<Option<ExpandedEager>> {
     let res = (|| {
@@ -457,7 +457,7 @@ fn include_expand(
 
 fn include_bytes_expand(
     _db: &dyn AstDatabase,
-    _arg_id: EagerMacroId,
+    _arg_id: MacroCallId,
     tt: &tt::Subtree,
 ) -> ExpandResult<Option<ExpandedEager>> {
     if let Err(e) = parse_string(tt) {
@@ -477,7 +477,7 @@ fn include_bytes_expand(
 
 fn include_str_expand(
     db: &dyn AstDatabase,
-    arg_id: EagerMacroId,
+    arg_id: MacroCallId,
     tt: &tt::Subtree,
 ) -> ExpandResult<Option<ExpandedEager>> {
     let path = match parse_string(tt) {
@@ -502,14 +502,14 @@ fn include_str_expand(
     ExpandResult::ok(Some(ExpandedEager::new(quote!(#text), FragmentKind::Expr)))
 }
 
-fn get_env_inner(db: &dyn AstDatabase, arg_id: EagerMacroId, key: &str) -> Option<String> {
-    let krate = db.lookup_intern_eager_expansion(arg_id).krate;
+fn get_env_inner(db: &dyn AstDatabase, arg_id: MacroCallId, key: &str) -> Option<String> {
+    let krate = db.lookup_intern_macro(arg_id).krate;
     db.crate_graph()[krate].env.get(key)
 }
 
 fn env_expand(
     db: &dyn AstDatabase,
-    arg_id: EagerMacroId,
+    arg_id: MacroCallId,
     tt: &tt::Subtree,
 ) -> ExpandResult<Option<ExpandedEager>> {
     let key = match parse_string(tt) {
@@ -540,7 +540,7 @@ fn env_expand(
 
 fn option_env_expand(
     db: &dyn AstDatabase,
-    arg_id: EagerMacroId,
+    arg_id: MacroCallId,
     tt: &tt::Subtree,
 ) -> ExpandResult<Option<ExpandedEager>> {
     let key = match parse_string(tt) {
@@ -560,7 +560,7 @@ fn option_env_expand(
 mod tests {
     use super::*;
     use crate::{
-        name::AsName, test_db::TestDB, AstNode, EagerCallLoc, MacroCallId, MacroCallKind,
+        name::AsName, test_db::TestDB, AstNode, EagerCallInfo, MacroCallId, MacroCallKind,
         MacroCallLoc,
     };
     use base_db::{fixture::WithFixture, SourceDatabase};
@@ -599,6 +599,7 @@ mod tests {
                 let loc = MacroCallLoc {
                     def,
                     krate,
+                    eager: None,
                     kind: MacroCallKind::FnLike {
                         ast_id: AstId::new(file_id.into(), ast_id_map.ast_id(&macro_call)),
                         fragment: FragmentKind::Expr,
@@ -620,28 +621,28 @@ mod tests {
                 let parsed_args = mbe::ast_to_token_tree(&args).0;
                 let call_id = AstId::new(file_id.into(), ast_id_map.ast_id(&macro_call));
 
-                let arg_id = db.intern_eager_expansion({
-                    EagerCallLoc {
-                        def,
-                        fragment: FragmentKind::Expr,
-                        subtree: Arc::new(parsed_args.clone()),
-                        krate,
-                        call: call_id,
+                let arg_id = db.intern_macro(MacroCallLoc {
+                    def,
+                    krate,
+                    eager: Some(EagerCallInfo {
+                        expansion: Arc::new(parsed_args.clone()),
                         included_file: None,
-                    }
+                    }),
+                    kind: MacroCallKind::FnLike { ast_id: call_id, fragment: FragmentKind::Expr },
                 });
 
                 let expanded = expander.expand(&db, arg_id, &parsed_args).value.unwrap();
-                let eager = EagerCallLoc {
+                let loc = MacroCallLoc {
                     def,
-                    fragment: expanded.fragment,
-                    subtree: Arc::new(expanded.subtree),
                     krate,
-                    call: call_id,
-                    included_file: expanded.included_file,
+                    eager: Some(EagerCallInfo {
+                        expansion: Arc::new(expanded.subtree),
+                        included_file: expanded.included_file,
+                    }),
+                    kind: MacroCallKind::FnLike { ast_id: call_id, fragment: expanded.fragment },
                 };
 
-                let id: MacroCallId = db.intern_eager_expansion(eager).into();
+                let id: MacroCallId = db.intern_macro(loc).into();
                 id.as_file()
             }
         };

--- a/crates/hir_expand/src/db.rs
+++ b/crates/hir_expand/src/db.rs
@@ -329,7 +329,7 @@ fn macro_expand_with_arg(
             );
         } else {
             return ExpandResult {
-                value: Some(eager.expansion.clone()),
+                value: Some(eager.arg_or_expansion.clone()),
                 // FIXME: There could be errors here!
                 err: None,
             };

--- a/crates/hir_expand/src/eager.rs
+++ b/crates/hir_expand/src/eager.rs
@@ -122,7 +122,7 @@ pub fn expand_eager_macro(
         def,
         krate,
         eager: Some(EagerCallInfo {
-            expansion: Arc::new(parsed_args.clone()),
+            arg_or_expansion: Arc::new(parsed_args.clone()),
             included_file: None,
         }),
         kind: MacroCallKind::FnLike { ast_id: call_id, fragment: FragmentKind::Expr },
@@ -149,7 +149,7 @@ pub fn expand_eager_macro(
             def,
             krate,
             eager: Some(EagerCallInfo {
-                expansion: Arc::new(expanded.subtree),
+                arg_or_expansion: Arc::new(expanded.subtree),
                 included_file: expanded.included_file,
             }),
             kind: MacroCallKind::FnLike { ast_id: call_id, fragment: expanded.fragment },

--- a/crates/hir_expand/src/input.rs
+++ b/crates/hir_expand/src/input.rs
@@ -8,13 +8,13 @@ use syntax::{
 use crate::{
     db::AstDatabase,
     name::{name, AsName},
-    LazyMacroId, MacroCallKind, MacroCallLoc,
+    MacroCallId, MacroCallKind, MacroCallLoc,
 };
 
 pub(crate) fn process_macro_input(
     db: &dyn AstDatabase,
     node: SyntaxNode,
-    id: LazyMacroId,
+    id: MacroCallId,
 ) -> SyntaxNode {
     let loc: MacroCallLoc = db.lookup_intern_macro(id);
 

--- a/crates/hir_expand/src/lib.rs
+++ b/crates/hir_expand/src/lib.rs
@@ -231,7 +231,7 @@ pub enum MacroDefKind {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct EagerCallInfo {
     /// NOTE: This can be *either* the expansion result, *or* the argument to the eager macro!
-    expansion: Arc<tt::Subtree>,
+    arg_or_expansion: Arc<tt::Subtree>,
     included_file: Option<FileId>,
 }
 

--- a/crates/ide_db/src/apply_change.rs
+++ b/crates/ide_db/src/apply_change.rs
@@ -222,7 +222,6 @@ impl RootDatabase {
         sweep_each_query![
             // AstDatabase
             hir::db::InternMacroQuery
-            hir::db::InternEagerExpansionQuery
 
             // InternDatabase
             hir::db::InternFunctionQuery


### PR DESCRIPTION
- Share structures with lazy macros, make both use `MacroCallLoc`.
- Remove `intern_eager_expansion`, `EagerCallLoc`, `EagerMacroId`, and *many* matches on `MacroCallId`.
- Make a lot of FIXMEs obsolete since the code no longer distinguishes between eager and lazy macros.
- Add `EagerCallInfo`, which is `Some` for calls to eager macros and holds the argument or expansion result and the included file.