### PR TITLE
fix: fix incorrect "unresolved import" error when using derive helpers

### DIFF
--- a/crates/hir_def/src/nameres/collector.rs
+++ b/crates/hir_def/src/nameres/collector.rs
@@ -1062,6 +1062,7 @@ impl DefCollector<'_> {
                                 .collect(&[*mod_item]);
 
                                 // Remove the original directive since we resolved it.
+                                res = ReachedFixedPoint::No;
                                 return false;
                             }
                         }


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/9133

cursed bug

bors r+