### PR TITLE
fix: Handle `::{self}` imports

### DIFF
--- a/crates/hir_def/src/nameres/tests.rs
+++ b/crates/hir_def/src/nameres/tests.rs
@@ -329,7 +329,7 @@ pub struct Baz;
 "#,
         expect![[r#"
             crate
-            Baz: t v
+            Baz: t
             foo: t
 
             crate::foo
@@ -813,6 +813,29 @@ fn bar() {}
             bar: v
             baz: v
             foo: t
+        "#]],
+    );
+}
+
+#[test]
+fn self_imports_only_types() {
+    check(
+        r#"
+//- /main.rs
+mod m {
+    pub macro S() {}
+    pub struct S;
+}
+
+use self::m::S::{self};
+    "#,
+        expect![[r#"
+            crate
+            S: t
+            m: t
+
+            crate::m
+            S: t v m
         "#]],
     );
 }


### PR DESCRIPTION
These import the preceding segment, but only in type namespace. Previously we've imported the name in all namespaces.

bors r+