### PR TITLE
Add Configuration for Highlight Related Feature

### DIFF
--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -76,7 +76,7 @@ pub use crate::{
     expand_macro::ExpandedMacro,
     file_structure::{StructureNode, StructureNodeKind},
     folding_ranges::{Fold, FoldKind},
-    highlight_related::HighlightedRange,
+    highlight_related::{HighlightRelatedConfig, HighlightedRange},
     hover::{HoverAction, HoverConfig, HoverDocFormat, HoverGotoTypeData, HoverResult},
     inlay_hints::{InlayHint, InlayHintsConfig, InlayKind},
     join_lines::JoinLinesConfig,
@@ -496,9 +496,12 @@ impl Analysis {
     /// Computes all ranges to highlight for a given item in a file.
     pub fn highlight_related(
         &self,
+        config: HighlightRelatedConfig,
         position: FilePosition,
     ) -> Cancellable<Option<Vec<HighlightedRange>>> {
-        self.with_db(|db| highlight_related::highlight_related(&Semantics::new(db), position))
+        self.with_db(|db| {
+            highlight_related::highlight_related(&Semantics::new(db), config, position)
+        })
     }
 
     /// Computes syntax highlighting for the given file range.

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -147,6 +147,15 @@ config_data! {
         /// also need to add the folders to Code's `files.watcherExclude`.
         files_excludeDirs: Vec<PathBuf> = "[]",
 
+        /// Enables highlighting of related references while hovering your mouse above any identifier.
+        highlightRelated_references: bool = "true",
+        /// Enables highlighting of all exit points while hovering your mouse above any `return`, `?`, or return type arrow (`->`).
+        highlightRelated_exitPoints: bool = "true",
+        /// Enables highlighting of related references while hovering your mouse `break`, `loop`, `while`, or `for` keywords.
+        highlightRelated_breakPoints: bool = "true",
+        /// Enables highlighting of all break points for a loop or block context while hovering your mouse above any `async` or `await` keywords.
+        highlightRelated_yieldPoints: bool = "true",
+
         /// Use semantic tokens for strings.
         ///
         /// In some editors (e.g. vscode) semantic tokens override other highlighting grammars.
@@ -261,14 +270,6 @@ config_data! {
         workspace_symbol_search_scope: WorskpaceSymbolSearchScopeDef = "\"workspace\"",
         /// Workspace symbol search kind.
         workspace_symbol_search_kind: WorskpaceSymbolSearchKindDef = "\"only_types\"",
-
-        highlightRelated_references: bool = "true",
-
-        highlightRelated_exitPoints: bool = "true",
-
-        highlightRelated_breakPoints: bool = "true",
-
-        highlightRelated_yieldPoints: bool = "true",
     }
 }
 

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -11,8 +11,8 @@ use std::{ffi::OsString, iter, path::PathBuf};
 
 use flycheck::FlycheckConfig;
 use ide::{
-    AssistConfig, CompletionConfig, DiagnosticsConfig, HoverConfig, HoverDocFormat,
-    InlayHintsConfig, JoinLinesConfig,
+    AssistConfig, CompletionConfig, DiagnosticsConfig, HighlightRelatedConfig, HoverConfig,
+    HoverDocFormat, InlayHintsConfig, JoinLinesConfig,
 };
 use ide_db::helpers::{
     insert_use::{ImportGranularity, InsertUseConfig, PrefixKind},
@@ -261,6 +261,14 @@ config_data! {
         workspace_symbol_search_scope: WorskpaceSymbolSearchScopeDef = "\"workspace\"",
         /// Workspace symbol search kind.
         workspace_symbol_search_kind: WorskpaceSymbolSearchKindDef = "\"only_types\"",
+
+        highlightRelated_references: bool = "true",
+
+        highlightRelated_exitPoints: bool = "true",
+
+        highlightRelated_breakPoints: bool = "true",
+
+        highlightRelated_yieldPoints: bool = "true",
     }
 }
 
@@ -851,6 +859,15 @@ impl Config {
                 .insert_replace_support?,
             false
         )
+    }
+
+    pub fn highlight_related(&self) -> HighlightRelatedConfig {
+        HighlightRelatedConfig {
+            references: self.data.highlightRelated_references,
+            break_points: self.data.highlightRelated_breakPoints,
+            exit_points: self.data.highlightRelated_exitPoints,
+            yield_points: self.data.highlightRelated_yieldPoints,
+        }
     }
 }
 

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -1188,7 +1188,7 @@ pub(crate) fn handle_document_highlight(
     let position = from_proto::file_position(&snap, params.text_document_position_params)?;
     let line_index = snap.file_line_index(position.file_id)?;
 
-    let refs = match snap.analysis.highlight_related(position)? {
+    let refs = match snap.analysis.highlight_related(snap.config.highlight_related(), position)? {
         None => return Ok(None),
         Some(refs) => refs,
     };

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -208,6 +208,26 @@ These directories will be ignored by rust-analyzer. They are
 relative to the workspace root, and globs are not supported. You may
 also need to add the folders to Code's `files.watcherExclude`.
 --
+[[rust-analyzer.highlightRelated.references]]rust-analyzer.highlightRelated.references (default: `true`)::
++
+--
+Enables highlighting of related references while hovering your mouse above any identifier.
+--
+[[rust-analyzer.highlightRelated.exitPoints]]rust-analyzer.highlightRelated.exitPoints (default: `true`)::
++
+--
+Enables highlighting of all exit points while hovering your mouse above any `return`, `?`, or return type arrow (`->`).
+--
+[[rust-analyzer.highlightRelated.breakPoints]]rust-analyzer.highlightRelated.breakPoints (default: `true`)::
++
+--
+Enables highlighting of related references while hovering your mouse `break`, `loop`, `while`, or `for` keywords.
+--
+[[rust-analyzer.highlightRelated.yieldPoints]]rust-analyzer.highlightRelated.yieldPoints (default: `true`)::
++
+--
+Enables highlighting of all break points for a loop or block context while hovering your mouse above any `async` or `await` keywords.
+--
 [[rust-analyzer.highlighting.strings]]rust-analyzer.highlighting.strings (default: `true`)::
 +
 --

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -881,6 +881,26 @@
                         "Search for all symbols kinds"
                     ]
                 },
+                "rust-analyzer.highlightRelated.references": {
+                    "markdownDescription": "Enables highlighting of related references while hovering your mouse above any identifier.",
+                    "default": true,
+                    "type": "boolean"
+                },
+                "rust-analyzer.highlightRelated.exitPoints": {
+                    "markdownDescription": "Enables highlighting of all exit points while hovering your mouse above any `return`, `?`, or return type arrow (`->`).",
+                    "default": true,
+                    "type": "boolean"
+                },
+                "rust-analyzer.highlightRelated.breakPoints": {
+                    "markdownDescription": "Enables highlighting of related references while hovering your mouse `break`, `loop`, `while`, or `for` keywords.",
+                    "default": true,
+                    "type": "boolean"
+                },
+                "rust-analyzer.highlightRelated.yieldPoints": {
+                    "markdownDescription": "Enables highlighting of all break points for a loop or block context while hovering your mouse above any `async` or `await` keywords.",
+                    "default": true,
+                    "type": "boolean"
+                },
                 "$generated-end": {}
             }
         },

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -655,6 +655,26 @@
                         "type": "string"
                     }
                 },
+                "rust-analyzer.highlightRelated.references": {
+                    "markdownDescription": "Enables highlighting of related references while hovering your mouse above any identifier.",
+                    "default": true,
+                    "type": "boolean"
+                },
+                "rust-analyzer.highlightRelated.exitPoints": {
+                    "markdownDescription": "Enables highlighting of all exit points while hovering your mouse above any `return`, `?`, or return type arrow (`->`).",
+                    "default": true,
+                    "type": "boolean"
+                },
+                "rust-analyzer.highlightRelated.breakPoints": {
+                    "markdownDescription": "Enables highlighting of related references while hovering your mouse `break`, `loop`, `while`, or `for` keywords.",
+                    "default": true,
+                    "type": "boolean"
+                },
+                "rust-analyzer.highlightRelated.yieldPoints": {
+                    "markdownDescription": "Enables highlighting of all break points for a loop or block context while hovering your mouse above any `async` or `await` keywords.",
+                    "default": true,
+                    "type": "boolean"
+                },
                 "rust-analyzer.highlighting.strings": {
                     "markdownDescription": "Use semantic tokens for strings.\n\nIn some editors (e.g. vscode) semantic tokens override other highlighting grammars.\nBy disabling semantic tokens for strings, other grammars can be used to highlight\ntheir contents.",
                     "default": true,
@@ -880,26 +900,6 @@
                         "Search for types only",
                         "Search for all symbols kinds"
                     ]
-                },
-                "rust-analyzer.highlightRelated.references": {
-                    "markdownDescription": "Enables highlighting of related references while hovering your mouse above any identifier.",
-                    "default": true,
-                    "type": "boolean"
-                },
-                "rust-analyzer.highlightRelated.exitPoints": {
-                    "markdownDescription": "Enables highlighting of all exit points while hovering your mouse above any `return`, `?`, or return type arrow (`->`).",
-                    "default": true,
-                    "type": "boolean"
-                },
-                "rust-analyzer.highlightRelated.breakPoints": {
-                    "markdownDescription": "Enables highlighting of related references while hovering your mouse `break`, `loop`, `while`, or `for` keywords.",
-                    "default": true,
-                    "type": "boolean"
-                },
-                "rust-analyzer.highlightRelated.yieldPoints": {
-                    "markdownDescription": "Enables highlighting of all break points for a loop or block context while hovering your mouse above any `async` or `await` keywords.",
-                    "default": true,
-                    "type": "boolean"
                 },
                 "$generated-end": {}
             }

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -120,12 +120,6 @@ export class Config {
         };
     }
 
-    get checkOnSave() {
-        return {
-            command: this.get<string>("checkOnSave.command"),
-        };
-    }
-
     get cargoRunner() {
         return this.get<string | undefined>("cargoRunner");
     }
@@ -147,17 +141,6 @@ export class Config {
             engineSettings: this.get<object>("debug.engineSettings"),
             openDebugPane: this.get<boolean>("debug.openDebugPane"),
             sourceFileMap: sourceFileMap
-        };
-    }
-
-    get lens() {
-        return {
-            enable: this.get<boolean>("lens.enable"),
-            run: this.get<boolean>("lens.run"),
-            debug: this.get<boolean>("lens.debug"),
-            implementations: this.get<boolean>("lens.implementations"),
-            methodReferences: this.get<boolean>("lens.methodReferences"),
-            references: this.get<boolean>("lens.references"),
         };
     }
 

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -172,6 +172,15 @@ export class Config {
         };
     }
 
+    get highlightRelated() {
+        return {
+            references: this.get<boolean>("highlightRelated.references"),
+            exitPoints: this.get<boolean>("highlightRelated.exit_points"),
+            breakPoints: this.get<boolean>("highlightRelated.exit_points"),
+            yieldPoints: this.get<boolean>("highlightRelated.yield_points")
+        };
+    }
+
     get currentExtensionIsNightly() {
         return this.package.releaseTag === NIGHTLY_TAG;
     }

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -172,15 +172,6 @@ export class Config {
         };
     }
 
-    get highlightRelated() {
-        return {
-            references: this.get<boolean>("highlightRelated.references"),
-            exitPoints: this.get<boolean>("highlightRelated.exit_points"),
-            breakPoints: this.get<boolean>("highlightRelated.exit_points"),
-            yieldPoints: this.get<boolean>("highlightRelated.yield_points")
-        };
-    }
-
     get currentExtensionIsNightly() {
         return this.package.releaseTag === NIGHTLY_TAG;
     }


### PR DESCRIPTION
# Summary
Adds basic configuration that allows you to control when the highlight related feature is activated. You can control this for references, break points, exit points, and yield points.

Resolves #9618 

![config](https://user-images.githubusercontent.com/2295721/126728849-a38b560c-b687-42c1-9c41-7584ad718469.gif)
