### PR TITLE
fix: Update sysroot crates

### DIFF
--- a/crates/project_model/src/sysroot.rs
+++ b/crates/project_model/src/sysroot.rs
@@ -68,8 +68,9 @@ impl Sysroot {
     pub fn load(sysroot_src_dir: &AbsPath) -> Result<Sysroot> {
         let mut sysroot = Sysroot { crates: Arena::default() };
 
-        for name in SYSROOT_CRATES.trim().lines() {
-            let root = [format!("{}/src/lib.rs", name), format!("lib{}/lib.rs", name)]
+        for path in SYSROOT_CRATES.trim().lines() {
+            let name = path.split('/').last().unwrap();
+            let root = [format!("{}/src/lib.rs", path), format!("lib{}/lib.rs", path)]
                 .iter()
                 .map(|it| sysroot_src_dir.join(it))
                 .find(|it| it.exists());
@@ -191,9 +192,8 @@ panic_abort
 panic_unwind
 proc_macro
 profiler_builtins
-rtstartup
 std
-stdarch
+stdarch/crates/std_detect
 term
 test
 unwind";
@@ -204,9 +204,8 @@ core
 panic_abort
 panic_unwind
 profiler_builtins
-rtstartup
 proc_macro
-stdarch
+std_detect
 term
 test
 unwind";


### PR DESCRIPTION
Removes `rtstartup`, since that's not a Cargo crate (its files are compiled into object files and linked alongside the stdlib).

Adds  `std_detect`.

Part of https://github.com/rust-analyzer/rust-analyzer/issues/9352 (doesn't fix it since std_detect is full of `cfg_if!`)

bors r+