### PR TITLE
hide keyword suggestions in non trivial paths

### DIFF
--- a/crates/ide_completion/src/completions/keyword.rs
+++ b/crates/ide_completion/src/completions/keyword.rs
@@ -20,6 +20,10 @@ pub(crate) fn complete_expr_keyword(acc: &mut Completions, ctx: &CompletionConte
         cov_mark::hit!(no_keyword_completion_in_attr_of_expr);
         return;
     }
+    if ctx.is_non_trivial_path() {
+        cov_mark::hit!(no_keyword_completion_in_non_trivial_path);
+        return;
+    }
 
     // Suggest .await syntax for types that implement Future trait
     if let Some(receiver) = ctx.dot_receiver() {

--- a/crates/ide_completion/src/context.rs
+++ b/crates/ide_completion/src/context.rs
@@ -353,6 +353,10 @@ impl<'a> CompletionContext<'a> {
         matches!(self.path_context, Some(PathCompletionContext { is_trivial_path: true, .. }))
     }
 
+    pub(crate) fn is_non_trivial_path(&self) -> bool {
+        matches!(self.path_context, Some(PathCompletionContext { is_trivial_path: false, .. }))
+    }
+
     pub(crate) fn path_qual(&self) -> Option<&ast::Path> {
         self.path_context.as_ref().and_then(|it| it.qualifier.as_ref())
     }

--- a/crates/ide_completion/src/tests/item_list.rs
+++ b/crates/ide_completion/src/tests/item_list.rs
@@ -101,25 +101,11 @@ fn in_item_list_after_attr() {
 
 #[test]
 fn in_qualified_path() {
+    cov_mark::check!(no_keyword_completion_in_non_trivial_path);
     check(
         r#"crate::$0"#,
         expect![[r##"
-            kw pub(crate)
-            kw pub
-            kw unsafe
-            kw fn
-            kw const
-            kw type
-            kw impl
-            kw extern
-            kw use
-            kw trait
-            kw static
-            kw mod
-            kw enum
-            kw struct
-            kw union
-            ma makro!(…)  #[macro_export] macro_rules! makro
+            ma makro!(…) #[macro_export] macro_rules! makro
             md module
         "##]],
     )


### PR DESCRIPTION
This pr hides keyword suggestions in non trivial paths:
![now](https://user-images.githubusercontent.com/14952658/126479635-819127d8-322b-4e34-acd2-194d1e9ba504.png)

Previously rust analyzer suggested a lot of keywords even when completing non trivial paths:
![prev](https://user-images.githubusercontent.com/14952658/126478222-54c742bb-2bd3-4e5b-b533-f835264604be.png)

This had 2 problems:
1. Suggesting a keyword in this position doesn't make sense.
2. There are a lot of keywords, so they make it a lot harder to find the things you're actually looking for (note the scrollbar and that `instructions`, `registers` and `structures` are not visible). 