### PR TITLE
Don't label derive macros with their banged_name

### DIFF
--- a/crates/ide_completion/src/render/macro_.rs
+++ b/crates/ide_completion/src/render/macro_.rs
@@ -74,7 +74,11 @@ impl<'a> MacroRender<'a> {
         if self.needs_bang() && self.ctx.snippet_cap().is_some() {
             format!("{}!{}…{}", self.name, self.bra, self.ket)
         } else {
-            self.banged_name()
+            if self.macro_.kind() == hir::MacroKind::Derive {
+                self.name.to_string()
+            } else {
+                self.banged_name()
+            }
         }
     }
 


### PR DESCRIPTION
cc https://github.com/rust-analyzer/rust-analyzer/issues/7072#issuecomment-850396203
This doesn't fix it non builtin derives yet I think cause of a FIXME somewhere that doesn't categorize proc-macro derives as derives yet
bors r+