### PR TITLE
Implement serialization and deserialization of `change` object

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,6 +516,7 @@ dependencies = [
  "parser",
  "profile",
  "rustc-hash",
+ "serde",
  "syntax",
  "test_utils",
  "tt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,7 @@ dependencies = [
  "expect-test",
  "mbe",
  "rustc-hash",
+ "serde",
  "syntax",
  "tt",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,6 +1837,7 @@ dependencies = [
  "indexmap",
  "paths",
  "rustc-hash",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,7 @@ dependencies = [
  "profile",
  "rustc-hash",
  "salsa",
+ "serde",
  "stdx",
  "syntax",
  "test_utils",

--- a/crates/base_db/Cargo.toml
+++ b/crates/base_db/Cargo.toml
@@ -19,3 +19,4 @@ tt = { path = "../tt", version = "0.0.0" }
 test_utils = { path = "../test_utils", version = "0.0.0" }
 vfs = { path = "../vfs", version = "0.0.0" }
 stdx = { path = "../stdx", version = "0.0.0" }
+serde = { version = "1.0.106", features = ["derive", "rc"] } 

--- a/crates/base_db/src/change.rs
+++ b/crates/base_db/src/change.rs
@@ -10,7 +10,7 @@ use vfs::FileId;
 use crate::{CrateGraph, SourceDatabaseExt, SourceRoot, SourceRootId};
 
 /// Encapsulate a bunch of raw `.set` calls on the database.
-#[derive(Default)]
+#[derive(serde::Serialize, serde::Deserialize, Default, PartialEq, Eq)]
 pub struct Change {
     pub roots: Option<Vec<SourceRoot>>,
     pub files_changed: Vec<(FileId, Option<Arc<String>>)>,

--- a/crates/base_db/src/change.rs
+++ b/crates/base_db/src/change.rs
@@ -3,14 +3,14 @@
 
 use std::{fmt, sync::Arc};
 
+use crate::{CrateGraph, SourceDatabaseExt, SourceRoot, SourceRootId};
 use rustc_hash::FxHashSet;
 use salsa::Durability;
+use serde::{Deserialize, Serialize};
 use vfs::FileId;
 
-use crate::{CrateGraph, SourceDatabaseExt, SourceRoot, SourceRootId};
-
 /// Encapsulate a bunch of raw `.set` calls on the database.
-#[derive(serde::Serialize, serde::Deserialize, Default, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct Change {
     pub roots: Option<Vec<SourceRoot>>,
     pub files_changed: Vec<(FileId, Option<Arc<String>>)>,

--- a/crates/base_db/src/input.rs
+++ b/crates/base_db/src/input.rs
@@ -10,10 +10,10 @@ use std::{fmt, iter::FromIterator, ops, panic::RefUnwindSafe, str::FromStr, sync
 
 use cfg::CfgOptions;
 use rustc_hash::{FxHashMap, FxHashSet};
+use serde::{ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer};
 use syntax::SmolStr;
 use tt::{ExpansionError, Subtree};
 use vfs::{file_set::FileSet, FileId, VfsPath};
-use serde::{Deserialize, Deserializer, Serialize, Serializer, ser::SerializeStruct};
 
 /// Files are grouped into source roots. A source root is a directory on the
 /// file systems which is watched for changes. Typically it corresponds to a
@@ -238,9 +238,7 @@ pub struct CrateData {
     pub proc_macro: Vec<ProcMacro>,
 }
 
-#[derive(
-    Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash,
-)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Edition {
     Edition2015,
     Edition2018,

--- a/crates/base_db/src/input.rs
+++ b/crates/base_db/src/input.rs
@@ -89,11 +89,11 @@ impl<'de> serde::Deserialize<'de> for CrateId {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
-        {
-            let s: &str = serde::Deserialize::deserialize(deserializer)?;
-            let id = s.parse::<u32>().unwrap();
-            Ok(CrateId(id))
-        }
+    {
+        let s: &str = serde::Deserialize::deserialize(deserializer)?;
+        let id = s.parse::<u32>().unwrap();
+        Ok(CrateId(id))
+    }
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/base_db/src/input.rs
+++ b/crates/base_db/src/input.rs
@@ -205,7 +205,7 @@ impl Serialize for ProcMacro {
 }
 
 impl<'de> Deserialize<'de> for ProcMacro {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    fn deserialize<D>(_deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {

--- a/crates/cfg/Cargo.toml
+++ b/crates/cfg/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 
 [dependencies]
 rustc-hash = "1.1.0"
+serde = { version = "1.0.106", features = ["derive"] }
 
 tt = { path = "../tt", version = "0.0.0" }
 

--- a/crates/cfg/src/cfg_expr.rs
+++ b/crates/cfg/src/cfg_expr.rs
@@ -4,12 +4,11 @@
 
 use std::{fmt, slice::Iter as SliceIter};
 
+use serde::{Deserialize, Serialize};
 use tt::SmolStr;
 
 /// A simple configuration value passed in from the outside.
-#[derive(
-    serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd,
-)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub enum CfgAtom {
     /// eg. `#[cfg(test)]`
     Flag(SmolStr),

--- a/crates/cfg/src/cfg_expr.rs
+++ b/crates/cfg/src/cfg_expr.rs
@@ -7,7 +7,9 @@ use std::{fmt, slice::Iter as SliceIter};
 use tt::SmolStr;
 
 /// A simple configuration value passed in from the outside.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
+#[derive(
+    serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd,
+)]
 pub enum CfgAtom {
     /// eg. `#[cfg(test)]`
     Flag(SmolStr),

--- a/crates/cfg/src/lib.rs
+++ b/crates/cfg/src/lib.rs
@@ -8,7 +8,7 @@ mod tests;
 use std::fmt;
 
 use rustc_hash::FxHashSet;
-use serde;
+use serde::{Deserialize, Serialize};
 use tt::SmolStr;
 
 pub use cfg_expr::{CfgAtom, CfgExpr};
@@ -24,7 +24,7 @@ pub use dnf::DnfExpr;
 /// of key and value in `key_values`.
 ///
 /// See: <https://doc.rust-lang.org/reference/conditional-compilation.html#set-configuration-options>
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
 pub struct CfgOptions {
     enabled: FxHashSet<CfgAtom>,
 }

--- a/crates/cfg/src/lib.rs
+++ b/crates/cfg/src/lib.rs
@@ -8,6 +8,7 @@ mod tests;
 use std::fmt;
 
 use rustc_hash::FxHashSet;
+use serde;
 use tt::SmolStr;
 
 pub use cfg_expr::{CfgAtom, CfgExpr};
@@ -23,7 +24,7 @@ pub use dnf::DnfExpr;
 /// of key and value in `key_values`.
 ///
 /// See: <https://doc.rust-lang.org/reference/conditional-compilation.html#set-configuration-options>
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Default)]
 pub struct CfgOptions {
     enabled: FxHashSet<CfgAtom>,
 }

--- a/crates/hir_expand/Cargo.toml
+++ b/crates/hir_expand/Cargo.toml
@@ -21,6 +21,7 @@ parser = { path = "../parser", version = "0.0.0" }
 profile = { path = "../profile", version = "0.0.0" }
 tt = { path = "../tt", version = "0.0.0" }
 mbe = { path = "../mbe", version = "0.0.0" }
+serde = { version = "1.0.106", features = ["derive"] }
 
 [dev-dependencies]
 test_utils = { path = "../test_utils" }

--- a/crates/hir_expand/src/proc_macro.rs
+++ b/crates/hir_expand/src/proc_macro.rs
@@ -3,7 +3,7 @@
 use crate::db::AstDatabase;
 use base_db::{CrateId, ProcMacroId};
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct ProcMacroExpander {
     krate: CrateId,
     proc_macro_id: Option<ProcMacroId>,

--- a/crates/hir_expand/src/proc_macro.rs
+++ b/crates/hir_expand/src/proc_macro.rs
@@ -2,8 +2,9 @@
 
 use crate::db::AstDatabase;
 use base_db::{CrateId, ProcMacroId};
+use serde::{Deserialize, Serialize};
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct ProcMacroExpander {
     krate: CrateId,
     proc_macro_id: Option<ProcMacroId>,

--- a/crates/paths/Cargo.toml
+++ b/crates/paths/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2018"
 doctest = false
 
 [dependencies]
-serde = "1"
+serde = { version = "1.0", features = ["derive"] }

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -11,7 +11,7 @@ use std::{
 
 /// Wrapper around an absolute [`PathBuf`].
 #[derive(
-    serde::Serialize, serde::Deserialize, Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash,
+    Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash,
 )]
 pub struct AbsPathBuf(PathBuf);
 

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -10,9 +10,7 @@ use std::{
 };
 
 /// Wrapper around an absolute [`PathBuf`].
-#[derive(
-    Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash,
-)]
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct AbsPathBuf(PathBuf);
 
 impl From<AbsPathBuf> for PathBuf {

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -1,6 +1,5 @@
 //! Thin wrappers around `std::path`, distinguishing between absolute and
 //! relative paths.
-use serde;
 use std::{
     borrow::Borrow,
     convert::{TryFrom, TryInto},
@@ -8,6 +7,8 @@ use std::{
     ops,
     path::{Component, Path, PathBuf},
 };
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Wrapper around an absolute [`PathBuf`].
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
@@ -67,19 +68,19 @@ impl PartialEq<AbsPath> for AbsPathBuf {
     }
 }
 
-impl serde::Serialize for AbsPathBuf {
+impl Serialize for AbsPathBuf {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: Serializer,
     {
         self.0.serialize(serializer)
     }
 }
 
-impl<'de> serde::Deserialize<'de> for AbsPathBuf {
+impl<'de> Deserialize<'de> for AbsPathBuf {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: Deserializer<'de>,
     {
         let path = PathBuf::deserialize(deserializer)?;
         AbsPathBuf::try_from(path).map_err(|path| {

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -1,5 +1,6 @@
 //! Thin wrappers around `std::path`, distinguishing between absolute and
 //! relative paths.
+use serde;
 use std::{
     borrow::Borrow,
     convert::{TryFrom, TryInto},
@@ -9,7 +10,9 @@ use std::{
 };
 
 /// Wrapper around an absolute [`PathBuf`].
-#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+#[derive(
+    serde::Serialize, serde::Deserialize, Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash,
+)]
 pub struct AbsPathBuf(PathBuf);
 
 impl From<AbsPathBuf> for PathBuf {

--- a/crates/rust-analyzer/src/bin/flags.rs
+++ b/crates/rust-analyzer/src/bin/flags.rs
@@ -100,7 +100,7 @@ xflags::xflags! {
 
         cmd proc-macro {}
 
-        cmd create-json
+        cmd json-change
             /// Directory with Cargo.toml.
             required path: PathBuf
         {}
@@ -131,7 +131,7 @@ pub enum RustAnalyzerCmd {
     Ssr(Ssr),
     Search(Search),
     ProcMacro(ProcMacro),
-    CreateJson(CreateJson),
+    JsonChange(JsonChange),
 }
 
 #[derive(Debug)]
@@ -201,7 +201,7 @@ impl RustAnalyzer {
 }
 
 #[derive(Debug)]
-pub struct CreateJson {
+pub struct JsonChange {
     pub path: PathBuf,
 }
 

--- a/crates/rust-analyzer/src/bin/flags.rs
+++ b/crates/rust-analyzer/src/bin/flags.rs
@@ -99,6 +99,11 @@ xflags::xflags! {
         }
 
         cmd proc-macro {}
+
+        cmd create-json
+            /// Directory with Cargo.toml.
+            required path: PathBuf
+        {}
     }
 }
 
@@ -126,6 +131,7 @@ pub enum RustAnalyzerCmd {
     Ssr(Ssr),
     Search(Search),
     ProcMacro(ProcMacro),
+    CreateJson(CreateJson),
 }
 
 #[derive(Debug)]
@@ -193,6 +199,12 @@ impl RustAnalyzer {
         Self::from_env_()
     }
 }
+
+#[derive(Debug)]
+pub struct CreateJson {
+    pub path: PathBuf,
+}
+
 // generated end
 
 impl RustAnalyzer {

--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -10,7 +10,7 @@ use std::{convert::TryFrom, env, fs, path::Path, process};
 use lsp_server::Connection;
 use project_model::ProjectManifest;
 use rust_analyzer::{
-    cli::{self, AnalysisStatsCmd, CreateJsonCmd},
+    cli::{self, AnalysisStatsCmd, JsonChangeCmd},
     config::Config,
     from_json,
     lsp_ext::supports_utf8,
@@ -109,7 +109,7 @@ fn try_main() -> Result<()> {
         }
         flags::RustAnalyzerCmd::Ssr(cmd) => cli::apply_ssr_rules(cmd.rule)?,
         flags::RustAnalyzerCmd::Search(cmd) => cli::search_for_patterns(cmd.pattern, cmd.debug)?,
-        flags::RustAnalyzerCmd::CreateJson(cmd) => CreateJsonCmd {}.run(&cmd.path)?,
+        flags::RustAnalyzerCmd::JsonChange(cmd) => JsonChangeCmd {}.run(&cmd.path)?,
     }
     Ok(())
 }

--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -10,7 +10,7 @@ use std::{convert::TryFrom, env, fs, path::Path, process};
 use lsp_server::Connection;
 use project_model::ProjectManifest;
 use rust_analyzer::{
-    cli::{self, AnalysisStatsCmd},
+    cli::{self, AnalysisStatsCmd, CreateJsonCmd},
     config::Config,
     from_json,
     lsp_ext::supports_utf8,
@@ -109,6 +109,7 @@ fn try_main() -> Result<()> {
         }
         flags::RustAnalyzerCmd::Ssr(cmd) => cli::apply_ssr_rules(cmd.rule)?,
         flags::RustAnalyzerCmd::Search(cmd) => cli::search_for_patterns(cmd.pattern, cmd.debug)?,
+        flags::RustAnalyzerCmd::CreateJson(cmd) => CreateJsonCmd {}.run(&cmd.path)?,
     }
     Ok(())
 }

--- a/crates/rust-analyzer/src/cli.rs
+++ b/crates/rust-analyzer/src/cli.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod load_cargo;
 mod analysis_stats;
+mod create_json;
 mod diagnostics;
 mod progress_report;
 mod ssr;
@@ -15,6 +16,7 @@ use vfs::Vfs;
 
 pub use self::{
     analysis_stats::AnalysisStatsCmd,
+    create_json::CreateJsonCmd,
     diagnostics::diagnostics,
     ssr::{apply_ssr_rules, search_for_patterns},
 };

--- a/crates/rust-analyzer/src/cli.rs
+++ b/crates/rust-analyzer/src/cli.rs
@@ -2,7 +2,7 @@
 
 pub(crate) mod load_cargo;
 mod analysis_stats;
-mod create_json;
+mod json_change;
 mod diagnostics;
 mod progress_report;
 mod ssr;
@@ -16,8 +16,8 @@ use vfs::Vfs;
 
 pub use self::{
     analysis_stats::AnalysisStatsCmd,
-    create_json::CreateJsonCmd,
     diagnostics::diagnostics,
+    json_change::JsonChangeCmd,
     ssr::{apply_ssr_rules, search_for_patterns},
 };
 

--- a/crates/rust-analyzer/src/cli/create_json.rs
+++ b/crates/rust-analyzer/src/cli/create_json.rs
@@ -1,0 +1,204 @@
+//! Fully type-check project and print various stats, like the number of type
+//! errors.
+
+use crossbeam_channel::{unbounded, Receiver};
+use ide::Change;
+use ide_db::base_db::CrateGraph;
+use project_model::{
+    BuildDataCollector, CargoConfig, ProcMacroClient, ProjectManifest, ProjectWorkspace,
+};
+use std::{path::Path, sync::Arc};
+
+use crate::cli::{load_cargo::LoadCargoConfig, Result};
+
+use crate::reload::{ProjectFolders, SourceRootConfig};
+
+use vfs::{loader::Handle, AbsPath, AbsPathBuf};
+
+pub struct CreateJsonCmd {}
+
+impl CreateJsonCmd {
+    /// Execute with e.g.
+    /// ```no_compile
+    /// cargo run --bin rust-analyzer create-json ../ink/examples/flipper/Cargo.toml
+    /// ```
+    pub fn run(self, root: &Path) -> Result<()> {
+        
+
+        let (_crate_graph, change) = get_crate_data(root, &|_| {})?;
+
+        // let (_, change2) = get_crate_data(root, &|_| {})?;
+
+        // let _json =
+        //    serde_json::to_string(&crate_graph).expect("serialization of crate_graph must work");
+        
+
+        let json =
+            serde_json::to_string(&change).expect("serialization of change must work");
+            /* 
+        _let deserialized_change: Change = serde_json::from_str(&json).expect("`Change` deserialization must work");
+        // let json = str::replace(&json,  "'","@@@"); 
+        let file_id = FileId(182);
+        let mut host = AnalysisHost::new(None);
+        host.apply_change(deserialized_change);
+        let analysis = host.analysis();
+        println!("getting status");
+        let status = analysis.status(Some(file_id)).unwrap();
+        println!("{}", status);
+        let _config = DiagnosticsConfig::default();
+        let _highlights: Vec<_> = analysis
+            .highlight(file_id)
+            .unwrap()
+            .into_iter()
+            .collect();
+        // let _highlights = analysis.highlight(file_id);
+        */
+        
+        println!("{}", json);
+      
+        /*  let mut host = AnalysisHost::new(None);
+        host.apply_change(change);
+        let analysis = host.analysis();
+        let file_id = FileId(0);
+        */
+        // let _highlights = analysis.highlight(file_id);
+        // println!("{}", json);
+ 
+        
+
+        // let deserialized_change: Change = serde_json::from_str(&json).expect("`Change` deserialization must work");
+
+
+        // println!("change_json:\n{}", change_json);
+
+        // deserialize from json string
+        /*
+        let deserialized_crate_graph: CrateGraph =
+            serde_json::from_str(&json).expect("deserialization must work");
+        assert_eq!(
+            crate_graph, deserialized_crate_graph,
+            "Deserialized `CrateGraph` is not equal!"
+        );
+        */
+
+        // Missing: Create a new `Change` object.
+        //
+        // `serde::Serialize` and `serde::Deserialize` are already supported by `Change`.
+        // So this should work out of the box after the object has been created:
+        //
+        // ```
+        // let json = serde_json::to_string(&change).expect("`Change` serialization must work");
+        // println!("change json:\n{}", json);
+        // let deserialized_change: Change = serde_json::from_str(&json).expect("`Change` deserialization must work");
+        // assert_eq!(change.roots, deserialized_change.roots, "Deserialized `Change.roots` is not equal!");
+        // assert_eq!(change.files_changed, deserialized_change.files_changed, "Deserialized `Change.roots` is not equal!");
+        // ```
+
+        Ok(())
+    }
+}
+
+fn get_crate_data(
+    root: &Path,
+    progress: &dyn Fn(String),
+) -> Result<(CrateGraph, Change)> {
+    let mut cargo_config = CargoConfig::default();
+    cargo_config.no_sysroot = false;
+    let root = AbsPathBuf::assert(std::env::current_dir()?.join(root));
+
+    let root = AbsPath::assert(&root);
+    let root = ProjectManifest::discover_single(root)?;
+    let ws = ProjectWorkspace::load(root, &cargo_config, &|_| {})?;
+
+    let config = LoadCargoConfig {
+        load_out_dirs_from_check: true,
+        wrap_rustc: true,
+        with_proc_macro: false,
+        prefill_caches: false,
+    };
+    let (sender, receiver) = unbounded();
+    let mut vfs = vfs::Vfs::default();
+    let mut loader = {
+        let loader =
+            vfs_notify::NotifyHandle::spawn(Box::new(move |msg| sender.send(msg).unwrap()));
+        Box::new(loader)
+    };
+
+    let proc_macro_client = if config.with_proc_macro {
+        let path = std::env::current_exe()?;
+        Some(ProcMacroClient::extern_process(path, &["proc-macro"]).unwrap())
+    } else {
+        None
+    };
+
+    let build_data = if config.load_out_dirs_from_check {
+        let mut collector = BuildDataCollector::new(config.wrap_rustc);
+        ws.collect_build_data_configs(&mut collector);
+        Some(collector.collect(progress)?)
+    } else {
+        None
+    };
+
+    let crate_graph = ws.to_crate_graph(
+        build_data.as_ref(),
+        proc_macro_client.as_ref(),
+        &mut |path: &AbsPath| {
+            let contents = loader.load_sync(path);
+            let path = vfs::VfsPath::from(path.to_path_buf());
+            vfs.set_file_contents(path.clone(), contents);
+            vfs.file_id(&path)
+        },
+    );
+
+    let project_folders = ProjectFolders::new(&[ws], &[], build_data.as_ref());
+    loader.set_config(vfs::loader::Config {
+        load: project_folders.load,
+        watch: vec![],
+        version: 0,
+    });
+
+    let change =
+        get_change(crate_graph.clone(), project_folders.source_root_config, &mut vfs, &receiver);
+
+    Ok((crate_graph, change))
+}
+
+fn get_change(
+    crate_graph: CrateGraph,
+    source_root_config: SourceRootConfig,
+    vfs: &mut vfs::Vfs,
+    receiver: &Receiver<vfs::loader::Message>,
+) -> Change {
+    let mut analysis_change = Change::new();
+
+    // wait until Vfs has loaded all roots
+    for task in receiver {
+        match task {
+            vfs::loader::Message::Progress { n_done, n_total, config_version: _ } => {
+                if n_done == n_total {
+                    break;
+                }
+            }
+            vfs::loader::Message::Loaded { files } => {
+                for (path, contents) in files {
+                    vfs.set_file_contents(path.into(), contents);
+                }
+            }
+        }
+    }
+    let changes = vfs.take_changes();
+    for file in changes {
+        if file.exists() {
+            let contents = vfs.file_contents(file.file_id).to_vec();
+            if let Ok(text) = String::from_utf8(contents) {
+                analysis_change.change_file(file.file_id, Some(Arc::new(text)))
+            }
+        }
+    }
+    let source_roots = source_root_config.partition(&vfs);
+    analysis_change.set_roots(source_roots);
+
+    analysis_change.set_crate_graph(crate_graph);
+
+    analysis_change
+}

--- a/crates/rust-analyzer/src/cli/create_json.rs
+++ b/crates/rust-analyzer/src/cli/create_json.rs
@@ -15,6 +15,8 @@ use crate::reload::{ProjectFolders, SourceRootConfig};
 
 use vfs::{loader::Handle, AbsPath, AbsPathBuf};
 
+use std::fs;
+
 pub struct CreateJsonCmd {}
 
 impl CreateJsonCmd {
@@ -23,7 +25,7 @@ impl CreateJsonCmd {
     /// cargo run --bin rust-analyzer create-json ../ink/examples/flipper/Cargo.toml
     /// ```
     pub fn run(self, root: &Path) -> Result<()> {
-        let (_crate_graph, change) = get_crate_data(root, &|_| {})?;
+        let change = get_crate_data(root, &|_| {})?;
 
         // let (_, change2) = get_crate_data(root, &|_| {})?;
 
@@ -50,7 +52,9 @@ impl CreateJsonCmd {
         // let _highlights = analysis.highlight(file_id);
         */
 
-        println!("{}", json);
+        fs::write("./change.json", json).expect("Unable to write file");
+
+        // println!("{}", json);
 
         /*  let mut host = AnalysisHost::new(None);
         host.apply_change(change);
@@ -91,7 +95,7 @@ impl CreateJsonCmd {
     }
 }
 
-fn get_crate_data(root: &Path, progress: &dyn Fn(String)) -> Result<(CrateGraph, Change)> {
+fn get_crate_data(root: &Path, progress: &dyn Fn(String)) -> Result<Change> {
     let mut cargo_config = CargoConfig::default();
     cargo_config.no_sysroot = false;
     let root = AbsPathBuf::assert(std::env::current_dir()?.join(root));
@@ -150,7 +154,7 @@ fn get_crate_data(root: &Path, progress: &dyn Fn(String)) -> Result<(CrateGraph,
     let change =
         get_change(crate_graph.clone(), project_folders.source_root_config, &mut vfs, &receiver);
 
-    Ok((crate_graph, change))
+    Ok(change)
 }
 
 fn get_change(
@@ -192,3 +196,6 @@ fn get_change(
 
     analysis_change
 }
+
+
+

--- a/crates/rust-analyzer/src/cli/create_json.rs
+++ b/crates/rust-analyzer/src/cli/create_json.rs
@@ -21,7 +21,7 @@ impl CreateJsonCmd {
     /// cargo run --bin rust-analyzer create-json ../ink/examples/flipper/Cargo.toml
     /// ```
     pub fn run(self, root: &Path) -> Result<()> {
-        let change = get_crate_data(root, &|_| {})?;
+        let change = get_change_data(root, &|_| {})?;
 
         // let (_, change2) = get_crate_data(root, &|_| {})?;
 
@@ -91,7 +91,7 @@ impl CreateJsonCmd {
     }
 }
 
-fn get_crate_data(root: &Path, progress: &dyn Fn(String)) -> Result<Change> {
+fn get_change_data(root: &Path, progress: &dyn Fn(String)) -> Result<Change> {
     let mut cargo_config = CargoConfig::default();
     cargo_config.no_sysroot = false;
     let root = AbsPathBuf::assert(std::env::current_dir()?.join(root));

--- a/crates/rust-analyzer/src/cli/create_json.rs
+++ b/crates/rust-analyzer/src/cli/create_json.rs
@@ -23,21 +23,17 @@ impl CreateJsonCmd {
     /// cargo run --bin rust-analyzer create-json ../ink/examples/flipper/Cargo.toml
     /// ```
     pub fn run(self, root: &Path) -> Result<()> {
-        
-
         let (_crate_graph, change) = get_crate_data(root, &|_| {})?;
 
         // let (_, change2) = get_crate_data(root, &|_| {})?;
 
         // let _json =
         //    serde_json::to_string(&crate_graph).expect("serialization of crate_graph must work");
-        
 
-        let json =
-            serde_json::to_string(&change).expect("serialization of change must work");
-            /* 
+        let json = serde_json::to_string(&change).expect("serialization of change must work");
+        /*
         _let deserialized_change: Change = serde_json::from_str(&json).expect("`Change` deserialization must work");
-        // let json = str::replace(&json,  "'","@@@"); 
+        // let json = str::replace(&json,  "'","@@@");
         let file_id = FileId(182);
         let mut host = AnalysisHost::new(None);
         host.apply_change(deserialized_change);
@@ -53,9 +49,9 @@ impl CreateJsonCmd {
             .collect();
         // let _highlights = analysis.highlight(file_id);
         */
-        
+
         println!("{}", json);
-      
+
         /*  let mut host = AnalysisHost::new(None);
         host.apply_change(change);
         let analysis = host.analysis();
@@ -63,11 +59,8 @@ impl CreateJsonCmd {
         */
         // let _highlights = analysis.highlight(file_id);
         // println!("{}", json);
- 
-        
 
         // let deserialized_change: Change = serde_json::from_str(&json).expect("`Change` deserialization must work");
-
 
         // println!("change_json:\n{}", change_json);
 
@@ -98,10 +91,7 @@ impl CreateJsonCmd {
     }
 }
 
-fn get_crate_data(
-    root: &Path,
-    progress: &dyn Fn(String),
-) -> Result<(CrateGraph, Change)> {
+fn get_crate_data(root: &Path, progress: &dyn Fn(String)) -> Result<(CrateGraph, Change)> {
     let mut cargo_config = CargoConfig::default();
     cargo_config.no_sysroot = false;
     let root = AbsPathBuf::assert(std::env::current_dir()?.join(root));

--- a/crates/rust-analyzer/src/cli/json_change.rs
+++ b/crates/rust-analyzer/src/cli/json_change.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 
 use crate::cli::{load_cargo::LoadCargoConfig, Result};
 
-use vfs::{AbsPath, AbsPathBuf};
+use vfs::{AbsPathBuf};
 
 use std::fs;
 
@@ -33,8 +33,7 @@ fn get_change_data(root: &Path, progress: &dyn Fn(String)) -> Result<Change> {
     cargo_config.no_sysroot = false;
     let root = AbsPathBuf::assert(std::env::current_dir()?.join(root));
 
-    let root = AbsPath::assert(&root);
-    let root = ProjectManifest::discover_single(root)?;
+    let root = ProjectManifest::discover_single(&root)?;
     let ws = ProjectWorkspace::load(root, &cargo_config, &|_| {})?;
 
     let config = LoadCargoConfig {

--- a/crates/rust-analyzer/src/cli/json_change.rs
+++ b/crates/rust-analyzer/src/cli/json_change.rs
@@ -22,71 +22,8 @@ impl JsonChangeCmd {
     /// ```
     pub fn run(self, root: &Path) -> Result<()> {
         let change = get_change_data(root, &|_| {})?;
-
-        // let (_, change2) = get_crate_data(root, &|_| {})?;
-
-        // let _json =
-        //    serde_json::to_string(&crate_graph).expect("serialization of crate_graph must work");
-
         let json = serde_json::to_string(&change).expect("serialization of change must work");
-        /*
-        _let deserialized_change: Change = serde_json::from_str(&json).expect("`Change` deserialization must work");
-        // let json = str::replace(&json,  "'","@@@");
-        let file_id = FileId(182);
-        let mut host = AnalysisHost::new(None);
-        host.apply_change(deserialized_change);
-        let analysis = host.analysis();
-        println!("getting status");
-        let status = analysis.status(Some(file_id)).unwrap();
-        println!("{}", status);
-        let _config = DiagnosticsConfig::default();
-        let _highlights: Vec<_> = analysis
-            .highlight(file_id)
-            .unwrap()
-            .into_iter()
-            .collect();
-        // let _highlights = analysis.highlight(file_id);
-        */
-
         fs::write("./change.json", json).expect("Unable to write file");
-
-        // println!("{}", json);
-
-        /*  let mut host = AnalysisHost::new(None);
-        host.apply_change(change);
-        let analysis = host.analysis();
-        let file_id = FileId(0);
-        */
-        // let _highlights = analysis.highlight(file_id);
-        // println!("{}", json);
-
-        // let deserialized_change: Change = serde_json::from_str(&json).expect("`Change` deserialization must work");
-
-        // println!("change_json:\n{}", change_json);
-
-        // deserialize from json string
-        /*
-        let deserialized_crate_graph: CrateGraph =
-            serde_json::from_str(&json).expect("deserialization must work");
-        assert_eq!(
-            crate_graph, deserialized_crate_graph,
-            "Deserialized `CrateGraph` is not equal!"
-        );
-        */
-
-        // Missing: Create a new `Change` object.
-        //
-        // `serde::Serialize` and `serde::Deserialize` are already supported by `Change`.
-        // So this should work out of the box after the object has been created:
-        //
-        // ```
-        // let json = serde_json::to_string(&change).expect("`Change` serialization must work");
-        // println!("change json:\n{}", json);
-        // let deserialized_change: Change = serde_json::from_str(&json).expect("`Change` deserialization must work");
-        // assert_eq!(change.roots, deserialized_change.roots, "Deserialized `Change.roots` is not equal!");
-        // assert_eq!(change.files_changed, deserialized_change.files_changed, "Deserialized `Change.roots` is not equal!");
-        // ```
-
         Ok(())
     }
 }

--- a/crates/rust-analyzer/src/cli/json_change.rs
+++ b/crates/rust-analyzer/src/cli/json_change.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 
 use crate::cli::{load_cargo::LoadCargoConfig, Result};
 
-use vfs::{AbsPathBuf};
+use vfs::AbsPathBuf;
 
 use std::fs;
 

--- a/crates/rust-analyzer/src/cli/json_change.rs
+++ b/crates/rust-analyzer/src/cli/json_change.rs
@@ -13,12 +13,12 @@ use std::fs;
 
 use crate::cli::load_cargo::load_change;
 
-pub struct CreateJsonCmd {}
+pub struct JsonChangeCmd {}
 
-impl CreateJsonCmd {
+impl JsonChangeCmd {
     /// Execute with e.g.
     /// ```no_compile
-    /// cargo run --bin rust-analyzer create-json ../ink/examples/flipper/Cargo.toml
+    /// cargo run --bin rust-analyzer json-change ../ink/examples/flipper/Cargo.toml
     /// ```
     pub fn run(self, root: &Path) -> Result<()> {
         let change = get_change_data(root, &|_| {})?;

--- a/crates/rust-analyzer/src/cli/json_change.rs
+++ b/crates/rust-analyzer/src/cli/json_change.rs
@@ -111,3 +111,18 @@ fn get_change_data(root: &Path, progress: &dyn Fn(String)) -> Result<Change> {
 
     Ok(change)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_serialize_deserialize_change() -> Result<()> {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap().parent().unwrap();
+        let change = get_change_data(path, &|_| {})?;
+        let json = serde_json::to_string(&change)?;
+        let deserialized_change: Change = serde_json::from_str(&json)?;
+        assert_eq!(change, deserialized_change);
+        Ok(())
+    }
+}

--- a/crates/rust-analyzer/src/cli/load_cargo.rs
+++ b/crates/rust-analyzer/src/cli/load_cargo.rs
@@ -55,7 +55,7 @@ fn load_workspace(
     Ok((host, vfs, proc_macro_client))
 }
 
-fn load_change(
+pub(crate) fn load_change(
     ws: ProjectWorkspace,
     config: &LoadCargoConfig,
     progress: &dyn Fn(String),
@@ -109,7 +109,7 @@ fn load_change(
     Ok((change, vfs, proc_macro_client))
 }
 
-pub(crate) fn load_crate_graph(
+fn load_crate_graph(
     crate_graph: CrateGraph,
     source_root_config: SourceRootConfig,
     vfs: &mut vfs::Vfs,

--- a/crates/vfs/Cargo.toml
+++ b/crates/vfs/Cargo.toml
@@ -11,6 +11,7 @@ doctest = false
 [dependencies]
 rustc-hash = "1.0"
 fst = "0.4"
+serde = { version = "1.0.106", features = ["derive"] }
 
 paths = { path = "../paths", version = "0.0.0" }
 indexmap = "1.6.2"

--- a/crates/vfs/src/file_set.rs
+++ b/crates/vfs/src/file_set.rs
@@ -10,7 +10,7 @@ use rustc_hash::FxHashMap;
 use crate::{AnchoredPath, FileId, Vfs, VfsPath};
 
 /// A set of [`VfsPath`]s identified by [`FileId`]s.
-#[derive(Default, Clone, Eq, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize, Default, Clone, Eq, PartialEq)]
 pub struct FileSet {
     files: FxHashMap<VfsPath, FileId>,
     paths: FxHashMap<FileId, VfsPath>,

--- a/crates/vfs/src/lib.rs
+++ b/crates/vfs/src/lib.rs
@@ -43,8 +43,9 @@ pub mod loader;
 mod path_interner;
 mod vfs_path;
 
-use serde;
 use std::{fmt, mem};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::path_interner::PathInterner;
 
@@ -60,22 +61,22 @@ pub use paths::{AbsPath, AbsPathBuf};
 #[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct FileId(pub u32);
 
-impl serde::Serialize for FileId {
+impl Serialize for FileId {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: Serializer,
     {
         let s = self.0.to_string();
         serializer.serialize_str(&s)
     }
 }
 
-impl<'de> serde::Deserialize<'de> for FileId {
+impl<'de> Deserialize<'de> for FileId {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: Deserializer<'de>,
     {
-        let s: &str = serde::Deserialize::deserialize(deserializer)?;
+        let s: &str = Deserialize::deserialize(deserializer)?;
         let id = s.parse::<u32>().unwrap();
         Ok(FileId(id))
     }

--- a/crates/vfs/src/lib.rs
+++ b/crates/vfs/src/lib.rs
@@ -43,6 +43,7 @@ pub mod loader;
 mod path_interner;
 mod vfs_path;
 
+use serde;
 use std::{fmt, mem};
 
 use crate::path_interner::PathInterner;
@@ -58,6 +59,27 @@ pub use paths::{AbsPath, AbsPathBuf};
 /// Most functions in rust-analyzer use this when they need to refer to a file.
 #[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct FileId(pub u32);
+
+impl serde::Serialize for FileId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let s = self.0.to_string();
+        serializer.serialize_str(&s)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for FileId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s: &str = serde::Deserialize::deserialize(deserializer)?;
+        let id = s.parse::<u32>().unwrap();
+        Ok(FileId(id))
+    }
+}
 
 /// Storage for all files read by rust-analyzer.
 ///

--- a/crates/vfs/src/vfs_path.rs
+++ b/crates/vfs/src/vfs_path.rs
@@ -2,6 +2,7 @@
 use std::fmt;
 
 use paths::{AbsPath, AbsPathBuf};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Path in [`Vfs`].
 ///
@@ -12,10 +13,10 @@ use paths::{AbsPath, AbsPathBuf};
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct VfsPath(VfsPathRepr);
 
-impl serde::Serialize for VfsPath {
+impl Serialize for VfsPath {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: Serializer,
     {
         let s = self.to_string();
         serializer.serialize_str(&s)
@@ -26,12 +27,12 @@ impl serde::Serialize for VfsPath {
 use std::path::{Path, PathBuf};
 
 #[cfg(not(target_arch = "wasm32"))]
-impl<'de> serde::Deserialize<'de> for VfsPath {
+impl<'de> Deserialize<'de> for VfsPath {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: Deserializer<'de>,
     {
-        let path: &str = serde::Deserialize::deserialize(deserializer)?;
+        let path: &str = Deserialize::deserialize(deserializer)?;
         let path = Path::new(path);
         let path = PathBuf::from(path);
         let path = AbsPathBuf::assert(path);
@@ -41,12 +42,12 @@ impl<'de> serde::Deserialize<'de> for VfsPath {
 }
 
 #[cfg(target_arch = "wasm32")]
-impl<'de> serde::Deserialize<'de> for VfsPath {
+impl<'de> Deserialize<'de> for VfsPath {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: Deserializer<'de>,
     {
-        let path: &str = serde::Deserialize::deserialize(deserializer)?;
+        let path: &str = Deserialize::deserialize(deserializer)?;
         let path = VfsPath::new_virtual_path(path.to_string());
         Ok(path)
     }
@@ -308,7 +309,7 @@ mod windows_paths {
 }
 
 /// Internal, private representation of [`VfsPath`].
-#[derive(serde::Serialize, serde::Deserialize, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+#[derive(Serialize, Deserialize, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 enum VfsPathRepr {
     PathBuf(AbsPathBuf),
     VirtualPath(VirtualPath),
@@ -347,9 +348,7 @@ impl fmt::Debug for VfsPathRepr {
 /// `/`-separated virtual path.
 ///
 /// This is used to describe files that do not reside on the file system.
-#[derive(
-    serde::Serialize, serde::Deserialize, Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash,
-)]
+#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 struct VirtualPath(String);
 
 impl VirtualPath {

--- a/crates/vfs/src/vfs_path.rs
+++ b/crates/vfs/src/vfs_path.rs
@@ -22,8 +22,10 @@ impl serde::Serialize for VfsPath {
     }
 }
 
-#[cfg(any(unix, windows))]
+#[cfg(not(target_arch = "wasm32"))]
 use std::path::{Path, PathBuf};
+
+#[cfg(not(target_arch = "wasm32"))]
 impl<'de> serde::Deserialize<'de> for VfsPath {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/crates/vfs/src/vfs_path.rs
+++ b/crates/vfs/src/vfs_path.rs
@@ -22,7 +22,7 @@ impl serde::Serialize for VfsPath {
     }
 }
 
-#[cfg(any(target_arch="x86", target_arch="x86_64"))]
+#[cfg(any(unix, windows))]
 use std::path::{Path, PathBuf};
 impl<'de> serde::Deserialize<'de> for VfsPath {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/crates/vfs/src/vfs_path.rs
+++ b/crates/vfs/src/vfs_path.rs
@@ -22,10 +22,8 @@ impl serde::Serialize for VfsPath {
     }
 }
 
-#[cfg(unix)]
-use std::path::{Path, PathBuf};
-
 #[cfg(not(target_arch = "wasm32"))]
+use std::path::{Path, PathBuf};
 impl<'de> serde::Deserialize<'de> for VfsPath {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/crates/vfs/src/vfs_path.rs
+++ b/crates/vfs/src/vfs_path.rs
@@ -22,7 +22,7 @@ impl serde::Serialize for VfsPath {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(target_arch="x86", target_arch="x86_64"))]
 use std::path::{Path, PathBuf};
 impl<'de> serde::Deserialize<'de> for VfsPath {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>


### PR DESCRIPTION
- add serialization and deserialization traits to the `change` object
- add a `json-change` option to the CLI. This command reads a `Cargo.toml` file, creates the corresponding `change` object, serializes it and writes the result into a `change.json` file. 

The existing WASM version of rust analyzer motivates this PR: https://github.com/rust-analyzer/rust-analyzer-wasm. Since the crates which load the Rust project dependencies into rust analyzer are not compilable to WASM, this PR makes it possible to load the `change` object from the json file, deserialize it and pass it into rust analyzer.