### PR TITLE
internal: even prettier itemtrees

### DIFF
--- a/crates/hir_def/src/item_tree/tests.rs
+++ b/crates/hir_def/src/item_tree/tests.rs
@@ -242,3 +242,49 @@ m!();
         "#]],
     );
 }
+
+#[test]
+fn mod_paths() {
+    check(
+        r#"
+struct S {
+    a: self::Ty,
+    b: super::SuperTy,
+    c: super::super::SuperSuperTy,
+    d: ::abs::Path,
+    e: crate::Crate,
+    f: plain::path::Ty,
+}
+        "#,
+        expect![[r#"
+            pub(self) struct S {
+                pub(self) a: self::Ty,
+                pub(self) b: super::SuperTy,
+                pub(self) c: super::super::SuperSuperTy,
+                pub(self) d: ::abs::Path,
+                pub(self) e: crate::Crate,
+                pub(self) f: plain::path::Ty,
+            }
+        "#]],
+    )
+}
+
+#[test]
+fn types() {
+    check(
+        r#"
+struct S {
+    a: Mixed<'a, T, Item=(), OtherItem=u8>,
+    b: <Fully as Qualified>::Syntax,
+    c: <TypeAnchored>::Path::<'a>,
+}
+        "#,
+        expect![[r#"
+            pub(self) struct S {
+                pub(self) a: Mixed<'a, T, Item = (), OtherItem = u8>,
+                pub(self) b: Qualified<Self=Fully>::Syntax,
+                pub(self) c: <TypeAnchored>::Path<'a>,
+            }
+        "#]],
+    )
+}

--- a/crates/hir_def/src/item_tree/tests.rs
+++ b/crates/hir_def/src/item_tree/tests.rs
@@ -288,3 +288,36 @@ struct S {
         "#]],
     )
 }
+
+#[test]
+fn generics() {
+    check(
+        r#"
+struct S<'a, 'b: 'a, T: Copy + 'a + 'b, const K: u8 = 0> {}
+
+impl<'a, 'b: 'a, T: Copy + 'a + 'b, const K: u8 = 0> S<'a, 'b, T, K> {
+    fn f<G: 'a>(arg: impl Copy) -> impl Copy {}
+}
+
+enum Enum<'a, T, const U: u8> {}
+union Union<'a, T, const U: u8> {}
+        "#,
+        expect![[r#"
+            pub(self) struct S<'a, 'b, T, const K: u8> {
+            }
+
+            impl<'a, 'b, T, const K: u8> S<'a, 'b, T, K> {
+                // flags = 0x2
+                pub(self) fn f<G>(
+                    _: impl Copy,
+                ) -> impl Copy;
+            }
+
+            pub(self) enum Enum<'a, T, const U: u8> {
+            }
+
+            pub(self) union Union<'a, T, const U: u8> {
+            }
+        "#]],
+    )
+}


### PR DESCRIPTION
Extends the ItemTree pretty printer to handle all `Path`s, and to print generic parameters and where-clauses.

bors r+