### PR TITLE
fix: make `include!` etc. work in expression position

### DIFF
--- a/crates/hir_expand/src/eager.rs
+++ b/crates/hir_expand/src/eager.rs
@@ -113,6 +113,7 @@ pub fn expand_eager_macro(
 
     let ast_map = db.ast_id_map(macro_call.file_id);
     let call_id = InFile::new(macro_call.file_id, ast_map.ast_id(&macro_call.value));
+    let fragment = crate::to_fragment_kind(&macro_call.value);
 
     // Note:
     // When `lazy_expand` is called, its *parent* file must be already exists.
@@ -152,7 +153,7 @@ pub fn expand_eager_macro(
                 arg_or_expansion: Arc::new(expanded.subtree),
                 included_file: expanded.included_file,
             }),
-            kind: MacroCallKind::FnLike { ast_id: call_id, fragment: expanded.fragment },
+            kind: MacroCallKind::FnLike { ast_id: call_id, fragment },
         };
 
         Ok(db.intern_macro(loc))

--- a/crates/hir_ty/src/tests/macros.rs
+++ b/crates/hir_ty/src/tests/macros.rs
@@ -752,6 +752,24 @@ fn bar() -> u32 {0}
 }
 
 #[test]
+fn infer_builtin_macros_include_expression() {
+    check_types(
+        r#"
+//- /main.rs
+#[rustc_builtin_macro]
+macro_rules! include {() => {}}
+fn main() {
+    let i = include!("bla.rs");
+    i;
+  //^ i32
+}
+//- /bla.rs
+0
+        "#,
+    )
+}
+
+#[test]
 fn infer_builtin_macros_include_child_mod() {
     check_types(
         r#"


### PR DESCRIPTION
This PR removes determination of fragment kinds from the eager macro implementations. The fragment kind is always determined by the syntax position in which a macro is invoked, not by the macro implementation, even for eager macros.

This makes `include!` work in expression position, and should have the same effect for all macros that may be used in different positions.

bors r+