### PR TITLE
internal: Use more strictly typed syntax nodes for analysis in extract_function assist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,6 +600,7 @@ dependencies = [
  "expect-test",
  "hir",
  "ide_db",
+ "indexmap",
  "itertools",
  "profile",
  "rustc-hash",

--- a/crates/ide_assists/Cargo.toml
+++ b/crates/ide_assists/Cargo.toml
@@ -13,6 +13,7 @@ cov-mark = "2.0.0-pre.1"
 rustc-hash = "1.1.0"
 itertools = "0.10.0"
 either = "1.6.1"
+indexmap = "1.6.2"
 
 stdx = { path = "../stdx", version = "0.0.0" }
 syntax = { path = "../syntax", version = "0.0.0" }


### PR DESCRIPTION
This also prevents it from looking into local items unnecessarily(which might even cause problems in some cases)
bors r+