### PR TITLE
fix: Create tasks for all workspaces

### DIFF
--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -32,14 +32,9 @@ export function createClient(serverPath: string, workspace: Workspace, extraEnv:
     const newEnv = Object.assign({}, process.env);
     Object.assign(newEnv, extraEnv);
 
-    let cwd = undefined;
-    if (workspace.kind === "Workspace Folder") {
-        cwd = workspace.folder.fsPath;
-    };
-
     const run: lc.Executable = {
         command: serverPath,
-        options: { cwd, env: newEnv },
+        options: { env: newEnv },
     };
     const serverOptions: lc.ServerOptions = {
         run,

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -10,7 +10,6 @@ import { ServerStatusParams } from './lsp_ext';
 export type Workspace =
     {
         kind: 'Workspace Folder';
-        folder: vscode.Uri;
     }
     | {
         kind: 'Detached Files';

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -45,8 +45,7 @@ async function tryActivate(context: vscode.ExtensionContext) {
         throw new Error(message);
     });
 
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-    if (workspaceFolder === undefined) {
+    if (vscode.workspace.workspaceFolders?.length === 0) {
         const rustDocuments = vscode.workspace.textDocuments.filter(document => isRustDocument(document));
         if (rustDocuments.length > 0) {
             ctx = await Ctx.create(config, context, serverPath, { kind: 'Detached Files', files: rustDocuments });
@@ -58,8 +57,8 @@ async function tryActivate(context: vscode.ExtensionContext) {
         // registers its `onDidChangeDocument` handler before us.
         //
         // This a horribly, horribly wrong way to deal with this problem.
-        ctx = await Ctx.create(config, context, serverPath, { kind: "Workspace Folder", folder: workspaceFolder.uri });
-        ctx.pushCleanup(activateTaskProvider(workspaceFolder, ctx.config));
+        ctx = await Ctx.create(config, context, serverPath, { kind: "Workspace Folder" });
+        ctx.pushCleanup(activateTaskProvider(ctx.config));
     }
     await initCommonContext(context, ctx);
 


### PR DESCRIPTION
Follow-up of https://github.com/rust-analyzer/rust-analyzer/pull/8955#discussion_r637897170

Before: 
<img width="593" alt="image" src="https://user-images.githubusercontent.com/2690773/119575267-712b5300-bdbf-11eb-833c-f688f7a7dd0f.png">

After: 
<img width="643" alt="image" src="https://user-images.githubusercontent.com/2690773/119575273-74264380-bdbf-11eb-8283-a78bbcb7346e.png">

This is the first time I've used multiple workspaces feature in VSCode, but so far looks like
* opening detached files works
* run and debug lens work
* Rust Analyzer: Run action works
* run task works and now shows tasks for all workspaces
* there are no platform-specific changes involved