### PR TITLE
Fix lowering of FnOnce() without return type

### DIFF
--- a/crates/hir_def/src/path/lower.rs
+++ b/crates/hir_def/src/path/lower.rs
@@ -205,15 +205,14 @@ fn lower_generic_args_from_fn_path(
 ) -> Option<GenericArgs> {
     let mut args = Vec::new();
     let mut bindings = Vec::new();
-    if let Some(params) = params {
-        let mut param_types = Vec::new();
-        for param in params.params() {
-            let type_ref = TypeRef::from_ast_opt(&ctx, param.ty());
-            param_types.push(type_ref);
-        }
-        let arg = GenericArg::Type(TypeRef::Tuple(param_types));
-        args.push(arg);
+    let params = params?;
+    let mut param_types = Vec::new();
+    for param in params.params() {
+        let type_ref = TypeRef::from_ast_opt(&ctx, param.ty());
+        param_types.push(type_ref);
     }
+    let arg = GenericArg::Type(TypeRef::Tuple(param_types));
+    args.push(arg);
     if let Some(ret_type) = ret_type {
         let type_ref = TypeRef::from_ast_opt(&ctx, ret_type.ty());
         bindings.push(AssociatedTypeBinding {
@@ -221,10 +220,14 @@ fn lower_generic_args_from_fn_path(
             type_ref: Some(type_ref),
             bounds: Vec::new(),
         });
-    }
-    if args.is_empty() && bindings.is_empty() {
-        None
     } else {
-        Some(GenericArgs { args, has_self_type: false, bindings })
+        // -> ()
+        let type_ref = TypeRef::Tuple(Vec::new());
+        bindings.push(AssociatedTypeBinding {
+            name: name![Output],
+            type_ref: Some(type_ref),
+            bounds: Vec::new(),
+        });
     }
+    Some(GenericArgs { args, has_self_type: false, bindings })
 }

--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -778,8 +778,10 @@ fn write_bounds_like_dyn_trait(
             }
             WhereClause::AliasEq(alias_eq) if is_fn_trait => {
                 is_fn_trait = false;
-                write!(f, " -> ")?;
-                alias_eq.ty.hir_fmt(f)?;
+                if !alias_eq.ty.is_unit() {
+                    write!(f, " -> ")?;
+                    alias_eq.ty.hir_fmt(f)?;
+                }
             }
             WhereClause::AliasEq(AliasEq { ty, alias }) => {
                 // in types in actual Rust, these will always come

--- a/crates/hir_ty/src/tests/traits.rs
+++ b/crates/hir_ty/src/tests/traits.rs
@@ -3095,16 +3095,16 @@ fn foo() {
             478..576 '{     ...&s); }': ()
             488..489 's': Option<i32>
             492..504 'Option::None': Option<i32>
-            514..515 'f': Box<dyn FnOnce(&Option<i32>) -> ()>
+            514..515 'f': Box<dyn FnOnce(&Option<i32>)>
             549..562 'box (|ps| {})': Box<|{unknown}| -> ()>
             554..561 '|ps| {}': |{unknown}| -> ()
             555..557 'ps': {unknown}
             559..561 '{}': ()
-            568..569 'f': Box<dyn FnOnce(&Option<i32>) -> ()>
+            568..569 'f': Box<dyn FnOnce(&Option<i32>)>
             568..573 'f(&s)': ()
             570..572 '&s': &Option<i32>
             571..572 's': Option<i32>
-            549..562: expected Box<dyn FnOnce(&Option<i32>) -> ()>, got Box<|{unknown}| -> ()>
+            549..562: expected Box<dyn FnOnce(&Option<i32>)>, got Box<|{unknown}| -> ()>
         "#]],
     );
 }


### PR DESCRIPTION
This should result in an implicit `-> ()`, not leaving out the binding.