### PR TITLE
Show test mod runnable in outline modules

### DIFF
--- a/crates/rust-analyzer/tests/slow-tests/main.rs
+++ b/crates/rust-analyzer/tests/slow-tests/main.rs
@@ -135,6 +135,49 @@ fn main() {}
           },
           {
             "args": {
+              "overrideCargo": null,
+              "workspaceRoot": server.path().join("foo"),
+              "cargoArgs": [
+                "test",
+                "--package",
+                "foo",
+                "--test",
+                "spam"
+              ],
+              "cargoExtraArgs": [],
+              "executableArgs": [
+                "",
+                "--nocapture"
+              ]
+            },
+            "kind": "cargo",
+            "label": "test-mod ",
+            "location": {
+              "targetUri": "file:///[..]/tests/spam.rs",
+              "targetRange": {
+                "start": {
+                  "line": 0,
+                  "character": 0
+                },
+                "end": {
+                  "line": 3,
+                  "character": 0
+                }
+              },
+              "targetSelectionRange": {
+                "start": {
+                  "line": 0,
+                  "character": 0
+                },
+                "end": {
+                  "line": 3,
+                  "character": 0
+                }
+              }
+            },
+          },
+          {
+            "args": {
               "cargoArgs": ["check", "--package", "foo", "--all-targets"],
               "executableArgs": [],
               "cargoExtraArgs": [],


### PR DESCRIPTION
This shows a runnable inside outline test modules at the top of its file:
![image](https://user-images.githubusercontent.com/3757771/125494747-169c9238-3faa-4eed-9700-90bd730b4e3c.png)
