### PR TITLE
Give ‘unsafe’ semantic token modifier to unsafe traits

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1085,6 +1085,10 @@ impl Trait {
     pub fn is_auto(self, db: &dyn HirDatabase) -> bool {
         db.trait_data(self.id).is_auto
     }
+
+    pub fn is_unsafe(&self, db: &dyn HirDatabase) -> bool {
+        db.trait_data(self.id).is_unsafe
+    }
 }
 
 impl HasVisibility for Trait {

--- a/crates/ide/src/syntax_highlighting/highlight.rs
+++ b/crates/ide/src/syntax_highlighting/highlight.rs
@@ -338,7 +338,14 @@ fn highlight_def(db: &RootDatabase, def: Definition) -> Highlight {
 
                 return h;
             }
-            hir::ModuleDef::Trait(_) => HlTag::Symbol(SymbolKind::Trait),
+            hir::ModuleDef::Trait(trait_) => {
+                let mut h = Highlight::new(HlTag::Symbol(SymbolKind::Trait));
+
+                if trait_.is_unsafe(db) {
+                    h |= HlMod::Unsafe;
+                }
+                return h;
+            }
             hir::ModuleDef::TypeAlias(type_) => {
                 let mut h = Highlight::new(HlTag::Symbol(SymbolKind::TypeAlias));
                 if let Some(item) = type_.as_assoc_item(db) {

--- a/crates/ide/src/syntax_highlighting/tags.rs
+++ b/crates/ide/src/syntax_highlighting/tags.rs
@@ -68,7 +68,7 @@ pub enum HlMod {
     /// Used with keywords like `async` and `await`.
     Async,
     // Keep this last!
-    /// Used for unsafe functions, mutable statics, union accesses and unsafe operations.
+    /// Used for unsafe functions, unsafe traits, mutable statics, union accesses and unsafe operations.
     Unsafe,
 }
 

--- a/crates/ide/src/syntax_highlighting/test_data/highlighting.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlighting.html
@@ -245,4 +245,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
     <span class="keyword">let</span> <span class="variable declaration">f1</span> <span class="operator">=</span> <span class="function async">learn_and_sing</span><span class="parenthesis">(</span><span class="parenthesis">)</span><span class="semicolon">;</span>
     <span class="keyword">let</span> <span class="variable declaration">f2</span> <span class="operator">=</span> <span class="unresolved_reference">dance</span><span class="parenthesis">(</span><span class="parenthesis">)</span><span class="semicolon">;</span>
     futures::<span class="macro">join!</span><span class="parenthesis">(</span>f1<span class="comma">,</span> f2<span class="parenthesis">)</span><span class="semicolon">;</span>
-<span class="brace">}</span></code></pre>
+<span class="brace">}</span>
+
+<span class="keyword unsafe">unsafe</span> <span class="keyword">trait</span> <span class="trait declaration unsafe">Dangerous</span> <span class="brace">{</span><span class="brace">}</span>
+<span class="keyword">impl</span> <span class="trait unsafe">Dangerous</span> <span class="keyword">for</span> <span class="parenthesis">(</span><span class="parenthesis">)</span> <span class="brace">{</span><span class="brace">}</span></code></pre>

--- a/crates/ide/src/syntax_highlighting/tests.rs
+++ b/crates/ide/src/syntax_highlighting/tests.rs
@@ -219,6 +219,9 @@ async fn async_main() {
     let f2 = dance();
     futures::join!(f1, f2);
 }
+
+unsafe trait Dangerous {}
+impl Dangerous for () {}
 "#
         .trim(),
         expect_file!["./test_data/highlighting.html"],


### PR DESCRIPTION
Hi! This is my first pull request that touches rust-analyzer itself beyond a search-and-replace, so please tell me if I should change anything or do anything differently. :)