### PR TITLE
fix: Improve nightly downloads with better local state management

### DIFF
--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -34,7 +34,7 @@ export class Config {
     readonly globalStoragePath: string;
 
     constructor(ctx: vscode.ExtensionContext) {
-        this.globalStoragePath = ctx.globalStoragePath;
+        this.globalStoragePath = ctx.globalStorageUri.path;
         vscode.workspace.onDidChangeConfiguration(this.onDidChangeConfiguration, this, ctx.subscriptions);
         this.refreshLogging();
     }

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -4,7 +4,7 @@ import { log } from "./util";
 
 export type UpdatesChannel = "stable" | "nightly";
 
-export const NIGHTLY_TAG = "nightly";
+const NIGHTLY_TAG = "nightly";
 
 export type RunnableEnvCfg = undefined | Record<string, string> | { mask?: string; env: Record<string, string> }[];
 
@@ -169,5 +169,9 @@ export class Config {
             debug: this.get<boolean>("hoverActions.debug"),
             gotoTypeDef: this.get<boolean>("hoverActions.gotoTypeDef"),
         };
+    }
+
+    get currentExtensionIsNightly() {
+        return this.package.releaseTag === NIGHTLY_TAG;
     }
 }

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -156,9 +156,11 @@ export async function deactivate() {
 async function bootstrap(config: Config, state: PersistentState): Promise<string> {
     await fs.mkdir(config.globalStoragePath, { recursive: true });
 
+    if (config.package.releaseTag != NIGHTLY_TAG) {
+        await state.removeReleaseId();
+    }
     await bootstrapExtension(config, state);
     const path = await bootstrapServer(config, state);
-
     return path;
 }
 

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -192,11 +192,18 @@ async function bootstrapExtension(config: Config, state: PersistentState): Promi
     }).catch(async (e) => {
         log.error(e);
         if (state.releaseId === undefined) { // Show error only for the initial download
-            await vscode.window.showErrorMessage(`Failed to download rust-analyzer nightly ${e}`);
+            await vscode.window.showErrorMessage(`Failed to download rust-analyzer nightly: ${e}`);
         }
-        return undefined;
+        return;
     });
-    if (release === undefined || release.id === state.releaseId) return;
+    if (release === undefined) {
+        if (state.releaseId === undefined) { // Show error only for the initial download
+            await vscode.window.showErrorMessage("Failed to download rust-analyzer nightly: empty release contents returned");
+        }
+        return;
+    }
+    // If currently used extension is nightly and its release id matches the downloaded release id, we're already on the latest nightly version
+    if (config.package.releaseTag === NIGHTLY_TAG && release.id === state.releaseId) return;
 
     const userResponse = await vscode.window.showInformationMessage(
         "New version of rust-analyzer (nightly) is available (requires reload).",

--- a/editors/code/src/persistent_state.ts
+++ b/editors/code/src/persistent_state.ts
@@ -27,6 +27,9 @@ export class PersistentState {
     async updateReleaseId(value: number) {
         await this.globalState.update("releaseId", value);
     }
+    async removeReleaseId() {
+        await this.globalState.update("releaseId", undefined);
+    }
 
     /**
      * Version of the extension that installed the server.

--- a/editors/code/src/persistent_state.ts
+++ b/editors/code/src/persistent_state.ts
@@ -3,8 +3,8 @@ import { log } from './util';
 
 export class PersistentState {
     constructor(private readonly globalState: vscode.Memento) {
-        const { lastCheck, releaseId, serverVersion } = this;
-        log.info("PersistentState:", { lastCheck, releaseId, serverVersion });
+        const { lastCheck, nightlyReleaseId, serverVersion } = this;
+        log.info("PersistentState:", { lastCheck, nightlyReleaseId, serverVersion });
     }
 
     /**
@@ -21,13 +21,13 @@ export class PersistentState {
      * Release id of the *nightly* extension.
      * Used to check if we should update.
      */
-    get releaseId(): number | undefined {
+    get nightlyReleaseId(): number | undefined {
         return this.globalState.get("releaseId");
     }
-    async updateReleaseId(value: number) {
+    async updateNightlyReleaseId(value: number) {
         await this.globalState.update("releaseId", value);
     }
-    async removeReleaseId() {
+    async removeNightlyReleaseId() {
         await this.globalState.update("releaseId", undefined);
     }
 

--- a/editors/code/src/persistent_state.ts
+++ b/editors/code/src/persistent_state.ts
@@ -24,11 +24,8 @@ export class PersistentState {
     get nightlyReleaseId(): number | undefined {
         return this.globalState.get("releaseId");
     }
-    async updateNightlyReleaseId(value: number) {
+    async updateNightlyReleaseId(value: number | undefined) {
         await this.globalState.update("releaseId", value);
-    }
-    async removeNightlyReleaseId() {
-        await this.globalState.update("releaseId", undefined);
     }
 
     /**


### PR DESCRIPTION
When any nightly is downloaded, we store its GitHub release id in the local cache and never invalidate that cache.

Due to this, it was possible to do the following sequence:
* have the nightly locally
* downgrade the extension to any stable version
* observe that despite the `"rust-analyzer.updates.channel": "nightly",` setting, no nightly updates are happening
* on the next day, the actual update happens (given the new nightly is released)

Since it's impossible to install nightly version directly through the VSCode marketplace, any fiddling with dev version results in the same situation: one have to wait for the next nightly release to happen in order to restore the nightly.

This PR 
* invalidates the cache eagerly during bootstrap if the current plugin is not nightly
* enforces the release id check for nightly versions only
* fixes the `ctx.globalStoragePath` deprecated API usage

Hopefully, it also helps mysterious non-updated plugins that we encounter from time to time, but hard to tell for sure.