### PR TITLE
internal: Explicitly check for reference locals or fields in Name classification

### DIFF
--- a/crates/ide/src/doc_links.rs
+++ b/crates/ide/src/doc_links.rs
@@ -112,8 +112,8 @@ pub(crate) fn external_docs(
     let node = token.parent()?;
     let definition = match_ast! {
         match node {
-            ast::NameRef(name_ref) => NameRefClass::classify(&sema, &name_ref).map(|d| d.referenced())?,
-            ast::Name(name) => NameClass::classify(&sema, &name).map(|d| d.referenced_or_defined())?,
+            ast::NameRef(name_ref) => NameRefClass::classify(&sema, &name_ref).map(|d| d.referenced_field())?,
+            ast::Name(name) => NameClass::classify(&sema, &name).map(|d| d.defined_or_referenced_field())?,
             _ => return None,
         }
     };

--- a/crates/ide/src/fixture.rs
+++ b/crates/ide/src/fixture.rs
@@ -51,11 +51,3 @@ pub(crate) fn annotations(ra_fixture: &str) -> (Analysis, FilePosition, Vec<(Fil
         .collect();
     (host.analysis(), FilePosition { file_id, offset }, annotations)
 }
-
-pub(crate) fn nav_target_annotation(ra_fixture: &str) -> (Analysis, FilePosition, FileRange) {
-    let (analysis, position, mut annotations) = annotations(ra_fixture);
-    let (expected, data) = annotations.pop().unwrap();
-    assert!(annotations.is_empty());
-    assert_eq!(data, "");
-    (analysis, position, expected)
-}

--- a/crates/ide/src/goto_declaration.rs
+++ b/crates/ide/src/goto_declaration.rs
@@ -25,10 +25,10 @@ pub(crate) fn goto_declaration(
         match parent {
             ast::NameRef(name_ref) => {
                 let name_kind = NameRefClass::classify(&sema, &name_ref)?;
-                name_kind.referenced()
+                name_kind.referenced_local()
             },
             ast::Name(name) => {
-                NameClass::classify(&sema, &name)?.referenced_or_defined()
+                NameClass::classify(&sema, &name)?.defined_or_referenced_local()
             },
             _ => return None,
         }

--- a/crates/ide/src/goto_declaration.rs
+++ b/crates/ide/src/goto_declaration.rs
@@ -24,36 +24,35 @@ pub(crate) fn goto_declaration(
     let def = match_ast! {
         match parent {
             ast::NameRef(name_ref) => match NameRefClass::classify(&sema, &name_ref)? {
-                NameRefClass::Definition(def) => def,
-                NameRefClass::FieldShorthand { local_ref, field_ref: _ } => {
-                    Definition::Local(local_ref)
-                }
+                NameRefClass::Definition(it) => Some(it),
+                _ => None
             },
             ast::Name(name) => match NameClass::classify(&sema, &name)? {
-                NameClass::Definition(it) | NameClass::ConstReference(it) => it,
-                NameClass::PatFieldShorthand { local_def, field_ref: _ } => Definition::Local(local_def),
+                NameClass::Definition(it) => Some(it),
+                _ => None
             },
-            _ => return None,
+            _ => None,
         }
     };
-    match def {
+    match def? {
         Definition::ModuleDef(hir::ModuleDef::Module(module)) => Some(RangeInfo::new(
             original_token.text_range(),
             vec![NavigationTarget::from_module_to_decl(db, module)],
         )),
-        _ => return None,
+        _ => None,
     }
 }
 
 #[cfg(test)]
 mod tests {
     use ide_db::base_db::FileRange;
+    use itertools::Itertools;
 
     use crate::fixture;
 
     fn check(ra_fixture: &str) {
-        let (analysis, position, expected) = fixture::nav_target_annotation(ra_fixture);
-        let mut navs = analysis
+        let (analysis, position, expected) = fixture::annotations(ra_fixture);
+        let navs = analysis
             .goto_declaration(position)
             .unwrap()
             .expect("no declaration or definition found")
@@ -61,10 +60,19 @@ mod tests {
         if navs.len() == 0 {
             panic!("unresolved reference")
         }
-        assert_eq!(navs.len(), 1);
 
-        let nav = navs.pop().unwrap();
-        assert_eq!(expected, FileRange { file_id: nav.file_id, range: nav.focus_or_full_range() });
+        let cmp = |&FileRange { file_id, range }: &_| (file_id, range.start());
+        let navs = navs
+            .into_iter()
+            .map(|nav| FileRange { file_id: nav.file_id, range: nav.focus_or_full_range() })
+            .sorted_by_key(cmp)
+            .collect::<Vec<_>>();
+        let expected = expected
+            .into_iter()
+            .map(|(FileRange { file_id, range }, _)| FileRange { file_id, range })
+            .sorted_by_key(cmp)
+            .collect::<Vec<_>>();
+        assert_eq!(expected, navs);
     }
 
     #[test]

--- a/crates/ide/src/goto_implementation.rs
+++ b/crates/ide/src/goto_implementation.rs
@@ -29,10 +29,10 @@ pub(crate) fn goto_implementation(
     let node = sema.find_node_at_offset_with_descend(&syntax, position.offset)?;
     let def = match &node {
         ast::NameLike::Name(name) => {
-            NameClass::classify(&sema, name).map(|class| class.referenced_or_defined())
+            NameClass::classify(&sema, name).map(|class| class.defined_or_referenced_local())
         }
         ast::NameLike::NameRef(name_ref) => {
-            NameRefClass::classify(&sema, name_ref).map(|class| class.referenced())
+            NameRefClass::classify(&sema, name_ref).map(|class| class.referenced_local())
         }
         ast::NameLike::Lifetime(_) => None,
     }?;

--- a/crates/ide/src/goto_implementation.rs
+++ b/crates/ide/src/goto_implementation.rs
@@ -28,11 +28,19 @@ pub(crate) fn goto_implementation(
 
     let node = sema.find_node_at_offset_with_descend(&syntax, position.offset)?;
     let def = match &node {
-        ast::NameLike::Name(name) => {
-            NameClass::classify(&sema, name).map(|class| class.defined_or_referenced_local())
-        }
+        ast::NameLike::Name(name) => NameClass::classify(&sema, name).map(|class| match class {
+            NameClass::Definition(it) | NameClass::ConstReference(it) => it,
+            NameClass::PatFieldShorthand { local_def, field_ref: _ } => {
+                Definition::Local(local_def)
+            }
+        }),
         ast::NameLike::NameRef(name_ref) => {
-            NameRefClass::classify(&sema, name_ref).map(|class| class.referenced_local())
+            NameRefClass::classify(&sema, name_ref).map(|class| match class {
+                NameRefClass::Definition(def) => def,
+                NameRefClass::FieldShorthand { local_ref, field_ref: _ } => {
+                    Definition::Local(local_ref)
+                }
+            })
         }
         ast::NameLike::Lifetime(_) => None,
     }?;

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -96,12 +96,21 @@ pub(crate) fn hover(
         match node {
             // we don't use NameClass::referenced_or_defined here as we do not want to resolve
             // field pattern shorthands to their definition
-            ast::Name(name) => NameClass::classify(&sema, &name).map(|class| class.defined_or_referenced_local()),
-            ast::NameRef(name_ref) => {
-                NameRefClass::classify(&sema, &name_ref).map(|d| d.referenced_field())
-            },
+            ast::Name(name) => NameClass::classify(&sema, &name).map(|class| match class {
+                NameClass::Definition(it) | NameClass::ConstReference(it) => it,
+                NameClass::PatFieldShorthand { local_def, field_ref: _ } => Definition::Local(local_def),
+            }),
+            ast::NameRef(name_ref) => NameRefClass::classify(&sema, &name_ref).map(|class| match class {
+                NameRefClass::Definition(def) => def,
+                NameRefClass::FieldShorthand { local_ref: _, field_ref } => {
+                    Definition::Field(field_ref)
+                }
+            }),
             ast::Lifetime(lifetime) => NameClass::classify_lifetime(&sema, &lifetime).map_or_else(
-                || NameRefClass::classify_lifetime(&sema, &lifetime).map(|d| d.referenced_local()),
+                || NameRefClass::classify_lifetime(&sema, &lifetime).and_then(|class| match class {
+                    NameRefClass::Definition(it) => Some(it),
+                    _ => None,
+                }),
                 |d| d.defined(),
             ),
             _ => {

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -96,18 +96,14 @@ pub(crate) fn hover(
         match node {
             // we don't use NameClass::referenced_or_defined here as we do not want to resolve
             // field pattern shorthands to their definition
-            ast::Name(name) => NameClass::classify(&sema, &name).and_then(|class| match class {
-                NameClass::ConstReference(def) => Some(def),
-                def => def.defined(),
-            }),
+            ast::Name(name) => NameClass::classify(&sema, &name).map(|class| class.defined_or_referenced_local()),
             ast::NameRef(name_ref) => {
-                NameRefClass::classify(&sema, &name_ref).map(|d| d.referenced())
+                NameRefClass::classify(&sema, &name_ref).map(|d| d.referenced_field())
             },
             ast::Lifetime(lifetime) => NameClass::classify_lifetime(&sema, &lifetime).map_or_else(
-                || NameRefClass::classify_lifetime(&sema, &lifetime).map(|d| d.referenced()),
+                || NameRefClass::classify_lifetime(&sema, &lifetime).map(|d| d.referenced_local()),
                 |d| d.defined(),
             ),
-
             _ => {
                 if ast::Comment::cast(token.clone()).is_some() {
                     cov_mark::hit!(no_highlight_on_comment_hover);

--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -108,11 +108,11 @@ fn find_definition(
             bail!("Renaming aliases is currently unsupported")
         }
         ast::NameLike::Name(name) => {
-            NameClass::classify(sema, &name).map(|class| class.referenced_or_defined())
+            NameClass::classify(sema, &name).map(|class| class.defined_or_referenced_local())
         }
         ast::NameLike::NameRef(name_ref) => {
             if let Some(def) =
-                NameRefClass::classify(sema, &name_ref).map(|class| class.referenced())
+                NameRefClass::classify(sema, &name_ref).map(|class| class.referenced_local())
             {
                 // if the name differs from the definitions name it has to be an alias
                 if def.name(sema.db).map_or(false, |it| it.to_string() != name_ref.text()) {
@@ -124,9 +124,10 @@ fn find_definition(
             }
         }
         ast::NameLike::Lifetime(lifetime) => NameRefClass::classify_lifetime(sema, &lifetime)
-            .map(|class| class.referenced())
+            .map(|class| class.referenced_local())
             .or_else(|| {
-                NameClass::classify_lifetime(sema, &lifetime).map(|it| it.referenced_or_defined())
+                NameClass::classify_lifetime(sema, &lifetime)
+                    .map(|it| it.defined_or_referenced_field())
             }),
     }
     .ok_or_else(|| format_err!("No references found at position"))?;

--- a/crates/ide/src/syntax_highlighting/highlight.rs
+++ b/crates/ide/src/syntax_highlighting/highlight.rs
@@ -58,10 +58,8 @@ pub(super) fn element(
                 Some(NameClass::ConstReference(def)) => highlight_def(db, krate, def),
                 Some(NameClass::PatFieldShorthand { field_ref, .. }) => {
                     let mut h = HlTag::Symbol(SymbolKind::Field).into();
-                    if let Definition::Field(field) = field_ref {
-                        if let hir::VariantDef::Union(_) = field.parent_def(db) {
-                            h |= HlMod::Unsafe;
-                        }
+                    if let hir::VariantDef::Union(_) = field_ref.parent_def(db) {
+                        h |= HlMod::Unsafe;
                     }
                     h
                 }

--- a/crates/ide_assists/src/handlers/extract_function.rs
+++ b/crates/ide_assists/src/handlers/extract_function.rs
@@ -638,7 +638,12 @@ fn vars_used_in_body(ctx: &AssistContext, body: &FunctionBody) -> Vec<Local> {
     body.descendants()
         .filter_map(ast::NameRef::cast)
         .filter_map(|name_ref| NameRefClass::classify(&ctx.sema, &name_ref))
-        .map(|name_kind| name_kind.referenced_local())
+        .map(|name_kind| match name_kind {
+            NameRefClass::Definition(def) => def,
+            NameRefClass::FieldShorthand { local_ref, field_ref: _ } => {
+                Definition::Local(local_ref)
+            }
+        })
         .filter_map(|definition| match definition {
             Definition::Local(local) => Some(local),
             _ => None,

--- a/crates/ide_assists/src/handlers/extract_function.rs
+++ b/crates/ide_assists/src/handlers/extract_function.rs
@@ -638,7 +638,7 @@ fn vars_used_in_body(ctx: &AssistContext, body: &FunctionBody) -> Vec<Local> {
     body.descendants()
         .filter_map(ast::NameRef::cast)
         .filter_map(|name_ref| NameRefClass::classify(&ctx.sema, &name_ref))
-        .map(|name_kind| name_kind.referenced())
+        .map(|name_kind| name_kind.referenced_local())
         .filter_map(|definition| match definition {
             Definition::Local(local) => Some(local),
             _ => None,

--- a/crates/ide_db/src/search.rs
+++ b/crates/ide_db/src/search.rs
@@ -550,6 +550,7 @@ impl<'a> FindUsages<'a> {
                 }
             }
             Some(NameRefClass::FieldShorthand { local_ref: local, field_ref: field }) => {
+                let field = Definition::Field(field);
                 let FileRange { file_id, range } = self.sema.original_range(name_ref.syntax());
                 let access = match self.def {
                     Definition::Field(_) if field == self.def => reference_access(&field, name_ref),
@@ -574,7 +575,7 @@ impl<'a> FindUsages<'a> {
         match NameClass::classify(self.sema, name) {
             Some(NameClass::PatFieldShorthand { local_def: _, field_ref })
                 if matches!(
-                    self.def, Definition::Field(_) if field_ref == self.def
+                    self.def, Definition::Field(_) if Definition::Field(field_ref) == self.def
                 ) =>
             {
                 let FileRange { file_id, range } = self.sema.original_range(name.syntax());


### PR DESCRIPTION
Closes #7524
Inlines all the calls to reference related name classification as well as emits both goto definition targets for field shorthands.