### PR TITLE
minor: Document installation via Homebrew

### DIFF
--- a/docs/user/.gitignore
+++ b/docs/user/.gitignore
@@ -1,0 +1,1 @@
+manual.html

--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -201,7 +201,7 @@ $ eselect repository enable guru && emaint sync -r guru
 $ emerge rust-analyzer-bin
 ----
 
-=== macOS
+==== macOS
 
 The `rust-analyzer` binary can be installed via https://brew.sh/[Homebrew].
 

--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -201,6 +201,15 @@ $ eselect repository enable guru && emaint sync -r guru
 $ emerge rust-analyzer-bin
 ----
 
+=== macOS
+
+The `rust-analyzer` binary can be installed via https://brew.sh/[Homebrew].
+
+[source,bash]
+----
+$ brew install rust-analyzer
+----
+
 === Emacs
 
 Note this excellent https://robert.kra.hn/posts/2021-02-07_rust-with-emacs/[guide] from https://github.com/rksm[@rksm].


### PR DESCRIPTION
`rust-analyzer` can be installed via [Homebrew](https://brew.sh) (AKA`brew`) on macOS. I've added instructions on how to do so to the documentation. Additionally, I added a `.gitignore` rule to ignore the HTML documentation produced by  `asciidoctor manual.adoc` so that it is not accidentally checked into `git`.