### PR TITLE
internal: Include `self` in usage search for modules in their definition source

### DIFF
--- a/crates/ide/src/highlight_related.rs
+++ b/crates/ide/src/highlight_related.rs
@@ -59,7 +59,11 @@ fn highlight_references(
     FilePosition { offset, file_id }: FilePosition,
 ) -> Option<Vec<HighlightedRange>> {
     let def = references::find_def(sema, syntax, offset)?;
-    let usages = def.usages(sema).set_scope(Some(SearchScope::single_file(file_id))).all();
+    let usages = def
+        .usages(sema)
+        .set_scope(Some(SearchScope::single_file(file_id)))
+        .include_self_refs()
+        .all();
 
     let declaration = match def {
         Definition::ModuleDef(hir::ModuleDef::Module(module)) => {
@@ -315,6 +319,7 @@ use self$0;
 mod foo;
 //- /foo.rs
 use self$0;
+ // ^^^^
 "#,
         );
     }

--- a/crates/ide/src/references.rs
+++ b/crates/ide/src/references.rs
@@ -707,6 +707,7 @@ use self$0;
             expect![[r#"
                 foo Module FileId(0) 0..8 4..7
 
+                FileId(1) 4..8
             "#]],
         );
     }

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -934,12 +934,18 @@ mod outer { mod fo$0o; }
         check(
             "baz",
             r#"
-mod $0foo { pub fn bar() {} }
+mod $0foo {
+    pub use self::bar as qux;
+    pub fn bar() {}
+}
 
 fn main() { foo::bar(); }
 "#,
             r#"
-mod baz { pub fn bar() {} }
+mod baz {
+    pub use self::bar as qux;
+    pub fn bar() {}
+}
 
 fn main() { baz::bar(); }
 "#,


### PR DESCRIPTION
bors r+