### PR TITLE
docs: Fix several typos and grammar mistakes

### DIFF
--- a/docs/dev/lsp-extensions.md
+++ b/docs/dev/lsp-extensions.md
@@ -656,7 +656,7 @@ interface TestInfo {
 }
 ```
 
-## Hover Actions
+## Move Item
 
 **Issue:** https://github.com/rust-analyzer/rust-analyzer/issues/6823
 

--- a/docs/dev/style.md
+++ b/docs/dev/style.md
@@ -170,7 +170,7 @@ More than one mark per test / code branch doesn't add significantly to understan
 Do not use `#[should_panic]` tests.
 Instead, explicitly check for `None`, `Err`, etc.
 
-**Rationale:** `#[should_panic]` is a tool for library authors, to makes sure that API does not fail silently, when misused.
+**Rationale:** `#[should_panic]` is a tool for library authors to make sure that the API does not fail silently when misused.
 `rust-analyzer` is not a library, we don't need to test for API misuse, and we have to handle any user input without panics.
 Panic messages in the logs from the `#[should_panic]` tests are confusing.
 
@@ -333,7 +333,7 @@ impl Foo {
 }
 ```
 
-Prefer `Default` even it has to be implemented manually.
+Prefer `Default` even if it has to be implemented manually.
 
 **Rationale:** less typing in the common case, uniformity.
 
@@ -343,7 +343,7 @@ Use `Vec::new` rather than `vec![]`.
 
 Avoid using "dummy" states to implement a `Default`.
 If a type doesn't have a sensible default, empty value, don't hide it.
-Let the caller explicitly decide what's the right initial state is.
+Let the caller explicitly decide what the right initial state is.
 
 ## Functions Over Objects
 
@@ -526,7 +526,7 @@ if words.len() != 2 {
 }
 ```
 
-**Rationale:** not allocating is almost often faster.
+**Rationale:** not allocating is almost always faster.
 
 ## Push Allocations to the Call Site
 
@@ -998,9 +998,9 @@ match output.status.code() {
 };
 ```
 
-**Rationale:** like blocks, single-use variables are a cognitively cheap abstraction, as they have access to all the context.
+**Rationale:** Like blocks, single-use variables are a cognitively cheap abstraction, as they have access to all the context.
 Extra variables help during debugging, they make it easy to print/view important intermediate results.
-Giving a name to a condition in `if` expression often improves clarity and leads to a nicer formatted code.
+Giving a name to a condition inside an `if` expression often improves clarity and leads to nicely formatted code.
 
 ## Token names
 

--- a/docs/dev/syntax.md
+++ b/docs/dev/syntax.md
@@ -6,7 +6,7 @@ This guide describes the current state of syntax trees and parsing in rust-analy
 
 ## Source Code
 
-The things described are implemented in two places
+The things described are implemented in three places
 
 * [rowan](https://github.com/rust-analyzer/rowan/tree/v0.9.0) -- a generic library for rowan syntax trees.
 * [ra_syntax](https://github.com/rust-analyzer/rust-analyzer/tree/cf5bdf464cad7ceb9a67e07985a3f4d3799ec0b6/crates/ra_syntax) crate inside rust-analyzer which wraps `rowan` into rust-analyzer specific API.
@@ -15,9 +15,9 @@ The things described are implemented in two places
 
 ## Design Goals
 
-* Syntax trees are lossless, or full fidelity. All comments and whitespace are preserved.
+* Syntax trees are lossless, or full fidelity. All comments and whitespace get preserved.
 * Syntax trees are semantic-less. They describe *strictly* the structure of a sequence of characters, they don't have hygiene, name resolution or type information attached.
-* Syntax trees are simple value type. It is possible to create trees for a syntax without any external context.
+* Syntax trees are simple value types. It is possible to create trees for a syntax without any external context.
 * Syntax trees have intuitive traversal API (parent, children, siblings, etc).
 * Parsing is lossless (even if the input is invalid, the tree produced by the parser represents it exactly).
 * Parsing is resilient (even if the input is invalid, parser tries to see as much syntax tree fragments in the input as it can).


### PR DESCRIPTION
I took some time to clean up the dev docs a bit since I spent the whole week reading them. I am not a native speaker, so if you find something wrong please tell me and I'll fix it 😁 