### PR TITLE
minor: Populate import maps eagerly to speed up flyimports

### DIFF
--- a/crates/ide/src/prime_caches.rs
+++ b/crates/ide/src/prime_caches.rs
@@ -33,14 +33,15 @@ pub(crate) fn prime_caches(db: &RootDatabase, cb: &(dyn Fn(PrimeCachesProgress) 
     // FIXME: This would be easy to parallelize, since it's in the ideal ordering for that.
     // Unfortunately rayon prevents panics from propagation out of a `scope`, which breaks
     // cancellation, so we cannot use rayon.
-    for (i, krate) in topo.iter().enumerate() {
-        let crate_name = graph[*krate].display_name.as_deref().unwrap_or_default().to_string();
+    for (i, &crate_id) in topo.iter().enumerate() {
+        let crate_name = graph[crate_id].display_name.as_deref().unwrap_or_default().to_string();
 
         cb(PrimeCachesProgress::StartedOnCrate {
             on_crate: crate_name,
             n_done: i,
             n_total: topo.len(),
         });
-        db.crate_def_map(*krate);
+        db.crate_def_map(crate_id);
+        db.import_map(crate_id);
     }
 }

--- a/crates/rust-analyzer/src/cli.rs
+++ b/crates/rust-analyzer/src/cli.rs
@@ -16,7 +16,6 @@ use vfs::Vfs;
 pub use self::{
     analysis_stats::AnalysisStatsCmd,
     diagnostics::diagnostics,
-    load_cargo::{load_workspace, load_workspace_at, LoadCargoConfig},
     ssr::{apply_ssr_rules, search_for_patterns},
 };
 

--- a/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -70,6 +70,7 @@ impl AnalysisStatsCmd {
             load_out_dirs_from_check: self.enable_build_scripts,
             wrap_rustc: false,
             with_proc_macro: self.enable_proc_macros,
+            prefill_caches: false,
         };
         let (host, vfs, _proc_macro) =
             load_workspace_at(&self.path, &cargo_config, &load_cargo_config, &|_| {})?;

--- a/crates/rust-analyzer/src/cli/diagnostics.rs
+++ b/crates/rust-analyzer/src/cli/diagnostics.rs
@@ -34,8 +34,12 @@ pub fn diagnostics(
     with_proc_macro: bool,
 ) -> Result<()> {
     let cargo_config = Default::default();
-    let load_cargo_config =
-        LoadCargoConfig { load_out_dirs_from_check, with_proc_macro, wrap_rustc: false };
+    let load_cargo_config = LoadCargoConfig {
+        load_out_dirs_from_check,
+        with_proc_macro,
+        wrap_rustc: false,
+        prefill_caches: false,
+    };
     let (host, _vfs, _proc_macro) =
         load_workspace_at(path, &cargo_config, &load_cargo_config, &|_| {})?;
     let db = host.raw_database();

--- a/crates/rust-analyzer/src/cli/load_cargo.rs
+++ b/crates/rust-analyzer/src/cli/load_cargo.rs
@@ -33,7 +33,7 @@ pub fn load_workspace_at(
     load_workspace(workspace, load_config, progress)
 }
 
-pub fn load_workspace(
+fn load_workspace(
     ws: ProjectWorkspace,
     config: &LoadCargoConfig,
     progress: &dyn Fn(String),
@@ -82,6 +82,8 @@ pub fn load_workspace(
     log::debug!("crate graph: {:?}", crate_graph);
     let host =
         load_crate_graph(crate_graph, project_folders.source_root_config, &mut vfs, &receiver);
+
+    host.analysis().prime_caches(|_| {})?;
     Ok((host, vfs, proc_macro_client))
 }
 

--- a/crates/rust-analyzer/src/cli/load_cargo.rs
+++ b/crates/rust-analyzer/src/cli/load_cargo.rs
@@ -18,6 +18,7 @@ pub(crate) struct LoadCargoConfig {
     pub(crate) load_out_dirs_from_check: bool,
     pub(crate) wrap_rustc: bool,
     pub(crate) with_proc_macro: bool,
+    pub(crate) prefill_caches: bool,
 }
 
 pub(crate) fn load_workspace_at(
@@ -83,7 +84,9 @@ fn load_workspace(
     let host =
         load_crate_graph(crate_graph, project_folders.source_root_config, &mut vfs, &receiver);
 
-    host.analysis().prime_caches(|_| {})?;
+    if config.prefill_caches {
+        host.analysis().prime_caches(|_| {})?;
+    }
     Ok((host, vfs, proc_macro_client))
 }
 
@@ -146,6 +149,7 @@ mod tests {
             load_out_dirs_from_check: false,
             wrap_rustc: false,
             with_proc_macro: false,
+            prefill_caches: false,
         };
         let (host, _vfs, _proc_macro) =
             load_workspace_at(path, &cargo_config, &load_cargo_config, &|_| {})?;

--- a/crates/rust-analyzer/src/cli/load_cargo.rs
+++ b/crates/rust-analyzer/src/cli/load_cargo.rs
@@ -14,13 +14,13 @@ use vfs::{loader::Handle, AbsPath, AbsPathBuf};
 
 use crate::reload::{ProjectFolders, SourceRootConfig};
 
-pub struct LoadCargoConfig {
-    pub load_out_dirs_from_check: bool,
-    pub wrap_rustc: bool,
-    pub with_proc_macro: bool,
+pub(crate) struct LoadCargoConfig {
+    pub(crate) load_out_dirs_from_check: bool,
+    pub(crate) wrap_rustc: bool,
+    pub(crate) with_proc_macro: bool,
 }
 
-pub fn load_workspace_at(
+pub(crate) fn load_workspace_at(
     root: &Path,
     cargo_config: &CargoConfig,
     load_config: &LoadCargoConfig,

--- a/crates/rust-analyzer/src/cli/ssr.rs
+++ b/crates/rust-analyzer/src/cli/ssr.rs
@@ -13,6 +13,7 @@ pub fn apply_ssr_rules(rules: Vec<SsrRule>) -> Result<()> {
         load_out_dirs_from_check: true,
         wrap_rustc: false,
         with_proc_macro: true,
+        prefill_caches: false,
     };
     let (host, vfs, _proc_macro) =
         load_workspace_at(&std::env::current_dir()?, &cargo_config, &load_cargo_config, &|_| {})?;
@@ -39,8 +40,12 @@ pub fn search_for_patterns(patterns: Vec<SsrPattern>, debug_snippet: Option<Stri
     use ide_db::base_db::SourceDatabaseExt;
     use ide_db::symbol_index::SymbolsDatabase;
     let cargo_config = Default::default();
-    let load_cargo_config =
-        LoadCargoConfig { load_out_dirs_from_check: true, wrap_rustc: true, with_proc_macro: true };
+    let load_cargo_config = LoadCargoConfig {
+        load_out_dirs_from_check: true,
+        wrap_rustc: true,
+        with_proc_macro: true,
+        prefill_caches: false,
+    };
     let (host, _vfs, _proc_macro) =
         load_workspace_at(&std::env::current_dir()?, &cargo_config, &load_cargo_config, &|_| {})?;
     let db = host.raw_database();

--- a/crates/rust-analyzer/src/integrated_benchmarks.rs
+++ b/crates/rust-analyzer/src/integrated_benchmarks.rs
@@ -37,6 +37,7 @@ fn integrated_highlighting_benchmark() {
         load_out_dirs_from_check: true,
         wrap_rustc: false,
         with_proc_macro: false,
+        prefill_caches: false,
     };
 
     let (mut host, vfs, _proc_macro) = {
@@ -91,6 +92,7 @@ fn integrated_completion_benchmark() {
         load_out_dirs_from_check: true,
         wrap_rustc: false,
         with_proc_macro: false,
+        prefill_caches: true,
     };
 
     let (mut host, vfs, _proc_macro) = {


### PR DESCRIPTION
Part of #7542
Follow up of https://github.com/rust-analyzer/rust-analyzer/pull/9206#issuecomment-859097783
Reduces `import_on_the_fly @ sel` case in the `integrated_completion_benchmark` by ~300ms.


Also enables cache priming for manual workspace loading to reflect the results in the benchmarks.

Before:
<img width="1198" alt="image" src="https://user-images.githubusercontent.com/2690773/121606148-4a734a80-ca56-11eb-812a-7955e93817f1.png">


After:
<img width="1200" alt="image" src="https://user-images.githubusercontent.com/2690773/121606156-4e06d180-ca56-11eb-891b-1ed878b53d7e.png">
