### PR TITLE
minor: update `CrateGraph` comment

### DIFF
--- a/crates/base_db/src/input.rs
+++ b/crates/base_db/src/input.rs
@@ -53,11 +53,15 @@ impl SourceRoot {
 }
 
 /// `CrateGraph` is a bit of information which turns a set of text files into a
-/// number of Rust crates. Each crate is defined by the `FileId` of its root module,
-/// the set of cfg flags (not yet implemented) and the set of dependencies. Note
-/// that, due to cfg's, there might be several crates for a single `FileId`! As
-/// in the rust-lang proper, a crate does not have a name. Instead, names are
-/// specified on dependency edges. That is, a crate might be known under
+/// number of Rust crates.
+///
+/// Each crate is defined by the `FileId` of its root module, the set of enabled
+/// `cfg` flags and the set of dependencies.
+///
+/// Note that, due to cfg's, there might be several crates for a single `FileId`!
+///
+/// For the purposes of analysis, a crate does not have a name. Instead, names
+/// are specified on dependency edges. That is, a crate might be known under
 /// different names in different dependent crates.
 ///
 /// Note that `CrateGraph` is build-system agnostic: it's a concept of the Rust


### PR DESCRIPTION
`cfg` flags are now implemented, and crates *may* have names, it doesn't
doesn't matter for name resolution

bors r+