### PR TITLE
Bump notify to 5.0.0-pre.11

### DIFF
--- a/crates/vfs-notify/Cargo.toml
+++ b/crates/vfs-notify/Cargo.toml
@@ -14,7 +14,7 @@ rustc-hash = "1.0"
 jod-thread = "0.1.0"
 walkdir = "2.3.1"
 crossbeam-channel = "0.5.0"
-notify = "5.0.0-pre.3"
+notify = "=5.0.0-pre.11"
 
 vfs = { path = "../vfs", version = "0.0.0" }
 paths = { path = "../paths", version = "0.0.0" }


### PR DESCRIPTION
It looks like the `INotifyWatcher::new` method was removed sometime after `5.0.0-pre.3` and then added back in `5.0.0-pre.11`. Without the `=`, cargo can resolve some version from `5.0.0-pre.4` -> `5.0.0-pre.10` which will not compile.