### PR TITLE
feat: Empower `replace_if_let_with_match`

### DIFF
--- a/crates/ide_assists/src/utils.rs
+++ b/crates/ide_assists/src/utils.rs
@@ -48,15 +48,14 @@ pub fn extract_trivial_expression(block: &ast::BlockExpr) -> Option<ast::Expr> {
         return Some(expr);
     }
     // Unwrap `{ continue; }`
-    let (stmt,) = block.statements().next_tuple()?;
+    let stmt = block.statements().next()?;
     if let ast::Stmt::ExprStmt(expr_stmt) = stmt {
         if has_anything_else(expr_stmt.syntax()) {
             return None;
         }
         let expr = expr_stmt.expr()?;
-        match expr.syntax().kind() {
-            CONTINUE_EXPR | BREAK_EXPR | RETURN_EXPR => return Some(expr),
-            _ => (),
+        if matches!(expr.syntax().kind(), CONTINUE_EXPR | BREAK_EXPR | RETURN_EXPR) {
+            return Some(expr);
         }
     }
     None


### PR DESCRIPTION
Now instead of only working on `if let ... {} else {}` if expressions it now works on all of them where the condition expression is the same text-wise.

This includes if let expressions without an else block, in which case a simple `_ => ()` will be generated in the resulting match but also in more complex cases where multiple `if let` expressions are chained.

bors r+