### PR TITLE
feat: Make flyimport respect `#[doc(hidden)]`

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1599,6 +1599,21 @@ impl ItemInNs {
             ItemInNs::Macros(_) => None,
         }
     }
+
+    /// Returns the crate defining this item (or `None` if `self` is built-in).
+    pub fn krate(&self, db: &dyn HirDatabase) -> Option<Crate> {
+        match self {
+            ItemInNs::Types(did) | ItemInNs::Values(did) => did.module(db).map(|m| m.krate()),
+            ItemInNs::Macros(id) => id.module(db).map(|m| m.krate()),
+        }
+    }
+
+    pub fn attrs(&self, db: &dyn HirDatabase) -> Option<AttrsWithOwner> {
+        match self {
+            ItemInNs::Types(it) | ItemInNs::Values(it) => it.attrs(db),
+            ItemInNs::Macros(it) => Some(it.attrs(db)),
+        }
+    }
 }
 
 /// Invariant: `inner.as_assoc_item(db).is_some()`

--- a/crates/ide_completion/src/context.rs
+++ b/crates/ide_completion/src/context.rs
@@ -378,6 +378,15 @@ impl<'a> CompletionContext<'a> {
         false
     }
 
+    pub(crate) fn is_item_hidden(&self, item: &hir::ItemInNs) -> bool {
+        let attrs = item.attrs(self.db);
+        let krate = item.krate(self.db);
+        match (attrs, krate) {
+            (Some(attrs), Some(krate)) => self.is_doc_hidden(&attrs, krate),
+            _ => false,
+        }
+    }
+
     /// A version of [`SemanticsScope::process_all_names`] that filters out `#[doc(hidden)]` items.
     pub(crate) fn process_all_names(&self, f: &mut dyn FnMut(Name, ScopeDef)) {
         self.scope.process_all_names(&mut |name, def| {


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/7718 (we still don't respect `#[doc(hidden)]` on reexports, but that is tracked by https://github.com/rust-analyzer/rust-analyzer/issues/9197)

bors r+