### PR TITLE
internal: Stop reexporting `hir_def`'s `ItemInNs` from HIR

### DIFF
--- a/crates/hir/src/from_id.rs
+++ b/crates/hir/src/from_id.rs
@@ -5,14 +5,13 @@
 
 use hir_def::{
     expr::{LabelId, PatId},
-    item_scope::ItemInNs,
     AdtId, AssocItemId, DefWithBodyId, EnumVariantId, FieldId, GenericDefId, GenericParamId,
     ModuleDefId, VariantId,
 };
 
 use crate::{
-    Adt, AssocItem, BuiltinType, DefWithBody, Field, GenericDef, GenericParam, Label, Local,
-    MacroDef, ModuleDef, Variant, VariantDef,
+    Adt, AssocItem, BuiltinType, DefWithBody, Field, GenericDef, GenericParam, ItemInNs, Label,
+    Local, ModuleDef, Variant, VariantDef,
 };
 
 macro_rules! from_id {
@@ -258,19 +257,22 @@ impl From<(DefWithBodyId, LabelId)> for Label {
     }
 }
 
-impl From<MacroDef> for ItemInNs {
-    fn from(macro_def: MacroDef) -> Self {
-        ItemInNs::Macros(macro_def.into())
+impl From<hir_def::item_scope::ItemInNs> for ItemInNs {
+    fn from(it: hir_def::item_scope::ItemInNs) -> Self {
+        match it {
+            hir_def::item_scope::ItemInNs::Types(it) => ItemInNs::Types(it.into()),
+            hir_def::item_scope::ItemInNs::Values(it) => ItemInNs::Values(it.into()),
+            hir_def::item_scope::ItemInNs::Macros(it) => ItemInNs::Macros(it.into()),
+        }
     }
 }
 
-impl From<ModuleDef> for ItemInNs {
-    fn from(module_def: ModuleDef) -> Self {
-        match module_def {
-            ModuleDef::Static(_) | ModuleDef::Const(_) | ModuleDef::Function(_) => {
-                ItemInNs::Values(module_def.into())
-            }
-            _ => ItemInNs::Types(module_def.into()),
+impl From<ItemInNs> for hir_def::item_scope::ItemInNs {
+    fn from(it: ItemInNs) -> Self {
+        match it {
+            ItemInNs::Types(it) => Self::Types(it.into()),
+            ItemInNs::Values(it) => Self::Values(it.into()),
+            ItemInNs::Macros(it) => Self::Macros(it.into()),
         }
     }
 }

--- a/crates/ide_assists/src/handlers/qualify_path.rs
+++ b/crates/ide_assists/src/handlers/qualify_path.rs
@@ -176,7 +176,7 @@ fn find_trait_method(
 }
 
 fn item_as_trait(db: &RootDatabase, item: hir::ItemInNs) -> Option<hir::Trait> {
-    let item_module_def = hir::ModuleDef::from(item.as_module_def_id()?);
+    let item_module_def = item.as_module_def()?;
 
     if let hir::ModuleDef::Trait(trait_) = item_module_def {
         Some(trait_)

--- a/crates/ide_assists/src/handlers/replace_derive_with_manual_impl.rs
+++ b/crates/ide_assists/src/handlers/replace_derive_with_manual_impl.rs
@@ -67,7 +67,7 @@ pub(crate) fn replace_derive_with_manual_impl(
         items_locator::AssocItemSearch::Exclude,
         Some(items_locator::DEFAULT_QUERY_SEARCH_LIMIT.inner()),
     )
-    .filter_map(|item| match ModuleDef::from(item.as_module_def_id()?) {
+    .filter_map(|item| match item.as_module_def()? {
         ModuleDef::Trait(trait_) => Some(trait_),
         _ => None,
     })

--- a/crates/ide_db/src/helpers/import_assets.rs
+++ b/crates/ide_db/src/helpers/import_assets.rs
@@ -620,6 +620,5 @@ fn path_import_candidate(
 }
 
 fn item_as_assoc(db: &RootDatabase, item: ItemInNs) -> Option<AssocItem> {
-    item.as_module_def_id()
-        .and_then(|module_def_id| ModuleDef::from(module_def_id).as_assoc_item(db))
+    item.as_module_def().and_then(|module_def| module_def.as_assoc_item(db))
 }

--- a/crates/ide_db/src/items_locator.rs
+++ b/crates/ide_db/src/items_locator.rs
@@ -5,7 +5,7 @@
 use either::Either;
 use hir::{
     import_map::{self, ImportKind},
-    AsAssocItem, Crate, ItemInNs, ModuleDef, Semantics,
+    AsAssocItem, Crate, ItemInNs, Semantics,
 };
 use limit::Limit;
 use syntax::{ast, AstNode, SyntaxKind::NAME};
@@ -147,7 +147,5 @@ fn get_name_definition(
 }
 
 fn is_assoc_item(item: ItemInNs, db: &RootDatabase) -> bool {
-    item.as_module_def_id()
-        .and_then(|module_def_id| ModuleDef::from(module_def_id).as_assoc_item(db))
-        .is_some()
+    item.as_module_def().and_then(|module_def| module_def.as_assoc_item(db)).is_some()
 }


### PR DESCRIPTION
Resolves a FIXME and simplifies downstream code

bors r+