### PR TITLE
fix: fix `matches!` macro on nightly toolchains

### DIFF
--- a/crates/mbe/src/expander/matcher.rs
+++ b/crates/mbe/src/expander/matcher.rs
@@ -701,7 +701,7 @@ fn match_meta_var(kind: &str, input: &mut TtIter) -> ExpandResult<Option<Fragmen
         "path" => Path,
         "expr" => Expr,
         "ty" => Type,
-        "pat" => Pattern,
+        "pat" | "pat_param" => Pattern, // FIXME: edition2021
         "stmt" => Statement,
         "block" => Block,
         "meta" => MetaItem,


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/9043

bors r+