### PR TITLE
fix: only import public items from other crates

### DIFF
--- a/crates/hir_def/src/nameres/collector.rs
+++ b/crates/hir_def/src/nameres/collector.rs
@@ -747,7 +747,9 @@ impl DefCollector<'_> {
 
             if let Some(krate) = res.krate {
                 if krate != self.def_map.krate {
-                    return PartialResolvedImport::Resolved(def);
+                    return PartialResolvedImport::Resolved(
+                        def.filter_visibility(|v| matches!(v, Visibility::Public)),
+                    );
                 }
             }
 

--- a/crates/hir_def/src/nameres/tests.rs
+++ b/crates/hir_def/src/nameres/tests.rs
@@ -296,7 +296,7 @@ use bar::Bar;
 use other_crate::FromLib;
 
 //- /lib.rs crate:other_crate edition:2018
-struct FromLib;
+pub struct FromLib;
 "#,
         expect![[r#"
             crate
@@ -371,7 +371,7 @@ mod sync;
 use alloc_crate::Arc;
 
 //- /lib.rs crate:alloc
-struct Arc;
+pub struct Arc;
 "#,
         expect![[r#"
             crate
@@ -397,7 +397,7 @@ mod sync;
 use alloc_crate::Arc;
 
 //- /lib.rs crate:alloc
-struct Arc;
+pub struct Arc;
 "#,
         expect![[r#"
             crate
@@ -476,13 +476,13 @@ fn no_std_prelude() {
 
         //- /core.rs crate:core
         pub mod prelude {
-            pud mod rust_2018 {
+            pub mod rust_2018 {
                 pub struct Rust;
             }
         }
         //- /std.rs crate:std deps:core
         pub mod prelude {
-            pud mod rust_2018 {
+            pub mod rust_2018 {
             }
         }
     "#,
@@ -505,7 +505,7 @@ fn edition_specific_preludes() {
 
         //- /std.rs crate:std
         pub mod prelude {
-            pud mod rust_2018 {
+            pub mod rust_2018 {
                 pub struct Rust2018;
             }
         }
@@ -522,7 +522,7 @@ fn edition_specific_preludes() {
 
         //- /std.rs crate:std
         pub mod prelude {
-            pud mod rust_2021 {
+            pub mod rust_2021 {
                 pub struct Rust2021;
             }
         }
@@ -838,4 +838,25 @@ use self::m::S::{self};
             S: t v m
         "#]],
     );
+}
+
+#[test]
+fn import_from_extern_crate_only_imports_public_items() {
+    check(
+        r#"
+//- /lib.rs crate:lib deps:settings,macros
+use macros::settings;
+use settings::Settings;
+//- /settings.rs crate:settings
+pub struct Settings;
+//- /macros.rs crate:macros
+mod settings {}
+pub const settings: () = ();
+        "#,
+        expect![[r#"
+            crate
+            Settings: t v
+            settings: v
+        "#]],
+    )
 }

--- a/crates/hir_def/src/nameres/tests/macros.rs
+++ b/crates/hir_def/src/nameres/tests/macros.rs
@@ -607,8 +607,8 @@ macro_rules! not_current2 {
     }
 }
 
-struct Bar;
-struct Baz;
+pub struct Bar;
+pub struct Baz;
 "#,
         expect![[r#"
             crate

--- a/crates/hir_ty/src/tests/macros.rs
+++ b/crates/hir_ty/src/tests/macros.rs
@@ -27,7 +27,7 @@ fn test() {
 } //^ (i32, {unknown}, i32, {unknown})
 
 //- /foo.rs crate:foo
-struct S;
+pub struct S;
 
 #[cfg(not(test))]
 impl S {

--- a/crates/hir_ty/src/tests/method_resolution.rs
+++ b/crates/hir_ty/src/tests/method_resolution.rs
@@ -256,8 +256,8 @@ fn test() {
 } //^ i128
 
 //- /lib.rs crate:other_crate
-mod foo {
-    struct S;
+pub mod foo {
+    pub struct S;
     impl S {
         fn thing() -> i128 { 0 }
     }

--- a/crates/hir_ty/src/tests/traits.rs
+++ b/crates/hir_ty/src/tests/traits.rs
@@ -209,8 +209,8 @@ pub mod prelude {
 
 //- /alloc.rs crate:alloc deps:core
 #![no_std]
-mod collections {
-    struct Vec<T> {}
+pub mod collections {
+    pub struct Vec<T> {}
     impl<T> Vec<T> {
         pub fn new() -> Self { Vec {} }
         pub fn push(&mut self, t: T) { }


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/9650

Also fixes a bunch of incorrect tests that were importing private items.

bors r+