### PR TITLE
feat: `replace_match_with_if_let` works on more 2-arm matches

### DIFF
--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -4137,6 +4137,7 @@ pub fn foo() {}
 
     #[test]
     fn hover_attr_path_qualifier() {
+        cov_mark::check!(name_ref_classify_attr_path_qualifier);
         check(
             r#"
 //- /foo.rs crate:foo

--- a/crates/ide_assists/src/handlers/replace_if_let_with_match.rs
+++ b/crates/ide_assists/src/handlers/replace_if_let_with_match.rs
@@ -265,10 +265,11 @@ fn binds_name(pat: &ast::Pat) -> bool {
         _ => false,
     }
 }
+
 fn is_sad_pat(sema: &hir::Semantics<RootDatabase>, pat: &ast::Pat) -> bool {
     sema.type_of_pat(pat)
         .and_then(|ty| TryEnum::from_ty(sema, &ty))
-        .map_or(false, |it| it.sad_pattern().syntax().text() == pat.syntax().text())
+        .map_or(false, |it| does_pat_match_variant(pat, &it.sad_pattern()))
 }
 
 #[cfg(test)]

--- a/crates/ide_db/src/defs.rs
+++ b/crates/ide_db/src/defs.rs
@@ -395,6 +395,7 @@ impl NameRefClass {
                         // Don't wanna collide with builtin attributes here like `test` hence guard
                         // so only resolve to modules that aren't the last segment
                         PathResolution::Def(module @ ModuleDef::Module(_)) if path != top_path => {
+                            cov_mark::hit!(name_ref_classify_attr_path_qualifier);
                             Some(NameRefClass::Definition(Definition::ModuleDef(module)))
                         }
                         PathResolution::Macro(mac) if mac.kind() == hir::MacroKind::Attr => {

--- a/crates/syntax/src/ast/node_ext.rs
+++ b/crates/syntax/src/ast/node_ext.rs
@@ -49,6 +49,10 @@ impl ast::BlockExpr {
     pub fn items(&self) -> AstChildren<ast::Item> {
         support::children(self.syntax())
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.statements().next().is_none() && self.tail_expr().is_none()
+    }
 }
 
 impl ast::Expr {


### PR DESCRIPTION
Now it works on pretty much on all 2-arm matches where only up to 1 arm binds a name instead of requiring either a sad or wildcard pattern to be present.

bors r+