### PR TITLE
Complete editable private items

### DIFF
--- a/crates/ide/src/references.rs
+++ b/crates/ide/src/references.rs
@@ -1375,13 +1375,13 @@ fn foo(_: bool) -> bo$0ol { true }
     fn test_transitive() {
         check(
             r#"
-//- /level3.rs new_source_root: crate:level3
+//- /level3.rs new_source_root:local crate:level3
 pub struct Fo$0o;
-//- /level2.rs new_source_root: crate:level2 deps:level3
+//- /level2.rs new_source_root:local crate:level2 deps:level3
 pub use level3::Foo;
-//- /level1.rs new_source_root: crate:level1 deps:level2
+//- /level1.rs new_source_root:local crate:level1 deps:level2
 pub use level2::Foo;
-//- /level0.rs new_source_root: crate:level0 deps:level1
+//- /level0.rs new_source_root:local crate:level0 deps:level1
 pub use level1::Foo;
 "#,
             expect![[r#"
@@ -1411,7 +1411,7 @@ macro_rules! foo$0 {
 }
 //- /bar.rs
 foo!();
-//- /other.rs crate:other deps:lib new_source_root:
+//- /other.rs crate:other deps:lib new_source_root:local
 lib::foo!();
 "#,
             expect![[r#"

--- a/crates/ide_completion/src/completions/qualified_path.rs
+++ b/crates/ide_completion/src/completions/qualified_path.rs
@@ -259,25 +259,25 @@ mod tests {
     fn associated_item_visibility() {
         check(
             r#"
-struct S;
+//- /lib.rs crate:lib new_source_root:library
+pub struct S;
 
-mod m {
-    impl super::S {
-        pub(crate) fn public_method() { }
-        fn private_method() { }
-        pub(crate) type PublicType = u32;
-        type PrivateType = u32;
-        pub(crate) const PUBLIC_CONST: u32 = 1;
-        const PRIVATE_CONST: u32 = 1;
-    }
+impl S {
+    pub fn public_method() { }
+    fn private_method() { }
+    pub type PublicType = u32;
+    type PrivateType = u32;
+    pub const PUBLIC_CONST: u32 = 1;
+    const PRIVATE_CONST: u32 = 1;
 }
 
-fn foo() { let _ = S::$0 }
+//- /main.rs crate:main deps:lib new_source_root:local
+fn foo() { let _ = lib::S::$0 }
 "#,
             expect![[r#"
                 fn public_method() fn()
-                ct PUBLIC_CONST    pub(crate) const PUBLIC_CONST: u32 = 1;
-                ta PublicType      pub(crate) type PublicType = u32;
+                ct PUBLIC_CONST    pub const PUBLIC_CONST: u32 = 1;
+                ta PublicType      pub type PublicType = u32;
             "#]],
         );
     }

--- a/crates/test_utils/src/fixture.rs
+++ b/crates/test_utils/src/fixture.rs
@@ -74,7 +74,7 @@ pub struct Fixture {
     pub cfg_key_values: Vec<(String, String)>,
     pub edition: Option<String>,
     pub env: FxHashMap<String, String>,
-    pub introduce_new_source_root: bool,
+    pub introduce_new_source_root: Option<String>,
 }
 
 pub struct MiniCore {
@@ -162,7 +162,7 @@ impl Fixture {
         let mut cfg_atoms = Vec::new();
         let mut cfg_key_values = Vec::new();
         let mut env = FxHashMap::default();
-        let mut introduce_new_source_root = false;
+        let mut introduce_new_source_root = None;
         for component in components[1..].iter() {
             let (key, value) = component
                 .split_once(':')
@@ -186,7 +186,7 @@ impl Fixture {
                         }
                     }
                 }
-                "new_source_root" => introduce_new_source_root = true,
+                "new_source_root" => introduce_new_source_root = Some(value.to_string()),
                 _ => panic!("bad component: {:?}", component),
             }
         }


### PR DESCRIPTION
This checks if a private item's location is editable (local source root), and completes them anyways if that's the case.

In order to test this, the `new_source_root` fixture command has been changed to take a `local` or `library` value, and to apply to all *following* files instead of the preceding ones (which would be hard to understand).

bors r+