### PR TITLE
Add first-class limits.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,6 +487,7 @@ dependencies = [
  "indexmap",
  "itertools",
  "la-arena",
+ "limit",
  "log",
  "mbe",
  "once_cell",
@@ -508,6 +509,7 @@ dependencies = [
  "either",
  "expect-test",
  "la-arena",
+ "limit",
  "log",
  "mbe",
  "parser",
@@ -534,6 +536,7 @@ dependencies = [
  "hir_expand",
  "itertools",
  "la-arena",
+ "limit",
  "log",
  "once_cell",
  "profile",
@@ -640,6 +643,7 @@ dependencies = [
  "fst",
  "hir",
  "itertools",
+ "limit",
  "log",
  "once_cell",
  "profile",
@@ -791,6 +795,10 @@ checksum = "1d1b8479c593dba88c2741fc50b92e13dbabbbe0bd504d979f244ccc1a5b1c01"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "limit"
+version = "0.0.0"
 
 [[package]]
 name = "lock_api"

--- a/crates/hir_def/Cargo.toml
+++ b/crates/hir_def/Cargo.toml
@@ -31,6 +31,7 @@ hir_expand = { path = "../hir_expand", version = "0.0.0" }
 mbe = { path = "../mbe", version = "0.0.0" }
 cfg = { path = "../cfg", version = "0.0.0" }
 tt = { path = "../tt", version = "0.0.0" }
+limit = { path = "../limit", version = "0.0.0" }
 
 [dev-dependencies]
 test_utils = { path = "../test_utils" }

--- a/crates/hir_def/src/nameres/mod_resolution.rs
+++ b/crates/hir_def/src/nameres/mod_resolution.rs
@@ -1,11 +1,12 @@
 //! This module resolves `mod foo;` declaration to file.
 use base_db::{AnchoredPath, FileId};
 use hir_expand::name::Name;
+use limit::Limit;
 use syntax::SmolStr;
 
 use crate::{db::DefDatabase, HirFileId};
 
-const MOD_DEPTH_LIMIT: u32 = 32;
+const MOD_DEPTH_LIMIT: Limit = Limit::new(32);
 
 #[derive(Clone, Debug)]
 pub(super) struct ModDir {
@@ -25,7 +26,7 @@ impl ModDir {
     }
     fn child(&self, dir_path: DirPath, root_non_dir_owner: bool) -> Option<ModDir> {
         let depth = self.depth + 1;
-        if depth > MOD_DEPTH_LIMIT {
+        if MOD_DEPTH_LIMIT.check(depth as usize).is_err() {
             log::error!("MOD_DEPTH_LIMIT exceeded");
             cov_mark::hit!(circular_mods);
             return None;

--- a/crates/hir_expand/Cargo.toml
+++ b/crates/hir_expand/Cargo.toml
@@ -21,6 +21,7 @@ parser = { path = "../parser", version = "0.0.0" }
 profile = { path = "../profile", version = "0.0.0" }
 tt = { path = "../tt", version = "0.0.0" }
 mbe = { path = "../mbe", version = "0.0.0" }
+limit = { path = "../limit", version = "0.0.0" }
 
 [dev-dependencies]
 test_utils = { path = "../test_utils" }

--- a/crates/hir_ty/Cargo.toml
+++ b/crates/hir_ty/Cargo.toml
@@ -29,6 +29,7 @@ hir_expand = { path = "../hir_expand", version = "0.0.0" }
 base_db = { path = "../base_db", version = "0.0.0" }
 profile = { path = "../profile", version = "0.0.0" }
 syntax = { path = "../syntax", version = "0.0.0" }
+limit = { path = "../limit", version = "0.0.0" }
 
 [dev-dependencies]
 test_utils = { path = "../test_utils" }

--- a/crates/ide_assists/src/handlers/replace_derive_with_manual_impl.rs
+++ b/crates/ide_assists/src/handlers/replace_derive_with_manual_impl.rs
@@ -65,7 +65,7 @@ pub(crate) fn replace_derive_with_manual_impl(
         current_crate,
         NameToImport::Exact(trait_name.to_string()),
         items_locator::AssocItemSearch::Exclude,
-        Some(items_locator::DEFAULT_QUERY_SEARCH_LIMIT),
+        Some(items_locator::DEFAULT_QUERY_SEARCH_LIMIT.inner()),
     )
     .filter_map(|item| match ModuleDef::from(item.as_module_def_id()?) {
         ModuleDef::Trait(trait_) => Some(trait_),

--- a/crates/ide_completion/src/lib.rs
+++ b/crates/ide_completion/src/lib.rs
@@ -187,7 +187,7 @@ pub fn resolve_completion_edits(
         current_crate,
         NameToImport::Exact(imported_name),
         items_locator::AssocItemSearch::Include,
-        Some(items_locator::DEFAULT_QUERY_SEARCH_LIMIT),
+        Some(items_locator::DEFAULT_QUERY_SEARCH_LIMIT.inner()),
     )
     .filter_map(|candidate| {
         current_module

--- a/crates/ide_db/Cargo.toml
+++ b/crates/ide_db/Cargo.toml
@@ -26,6 +26,7 @@ profile = { path = "../profile", version = "0.0.0" }
 # ide should depend only on the top-level `hir` package. if you need
 # something from some `hir_xxx` subpackage, reexport the API via `hir`.
 hir = { path = "../hir", version = "0.0.0" }
+limit = { path = "../limit", version = "0.0.0" }
 
 [dev-dependencies]
 test_utils = { path = "../test_utils" }

--- a/crates/ide_db/src/helpers/import_assets.rs
+++ b/crates/ide_db/src/helpers/import_assets.rs
@@ -282,7 +282,7 @@ fn path_applicable_imports(
                 //
                 // see also an ignored test under FIXME comment in the qualify_path.rs module
                 AssocItemSearch::Exclude,
-                Some(DEFAULT_QUERY_SEARCH_LIMIT),
+                Some(DEFAULT_QUERY_SEARCH_LIMIT.inner()),
             )
             .filter_map(|item| {
                 let mod_path = mod_path(item)?;
@@ -299,7 +299,7 @@ fn path_applicable_imports(
                 current_crate,
                 path_candidate.name.clone(),
                 AssocItemSearch::Include,
-                Some(DEFAULT_QUERY_SEARCH_LIMIT),
+                Some(DEFAULT_QUERY_SEARCH_LIMIT.inner()),
             )
             .filter_map(|item| {
                 import_for_item(
@@ -445,7 +445,7 @@ fn trait_applicable_items(
         current_crate,
         trait_candidate.assoc_item_name.clone(),
         AssocItemSearch::AssocItemsOnly,
-        Some(DEFAULT_QUERY_SEARCH_LIMIT),
+        Some(DEFAULT_QUERY_SEARCH_LIMIT.inner()),
     )
     .filter_map(|input| item_as_assoc(db, input))
     .filter_map(|assoc| {

--- a/crates/ide_db/src/items_locator.rs
+++ b/crates/ide_db/src/items_locator.rs
@@ -7,6 +7,7 @@ use hir::{
     import_map::{self, ImportKind},
     AsAssocItem, Crate, ItemInNs, ModuleDef, Semantics,
 };
+use limit::Limit;
 use syntax::{ast, AstNode, SyntaxKind::NAME};
 
 use crate::{
@@ -17,7 +18,7 @@ use crate::{
 };
 
 /// A value to use, when uncertain which limit to pick.
-pub const DEFAULT_QUERY_SEARCH_LIMIT: usize = 40;
+pub const DEFAULT_QUERY_SEARCH_LIMIT: Limit = Limit::new(40);
 
 /// Three possible ways to search for the name in associated and/or other items.
 #[derive(Debug, Clone, Copy)]

--- a/crates/limit/Cargo.toml
+++ b/crates/limit/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "limit"
+version = "0.0.0"
+description = "TBD"
+license = "MIT OR Apache-2.0"
+authors = ["rust-analyzer developers"]
+edition = "2018"
+
+[dependencies]

--- a/crates/limit/src/lib.rs
+++ b/crates/limit/src/lib.rs
@@ -1,0 +1,31 @@
+//! limit defines a struct to enforce limits.
+
+/// Represents a struct used to enforce a numerical limit.
+pub struct Limit {
+    upper_bound: usize,
+}
+
+impl Limit {
+    /// Creates a new limit.
+    #[inline]
+    pub const fn new(upper_bound: usize) -> Self {
+        Self { upper_bound }
+    }
+
+    /// Gets the underlying numeric limit.
+    #[inline]
+    pub const fn inner(&self) -> usize {
+        self.upper_bound
+    }
+
+    /// Checks whether the given value is below the limit.
+    /// Returns `Ok` when `other` is below `self`, and `Err` otherwise.
+    #[inline]
+    pub const fn check(&self, other: usize) -> Result<(), ()> {
+        if other > self.upper_bound {
+            Err(())
+        } else {
+            Ok(())
+        }
+    }
+}


### PR DESCRIPTION
Partially fixes #9286.

This introduces a new `Limits` structure which is passed as an input
to `SourceDatabase`. This makes limits accessible almost everywhere in
the code, since most places have a database in scope.

One downside of this approach is that whenever you query limits, you
essentially do an `Arc::clone` which is less than ideal.

Let me know if I missed anything, or would like me to take a different approach!