### PR TITLE
fix: Remove the legacy macro scoping hack

### DIFF
--- a/crates/hir_def/src/nameres/collector.rs
+++ b/crates/hir_def/src/nameres/collector.rs
@@ -1890,7 +1890,7 @@ impl ModCollector<'_, '_> {
     }
 
     fn collect_macro_call(&mut self, mac: &MacroCall) {
-        let mut ast_id = AstIdWithPath::new(self.file_id(), mac.ast_id, (*mac.path).clone());
+        let ast_id = AstIdWithPath::new(self.file_id(), mac.ast_id, (*mac.path).clone());
 
         // Case 1: try to resolve in legacy scope and expand macro_rules
         let mut error = None;
@@ -1941,11 +1941,6 @@ impl ModCollector<'_, '_> {
         }
 
         // Case 2: resolve in module scope, expand during name resolution.
-        // We rewrite simple path `macro_name` to `self::macro_name` to force resolve in module scope only.
-        if ast_id.path.is_ident() {
-            ast_id.path.kind = PathKind::Super(0);
-        }
-
         self.def_collector.unresolved_macros.push(MacroDirective {
             module_id: self.module_id,
             depth: self.macro_depth + 1,

--- a/crates/hir_def/src/nameres/tests/macros.rs
+++ b/crates/hir_def/src/nameres/tests/macros.rs
@@ -349,8 +349,10 @@ macro_rules! m {
 "#,
         expect![[r#"
             crate
+            S: t v
         "#]],
     );
+    // FIXME: should not expand. legacy macro scoping is not implemented.
 }
 
 #[test]
@@ -427,6 +429,7 @@ macro_rules! baz {
 "#,
         expect![[r#"
             crate
+            NotFoundBefore: t v
             Ok: t v
             OkAfter: t v
             OkShadowStop: t v
@@ -462,6 +465,7 @@ macro_rules! baz {
             crate::m3::m5
         "#]],
     );
+    // FIXME: should not see `NotFoundBefore`
 }
 
 #[test]
@@ -993,4 +997,27 @@ structs!(Foo);
             structs: m
         "#]],
     );
+}
+
+#[test]
+fn macro_in_prelude() {
+    check(
+        r#"
+//- /lib.rs crate:lib deps:std
+global_asm!();
+
+//- /std.rs crate:std
+pub mod prelude {
+    pub mod rust_2018 {
+        pub macro global_asm() {
+            pub struct S;
+        }
+    }
+}
+        "#,
+        expect![[r#"
+            crate
+            S: t v
+        "#]],
+    )
 }

--- a/crates/ide_diagnostics/src/handlers/unresolved_macro_call.rs
+++ b/crates/ide_diagnostics/src/handlers/unresolved_macro_call.rs
@@ -63,7 +63,7 @@ foo::bar!(92);
 macro_rules! m { () => {} }
 
 m!(); m2!();
-    //^^ error: unresolved macro `self::m2!`
+    //^^ error: unresolved macro `m2!`
 "#,
         );
     }


### PR DESCRIPTION
This stops prepending `self::` to single-ident macro paths, resolving even legacy-scoped macros using the fixed-point algorithm. This is not correct, but a lot easier than fixing this properly (which involves pushing a new scope for every macro definition and invocation).

This allows resolution of macros from the prelude, fixing https://github.com/rust-analyzer/rust-analyzer/issues/9687.