### PR TITLE
feat: Make most completions respect `#[doc(hidden)]`

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -351,6 +351,20 @@ impl ModuleDef {
         }
         acc
     }
+
+    pub fn attrs(&self, db: &dyn HirDatabase) -> Option<AttrsWithOwner> {
+        Some(match self {
+            ModuleDef::Module(it) => it.attrs(db),
+            ModuleDef::Function(it) => it.attrs(db),
+            ModuleDef::Adt(it) => it.attrs(db),
+            ModuleDef::Variant(it) => it.attrs(db),
+            ModuleDef::Const(it) => it.attrs(db),
+            ModuleDef::Static(it) => it.attrs(db),
+            ModuleDef::Trait(it) => it.attrs(db),
+            ModuleDef::TypeAlias(it) => it.attrs(db),
+            ModuleDef::BuiltinType(_) => return None,
+        })
+    }
 }
 
 impl HasVisibility for ModuleDef {
@@ -2724,6 +2738,32 @@ impl ScopeDef {
         }
 
         items
+    }
+
+    pub fn attrs(&self, db: &dyn HirDatabase) -> Option<AttrsWithOwner> {
+        match self {
+            ScopeDef::ModuleDef(it) => it.attrs(db),
+            ScopeDef::MacroDef(it) => Some(it.attrs(db)),
+            ScopeDef::GenericParam(it) => Some(it.attrs(db)),
+            ScopeDef::ImplSelfType(_)
+            | ScopeDef::AdtSelfType(_)
+            | ScopeDef::Local(_)
+            | ScopeDef::Label(_)
+            | ScopeDef::Unknown => None,
+        }
+    }
+
+    pub fn krate(&self, db: &dyn HirDatabase) -> Option<Crate> {
+        match self {
+            ScopeDef::ModuleDef(it) => it.module(db).map(|m| m.krate()),
+            ScopeDef::MacroDef(it) => it.module(db).map(|m| m.krate()),
+            ScopeDef::GenericParam(it) => Some(it.module(db).krate()),
+            ScopeDef::ImplSelfType(_) => None,
+            ScopeDef::AdtSelfType(it) => Some(it.module(db).krate()),
+            ScopeDef::Local(it) => Some(it.module(db).krate()),
+            ScopeDef::Label(it) => Some(it.module(db).krate()),
+            ScopeDef::Unknown => None,
+        }
     }
 }
 

--- a/crates/ide_completion/src/completions/attribute/derive.rs
+++ b/crates/ide_completion/src/completions/attribute/derive.rs
@@ -54,7 +54,7 @@ fn get_derive_names_in_scope(
     ctx: &CompletionContext,
 ) -> FxHashMap<String, Option<hir::Documentation>> {
     let mut result = FxHashMap::default();
-    ctx.scope.process_all_names(&mut |name, scope_def| {
+    ctx.process_all_names(&mut |name, scope_def| {
         if let hir::ScopeDef::MacroDef(mac) = scope_def {
             if mac.kind() == hir::MacroKind::Derive {
                 result.insert(name.to_string(), mac.docs(ctx.db));

--- a/crates/ide_completion/src/completions/pattern.rs
+++ b/crates/ide_completion/src/completions/pattern.rs
@@ -22,7 +22,7 @@ pub(crate) fn complete_pattern(acc: &mut Completions, ctx: &CompletionContext) {
 
     // FIXME: ideally, we should look at the type we are matching against and
     // suggest variants + auto-imports
-    ctx.scope.process_all_names(&mut |name, res| {
+    ctx.process_all_names(&mut |name, res| {
         let add_resolution = match &res {
             hir::ScopeDef::ModuleDef(def) => match def {
                 hir::ModuleDef::Adt(hir::Adt::Struct(strukt)) => {


### PR DESCRIPTION
Closes https://github.com/rust-analyzer/rust-analyzer/issues/2003

This continues https://github.com/rust-analyzer/rust-analyzer/pull/9681 and makes most other completion sources respect `#[doc(hidden)]`. After this, only flyimport is missing support for this.

bors r+