### PR TITLE
internal: replace attribute with equivalent whitespace

### DIFF
--- a/crates/hir_expand/src/input.rs
+++ b/crates/hir_expand/src/input.rs
@@ -1,7 +1,7 @@
 //! Macro input conditioning.
 
 use syntax::{
-    ast::{self, AttrsOwner},
+    ast::{self, make, AttrsOwner},
     AstNode, SyntaxNode,
 };
 
@@ -61,7 +61,9 @@ fn remove_attr_invoc(item: ast::Item, attr_index: usize) -> ast::Item {
         .attrs()
         .nth(attr_index)
         .unwrap_or_else(|| panic!("cannot find attribute #{}", attr_index));
-    attr.syntax().detach();
+    let syntax_index = attr.syntax().index();
+    let ws = make::tokens::whitespace(&" ".repeat(u32::from(attr.syntax().text().len()) as usize));
+    item.syntax().splice_children(syntax_index..syntax_index + 1, vec![ws.into()]);
     item
 }
 


### PR DESCRIPTION
This is needed to that the `TokenMap` we create contains offsets that match the source. Currently the offsets don't match because the attribute is removed, shifting all subsequent token offsets by the attribute's text length.

Currently this fix has no visible effect because we don't remap tokens in attribute macros.

bors r+