### PR TITLE
output to log file if RA_LOG_FILE is defined in environment

### DIFF
--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -60,7 +60,14 @@ fn try_main() -> Result<()> {
         }
     }
 
-    setup_logging(flags.log_file.as_deref(), flags.no_log_buffering)?;
+    let mut log_file = flags.log_file.as_deref();
+
+    let env_log_file = env::var("RA_LOG_FILE").ok();
+    if let Some(env_log_file) = env_log_file.as_deref() {
+        log_file = Some(Path::new(env_log_file));
+    }
+
+    setup_logging(log_file, flags.no_log_buffering)?;
     let verbosity = flags.verbosity();
 
     match flags.subcommand {

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -131,7 +131,8 @@ Logging is done by both rust-analyzer and VS Code, so it might be tricky to figu
 
 Inside rust-analyzer, we use the standard `log` crate for logging, and `env_logger` for logging frontend.
 By default, log goes to stderr, but the stderr itself is processed by VS Code.
-`--log-file <PATH>` CLI argument allows logging to file.
+`--log-file <PATH>` CLI argument allows logging to file. 
+Setting the `RA_LOG_FILE=<PATH>` environment variable will also log to file, it will also override `--log-file`.
 
 To see stderr in the running VS Code instance, go to the "Output" tab of the panel and select `rust-analyzer`.
 This shows `eprintln!` as well.


### PR DESCRIPTION
This adds a check for RA_LOG_FILE, and logs to that if defined. It currently overrides flags.log_file. If this is undesirable, I will add a check.