### PR TITLE
cargo_metadata 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,14 +126,13 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "081e3f0755c1f380c2d010481b6fa2e02973586d5f2b24eebb7a2a1d98b143d8"
+checksum = "c297bd3135f558552f99a0daa180876984ea2c4ffa7470314540dff8c654109a"
 dependencies = [
  "camino",
  "cargo-platform",
  "semver",
- "semver-parser",
  "serde",
  "serde_json",
 ]
@@ -770,9 +769,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.97"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "libloading"
@@ -1070,15 +1069,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pest"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
-dependencies = [
- "ucd-trie",
-]
-
-[[package]]
 name = "petgraph"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1179,7 +1169,6 @@ dependencies = [
  "base_db",
  "cargo_metadata",
  "cfg",
- "itertools",
  "la-arena",
  "log",
  "paths",
@@ -1425,21 +1414,11 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "0.11.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
 dependencies = [
- "semver-parser",
  "serde",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
 ]
 
 [[package]]
@@ -1778,12 +1757,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ucd-trie"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
-
-[[package]]
 name = "ungrammar"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1818,9 +1791,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-xid"

--- a/crates/flycheck/Cargo.toml
+++ b/crates/flycheck/Cargo.toml
@@ -11,7 +11,7 @@ doctest = false
 [dependencies]
 crossbeam-channel = "0.5.0"
 log = "0.4.8"
-cargo_metadata = "0.13"
+cargo_metadata = "0.14"
 serde = { version = "1.0.106", features = ["derive"] }
 serde_json = "1.0.48"
 jod-thread = "0.1.1"

--- a/crates/proc_macro_srv/Cargo.toml
+++ b/crates/proc_macro_srv/Cargo.toml
@@ -20,7 +20,7 @@ proc_macro_api = { path = "../proc_macro_api", version = "0.0.0" }
 [dev-dependencies]
 test_utils = { path = "../test_utils" }
 toolchain = { path = "../toolchain" }
-cargo_metadata = "0.13"
+cargo_metadata = "0.14"
 expect-test = "1.1.0"
 
 # used as proc macro test targets

--- a/crates/proc_macro_test/Cargo.toml
+++ b/crates/proc_macro_test/Cargo.toml
@@ -11,4 +11,4 @@ doctest = false
 [build-dependencies]
 proc_macro_test_impl = { path = "imp", version = "0.0.0" }
 toolchain = { path = "../toolchain", version = "0.0.0" }
-cargo_metadata = "0.13"
+cargo_metadata = "0.14"

--- a/crates/project_model/Cargo.toml
+++ b/crates/project_model/Cargo.toml
@@ -11,11 +11,10 @@ doctest = false
 [dependencies]
 log = "0.4.8"
 rustc-hash = "1.1.0"
-cargo_metadata = "0.13"
+cargo_metadata = "0.14"
 serde = { version = "1.0.106", features = ["derive"] }
 serde_json = "1.0.48"
 anyhow = "1.0.26"
-itertools = "0.10.0"
 la-arena = { version = "0.2.0", path = "../../lib/arena" }
 
 cfg = { path = "../cfg", version = "0.0.0" }

--- a/crates/project_model/src/build_data.rs
+++ b/crates/project_model/src/build_data.rs
@@ -9,7 +9,6 @@ use std::{
 use anyhow::Result;
 use cargo_metadata::camino::Utf8Path;
 use cargo_metadata::{BuildScript, Message};
-use itertools::Itertools;
 use paths::{AbsPath, AbsPathBuf};
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
@@ -304,9 +303,7 @@ fn inject_cargo_env(package: &cargo_metadata::Package, build_data: &mut PackageB
     env.push(("CARGO_PKG_VERSION_MAJOR".into(), package.version.major.to_string()));
     env.push(("CARGO_PKG_VERSION_MINOR".into(), package.version.minor.to_string()));
     env.push(("CARGO_PKG_VERSION_PATCH".into(), package.version.patch.to_string()));
-
-    let pre = package.version.pre.iter().map(|id| id.to_string()).format(".");
-    env.push(("CARGO_PKG_VERSION_PRE".into(), pre.to_string()));
+    env.push(("CARGO_PKG_VERSION_PRE".into(), package.version.pre.to_string()));
 
     let authors = package.authors.join(";");
     env.push(("CARGO_PKG_AUTHORS".into(), authors));


### PR DESCRIPTION
Removes the following dependent crates:
* semver-parser
* pest
* ucd-trie

Removes project_model's dependency on itertools