### PR TITLE
fix: Remove incorrect std dep

### DIFF
--- a/crates/project_model/src/sysroot.rs
+++ b/crates/project_model/src/sysroot.rs
@@ -210,7 +210,6 @@ core
 panic_abort
 panic_unwind
 profiler_builtins
-proc_macro
 std_detect
 term
 test


### PR DESCRIPTION
libstd doesn't actually depend on `proc_macro`. cc https://github.com/rust-analyzer/rust-analyzer/pull/9456#issuecomment-873005974

bors r+