### PR TITLE
Shorten thread names

### DIFF
--- a/crates/flycheck/src/lib.rs
+++ b/crates/flycheck/src/lib.rs
@@ -68,7 +68,7 @@ impl FlycheckHandle {
         let actor = FlycheckActor::new(id, sender, config, workspace_root);
         let (sender, receiver) = unbounded::<Restart>();
         let thread = jod_thread::Builder::new()
-            .name("FlycheckThread".to_owned())
+            .name("Flycheck".to_owned())
             .spawn(move || actor.run(receiver))
             .expect("failed to spawn thread");
         FlycheckHandle { sender, thread }
@@ -270,7 +270,7 @@ impl CargoHandle {
         let (sender, receiver) = unbounded();
         let actor = CargoActor::new(child_stdout, sender);
         let thread = jod_thread::Builder::new()
-            .name("CargoHandleThread".to_owned())
+            .name("CargoHandle".to_owned())
             .spawn(move || actor.run())
             .expect("failed to spawn thread");
         CargoHandle { child, thread, receiver }

--- a/crates/proc_macro_api/src/process.rs
+++ b/crates/proc_macro_api/src/process.rs
@@ -38,7 +38,7 @@ impl ProcMacroProcessSrv {
 
         let (task_tx, task_rx) = bounded(0);
         let handle = jod_thread::Builder::new()
-            .name("ProcMacroClientThread".to_owned())
+            .name("ProcMacroClient".to_owned())
             .spawn(move || {
                 client_loop(task_rx, process);
             })

--- a/crates/proc_macro_srv/src/proc_macro/bridge/server.rs
+++ b/crates/proc_macro_srv/src/proc_macro/bridge/server.rs
@@ -182,7 +182,7 @@ impl ExecutionStrategy for CrossThread1 {
         let (res_tx, res_rx) = channel();
 
         let join_handle = thread::Builder::new()
-            .name("DispatchThread".to_owned())
+            .name("Dispatch".to_owned())
             .spawn(move || {
                 let mut dispatch = |b| {
                     req_tx.send(b).unwrap();
@@ -231,7 +231,7 @@ impl ExecutionStrategy for CrossThread2 {
         let server_thread = thread::current();
         let state2 = state.clone();
         let join_handle = thread::Builder::new()
-            .name("ServerThread".to_owned())
+            .name("ProcMacroServer".to_owned())
             .spawn(move || {
                 let mut dispatch = |b| {
                     *state2.lock().unwrap() = State::Req(b);

--- a/crates/vfs-notify/src/lib.rs
+++ b/crates/vfs-notify/src/lib.rs
@@ -32,7 +32,7 @@ impl loader::Handle for NotifyHandle {
         let actor = NotifyActor::new(sender);
         let (sender, receiver) = unbounded::<Message>();
         let thread = jod_thread::Builder::new()
-            .name("LoaderThread".to_owned())
+            .name("VfsLoader".to_owned())
             .spawn(move || actor.run(receiver))
             .expect("failed to spawn thread");
         NotifyHandle { sender, thread }


### PR DESCRIPTION
Threads on Linux have an upper limit of 16 characters, hence dropping `Thread` from their names.