### PR TITLE
show imported trait on autocompletion of associated items

### DIFF
--- a/crates/ide_completion/src/completions/dot.rs
+++ b/crates/ide_completion/src/completions/dot.rs
@@ -250,7 +250,7 @@ impl Trait for A {}
 fn foo(a: A) { a.$0 }
 "#,
             expect![[r#"
-                me the_method() fn(&self)
+                me the_method() (Trait) fn(&self)
             "#]],
         );
     }
@@ -265,7 +265,7 @@ impl<T> Trait for T {}
 fn foo(a: &A) { a.$0 }
 ",
             expect![[r#"
-                me the_method() fn(&self)
+                me the_method() (Trait) fn(&self)
             "#]],
         );
     }
@@ -283,7 +283,7 @@ impl Trait for A {}
 fn foo(a: A) { a.$0 }
 ",
             expect![[r#"
-                me the_method() fn(&self)
+                me the_method() (Trait) fn(&self)
             "#]],
         );
     }

--- a/crates/ide_completion/src/completions/qualified_path.rs
+++ b/crates/ide_completion/src/completions/qualified_path.rs
@@ -333,7 +333,7 @@ trait Trait { fn m(); }
 fn foo() { let _ = Trait::$0 }
 "#,
             expect![[r#"
-                fn m() fn()
+                fn m() (Trait) fn()
             "#]],
         );
     }
@@ -350,7 +350,7 @@ impl Trait for S {}
 fn foo() { let _ = S::$0 }
 "#,
             expect![[r#"
-                fn m() fn()
+                fn m() (Trait) fn()
             "#]],
         );
     }
@@ -367,7 +367,7 @@ impl Trait for S {}
 fn foo() { let _ = <S as Trait>::$0 }
 "#,
             expect![[r#"
-                fn m() fn()
+                fn m() (Trait) fn()
             "#]],
         );
     }
@@ -393,14 +393,14 @@ trait Sub: Super {
 fn foo<T: Sub>() { T::$0 }
 "#,
             expect![[r#"
-                ta SubTy        type SubTy;
-                ta Ty           type Ty;
-                ct C2           const C2: ();
-                fn subfunc()    fn()
-                me submethod(…) fn(&self)
-                ct CONST        const CONST: u8;
-                fn func()       fn()
-                me method(…)    fn(&self)
+                ta SubTy (Sub)        type SubTy;
+                ta Ty (Super)         type Ty;
+                ct C2 (Sub)           const C2: ();
+                fn subfunc() (Sub)    fn()
+                me submethod(…) (Sub) fn(&self)
+                ct CONST (Super)      const CONST: u8;
+                fn func() (Super)     fn()
+                me method(…) (Super)  fn(&self)
             "#]],
         );
     }
@@ -433,14 +433,14 @@ impl<T> Sub for Wrap<T> {
 }
 "#,
             expect![[r#"
-                ta SubTy        type SubTy;
-                ta Ty           type Ty;
-                ct CONST        const CONST: u8 = 0;
-                fn func()       fn()
-                me method(…)    fn(&self)
-                ct C2           const C2: () = ();
-                fn subfunc()    fn()
-                me submethod(…) fn(&self)
+                ta SubTy (Sub)        type SubTy;
+                ta Ty (Super)         type Ty;
+                ct CONST (Super)      const CONST: u8 = 0;
+                fn func() (Super)     fn()
+                me method(…) (Super)  fn(&self)
+                ct C2 (Sub)           const C2: () = ();
+                fn subfunc() (Sub)    fn()
+                me submethod(…) (Sub) fn(&self)
             "#]],
         );
     }

--- a/crates/ide_completion/src/item.rs
+++ b/crates/ide_completion/src/item.rs
@@ -295,6 +295,7 @@ impl CompletionItem {
             label,
             insert_text: None,
             is_snippet: false,
+            trait_name: None,
             detail: None,
             documentation: None,
             lookup: None,
@@ -398,6 +399,7 @@ pub(crate) struct Builder {
     source_range: TextRange,
     completion_kind: CompletionKind,
     import_to_add: Option<ImportEdit>,
+    trait_name: Option<String>,
     label: String,
     insert_text: Option<String>,
     is_snippet: bool,
@@ -434,6 +436,8 @@ impl Builder {
             } else {
                 format_to!(label, " ({})", original_path)
             }
+        } else if let Some(trait_name) = self.trait_name {
+            format_to!(label, " ({})", trait_name)
         }
 
         let text_edit = match self.text_edit {
@@ -466,6 +470,10 @@ impl Builder {
     }
     pub(crate) fn label(&mut self, label: impl Into<String>) -> &mut Builder {
         self.label = label.into();
+        self
+    }
+    pub(crate) fn trait_name(&mut self, trait_name: impl Into<String>) -> &mut Builder {
+        self.trait_name = Some(trait_name.into());
         self
     }
     pub(crate) fn insert_text(&mut self, insert_text: impl Into<String>) -> &mut Builder {

--- a/crates/ide_completion/src/render/const_.rs
+++ b/crates/ide_completion/src/render/const_.rs
@@ -1,6 +1,6 @@
 //! Renderer for `const` fields.
 
-use hir::{AsAssocItem, HasSource, ModuleDef};
+use hir::{AsAssocItem, HasSource};
 use ide_db::SymbolKind;
 use syntax::{
     ast::{Const, NameOwner},
@@ -49,11 +49,8 @@ impl<'a> ConstRender<'a> {
         let db = self.ctx.db();
         if let Some(actm) = self.const_.as_assoc_item(db) {
             if let Some(trt) = actm.containing_trait_or_trait_impl(db) {
-                let module = self.ctx.completion.scope.module().unwrap();
-                if let Some(path) = module.find_use_path(db, ModuleDef::Trait(trt)) {
-                    item.label(format!("{} ({})", name.clone(), path));
-                    item.insert_text(name.clone());
-                }
+                item.trait_name(trt.name(db).to_string());
+                item.insert_text(name.clone());
             }
         }
 

--- a/crates/ide_completion/src/render/const_.rs
+++ b/crates/ide_completion/src/render/const_.rs
@@ -1,6 +1,6 @@
 //! Renderer for `const` fields.
 
-use hir::HasSource;
+use hir::{AsAssocItem, HasSource, ModuleDef};
 use ide_db::SymbolKind;
 use syntax::{
     ast::{Const, NameOwner},
@@ -37,7 +37,7 @@ impl<'a> ConstRender<'a> {
         let detail = self.detail();
 
         let mut item =
-            CompletionItem::new(CompletionKind::Reference, self.ctx.source_range(), name);
+            CompletionItem::new(CompletionKind::Reference, self.ctx.source_range(), name.clone());
         item.kind(SymbolKind::Const)
             .set_documentation(self.ctx.docs(self.const_))
             .set_deprecated(
@@ -45,6 +45,17 @@ impl<'a> ConstRender<'a> {
                     || self.ctx.is_deprecated_assoc_item(self.const_),
             )
             .detail(detail);
+
+        let db = self.ctx.db();
+        if let Some(actm) = self.const_.as_assoc_item(db) {
+            if let Some(trt) = actm.containing_trait_or_trait_impl(db) {
+                let module = self.ctx.completion.scope.module().unwrap();
+                if let Some(path) = module.find_use_path(db, ModuleDef::Trait(trt)) {
+                    item.label(format!("{} ({})", name.clone(), path));
+                    item.insert_text(name.clone());
+                }
+            }
+        }
 
         Some(item.build())
     }

--- a/crates/ide_completion/src/render/function.rs
+++ b/crates/ide_completion/src/render/function.rs
@@ -1,6 +1,6 @@
 //! Renderer for function calls.
 
-use hir::{HasSource, HirDisplay};
+use hir::{AsAssocItem, HasSource, HirDisplay, ModuleDef};
 use ide_db::SymbolKind;
 use itertools::Itertools;
 use syntax::ast::Fn;
@@ -73,9 +73,25 @@ impl<'a> FunctionRender<'a> {
                 self.ctx.is_deprecated(self.func) || self.ctx.is_deprecated_assoc_item(self.func),
             )
             .detail(self.detail())
-            .add_call_parens(self.ctx.completion, call.clone(), params)
-            .add_import(import_to_add)
-            .lookup_by(self.name);
+            .add_call_parens(self.ctx.completion, call.clone(), params);
+
+        if import_to_add.is_none() {
+            let db = self.ctx.db();
+            if let Some(actm) = self.func.as_assoc_item(db) {
+                if let Some(trt) = actm.containing_trait_or_trait_impl(db) {
+                    let module = self.ctx.completion.scope.module().unwrap();
+                    if let Some(path) = module.find_use_path(db, ModuleDef::Trait(trt)) {
+                        item.label(format!(
+                            "{} ({})",
+                            item.clone().build().label().to_owned(),
+                            path
+                        ));
+                    }
+                }
+            }
+        }
+
+        item.add_import(import_to_add).lookup_by(self.name);
 
         let ret_type = self.func.ret_type(self.ctx.db());
         item.set_relevance(CompletionRelevance {

--- a/crates/ide_completion/src/render/function.rs
+++ b/crates/ide_completion/src/render/function.rs
@@ -1,6 +1,6 @@
 //! Renderer for function calls.
 
-use hir::{AsAssocItem, HasSource, HirDisplay, ModuleDef};
+use hir::{AsAssocItem, HasSource, HirDisplay};
 use ide_db::SymbolKind;
 use itertools::Itertools;
 use syntax::ast::Fn;
@@ -79,14 +79,7 @@ impl<'a> FunctionRender<'a> {
             let db = self.ctx.db();
             if let Some(actm) = self.func.as_assoc_item(db) {
                 if let Some(trt) = actm.containing_trait_or_trait_impl(db) {
-                    let module = self.ctx.completion.scope.module().unwrap();
-                    if let Some(path) = module.find_use_path(db, ModuleDef::Trait(trt)) {
-                        item.label(format!(
-                            "{} ({})",
-                            item.clone().build().label().to_owned(),
-                            path
-                        ));
-                    }
+                    item.trait_name(trt.name(db).to_string());
                 }
             }
         }

--- a/crates/ide_completion/src/render/type_alias.rs
+++ b/crates/ide_completion/src/render/type_alias.rs
@@ -1,6 +1,6 @@
 //! Renderer for type aliases.
 
-use hir::{AsAssocItem, HasSource, ModuleDef};
+use hir::{AsAssocItem, HasSource};
 use ide_db::SymbolKind;
 use syntax::{
     ast::{NameOwner, TypeAlias},
@@ -62,11 +62,8 @@ impl<'a> TypeAliasRender<'a> {
         let db = self.ctx.db();
         if let Some(actm) = self.type_alias.as_assoc_item(db) {
             if let Some(trt) = actm.containing_trait_or_trait_impl(db) {
-                let module = self.ctx.completion.scope.module().unwrap();
-                if let Some(path) = module.find_use_path(db, ModuleDef::Trait(trt)) {
-                    item.label(format!("{} ({})", name.clone(), path));
-                    item.insert_text(name.clone());
-                }
+                item.trait_name(trt.name(db).to_string());
+                item.insert_text(name.clone());
             }
         }
 

--- a/crates/ide_completion/src/render/type_alias.rs
+++ b/crates/ide_completion/src/render/type_alias.rs
@@ -1,6 +1,6 @@
 //! Renderer for type aliases.
 
-use hir::HasSource;
+use hir::{AsAssocItem, HasSource, ModuleDef};
 use ide_db::SymbolKind;
 use syntax::{
     ast::{NameOwner, TypeAlias},
@@ -50,7 +50,7 @@ impl<'a> TypeAliasRender<'a> {
         let detail = self.detail();
 
         let mut item =
-            CompletionItem::new(CompletionKind::Reference, self.ctx.source_range(), name);
+            CompletionItem::new(CompletionKind::Reference, self.ctx.source_range(), name.clone());
         item.kind(SymbolKind::TypeAlias)
             .set_documentation(self.ctx.docs(self.type_alias))
             .set_deprecated(
@@ -58,6 +58,17 @@ impl<'a> TypeAliasRender<'a> {
                     || self.ctx.is_deprecated_assoc_item(self.type_alias),
             )
             .detail(detail);
+
+        let db = self.ctx.db();
+        if let Some(actm) = self.type_alias.as_assoc_item(db) {
+            if let Some(trt) = actm.containing_trait_or_trait_impl(db) {
+                let module = self.ctx.completion.scope.module().unwrap();
+                if let Some(path) = module.find_use_path(db, ModuleDef::Trait(trt)) {
+                    item.label(format!("{} ({})", name.clone(), path));
+                    item.insert_text(name.clone());
+                }
+            }
+        }
 
         Some(item.build())
     }

--- a/crates/ide_completion/src/tests.rs
+++ b/crates/ide_completion/src/tests.rs
@@ -126,7 +126,7 @@ fn render_completion_list(completions: Vec<CompletionItem>) -> String {
         s.chars().count()
     }
     let label_width =
-        completions.iter().map(|it| monospace_width(it.label())).max().unwrap_or_default().min(16);
+        completions.iter().map(|it| monospace_width(it.label())).max().unwrap_or_default().min(22);
     completions
         .into_iter()
         .map(|it| {

--- a/crates/ide_completion/src/tests/item_list.rs
+++ b/crates/ide_completion/src/tests/item_list.rs
@@ -30,7 +30,7 @@ fn in_mod_item_list() {
             sn tmod (Test module)
             sn tfn (Test function)
             sn macro_rules
-            ma makro!(…)        #[macro_export] macro_rules! makro
+            ma makro!(…)           #[macro_export] macro_rules! makro
         "##]],
     )
 }
@@ -58,9 +58,9 @@ fn in_source_file_item_list() {
             sn tmod (Test module)
             sn tfn (Test function)
             sn macro_rules
-            ma makro!(…)        #[macro_export] macro_rules! makro
+            ma makro!(…)           #[macro_export] macro_rules! makro
             md module
-            ma makro!(…)        #[macro_export] macro_rules! makro
+            ma makro!(…)           #[macro_export] macro_rules! makro
         "##]],
     )
 }

--- a/crates/ide_completion/src/tests/type_pos.rs
+++ b/crates/ide_completion/src/tests/type_pos.rs
@@ -140,7 +140,7 @@ trait Trait2 {
 fn foo<'lt, T: Trait2<$0>, const CONST_PARAM: usize>(_: T) {}
 "#,
         expect![[r#"
-            ta Foo =       type Foo;
+            ta Foo =  (Trait2) type Foo;
             tp T
             cp CONST_PARAM
             tt Trait
@@ -151,7 +151,7 @@ fn foo<'lt, T: Trait2<$0>, const CONST_PARAM: usize>(_: T) {}
             md module
             st Unit
             ct CONST
-            ma makro!(…)   macro_rules! makro
+            ma makro!(…)       macro_rules! makro
             bt u32
         "#]],
     );


### PR DESCRIPTION
Fixes: #7456

The thing is however, due to the trait being already imported, the path to the trait is just the name of the trait itself.
I also updated the test concerning the labels.