### PR TITLE
Fix type mismatch caused by macros

### DIFF
--- a/crates/hir_ty/src/infer/expr.rs
+++ b/crates/hir_ty/src/infer/expr.rs
@@ -805,7 +805,7 @@ impl<'a> InferenceContext<'a> {
                     None => self.table.new_float_var(),
                 },
             },
-            Expr::MacroStmts { tail } => self.infer_expr(*tail, expected),
+            Expr::MacroStmts { tail } => self.infer_expr_inner(*tail, expected),
         };
         // use a new type variable if we got unknown here
         let ty = self.insert_type_vars_shallow(ty);


### PR DESCRIPTION
MacroStmts should be completely transparent, but it prevented
coercion. (I should maybe give `infer_expr` and `infer_expr_inner`
better names.)