### PR TITLE
internal: remove `StructDefKind`

### DIFF
--- a/crates/hir_def/src/item_tree.rs
+++ b/crates/hir_def/src/item_tree.rs
@@ -560,17 +560,6 @@ pub struct Struct {
     pub generic_params: Interned<GenericParams>,
     pub fields: Fields,
     pub ast_id: FileAstId<ast::Struct>,
-    pub kind: StructDefKind,
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub enum StructDefKind {
-    /// `struct S { ... }` - type namespace only.
-    Record,
-    /// `struct S(...);`
-    Tuple,
-    /// `struct S;`
-    Unit,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/crates/hir_def/src/item_tree/lower.rs
+++ b/crates/hir_def/src/item_tree/lower.rs
@@ -228,12 +228,7 @@ impl<'a> Ctx<'a> {
         let generic_params = self.lower_generic_params(GenericsOwner::Struct, strukt);
         let fields = self.lower_fields(&strukt.kind());
         let ast_id = self.source_ast_id_map.ast_id(strukt);
-        let kind = match strukt.kind() {
-            ast::StructKind::Record(_) => StructDefKind::Record,
-            ast::StructKind::Tuple(_) => StructDefKind::Tuple,
-            ast::StructKind::Unit => StructDefKind::Unit,
-        };
-        let res = Struct { name, visibility, generic_params, fields, ast_id, kind };
+        let res = Struct { name, visibility, generic_params, fields, ast_id };
         Some(id(self.data().structs.alloc(res)))
     }
 

--- a/crates/hir_def/src/nameres/collector.rs
+++ b/crates/hir_def/src/nameres/collector.rs
@@ -27,8 +27,8 @@ use crate::{
     intern::Interned,
     item_scope::{ImportType, PerNsGlobImports},
     item_tree::{
-        self, FileItemTreeId, ItemTree, ItemTreeId, MacroCall, MacroDef, MacroRules, Mod, ModItem,
-        ModKind, StructDefKind,
+        self, Fields, FileItemTreeId, ItemTree, ItemTreeId, MacroCall, MacroDef, MacroRules, Mod,
+        ModItem, ModKind,
     },
     macro_call_as_call_id,
     nameres::{
@@ -1281,7 +1281,7 @@ impl ModCollector<'_, '_> {
                             .into(),
                         name: &it.name,
                         visibility: &self.item_tree[it.visibility],
-                        has_constructor: it.kind != StructDefKind::Record,
+                        has_constructor: !matches!(it.fields, Fields::Record(_)),
                     });
                 }
                 ModItem::Union(id) => {


### PR DESCRIPTION
The `Fields` enum already encodes this, so `StructDefKind` is redundant.

bors r+