### PR TITLE
feat: show 'as' or 'use' before label traits

### DIFF
--- a/crates/ide_completion/src/completions/dot.rs
+++ b/crates/ide_completion/src/completions/dot.rs
@@ -250,7 +250,7 @@ impl Trait for A {}
 fn foo(a: A) { a.$0 }
 "#,
             expect![[r#"
-                me the_method() (Trait) fn(&self)
+                me the_method() (as Trait) fn(&self)
             "#]],
         );
     }
@@ -265,7 +265,7 @@ impl<T> Trait for T {}
 fn foo(a: &A) { a.$0 }
 ",
             expect![[r#"
-                me the_method() (Trait) fn(&self)
+                me the_method() (as Trait) fn(&self)
             "#]],
         );
     }
@@ -283,7 +283,7 @@ impl Trait for A {}
 fn foo(a: A) { a.$0 }
 ",
             expect![[r#"
-                me the_method() (Trait) fn(&self)
+                me the_method() (as Trait) fn(&self)
             "#]],
         );
     }

--- a/crates/ide_completion/src/completions/flyimport.rs
+++ b/crates/ide_completion/src/completions/flyimport.rs
@@ -404,7 +404,7 @@ fn main() {
         check(
             fixture,
             expect![[r#"
-                fn weird_function() (dep::test_mod::TestTrait) fn()
+                fn weird_function() (use dep::test_mod::TestTrait) fn()
             "#]],
         );
 
@@ -450,7 +450,7 @@ fn main() {
         check(
             fixture,
             expect![[r#"
-            ct SPECIAL_CONST (dep::test_mod::TestTrait)
+            ct SPECIAL_CONST (use dep::test_mod::TestTrait)
         "#]],
         );
 
@@ -497,7 +497,7 @@ fn main() {
         check(
             fixture,
             expect![[r#"
-                me random_method() (dep::test_mod::TestTrait) fn(&self)
+                me random_method() (use dep::test_mod::TestTrait) fn(&self)
             "#]],
         );
 
@@ -667,7 +667,7 @@ fn main() {
 }
         "#,
             expect![[r#"
-                me random_method() (dep::test_mod::TestTrait) fn(&self) DEPRECATED
+                me random_method() (use dep::test_mod::TestTrait) fn(&self) DEPRECATED
             "#]],
         );
 
@@ -697,8 +697,8 @@ fn main() {
 }
 "#,
             expect![[r#"
-                ct SPECIAL_CONST (dep::test_mod::TestTrait) DEPRECATED
-                fn weird_function() (dep::test_mod::TestTrait) fn() DEPRECATED
+                ct SPECIAL_CONST (use dep::test_mod::TestTrait) DEPRECATED
+                fn weird_function() (use dep::test_mod::TestTrait) fn() DEPRECATED
             "#]],
         );
     }
@@ -859,7 +859,7 @@ fn main() {
         check(
             fixture,
             expect![[r#"
-        ct TEST_ASSOC (foo::Item)
+        ct TEST_ASSOC (use foo::Item)
         "#]],
         );
 
@@ -903,7 +903,7 @@ fn main() {
         check(
             fixture,
             expect![[r#"
-        ct TEST_ASSOC (foo::bar::Item)
+        ct TEST_ASSOC (use foo::bar::Item)
     "#]],
         );
 
@@ -1015,7 +1015,7 @@ fn main() {
 }"#,
             expect![[r#"
         ct foo::TEST_CONST
-        fn test_function() (foo::test_function) fn() -> i32
+        fn test_function() (use foo::test_function) fn() -> i32
     "#]],
         );
 
@@ -1072,7 +1072,7 @@ fn main() {
 }
 "#,
             expect![[r#"
-                fn some_fn() (m::some_fn) fn() -> i32
+                fn some_fn() (use m::some_fn) fn() -> i32
             "#]],
         );
     }

--- a/crates/ide_completion/src/completions/qualified_path.rs
+++ b/crates/ide_completion/src/completions/qualified_path.rs
@@ -333,7 +333,7 @@ trait Trait { fn m(); }
 fn foo() { let _ = Trait::$0 }
 "#,
             expect![[r#"
-                fn m() (Trait) fn()
+                fn m() (as Trait) fn()
             "#]],
         );
     }
@@ -350,7 +350,7 @@ impl Trait for S {}
 fn foo() { let _ = S::$0 }
 "#,
             expect![[r#"
-                fn m() (Trait) fn()
+                fn m() (as Trait) fn()
             "#]],
         );
     }
@@ -367,7 +367,7 @@ impl Trait for S {}
 fn foo() { let _ = <S as Trait>::$0 }
 "#,
             expect![[r#"
-                fn m() (Trait) fn()
+                fn m() (as Trait) fn()
             "#]],
         );
     }
@@ -393,14 +393,14 @@ trait Sub: Super {
 fn foo<T: Sub>() { T::$0 }
 "#,
             expect![[r#"
-                ta SubTy (Sub)        type SubTy;
-                ta Ty (Super)         type Ty;
-                ct C2 (Sub)           const C2: ();
-                fn subfunc() (Sub)    fn()
-                me submethod(…) (Sub) fn(&self)
-                ct CONST (Super)      const CONST: u8;
-                fn func() (Super)     fn()
-                me method(…) (Super)  fn(&self)
+                ta SubTy (as Sub)        type SubTy;
+                ta Ty (as Super)         type Ty;
+                ct C2 (as Sub)           const C2: ();
+                fn subfunc() (as Sub)    fn()
+                me submethod(…) (as Sub) fn(&self)
+                ct CONST (as Super)      const CONST: u8;
+                fn func() (as Super)     fn()
+                me method(…) (as Super)  fn(&self)
             "#]],
         );
     }
@@ -433,14 +433,14 @@ impl<T> Sub for Wrap<T> {
 }
 "#,
             expect![[r#"
-                ta SubTy (Sub)        type SubTy;
-                ta Ty (Super)         type Ty;
-                ct CONST (Super)      const CONST: u8 = 0;
-                fn func() (Super)     fn()
-                me method(…) (Super)  fn(&self)
-                ct C2 (Sub)           const C2: () = ();
-                fn subfunc() (Sub)    fn()
-                me submethod(…) (Sub) fn(&self)
+                ta SubTy (as Sub)        type SubTy;
+                ta Ty (as Super)         type Ty;
+                ct CONST (as Super)      const CONST: u8 = 0;
+                fn func() (as Super)     fn()
+                me method(…) (as Super)  fn(&self)
+                ct C2 (as Sub)           const C2: () = ();
+                fn subfunc() (as Sub)    fn()
+                me submethod(…) (as Sub) fn(&self)
             "#]],
         );
     }

--- a/crates/ide_completion/src/item.rs
+++ b/crates/ide_completion/src/item.rs
@@ -434,10 +434,10 @@ impl Builder {
             if original_path_label.ends_with(&label) {
                 label = original_path_label;
             } else {
-                format_to!(label, " ({})", original_path)
+                format_to!(label, " (use {})", original_path)
             }
         } else if let Some(trait_name) = self.trait_name {
-            format_to!(label, " ({})", trait_name)
+            format_to!(label, " (as {})", trait_name)
         }
 
         let text_edit = match self.text_edit {

--- a/crates/ide_completion/src/render.rs
+++ b/crates/ide_completion/src/render.rs
@@ -1379,7 +1379,7 @@ fn main() {
 "#,
             expect![[r#"
                 sn not [snippet]
-                me not() (ops::Not) [type_could_unify]
+                me not() (use ops::Not) [type_could_unify]
                 sn if []
                 sn while []
                 sn ref []

--- a/crates/ide_completion/src/tests/type_pos.rs
+++ b/crates/ide_completion/src/tests/type_pos.rs
@@ -140,7 +140,7 @@ trait Trait2 {
 fn foo<'lt, T: Trait2<$0>, const CONST_PARAM: usize>(_: T) {}
 "#,
         expect![[r#"
-            ta Foo =  (Trait2) type Foo;
+            ta Foo =  (as Trait2) type Foo;
             tp T
             cp CONST_PARAM
             tt Trait
@@ -151,7 +151,7 @@ fn foo<'lt, T: Trait2<$0>, const CONST_PARAM: usize>(_: T) {}
             md module
             st Unit
             ct CONST
-            ma makro!(…)       macro_rules! makro
+            ma makro!(…)          macro_rules! makro
             bt u32
         "#]],
     );


### PR DESCRIPTION
based on #9478 discussions: showing 'as' before already imported traits and 'use' on auto-import cased

![Screenshot from 2021-07-05 16-54-59](https://user-images.githubusercontent.com/62165556/124471905-b5dcdd80-ddb2-11eb-8852-1d703ef6023f.png)

![Screenshot from 2021-07-05 16-55-20](https://user-images.githubusercontent.com/62165556/124471923-bffedc00-ddb2-11eb-9571-31b8b95499f1.png)


