### PR TITLE
fix: Only complete derive proc macros in `#[derive]`

### DIFF
--- a/crates/ide_completion/src/completions/attribute/derive.rs
+++ b/crates/ide_completion/src/completions/attribute/derive.rs
@@ -50,8 +50,7 @@ fn get_derive_names_in_scope(ctx: &CompletionContext) -> FxHashSet<String> {
     let mut result = FxHashSet::default();
     ctx.scope.process_all_names(&mut |name, scope_def| {
         if let hir::ScopeDef::MacroDef(mac) = scope_def {
-            // FIXME kind() doesn't check whether proc-macro is a derive
-            if mac.kind() == hir::MacroKind::Derive || mac.kind() == hir::MacroKind::ProcMacro {
+            if mac.kind() == hir::MacroKind::Derive {
                 result.insert(name.to_string());
             }
         }


### PR DESCRIPTION
HIR now gives them `MacroKind::Derive` instead of `MacroKind::ProcMacro`

bors r+