### PR TITLE
tree-wide: make rustdoc links spiky so they are clickable

### DIFF
--- a/crates/cfg/src/cfg_expr.rs
+++ b/crates/cfg/src/cfg_expr.rs
@@ -1,6 +1,6 @@
 //! The condition expression used in `#[cfg(..)]` attributes.
 //!
-//! See: https://doc.rust-lang.org/reference/conditional-compilation.html#conditional-compilation
+//! See: <https://doc.rust-lang.org/reference/conditional-compilation.html#conditional-compilation>
 
 use std::{fmt, slice::Iter as SliceIter};
 

--- a/crates/cfg/src/lib.rs
+++ b/crates/cfg/src/lib.rs
@@ -22,7 +22,7 @@ pub use dnf::DnfExpr;
 /// `foo` and `bar` are both enabled. And here, we store key-value options as a set of tuple
 /// of key and value in `key_values`.
 ///
-/// See: https://doc.rust-lang.org/reference/conditional-compilation.html#set-configuration-options
+/// See: <https://doc.rust-lang.org/reference/conditional-compilation.html#set-configuration-options>
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct CfgOptions {
     enabled: FxHashSet<CfgAtom>,

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! `hir` is what insulates the "we don't know how to actually write an incremental compiler"
 //! from the ide with completions, hovers, etc. It is a (soft, internal) boundary:
-//! https://www.tedinski.com/2018/02/06/system-boundaries.html.
+//! <https://www.tedinski.com/2018/02/06/system-boundaries.html>.
 
 #![recursion_limit = "512"]
 

--- a/crates/hir_expand/src/eager.rs
+++ b/crates/hir_expand/src/eager.rs
@@ -17,7 +17,7 @@
 //! > and we need to live with it because it's available on stable and widely relied upon.
 //!
 //!
-//! See the full discussion : https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/Eager.20expansion.20of.20built-in.20macros
+//! See the full discussion : <https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/Eager.20expansion.20of.20built-in.20macros>
 
 use crate::{
     ast::{self, AstNode},

--- a/crates/hir_expand/src/lib.rs
+++ b/crates/hir_expand/src/lib.rs
@@ -53,7 +53,7 @@ mod test_db;
 /// this is a recursive definition! However, the size_of of `HirFileId` is
 /// finite (because everything bottoms out at the real `FileId`) and small
 /// (`MacroCallId` uses the location interning. You can check details here:
-/// https://en.wikipedia.org/wiki/String_interning).
+/// <https://en.wikipedia.org/wiki/String_interning>).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct HirFileId(HirFileIdRepr);
 

--- a/crates/hir_ty/src/diagnostics/match_check/usefulness.rs
+++ b/crates/hir_ty/src/diagnostics/match_check/usefulness.rs
@@ -1,5 +1,5 @@
 //! Based on rust-lang/rust 1.52.0-nightly (25c15cdbe 2021-04-22)
-//! https://github.com/rust-lang/rust/blob/25c15cdbe/compiler/rustc_mir_build/src/thir/pattern/usefulness.rs
+//! <https://github.com/rust-lang/rust/blob/25c15cdbe/compiler/rustc_mir_build/src/thir/pattern/usefulness.rs>
 //!
 //! -----
 //!

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -80,7 +80,7 @@ enum ExprOrPatId {
 impl_from!(ExprId, PatId for ExprOrPatId);
 
 /// Binding modes inferred for patterns.
-/// https://doc.rust-lang.org/reference/patterns.html#binding-modes
+/// <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 enum BindingMode {
     Move,

--- a/crates/hir_ty/src/infer/coerce.rs
+++ b/crates/hir_ty/src/infer/coerce.rs
@@ -2,8 +2,8 @@
 //! happen in certain places, e.g. weakening `&mut` to `&` or deref coercions
 //! like going from `&Vec<T>` to `&[T]`.
 //!
-//! See https://doc.rust-lang.org/nomicon/coercions.html and
-//! librustc_typeck/check/coercion.rs.
+//! See <https://doc.rust-lang.org/nomicon/coercions.html> and
+//! `librustc_typeck/check/coercion.rs`.
 
 use chalk_ir::{cast::Cast, Mutability, TyVariableKind};
 use hir_def::{expr::ExprId, lang_item::LangItemTarget};
@@ -331,7 +331,7 @@ impl<'a> InferenceContext<'a> {
 
     /// Coerce a type using `from_ty: CoerceUnsized<ty_ty>`
     ///
-    /// See: https://doc.rust-lang.org/nightly/std/marker/trait.CoerceUnsized.html
+    /// See: <https://doc.rust-lang.org/nightly/std/marker/trait.CoerceUnsized.html>
     fn try_coerce_unsized(&mut self, from_ty: &Ty, to_ty: &Ty) -> InferResult {
         // These 'if' statements require some explanation.
         // The `CoerceUnsized` trait is special - it is only

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -957,7 +957,7 @@ pub(crate) fn field_types_query(
 /// like `T::Item`.
 ///
 /// See the analogous query in rustc and its comment:
-/// https://github.com/rust-lang/rust/blob/9150f844e2624eb013ec78ca08c1d416e6644026/src/librustc_typeck/astconv.rs#L46
+/// <https://github.com/rust-lang/rust/blob/9150f844e2624eb013ec78ca08c1d416e6644026/src/librustc_typeck/astconv.rs#L46>
 /// This is a query mostly to handle cycles somewhat gracefully; e.g. the
 /// following bounds are disallowed: `T: Foo<U::Item>, U: Foo<T::Item>`, but
 /// these are fine: `T: Foo<U::Item>, U: Foo<()>`.

--- a/crates/ide_completion/src/completions/attribute.rs
+++ b/crates/ide_completion/src/completions/attribute.rs
@@ -219,7 +219,7 @@ static KIND_TO_ATTRIBUTES: Lazy<FxHashMap<SyntaxKind, &[&str]>> = Lazy::new(|| {
 });
 const EXPR_ATTRIBUTES: &[&str] = attrs!();
 
-/// https://doc.rust-lang.org/reference/attributes.html#built-in-attributes-index
+/// <https://doc.rust-lang.org/reference/attributes.html#built-in-attributes-index>
 // Keep these sorted for the binary search!
 const ATTRIBUTES: &[AttrCompletion] = &[
     attr("allow(…)", Some("allow"), Some("allow(${0:lint})")),

--- a/crates/mbe/src/expander/matcher.rs
+++ b/crates/mbe/src/expander/matcher.rs
@@ -1,6 +1,6 @@
 //! An NFA-based parser, which is porting from rustc mbe parsing code
 //!
-//! See https://github.com/rust-lang/rust/blob/70b18bc2cbac4712020019f5bf57c00905373205/compiler/rustc_expand/src/mbe/macro_parser.rs
+//! See <https://github.com/rust-lang/rust/blob/70b18bc2cbac4712020019f5bf57c00905373205/compiler/rustc_expand/src/mbe/macro_parser.rs>
 //! Here is a quick intro to how the parser works, copied from rustc:
 //!
 //! A 'position' is a dot in the middle of a matcher, usually represented as a

--- a/crates/parser/src/grammar/expressions.rs
+++ b/crates/parser/src/grammar/expressions.rs
@@ -208,7 +208,7 @@ struct Restrictions {
 
 /// Binding powers of operators for a Pratt parser.
 ///
-/// See https://www.oilshell.org/blog/2016/11/03.html
+/// See <https://www.oilshell.org/blog/2016/11/03.html>
 #[rustfmt::skip]
 fn current_op(p: &Parser) -> (u8, SyntaxKind) {
     const NOT_AN_OP: (u8, SyntaxKind) = (0, T![@]);

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -244,7 +244,7 @@ impl RelPath {
     }
 }
 
-/// Taken from https://github.com/rust-lang/cargo/blob/79c769c3d7b4c2cf6a93781575b7f592ef974255/src/cargo/util/paths.rs#L60-L85
+/// Taken from <https://github.com/rust-lang/cargo/blob/79c769c3d7b4c2cf6a93781575b7f592ef974255/src/cargo/util/paths.rs#L60-L85>
 fn normalize_path(path: &Path) -> PathBuf {
     let mut components = path.components().peekable();
     let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {

--- a/crates/proc_macro_api/src/version.rs
+++ b/crates/proc_macro_api/src/version.rs
@@ -95,7 +95,7 @@ fn read_section<'a>(dylib_binary: &'a [u8], section_name: &str) -> io::Result<&'
 /// * [version string bytes encoded in utf8] <- GET THIS BOI
 /// * [some more bytes that we don really care but still there] :-)
 /// Check this issue for more about the bytes layout:
-/// https://github.com/rust-analyzer/rust-analyzer/issues/6174
+/// <https://github.com/rust-analyzer/rust-analyzer/issues/6174>
 fn read_version(dylib_path: &Path) -> io::Result<String> {
     let dylib_file = File::open(dylib_path)?;
     let dylib_mmaped = unsafe { Mmap::map(&dylib_file) }?;

--- a/crates/proc_macro_srv/src/lib.rs
+++ b/crates/proc_macro_srv/src/lib.rs
@@ -1,7 +1,7 @@
 //! RA Proc Macro Server
 //!
 //! This library is able to call compiled Rust custom derive dynamic libraries on arbitrary code.
-//! The general idea here is based on https://github.com/fedochet/rust-proc-macro-expander.
+//! The general idea here is based on <https://github.com/fedochet/rust-proc-macro-expander>.
 //!
 //! But we adapt it to better fit RA needs:
 //!

--- a/crates/proc_macro_srv/src/proc_macro/bridge/buffer.rs
+++ b/crates/proc_macro_srv/src/proc_macro/bridge/buffer.rs
@@ -1,6 +1,6 @@
 //! lib-proc-macro Buffer management for same-process client<->server communication.
 //!
-//! Copy from https://github.com/rust-lang/rust/blob/6050e523bae6de61de4e060facc43dc512adaccd/src/libproc_macro/bridge/buffer.rs
+//! Copy from <https://github.com/rust-lang/rust/blob/6050e523bae6de61de4e060facc43dc512adaccd/src/libproc_macro/bridge/buffer.rs>
 //! augmented with removing unstable features
 
 use std::io::{self, Write};

--- a/crates/proc_macro_srv/src/proc_macro/bridge/client.rs
+++ b/crates/proc_macro_srv/src/proc_macro/bridge/client.rs
@@ -1,6 +1,6 @@
 //! lib-proc-macro Client-side types.
 //!
-//! Copy from https://github.com/rust-lang/rust/blob/6050e523bae6de61de4e060facc43dc512adaccd/src/libproc_macro/bridge/client.rs
+//! Copy from <https://github.com/rust-lang/rust/blob/6050e523bae6de61de4e060facc43dc512adaccd/src/libproc_macro/bridge/client.rs>
 //! augmented with removing unstable features
 
 use super::*;

--- a/crates/proc_macro_srv/src/proc_macro/bridge/closure.rs
+++ b/crates/proc_macro_srv/src/proc_macro/bridge/closure.rs
@@ -1,6 +1,6 @@
 //! lib-proc-macro Closure type (equivalent to `&mut dyn FnMut(A) -> R`) that's `repr(C)`.
 //!
-//! Copy from https://github.com/rust-lang/rust/blob/6050e523bae6de61de4e060facc43dc512adaccd/src/libproc_macro/bridge/closure.rs#
+//! Copy from <https://github.com/rust-lang/rust/blob/6050e523bae6de61de4e060facc43dc512adaccd/src/libproc_macro/bridge/closure.rs>
 //! augmented with removing unstable features
 
 #[repr(C)]

--- a/crates/proc_macro_srv/src/proc_macro/bridge/handle.rs
+++ b/crates/proc_macro_srv/src/proc_macro/bridge/handle.rs
@@ -1,6 +1,6 @@
 //! lib-proc-macro Server-side handles and storage for per-handle data.
 //!
-//! Copy from https://github.com/rust-lang/rust/blob/6050e523bae6de61de4e060facc43dc512adaccd/src/libproc_macro/bridge/handle.rs
+//! Copy from <https://github.com/rust-lang/rust/blob/6050e523bae6de61de4e060facc43dc512adaccd/src/libproc_macro/bridge/handle.rs>
 //! augmented with removing unstable features
 
 use std::collections::{BTreeMap, HashMap};

--- a/crates/proc_macro_srv/src/proc_macro/bridge/mod.rs
+++ b/crates/proc_macro_srv/src/proc_macro/bridge/mod.rs
@@ -1,6 +1,6 @@
 //! lib-proc-macro Internal interface for communicating between a `proc_macro` client
 //!
-//! Copy from https://github.com/rust-lang/rust/blob/6050e523bae6de61de4e060facc43dc512adaccd/src/libproc_macro/bridge/mod.rs
+//! Copy from <https://github.com/rust-lang/rust/blob/6050e523bae6de61de4e060facc43dc512adaccd/src/libproc_macro/bridge/mod.rs>
 //! augmented with removing unstable features
 //!
 //! Internal interface for communicating between a `proc_macro` client

--- a/crates/proc_macro_srv/src/proc_macro/bridge/rpc.rs
+++ b/crates/proc_macro_srv/src/proc_macro/bridge/rpc.rs
@@ -1,6 +1,6 @@
 //! lib-proc-macro Serialization for client-server communication.
 //!
-//! Copy from https://github.com/rust-lang/rust/blob/6050e523bae6de61de4e060facc43dc512adaccd/src/libproc_macro/bridge/rpc.rs
+//! Copy from <https://github.com/rust-lang/rust/blob/6050e523bae6de61de4e060facc43dc512adaccd/src/libproc_macro/bridge/rpc.rs>
 //! augmented with removing unstable features
 //!
 //! Serialization for client-server communication.

--- a/crates/proc_macro_srv/src/proc_macro/bridge/scoped_cell.rs
+++ b/crates/proc_macro_srv/src/proc_macro/bridge/scoped_cell.rs
@@ -1,6 +1,6 @@
 //! lib-proc-macro `Cell` variant for (scoped) existential lifetimes.
 //!
-//! Copy from https://github.com/rust-lang/rust/blob/6050e523bae6de61de4e060facc43dc512adaccd/src/libproc_macro/bridge/scoped_cell.rs#L1
+//! Copy from <https://github.com/rust-lang/rust/blob/6050e523bae6de61de4e060facc43dc512adaccd/src/libproc_macro/bridge/scoped_cell.rs#L1>
 //! augmented with removing unstable features
 
 use std::cell::Cell;

--- a/crates/proc_macro_srv/src/proc_macro/bridge/server.rs
+++ b/crates/proc_macro_srv/src/proc_macro/bridge/server.rs
@@ -1,6 +1,6 @@
 //! lib-proc-macro server-side traits
 //!
-//! Copy from https://github.com/rust-lang/rust/blob/6050e523bae6de61de4e060facc43dc512adaccd/src/libproc_macro/bridge/server.rs
+//! Copy from <https://github.com/rust-lang/rust/blob/6050e523bae6de61de4e060facc43dc512adaccd/src/libproc_macro/bridge/server.rs>
 //! augmented with removing unstable features
 
 use super::*;

--- a/crates/proc_macro_srv/src/proc_macro/diagnostic.rs
+++ b/crates/proc_macro_srv/src/proc_macro/diagnostic.rs
@@ -1,6 +1,6 @@
 //! lib-proc-macro diagnostic
 //!
-//! Copy from https://github.com/rust-lang/rust/blob/6050e523bae6de61de4e060facc43dc512adaccd/src/libproc_macro/diagnostic.rs
+//! Copy from <https://github.com/rust-lang/rust/blob/6050e523bae6de61de4e060facc43dc512adaccd/src/libproc_macro/diagnostic.rs>
 //! augmented with removing unstable features
 
 use crate::proc_macro::Span;

--- a/crates/proc_macro_srv/src/proc_macro/mod.rs
+++ b/crates/proc_macro_srv/src/proc_macro/mod.rs
@@ -1,6 +1,6 @@
 //! lib-proc-macro main module
 //!
-//! Copy from https://github.com/rust-lang/rust/blob/6050e523bae6de61de4e060facc43dc512adaccd/src/libproc_macro/lib.rs
+//! Copy from <https://github.com/rust-lang/rust/blob/6050e523bae6de61de4e060facc43dc512adaccd/src/libproc_macro/lib.rs>
 //! augmented with removing unstable features
 
 // NOTE(@edwin0cheng):

--- a/crates/proc_macro_srv/src/rustc_server.rs
+++ b/crates/proc_macro_srv/src/rustc_server.rs
@@ -1,6 +1,6 @@
 //! Rustc proc-macro server implementation with tt
 //!
-//! Based on idea from https://github.com/fedochet/rust-proc-macro-expander
+//! Based on idea from <https://github.com/fedochet/rust-proc-macro-expander>
 //! The lib-proc-macro server backend is `TokenStream`-agnostic, such that
 //! we could provide any TokenStream implementation.
 //! The original idea from fedochet is using proc-macro2 as backend,

--- a/crates/profile/src/lib.rs
+++ b/crates/profile/src/lib.rs
@@ -50,10 +50,10 @@ impl Drop for Scope {
 /// A wrapper around google_cpu_profiler.
 ///
 /// Usage:
-/// 1. Install gpref_tools (https://github.com/gperftools/gperftools), probably packaged with your Linux distro.
+/// 1. Install gpref_tools (<https://github.com/gperftools/gperftools>), probably packaged with your Linux distro.
 /// 2. Build with `cpu_profiler` feature.
 /// 3. Run the code, the *raw* output would be in the `./out.profile` file.
-/// 4. Install pprof for visualization (https://github.com/google/pprof).
+/// 4. Install pprof for visualization (<https://github.com/google/pprof>).
 /// 5. Bump sampling frequency to once per ms: `export CPUPROFILE_FREQUENCY=1000`
 /// 6. Use something like `pprof -svg target/release/rust-analyzer ./out.profile` to see the results.
 ///
@@ -75,7 +75,7 @@ impl Drop for Scope {
 ///
 /// See this diff for how to profile completions:
 ///
-/// https://github.com/rust-analyzer/rust-analyzer/pull/5306
+/// <https://github.com/rust-analyzer/rust-analyzer/pull/5306>
 #[derive(Debug)]
 pub struct CpuSpan {
     _private: (),

--- a/crates/rust-analyzer/src/semantic_tokens.rs
+++ b/crates/rust-analyzer/src/semantic_tokens.rs
@@ -112,7 +112,7 @@ impl ops::BitOrAssign<SemanticTokenModifier> for ModifierSet {
 
 /// Tokens are encoded relative to each other.
 ///
-/// This is a direct port of https://github.com/microsoft/vscode-languageserver-node/blob/f425af9de46a0187adb78ec8a46b9b2ce80c5412/server/src/sematicTokens.proposed.ts#L45
+/// This is a direct port of <https://github.com/microsoft/vscode-languageserver-node/blob/f425af9de46a0187adb78ec8a46b9b2ce80c5412/server/src/sematicTokens.proposed.ts#L45>
 pub(crate) struct SemanticTokensBuilder {
     id: String,
     prev_line: u32,

--- a/crates/stdx/src/panic_context.rs
+++ b/crates/stdx/src/panic_context.rs
@@ -1,6 +1,6 @@
 //! A micro-crate to enhance panic messages with context info.
 //!
-//! FIXME: upstream to https://github.com/kriomant/panic-context ?
+//! FIXME: upstream to <https://github.com/kriomant/panic-context> ?
 
 use std::{cell::RefCell, panic, sync::Once};
 

--- a/crates/stdx/src/process.rs
+++ b/crates/stdx/src/process.rs
@@ -1,7 +1,7 @@
 //! Read both stdout and stderr of child without deadlocks.
 //!
-//! https://github.com/rust-lang/cargo/blob/905af549966f23a9288e9993a85d1249a5436556/crates/cargo-util/src/read2.rs
-//! https://github.com/rust-lang/cargo/blob/58a961314437258065e23cb6316dfc121d96fb71/crates/cargo-util/src/process_builder.rs#L231
+//! <https://github.com/rust-lang/cargo/blob/905af549966f23a9288e9993a85d1249a5436556/crates/cargo-util/src/read2.rs>
+//! <https://github.com/rust-lang/cargo/blob/58a961314437258065e23cb6316dfc121d96fb71/crates/cargo-util/src/process_builder.rs#L231>
 
 use std::{
     io,

--- a/crates/tt/src/buffer.rs
+++ b/crates/tt/src/buffer.rs
@@ -133,7 +133,7 @@ impl<'a> TokenTreeRef<'a> {
     }
 }
 
-/// A safe version of `Cursor` from `syn` crate https://github.com/dtolnay/syn/blob/6533607f91686545cb034d2838beea338d9d0742/src/buffer.rs#L125
+/// A safe version of `Cursor` from `syn` crate <https://github.com/dtolnay/syn/blob/6533607f91686545cb034d2838beea338d9d0742/src/buffer.rs#L125>
 #[derive(Copy, Clone, Debug)]
 pub struct Cursor<'a> {
     buffer: &'a TokenBuffer<'a>,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,4 +1,4 @@
-//! See https://github.com/matklad/cargo-xtask/.
+//! See <https://github.com/matklad/cargo-xtask/>.
 //!
 //! This binary defines various auxiliary build commands, which are not
 //! expressible with just `cargo`. Notably, it provides tests via `cargo test -p xtask`


### PR DESCRIPTION
Rustdoc was complaining about these while I was running with --document-private-items and I figure they should be fixed.