### PR TITLE
Explicitly name all spawned threads

### DIFF
--- a/crates/flycheck/src/lib.rs
+++ b/crates/flycheck/src/lib.rs
@@ -67,7 +67,10 @@ impl FlycheckHandle {
     ) -> FlycheckHandle {
         let actor = FlycheckActor::new(id, sender, config, workspace_root);
         let (sender, receiver) = unbounded::<Restart>();
-        let thread = jod_thread::spawn(move || actor.run(receiver));
+        let thread = jod_thread::Builder::new()
+            .name("FlycheckThread".to_owned())
+            .spawn(move || actor.run(receiver))
+            .expect("failed to spawn thread");
         FlycheckHandle { sender, thread }
     }
 
@@ -266,7 +269,10 @@ impl CargoHandle {
         let child_stdout = child.stdout.take().unwrap();
         let (sender, receiver) = unbounded();
         let actor = CargoActor::new(child_stdout, sender);
-        let thread = jod_thread::spawn(move || actor.run());
+        let thread = jod_thread::Builder::new()
+            .name("CargoHandleThread".to_owned())
+            .spawn(move || actor.run())
+            .expect("failed to spawn thread");
         CargoHandle { child, thread, receiver }
     }
     fn join(mut self) -> io::Result<()> {

--- a/crates/proc_macro_api/src/process.rs
+++ b/crates/proc_macro_api/src/process.rs
@@ -37,9 +37,12 @@ impl ProcMacroProcessSrv {
         let process = Process::run(process_path, args)?;
 
         let (task_tx, task_rx) = bounded(0);
-        let handle = jod_thread::spawn(move || {
-            client_loop(task_rx, process);
-        });
+        let handle = jod_thread::Builder::new()
+            .name("ProcMacroClientThread".to_owned())
+            .spawn(move || {
+                client_loop(task_rx, process);
+            })
+            .expect("failed to spawn thread");
 
         let task_tx = Arc::new(task_tx);
         let srv = ProcMacroProcessSrv { inner: Arc::downgrade(&task_tx) };

--- a/crates/vfs-notify/src/lib.rs
+++ b/crates/vfs-notify/src/lib.rs
@@ -31,7 +31,10 @@ impl loader::Handle for NotifyHandle {
     fn spawn(sender: loader::Sender) -> NotifyHandle {
         let actor = NotifyActor::new(sender);
         let (sender, receiver) = unbounded::<Message>();
-        let thread = jod_thread::spawn(move || actor.run(receiver));
+        let thread = jod_thread::Builder::new()
+            .name("LoaderThread".to_owned())
+            .spawn(move || actor.run(receiver))
+            .expect("failed to spawn thread");
         NotifyHandle { sender, thread }
     }
     fn set_config(&mut self, config: loader::Config) {


### PR DESCRIPTION
Fixes: [#9385](https://github.com/rust-analyzer/rust-analyzer/issues/9385)

The thread name is shown in debugger as well as panic messages and this
patch makes it easier to follow a thread instead of looking through
full backtrace, by naming all spawned threads according to their
functioning.