### PR TITLE
add note about passing cfg(debug_assertions)

### DIFF
--- a/docs/dev/debugging.md
+++ b/docs/dev/debugging.md
@@ -65,6 +65,11 @@ If you need to debug the server from the very beginning, including its initializ
     }
 ```
 
+However for this to work, you will need to enable debug_assertions in your build
+```rust
+RUSTFLAGS='--cfg debug_assertions' cargo build --release
+```
+
 ## Demo
 
 - [Debugging TypeScript VScode extension](https://www.youtube.com/watch?v=T-hvpK6s4wM).


### PR DESCRIPTION
add note about passing cfg(debug_assertions) to rustc on build. The server will not spin on start  without this arcane hack