### PR TITLE
minor: Give `ImportPrefix` variants better config names

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -801,7 +801,9 @@ enum ImportGranularityDef {
 #[serde(rename_all = "snake_case")]
 enum ImportPrefixDef {
     Plain,
+    #[serde(alias = "self")]
     BySelf,
+    #[serde(alias = "crate")]
     ByCrate,
 }
 
@@ -986,13 +988,13 @@ fn field_props(field: &str, ty: &str, doc: &[&str], default: &str) -> serde_json
             "type": "string",
             "enum": [
                 "plain",
-                "by_self",
-                "by_crate"
+                "self",
+                "crate"
             ],
             "enumDescriptions": [
                 "Insert import paths relative to the current module, using up to one `super` prefix if the parent module contains the requested item.",
-                "Prefix all import paths with `self` if they don't begin with `self`, `super`, `crate` or a crate name.",
-                "Force import paths to be absolute by always starting them with `crate` or the crate name they refer to."
+                "Insert import paths relative to the current module, using up to one `super` prefix if the parent module contains the requested item. Prefixes `self` in front of the path if it starts with a module.",
+                "Force import paths to be absolute by always starting them with `crate` or the extern crate name they come from."
             ],
         },
         "Vec<ManifestOrProjectJson>" => set! {

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -418,13 +418,13 @@
                     "type": "string",
                     "enum": [
                         "plain",
-                        "by_self",
-                        "by_crate"
+                        "self",
+                        "crate"
                     ],
                     "enumDescriptions": [
                         "Insert import paths relative to the current module, using up to one `super` prefix if the parent module contains the requested item.",
-                        "Prefix all import paths with `self` if they don't begin with `self`, `super`, `crate` or a crate name.",
-                        "Force import paths to be absolute by always starting them with `crate` or the crate name they refer to."
+                        "Insert import paths relative to the current module, using up to one `super` prefix if the parent module contains the requested item. Prefixes `self` in front of the path if it starts with a module.",
+                        "Force import paths to be absolute by always starting them with `crate` or the extern crate name they come from."
                     ]
                 },
                 "rust-analyzer.assist.importGroup": {


### PR DESCRIPTION
I feel like `crate` and `self` work better than `by_crate` and `by_self`. The only reason for the current names were that `Self` doesn't work for the variant name on the rust side so I forgot about setting proper config names on serde layer.