### PR TITLE
fix: Code: update the LSP server without asking

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,17 +1,1 @@
-# Privacy Notes
-
-## LSP server binary
-
-The LSP server performs no network access in itself, but runs `cargo metadata` which will update or download the crate registry and the source code of the project dependencies.
-
-## Visual Studio Code extension
-
-The Code extension automatically connects to GitHub to download updated LSP binaries and, if the nightly channel is selected, to perform update checks.
-
-## Other editor plugins
-
-Any other editor plugins that integrate with `rust-analyzer` are not under the control of the `rust-analyzer` developers. For any privacy concerns, you should check with their respective developers.
-
-## Others
-
-If `cargo check` is enabled (the default), any build scripts or procedural macros used by the project or its dependencies will be executed. This is also the case when `cargo check` is disabled, but build script or procedural macro support is enabled in `rust-analyzer` (on by default).
+See the [Privacy](https://rust-analyzer.github.io/manual.html#security) section of the user manual.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -6,7 +6,7 @@ The LSP server performs no network access in itself, but runs `cargo metadata` w
 
 ## Visual Studio Code extension
 
-The Code extension connects to GitHub to download updated LSP binaries and, if the nightly channel is selected, to perform update checks.
+The Code extension automatically connects to GitHub to download updated LSP binaries and, if the nightly channel is selected, to perform update checks.
 
 ## Other editor plugins
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ If you want to **use** rust-analyzer's language server with your editor of
 choice, check [the manual](https://rust-analyzer.github.io/manual.html) folder.
 It also contains some tips & tricks to help you be more productive when using rust-analyzer.
 
+## Security and Privacy
+
+See the corresponding sections of [the manual](https://rust-analyzer.github.io/manual.html#security).
+
 ## Communication
 
 For usage and troubleshooting requests, please use "IDEs and Editors" category of the Rust forum:

--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -609,9 +609,14 @@ Here is a **non-exhaustive** list of ways to make rust-analyzer execute arbitrar
 * VS Code plugin reads configuration from project directory, and that can be used to override paths to various executables, like `rustfmt` or `rust-analyzer` itself.
 * rust-analyzer's syntax trees library uses a lot of `unsafe` and hasn't been properly audited for memory safety.
 
-rust-analyzer itself doesn't access the network.
-The VS Code plugin doesn't access the network unless the nightly channel is selected in the settings.
-In that case, the plugin uses the GitHub API to check for and download updates.
+== Privacy
+
+The LSP server performs no network access in itself, but runs `cargo metadata` which will update or download the crate registry and the source code of the project dependencies.
+If enabled (the default), build scripts and procedural macros can do anything.
+
+The Code extension automatically connects to GitHub to download updated LSP binaries and, if the nightly channel is selected, to perform update checks using the GitHub API. For `rust-analyzer` developers, using `cargo xtask release` uses the same API to put together the release notes.
+
+Any other editor plugins are not under the control of the `rust-analyzer` developers. For any privacy concerns, you should check with their respective developers.
 
 == Features
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -313,7 +313,7 @@
                 },
                 "rust-analyzer.updates.askBeforeDownload": {
                     "type": "boolean",
-                    "default": true,
+                    "default": false,
                     "description": "Whether to ask for permission before downloading any files from the Internet."
                 },
                 "rust-analyzer.server.path": {


### PR DESCRIPTION
Most LSP extensions seem to do the same thing, and this is causing some
confusion for users who don't notice the update prompt before Code hides
it.