### PR TITLE
feat: Emit test names in `Run test` runnables if they come from a macro expansion

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1634,6 +1634,16 @@ impl HasVisibility for AssocItem {
     }
 }
 
+impl From<AssocItem> for ModuleDef {
+    fn from(assoc: AssocItem) -> Self {
+        match assoc {
+            AssocItem::Function(it) => ModuleDef::Function(it),
+            AssocItem::Const(it) => ModuleDef::Const(it),
+            AssocItem::TypeAlias(it) => ModuleDef::TypeAlias(it),
+        }
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 pub enum GenericDef {
     Function(Function),

--- a/crates/ide/src/annotations.rs
+++ b/crates/ide/src/annotations.rs
@@ -57,24 +57,22 @@ pub(crate) fn annotations(
                 continue;
             }
 
-            let action = runnable.action();
             let range = runnable.nav.focus_or_full_range();
+
+            // dbg_runnable should go after the run annotation, to prevent a clone we do it this way
+            let dbg_runnable = (runnable.debugee() && config.debug).then(|| Annotation {
+                range,
+                kind: AnnotationKind::Runnable { debug: true, runnable: runnable.clone() },
+            });
 
             if config.run {
                 annotations.push(Annotation {
                     range,
-
-                    // FIXME: This one allocates without reason if run is enabled, but debug is disabled
-                    kind: AnnotationKind::Runnable { debug: false, runnable: runnable.clone() },
+                    kind: AnnotationKind::Runnable { debug: false, runnable },
                 });
             }
 
-            if action.debugee && config.debug {
-                annotations.push(Annotation {
-                    range,
-                    kind: AnnotationKind::Runnable { debug: true, runnable },
-                });
-            }
+            annotations.extend(dbg_runnable);
         }
     }
 
@@ -228,6 +226,7 @@ fn main() {
                         kind: Runnable {
                             debug: false,
                             runnable: Runnable {
+                                use_name_in_title: false,
                                 nav: NavigationTarget {
                                     file_id: FileId(
                                         0,
@@ -247,6 +246,7 @@ fn main() {
                         kind: Runnable {
                             debug: true,
                             runnable: Runnable {
+                                use_name_in_title: false,
                                 nav: NavigationTarget {
                                     file_id: FileId(
                                         0,
@@ -332,6 +332,7 @@ fn main() {
                         kind: Runnable {
                             debug: false,
                             runnable: Runnable {
+                                use_name_in_title: false,
                                 nav: NavigationTarget {
                                     file_id: FileId(
                                         0,
@@ -351,6 +352,7 @@ fn main() {
                         kind: Runnable {
                             debug: true,
                             runnable: Runnable {
+                                use_name_in_title: false,
                                 nav: NavigationTarget {
                                     file_id: FileId(
                                         0,
@@ -440,6 +442,7 @@ fn main() {
                         kind: Runnable {
                             debug: false,
                             runnable: Runnable {
+                                use_name_in_title: false,
                                 nav: NavigationTarget {
                                     file_id: FileId(
                                         0,
@@ -459,6 +462,7 @@ fn main() {
                         kind: Runnable {
                             debug: true,
                             runnable: Runnable {
+                                use_name_in_title: false,
                                 nav: NavigationTarget {
                                     file_id: FileId(
                                         0,
@@ -601,6 +605,7 @@ fn main() {}
                         kind: Runnable {
                             debug: false,
                             runnable: Runnable {
+                                use_name_in_title: false,
                                 nav: NavigationTarget {
                                     file_id: FileId(
                                         0,
@@ -620,6 +625,7 @@ fn main() {}
                         kind: Runnable {
                             debug: true,
                             runnable: Runnable {
+                                use_name_in_title: false,
                                 nav: NavigationTarget {
                                     file_id: FileId(
                                         0,
@@ -674,6 +680,7 @@ fn main() {
                         kind: Runnable {
                             debug: false,
                             runnable: Runnable {
+                                use_name_in_title: false,
                                 nav: NavigationTarget {
                                     file_id: FileId(
                                         0,
@@ -693,6 +700,7 @@ fn main() {
                         kind: Runnable {
                             debug: true,
                             runnable: Runnable {
+                                use_name_in_title: false,
                                 nav: NavigationTarget {
                                     file_id: FileId(
                                         0,
@@ -816,6 +824,7 @@ mod tests {
                         kind: Runnable {
                             debug: false,
                             runnable: Runnable {
+                                use_name_in_title: false,
                                 nav: NavigationTarget {
                                     file_id: FileId(
                                         0,
@@ -835,6 +844,7 @@ mod tests {
                         kind: Runnable {
                             debug: true,
                             runnable: Runnable {
+                                use_name_in_title: false,
                                 nav: NavigationTarget {
                                     file_id: FileId(
                                         0,
@@ -854,6 +864,7 @@ mod tests {
                         kind: Runnable {
                             debug: false,
                             runnable: Runnable {
+                                use_name_in_title: false,
                                 nav: NavigationTarget {
                                     file_id: FileId(
                                         0,
@@ -876,6 +887,7 @@ mod tests {
                         kind: Runnable {
                             debug: true,
                             runnable: Runnable {
+                                use_name_in_title: false,
                                 nav: NavigationTarget {
                                     file_id: FileId(
                                         0,
@@ -898,6 +910,7 @@ mod tests {
                         kind: Runnable {
                             debug: false,
                             runnable: Runnable {
+                                use_name_in_title: false,
                                 nav: NavigationTarget {
                                     file_id: FileId(
                                         0,
@@ -924,6 +937,7 @@ mod tests {
                         kind: Runnable {
                             debug: true,
                             runnable: Runnable {
+                                use_name_in_title: false,
                                 nav: NavigationTarget {
                                     file_id: FileId(
                                         0,

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -2463,6 +2463,7 @@ fn foo_$0test() {}
                     ),
                     Runnable(
                         Runnable {
+                            use_name_in_title: false,
                             nav: NavigationTarget {
                                 file_id: FileId(
                                     0,
@@ -2501,6 +2502,7 @@ mod tests$0 {
                 [
                     Runnable(
                         Runnable {
+                            use_name_in_title: false,
                             nav: NavigationTarget {
                                 file_id: FileId(
                                     0,

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -1554,12 +1554,12 @@ fn runnable_action_links(
         return None;
     }
 
-    let action: &'static _ = runnable.action();
+    let title = runnable.title();
     to_proto::runnable(snap, runnable).ok().map(|r| {
         let mut group = lsp_ext::CommandLinkGroup::default();
 
         if hover_actions_config.run {
-            let run_command = to_proto::command::run_single(&r, action.run_title);
+            let run_command = to_proto::command::run_single(&r, &title);
             group.commands.push(to_command_link(run_command, r.label.clone()));
         }
 

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -958,15 +958,11 @@ pub(crate) fn code_lens(
             let line_index = snap.file_line_index(run.nav.file_id)?;
             let annotation_range = range(&line_index, annotation.range);
 
-            let action = run.action();
+            let title = run.title();
             let r = runnable(snap, run)?;
 
-            let command = if debug {
-                command::debug_single(&r)
-            } else {
-                let title = action.run_title.to_string();
-                command::run_single(&r, &title)
-            };
+            let command =
+                if debug { command::debug_single(&r) } else { command::run_single(&r, &title) };
 
             Ok(lsp_types::CodeLens { range: annotation_range, command: Some(command), data: None })
         }


### PR DESCRIPTION
Fixes #8964
Before:
![Code_D1Tu5Iuh5I](https://user-images.githubusercontent.com/3757771/124174685-f552b380-daac-11eb-9086-c97db014b77c.png)
After:
![image](https://user-images.githubusercontent.com/3757771/124174493-bb81ad00-daac-11eb-96c7-3de6545a62e1.png)

Basically when a macro emits more than one test we name the test functions/modules name in the runnable instead to not emit a bunch of equally named `Run Test` annotations which don't really tell much.

Note that the `Run fibonacci_test Tests` line is below the attributes due to the fact that the function name span is being reused for the generated module in rstest's expansion.