### PR TITLE
minor update to excludeDirs doc

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -144,7 +144,7 @@ config_data! {
         files_watcher: String = "\"client\"",
         /// These directories will be ignored by rust-analyzer. They are
         /// relative to the workspace root, and globs are not supported. You may
-        /// also need to add the folders to Code's 'watcher exclude'.
+        /// also need to add the folders to Code's `files.watcherExclude`.
         files_excludeDirs: Vec<PathBuf> = "[]",
 
         /// Use semantic tokens for strings.

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -142,7 +142,9 @@ config_data! {
 
         /// Controls file watching implementation.
         files_watcher: String = "\"client\"",
-        /// These directories will be ignored by rust-analyzer.
+        /// These directories will be ignored by rust-analyzer. They are
+        /// relative to the workspace root, and globs are not supported. You may
+        /// also need to add the folders to Code's 'watcher exclude'.
         files_excludeDirs: Vec<PathBuf> = "[]",
 
         /// Use semantic tokens for strings.

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -206,7 +206,7 @@ Controls file watching implementation.
 --
 These directories will be ignored by rust-analyzer. They are
 relative to the workspace root, and globs are not supported. You may
-also need to add the folders to Code's 'watcher exclude'.
+also need to add the folders to Code's `files.watcherExclude`.
 --
 [[rust-analyzer.highlighting.strings]]rust-analyzer.highlighting.strings (default: `true`)::
 +

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -204,7 +204,9 @@ Controls file watching implementation.
 [[rust-analyzer.files.excludeDirs]]rust-analyzer.files.excludeDirs (default: `[]`)::
 +
 --
-These directories will be ignored by rust-analyzer.
+These directories will be ignored by rust-analyzer. They are
+relative to the workspace root, and globs are not supported. You may
+also need to add the folders to Code's 'watcher exclude'.
 --
 [[rust-analyzer.highlighting.strings]]rust-analyzer.highlighting.strings (default: `true`)::
 +

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -648,7 +648,7 @@
                     "type": "string"
                 },
                 "rust-analyzer.files.excludeDirs": {
-                    "markdownDescription": "These directories will be ignored by rust-analyzer. They are\nrelative to the workspace root, and globs are not supported. You may\nalso need to add the folders to Code's 'watcher exclude'.",
+                    "markdownDescription": "These directories will be ignored by rust-analyzer. They are\nrelative to the workspace root, and globs are not supported. You may\nalso need to add the folders to Code's `files.watcherExclude`.",
                     "default": [],
                     "type": "array",
                     "items": {

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -648,7 +648,7 @@
                     "type": "string"
                 },
                 "rust-analyzer.files.excludeDirs": {
-                    "markdownDescription": "These directories will be ignored by rust-analyzer.",
+                    "markdownDescription": "These directories will be ignored by rust-analyzer. They are\nrelative to the workspace root, and globs are not supported. You may\nalso need to add the folders to Code's 'watcher exclude'.",
                     "default": [],
                     "type": "array",
                     "items": {


### PR DESCRIPTION
I saw reference to globs in #7755, but it doesn't look like they're
actually supported, and I had to dig through the source to discover
that the folders are relative to the workspace root. Further digging
was required to get VS Code from hanging for long periods trying to
watch giant Bazel folders that had already been excluded from Rust
Analyzer. Hopefully this tweak will save others the confusion :-)