### PR TITLE
fix: Fix incorrect guard for NameRefClass attribute resolution

### DIFF
--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -4134,4 +4134,24 @@ pub fn foo() {}
             "#]],
         )
     }
+
+    #[test]
+    fn hover_attr_path_qualifier() {
+        check(
+            r#"
+//- /foo.rs crate:foo
+
+//- /lib.rs crate:main.rs deps:foo
+#[fo$0o::bar()]
+struct Foo;
+            "#,
+            expect![[r#"
+                *foo*
+
+                ```rust
+                extern crate foo
+                ```
+            "#]],
+        )
+    }
 }

--- a/crates/ide_db/src/defs.rs
+++ b/crates/ide_db/src/defs.rs
@@ -393,7 +393,8 @@ impl NameRefClass {
                 Some(true) => sema.resolve_path(&path).and_then(|resolved| {
                     match resolved {
                         // Don't wanna collide with builtin attributes here like `test` hence guard
-                        PathResolution::Def(module @ ModuleDef::Module(_)) if path == top_path => {
+                        // so only resolve to modules that aren't the last segment
+                        PathResolution::Def(module @ ModuleDef::Module(_)) if path != top_path => {
                             Some(NameRefClass::Definition(Definition::ModuleDef(module)))
                         }
                         PathResolution::Macro(mac) if mac.kind() == hir::MacroKind::Attr => {


### PR DESCRIPTION
This is what happens when you forget to write a test
bors r+
