### PR TITLE
fix: Code: clean-up #8951

### DIFF
--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -158,9 +158,7 @@ export async function deactivate() {
 }
 
 async function bootstrap(config: Config, state: PersistentState): Promise<string> {
-    try {
-        await vscode.workspace.fs.createDirectory(config.globalStorageUri);
-    } catch {}
+    await vscode.workspace.fs.createDirectory(config.globalStorageUri).then();
 
     if (!config.currentExtensionIsNightly) {
         await state.updateNightlyReleaseId(undefined);

--- a/editors/code/src/net.ts
+++ b/editors/code/src/net.ts
@@ -91,7 +91,7 @@ export async function download(opts: DownloadOpts) {
     // to prevent partially downloaded files when user kills vscode
     // This also avoids overwriting running executables
     const randomHex = crypto.randomBytes(5).toString("hex");
-    const rawDest = path.parse(opts.dest.path);
+    const rawDest = path.parse(opts.dest.fsPath);
     const tempFilePath = vscode.Uri.joinPath(vscode.Uri.file(rawDest.dir), `${rawDest.name}${randomHex}`);
 
     await vscode.window.withProgress(
@@ -116,7 +116,7 @@ export async function download(opts: DownloadOpts) {
         }
     );
 
-    await vscode.workspace.fs.rename(tempFilePath, opts.dest);
+    await vscode.workspace.fs.rename(tempFilePath, opts.dest, { overwrite: true });
 }
 
 async function downloadFile(
@@ -148,7 +148,7 @@ async function downloadFile(
     const totalBytes = Number(res.headers.get('content-length'));
     assert(!Number.isNaN(totalBytes), "Sanity check of content-length protocol");
 
-    log.debug("Downloading file of", totalBytes, "bytes size from", urlString, "to", destFilePath.path);
+    log.debug("Downloading file of", totalBytes, "bytes size from", urlString, "to", destFilePath.fsPath);
 
     let readBytes = 0;
     res.body.on("data", (chunk: Buffer) => {
@@ -156,7 +156,7 @@ async function downloadFile(
         onProgress(readBytes, totalBytes);
     });
 
-    const destFileStream = fs.createWriteStream(destFilePath.path, { mode });
+    const destFileStream = fs.createWriteStream(destFilePath.fsPath, { mode });
     const srcStream = gunzip ? res.body.pipe(zlib.createGunzip()) : res.body;
 
     await pipeline(srcStream, destFileStream);

--- a/editors/code/src/toolchain.ts
+++ b/editors/code/src/toolchain.ts
@@ -159,7 +159,7 @@ export const getPathForExecutable = memoize(
             // it is not mentioned in docs and cannot be infered by the type signature...
             const standardPath = vscode.Uri.joinPath(vscode.Uri.file(os.homedir()), ".cargo", "bin", executableName);
 
-            if (isFile(standardPath.path)) return standardPath.path;
+            if (isFileAtUri(standardPath)) return standardPath.fsPath;
         } catch (err) {
             log.error("Failed to read the fs info", err);
         }
@@ -177,9 +177,17 @@ function lookupInPath(exec: string): boolean {
             : [candidate];
     });
 
-    return candidates.some(isFile);
+    return candidates.some(isFileAtPath);
 }
 
-async function isFile(path: string): Promise<boolean> {
-    return ((await vscode.workspace.fs.stat(vscode.Uri.file(path))).type & vscode.FileType.File) !== 0;
+async function isFileAtPath(path: string): Promise<boolean> {
+    return isFileAtUri(vscode.Uri.file(path));
+}
+
+async function isFileAtUri(uri: vscode.Uri): Promise<boolean> {
+    try {
+        return ((await vscode.workspace.fs.stat(uri)).type & vscode.FileType.File) !== 0;
+    } catch {
+        return false;
+    }
 }


### PR DESCRIPTION
#8951 was a major change in the VS Code extension and caused quite a few problems. This PR is a catch-all for bugs and improvements in the new code.

This should fix:
- #9284
- [this unreported bug](https://github.com/rust-analyzer/rust-analyzer/pull/8951/files#r651570446)
- ...and one or two uncaught exceptions I just found

The original lack of testing was my own fault, but this area of the VS Code API is also tricky for a couple reasons:
- The [FileSystem](https://github.com/rust-analyzer/rust-analyzer/pull/8951/files#r651570446) API does not list or warn about any exceptions, but [FileSystemProvider](https://github.com/rust-analyzer/rust-analyzer/pull/8951/files#r651570446) (which `FileSystem` is a wrapper of, AFAICT) does.
- At first glance, [Uri.path](https://github.com/rust-analyzer/rust-analyzer/pull/8951/files#r651570446) *looks* like it works for FS operations. It does not, at least, on Windows. You need to use `Uri.fsPath`.

I only use Windows, so I need people on macOS, Linux, and (possibly) NixOS to test this.