### PR TITLE
internal: Merge pattern completion related bools into an enum

### DIFF
--- a/crates/ide_completion/src/completions/unqualified_path.rs
+++ b/crates/ide_completion/src/completions/unqualified_path.rs
@@ -88,7 +88,7 @@ fn quux(x: Option<Enum>) {
     }
 }
 "#,
-            expect![[""]],
+            expect![[r#""#]],
         );
     }
 
@@ -104,7 +104,7 @@ fn quux(x: Option<Enum>) {
     }
 }
 "#,
-            expect![[""]],
+            expect![[r#""#]],
         );
     }
 

--- a/crates/ide_completion/src/render.rs
+++ b/crates/ide_completion/src/render.rs
@@ -20,6 +20,7 @@ use ide_db::{
 use syntax::TextRange;
 
 use crate::{
+    context::IsPatOrConst,
     item::{CompletionRelevanceTypeMatch, ImportEdit},
     CompletionContext, CompletionItem, CompletionItemKind, CompletionKind, CompletionRelevance,
 };
@@ -188,8 +189,7 @@ impl<'a> Render<'a> {
                 return render_fn(self.ctx, import_to_add, Some(local_name), *func);
             }
             ScopeDef::ModuleDef(Variant(_))
-                if self.ctx.completion.is_pat_binding_or_const
-                    | self.ctx.completion.is_irrefutable_pat_binding =>
+                if self.ctx.completion.is_pat_or_const != IsPatOrConst::No =>
             {
                 CompletionItemKind::SymbolKind(SymbolKind::Variant)
             }


### PR DESCRIPTION
The two bools, `is_pat_binding_or_const` and `is_irrefutable_pat_binding` can never both be set so this is basically just a tri-state enum.
bors r+