### PR TITLE
fix: Don't complete keywords in attributes inside expressions

### DIFF
--- a/crates/ide_completion/src/completions/attribute.rs
+++ b/crates/ide_completion/src/completions/attribute.rs
@@ -786,13 +786,13 @@ mod tests {
                 at target_feature = "…"
                 at test
                 at track_caller
-                kw return
             "#]],
         );
     }
 
     #[test]
     fn complete_attribute_on_expr() {
+        cov_mark::check!(no_keyword_completion_in_attr_of_expr);
         check(
             r#"fn main() { #[$0] foo() }"#,
             expect![[r#"
@@ -802,7 +802,6 @@ mod tests {
                 at deny(…)
                 at forbid(…)
                 at warn(…)
-                kw return
             "#]],
         );
     }

--- a/crates/ide_completion/src/completions/keyword.rs
+++ b/crates/ide_completion/src/completions/keyword.rs
@@ -48,6 +48,10 @@ pub(crate) fn complete_expr_keyword(acc: &mut Completions, ctx: &CompletionConte
         cov_mark::hit!(no_keyword_completion_in_record_lit);
         return;
     }
+    if ctx.attribute_under_caret.is_some() {
+        cov_mark::hit!(no_keyword_completion_in_attr_of_expr);
+        return;
+    }
 
     // Suggest .await syntax for types that implement Future trait
     if let Some(receiver) = ctx.dot_receiver() {


### PR DESCRIPTION
bors r+