### PR TITLE
feat: Add "View Crate Graph (Full)"

### DIFF
--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -299,8 +299,8 @@ impl Analysis {
     }
 
     /// Renders the crate graph to GraphViz "dot" syntax.
-    pub fn view_crate_graph(&self) -> Cancellable<Result<String, String>> {
-        self.with_db(|db| view_crate_graph::view_crate_graph(db))
+    pub fn view_crate_graph(&self, full: bool) -> Cancellable<Result<String, String>> {
+        self.with_db(|db| view_crate_graph::view_crate_graph(db, full))
     }
 
     pub fn expand_macro(&self, position: FilePosition) -> Cancellable<Option<ExpandedMacro>> {

--- a/crates/ide/src/view_crate_graph.rs
+++ b/crates/ide/src/view_crate_graph.rs
@@ -19,14 +19,18 @@ use rustc_hash::FxHashSet;
 //
 // | VS Code | **Rust Analyzer: View Crate Graph**
 // |===
-pub(crate) fn view_crate_graph(db: &RootDatabase) -> Result<String, String> {
+pub(crate) fn view_crate_graph(db: &RootDatabase, full: bool) -> Result<String, String> {
     let crate_graph = db.crate_graph();
     let crates_to_render = crate_graph
         .iter()
         .filter(|krate| {
-            // Only render workspace crates
-            let root_id = db.file_source_root(crate_graph[*krate].root_file_id);
-            !db.source_root(root_id).is_library
+            if full {
+                true
+            } else {
+                // Only render workspace crates
+                let root_id = db.file_source_root(crate_graph[*krate].root_file_id);
+                !db.source_root(root_id).is_library
+            }
         })
         .collect();
     let graph = DotCrateGraph { graph: crate_graph, crates_to_render };

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -38,7 +38,7 @@ use crate::{
     from_proto,
     global_state::{GlobalState, GlobalStateSnapshot},
     line_index::LineEndings,
-    lsp_ext::{self, InlayHint, InlayHintsParams, WorkspaceSymbolParams},
+    lsp_ext::{self, InlayHint, InlayHintsParams, ViewCrateGraphParams, WorkspaceSymbolParams},
     lsp_utils::all_edits_are_disjoint,
     to_proto, LspError, Result,
 };
@@ -131,9 +131,12 @@ pub(crate) fn handle_view_item_tree(
     Ok(res)
 }
 
-pub(crate) fn handle_view_crate_graph(snap: GlobalStateSnapshot, (): ()) -> Result<String> {
+pub(crate) fn handle_view_crate_graph(
+    snap: GlobalStateSnapshot,
+    params: ViewCrateGraphParams,
+) -> Result<String> {
     let _p = profile::span("handle_view_crate_graph");
-    let dot = snap.analysis.view_crate_graph()??;
+    let dot = snap.analysis.view_crate_graph(params.full)??;
 
     // We shell out to `dot` to render to SVG, as there does not seem to be a pure-Rust renderer.
     let child = Command::new("dot")

--- a/crates/rust-analyzer/src/lsp_ext.rs
+++ b/crates/rust-analyzer/src/lsp_ext.rs
@@ -62,10 +62,17 @@ impl Request for ViewHir {
     const METHOD: &'static str = "rust-analyzer/viewHir";
 }
 
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ViewCrateGraphParams {
+    /// Include *all* crates, not just crates in the workspace.
+    pub full: bool,
+}
+
 pub enum ViewCrateGraph {}
 
 impl Request for ViewCrateGraph {
-    type Params = ();
+    type Params = ViewCrateGraphParams;
     type Result = String;
     const METHOD: &'static str = "rust-analyzer/viewCrateGraph";
 }

--- a/docs/dev/lsp-extensions.md
+++ b/docs/dev/lsp-extensions.md
@@ -1,5 +1,5 @@
 <!---
-lsp_ext.rs hash: 49f253e4a9307d4f
+lsp_ext.rs hash: 3f2879db0013a72
 
 If you need to change the above hash to make the test pass, please check if you
 need to adjust this doc as well and ping this issue:
@@ -512,11 +512,19 @@ Returns a textual representation of the `ItemTree` of the currently open file, f
 
 **Method:** `rust-analyzer/viewCrateGraph`
 
-**Request:** `null`
+**Request:**
+
+```typescript
+interface ViewCrateGraphParams {
+    full: boolean,
+}
+```
 
 **Response:** `string`
 
 Renders rust-analyzer's crate graph as an SVG image.
+
+If `full` is `true`, the graph includes non-workspace crates (crates.io dependencies as well as sysroot crates).
 
 ## Expand Macro
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -120,6 +120,11 @@
                 "category": "Rust Analyzer"
             },
             {
+                "command": "rust-analyzer.viewFullCrateGraph",
+                "title": "View Crate Graph (Full)",
+                "category": "Rust Analyzer"
+            },
+            {
                 "command": "rust-analyzer.expandMacro",
                 "title": "Expand macro recursively",
                 "category": "Rust Analyzer"

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -479,12 +479,23 @@ export function viewItemTree(ctx: Ctx): Cmd {
     };
 }
 
-export function viewCrateGraph(ctx: Ctx): Cmd {
+function crateGraph(ctx: Ctx, full: boolean): Cmd {
     return async () => {
         const panel = vscode.window.createWebviewPanel("rust-analyzer.crate-graph", "rust-analyzer crate graph", vscode.ViewColumn.Two);
-        const svg = await ctx.client.sendRequest(ra.viewCrateGraph);
+        const params = {
+            full: full,
+        };
+        const svg = await ctx.client.sendRequest(ra.viewCrateGraph, params);
         panel.webview.html = svg;
     };
+}
+
+export function viewCrateGraph(ctx: Ctx): Cmd {
+    return crateGraph(ctx, false);
+}
+
+export function viewFullCrateGraph(ctx: Ctx): Cmd {
+    return crateGraph(ctx, true);
 }
 
 // Opens the virtual file that will show the syntax tree

--- a/editors/code/src/lsp_ext.ts
+++ b/editors/code/src/lsp_ext.ts
@@ -33,7 +33,11 @@ export interface ViewItemTreeParams {
 
 export const viewItemTree = new lc.RequestType<ViewItemTreeParams, string, void>("rust-analyzer/viewItemTree");
 
-export const viewCrateGraph = new lc.RequestType0<string, void>("rust-analyzer/viewCrateGraph");
+export interface ViewCrateGraphParams {
+    full: boolean;
+}
+
+export const viewCrateGraph = new lc.RequestType<ViewCrateGraphParams, string, void>("rust-analyzer/viewCrateGraph");
 
 export interface ExpandMacroParams {
     textDocument: lc.TextDocumentIdentifier;

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -123,6 +123,7 @@ async function initCommonContext(context: vscode.ExtensionContext, ctx: Ctx) {
     ctx.registerCommand('viewHir', commands.viewHir);
     ctx.registerCommand('viewItemTree', commands.viewItemTree);
     ctx.registerCommand('viewCrateGraph', commands.viewCrateGraph);
+    ctx.registerCommand('viewFullCrateGraph', commands.viewFullCrateGraph);
     ctx.registerCommand('expandMacro', commands.expandMacro);
     ctx.registerCommand('run', commands.run);
     ctx.registerCommand('copyRunCommandLine', commands.copyRunCommandLine);


### PR DESCRIPTION
Works like "View Crate Graph", but also includes crates.io and sysroot dependencies. The resulting graph might be enormous.

Closes https://github.com/rust-analyzer/rust-analyzer/issues/8867

bors r+