### PR TITLE
fix: Don't add test runnables for outline modules in the wrong file

### DIFF
--- a/crates/ide/src/annotations.rs
+++ b/crates/ide/src/annotations.rs
@@ -862,6 +862,7 @@ mod tests {
                                     focus_range: 18..23,
                                     name: "tests",
                                     kind: Module,
+                                    description: "mod tests",
                                 },
                                 kind: TestMod {
                                     path: "tests",
@@ -883,6 +884,7 @@ mod tests {
                                     focus_range: 18..23,
                                     name: "tests",
                                     kind: Module,
+                                    description: "mod tests",
                                 },
                                 kind: TestMod {
                                     path: "tests",

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -2508,6 +2508,7 @@ mod tests$0 {
                                 focus_range: 4..9,
                                 name: "tests",
                                 kind: Module,
+                                description: "mod tests",
                             },
                             kind: TestMod {
                                 path: "tests",


### PR DESCRIPTION
bors r+