### PR TITLE
Represent opaque types with TyKind::OpaqueType

### DIFF
--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -384,7 +384,8 @@ impl HirDisplay for Ty {
                     &TyKind::Alias(AliasTy::Opaque(OpaqueTy {
                         opaque_ty_id,
                         substitution: ref parameters,
-                    })) => {
+                    }))
+                    | &TyKind::OpaqueType(opaque_ty_id, ref parameters) => {
                         let impl_trait_id = f.db.lookup_intern_impl_trait_id(opaque_ty_id.into());
                         if let ImplTraitId::ReturnTypeImplTrait(func, idx) = impl_trait_id {
                             datas =

--- a/crates/hir_ty/src/interner.rs
+++ b/crates/hir_ty/src/interner.rs
@@ -93,7 +93,13 @@ impl chalk_ir::interner::Interner for Interner {
         alias: &chalk_ir::AliasTy<Interner>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Option<fmt::Result> {
-        tls::with_current_program(|prog| Some(prog?.debug_alias(alias, fmt)))
+        use std::fmt::Debug;
+        match alias {
+            chalk_ir::AliasTy::Projection(projection_ty) => {
+                Interner::debug_projection_ty(projection_ty, fmt)
+            }
+            chalk_ir::AliasTy::Opaque(opaque_ty) => Some(opaque_ty.fmt(fmt)),
+        }
     }
 
     fn debug_projection_ty(
@@ -114,7 +120,7 @@ impl chalk_ir::interner::Interner for Interner {
         opaque_ty_id: chalk_ir::OpaqueTyId<Self>,
         fmt: &mut fmt::Formatter<'_>,
     ) -> Option<fmt::Result> {
-        Some(fmt.debug_struct("OpaqueTyId").field("index", &opaque_ty_id.0).finish())
+        Some(write!(fmt, "OpaqueTy#{}", opaque_ty_id.0))
     }
 
     fn debug_ty(ty: &chalk_ir::Ty<Interner>, fmt: &mut fmt::Formatter<'_>) -> Option<fmt::Result> {

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -38,7 +38,7 @@ use crate::{
         all_super_trait_refs, associated_type_by_name_including_super_traits, generics, Generics,
     },
     AliasEq, AliasTy, Binders, BoundVar, CallableSig, DebruijnIndex, DynTy, FnPointer, FnSig,
-    FnSubst, ImplTraitId, Interner, OpaqueTy, PolyFnSig, ProjectionTy, QuantifiedWhereClause,
+    FnSubst, ImplTraitId, Interner, PolyFnSig, ProjectionTy, QuantifiedWhereClause,
     QuantifiedWhereClauses, ReturnTypeImplTrait, ReturnTypeImplTraits, Substitution,
     TraitEnvironment, TraitRef, TraitRefExt, Ty, TyBuilder, TyKind, WhereClause,
 };
@@ -250,11 +250,7 @@ impl<'a> TyLoweringContext<'a> {
                         let opaque_ty_id = self.db.intern_impl_trait_id(impl_trait_id).into();
                         let generics = generics(self.db.upcast(), func.into());
                         let parameters = generics.bound_vars_subst(self.in_binders);
-                        TyKind::Alias(AliasTy::Opaque(OpaqueTy {
-                            opaque_ty_id,
-                            substitution: parameters,
-                        }))
-                        .intern(&Interner)
+                        TyKind::OpaqueType(opaque_ty_id, parameters).intern(&Interner)
                     }
                     ImplTraitLoweringMode::Param => {
                         let idx = self.impl_trait_counter.get();

--- a/crates/hir_ty/src/tests/regression.rs
+++ b/crates/hir_ty/src/tests/regression.rs
@@ -1058,3 +1058,22 @@ fn cfg_tail() {
         "#]],
     )
 }
+
+#[test]
+fn impl_trait_in_option_9530() {
+    check_types(
+        r#"
+struct Option<T>;
+impl<T> Option<T> {
+    fn unwrap(self) -> T { loop {} }
+}
+fn make() -> Option<impl Copy> { Option }
+trait Copy {}
+fn test() {
+    let o = make();
+    o.unwrap();
+  //^^^^^^^^^^ impl Copy
+}
+        "#,
+    )
+}

--- a/crates/hir_ty/src/tls.rs
+++ b/crates/hir_ty/src/tls.rs
@@ -1,7 +1,6 @@
 //! Implementation of Chalk debug helper functions using TLS.
-use std::fmt::{self, Debug};
+use std::fmt;
 
-use chalk_ir::AliasTy;
 use itertools::Itertools;
 
 use crate::{
@@ -51,17 +50,6 @@ impl DebugContext<'_> {
         };
         let trait_data = self.0.trait_data(trait_);
         write!(fmt, "{}::{}", trait_data.name, type_alias_data.name)
-    }
-
-    pub(crate) fn debug_alias(
-        &self,
-        alias_ty: &AliasTy<Interner>,
-        fmt: &mut fmt::Formatter<'_>,
-    ) -> Result<(), fmt::Error> {
-        match alias_ty {
-            AliasTy::Projection(projection_ty) => self.debug_projection_ty(projection_ty, fmt),
-            AliasTy::Opaque(opaque_ty) => opaque_ty.fmt(fmt),
-        }
     }
 
     pub(crate) fn debug_projection_ty(


### PR DESCRIPTION
... instead of using `AliasTy`. Chalk turns the alias type into the
placeholder during unification anyway, which confuses our method
resolution logic.

Fixes #9530.