### PR TITLE
minor: Don't force-disable incremental

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,6 @@ resolver = "2"
 members = ["xtask/", "lib/*", "crates/*"]
 
 [profile.dev]
-# We do want incremental builds, but they are broken at the moment :(
-# https://github.com/rust-lang/rust/issues/85003#issuecomment-833796289
-incremental = false
-
 # Disabling debug info speeds up builds a bunch,
 # and we don't rely on it for debugging that much.
 debug = 0
@@ -21,9 +17,6 @@ text-size.opt-level = 3
 miniz_oxide.opt-level = 3
 
 [profile.release]
-# We do want incremental release builds, but they are broken at the moment :(
-# https://github.com/rust-lang/rust/issues/85003#issuecomment-833796289
-incremental = false
 debug = 0 # Set this to 1 or 2 to get more useful backtraces in debugger.
 
 [profile.test]


### PR DESCRIPTION
1.52.1 turns incremental off regardless of this setting, so this is unnecessary. Removing this allow manually overriding Cargo to enable incremental.

bors r+