### PR TITLE
internal: Deduplicate ast expression walking logic

### DIFF
--- a/crates/ide_assists/src/handlers/wrap_return_type_in_result.rs
+++ b/crates/ide_assists/src/handlers/wrap_return_type_in_result.rs
@@ -1,8 +1,9 @@
 use std::iter;
 
+use ide_db::helpers::for_each_tail_expr;
 use syntax::{
-    ast::{self, make, BlockExpr, Expr, LoopBodyOwner},
-    match_ast, AstNode, SyntaxNode,
+    ast::{self, make, Expr},
+    match_ast, AstNode,
 };
 
 use crate::{AssistContext, AssistId, AssistKind, Assists};
@@ -21,7 +22,7 @@ use crate::{AssistContext, AssistId, AssistKind, Assists};
 pub(crate) fn wrap_return_type_in_result(acc: &mut Assists, ctx: &AssistContext) -> Option<()> {
     let ret_type = ctx.find_node_at_offset::<ast::RetType>()?;
     let parent = ret_type.syntax().parent()?;
-    let block_expr = match_ast! {
+    let body = match_ast! {
         match parent {
             ast::Fn(func) => func.body()?,
             ast::ClosureExpr(closure) => match closure.body()? {
@@ -32,6 +33,7 @@ pub(crate) fn wrap_return_type_in_result(acc: &mut Assists, ctx: &AssistContext)
             _ => return None,
         }
     };
+    let body = ast::Expr::BlockExpr(body);
 
     let type_ref = &ret_type.ty()?;
     let ret_type_str = type_ref.syntax().text().to_string();
@@ -48,11 +50,18 @@ pub(crate) fn wrap_return_type_in_result(acc: &mut Assists, ctx: &AssistContext)
         "Wrap return type in Result",
         type_ref.syntax().text_range(),
         |builder| {
-            let mut tail_return_expr_collector = TailReturnCollector::new();
-            tail_return_expr_collector.collect_jump_exprs(&block_expr, false);
-            tail_return_expr_collector.collect_tail_exprs(&block_expr);
+            let mut exprs_to_wrap = Vec::new();
+            let tail_cb = &mut |e: &_| tail_cb_impl(&mut exprs_to_wrap, e);
+            body.walk(&mut |expr| {
+                if let Expr::ReturnExpr(ret_expr) = expr {
+                    if let Some(ret_expr_arg) = &ret_expr.expr() {
+                        for_each_tail_expr(ret_expr_arg, tail_cb);
+                    }
+                }
+            });
+            for_each_tail_expr(&body, tail_cb);
 
-            for ret_expr_arg in tail_return_expr_collector.exprs_to_wrap {
+            for ret_expr_arg in exprs_to_wrap {
                 let ok_wrapped = make::expr_call(
                     make::expr_path(make::ext::ident_path("Ok")),
                     make::arg_list(iter::once(ret_expr_arg.clone())),
@@ -72,199 +81,14 @@ pub(crate) fn wrap_return_type_in_result(acc: &mut Assists, ctx: &AssistContext)
     )
 }
 
-struct TailReturnCollector {
-    exprs_to_wrap: Vec<ast::Expr>,
-}
-
-impl TailReturnCollector {
-    fn new() -> Self {
-        Self { exprs_to_wrap: vec![] }
-    }
-    /// Collect all`return` expression
-    fn collect_jump_exprs(&mut self, block_expr: &BlockExpr, collect_break: bool) {
-        let statements = block_expr.statements();
-        for stmt in statements {
-            let expr = match &stmt {
-                ast::Stmt::ExprStmt(stmt) => stmt.expr(),
-                ast::Stmt::LetStmt(stmt) => stmt.initializer(),
-                ast::Stmt::Item(_) => continue,
-            };
-            if let Some(expr) = &expr {
-                self.handle_exprs(expr, collect_break);
+fn tail_cb_impl(acc: &mut Vec<ast::Expr>, e: &ast::Expr) {
+    match e {
+        Expr::BreakExpr(break_expr) => {
+            if let Some(break_expr_arg) = break_expr.expr() {
+                for_each_tail_expr(&break_expr_arg, &mut |e| tail_cb_impl(acc, e))
             }
         }
-
-        // Browse tail expressions for each block
-        if let Some(expr) = block_expr.tail_expr() {
-            if let Some(last_exprs) = get_tail_expr_from_block(&expr) {
-                for last_expr in last_exprs {
-                    let last_expr = match last_expr {
-                        NodeType::Node(expr) => expr,
-                        NodeType::Leaf(expr) => expr.syntax().clone(),
-                    };
-
-                    if let Some(last_expr) = Expr::cast(last_expr.clone()) {
-                        self.handle_exprs(&last_expr, collect_break);
-                    } else if let Some(expr_stmt) = ast::Stmt::cast(last_expr) {
-                        let expr_stmt = match &expr_stmt {
-                            ast::Stmt::ExprStmt(stmt) => stmt.expr(),
-                            ast::Stmt::LetStmt(stmt) => stmt.initializer(),
-                            ast::Stmt::Item(_) => None,
-                        };
-                        if let Some(expr) = &expr_stmt {
-                            self.handle_exprs(expr, collect_break);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    fn handle_exprs(&mut self, expr: &Expr, collect_break: bool) {
-        match expr {
-            Expr::BlockExpr(block_expr) => {
-                self.collect_jump_exprs(block_expr, collect_break);
-            }
-            Expr::ReturnExpr(ret_expr) => {
-                if let Some(ret_expr_arg) = &ret_expr.expr() {
-                    self.exprs_to_wrap.push(ret_expr_arg.clone());
-                }
-            }
-            Expr::BreakExpr(break_expr) if collect_break => {
-                if let Some(break_expr_arg) = &break_expr.expr() {
-                    self.exprs_to_wrap.push(break_expr_arg.clone());
-                }
-            }
-            Expr::IfExpr(if_expr) => {
-                for block in if_expr.blocks() {
-                    self.collect_jump_exprs(&block, collect_break);
-                }
-            }
-            Expr::LoopExpr(loop_expr) => {
-                if let Some(block_expr) = loop_expr.loop_body() {
-                    self.collect_jump_exprs(&block_expr, collect_break);
-                }
-            }
-            Expr::ForExpr(for_expr) => {
-                if let Some(block_expr) = for_expr.loop_body() {
-                    self.collect_jump_exprs(&block_expr, collect_break);
-                }
-            }
-            Expr::WhileExpr(while_expr) => {
-                if let Some(block_expr) = while_expr.loop_body() {
-                    self.collect_jump_exprs(&block_expr, collect_break);
-                }
-            }
-            Expr::MatchExpr(match_expr) => {
-                if let Some(arm_list) = match_expr.match_arm_list() {
-                    arm_list.arms().filter_map(|match_arm| match_arm.expr()).for_each(|expr| {
-                        self.handle_exprs(&expr, collect_break);
-                    });
-                }
-            }
-            _ => {}
-        }
-    }
-
-    fn collect_tail_exprs(&mut self, block: &BlockExpr) {
-        if let Some(expr) = block.tail_expr() {
-            self.handle_exprs(&expr, true);
-            self.fetch_tail_exprs(&expr);
-        }
-    }
-
-    fn fetch_tail_exprs(&mut self, expr: &Expr) {
-        if let Some(exprs) = get_tail_expr_from_block(expr) {
-            for node_type in &exprs {
-                match node_type {
-                    NodeType::Leaf(expr) => {
-                        self.exprs_to_wrap.push(expr.clone());
-                    }
-                    NodeType::Node(expr) => {
-                        if let Some(last_expr) = Expr::cast(expr.clone()) {
-                            self.fetch_tail_exprs(&last_expr);
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-#[derive(Debug)]
-enum NodeType {
-    Leaf(ast::Expr),
-    Node(SyntaxNode),
-}
-
-/// Get a tail expression inside a block
-fn get_tail_expr_from_block(expr: &Expr) -> Option<Vec<NodeType>> {
-    match expr {
-        Expr::IfExpr(if_expr) => {
-            let mut nodes = vec![];
-            for block in if_expr.blocks() {
-                if let Some(block_expr) = block.tail_expr() {
-                    if let Some(tail_exprs) = get_tail_expr_from_block(&block_expr) {
-                        nodes.extend(tail_exprs);
-                    }
-                } else if let Some(last_expr) = block.syntax().last_child() {
-                    nodes.push(NodeType::Node(last_expr));
-                } else {
-                    nodes.push(NodeType::Node(block.syntax().clone()));
-                }
-            }
-            Some(nodes)
-        }
-        Expr::LoopExpr(loop_expr) => {
-            loop_expr.syntax().last_child().map(|lc| vec![NodeType::Node(lc)])
-        }
-        Expr::ForExpr(for_expr) => {
-            for_expr.syntax().last_child().map(|lc| vec![NodeType::Node(lc)])
-        }
-        Expr::WhileExpr(while_expr) => {
-            while_expr.syntax().last_child().map(|lc| vec![NodeType::Node(lc)])
-        }
-        Expr::BlockExpr(block_expr) => {
-            block_expr.tail_expr().map(|lc| vec![NodeType::Node(lc.syntax().clone())])
-        }
-        Expr::MatchExpr(match_expr) => {
-            let arm_list = match_expr.match_arm_list()?;
-            let arms: Vec<NodeType> = arm_list
-                .arms()
-                .filter_map(|match_arm| match_arm.expr())
-                .map(|expr| match expr {
-                    Expr::ReturnExpr(ret_expr) => NodeType::Node(ret_expr.syntax().clone()),
-                    Expr::BreakExpr(break_expr) => NodeType::Node(break_expr.syntax().clone()),
-                    _ => match expr.syntax().last_child() {
-                        Some(last_expr) => NodeType::Node(last_expr),
-                        None => NodeType::Node(expr.syntax().clone()),
-                    },
-                })
-                .collect();
-
-            Some(arms)
-        }
-        Expr::BreakExpr(expr) => expr.expr().map(|e| vec![NodeType::Leaf(e)]),
-        Expr::ReturnExpr(ret_expr) => Some(vec![NodeType::Node(ret_expr.syntax().clone())]),
-
-        Expr::CallExpr(_)
-        | Expr::Literal(_)
-        | Expr::TupleExpr(_)
-        | Expr::ArrayExpr(_)
-        | Expr::ParenExpr(_)
-        | Expr::PathExpr(_)
-        | Expr::RecordExpr(_)
-        | Expr::IndexExpr(_)
-        | Expr::MethodCallExpr(_)
-        | Expr::AwaitExpr(_)
-        | Expr::CastExpr(_)
-        | Expr::RefExpr(_)
-        | Expr::PrefixExpr(_)
-        | Expr::RangeExpr(_)
-        | Expr::BinExpr(_)
-        | Expr::MacroCall(_)
-        | Expr::BoxExpr(_) => Some(vec![NodeType::Leaf(expr.clone())]),
-        _ => None,
+        e => acc.push(e.clone()),
     }
 }
 
@@ -288,6 +112,35 @@ fn foo() -> i3$02 {
 fn foo() -> Result<i32, ${0:_}> {
     let test = "test";
     return Ok(42i32);
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn wrap_return_type_break_split_tail() {
+        check_assist(
+            wrap_return_type_in_result,
+            r#"
+fn foo() -> i3$02 {
+    loop {
+        break if true {
+            1
+        } else {
+            0
+        };
+    }
+}
+"#,
+            r#"
+fn foo() -> Result<i32, ${0:_}> {
+    loop {
+        break if true {
+            Ok(1)
+        } else {
+            Ok(0)
+        };
+    }
 }
 "#,
         );
@@ -935,90 +788,6 @@ fn foo() -> Result<i32, ${0:_}> {
             break Ok(55);
         }
         i += 1;
-    }
-}
-"#,
-        );
-
-        check_assist(
-            wrap_return_type_in_result,
-            r#"
-fn foo() -> i32$0 {
-    let test = "test";
-    if test == "test" {
-        return 24i32;
-    }
-    let mut i = 0;
-    loop {
-        loop {
-            if i == 1 {
-                break 55;
-            }
-            i += 1;
-        }
-    }
-}
-"#,
-            r#"
-fn foo() -> Result<i32, ${0:_}> {
-    let test = "test";
-    if test == "test" {
-        return Ok(24i32);
-    }
-    let mut i = 0;
-    loop {
-        loop {
-            if i == 1 {
-                break Ok(55);
-            }
-            i += 1;
-        }
-    }
-}
-"#,
-        );
-
-        check_assist(
-            wrap_return_type_in_result,
-            r#"
-fn foo() -> i3$02 {
-    let test = "test";
-    let other = 5;
-    if test == "test" {
-        let res = match other {
-            5 => 43,
-            _ => return 56,
-        };
-    }
-    let mut i = 0;
-    loop {
-        loop {
-            if i == 1 {
-                break 55;
-            }
-            i += 1;
-        }
-    }
-}
-"#,
-            r#"
-fn foo() -> Result<i32, ${0:_}> {
-    let test = "test";
-    let other = 5;
-    if test == "test" {
-        let res = match other {
-            5 => 43,
-            _ => return Ok(56),
-        };
-    }
-    let mut i = 0;
-    loop {
-        loop {
-            if i == 1 {
-                break Ok(55);
-            }
-            i += 1;
-        }
     }
 }
 "#,

--- a/crates/syntax/src/ast/node_ext.rs
+++ b/crates/syntax/src/ast/node_ext.rs
@@ -5,7 +5,7 @@ use std::{borrow::Cow, fmt, iter::successors};
 
 use itertools::Itertools;
 use parser::SyntaxKind;
-use rowan::{GreenNodeData, GreenTokenData};
+use rowan::{GreenNodeData, GreenTokenData, WalkEvent};
 
 use crate::{
     ast::{self, support, AstChildren, AstNode, AstToken, AttrsOwner, NameOwner, SyntaxNode},
@@ -48,6 +48,56 @@ fn text_of_first_token(node: &SyntaxNode) -> TokenText<'_> {
 impl ast::BlockExpr {
     pub fn items(&self) -> AstChildren<ast::Item> {
         support::children(self.syntax())
+    }
+}
+
+impl ast::Expr {
+    /// Preorder walk all the expression's child expressions.
+    pub fn walk(&self, cb: &mut dyn FnMut(ast::Expr)) {
+        let mut preorder = self.syntax().preorder();
+        while let Some(event) = preorder.next() {
+            let node = match event {
+                WalkEvent::Enter(node) => node,
+                WalkEvent::Leave(_) => continue,
+            };
+            match ast::Stmt::cast(node.clone()) {
+                // recursively walk the initializer, skipping potential const pat expressions
+                // let statements aren't usually nested too deeply so this is fine to recurse on
+                Some(ast::Stmt::LetStmt(l)) => {
+                    if let Some(expr) = l.initializer() {
+                        expr.walk(cb);
+                    }
+                    preorder.skip_subtree();
+                }
+                // Don't skip subtree since we want to process the expression child next
+                Some(ast::Stmt::ExprStmt(_)) => (),
+                // skip inner items which might have their own expressions
+                Some(ast::Stmt::Item(_)) => preorder.skip_subtree(),
+                None => {
+                    // skip const args, those expressions are a different context
+                    if ast::GenericArg::can_cast(node.kind()) {
+                        preorder.skip_subtree();
+                    } else if let Some(expr) = ast::Expr::cast(node) {
+                        let is_different_context = match &expr {
+                            ast::Expr::EffectExpr(effect) => {
+                                matches!(
+                                    effect.effect(),
+                                    ast::Effect::Async(_)
+                                        | ast::Effect::Try(_)
+                                        | ast::Effect::Const(_)
+                                )
+                            }
+                            ast::Expr::ClosureExpr(__) => true,
+                            _ => false,
+                        };
+                        cb(expr);
+                        if is_different_context {
+                            preorder.skip_subtree();
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Deduplicates the duplication introduced in #9375 and #9396 while also fixing a few bugs in both the assist and related highlighting.