### PR TITLE
fix: `replace_qualified_name_with_use` inserts qualified import paths

### DIFF
--- a/crates/ide_assists/src/tests/generated.rs
+++ b/crates/ide_assists/src/tests/generated.rs
@@ -1479,11 +1479,13 @@ fn doctest_replace_qualified_name_with_use() {
     check_doc_test(
         "replace_qualified_name_with_use",
         r#####"
+mod std { pub mod collections { pub struct HashMap<T, U>(T, U); } }
 fn process(map: std::collections::$0HashMap<String, String>) {}
 "#####,
         r#####"
 use std::collections::HashMap;
 
+mod std { pub mod collections { pub struct HashMap<T, U>(T, U); } }
 fn process(map: HashMap<String, String>) {}
 "#####,
     )

--- a/crates/ide_db/src/helpers/insert_use.rs
+++ b/crates/ide_db/src/helpers/insert_use.rs
@@ -214,7 +214,7 @@ pub fn insert_use<'a>(scope: &ImportScope, path: ast::Path, cfg: &InsertUseConfi
 
     // either we weren't allowed to merge or there is no import that fits the merge conditions
     // so look for the place we have to insert to
-    insert_use_(scope, path, cfg.group, use_item);
+    insert_use_(scope, &path, cfg.group, use_item);
 }
 
 #[derive(Eq, PartialEq, PartialOrd, Ord)]
@@ -253,12 +253,12 @@ impl ImportGroup {
 
 fn insert_use_(
     scope: &ImportScope,
-    insert_path: ast::Path,
+    insert_path: &ast::Path,
     group_imports: bool,
     use_item: ast::Use,
 ) {
     let scope_syntax = scope.as_syntax_node();
-    let group = ImportGroup::new(&insert_path);
+    let group = ImportGroup::new(insert_path);
     let path_node_iter = scope_syntax
         .children()
         .filter_map(|node| ast::Use::cast(node.clone()).zip(Some(node)))
@@ -294,7 +294,7 @@ fn insert_use_(
     let post_insert: Option<(_, _, SyntaxNode)> = group_iter
         .inspect(|(.., node)| last = Some(node.clone()))
         .find(|&(ref path, has_tl, _)| {
-            use_tree_path_cmp(&insert_path, false, path, has_tl) != Ordering::Greater
+            use_tree_path_cmp(insert_path, false, path, has_tl) != Ordering::Greater
         });
 
     if let Some((.., node)) = post_insert {


### PR DESCRIPTION
Also prevents the assist from triggering on associated items.

Fixes #9472.

This PR gets rid of a lot of tests that only really test the `insert_use` infra which already has its own tests, so these tests are of no use.

bors r+