### PR TITLE
internal: Add a simpler legacy macro scoping test

### DIFF
--- a/crates/hir_def/src/nameres/tests/macros.rs
+++ b/crates/hir_def/src/nameres/tests/macros.rs
@@ -336,6 +336,24 @@ mod prelude {
 }
 
 #[test]
+fn legacy_macro_use_before_def() {
+    check(
+        r#"
+m!();
+
+macro_rules! m {
+    () => {
+        struct S;
+    }
+}
+"#,
+        expect![[r#"
+            crate
+        "#]],
+    );
+}
+
+#[test]
 fn plain_macros_are_legacy_textual_scoped() {
     check(
         r#"


### PR DESCRIPTION
This is a lot simpler to understand and debug than the `plain_macros_are_legacy_textual_scoped` test.

bors r+