### PR TITLE
fix: Wrap inlined closures in parens when inlined in an expression in `inline_call`

### DIFF
--- a/crates/ide_assists/src/handlers/inline_call.rs
+++ b/crates/ide_assists/src/handlers/inline_call.rs
@@ -17,23 +17,18 @@ use crate::{
 // Inlines a function or method body.
 //
 // ```
-// fn align(a: u32, b: u32) -> u32 {
-//     (a + b - 1) & !(b - 1)
-// }
-// fn main() {
-//     let x = align$0(1, 2);
+// # //- minicore: option
+// fn foo(name: Option<&str>) {
+//     let name = name.unwrap$0();
 // }
 // ```
 // ->
 // ```
-// fn align(a: u32, b: u32) -> u32 {
-//     (a + b - 1) & !(b - 1)
-// }
-// fn main() {
-//     let x = {
-//         let b = 2;
-//         (1 + b - 1) & !(b - 1)
-//     };
+// fn foo(name: Option<&str>) {
+//     let name = match name {
+//             Some(val) => val,
+//             None => panic!("called `Option::unwrap()` on a `None` value"),
+//         };
 // }
 // ```
 pub(crate) fn inline_call(acc: &mut Assists, ctx: &AssistContext) -> Option<()> {

--- a/crates/ide_assists/src/tests/generated.rs
+++ b/crates/ide_assists/src/tests/generated.rs
@@ -923,22 +923,17 @@ fn doctest_inline_call() {
     check_doc_test(
         "inline_call",
         r#####"
-fn align(a: u32, b: u32) -> u32 {
-    (a + b - 1) & !(b - 1)
-}
-fn main() {
-    let x = align$0(1, 2);
+//- minicore: option
+fn foo(name: Option<&str>) {
+    let name = name.unwrap$0();
 }
 "#####,
         r#####"
-fn align(a: u32, b: u32) -> u32 {
-    (a + b - 1) & !(b - 1)
-}
-fn main() {
-    let x = {
-        let b = 2;
-        (1 + b - 1) & !(b - 1)
-    };
+fn foo(name: Option<&str>) {
+    let name = match name {
+            Some(val) => val,
+            None => panic!("called `Option::unwrap()` on a `None` value"),
+        };
 }
 "#####,
     )

--- a/crates/ide_db/src/helpers/insert_use.rs
+++ b/crates/ide_db/src/helpers/insert_use.rs
@@ -1,4 +1,7 @@
 //! Handle syntactic aspects of inserting a new `use`.
+#[cfg(test)]
+mod tests;
+
 use std::cmp::Ordering;
 
 use hir::Semantics;
@@ -378,5 +381,3 @@ fn is_inner_comment(token: SyntaxToken) -> bool {
     ast::Comment::cast(token).and_then(|comment| comment.kind().doc)
         == Some(ast::CommentPlacement::Inner)
 }
-#[cfg(test)]
-mod tests;

--- a/crates/ide_db/src/helpers/insert_use/tests.rs
+++ b/crates/ide_db/src/helpers/insert_use/tests.rs
@@ -14,7 +14,7 @@ fn foo() {$0}
         r#"
 #[cfg(test)]
 fn foo() {
-use bar::Bar;
+    use bar::Bar;
 }
 "#,
         ImportGranularity::Crate,
@@ -32,7 +32,7 @@ const FOO: Bar = {$0};
         r#"
 #[cfg(test)]
 const FOO: Bar = {
-use bar::Bar;
+    use bar::Bar;
 };
 "#,
         ImportGranularity::Crate,

--- a/crates/syntax/src/ted.rs
+++ b/crates/syntax/src/ted.rs
@@ -161,6 +161,14 @@ fn ws_before(position: &Position, new: &SyntaxElement) -> Option<SyntaxToken> {
         }
     }
 
+    if prev.kind() == T!['{'] && ast::Stmt::can_cast(new.kind()) {
+        if let Some(block_expr) = prev.parent().and_then(ast::BlockExpr::cast) {
+            let mut indent = IndentLevel::from_element(&block_expr.syntax().clone().into());
+            indent.0 += 1;
+            return Some(make::tokens::whitespace(&format!("\n{}", indent)));
+        }
+    }
+
     ws_between(prev, new)
 }
 fn ws_after(position: &Position, new: &SyntaxElement) -> Option<SyntaxToken> {
@@ -185,12 +193,6 @@ fn ws_between(left: &SyntaxElement, right: &SyntaxElement) -> Option<SyntaxToken
     }
     if right.kind() == SyntaxKind::GENERIC_ARG_LIST {
         return None;
-    }
-
-    if left.kind() == T!['{'] && right.kind() == SyntaxKind::LET_STMT {
-        let mut indent = IndentLevel::from_element(left);
-        indent.0 += 1;
-        return Some(make::tokens::whitespace(&format!("\n{}", indent)));
     }
 
     if right.kind() == SyntaxKind::USE {

--- a/crates/test_utils/src/minicore.rs
+++ b/crates/test_utils/src/minicore.rs
@@ -330,6 +330,15 @@ pub mod option {
         #[lang = "Some"]
         Some(T),
     }
+
+    impl<T> Option<T> {
+        pub const fn unwrap(self) -> T {
+            match self {
+                Some(val) => val,
+                None => panic!("called `Option::unwrap()` on a `None` value"),
+            }
+        }
+    }
 }
 // endregion:option
 


### PR DESCRIPTION
bors r+