### PR TITLE
feat: Make documentation on hover configurable

### DIFF
--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -181,7 +181,8 @@ pub(crate) fn hover(
         }
     }
 
-    if let res @ Some(_) = hover_for_keyword(&sema, links_in_hover, markdown, &token) {
+    if let res @ Some(_) = hover_for_keyword(&sema, links_in_hover, markdown, documentation, &token)
+    {
         return res;
     }
 
@@ -504,9 +505,10 @@ fn hover_for_keyword(
     sema: &hir::Semantics<RootDatabase>,
     links_in_hover: bool,
     markdown: bool,
+    documentation: bool,
     token: &SyntaxToken,
 ) -> Option<RangeInfo<HoverResult>> {
-    if !token.kind().is_keyword() {
+    if !token.kind().is_keyword() || documentation {
         return None;
     }
     let famous_defs = FamousDefs(sema, sema.scope(&token.parent()?).krate());

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -508,7 +508,7 @@ fn hover_for_keyword(
     documentation: bool,
     token: &SyntaxToken,
 ) -> Option<RangeInfo<HoverResult>> {
-    if !token.kind().is_keyword() || documentation {
+    if !token.kind().is_keyword() || !documentation {
         return None;
     }
     let famous_defs = FamousDefs(sema, sema.scope(&token.parent()?).krate());

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -407,9 +407,10 @@ impl Analysis {
         &self,
         position: FilePosition,
         links_in_hover: bool,
+        documentation: bool,
         markdown: bool,
     ) -> Cancellable<Option<RangeInfo<HoverResult>>> {
-        self.with_db(|db| hover::hover(db, position, links_in_hover, markdown))
+        self.with_db(|db| hover::hover(db, position, links_in_hover, documentation, markdown))
     }
 
     /// Return URL(s) for the documentation of the symbol under the cursor.

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -141,6 +141,11 @@ config_data! {
         /// their contents.
         highlighting_strings: bool = "true",
 
+        /// Whether to show documentation on hover.
+        hover_documentation: bool   = "true",
+        /// Use markdown syntax for links in hover.
+        hover_linksInHover: bool    = "true",
+
         /// Whether to show `Debug` action. Only applies when
         /// `#rust-analyzer.hoverActions.enable#` is set.
         hoverActions_debug: bool           = "true",
@@ -158,8 +163,6 @@ config_data! {
         /// Whether to show `Run` action. Only applies when
         /// `#rust-analyzer.hoverActions.enable#` is set.
         hoverActions_run: bool             = "true",
-        /// Use markdown syntax for links in hover.
-        hoverActions_linksInHover: bool    = "true",
 
         /// Whether to show inlay type hints for method chains.
         inlayHints_chainingHints: bool      = "true",
@@ -726,7 +729,7 @@ impl Config {
             run: self.data.hoverActions_enable && self.data.hoverActions_run,
             debug: self.data.hoverActions_enable && self.data.hoverActions_debug,
             goto_type_def: self.data.hoverActions_enable && self.data.hoverActions_gotoTypeDef,
-            links_in_hover: self.data.hoverActions_linksInHover,
+            links_in_hover: self.data.hover_linksInHover,
             markdown: try_or!(
                 self.caps
                     .text_document
@@ -739,6 +742,7 @@ impl Config {
                 &[]
             )
             .contains(&MarkupKind::Markdown),
+            documentation: self.data.hover_documentation,
         }
     }
 

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -862,11 +862,15 @@ pub(crate) fn handle_hover(
     let _p = profile::span("handle_hover");
     let position = from_proto::file_position(&snap, params.text_document_position_params)?;
     let hover_config = snap.config.hover();
-    let info =
-        match snap.analysis.hover(position, hover_config.links_in_hover, hover_config.markdown)? {
-            None => return Ok(None),
-            Some(info) => info,
-        };
+    let info = match snap.analysis.hover(
+        position,
+        hover_config.links_in_hover,
+        hover_config.documentation,
+        hover_config.markdown,
+    )? {
+        None => return Ok(None),
+        Some(info) => info,
+    };
     let line_index = snap.file_line_index(position.file_id)?;
     let range = to_proto::range(&line_index, info.range);
     let hover = lsp_ext::Hover {
@@ -1587,7 +1591,7 @@ fn prepare_hover_actions(
     snap: &GlobalStateSnapshot,
     actions: &[HoverAction],
 ) -> Vec<lsp_ext::CommandLinkGroup> {
-    if snap.config.hover().none() || !snap.config.hover_actions() {
+    if snap.config.hover().no_actions() || !snap.config.hover_actions() {
         return Vec::new();
     }
 

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -205,6 +205,16 @@ In some editors (e.g. vscode) semantic tokens override other highlighting gramma
 By disabling semantic tokens for strings, other grammars can be used to highlight
 their contents.
 --
+[[rust-analyzer.hover.documentation]]rust-analyzer.hover.documentation (default: `true`)::
++
+--
+Whether to show documentation on hover.
+--
+[[rust-analyzer.hover.linksInHover]]rust-analyzer.hover.linksInHover (default: `true`)::
++
+--
+Use markdown syntax for links in hover.
+--
 [[rust-analyzer.hoverActions.debug]]rust-analyzer.hoverActions.debug (default: `true`)::
 +
 --
@@ -239,11 +249,6 @@ Whether to show `References` action. Only applies when
 --
 Whether to show `Run` action. Only applies when
 `#rust-analyzer.hoverActions.enable#` is set.
---
-[[rust-analyzer.hoverActions.linksInHover]]rust-analyzer.hoverActions.linksInHover (default: `true`)::
-+
---
-Use markdown syntax for links in hover.
 --
 [[rust-analyzer.inlayHints.chainingHints]]rust-analyzer.inlayHints.chainingHints (default: `true`)::
 +

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -250,6 +250,11 @@ Whether to show `References` action. Only applies when
 Whether to show `Run` action. Only applies when
 `#rust-analyzer.hoverActions.enable#` is set.
 --
+[[rust-analyzer.hoverActions.linksInHover]]rust-analyzer.hoverActions.linksInHover (deprecated: `Use hover.linksInHover instead`)::
++
+--
+Use markdown syntax for links in hover.
+--
 [[rust-analyzer.inlayHints.chainingHints]]rust-analyzer.inlayHints.chainingHints (default: `true`)::
 +
 --

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -250,11 +250,6 @@ Whether to show `References` action. Only applies when
 Whether to show `Run` action. Only applies when
 `#rust-analyzer.hoverActions.enable#` is set.
 --
-[[rust-analyzer.hoverActions.linksInHover]]rust-analyzer.hoverActions.linksInHover (deprecated: `Use hover.linksInHover instead`)::
-+
---
-Use markdown syntax for links in hover.
---
 [[rust-analyzer.inlayHints.chainingHints]]rust-analyzer.inlayHints.chainingHints (default: `true`)::
 +
 --

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -680,12 +680,6 @@
                     "default": true,
                     "type": "boolean"
                 },
-                "rust-analyzer.hoverActions.linksInHover": {
-                    "markdownDescription": "Use markdown syntax for links in hover.",
-                    "default": false,
-                    "deprecationMessage": "Use hover.linksInHover instead",
-                    "type": "boolean"
-                },
                 "rust-analyzer.inlayHints.chainingHints": {
                     "markdownDescription": "Whether to show inlay type hints for method chains.",
                     "default": true,

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -680,6 +680,12 @@
                     "default": true,
                     "type": "boolean"
                 },
+                "rust-analyzer.hoverActions.linksInHover": {
+                    "markdownDescription": "Use markdown syntax for links in hover.",
+                    "default": false,
+                    "deprecationMessage": "Use hover.linksInHover instead",
+                    "type": "boolean"
+                },
                 "rust-analyzer.inlayHints.chainingHints": {
                     "markdownDescription": "Whether to show inlay type hints for method chains.",
                     "default": true,

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -640,6 +640,16 @@
                     "default": true,
                     "type": "boolean"
                 },
+                "rust-analyzer.hover.documentation": {
+                    "markdownDescription": "Whether to show documentation on hover.",
+                    "default": true,
+                    "type": "boolean"
+                },
+                "rust-analyzer.hover.linksInHover": {
+                    "markdownDescription": "Use markdown syntax for links in hover.",
+                    "default": true,
+                    "type": "boolean"
+                },
                 "rust-analyzer.hoverActions.debug": {
                     "markdownDescription": "Whether to show `Debug` action. Only applies when\n`#rust-analyzer.hoverActions.enable#` is set.",
                     "default": true,
@@ -667,11 +677,6 @@
                 },
                 "rust-analyzer.hoverActions.run": {
                     "markdownDescription": "Whether to show `Run` action. Only applies when\n`#rust-analyzer.hoverActions.enable#` is set.",
-                    "default": true,
-                    "type": "boolean"
-                },
-                "rust-analyzer.hoverActions.linksInHover": {
-                    "markdownDescription": "Use markdown syntax for links in hover.",
                     "default": true,
                     "type": "boolean"
                 },


### PR DESCRIPTION
This also implements deprecation support for config options as this renames `hoverActions_linksInHover` to `hover_linksInHover`.

Fixes #9232