### PR TITLE
minor: Prevent renaming of aliases on usages

### DIFF
--- a/crates/ide/src/references/rename.rs
+++ b/crates/ide/src/references/rename.rs
@@ -170,7 +170,17 @@ fn find_definition(
             NameClass::classify(sema, &name).map(|class| class.referenced_or_defined(sema.db))
         }
         ast::NameLike::NameRef(name_ref) => {
-            NameRefClass::classify(sema, &name_ref).map(|class| class.referenced(sema.db))
+            if let Some(def) =
+                NameRefClass::classify(sema, &name_ref).map(|class| class.referenced(sema.db))
+            {
+                // if the name differs from the definitions name it has to be an alias
+                if def.name(sema.db).map_or(false, |it| it.to_string() != name_ref.text()) {
+                    bail!("Renaming aliases is currently unsupported");
+                }
+                Some(def)
+            } else {
+                None
+            }
         }
         ast::NameLike::Lifetime(lifetime) => NameRefClass::classify_lifetime(sema, &lifetime)
             .map(|class| NameRefClass::referenced(class, sema.db))
@@ -1905,6 +1915,27 @@ struct Fo0;
 
 impl Fo0 where Self: {}
 "#,
+        );
+    }
+
+    #[test]
+    fn test_rename_fails_on_aliases() {
+        check(
+            "Baz",
+            r#"
+struct Foo;
+use Foo as Bar$0;
+"#,
+            "error: Renaming aliases is currently unsupported",
+        );
+        check(
+            "Baz",
+            r#"
+struct Foo;
+use Foo as Bar;
+use Bar$0;
+"#,
+            "error: Renaming aliases is currently unsupported",
         );
     }
 }


### PR DESCRIPTION
Otherwise trying to rename a usage that goes through an alias will still rename the aliased item instead, cc https://github.com/rust-analyzer/rust-analyzer/issues/5671
bors r+