### PR TITLE
feat: Implement per-edition preludes

### DIFF
--- a/crates/hir_def/src/find_path.rs
+++ b/crates/hir_def/src/find_path.rs
@@ -682,9 +682,11 @@ pub struct S;
 //- /main.rs crate:main deps:std
 $0
 //- /std.rs crate:std
-pub mod prelude { pub struct S; }
-#[prelude_import]
-pub use prelude::*;
+pub mod prelude {
+    pub mod rust_2018 {
+        pub struct S;
+    }
+}
         "#,
             "S",
             "S",
@@ -700,11 +702,11 @@ pub use prelude::*;
 $0
 //- /std.rs crate:std
 pub mod prelude {
-    pub enum Option<T> { Some(T), None }
-    pub use Option::*;
+    pub mod rust_2018 {
+        pub enum Option<T> { Some(T), None }
+        pub use Option::*;
+    }
 }
-#[prelude_import]
-pub use prelude::*;
         "#;
         check_found_path(code, "None", "None", "None", "None");
         check_found_path(code, "Some", "Some", "Some", "Some");
@@ -1080,11 +1082,11 @@ fn f() {
 }
 //- /std.rs crate:std
 pub mod prelude {
-    pub enum Option { None }
-    pub use Option::*;
+    pub mod rust_2018 {
+        pub enum Option { None }
+        pub use Option::*;
+    }
 }
-#[prelude_import]
-pub use prelude::*;
         "#,
             "None",
             "None",

--- a/crates/hir_def/src/nameres/tests/macros.rs
+++ b/crates/hir_def/src/nameres/tests/macros.rs
@@ -264,7 +264,7 @@ fn prelude_is_macro_use() {
     cov_mark::check!(prelude_is_macro_use);
     check(
         r#"
-//- /main.rs crate:main deps:foo
+//- /main.rs crate:main deps:std
 structs!(Foo);
 structs_priv!(Bar);
 structs_outside!(Out);
@@ -276,20 +276,19 @@ mod bar;
 structs!(Baz);
 crate::structs!(MacroNotResolved3);
 
-//- /lib.rs crate:foo
-#[prelude_import]
-use self::prelude::*;
-
-mod prelude {
-    #[macro_export]
-    macro_rules! structs {
-        ($i:ident) => { struct $i; }
-    }
-
-    mod priv_mod {
+//- /lib.rs crate:std
+pub mod prelude {
+    pub mod rust_2018 {
         #[macro_export]
-        macro_rules! structs_priv {
+        macro_rules! structs {
             ($i:ident) => { struct $i; }
+        }
+
+        mod priv_mod {
+            #[macro_export]
+            macro_rules! structs_priv {
+                ($i:ident) => { struct $i; }
+            }
         }
     }
 }
@@ -617,12 +616,11 @@ fn macro_dollar_crate_is_correct_in_indirect_deps() {
 foo!();
 
 //- /std.rs crate:std deps:core
-#[prelude_import]
-use self::prelude::*;
-
 pub use core::foo;
 
-mod prelude {}
+pub mod prelude {
+    pub mod rust_2018 {}
+}
 
 #[macro_use]
 mod std_macros;

--- a/crates/hir_expand/src/name.rs
+++ b/crates/hir_expand/src/name.rs
@@ -176,6 +176,10 @@ pub mod known {
         result,
         boxed,
         option,
+        prelude,
+        rust_2015,
+        rust_2018,
+        rust_2021,
         // Components of known path (type name)
         Iterator,
         IntoIterator,

--- a/crates/hir_ty/src/tests/macros.rs
+++ b/crates/hir_ty/src/tests/macros.rs
@@ -982,14 +982,18 @@ fn test() {
 }         //^ S
 
 //- /lib.rs crate:core
-#[prelude_import]
-use clone::*;
-mod clone {
-    trait Clone {
+pub mod prelude {
+    pub mod rust_2018 {
+        #[rustc_builtin_macro]
+        pub macro Clone {}
+        pub use crate::clone::Clone;
+    }
+}
+
+pub mod clone {
+    pub trait Clone {
         fn clone(&self) -> Self;
     }
-    #[rustc_builtin_macro]
-    macro Clone {}
 }
 "#,
     );
@@ -1001,14 +1005,22 @@ fn infer_derive_clone_in_core() {
         r#"
 //- /lib.rs crate:core
 #[prelude_import]
-use clone::*;
-mod clone {
-    trait Clone {
+use prelude::rust_2018::*;
+
+pub mod prelude {
+    pub mod rust_2018 {
+        #[rustc_builtin_macro]
+        pub macro Clone {}
+        pub use crate::clone::Clone;
+    }
+}
+
+pub mod clone {
+    pub trait Clone {
         fn clone(&self) -> Self;
     }
-    #[rustc_builtin_macro]
-    macro Clone {}
 }
+
 #[derive(Clone)]
 pub struct S;
 
@@ -1037,14 +1049,18 @@ fn test() {
 }
 
 //- /lib.rs crate:core
-#[prelude_import]
-use clone::*;
-mod clone {
-    trait Clone {
+pub mod prelude {
+    pub mod rust_2018 {
+        #[rustc_builtin_macro]
+        pub macro Clone {}
+        pub use crate::clone::Clone;
+    }
+}
+
+pub mod clone {
+    pub trait Clone {
         fn clone(&self) -> Self;
     }
-    #[rustc_builtin_macro]
-    macro Clone {}
 }
 "#,
     );

--- a/crates/hir_ty/src/tests/method_resolution.rs
+++ b/crates/hir_ty/src/tests/method_resolution.rs
@@ -796,7 +796,7 @@ fn test() {
 fn method_resolution_trait_from_prelude() {
     check_types(
         r#"
-//- /main.rs crate:main deps:other_crate
+//- /main.rs crate:main deps:core
 struct S;
 impl Clone for S {}
 
@@ -805,12 +805,12 @@ fn test() {
           //^ S
 }
 
-//- /lib.rs crate:other_crate
-#[prelude_import] use foo::*;
-
-mod foo {
-    trait Clone {
-        fn clone(&self) -> Self;
+//- /lib.rs crate:core
+pub mod prelude {
+    pub mod rust_2018 {
+        pub trait Clone {
+            fn clone(&self) -> Self;
+        }
     }
 }
 "#,

--- a/crates/hir_ty/src/tests/regression.rs
+++ b/crates/hir_ty/src/tests/regression.rs
@@ -426,11 +426,12 @@ fn test() {
 
 //- /std.rs crate:std
 #[prelude_import]
-use prelude::*;
-
+use self::prelude::rust_2018::*;
 pub mod prelude {
-    pub use crate::iter::Iterator;
-    pub use crate::option::Option;
+    pub mod rust_2018 {
+        pub use crate::iter::Iterator;
+        pub use crate::option::Option;
+    }
 }
 
 pub mod iter {

--- a/crates/hir_ty/src/tests/simple.rs
+++ b/crates/hir_ty/src/tests/simple.rs
@@ -2712,3 +2712,23 @@ fn main() {
         "#]],
     );
 }
+
+#[test]
+fn prelude_2015() {
+    check_types(
+        r#"
+//- /main.rs edition:2015 crate:main deps:core
+fn f() {
+    Rust;
+     //^ Rust
+}
+
+//- /core.rs crate:core
+pub mod prelude {
+    pub mod rust_2015 {
+        pub struct Rust;
+    }
+}
+    "#,
+    );
+}

--- a/crates/ide_completion/src/completions/unqualified_path.rs
+++ b/crates/ide_completion/src/completions/unqualified_path.rs
@@ -385,10 +385,11 @@ fn foo() {
 fn foo() { let x: $0 }
 
 //- /std/lib.rs crate:std
-#[prelude_import]
-use prelude::*;
-
-mod prelude { struct Option; }
+pub mod prelude {
+    pub mod rust_2018 {
+        pub struct Option;
+    }
+}
 "#,
             expect![[r#"
                 fn foo()  fn()
@@ -406,12 +407,10 @@ mod prelude { struct Option; }
 fn f() {$0}
 
 //- /std/lib.rs crate:std
-#[prelude_import]
-pub use prelude::*;
-
-#[macro_use]
-mod prelude {
-    pub use crate::concat;
+pub mod prelude {
+    pub mod rust_2018 {
+        pub use crate::concat;
+    }
 }
 
 mod macros {
@@ -436,16 +435,18 @@ mod macros {
 fn foo() { let x: $0 }
 
 //- /core/lib.rs crate:core
-#[prelude_import]
-use prelude::*;
-
-mod prelude { struct Option; }
+pub mod prelude {
+    pub mod rust_2018 {
+        pub struct Option;
+    }
+}
 
 //- /std/lib.rs crate:std deps:core
-#[prelude_import]
-use prelude::*;
-
-mod prelude { struct String; }
+pub mod prelude {
+    pub mod rust_2018 {
+        pub struct String;
+    }
+}
 "#,
             expect![[r#"
                 fn foo()  fn()

--- a/crates/ide_db/src/helpers/famous_defs_fixture.rs
+++ b/crates/ide_db/src/helpers/famous_defs_fixture.rs
@@ -128,17 +128,19 @@ pub mod option {
 }
 
 pub mod prelude {
-    pub use crate::{
-        cmp::Ord,
-        convert::{From, Into},
-        default::Default,
-        iter::{IntoIterator, Iterator},
-        ops::{Fn, FnMut, FnOnce},
-        option::Option::{self, *},
-    };
+    pub mod rust_2018 {
+        pub use crate::{
+            cmp::Ord,
+            convert::{From, Into},
+            default::Default,
+            iter::{IntoIterator, Iterator},
+            ops::{Fn, FnMut, FnOnce},
+            option::Option::{self, *},
+        };
+    }
 }
 #[prelude_import]
-pub use prelude::*;
+pub use prelude::rust_2018::*;
 //- /libstd.rs crate:std deps:core
 //! Signatures of traits, types and functions from the std lib for use in tests.
 


### PR DESCRIPTION
Part of https://github.com/rust-analyzer/rust-analyzer/issues/9056

Our previous implementation was incorrect (presumably because of the misleading comment in libstd [here](https://github.com/rust-lang/rust/blob/a7890c7952bdc9445eb6c63dc671fa7a1ab0260d/library/std/src/lib.rs#L339-L343)). `#[prelude_import]` does not define the prelude, it can only override the implicit prelude for the current crate.

This PR fixes that, which also makes the prelude imports in `rustc_span` work. Closes https://github.com/rust-analyzer/rust-analyzer/issues/8815.

bors r+