### PR TITLE
Revert #9655 because it breaks some type inference

### DIFF
--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -845,9 +845,8 @@ impl Expectation {
     /// which still is useful, because it informs integer literals and the like.
     /// See the test case `test/ui/coerce-expect-unsized.rs` and #20169
     /// for examples of where this comes up,.
-    fn rvalue_hint(table: &mut unify::InferenceTable, ty: Ty) -> Self {
-        // FIXME: do struct_tail_without_normalization
-        match table.resolve_ty_shallow(&ty).kind(&Interner) {
+    fn rvalue_hint(ty: Ty) -> Self {
+        match ty.strip_references().kind(&Interner) {
             TyKind::Slice(_) | TyKind::Str | TyKind::Dyn(_) => Expectation::RValueLikeUnsized(ty),
             _ => Expectation::has_type(ty),
         }

--- a/crates/hir_ty/src/infer/expr.rs
+++ b/crates/hir_ty/src/infer/expr.rs
@@ -340,25 +340,11 @@ impl<'a> InferenceContext<'a> {
                     None => (Vec::new(), self.err_ty()),
                 };
                 self.register_obligations_for_call(&callee_ty);
-
-                let expected_inputs = self.expected_inputs_for_expected_output(
-                    expected,
-                    ret_ty.clone(),
-                    param_tys.clone(),
-                );
-
-                self.check_call_arguments(args, &expected_inputs, &param_tys);
+                self.check_call_arguments(args, &param_tys);
                 self.normalize_associated_types_in(ret_ty)
             }
             Expr::MethodCall { receiver, args, method_name, generic_args } => self
-                .infer_method_call(
-                    tgt_expr,
-                    *receiver,
-                    args,
-                    method_name,
-                    generic_args.as_deref(),
-                    expected,
-                ),
+                .infer_method_call(tgt_expr, *receiver, args, method_name, generic_args.as_deref()),
             Expr::Match { expr, arms } => {
                 let input_ty = self.infer_expr(*expr, &Expectation::none());
 
@@ -589,7 +575,7 @@ impl<'a> InferenceContext<'a> {
                         // FIXME: record type error - expected reference but found ptr,
                         // which cannot be coerced
                     }
-                    Expectation::rvalue_hint(&mut self.table, Ty::clone(exp_inner))
+                    Expectation::rvalue_hint(Ty::clone(exp_inner))
                 } else {
                     Expectation::none()
                 };
@@ -916,7 +902,6 @@ impl<'a> InferenceContext<'a> {
         args: &[ExprId],
         method_name: &Name,
         generic_args: Option<&GenericArgs>,
-        expected: &Expectation,
     ) -> Ty {
         let receiver_ty = self.infer_expr(receiver, &Expectation::none());
         let canonicalized_receiver = self.canonicalize(receiver_ty.clone());
@@ -950,7 +935,7 @@ impl<'a> InferenceContext<'a> {
         };
         let method_ty = method_ty.substitute(&Interner, &substs);
         self.register_obligations_for_call(&method_ty);
-        let (formal_receiver_ty, param_tys, ret_ty) = match method_ty.callable_sig(self.db) {
+        let (expected_receiver_ty, param_tys, ret_ty) = match method_ty.callable_sig(self.db) {
             Some(sig) => {
                 if !sig.params().is_empty() {
                     (sig.params()[0].clone(), sig.params()[1..].to_vec(), sig.ret().clone())
@@ -960,41 +945,13 @@ impl<'a> InferenceContext<'a> {
             }
             None => (self.err_ty(), Vec::new(), self.err_ty()),
         };
-        self.unify(&formal_receiver_ty, &receiver_ty);
+        self.unify(&expected_receiver_ty, &receiver_ty);
 
-        let expected_inputs =
-            self.expected_inputs_for_expected_output(expected, ret_ty.clone(), param_tys.clone());
-
-        self.check_call_arguments(args, &expected_inputs, &param_tys);
+        self.check_call_arguments(args, &param_tys);
         self.normalize_associated_types_in(ret_ty)
     }
 
-    fn expected_inputs_for_expected_output(
-        &mut self,
-        expected_output: &Expectation,
-        output: Ty,
-        inputs: Vec<Ty>,
-    ) -> Vec<Ty> {
-        // rustc does a snapshot here and rolls back the unification, but since
-        // we actually want to keep unbound variables in the result it then
-        // needs to do 'fudging' to recreate them. So I'm not sure rustc's
-        // approach is cleaner than ours, which is to create independent copies
-        // of the variables before unifying. It might be more performant though,
-        // so we might want to benchmark when we can actually do
-        // snapshot/rollback.
-        if let Some(expected_ty) = expected_output.to_option(&mut self.table) {
-            let (expected_ret_ty, expected_params) = self.table.reinstantiate((output, inputs));
-            if self.table.try_unify(&expected_ty, &expected_ret_ty).is_ok() {
-                expected_params
-            } else {
-                Vec::new()
-            }
-        } else {
-            Vec::new()
-        }
-    }
-
-    fn check_call_arguments(&mut self, args: &[ExprId], expected_inputs: &[Ty], param_tys: &[Ty]) {
+    fn check_call_arguments(&mut self, args: &[ExprId], param_tys: &[Ty]) {
         // Quoting https://github.com/rust-lang/rust/blob/6ef275e6c3cb1384ec78128eceeb4963ff788dca/src/librustc_typeck/check/mod.rs#L3325 --
         // We do this in a pretty awful way: first we type-check any arguments
         // that are not closures, then we type-check the closures. This is so
@@ -1002,45 +959,14 @@ impl<'a> InferenceContext<'a> {
         // type-check the functions. This isn't really the right way to do this.
         for &check_closures in &[false, true] {
             let param_iter = param_tys.iter().cloned().chain(repeat(self.err_ty()));
-            let expected_iter = expected_inputs
-                .iter()
-                .cloned()
-                .chain(param_iter.clone().skip(expected_inputs.len()));
-            for ((&arg, param_ty), expected_ty) in args.iter().zip(param_iter).zip(expected_iter) {
+            for (&arg, param_ty) in args.iter().zip(param_iter) {
                 let is_closure = matches!(&self.body[arg], Expr::Lambda { .. });
                 if is_closure != check_closures {
                     continue;
                 }
 
-                // the difference between param_ty and expected here is that
-                // expected is the parameter when the expected *return* type is
-                // taken into account. So in `let _: &[i32] = identity(&[1, 2])`
-                // the expected type is already `&[i32]`, whereas param_ty is
-                // still an unbound type variable. We don't always want to force
-                // the parameter to coerce to the expected type (for example in
-                // `coerce_unsize_expected_type_4`).
                 let param_ty = self.normalize_associated_types_in(param_ty);
-                let expected = Expectation::rvalue_hint(&mut self.table, expected_ty);
-                // infer with the expected type we have...
-                let ty = self.infer_expr_inner(arg, &expected);
-
-                // then coerce to either the expected type or just the formal parameter type
-                let coercion_target = if let Some(ty) = expected.only_has_type(&mut self.table) {
-                    // if we are coercing to the expectation, unify with the
-                    // formal parameter type to connect everything
-                    self.unify(&ty, &param_ty);
-                    ty
-                } else {
-                    param_ty
-                };
-                if !coercion_target.is_unknown() {
-                    if self.coerce(Some(arg), &ty, &coercion_target).is_err() {
-                        self.result.type_mismatches.insert(
-                            arg.into(),
-                            TypeMismatch { expected: coercion_target, actual: ty.clone() },
-                        );
-                    }
-                }
+                self.infer_expr_coerce(arg, &Expectation::has_type(param_ty.clone()));
             }
         }
     }

--- a/crates/hir_ty/src/infer/unify.rs
+++ b/crates/hir_ty/src/infer/unify.rs
@@ -302,18 +302,6 @@ impl<'a> InferenceTable<'a> {
         self.resolve_with_fallback(t, |_, _, d, _| d)
     }
 
-    /// This makes a copy of the given `t` where all unbound inference variables
-    /// have been replaced by fresh ones. This is useful for 'speculatively'
-    /// unifying the result with something, without affecting the original types.
-    pub(crate) fn reinstantiate<T>(&mut self, t: T) -> T::Result
-    where
-        T: HasInterner<Interner = Interner> + Fold<Interner>,
-        T::Result: HasInterner<Interner = Interner> + Fold<Interner, Result = T::Result>,
-    {
-        let canonicalized = self.canonicalize(t);
-        self.var_unification_table.instantiate_canonical(&Interner, canonicalized.value)
-    }
-
     /// Unify two types and register new trait goals that arise from that.
     pub(crate) fn unify(&mut self, ty1: &Ty, ty2: &Ty) -> bool {
         let result = if let Ok(r) = self.try_unify(ty1, ty2) {

--- a/crates/hir_ty/src/tests/coercion.rs
+++ b/crates/hir_ty/src/tests/coercion.rs
@@ -390,7 +390,7 @@ fn test() {
     let _: &Foo<[usize]> = &Foo { t: [1, 2, 3] };
                                    //^^^^^^^^^ expected [usize], got [usize; 3]
     let _: &Bar<[usize]> = &Bar(Foo { t: [1, 2, 3] });
-                                       //^^^^^^^^^ expected [usize], got [usize; 3]
+                         //^^^^^^^^^^^^^^^^^^^^^^^^^^ expected &Bar<[usize]>, got &Bar<[i32; 3]>
 }
 "#,
     );
@@ -522,7 +522,8 @@ fn main() {
 
 #[test]
 fn coerce_unsize_expected_type_2() {
-    check_no_mismatches(
+    // FIXME: this is wrong, #9560
+    check(
         r#"
 //- minicore: coerce_unsized
 struct InFile<T>;
@@ -539,48 +540,7 @@ fn test() {
     let x: InFile<()> = InFile;
     let n = &RecordField;
     takes_dyn(x.with_value(n));
-}
-        "#,
-    );
-}
-
-#[test]
-fn coerce_unsize_expected_type_3() {
-    check_no_mismatches(
-        r#"
-//- minicore: coerce_unsized
-enum Option<T> { Some(T), None }
-struct RecordField;
-trait AstNode {}
-impl AstNode for RecordField {}
-
-fn takes_dyn(it: Option<&dyn AstNode>) {}
-
-fn test() {
-    let x: InFile<()> = InFile;
-    let n = &RecordField;
-    takes_dyn(Option::Some(n));
-}
-        "#,
-    );
-}
-
-#[test]
-fn coerce_unsize_expected_type_4() {
-    check_no_mismatches(
-        r#"
-//- minicore: coerce_unsized
-use core::{marker::Unsize, ops::CoerceUnsized};
-
-struct B<T: ?Sized>(*const T);
-impl<T: ?Sized> B<T> {
-    fn new(t: T) -> Self { B(&t) }
-}
-
-impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<B<U>> for B<T> {}
-
-fn test() {
-    let _: B<[isize]> = B::new({ [1, 2, 3] });
+           // ^^^^^^^^^^^^^^^ expected InFile<&dyn AstNode>, got InFile<&RecordField>
 }
         "#,
     );


### PR DESCRIPTION
This reverts commit 8c8c6fb73da613b915e4b18decd74f06d46ab76a, reversing
changes made to ec7b4cbf8f7d6d88ae5280b72a93a7e5d0adb7c4.

bors r+