### PR TITLE
feat: Make `MemoryUsage` work on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,6 +1170,7 @@ dependencies = [
  "once_cell",
  "perf-event",
  "tikv-jemalloc-ctl",
+ "winapi",
 ]
 
 [[package]]

--- a/crates/profile/Cargo.toml
+++ b/crates/profile/Cargo.toml
@@ -20,6 +20,9 @@ jemalloc-ctl = { version = "0.4.1", package = "tikv-jemalloc-ctl", optional = tr
 [target.'cfg(target_os = "linux")'.dependencies]
 perf-event = "0.4"
 
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3.8", features = ["psapi"] }
+
 [features]
 cpu_profiler = []
 jemalloc = ["jemalloc-ctl"]


### PR DESCRIPTION
Unfortunately there is no convenient API for heap statistics, so this instead uses the Commit Charge value, which is the amount of memory that needs to be allocated either in physical RAM or in the page file. This approximation seems to be good enough to find queries that waste a large amount of memory, but it should generally be expected to be off by several MB.

bors r+