### PR TITLE
Do not erase Cargo diagnostics from the closed documents

### DIFF
--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -633,11 +633,9 @@ impl GlobalState {
                 Ok(())
             })?
             .on::<lsp_types::notification::DidCloseTextDocument>(|this, params| {
-                let mut version = None;
                 if let Ok(path) = from_proto::vfs_path(&params.text_document.uri) {
-                    match this.mem_docs.remove(&path) {
-                        Some(doc) => version = Some(doc.version),
-                        None => log::error!("orphan DidCloseTextDocument: {}", path),
+                    if this.mem_docs.remove(&path).is_none() {
+                        log::error!("orphan DidCloseTextDocument: {}", path);
                     }
 
                     this.semantic_tokens_cache.lock().remove(&params.text_document.uri);
@@ -646,17 +644,6 @@ impl GlobalState {
                         this.loader.handle.invalidate(path.to_path_buf());
                     }
                 }
-
-                // Clear the diagnostics for the previously known version of the file.
-                // This prevents stale "cargo check" diagnostics if the file is
-                // closed, "cargo check" is run and then the file is reopened.
-                this.send_notification::<lsp_types::notification::PublishDiagnostics>(
-                    lsp_types::PublishDiagnosticsParams {
-                        uri: params.text_document.uri,
-                        diagnostics: Vec::new(),
-                        version,
-                    },
-                );
                 Ok(())
             })?
             .on::<lsp_types::notification::DidSaveTextDocument>(|this, params| {


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/6850

The LSP specification at https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#textDocument_publishDiagnostics states that


> Diagnostics notification are sent from the server to the client to signal results of validation runs.
> 
> Diagnostics are “owned” by the server so it is the server’s responsibility to clear them if necessary. The following rule is used for VS Code servers that generate diagnostics:
> 
>  *  if a language is single file only (for example HTML) then diagnostics are cleared by the server when the file is closed.
>  *  if a language has a project system (for example C#) diagnostics are not cleared when a file closes. When a project is opened all diagnostics for all files are recomputed (or read from a cache).
> 
> When a file changes it is the server’s responsibility to re-compute diagnostics and push them to the client. If the computed set is empty it has to push the empty array to clear former diagnostics. Newly pushed diagnostics always replace previously pushed diagnostics. There is no merging that happens on the client side.


So for projects we should not clear any diagnostics from cargo/json projects.
Our "standalone file" mode is in a way a project too, with sysroot attached and a potential support for dynamic standalone files.