### PR TITLE
fix: make the logs line buffered

### DIFF
--- a/crates/rust-analyzer/src/bin/logger.rs
+++ b/crates/rust-analyzer/src/bin/logger.rs
@@ -50,8 +50,9 @@ impl Log for Logger {
 
         match &self.file {
             Some(w) => {
+                let mut writer = w.lock();
                 let _ = writeln!(
-                    w.lock(),
+                    writer,
                     "[{} {}] {}",
                     record.level(),
                     record.module_path().unwrap_or_default(),
@@ -59,7 +60,7 @@ impl Log for Logger {
                 );
 
                 if self.no_buffering {
-                    self.flush();
+                    let _ = writer.flush();
                 }
             }
             None => {

--- a/crates/rust-analyzer/src/bin/logger.rs
+++ b/crates/rust-analyzer/src/bin/logger.rs
@@ -48,7 +48,7 @@ impl Log for Logger {
             return;
         }
 
-        let should_flush = match &self.file {
+        match &self.file {
             Some(w) => {
                 let _ = writeln!(
                     w.lock(),
@@ -57,22 +57,21 @@ impl Log for Logger {
                     record.module_path().unwrap_or_default(),
                     record.args(),
                 );
-                self.no_buffering
+
+                if self.no_buffering {
+                    self.flush();
+                }
             }
             None => {
-                eprintln!(
-                    "[{} {}] {}",
+                let message = format!(
+                    "[{} {}] {}\n",
                     record.level(),
                     record.module_path().unwrap_or_default(),
                     record.args(),
                 );
-                true // flush stderr unconditionally
+                eprint!("{}", message);
             }
         };
-
-        if should_flush {
-            self.flush();
-        }
     }
 
     fn flush(&self) {


### PR DESCRIPTION
fixes #9432
Not quite sure if that's what you want, but storing the log message in buffers eliminated the tiny write syscalls for me.
I just changed the Logger struct.