### PR TITLE
feat: Diagnose unimplemented built-in macros

### DIFF
--- a/crates/hir/src/diagnostics.rs
+++ b/crates/hir/src/diagnostics.rs
@@ -227,3 +227,27 @@ impl Diagnostic for MacroError {
         true
     }
 }
+
+#[derive(Debug)]
+pub struct UnimplementedBuiltinMacro {
+    pub file: HirFileId,
+    pub node: SyntaxNodePtr,
+}
+
+impl Diagnostic for UnimplementedBuiltinMacro {
+    fn code(&self) -> DiagnosticCode {
+        DiagnosticCode("unimplemented-builtin-macro")
+    }
+
+    fn message(&self) -> String {
+        "unimplemented built-in macro".to_string()
+    }
+
+    fn display_source(&self) -> InFile<SyntaxNodePtr> {
+        InFile::new(self.file, self.node.clone())
+    }
+
+    fn as_any(&self) -> &(dyn Any + Send + 'static) {
+        self
+    }
+}

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -36,8 +36,8 @@ use std::{iter, sync::Arc};
 use arrayvec::ArrayVec;
 use base_db::{CrateDisplayName, CrateId, Edition, FileId};
 use diagnostics::{
-    InactiveCode, MacroError, UnresolvedExternCrate, UnresolvedImport, UnresolvedMacroCall,
-    UnresolvedModule, UnresolvedProcMacro,
+    InactiveCode, MacroError, UnimplementedBuiltinMacro, UnresolvedExternCrate, UnresolvedImport,
+    UnresolvedMacroCall, UnresolvedModule, UnresolvedProcMacro,
 };
 use either::Either;
 use hir_def::{
@@ -564,6 +564,14 @@ impl Module {
                         }
                     };
                     sink.push(MacroError { file, node: ast, message: message.clone() });
+                }
+
+                DefDiagnosticKind::UnimplementedBuiltinMacro { ast } => {
+                    let node = ast.to_node(db.upcast());
+                    // Must have a name, otherwise we wouldn't emit it.
+                    let name = node.name().expect("unimplemented builtin macro with no name");
+                    let ptr = SyntaxNodePtr::from(AstPtr::new(&name));
+                    sink.push(UnimplementedBuiltinMacro { file: ast.file_id, node: ptr });
                 }
             }
         }

--- a/crates/hir_def/src/nameres/diagnostics.rs
+++ b/crates/hir_def/src/nameres/diagnostics.rs
@@ -27,6 +27,8 @@ pub enum DefDiagnosticKind {
     UnresolvedMacroCall { ast: AstId<ast::MacroCall>, path: ModPath },
 
     MacroError { ast: MacroCallKind, message: String },
+
+    UnimplementedBuiltinMacro { ast: AstId<ast::Macro> },
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -92,5 +94,12 @@ impl DefDiagnostic {
         path: ModPath,
     ) -> Self {
         Self { in_module: container, kind: DefDiagnosticKind::UnresolvedMacroCall { ast, path } }
+    }
+
+    pub(super) fn unimplemented_builtin_macro(
+        container: LocalModuleId,
+        ast: AstId<ast::Macro>,
+    ) -> Self {
+        Self { in_module: container, kind: DefDiagnosticKind::UnimplementedBuiltinMacro { ast } }
     }
 }

--- a/crates/hir_def/src/test_db.rs
+++ b/crates/hir_def/src/test_db.rs
@@ -298,6 +298,13 @@ impl TestDB {
                     DefDiagnosticKind::MacroError { ast, message } => {
                         (ast.to_node(self.upcast()), message.as_str())
                     }
+                    DefDiagnosticKind::UnimplementedBuiltinMacro { ast } => {
+                        let node = ast.to_node(self.upcast());
+                        (
+                            InFile::new(ast.file_id, node.syntax().clone()),
+                            "UnimplementedBuiltinMacro",
+                        )
+                    }
                 };
 
                 let frange = node.as_ref().original_file_range(self);

--- a/crates/ide/src/diagnostics.rs
+++ b/crates/ide/src/diagnostics.rs
@@ -182,6 +182,11 @@ pub(crate) fn diagnostics(
             res.borrow_mut()
                 .push(Diagnostic::error(display_range, d.message()).with_code(Some(d.code())));
         })
+        .on::<hir::diagnostics::UnimplementedBuiltinMacro, _>(|d| {
+            let display_range = sema.diagnostics_display_range(d.display_source()).range;
+            res.borrow_mut()
+                .push(Diagnostic::hint(display_range, d.message()).with_code(Some(d.code())));
+        })
         // Only collect experimental diagnostics when they're enabled.
         .filter(|diag| !(diag.is_experimental() && config.disable_experimental))
         .filter(|diag| !config.disabled.contains(diag.code().as_str()));


### PR DESCRIPTION
A number of built-in attribute macros are unsupported, I thought it might be useful to put a diagnostic on their definition in libcore. Not sure.