### PR TITLE
Respect `#[doc(hidden)]` in dot-completion

### DIFF
--- a/crates/hir/src/attrs.rs
+++ b/crates/hir/src/attrs.rs
@@ -11,8 +11,8 @@ use hir_ty::db::HirDatabase;
 use syntax::ast;
 
 use crate::{
-    Adt, Const, ConstParam, Enum, Field, Function, GenericParam, Impl, LifetimeParam, MacroDef,
-    Module, ModuleDef, Static, Struct, Trait, TypeAlias, TypeParam, Union, Variant,
+    Adt, AssocItem, Const, ConstParam, Enum, Field, Function, GenericParam, Impl, LifetimeParam,
+    MacroDef, Module, ModuleDef, Static, Struct, Trait, TypeAlias, TypeParam, Union, Variant,
 };
 
 pub trait HasAttrs {
@@ -85,6 +85,37 @@ macro_rules! impl_has_attrs_enum {
 
 impl_has_attrs_enum![Struct, Union, Enum for Adt];
 impl_has_attrs_enum![TypeParam, ConstParam, LifetimeParam for GenericParam];
+
+impl HasAttrs for AssocItem {
+    fn attrs(self, db: &dyn HirDatabase) -> AttrsWithOwner {
+        match self {
+            AssocItem::Function(it) => it.attrs(db),
+            AssocItem::Const(it) => it.attrs(db),
+            AssocItem::TypeAlias(it) => it.attrs(db),
+        }
+    }
+
+    fn docs(self, db: &dyn HirDatabase) -> Option<Documentation> {
+        match self {
+            AssocItem::Function(it) => it.docs(db),
+            AssocItem::Const(it) => it.docs(db),
+            AssocItem::TypeAlias(it) => it.docs(db),
+        }
+    }
+
+    fn resolve_doc_path(
+        self,
+        db: &dyn HirDatabase,
+        link: &str,
+        ns: Option<Namespace>,
+    ) -> Option<ModuleDef> {
+        match self {
+            AssocItem::Function(it) => it.resolve_doc_path(db, link, ns),
+            AssocItem::Const(it) => it.resolve_doc_path(db, link, ns),
+            AssocItem::TypeAlias(it) => it.resolve_doc_path(db, link, ns),
+        }
+    }
+}
 
 fn resolve_doc_path(
     db: &dyn HirDatabase,

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2744,3 +2744,32 @@ pub trait HasVisibility {
         vis.is_visible_from(db.upcast(), module.id)
     }
 }
+
+/// Trait for obtaining the defining crate of an item.
+pub trait HasCrate {
+    fn krate(&self, db: &dyn HirDatabase) -> Crate;
+}
+
+impl<T: hir_def::HasModule> HasCrate for T {
+    fn krate(&self, db: &dyn HirDatabase) -> Crate {
+        self.module(db.upcast()).krate().into()
+    }
+}
+
+impl HasCrate for AssocItem {
+    fn krate(&self, db: &dyn HirDatabase) -> Crate {
+        self.module(db).krate()
+    }
+}
+
+impl HasCrate for Field {
+    fn krate(&self, db: &dyn HirDatabase) -> Crate {
+        self.parent_def(db).module(db).krate()
+    }
+}
+
+impl HasCrate for Function {
+    fn krate(&self, db: &dyn HirDatabase) -> Crate {
+        self.module(db).krate()
+    }
+}

--- a/crates/hir_def/src/attr.rs
+++ b/crates/hir_def/src/attr.rs
@@ -12,7 +12,7 @@ use either::Either;
 use hir_expand::{hygiene::Hygiene, name::AsName, AstId, InFile};
 use itertools::Itertools;
 use la_arena::ArenaMap;
-use mbe::ast_to_token_tree;
+use mbe::{ast_to_token_tree, DelimiterKind};
 use smallvec::{smallvec, SmallVec};
 use syntax::{
     ast::{self, AstNode, AttrsOwner},
@@ -289,6 +289,13 @@ impl Attrs {
         } else {
             Some(Documentation(buf))
         }
+    }
+
+    pub fn has_doc_hidden(&self) -> bool {
+        self.by_key("doc").tt_values().find(|tt| {
+            tt.delimiter_kind() == Some(DelimiterKind::Parenthesis) &&
+                matches!(&*tt.token_trees, [tt::TokenTree::Leaf(tt::Leaf::Ident(ident))] if ident.text == "hidden")
+        }).is_some()
     }
 }
 

--- a/crates/hir_def/src/attr.rs
+++ b/crates/hir_def/src/attr.rs
@@ -292,10 +292,10 @@ impl Attrs {
     }
 
     pub fn has_doc_hidden(&self) -> bool {
-        self.by_key("doc").tt_values().find(|tt| {
+        self.by_key("doc").tt_values().any(|tt| {
             tt.delimiter_kind() == Some(DelimiterKind::Parenthesis) &&
                 matches!(&*tt.token_trees, [tt::TokenTree::Leaf(tt::Leaf::Ident(ident))] if ident.text == "hidden")
-        }).is_some()
+        })
     }
 }
 

--- a/crates/ide_completion/src/completions/dot.rs
+++ b/crates/ide_completion/src/completions/dot.rs
@@ -231,7 +231,7 @@ impl A {
             expect![[r#"
                 fd pub_field    u32
                 me pub_method() fn(&self)
-            "#]]
+            "#]],
         )
     }
 

--- a/crates/ide_completion/src/context.rs
+++ b/crates/ide_completion/src/context.rs
@@ -361,6 +361,37 @@ impl<'a> CompletionContext<'a> {
         self.path_context.as_ref().and_then(|it| it.qualifier.as_ref())
     }
 
+    /// Checks if an item is visible and not `doc(hidden)` at the completion site.
+    pub(crate) fn is_visible<I>(&self, item: &I) -> bool
+    where
+        I: hir::HasVisibility + hir::HasAttrs + hir::HasCrate + Copy,
+    {
+        self.is_visible_impl(&item.visibility(self.db), &item.attrs(self.db), item.krate(self.db))
+    }
+
+    fn is_visible_impl(
+        &self,
+        vis: &hir::Visibility,
+        attrs: &hir::Attrs,
+        defining_crate: hir::Crate,
+    ) -> bool {
+        let module = match self.scope.module() {
+            Some(it) => it,
+            None => return false,
+        };
+        if !vis.is_visible_from(self.db, module.into()) {
+            // FIXME: if the definition location is editable, also show private items
+            return false;
+        }
+
+        if module.krate() != defining_crate && attrs.has_doc_hidden() {
+            // `doc(hidden)` items are only completed within the defining crate.
+            return false;
+        }
+
+        true
+    }
+
     fn fill_impl_def(&mut self) {
         self.impl_def = self
             .sema


### PR DESCRIPTION
This adds `CompletionContext::is_visible` as a convenience method that checks visibility, presence of `doc(hidden)`, and whether the completed item is in the same crate as the completion site or not. We only complete `doc(hidden)` items from the same crate.

This doesn't yet work for *all* completions: `qualified_path` completions use `Module::scope` and `ScopeDef`, which doesn't work with this.

Part of https://github.com/rust-analyzer/rust-analyzer/issues/7718