### PR TITLE
internal: remove proc macro management thread

### DIFF
--- a/crates/proc_macro_api/src/lib.rs
+++ b/crates/proc_macro_api/src/lib.rs
@@ -20,7 +20,7 @@ use std::{
 
 use tt::{SmolStr, Subtree};
 
-use crate::process::{ProcMacroProcessSrv, ProcMacroProcessThread};
+use crate::process::ProcMacroProcessSrv;
 
 pub use rpc::{ExpansionResult, ExpansionTask, ListMacrosResult, ListMacrosTask, ProcMacroKind};
 pub use version::{read_dylib_info, RustCInfo};
@@ -64,16 +64,16 @@ impl base_db::ProcMacroExpander for ProcMacroProcessExpander {
 #[derive(Debug)]
 pub struct ProcMacroClient {
     process: Arc<ProcMacroProcessSrv>,
-    thread: ProcMacroProcessThread,
 }
 
 impl ProcMacroClient {
+    /// Spawns an external process as the proc macro server and returns a client connected to it.
     pub fn extern_process(
         process_path: PathBuf,
         args: impl IntoIterator<Item = impl AsRef<OsStr>>,
     ) -> io::Result<ProcMacroClient> {
-        let (thread, process) = ProcMacroProcessSrv::run(process_path, args)?;
-        Ok(ProcMacroClient { process: Arc::new(process), thread })
+        let process = ProcMacroProcessSrv::run(process_path, args)?;
+        Ok(ProcMacroClient { process: Arc::new(process) })
     }
 
     pub fn by_dylib_path(&self, dylib_path: &Path) -> Vec<ProcMacro> {

--- a/crates/proc_macro_api/src/lib.rs
+++ b/crates/proc_macro_api/src/lib.rs
@@ -15,7 +15,7 @@ use std::{
     ffi::OsStr,
     io,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
 use tt::{SmolStr, Subtree};
@@ -27,7 +27,7 @@ pub use version::{read_dylib_info, RustCInfo};
 
 #[derive(Debug, Clone)]
 struct ProcMacroProcessExpander {
-    process: Arc<ProcMacroProcessSrv>,
+    process: Arc<Mutex<ProcMacroProcessSrv>>,
     dylib_path: PathBuf,
     name: SmolStr,
 }
@@ -56,14 +56,24 @@ impl base_db::ProcMacroExpander for ProcMacroProcessExpander {
             env: env.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect(),
         };
 
-        let result: ExpansionResult = self.process.send_task(msg::Request::ExpansionMacro(task))?;
+        let result: ExpansionResult = self
+            .process
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .send_task(msg::Request::ExpansionMacro(task))?;
         Ok(result.expansion)
     }
 }
 
 #[derive(Debug)]
 pub struct ProcMacroClient {
-    process: Arc<ProcMacroProcessSrv>,
+    /// Currently, the proc macro process expands all procedural macros sequentially.
+    ///
+    /// That means that concurrent salsa requests may block each other when expanding proc macros,
+    /// which is unfortunate, but simple and good enough for the time being.
+    ///
+    /// Therefore, we just wrap the `ProcMacroProcessSrv` in a mutex here.
+    process: Arc<Mutex<ProcMacroProcessSrv>>,
 }
 
 impl ProcMacroClient {
@@ -73,7 +83,7 @@ impl ProcMacroClient {
         args: impl IntoIterator<Item = impl AsRef<OsStr>>,
     ) -> io::Result<ProcMacroClient> {
         let process = ProcMacroProcessSrv::run(process_path, args)?;
-        Ok(ProcMacroClient { process: Arc::new(process) })
+        Ok(ProcMacroClient { process: Arc::new(Mutex::new(process)) })
     }
 
     pub fn by_dylib_path(&self, dylib_path: &Path) -> Vec<ProcMacro> {
@@ -93,7 +103,12 @@ impl ProcMacroClient {
             }
         }
 
-        let macros = match self.process.find_proc_macros(dylib_path) {
+        let macros = match self
+            .process
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .find_proc_macros(dylib_path)
+        {
             Err(err) => {
                 eprintln!("Failed to find proc macros. Error: {:#?}", err);
                 return vec![];

--- a/crates/proc_macro_api/src/process.rs
+++ b/crates/proc_macro_api/src/process.rs
@@ -3,13 +3,13 @@
 use std::{
     convert::{TryFrom, TryInto},
     ffi::{OsStr, OsString},
+    fmt,
     io::{self, BufRead, BufReader, Write},
     path::{Path, PathBuf},
-    process::{Child, Command, Stdio},
-    sync::{Arc, Weak},
+    process::{Child, ChildStdin, ChildStdout, Command, Stdio},
+    sync::Mutex,
 };
 
-use crossbeam_channel::{bounded, Receiver, Sender};
 use stdx::JodChild;
 
 use crate::{
@@ -17,38 +17,31 @@ use crate::{
     rpc::{ListMacrosResult, ListMacrosTask, ProcMacroKind},
 };
 
-#[derive(Debug, Default)]
 pub(crate) struct ProcMacroProcessSrv {
-    inner: Weak<Sender<Task>>,
+    process: Mutex<Process>,
+    stdio: Mutex<(ChildStdin, BufReader<ChildStdout>)>,
 }
 
-#[derive(Debug)]
-pub(crate) struct ProcMacroProcessThread {
-    // XXX: drop order is significant
-    sender: Arc<Sender<Task>>,
-    handle: jod_thread::JoinHandle<()>,
+impl fmt::Debug for ProcMacroProcessSrv {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProcMacroProcessSrv").field("process", &self.process).finish()
+    }
 }
 
 impl ProcMacroProcessSrv {
     pub(crate) fn run(
         process_path: PathBuf,
         args: impl IntoIterator<Item = impl AsRef<OsStr>>,
-    ) -> io::Result<(ProcMacroProcessThread, ProcMacroProcessSrv)> {
-        let process = Process::run(process_path, args)?;
+    ) -> io::Result<ProcMacroProcessSrv> {
+        let mut process = Process::run(process_path, args)?;
+        let (stdin, stdout) = process.stdio().expect("couldn't access child stdio");
 
-        let (task_tx, task_rx) = bounded(0);
-        let handle = jod_thread::Builder::new()
-            .name("ProcMacroClient".to_owned())
-            .spawn(move || {
-                client_loop(task_rx, process);
-            })
-            .expect("failed to spawn thread");
+        let srv = ProcMacroProcessSrv {
+            process: Mutex::new(process),
+            stdio: Mutex::new((stdin, stdout)),
+        };
 
-        let task_tx = Arc::new(task_tx);
-        let srv = ProcMacroProcessSrv { inner: Arc::downgrade(&task_tx) };
-        let thread = ProcMacroProcessThread { handle, sender: task_tx };
-
-        Ok((thread, srv))
+        Ok(srv)
     }
 
     pub(crate) fn find_proc_macros(
@@ -65,18 +58,27 @@ impl ProcMacroProcessSrv {
     where
         R: TryFrom<Response, Error = &'static str>,
     {
-        let (result_tx, result_rx) = bounded(0);
-        let sender = match self.inner.upgrade() {
-            None => return Err(tt::ExpansionError::Unknown("proc macro process is closed".into())),
-            Some(it) => it,
-        };
-        sender
-            .send(Task { req, result_tx })
-            .map_err(|_| tt::ExpansionError::Unknown("proc macro server crashed".into()))?;
+        let mut guard = self.stdio.lock().unwrap_or_else(|e| e.into_inner());
+        let stdio = &mut *guard;
+        let (stdin, stdout) = (&mut stdio.0, &mut stdio.1);
 
-        let res = result_rx
-            .recv()
-            .map_err(|_| tt::ExpansionError::Unknown("proc macro server crashed".into()))?;
+        let mut buf = String::new();
+        let res = match send_request(stdin, stdout, req, &mut buf) {
+            Ok(res) => res,
+            Err(err) => {
+                let mut process = self.process.lock().unwrap_or_else(|e| e.into_inner());
+                log::error!(
+                    "proc macro server crashed, server process state: {:?}, server request error: {:?}",
+                    process.child.try_wait(),
+                    err
+                );
+                let res = Response::Error(ResponseError {
+                    code: ErrorCode::ServerErrorEnd,
+                    message: "proc macro server crashed".into(),
+                });
+                Some(res)
+            }
+        };
 
         match res {
             Some(Response::Error(err)) => Err(tt::ExpansionError::ExpansionError(err.message)),
@@ -88,37 +90,7 @@ impl ProcMacroProcessSrv {
     }
 }
 
-fn client_loop(task_rx: Receiver<Task>, mut process: Process) {
-    let (mut stdin, mut stdout) = process.stdio().expect("couldn't access child stdio");
-
-    let mut buf = String::new();
-
-    for Task { req, result_tx } in task_rx {
-        match send_request(&mut stdin, &mut stdout, req, &mut buf) {
-            Ok(res) => result_tx.send(res).unwrap(),
-            Err(err) => {
-                log::error!(
-                    "proc macro server crashed, server process state: {:?}, server request error: {:?}",
-                    process.child.try_wait(),
-                    err
-                );
-                let res = Response::Error(ResponseError {
-                    code: ErrorCode::ServerErrorEnd,
-                    message: "proc macro server crashed".into(),
-                });
-                result_tx.send(res.into()).unwrap();
-                // Exit the thread.
-                break;
-            }
-        }
-    }
-}
-
-struct Task {
-    req: Request,
-    result_tx: Sender<Option<Response>>,
-}
-
+#[derive(Debug)]
 struct Process {
     child: JodChild,
 }
@@ -133,7 +105,7 @@ impl Process {
         Ok(Process { child })
     }
 
-    fn stdio(&mut self) -> Option<(impl Write, impl BufRead)> {
+    fn stdio(&mut self) -> Option<(ChildStdin, BufReader<ChildStdout>)> {
         let stdin = self.child.stdin.take()?;
         let stdout = self.child.stdout.take()?;
         let read = BufReader::new(stdout);

--- a/crates/proc_macro_api/src/process.rs
+++ b/crates/proc_macro_api/src/process.rs
@@ -3,7 +3,6 @@
 use std::{
     convert::{TryFrom, TryInto},
     ffi::{OsStr, OsString},
-    fmt,
     io::{self, BufRead, BufReader, Write},
     path::{Path, PathBuf},
     process::{Child, ChildStdin, ChildStdout, Command, Stdio},
@@ -17,15 +16,10 @@ use crate::{
     rpc::{ListMacrosResult, ListMacrosTask, ProcMacroKind},
 };
 
+#[derive(Debug)]
 pub(crate) struct ProcMacroProcessSrv {
     process: Mutex<Process>,
     stdio: Mutex<(ChildStdin, BufReader<ChildStdout>)>,
-}
-
-impl fmt::Debug for ProcMacroProcessSrv {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ProcMacroProcessSrv").field("process", &self.process).finish()
-    }
 }
 
 impl ProcMacroProcessSrv {

--- a/crates/stdx/src/lib.rs
+++ b/crates/stdx/src/lib.rs
@@ -111,6 +111,7 @@ pub fn defer<F: FnOnce()>(f: F) -> impl Drop {
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), repr(transparent))]
+#[derive(Debug)]
 pub struct JodChild(pub std::process::Child);
 
 impl ops::Deref for JodChild {


### PR DESCRIPTION
Communication with the proc macro server process has always happened one request at a time, so the additional thread isn't really needed (it just forwarded each request, and sent back the response). This removes some indirection that was a bit hard to understand (a channel was allocated and sent over another channel to return the response).

Hope I'm not missing anything here