### PR TITLE
fix: Don't hang on unresolved attribute on extern block and its children

### DIFF
--- a/crates/hir_def/src/item_tree.rs
+++ b/crates/hir_def/src/item_tree.rs
@@ -132,6 +132,7 @@ impl ItemTree {
             let ItemTreeData {
                 imports,
                 extern_crates,
+                extern_blocks,
                 functions,
                 params,
                 structs,
@@ -154,6 +155,7 @@ impl ItemTree {
 
             imports.shrink_to_fit();
             extern_crates.shrink_to_fit();
+            extern_blocks.shrink_to_fit();
             functions.shrink_to_fit();
             params.shrink_to_fit();
             structs.shrink_to_fit();
@@ -239,6 +241,7 @@ static VIS_PUB_CRATE: RawVisibility = RawVisibility::Module(ModPath::from_kind(P
 struct ItemTreeData {
     imports: Arena<Import>,
     extern_crates: Arena<ExternCrate>,
+    extern_blocks: Arena<ExternBlock>,
     functions: Arena<Function>,
     params: Arena<Param>,
     structs: Arena<Struct>,
@@ -432,6 +435,7 @@ macro_rules! mod_items {
 mod_items! {
     Import in imports -> ast::Use,
     ExternCrate in extern_crates -> ast::ExternCrate,
+    ExternBlock in extern_blocks -> ast::ExternBlock,
     Function in functions -> ast::Fn,
     Struct in structs -> ast::Struct,
     Union in unions -> ast::Union,
@@ -505,6 +509,13 @@ pub struct ExternCrate {
     pub alias: Option<ImportAlias>,
     pub visibility: RawVisibilityId,
     pub ast_id: FileAstId<ast::ExternCrate>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ExternBlock {
+    pub abi: Option<Interned<str>>,
+    pub ast_id: FileAstId<ast::ExternBlock>,
+    pub children: Box<[ModItem]>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -691,6 +702,7 @@ impl ModItem {
         match self {
             ModItem::Import(_)
             | ModItem::ExternCrate(_)
+            | ModItem::ExternBlock(_)
             | ModItem::Struct(_)
             | ModItem::Union(_)
             | ModItem::Enum(_)
@@ -715,6 +727,7 @@ impl ModItem {
         match self {
             ModItem::Import(it) => tree[it.index].ast_id().upcast(),
             ModItem::ExternCrate(it) => tree[it.index].ast_id().upcast(),
+            ModItem::ExternBlock(it) => tree[it.index].ast_id().upcast(),
             ModItem::Function(it) => tree[it.index].ast_id().upcast(),
             ModItem::Struct(it) => tree[it.index].ast_id().upcast(),
             ModItem::Union(it) => tree[it.index].ast_id().upcast(),

--- a/crates/hir_def/src/nameres/collector.rs
+++ b/crates/hir_def/src/nameres/collector.rs
@@ -1243,6 +1243,7 @@ impl ModCollector<'_, '_> {
                         status: PartialResolvedImport::Unresolved,
                     })
                 }
+                ModItem::ExternBlock(block) => self.collect(&self.item_tree[block].children),
                 ModItem::MacroCall(mac) => self.collect_macro_call(&self.item_tree[mac]),
                 ModItem::MacroRules(id) => self.collect_macro_rules(id),
                 ModItem::MacroDef(id) => self.collect_macro_def(id),

--- a/crates/hir_def/src/nameres/tests/macros.rs
+++ b/crates/hir_def/src/nameres/tests/macros.rs
@@ -736,6 +736,42 @@ fn unresolved_attributes_fall_back_track_per_file_moditems() {
 }
 
 #[test]
+fn unresolved_attrs_extern_block_hang() {
+    check(
+        r#"
+#[unresolved]
+extern "C" {
+    #[unresolved]
+    fn f();
+}
+    "#,
+        expect![[r#"
+        crate
+        f: v
+    "#]],
+    );
+}
+
+#[test]
+fn macros_in_extern_block() {
+    check(
+        r#"
+macro_rules! m {
+    () => { static S: u8; };
+}
+
+extern {
+    m!();
+}
+    "#,
+        expect![[r#"
+            crate
+            S: v
+        "#]],
+    );
+}
+
+#[test]
 fn resolves_derive_helper() {
     cov_mark::check!(resolved_derive_helper);
     check(


### PR DESCRIPTION
The ItemTree lowering code used to attach attributes on an `extern {}` block to all the children. This is wrong and causes problems with attribute resolution that manifested as a hang.

This PR treats extern blocks as first-class items in the ItemTree and lowers its contents in the `ModCollector` instead.

Fixes https://github.com/rust-analyzer/rust-analyzer/issues/8414#issuecomment-845607923
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/8905
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/8909

bors r+