### PR TITLE
fix: Make expected type work in more situations

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -514,8 +514,7 @@ impl Field {
 
     /// Returns the type as in the signature of the struct (i.e., with
     /// placeholder types for type parameters). Only use this in the context of
-    /// the field *definition*; if you've already got a variable of the struct
-    /// type, use `Type::field_type` to get to the field type.
+    /// the field definition.
     pub fn ty(&self, db: &dyn HirDatabase) -> Type {
         let var_id = self.parent.into();
         let generic_def_id: GenericDefId = match self.parent {
@@ -1942,18 +1941,6 @@ impl Type {
                 | TyKind::GeneratorWitness(..) => false,
             }
         }
-    }
-
-    pub fn field_type(&self, db: &dyn HirDatabase, field: Field) -> Option<Type> {
-        let (adt_id, substs) = self.ty.as_adt()?;
-        let variant_id: hir_def::VariantId = field.parent.into();
-        if variant_id.adt_id() != adt_id {
-            return None;
-        }
-
-        let ty = db.field_types(variant_id).get(field.id)?.clone();
-        let ty = ty.substitute(&Interner, substs);
-        Some(self.derived(ty))
     }
 
     pub fn fields(&self, db: &dyn HirDatabase) -> Vec<(Field, Type)> {

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -11,7 +11,7 @@ use hir_def::{
     AsMacroCall, FunctionId, TraitId, VariantId,
 };
 use hir_expand::{name::AsName, ExpansionInfo};
-use hir_ty::associated_type_shorthand_candidates;
+use hir_ty::{associated_type_shorthand_candidates, Interner};
 use itertools::Itertools;
 use rustc_hash::{FxHashMap, FxHashSet};
 use syntax::{
@@ -501,14 +501,12 @@ impl<'db> SemanticsImpl<'db> {
     }
 
     fn resolve_method_call(&self, call: &ast::MethodCallExpr) -> Option<FunctionId> {
-        self.analyze(call.syntax()).resolve_method_call(self.db, call)
+        self.analyze(call.syntax()).resolve_method_call(self.db, call).map(|(id, _)| id)
     }
 
     fn resolve_method_call_as_callable(&self, call: &ast::MethodCallExpr) -> Option<Callable> {
-        // FIXME: this erases Substs, we should instead record the correct
-        // substitution during inference and use that
-        let func = self.resolve_method_call(call)?;
-        let ty = hir_ty::TyBuilder::value_ty(self.db, func.into()).fill_with_unknown().build();
+        let (func, subst) = self.analyze(call.syntax()).resolve_method_call(self.db, call)?;
+        let ty = self.db.value_ty(func.into()).substitute(&Interner, &subst);
         let resolver = self.analyze(call.syntax()).resolver;
         let ty = Type::new_with_resolver(self.db, &resolver, ty)?;
         let mut res = ty.as_callable(self.db)?;

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -227,7 +227,7 @@ impl<'db, DB: HirDatabase> Semantics<'db, DB> {
     pub fn resolve_record_field(
         &self,
         field: &ast::RecordExprField,
-    ) -> Option<(Field, Option<Local>)> {
+    ) -> Option<(Field, Option<Local>, Type)> {
         self.imp.resolve_record_field(field)
     }
 
@@ -518,7 +518,10 @@ impl<'db> SemanticsImpl<'db> {
         self.analyze(field.syntax()).resolve_field(self.db, field)
     }
 
-    fn resolve_record_field(&self, field: &ast::RecordExprField) -> Option<(Field, Option<Local>)> {
+    fn resolve_record_field(
+        &self,
+        field: &ast::RecordExprField,
+    ) -> Option<(Field, Option<Local>, Type)> {
         self.analyze(field.syntax()).resolve_record_field(self.db, field)
     }
 

--- a/crates/hir/src/source_analyzer.rs
+++ b/crates/hir/src/source_analyzer.rs
@@ -143,7 +143,7 @@ impl SourceAnalyzer {
         &self,
         db: &dyn HirDatabase,
         call: &ast::MethodCallExpr,
-    ) -> Option<FunctionId> {
+    ) -> Option<(FunctionId, Substitution)> {
         let expr_id = self.expr_id(db, &call.clone().into())?;
         self.infer.as_ref()?.method_resolution(expr_id)
     }

--- a/crates/hir_def/src/lib.rs
+++ b/crates/hir_def/src/lib.rs
@@ -485,6 +485,14 @@ impl VariantId {
             VariantId::UnionId(it) => it.lookup(db).id.file_id(),
         }
     }
+
+    pub fn adt_id(self) -> AdtId {
+        match self {
+            VariantId::EnumVariantId(it) => it.parent.into(),
+            VariantId::StructId(it) => it.into(),
+            VariantId::UnionId(it) => it.into(),
+        }
+    }
 }
 
 trait Intern {

--- a/crates/hir_ty/src/diagnostics/expr.rs
+++ b/crates/hir_ty/src/diagnostics/expr.rs
@@ -181,7 +181,7 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
         for (id, expr) in body.exprs.iter() {
             if let Expr::MethodCall { receiver, .. } = expr {
                 let function_id = match self.infer.method_resolution(id) {
-                    Some(id) => id,
+                    Some((id, _)) => id,
                     None => continue,
                 };
 
@@ -239,15 +239,11 @@ impl<'a, 'b> ExprValidator<'a, 'b> {
                     return;
                 }
 
-                // FIXME: note that we erase information about substs here. This
-                // is not right, but, luckily, doesn't matter as we care only
-                // about the number of params
-                let callee = match self.infer.method_resolution(call_id) {
-                    Some(callee) => callee,
+                let (callee, subst) = match self.infer.method_resolution(call_id) {
+                    Some(it) => it,
                     None => return,
                 };
-                let sig =
-                    db.callable_item_signature(callee.into()).into_value_and_skipped_binders().0;
+                let sig = db.callable_item_signature(callee.into()).substitute(&Interner, &subst);
 
                 (sig, args)
             }

--- a/crates/hir_ty/src/diagnostics/unsafe_check.rs
+++ b/crates/hir_ty/src/diagnostics/unsafe_check.rs
@@ -105,7 +105,7 @@ fn walk_unsafe(
         Expr::MethodCall { .. } => {
             if infer
                 .method_resolution(current)
-                .map(|func| db.function_data(func).is_unsafe())
+                .map(|(func, _)| db.function_data(func).is_unsafe())
                 .unwrap_or(false)
             {
                 unsafe_exprs.push(UnsafeExpr { expr: current, inside_unsafe_block });

--- a/crates/hir_ty/src/infer/unify.rs
+++ b/crates/hir_ty/src/infer/unify.rs
@@ -295,8 +295,11 @@ impl<'a> InferenceTable<'a> {
         .expect("fold failed unexpectedly")
     }
 
-    pub(crate) fn resolve_ty_completely(&mut self, ty: Ty) -> Ty {
-        self.resolve_with_fallback(ty, |_, _, d, _| d)
+    pub(crate) fn resolve_completely<T>(&mut self, t: T) -> T::Result
+    where
+        T: HasInterner<Interner = Interner> + Fold<Interner>,
+    {
+        self.resolve_with_fallback(t, |_, _, d, _| d)
     }
 
     /// Unify two types and register new trait goals that arise from that.

--- a/crates/ide_assists/src/handlers/fix_visibility.rs
+++ b/crates/ide_assists/src/handlers/fix_visibility.rs
@@ -85,7 +85,7 @@ fn add_vis_to_referenced_module_def(acc: &mut Assists, ctx: &AssistContext) -> O
 
 fn add_vis_to_referenced_record_field(acc: &mut Assists, ctx: &AssistContext) -> Option<()> {
     let record_field: ast::RecordExprField = ctx.find_node_at_offset()?;
-    let (record_field_def, _) = ctx.sema.resolve_record_field(&record_field)?;
+    let (record_field_def, _, _) = ctx.sema.resolve_record_field(&record_field)?;
 
     let current_module = ctx.sema.scope(record_field.syntax()).module()?;
     let visibility = record_field_def.visibility(ctx.db());

--- a/crates/ide_completion/src/context.rs
+++ b/crates/ide_completion/src/context.rs
@@ -339,13 +339,12 @@ impl<'a> CompletionContext<'a> {
                         cov_mark::hit!(expected_type_struct_field_without_leading_char);
                         // wouldn't try {} be nice...
                         (|| {
-                            let record_ty = self.sema.type_of_expr(&ast::Expr::cast(node.parent()?)?)?;
                             let expr_field = self.token.prev_sibling_or_token()?
-                            .into_node()
+                                      .into_node()
                                       .and_then(|node| ast::RecordExprField::cast(node))?;
-                            let field = self.sema.resolve_record_field(&expr_field)?.0;
+                            let (_, _, ty) = self.sema.resolve_record_field(&expr_field)?;
                             Some((
-                                record_ty.field_type(self.db, field),
+                                Some(ty),
                                 expr_field.field_name().map(NameOrNameRef::NameRef),
                             ))
                         })().unwrap_or((None, None))

--- a/crates/ide_completion/src/context.rs
+++ b/crates/ide_completion/src/context.rs
@@ -785,6 +785,19 @@ fn foo() {
     }
 
     #[test]
+    fn expected_type_generic_struct_field() {
+        check_expected_type_and_name(
+            r#"
+struct Foo<T> { a: T }
+fn foo() -> Foo<u32> {
+    Foo { a: $0 }
+}
+"#,
+            expect![[r#"ty: u32, name: a"#]],
+        )
+    }
+
+    #[test]
     fn expected_type_struct_field_with_leading_char() {
         cov_mark::check!(expected_type_struct_field_with_leading_char);
         check_expected_type_and_name(
@@ -894,5 +907,52 @@ fn foo() -> u32 {
 "#,
             expect![[r#"ty: u32, name: ?"#]],
         )
+    }
+
+    #[test]
+    fn expected_type_closure_param() {
+        check_expected_type_and_name(
+            r#"
+fn foo() {
+    bar(|| $0);
+}
+
+fn bar(f: impl FnOnce() -> u32) {}
+#[lang = "fn_once"]
+trait FnOnce { type Output; }
+"#,
+            expect![[r#"ty: u32, name: ?"#]],
+        );
+    }
+
+    #[test]
+    fn expected_type_generic_function() {
+        check_expected_type_and_name(
+            r#"
+fn foo() {
+    bar::<u32>($0);
+}
+
+fn bar<T>(t: T) {}
+"#,
+            expect![[r#"ty: u32, name: t"#]],
+        );
+    }
+
+    #[test]
+    fn expected_type_generic_method() {
+        check_expected_type_and_name(
+            r#"
+fn foo() {
+    S(1u32).bar($0);
+}
+
+struct S<T>(T);
+impl<T> S<T> {
+    fn bar(self, t: T) {}
+}
+"#,
+            expect![[r#"ty: u32, name: t"#]],
+        );
     }
 }

--- a/crates/ide_completion/src/render.rs
+++ b/crates/ide_completion/src/render.rs
@@ -667,6 +667,13 @@ fn foo() { A { the$0 } }
                         ),
                         detail: "u32",
                         deprecated: true,
+                        relevance: CompletionRelevance {
+                            exact_name_match: false,
+                            type_match: Some(
+                                CouldUnify,
+                            ),
+                            is_local: false,
+                        },
                     },
                 ]
             "#]],

--- a/crates/ide_db/src/call_info/tests.rs
+++ b/crates/ide_db/src/call_info/tests.rs
@@ -189,6 +189,24 @@ fn main() { S.foo($0); }
 }
 
 #[test]
+fn test_fn_signature_for_generic_method() {
+    check(
+        r#"
+struct S<T>(T);
+impl<T> S<T> {
+    fn foo(&self, x: T) {}
+}
+
+fn main() { S(1u32).foo($0); }
+"#,
+        expect![[r#"
+                fn foo(&self, x: u32)
+                (<x: u32>)
+            "#]],
+    );
+}
+
+#[test]
 fn test_fn_signature_for_method_with_arg_as_assoc_fn() {
     check(
         r#"

--- a/crates/ide_db/src/defs.rs
+++ b/crates/ide_db/src/defs.rs
@@ -311,7 +311,7 @@ impl NameRefClass {
         }
 
         if let Some(record_field) = ast::RecordExprField::for_field_name(name_ref) {
-            if let Some((field, local)) = sema.resolve_record_field(&record_field) {
+            if let Some((field, local, _)) = sema.resolve_record_field(&record_field) {
                 let field = Definition::Field(field);
                 let res = match local {
                     None => NameRefClass::Definition(field),


### PR DESCRIPTION
Also makes call info show the correct types for generic methods.

![2021-05-23-182952_1134x616_scrot](https://user-images.githubusercontent.com/906069/119269023-dd5a5b00-bbf5-11eb-993a-b6e122c3b9a6.png)
![2021-05-23-183117_922x696_scrot](https://user-images.githubusercontent.com/906069/119269025-dfbcb500-bbf5-11eb-983c-fc415b8428e0.png)
