### PR TITLE
fix: sysroot: add proc_macro -> std dependency edge

### DIFF
--- a/crates/project_model/src/sysroot.rs
+++ b/crates/project_model/src/sysroot.rs
@@ -98,6 +98,12 @@ impl Sysroot {
             }
         }
 
+        if let Some(proc_macro) = sysroot.by_name("proc_macro") {
+            if let Some(std) = sysroot.by_name("std") {
+                sysroot.crates[proc_macro].deps.push(std);
+            }
+        }
+
         if sysroot.by_name("core").is_none() {
             let var_note = if env::var_os("RUST_SRC_PATH").is_some() {
                 " (`RUST_SRC_PATH` might be incorrect, try unsetting it)"


### PR DESCRIPTION
This fixes missing trait implementation on the proc_macro types.

bors r+