### PR TITLE
minor: Print runnable kind on assertion failure for better debuggability

### DIFF
--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -105,10 +105,12 @@ pub(crate) fn runnables(db: &RootDatabase, file_id: FileId) -> Vec<Runnable> {
 
     let mut res = Vec::new();
     let mut add_opt = |runnable: Option<Runnable>| {
-        if let Some(runnable) = runnable.filter(|r| {
+        if let Some(runnable) = runnable.filter(|runnable| {
             always!(
-                r.nav.file_id == file_id,
-                "tried adding a runnable pointing to a different file"
+                runnable.nav.file_id == file_id,
+                "tried adding a runnable pointing to a different file: {:?} for {:?}",
+                runnable.kind,
+                file_id
             )
         }) {
             res.push(runnable);


### PR DESCRIPTION
We are somehow hitting this when looking at `crates\ide_db\src\lib.rs` and I don't see how.
bors r+