### PR TITLE
minor: Disambiguate replace with if let assist labels

### DIFF
--- a/crates/ide_assists/src/handlers/replace_if_let_with_match.rs
+++ b/crates/ide_assists/src/handlers/replace_if_let_with_match.rs
@@ -82,7 +82,7 @@ pub(crate) fn replace_if_let_with_match(acc: &mut Assists, ctx: &AssistContext) 
     let target = if_expr.syntax().text_range();
     acc.add(
         AssistId("replace_if_let_with_match", AssistKind::RefactorRewrite),
-        "Replace with match",
+        "Replace if let with match",
         target,
         move |edit| {
             let match_expr = {
@@ -195,7 +195,7 @@ pub(crate) fn replace_match_with_if_let(acc: &mut Assists, ctx: &AssistContext) 
     let target = match_expr.syntax().text_range();
     acc.add(
         AssistId("replace_match_with_if_let", AssistKind::RefactorRewrite),
-        "Replace with if let",
+        "Replace match with if let",
         target,
         move |edit| {
             let condition = make::condition(scrutinee, Some(if_let_pat));

--- a/crates/ide_assists/src/handlers/replace_let_with_if_let.rs
+++ b/crates/ide_assists/src/handlers/replace_let_with_if_let.rs
@@ -14,7 +14,7 @@ use crate::{AssistContext, AssistId, AssistKind, Assists};
 
 // Assist: replace_let_with_if_let
 //
-// Replaces `let` with an `if-let`.
+// Replaces `let` with an `if let`.
 //
 // ```
 // # enum Option<T> { Some(T), None }
@@ -45,7 +45,7 @@ pub(crate) fn replace_let_with_if_let(acc: &mut Assists, ctx: &AssistContext) ->
     let target = let_kw.text_range();
     acc.add(
         AssistId("replace_let_with_if_let", AssistKind::RefactorRewrite),
-        "Replace with if-let",
+        "Replace let with if let",
         target,
         |edit| {
             let ty = ctx.sema.type_of_expr(&init);

--- a/crates/ide_assists/src/tests.rs
+++ b/crates/ide_assists/src/tests.rs
@@ -246,7 +246,7 @@ pub fn test_some_range(a: int) -> bool {
         Convert integer base
         Extract into variable
         Extract into function
-        Replace with match
+        Replace if let with match
     "#]]
     .assert_eq(&expected);
 }
@@ -275,7 +275,7 @@ pub fn test_some_range(a: int) -> bool {
             Convert integer base
             Extract into variable
             Extract into function
-            Replace with match
+            Replace if let with match
         "#]]
         .assert_eq(&expected);
     }


### PR DESCRIPTION
Turns out we have two assists for replacing something with `if let` constructs, so having the cursor on a `let` keyword inside a match gave you two identical assist labels which is rather confusing.
bors r+