### PR TITLE
fix: Highlight unsafe trait refs as unsafe only in impl blocks and definitions

### DIFF
--- a/crates/ide/src/syntax_highlighting/html.rs
+++ b/crates/ide/src/syntax_highlighting/html.rs
@@ -67,6 +67,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .field              { color: #94BFF3; }
 .function           { color: #93E0E3; }
 .function.unsafe    { color: #BC8383; }
+.trait.unsafe       { color: #BC8383; }
 .operator.unsafe    { color: #BC8383; }
 .parameter          { color: #94BFF3; }
 .text               { color: #DCDCCC; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_assoc_functions.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_assoc_functions.html
@@ -15,6 +15,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .field              { color: #94BFF3; }
 .function           { color: #93E0E3; }
 .function.unsafe    { color: #BC8383; }
+.trait.unsafe       { color: #BC8383; }
 .operator.unsafe    { color: #BC8383; }
 .parameter          { color: #94BFF3; }
 .text               { color: #DCDCCC; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_doctest.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_doctest.html
@@ -15,6 +15,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .field              { color: #94BFF3; }
 .function           { color: #93E0E3; }
 .function.unsafe    { color: #BC8383; }
+.trait.unsafe       { color: #BC8383; }
 .operator.unsafe    { color: #BC8383; }
 .parameter          { color: #94BFF3; }
 .text               { color: #DCDCCC; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_extern_crate.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_extern_crate.html
@@ -15,6 +15,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .field              { color: #94BFF3; }
 .function           { color: #93E0E3; }
 .function.unsafe    { color: #BC8383; }
+.trait.unsafe       { color: #BC8383; }
 .operator.unsafe    { color: #BC8383; }
 .parameter          { color: #94BFF3; }
 .text               { color: #DCDCCC; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_injection.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_injection.html
@@ -15,6 +15,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .field              { color: #94BFF3; }
 .function           { color: #93E0E3; }
 .function.unsafe    { color: #BC8383; }
+.trait.unsafe       { color: #BC8383; }
 .operator.unsafe    { color: #BC8383; }
 .parameter          { color: #94BFF3; }
 .text               { color: #DCDCCC; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_strings.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_strings.html
@@ -15,6 +15,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .field              { color: #94BFF3; }
 .function           { color: #93E0E3; }
 .function.unsafe    { color: #BC8383; }
+.trait.unsafe       { color: #BC8383; }
 .operator.unsafe    { color: #BC8383; }
 .parameter          { color: #94BFF3; }
 .text               { color: #DCDCCC; }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_unsafe.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_unsafe.html
@@ -15,6 +15,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .field              { color: #94BFF3; }
 .function           { color: #93E0E3; }
 .function.unsafe    { color: #BC8383; }
+.trait.unsafe       { color: #BC8383; }
 .operator.unsafe    { color: #BC8383; }
 .parameter          { color: #94BFF3; }
 .text               { color: #DCDCCC; }
@@ -60,6 +61,11 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 <span class="keyword">struct</span> <span class="struct declaration">Packed</span> <span class="brace">{</span>
     <span class="field declaration">a</span><span class="colon">:</span> <span class="builtin_type">u16</span><span class="comma">,</span>
 <span class="brace">}</span>
+
+<span class="keyword unsafe">unsafe</span> <span class="keyword">trait</span> <span class="trait declaration unsafe">UnsafeTrait</span> <span class="brace">{</span><span class="brace">}</span>
+<span class="keyword unsafe">unsafe</span> <span class="keyword">impl</span> <span class="trait unsafe">UnsafeTrait</span> <span class="keyword">for</span> <span class="struct">Packed</span> <span class="brace">{</span><span class="brace">}</span>
+
+<span class="keyword">fn</span> <span class="function declaration">require_unsafe_trait</span><span class="angle">&lt;</span><span class="type_param declaration">T</span><span class="colon">:</span> <span class="trait">UnsafeTrait</span><span class="angle">&gt;</span><span class="parenthesis">(</span><span class="punctuation">_</span><span class="colon">:</span> <span class="type_param">T</span><span class="parenthesis">)</span> <span class="brace">{</span><span class="brace">}</span>
 
 <span class="keyword">trait</span> <span class="trait declaration">DoTheAutoref</span> <span class="brace">{</span>
     <span class="keyword">fn</span> <span class="function associated declaration trait">calls_autoref</span><span class="parenthesis">(</span><span class="operator">&</span><span class="self_keyword declaration">self</span><span class="parenthesis">)</span><span class="semicolon">;</span>

--- a/crates/ide/src/syntax_highlighting/test_data/highlighting.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlighting.html
@@ -15,6 +15,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .field              { color: #94BFF3; }
 .function           { color: #93E0E3; }
 .function.unsafe    { color: #BC8383; }
+.trait.unsafe       { color: #BC8383; }
 .operator.unsafe    { color: #BC8383; }
 .parameter          { color: #94BFF3; }
 .text               { color: #DCDCCC; }

--- a/crates/ide/src/syntax_highlighting/test_data/injection.html
+++ b/crates/ide/src/syntax_highlighting/test_data/injection.html
@@ -15,6 +15,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .field              { color: #94BFF3; }
 .function           { color: #93E0E3; }
 .function.unsafe    { color: #BC8383; }
+.trait.unsafe       { color: #BC8383; }
 .operator.unsafe    { color: #BC8383; }
 .parameter          { color: #94BFF3; }
 .text               { color: #DCDCCC; }

--- a/crates/ide/src/syntax_highlighting/test_data/rainbow_highlighting.html
+++ b/crates/ide/src/syntax_highlighting/test_data/rainbow_highlighting.html
@@ -15,6 +15,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 .field              { color: #94BFF3; }
 .function           { color: #93E0E3; }
 .function.unsafe    { color: #BC8383; }
+.trait.unsafe       { color: #BC8383; }
 .operator.unsafe    { color: #BC8383; }
 .parameter          { color: #94BFF3; }
 .text               { color: #DCDCCC; }

--- a/crates/ide/src/syntax_highlighting/tests.rs
+++ b/crates/ide/src/syntax_highlighting/tests.rs
@@ -527,6 +527,11 @@ struct Packed {
     a: u16,
 }
 
+unsafe trait UnsafeTrait {}
+unsafe impl UnsafeTrait for Packed {}
+
+fn require_unsafe_trait<T: UnsafeTrait>(_: T) {}
+
 trait DoTheAutoref {
     fn calls_autoref(&self);
 }

--- a/crates/syntax/src/ast/node_ext.rs
+++ b/crates/syntax/src/ast/node_ext.rs
@@ -325,6 +325,15 @@ impl ast::Impl {
         let second = types.next();
         (first, second)
     }
+
+    pub fn for_trait_name_ref(name_ref: &ast::NameRef) -> Option<ast::Impl> {
+        let this = name_ref.syntax().ancestors().find_map(ast::Impl::cast)?;
+        if this.trait_()?.syntax().text_range().start() == name_ref.syntax().text_range().start() {
+            Some(this)
+        } else {
+            None
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
bors r+