### PR TITLE
internal: stop expanding UseTrees during ItemTree lowering

### DIFF
--- a/crates/hir_def/src/item_tree.rs
+++ b/crates/hir_def/src/item_tree.rs
@@ -543,18 +543,18 @@ pub enum UseTreeKind {
     /// use path::to::Item as Renamed;
     /// use path::to::Trait as _;
     /// ```
-    Single { path: ModPath, alias: Option<ImportAlias> },
+    Single { path: Interned<ModPath>, alias: Option<ImportAlias> },
 
     /// ```ignore
     /// use *;  // (invalid, but can occur in nested tree)
     /// use path::*;
     /// ```
-    Glob { path: Option<ModPath> },
+    Glob { path: Option<Interned<ModPath>> },
 
     /// ```ignore
     /// use prefix::{self, Item, ...};
     /// ```
-    Prefixed { prefix: Option<ModPath>, list: Vec<UseTree> },
+    Prefixed { prefix: Option<Interned<ModPath>>, list: Box<[UseTree]> },
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -811,7 +811,7 @@ impl UseTree {
                     },
                     None => prefix,
                 };
-                for tree in list {
+                for tree in &**list {
                     tree.expand_impl(prefix.clone(), cb);
                 }
             }

--- a/crates/hir_def/src/item_tree.rs
+++ b/crates/hir_def/src/item_tree.rs
@@ -538,20 +538,20 @@ pub struct UseTree {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum UseTreeKind {
-    /// ```ignore
+    /// ```
     /// use path::to::Item;
     /// use path::to::Item as Renamed;
     /// use path::to::Trait as _;
     /// ```
     Single { path: Interned<ModPath>, alias: Option<ImportAlias> },
 
-    /// ```ignore
+    /// ```
     /// use *;  // (invalid, but can occur in nested tree)
     /// use path::*;
     /// ```
     Glob { path: Option<Interned<ModPath>> },
 
-    /// ```ignore
+    /// ```
     /// use prefix::{self, Item, ...};
     /// ```
     Prefixed { prefix: Option<Interned<ModPath>>, list: Box<[UseTree]> },

--- a/crates/hir_def/src/item_tree/lower.rs
+++ b/crates/hir_def/src/item_tree/lower.rs
@@ -864,7 +864,12 @@ impl UseTreeLowering<'_> {
             let list =
                 use_tree_list.use_trees().filter_map(|tree| self.lower_use_tree(tree)).collect();
 
-            Some(self.use_tree(UseTreeKind::Prefixed { prefix, list }, tree))
+            Some(
+                self.use_tree(
+                    UseTreeKind::Prefixed { prefix: prefix.map(Interned::new), list },
+                    tree,
+                ),
+            )
         } else {
             let is_glob = tree.star_token().is_some();
             let path = match tree.path() {
@@ -883,15 +888,15 @@ impl UseTreeLowering<'_> {
                     if path.is_none() {
                         cov_mark::hit!(glob_enum_group);
                     }
-                    Some(self.use_tree(UseTreeKind::Glob { path }, tree))
+                    Some(self.use_tree(UseTreeKind::Glob { path: path.map(Interned::new) }, tree))
                 }
                 // Globs can't be renamed
                 (_, Some(_), true) | (None, None, false) => None,
                 // `bla::{ as Name}` is invalid
                 (None, Some(_), false) => None,
-                (Some(path), alias, false) => {
-                    Some(self.use_tree(UseTreeKind::Single { path, alias }, tree))
-                }
+                (Some(path), alias, false) => Some(
+                    self.use_tree(UseTreeKind::Single { path: Interned::new(path), alias }, tree),
+                ),
             }
         }
     }

--- a/crates/hir_def/src/item_tree/tests.rs
+++ b/crates/hir_def/src/item_tree/tests.rs
@@ -26,6 +26,8 @@ use globs::*;
 
 /// docs on import
 use crate::{A, B};
+
+use a::{c, d::{e}};
         "#,
         expect![[r##"
             #![doc = " file comment"]  // AttrId { is_doc_comment: true, ast_index: 0 }
@@ -36,19 +38,14 @@ use crate::{A, B};
 
             pub(super) extern crate bli;
 
-            pub use crate::path::nested;  // 0
+            pub use crate::path::{nested, items as renamed, Trait as _};
 
-            pub use crate::path::items as renamed;  // 1
-
-            pub use crate::path::Trait as _;  // 2
-
-            pub(self) use globs::*;  // 0
+            pub(self) use globs::*;
 
             #[doc = " docs on import"]  // AttrId { is_doc_comment: true, ast_index: 0 }
-            pub(self) use crate::A;  // 0
+            pub(self) use crate::{A, B};
 
-            #[doc = " docs on import"]  // AttrId { is_doc_comment: true, ast_index: 0 }
-            pub(self) use crate::B;  // 1
+            pub(self) use a::{c, d::{e}};
         "##]],
     );
 }
@@ -218,7 +215,7 @@ mod outline;
             #[doc = " outer"]  // AttrId { is_doc_comment: true, ast_index: 0 }
             #[doc = " inner"]  // AttrId { is_doc_comment: true, ast_index: 1 }
             pub(self) mod inline {
-                pub(self) use super::*;  // 0
+                pub(self) use super::*;
 
                 // flags = 0x2
                 pub(self) fn fn_in_module() -> ();

--- a/crates/hir_def/src/nameres/diagnostics.rs
+++ b/crates/hir_def/src/nameres/diagnostics.rs
@@ -2,9 +2,15 @@
 
 use cfg::{CfgExpr, CfgOptions};
 use hir_expand::MacroCallKind;
+use la_arena::Idx;
 use syntax::ast;
 
-use crate::{nameres::LocalModuleId, path::ModPath, AstId};
+use crate::{
+    item_tree::{self, ItemTreeId},
+    nameres::LocalModuleId,
+    path::ModPath,
+    AstId,
+};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum DefDiagnosticKind {
@@ -12,7 +18,7 @@ pub enum DefDiagnosticKind {
 
     UnresolvedExternCrate { ast: AstId<ast::ExternCrate> },
 
-    UnresolvedImport { ast: AstId<ast::Use>, index: usize },
+    UnresolvedImport { id: ItemTreeId<item_tree::Import>, index: Idx<ast::UseTree> },
 
     UnconfiguredCode { ast: AstId<ast::Item>, cfg: CfgExpr, opts: CfgOptions },
 
@@ -53,10 +59,10 @@ impl DefDiagnostic {
 
     pub(super) fn unresolved_import(
         container: LocalModuleId,
-        ast: AstId<ast::Use>,
-        index: usize,
+        id: ItemTreeId<item_tree::Import>,
+        index: Idx<ast::UseTree>,
     ) -> Self {
-        Self { in_module: container, kind: DefDiagnosticKind::UnresolvedImport { ast, index } }
+        Self { in_module: container, kind: DefDiagnosticKind::UnresolvedImport { id, index } }
     }
 
     pub(super) fn unconfigured_code(

--- a/crates/hir_def/src/path.rs
+++ b/crates/hir_def/src/path.rs
@@ -14,10 +14,7 @@ use hir_expand::{
 };
 use syntax::ast;
 
-use crate::{
-    type_ref::{TypeBound, TypeRef},
-    InFile,
-};
+use crate::type_ref::{TypeBound, TypeRef};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ModPath {
@@ -56,8 +53,7 @@ impl Display for ImportAlias {
 
 impl ModPath {
     pub fn from_src(db: &dyn DefDatabase, path: ast::Path, hygiene: &Hygiene) -> Option<ModPath> {
-        let ctx = LowerCtx::with_hygiene(db, hygiene);
-        lower::lower_path(path, &ctx).map(|it| (*it.mod_path).clone())
+        lower::convert_path(db, None, path, hygiene)
     }
 
     pub fn from_segments(kind: PathKind, segments: impl IntoIterator<Item = Name>) -> ModPath {
@@ -68,18 +64,6 @@ impl ModPath {
     /// Creates a `ModPath` from a `PathKind`, with no extra path segments.
     pub const fn from_kind(kind: PathKind) -> ModPath {
         ModPath { kind, segments: Vec::new() }
-    }
-
-    /// Calls `cb` with all paths, represented by this use item.
-    pub fn expand_use_item(
-        db: &dyn DefDatabase,
-        item_src: InFile<ast::Use>,
-        hygiene: &Hygiene,
-        mut cb: impl FnMut(ModPath, &ast::UseTree, /* is_glob */ bool, Option<ImportAlias>),
-    ) {
-        if let Some(tree) = item_src.value.use_tree() {
-            lower::lower_use_tree(db, None, tree, hygiene, &mut cb);
-        }
     }
 
     pub fn segments(&self) -> &[Name] {

--- a/crates/hir_def/src/path/lower.rs
+++ b/crates/hir_def/src/path/lower.rs
@@ -15,7 +15,7 @@ use crate::{
     type_ref::{LifetimeRef, TypeBound, TypeRef},
 };
 
-pub(super) use lower_use::lower_use_tree;
+pub(super) use lower_use::convert_path;
 
 /// Converts an `ast::Path` to `Path`. Works with use trees.
 /// It correctly handles `$crate` based path from macro call.

--- a/crates/hir_def/src/test_db.rs
+++ b/crates/hir_def/src/test_db.rs
@@ -278,9 +278,11 @@ impl TestDB {
                         let node = ast.to_node(self.upcast());
                         (InFile::new(ast.file_id, node.syntax().clone()), "UnresolvedExternCrate")
                     }
-                    DefDiagnosticKind::UnresolvedImport { ast, .. } => {
-                        let node = ast.to_node(self.upcast());
-                        (InFile::new(ast.file_id, node.syntax().clone()), "UnresolvedImport")
+                    DefDiagnosticKind::UnresolvedImport { id, .. } => {
+                        let item_tree = id.item_tree(self.upcast());
+                        let import = &item_tree[id.value];
+                        let node = InFile::new(id.file_id(), import.ast_id).to_node(self.upcast());
+                        (InFile::new(id.file_id(), node.syntax().clone()), "UnresolvedImport")
                     }
                     DefDiagnosticKind::UnconfiguredCode { ast, .. } => {
                         let node = ast.to_node(self.upcast());

--- a/crates/ide/src/diagnostics.rs
+++ b/crates/ide/src/diagnostics.rs
@@ -311,6 +311,7 @@ mod tests {
     ///  * a diagnostic is produced
     ///  * the first diagnostic fix trigger range touches the input cursor position
     ///  * that the contents of the file containing the cursor match `after` after the diagnostic fix is applied
+    #[track_caller]
     pub(crate) fn check_fix(ra_fixture_before: &str, ra_fixture_after: &str) {
         check_nth_fix(0, ra_fixture_before, ra_fixture_after);
     }
@@ -325,6 +326,7 @@ mod tests {
         }
     }
 
+    #[track_caller]
     fn check_nth_fix(nth: usize, ra_fixture_before: &str, ra_fixture_after: &str) {
         let after = trim_indent(ra_fixture_after);
 


### PR DESCRIPTION
Closes https://github.com/rust-analyzer/rust-analyzer/issues/8908

Messy diff, but `ItemTree` lowering got simpler, since we now have a strict 1-to-1 mapping between `ast::Item` and `ModItem`.

The most messy part is mapping a single `UseTree` back to its `ast::UseTree` counterpart for diagnostics, but I think the ad-hoc source map built during lowering does the job.