### PR TITLE
feature: Support standalone Rust files

### DIFF
--- a/crates/project_model/src/lib.rs
+++ b/crates/project_model/src/lib.rs
@@ -50,7 +50,6 @@ pub use proc_macro_api::ProcMacroClient;
 pub enum ProjectManifest {
     ProjectJson(AbsPathBuf),
     CargoToml(AbsPathBuf),
-    DetachedFile(AbsPathBuf),
 }
 
 impl ProjectManifest {

--- a/crates/project_model/src/lib.rs
+++ b/crates/project_model/src/lib.rs
@@ -50,6 +50,7 @@ pub use proc_macro_api::ProcMacroClient;
 pub enum ProjectManifest {
     ProjectJson(AbsPathBuf),
     CargoToml(AbsPathBuf),
+    DetachedFile(AbsPathBuf),
 }
 
 impl ProjectManifest {

--- a/crates/project_model/src/sysroot.rs
+++ b/crates/project_model/src/sysroot.rs
@@ -50,7 +50,9 @@ impl Sysroot {
 
     pub fn discover(cargo_toml: &AbsPath) -> Result<Sysroot> {
         log::debug!("Discovering sysroot for {}", cargo_toml.display());
-        let current_dir = cargo_toml.parent().unwrap();
+        let current_dir = cargo_toml.parent().ok_or_else(|| {
+            format_err!("Failed to find the parent directory for file {:?}", cargo_toml)
+        })?;
         let sysroot_dir = discover_sysroot_dir(current_dir)?;
         let sysroot_src_dir = discover_sysroot_src_dir(&sysroot_dir, current_dir)?;
         let res = Sysroot::load(&sysroot_src_dir)?;

--- a/crates/project_model/src/sysroot.rs
+++ b/crates/project_model/src/sysroot.rs
@@ -51,7 +51,7 @@ impl Sysroot {
     pub fn discover(cargo_toml: &AbsPath) -> Result<Sysroot> {
         log::debug!("Discovering sysroot for {}", cargo_toml.display());
         let current_dir = cargo_toml.parent().ok_or_else(|| {
-            format_err!("Failed to find the parent directory for file {:?}", cargo_toml)
+            format_err!("Failed to find the parent directory for {}", cargo_toml.display())
         })?;
         let sysroot_dir = discover_sysroot_dir(current_dir)?;
         let sysroot_src_dir = discover_sysroot_src_dir(&sysroot_dir, current_dir)?;

--- a/crates/project_model/src/workspace.rs
+++ b/crates/project_model/src/workspace.rs
@@ -4,7 +4,7 @@
 
 use std::{collections::VecDeque, fmt, fs, path::Path, process::Command};
 
-use anyhow::{Context, Result};
+use anyhow::{format_err, Context, Result};
 use base_db::{CrateDisplayName, CrateGraph, CrateId, CrateName, Edition, Env, FileId, ProcMacro};
 use cargo_workspace::DepKind;
 use cfg::CfgOptions;
@@ -49,6 +49,8 @@ pub enum ProjectWorkspace {
     },
     /// Project workspace was manually specified using a `rust-project.json` file.
     Json { project: ProjectJson, sysroot: Option<Sysroot>, rustc_cfg: Vec<CfgFlag> },
+    /// TODO kb docs
+    DetachedFiles { files: Vec<AbsPathBuf>, sysroot: Sysroot, rustc_cfg: Vec<CfgFlag> },
 }
 
 impl fmt::Debug for ProjectWorkspace {
@@ -75,6 +77,12 @@ impl fmt::Debug for ProjectWorkspace {
                 debug_struct.field("n_rustc_cfg", &rustc_cfg.len());
                 debug_struct.finish()
             }
+            ProjectWorkspace::DetachedFiles { files, sysroot, rustc_cfg } => f
+                .debug_struct("DetachedFiles")
+                .field("n_files", &files.len())
+                .field("n_sysroot_crates", &sysroot.crates().len())
+                .field("n_rustc_cfg", &rustc_cfg.len())
+                .finish(),
         }
     }
 }
@@ -148,9 +156,6 @@ impl ProjectWorkspace {
                 let rustc_cfg = rustc_cfg::get(Some(&cargo_toml), config.target.as_deref());
                 ProjectWorkspace::Cargo { cargo, sysroot, rustc, rustc_cfg }
             }
-            ProjectManifest::DetachedFile(_) => {
-                todo!("TODO kb")
-            }
         };
 
         Ok(res)
@@ -166,6 +171,14 @@ impl ProjectWorkspace {
         };
         let rustc_cfg = rustc_cfg::get(None, target);
         Ok(ProjectWorkspace::Json { project: project_json, sysroot, rustc_cfg })
+    }
+
+    pub fn load_detached_files(detached_files: Vec<AbsPathBuf>) -> Result<ProjectWorkspace> {
+        let sysroot = Sysroot::discover(
+            &detached_files.first().ok_or_else(|| format_err!("No detached files to load"))?,
+        )?;
+        let rustc_cfg = rustc_cfg::get(None, None);
+        Ok(ProjectWorkspace::DetachedFiles { files: detached_files, sysroot, rustc_cfg })
     }
 
     /// Returns the roots for the current `ProjectWorkspace`
@@ -227,6 +240,19 @@ impl ProjectWorkspace {
                     })
                 }))
                 .collect(),
+            ProjectWorkspace::DetachedFiles { files, sysroot, .. } => files
+                .into_iter()
+                .map(|detached_file| PackageRoot {
+                    is_member: true,
+                    include: vec![detached_file.clone()],
+                    exclude: Vec::new(),
+                })
+                .chain(sysroot.crates().map(|krate| PackageRoot {
+                    is_member: false,
+                    include: vec![sysroot[krate].root_dir().to_path_buf()],
+                    exclude: Vec::new(),
+                }))
+                .collect(),
         }
     }
 
@@ -236,6 +262,9 @@ impl ProjectWorkspace {
             ProjectWorkspace::Cargo { cargo, sysroot, rustc, .. } => {
                 let rustc_package_len = rustc.as_ref().map_or(0, |rc| rc.packages().len());
                 cargo.packages().len() + sysroot.crates().len() + rustc_package_len
+            }
+            ProjectWorkspace::DetachedFiles { sysroot, files, .. } => {
+                sysroot.crates().len() + files.len()
             }
         }
     }
@@ -270,6 +299,9 @@ impl ProjectWorkspace {
                 rustc,
                 rustc.as_ref().zip(build_data).and_then(|(it, map)| map.get(it.workspace_root())),
             ),
+            ProjectWorkspace::DetachedFiles { files, sysroot, rustc_cfg } => {
+                detached_files_to_crate_graph(rustc_cfg.clone(), load, files, sysroot)
+            }
         };
         if crate_graph.patch_cfg_if() {
             log::debug!("Patched std to depend on cfg-if")
@@ -472,6 +504,39 @@ fn cargo_to_crate_graph(
                 cargo,
                 &pkg_crates,
             );
+        }
+    }
+    crate_graph
+}
+
+// TODO kb refactor and check for correctness
+fn detached_files_to_crate_graph(
+    rustc_cfg: Vec<CfgFlag>,
+    load: &mut dyn FnMut(&AbsPath) -> Option<FileId>,
+    detached_files: &[AbsPathBuf],
+    sysroot: &Sysroot,
+) -> CrateGraph {
+    let _p = profile::span("detached_files_to_crate_graph");
+    let mut crate_graph = CrateGraph::default();
+    let (public_deps, _libproc_macro) =
+        sysroot_to_crate_graph(&mut crate_graph, sysroot, rustc_cfg.clone(), load);
+
+    let mut cfg_options = CfgOptions::default();
+    cfg_options.extend(rustc_cfg);
+
+    for detached_file in detached_files {
+        let file_id = load(&detached_file).unwrap();
+        let detached_file_crate = crate_graph.add_crate_root(
+            file_id,
+            Edition::Edition2018,
+            None,
+            cfg_options.clone(),
+            Env::default(),
+            Vec::new(),
+        );
+
+        for (name, krate) in public_deps.iter() {
+            add_dep(&mut crate_graph, detached_file_crate, name.clone(), *krate);
         }
     }
     crate_graph

--- a/crates/project_model/src/workspace.rs
+++ b/crates/project_model/src/workspace.rs
@@ -148,6 +148,9 @@ impl ProjectWorkspace {
                 let rustc_cfg = rustc_cfg::get(Some(&cargo_toml), config.target.as_deref());
                 ProjectWorkspace::Cargo { cargo, sysroot, rustc, rustc_cfg }
             }
+            ProjectManifest::DetachedFile(_) => {
+                todo!("TODO kb")
+            }
         };
 
         Ok(res)

--- a/crates/project_model/src/workspace.rs
+++ b/crates/project_model/src/workspace.rs
@@ -49,6 +49,15 @@ pub enum ProjectWorkspace {
     },
     /// Project workspace was manually specified using a `rust-project.json` file.
     Json { project: ProjectJson, sysroot: Option<Sysroot>, rustc_cfg: Vec<CfgFlag> },
+
+    // FIXME: The primary limitation of this approach is that the set of detached files needs to be fixed at the beginning.
+    // That's not the end user experience we should strive for.
+    // Ideally, you should be able to just open a random detached file in existing cargo projects, and get the basic features working.
+    // That needs some changes on the salsa-level though.
+    // In particular, we should split the unified CrateGraph (which currently has maximal durability) into proper crate graph, and a set of ad hoc roots (with minimal durability).
+    // Then, we need to hide the graph behind the queries such that most queries look only at the proper crate graph, and fall back to ad hoc roots only if there's no results.
+    // After this, we should be able to tweak the logic in reload.rs to add newly opened files, which don't belong to any existing crates, to the set of the detached files.
+    // //
     /// Project with a set of disjoint files, not belonging to any particular workspace.
     /// Backed by basic sysroot crates for basic completion and highlighting.
     DetachedFiles { files: Vec<AbsPathBuf>, sysroot: Sysroot, rustc_cfg: Vec<CfgFlag> },

--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -199,7 +199,7 @@ fn run_server() -> Result<()> {
             config.update(json);
         }
 
-        if config.linked_projects().is_empty() {
+        if config.linked_projects().is_empty() && config.detached_files().is_empty() {
             let workspace_roots = initialize_params
                 .workspace_folders
                 .map(|workspaces| {
@@ -214,10 +214,9 @@ fn run_server() -> Result<()> {
 
             let discovered = ProjectManifest::discover_all(&workspace_roots);
             log::info!("discovered projects: {:?}", discovered);
-            if discovered.is_empty() && config.detached_files().is_empty() {
+            if discovered.is_empty() {
                 log::error!("failed to find any projects in {:?}", workspace_roots);
             }
-
             config.discovered_projects = Some(discovered);
         }
 

--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -214,7 +214,7 @@ fn run_server() -> Result<()> {
 
             let discovered = ProjectManifest::discover_all(&workspace_roots);
             log::info!("discovered projects: {:?}", discovered);
-            if discovered.is_empty() {
+            if discovered.is_empty() && config.detached_files().is_empty() {
                 log::error!("failed to find any projects in {:?}", workspace_roots);
             }
 

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -236,7 +236,7 @@ impl Default for ConfigData {
 pub struct Config {
     caps: lsp_types::ClientCapabilities,
     data: ConfigData,
-    detached_files: Vec<ProjectManifest>,
+    detached_files: Vec<AbsPathBuf>,
     pub discovered_projects: Option<Vec<ProjectManifest>>,
     pub root_path: AbsPathBuf,
 }
@@ -345,7 +345,6 @@ impl Config {
         self.detached_files = get_field::<Vec<PathBuf>>(&mut json, "detachedFiles", None, "[]")
             .into_iter()
             .map(AbsPathBuf::assert)
-            .map(ProjectManifest::DetachedFile)
             .collect();
         self.data = ConfigData::from_json(json);
     }
@@ -399,7 +398,7 @@ impl Config {
         }
     }
 
-    pub fn detached_files(&self) -> &[ProjectManifest] {
+    pub fn detached_files(&self) -> &[AbsPathBuf] {
         &self.detached_files
     }
 

--- a/crates/rust-analyzer/src/global_state.rs
+++ b/crates/rust-analyzer/src/global_state.rs
@@ -312,6 +312,7 @@ impl GlobalStateSnapshot {
                 cargo.target_by_root(&path).map(|it| (cargo, it))
             }
             ProjectWorkspace::Json { .. } => None,
+            ProjectWorkspace::DetachedFiles { .. } => None,
         })
     }
 }

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -661,19 +661,28 @@ pub(crate) fn handle_runnables(
             }
         }
         None => {
-            res.push(lsp_ext::Runnable {
-                label: "cargo check --workspace".to_string(),
-                location: None,
-                kind: lsp_ext::RunnableKind::Cargo,
-                args: lsp_ext::CargoRunnable {
-                    workspace_root: None,
-                    override_cargo: config.override_cargo,
-                    cargo_args: vec!["check".to_string(), "--workspace".to_string()],
-                    cargo_extra_args: config.cargo_extra_args,
-                    executable_args: Vec::new(),
-                    expect_test: None,
-                },
-            });
+            if !snap.config.linked_projects().is_empty()
+                || !snap
+                    .config
+                    .discovered_projects
+                    .as_ref()
+                    .map(|projects| projects.is_empty())
+                    .unwrap_or(true)
+            {
+                res.push(lsp_ext::Runnable {
+                    label: "cargo check --workspace".to_string(),
+                    location: None,
+                    kind: lsp_ext::RunnableKind::Cargo,
+                    args: lsp_ext::CargoRunnable {
+                        workspace_root: None,
+                        override_cargo: config.override_cargo,
+                        cargo_args: vec!["check".to_string(), "--workspace".to_string()],
+                        cargo_extra_args: config.cargo_extra_args,
+                        executable_args: Vec::new(),
+                        expect_test: None,
+                    },
+                });
+            }
         }
     }
     Ok(res)

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -103,6 +103,7 @@ impl fmt::Debug for Event {
 impl GlobalState {
     fn run(mut self, inbox: Receiver<lsp_server::Message>) -> Result<()> {
         if self.config.linked_projects().is_empty()
+            && self.config.detached_files().is_empty()
             && self.config.notifications().cargo_toml_not_found
         {
             self.show_message(

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -146,6 +146,7 @@ impl GlobalState {
         log::info!("will fetch workspaces");
 
         self.task_pool.handle.spawn_with_sender({
+            // TODO kb reload workspace here?
             let linked_projects = self.config.linked_projects();
             let cargo_config = self.config.cargo();
 

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -146,8 +146,8 @@ impl GlobalState {
         log::info!("will fetch workspaces");
 
         self.task_pool.handle.spawn_with_sender({
-            // TODO kb reload workspace here?
             let linked_projects = self.config.linked_projects();
+            let detached_files = self.config.detached_files().to_vec();
             let cargo_config = self.config.cargo();
 
             move |sender| {
@@ -162,7 +162,7 @@ impl GlobalState {
 
                 sender.send(Task::FetchWorkspace(ProjectWorkspaceProgress::Begin)).unwrap();
 
-                let workspaces = linked_projects
+                let mut workspaces = linked_projects
                     .iter()
                     .map(|project| match project {
                         LinkedProject::ProjectManifest(manifest) => {
@@ -180,6 +180,11 @@ impl GlobalState {
                         }
                     })
                     .collect::<Vec<_>>();
+
+                if !detached_files.is_empty() {
+                    workspaces
+                        .push(project_model::ProjectWorkspace::load_detached_files(detached_files));
+                }
 
                 log::info!("did fetch workspaces {:?}", workspaces);
                 sender
@@ -408,6 +413,7 @@ impl GlobalState {
                         _ => None,
                     }
                 }
+                ProjectWorkspace::DetachedFiles { .. } => None,
             })
             .map(|(id, root)| {
                 let sender = sender.clone();

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -4,6 +4,7 @@ import * as ra from '../src/lsp_ext';
 import * as Is from 'vscode-languageclient/lib/common/utils/is';
 import { assert } from './util';
 import { WorkspaceEdit } from 'vscode';
+import { Workspace } from './ctx';
 
 export interface Env {
     [name: string]: string;
@@ -23,13 +24,18 @@ function renderHoverActions(actions: ra.CommandLinkGroup[]): vscode.MarkdownStri
     return result;
 }
 
-export function createClient(serverPath: string, cwd: string | undefined, extraEnv: Env): lc.LanguageClient {
+export function createClient(serverPath: string, workspace: Workspace, extraEnv: Env): lc.LanguageClient {
     // '.' Is the fallback if no folder is open
     // TODO?: Workspace folders support Uri's (eg: file://test.txt).
     // It might be a good idea to test if the uri points to a file.
 
     const newEnv = Object.assign({}, process.env);
     Object.assign(newEnv, extraEnv);
+
+    let cwd = undefined;
+    if (workspace.kind == "Workspace Folder") {
+        cwd = workspace.folder.fsPath;
+    };
 
     const run: lc.Executable = {
         command: serverPath,
@@ -43,9 +49,14 @@ export function createClient(serverPath: string, cwd: string | undefined, extraE
         'Rust Analyzer Language Server Trace',
     );
 
+    let initializationOptions = vscode.workspace.getConfiguration("rust-analyzer");
+    if (workspace.kind == "Detached files") {
+        initializationOptions = { "detachedFiles": workspace.files.map(file => file.uri.fsPath), ...initializationOptions };
+    }
+
     const clientOptions: lc.LanguageClientOptions = {
         documentSelector: [{ scheme: 'file', language: 'rust' }],
-        initializationOptions: vscode.workspace.getConfiguration("rust-analyzer"),
+        initializationOptions,
         diagnosticCollectionName: "rustc",
         traceOutputChannel,
         middleware: {

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -33,7 +33,7 @@ export function createClient(serverPath: string, workspace: Workspace, extraEnv:
     Object.assign(newEnv, extraEnv);
 
     let cwd = undefined;
-    if (workspace.kind == "Workspace Folder") {
+    if (workspace.kind === "Workspace Folder") {
         cwd = workspace.folder.fsPath;
     };
 
@@ -50,7 +50,7 @@ export function createClient(serverPath: string, workspace: Workspace, extraEnv:
     );
 
     let initializationOptions = vscode.workspace.getConfiguration("rust-analyzer");
-    if (workspace.kind == "Detached files") {
+    if (workspace.kind === "Detached Files") {
         initializationOptions = { "detachedFiles": workspace.files.map(file => file.uri.fsPath), ...initializationOptions };
     }
 

--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -23,7 +23,7 @@ function renderHoverActions(actions: ra.CommandLinkGroup[]): vscode.MarkdownStri
     return result;
 }
 
-export function createClient(serverPath: string, cwd: string, extraEnv: Env): lc.LanguageClient {
+export function createClient(serverPath: string, cwd: string | undefined, extraEnv: Env): lc.LanguageClient {
     // '.' Is the fallback if no folder is open
     // TODO?: Workspace folders support Uri's (eg: file://test.txt).
     // It might be a good idea to test if the uri points to a file.

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -7,6 +7,16 @@ import { createClient } from './client';
 import { isRustEditor, RustEditor } from './util';
 import { ServerStatusParams } from './lsp_ext';
 
+export type Workspace =
+    {
+        kind: 'Workspace Folder',
+        folder: vscode.Uri,
+    }
+    | {
+        kind: 'Detached files',
+        files: vscode.TextDocument[],
+    };
+
 export class Ctx {
     private constructor(
         readonly config: Config,
@@ -22,9 +32,9 @@ export class Ctx {
         config: Config,
         extCtx: vscode.ExtensionContext,
         serverPath: string,
-        cwd?: string,
+        workspace: Workspace,
     ): Promise<Ctx> {
-        const client = createClient(serverPath, cwd, config.serverExtraEnv);
+        const client = createClient(serverPath, workspace, config.serverExtraEnv);
 
         const statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
         extCtx.subscriptions.push(statusBar);

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -9,12 +9,12 @@ import { ServerStatusParams } from './lsp_ext';
 
 export type Workspace =
     {
-        kind: 'Workspace Folder',
-        folder: vscode.Uri,
+        kind: 'Workspace Folder';
+        folder: vscode.Uri;
     }
     | {
-        kind: 'Detached files',
-        files: vscode.TextDocument[],
+        kind: 'Detached Files';
+        files: vscode.TextDocument[];
     };
 
 export class Ctx {

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -22,7 +22,7 @@ export class Ctx {
         config: Config,
         extCtx: vscode.ExtensionContext,
         serverPath: string,
-        cwd: string,
+        cwd?: string,
     ): Promise<Ctx> {
         const client = createClient(serverPath, cwd, config.serverExtraEnv);
 

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -47,9 +47,9 @@ async function tryActivate(context: vscode.ExtensionContext) {
 
     const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
     if (workspaceFolder === undefined) {
-        let rustDocuments = vscode.workspace.textDocuments.filter(document => isRustDocument(document));
+        const rustDocuments = vscode.workspace.textDocuments.filter(document => isRustDocument(document));
         if (rustDocuments.length > 0) {
-            ctx = await Ctx.create(config, context, serverPath, { kind: 'Detached files', files: rustDocuments });
+            ctx = await Ctx.create(config, context, serverPath, { kind: 'Detached Files', files: rustDocuments });
         } else {
             throw new Error("no rust files are opened");
         }

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -49,7 +49,7 @@ async function tryActivate(context: vscode.ExtensionContext) {
     if (workspaceFolder === undefined) {
         let rustDocuments = vscode.workspace.textDocuments.filter(document => isRustDocument(document));
         if (rustDocuments.length > 0) {
-            ctx = await Ctx.create(config, context, serverPath);
+            ctx = await Ctx.create(config, context, serverPath, { kind: 'Detached files', files: rustDocuments });
         } else {
             throw new Error("no rust files are opened");
         }
@@ -58,7 +58,7 @@ async function tryActivate(context: vscode.ExtensionContext) {
         // registers its `onDidChangeDocument` handler before us.
         //
         // This a horribly, horribly wrong way to deal with this problem.
-        ctx = await Ctx.create(config, context, serverPath, workspaceFolder.uri.fsPath);
+        ctx = await Ctx.create(config, context, serverPath, { kind: "Workspace Folder", folder: workspaceFolder.uri });
         ctx.pushCleanup(activateTaskProvider(workspaceFolder, ctx.config));
     }
     await initCommonContext(context, ctx);


### PR DESCRIPTION
![standalone](https://user-images.githubusercontent.com/2690773/119277037-0b579380-bc26-11eb-8d77-20d46ab4916a.gif)

Closes https://github.com/rust-analyzer/rust-analyzer/issues/6388

Caveats: 

* I've decided to support multiple detached files in the code (anticipating the scratch files), but I found no way to open multiple files in VSCode at once: running `code *.rs` makes the plugin to register in the `vscode.workspace.textDocuments` only the first file, while code actually displays all files later.
Apparently what happens is the same as when you have VSCode open at some workplace already and then run `code some_other_file.rs`: it gets opened in the same workspace of the same VSCode with no server to support it.
If there's a way to override it, I'd appreciate the pointer.

* No way to toggle inlay hints, since the setting is updated for the workspace (which does not exist for a single file opened)
> [2021-05-24 00:22:49.100] [exthost] [error] Error: Unable to write to Workspace Settings because no workspace is opened. Please open a workspace first and try again.

* No runners/lens to run or check the code are implemented for this mode. 
In theory, we can detect `rustc`, run it on a file and run the resulting binary, but not sure if worth doing it at this stage.

Otherwise imports, hints, completion and other features work.