### PR TITLE
internal: migrate to vscode.FileSystem API

### DIFF
--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -31,10 +31,10 @@ export class Config {
         enableProposedApi: boolean | undefined;
     } = vscode.extensions.getExtension(this.extensionId)!.packageJSON;
 
-    readonly globalStoragePath: string;
+    readonly globalStorageUri: vscode.Uri;
 
     constructor(ctx: vscode.ExtensionContext) {
-        this.globalStoragePath = ctx.globalStorageUri.fsPath;
+        this.globalStorageUri = ctx.globalStorageUri;
         vscode.workspace.onDidChangeConfiguration(this.onDidChangeConfiguration, this, ctx.subscriptions);
         this.refreshLogging();
     }

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -160,7 +160,7 @@ export async function deactivate() {
 }
 
 async function bootstrap(config: Config, state: PersistentState): Promise<string> {
-    await fs.mkdir(config.globalStoragePath, { recursive: true });
+    await vscode.workspace.fs.createDirectory(config.globalStorageUri);
 
     if (!config.currentExtensionIsNightly) {
         await state.updateNightlyReleaseId(undefined);
@@ -222,7 +222,7 @@ async function bootstrapExtension(config: Config, state: PersistentState): Promi
     const artifact = latestNightlyRelease.assets.find(artifact => artifact.name === "rust-analyzer.vsix");
     assert(!!artifact, `Bad release: ${JSON.stringify(latestNightlyRelease)}`);
 
-    const dest = path.join(config.globalStoragePath, "rust-analyzer.vsix");
+    const dest = path.join(config.globalStorageUri.path, "rust-analyzer.vsix");
 
     await downloadWithRetryDialog(state, async () => {
         await download({
@@ -334,7 +334,7 @@ async function getServer(config: Config, state: PersistentState): Promise<string
         platform = "x86_64-unknown-linux-musl";
     }
     const ext = platform.indexOf("-windows-") !== -1 ? ".exe" : "";
-    const dest = path.join(config.globalStoragePath, `rust-analyzer-${platform}${ext}`);
+    const dest = path.join(config.globalStorageUri.path, `rust-analyzer-${platform}${ext}`);
     const exists = await fs.stat(dest).then(() => true, () => false);
     if (!exists) {
         await state.updateServerVersion(undefined);

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -1,7 +1,5 @@
 import * as vscode from 'vscode';
-import * as path from "path";
 import * as os from "os";
-import { promises as fs, PathLike } from "fs";
 
 import * as commands from './commands';
 import { activateInlayHints } from './inlay_hints';
@@ -222,7 +220,7 @@ async function bootstrapExtension(config: Config, state: PersistentState): Promi
     const artifact = latestNightlyRelease.assets.find(artifact => artifact.name === "rust-analyzer.vsix");
     assert(!!artifact, `Bad release: ${JSON.stringify(latestNightlyRelease)}`);
 
-    const dest = path.join(config.globalStorageUri.path, "rust-analyzer.vsix");
+    const dest = vscode.Uri.joinPath(config.globalStorageUri, "rust-analyzer.vsix");
 
     await downloadWithRetryDialog(state, async () => {
         await download({
@@ -233,8 +231,8 @@ async function bootstrapExtension(config: Config, state: PersistentState): Promi
         });
     });
 
-    await vscode.commands.executeCommand("workbench.extensions.installExtension", vscode.Uri.file(dest));
-    await fs.unlink(dest);
+    await vscode.commands.executeCommand("workbench.extensions.installExtension", dest);
+    await vscode.workspace.fs.delete(dest);
 
     await state.updateNightlyReleaseId(latestNightlyRelease.id);
     await state.updateLastCheck(now);
@@ -259,7 +257,7 @@ async function bootstrapServer(config: Config, state: PersistentState): Promise<
     return path;
 }
 
-async function patchelf(dest: PathLike): Promise<void> {
+async function patchelf(dest: vscode.Uri): Promise<void> {
     await vscode.window.withProgress(
         {
             location: vscode.ProgressLocation.Notification,
@@ -279,11 +277,11 @@ async function patchelf(dest: PathLike): Promise<void> {
                     '';
                 }
             `;
-            const origFile = dest + "-orig";
-            await fs.rename(dest, origFile);
+            const origFile = vscode.Uri.file(dest.path + "-orig");
+            await vscode.workspace.fs.rename(dest, origFile);
             progress.report({ message: "Patching executable", increment: 20 });
             await new Promise((resolve, reject) => {
-                const handle = exec(`nix-build -E - --argstr srcStr '${origFile}' -o '${dest}'`,
+                const handle = exec(`nix-build -E - --argstr srcStr '${origFile.path}' -o '${dest.path}'`,
                     (err, stdout, stderr) => {
                         if (err != null) {
                             reject(Error(stderr));
@@ -294,7 +292,7 @@ async function patchelf(dest: PathLike): Promise<void> {
                 handle.stdin?.write(expression);
                 handle.stdin?.end();
             });
-            await fs.unlink(origFile);
+            await vscode.workspace.fs.delete(origFile);
         }
     );
 }
@@ -334,20 +332,20 @@ async function getServer(config: Config, state: PersistentState): Promise<string
         platform = "x86_64-unknown-linux-musl";
     }
     const ext = platform.indexOf("-windows-") !== -1 ? ".exe" : "";
-    const dest = path.join(config.globalStorageUri.path, `rust-analyzer-${platform}${ext}`);
-    const exists = await fs.stat(dest).then(() => true, () => false);
+    const dest = vscode.Uri.joinPath(config.globalStorageUri, `rust-analyzer-${platform}${ext}`);
+    const exists = await vscode.workspace.fs.stat(dest).then(() => true, () => false);
     if (!exists) {
         await state.updateServerVersion(undefined);
     }
 
-    if (state.serverVersion === config.package.version) return dest;
+    if (state.serverVersion === config.package.version) return dest.path;
 
     if (config.askBeforeDownload) {
         const userResponse = await vscode.window.showInformationMessage(
             `Language server version ${config.package.version} for rust-analyzer is not installed.`,
             "Download now"
         );
-        if (userResponse !== "Download now") return dest;
+        if (userResponse !== "Download now") return dest.path;
     }
 
     const releaseTag = config.package.releaseTag;
@@ -374,7 +372,7 @@ async function getServer(config: Config, state: PersistentState): Promise<string
     }
 
     await state.updateServerVersion(config.package.version);
-    return dest;
+    return dest.path;
 }
 
 function serverPath(config: Config): string | null {
@@ -383,7 +381,7 @@ function serverPath(config: Config): string | null {
 
 async function isNixOs(): Promise<boolean> {
     try {
-        const contents = await fs.readFile("/etc/os-release");
+        const contents = (await vscode.workspace.fs.readFile(vscode.Uri.file("/etc/os-release"))).toString();
         return contents.indexOf("ID=nixos") !== -1;
     } catch (e) {
         return false;

--- a/editors/code/src/toolchain.ts
+++ b/editors/code/src/toolchain.ts
@@ -181,5 +181,5 @@ function lookupInPath(exec: string): boolean {
 }
 
 async function isFile(path: string): Promise<boolean> {
-    return ((await vscode.workspace.fs.stat(vscode.Uri.file(path))).type & vscode.FileType.File) != 0;
+    return ((await vscode.workspace.fs.stat(vscode.Uri.file(path))).type & vscode.FileType.File) !== 0;
 }

--- a/editors/code/src/toolchain.ts
+++ b/editors/code/src/toolchain.ts
@@ -1,9 +1,8 @@
 import * as cp from 'child_process';
 import * as os from 'os';
 import * as path from 'path';
-import * as fs from 'fs';
 import * as readline from 'readline';
-import { OutputChannel } from 'vscode';
+import * as vscode from 'vscode';
 import { execute, log, memoize } from './util';
 
 interface CompilationArtifact {
@@ -19,7 +18,7 @@ export interface ArtifactSpec {
 }
 
 export class Cargo {
-    constructor(readonly rootFolder: string, readonly output: OutputChannel) { }
+    constructor(readonly rootFolder: string, readonly output: vscode.OutputChannel) { }
 
     // Made public for testing purposes
     static artifactSpec(args: readonly string[]): ArtifactSpec {
@@ -158,9 +157,9 @@ export const getPathForExecutable = memoize(
         try {
             // hmm, `os.homedir()` seems to be infallible
             // it is not mentioned in docs and cannot be infered by the type signature...
-            const standardPath = path.join(os.homedir(), ".cargo", "bin", executableName);
+            const standardPath = vscode.Uri.joinPath(vscode.Uri.file(os.homedir()), ".cargo", "bin", executableName);
 
-            if (isFile(standardPath)) return standardPath;
+            if (isFile(standardPath.path)) return standardPath.path;
         } catch (err) {
             log.error("Failed to read the fs info", err);
         }
@@ -181,12 +180,6 @@ function lookupInPath(exec: string): boolean {
     return candidates.some(isFile);
 }
 
-function isFile(suspectPath: string): boolean {
-    // It is not mentionned in docs, but `statSync()` throws an error when
-    // the path doesn't exist
-    try {
-        return fs.statSync(suspectPath).isFile();
-    } catch {
-        return false;
-    }
+async function isFile(path: string): Promise<boolean> {
+    return ((await vscode.workspace.fs.stat(vscode.Uri.file(path))).type & vscode.FileType.File) != 0;
 }


### PR DESCRIPTION
I encountered an error where `bootstrap()` attempts to create a directory with the path `C:\C:\...`. I couldn't find this reported anywhere else. Using the `vscode.FileSystem` API instead of the `fs` one works here. I assume the latter automatically prepends `C:\` to paths whereas the former does not. I don't know if this suggests `vscode.FileSystem` should be used in more places for consistency.