### PR TITLE
internal: Enable attribute macro expansion in `analysis-stats`

### DIFF
--- a/crates/rust-analyzer/src/cli/load_cargo.rs
+++ b/crates/rust-analyzer/src/cli/load_cargo.rs
@@ -4,6 +4,7 @@ use std::{path::Path, sync::Arc};
 
 use anyhow::Result;
 use crossbeam_channel::{unbounded, Receiver};
+use hir::db::DefDatabase;
 use ide::{AnalysisHost, Change};
 use ide_db::base_db::CrateGraph;
 use project_model::{
@@ -93,6 +94,8 @@ fn load_crate_graph(
     let lru_cap = std::env::var("RA_LRU_CAP").ok().and_then(|it| it.parse::<usize>().ok());
     let mut host = AnalysisHost::new(lru_cap);
     let mut analysis_change = Change::new();
+
+    host.raw_database_mut().set_enable_proc_attr_macros(true);
 
     // wait until Vfs has loaded all roots
     for task in receiver {


### PR DESCRIPTION
Before:
```
> $ rust-analyzer -q analysis-stats --with-proc-macro --load-output-dirs .
Database loaded:     19.08s, 277minstr
  crates: 34, mods: 688, decls: 13202, fns: 10412
Item Collection:     16.21s, 76ginstr
  exprs: 290580, ??ty: 2508 (0%), ?ty: 1814 (0%), !ty: 947
Inference:           27.46s, 108ginstr
Total:               43.67s, 184ginstr
```
After:
```
> $ ./target/release/rust-analyzer -q analysis-stats --with-proc-macro --load-output-dirs .
Database loaded:     1.09s, 277minstr
  crates: 34, mods: 688, decls: 14790, fns: 11006
Item Collection:     18.20s, 78ginstr
  exprs: 297826, ??ty: 493 (0%), ?ty: 558 (0%), !ty: 342
Inference:           28.34s, 111ginstr
Total:               46.54s, 190ginstr
```