### PR TITLE
fix: don't complete derive macros as fn-like macros

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1351,6 +1351,13 @@ impl MacroDef {
             MacroDefKind::ProcMacro(_, base_db::ProcMacroKind::FuncLike, _) => MacroKind::ProcMacro,
         }
     }
+
+    pub fn is_fn_like(&self) -> bool {
+        match self.kind() {
+            MacroKind::Declarative | MacroKind::BuiltIn | MacroKind::ProcMacro => true,
+            MacroKind::Attr | MacroKind::Derive => false,
+        }
+    }
 }
 
 /// Invariant: `inner.as_assoc_item(db).is_some()`

--- a/crates/ide_completion/src/completions/qualified_path.rs
+++ b/crates/ide_completion/src/completions/qualified_path.rs
@@ -26,7 +26,9 @@ pub(crate) fn complete_qualified_path(acc: &mut Completions, ctx: &CompletionCon
             let module_scope = module.scope(ctx.db, context_module);
             for (name, def) in module_scope {
                 if let hir::ScopeDef::MacroDef(macro_def) = def {
-                    acc.add_macro(ctx, Some(name.clone()), macro_def);
+                    if macro_def.is_fn_like() {
+                        acc.add_macro(ctx, Some(name.clone()), macro_def);
+                    }
                 }
                 if let hir::ScopeDef::ModuleDef(hir::ModuleDef::Module(_)) = def {
                     acc.add_resolution(ctx, name, &def);
@@ -55,6 +57,13 @@ pub(crate) fn complete_qualified_path(acc: &mut Completions, ctx: &CompletionCon
                                 continue;
                             }
                         }
+                    }
+                }
+
+                if let hir::ScopeDef::MacroDef(macro_def) = def {
+                    if !macro_def.is_fn_like() {
+                        // Don't suggest attribute macros and derives.
+                        continue;
                     }
                 }
 


### PR DESCRIPTION
Part of https://github.com/rust-analyzer/rust-analyzer/issues/8518

bors r+