### PR TITLE
internal: make variant fields inherit the enum's visibility in the ItemTree

### DIFF
--- a/crates/hir_def/src/item_tree/lower.rs
+++ b/crates/hir_def/src/item_tree/lower.rs
@@ -276,10 +276,11 @@ impl<'a> Ctx<'a> {
         let visibility = self.lower_visibility(enum_);
         let name = enum_.name()?.as_name();
         let generic_params = self.lower_generic_params(GenericsOwner::Enum, enum_);
-        let variants = match &enum_.variant_list() {
-            Some(variant_list) => self.lower_variants(variant_list),
-            None => IdRange::new(self.next_variant_idx()..self.next_variant_idx()),
-        };
+        let variants =
+            self.with_inherited_visibility(visibility, |this| match &enum_.variant_list() {
+                Some(variant_list) => this.lower_variants(variant_list),
+                None => IdRange::new(this.next_variant_idx()..this.next_variant_idx()),
+            });
         let ast_id = self.source_ast_id_map.ast_id(enum_);
         let res = Enum { name, visibility, generic_params, variants, ast_id };
         Some(id(self.data().enums.alloc(res)))

--- a/crates/hir_def/src/item_tree/tests.rs
+++ b/crates/hir_def/src/item_tree/tests.rs
@@ -359,3 +359,41 @@ trait Tr<'a, T: 'a>: Super {}
         "#]],
     )
 }
+
+#[test]
+fn inherit_visibility() {
+    check(
+        r#"
+pub(crate) enum En {
+    Var1(u8),
+    Var2 {
+        fld: u8,
+    },
+}
+
+pub(crate) trait Tr {
+    fn f();
+    fn method(&self) {}
+}
+        "#,
+        expect![[r#"
+            pub(crate) enum En {
+                Var1(
+                    pub(crate) 0: u8,
+                ),
+                Var2 {
+                    pub(crate) fld: u8,
+                },
+            }
+
+            pub(crate) trait Tr<Self> {
+                pub(crate) fn f() -> ();
+
+                // flags = 0x3
+                pub(crate) fn method(
+                    _: &Self,
+                ) -> ();
+            }
+        "#]],
+    )
+}


### PR DESCRIPTION
No observable changes from what I can tell, but this is "more correct".

bors r+