### PR TITLE
feat: add 'for' postfix completion

### DIFF
--- a/crates/ide_completion/src/completions/postfix.rs
+++ b/crates/ide_completion/src/completions/postfix.rs
@@ -2,7 +2,10 @@
 
 mod format_like;
 
-use ide_db::{helpers::SnippetCap, ty_filter::TryEnum};
+use ide_db::{
+    helpers::{FamousDefs, SnippetCap},
+    ty_filter::TryEnum,
+};
 use syntax::{
     ast::{self, AstNode, AstToken},
     SyntaxKind::{BLOCK_EXPR, EXPR_STMT},
@@ -110,6 +113,18 @@ pub(crate) fn complete_postfix(acc: &mut Completions, ctx: &CompletionContext) {
         .add_to(acc);
         postfix_snippet(ctx, cap, dot_receiver, "not", "!expr", &format!("!{}", receiver_text))
             .add_to(acc);
+    } else if let Some(trait_) = FamousDefs(&ctx.sema, ctx.krate).core_iter_IntoIterator() {
+        if receiver_ty.impls_trait(ctx.db, trait_, &[]) {
+            postfix_snippet(
+                ctx,
+                cap,
+                dot_receiver,
+                "for",
+                "for ele in expr {}",
+                &format!("for ele in {} {{\n    $0\n}}", receiver_text),
+            )
+            .add_to(acc);
+        }
     }
 
     postfix_snippet(ctx, cap, dot_receiver, "ref", "&expr", &format!("&{}", receiver_text))

--- a/crates/ide_db/src/helpers.rs
+++ b/crates/ide_db/src/helpers.rs
@@ -134,6 +134,10 @@ impl FamousDefs<'_, '_> {
         self.find_trait("core:iter:traits:iterator:Iterator")
     }
 
+    pub fn core_iter_IntoIterator(&self) -> Option<Trait> {
+        self.find_trait("core:iter:traits:collect:IntoIterator")
+    }
+
     pub fn core_iter(&self) -> Option<Module> {
         self.find_module("core:iter")
     }


### PR DESCRIPTION

![Peek 2021-07-11 16-45](https://user-images.githubusercontent.com/62165556/125194692-a0aaf780-e267-11eb-952a-81de7955d9a1.gif)


adds #9561

used ```ele``` as identifier for each element in the iteration