### PR TITLE
feat: Add `replace_char_with_string` assist

### DIFF
--- a/crates/ide_assists/src/lib.rs
+++ b/crates/ide_assists/src/lib.rs
@@ -194,6 +194,7 @@ mod handlers {
             add_missing_impl_members::add_missing_default_members,
             //
             replace_string_with_char::replace_string_with_char,
+            replace_string_with_char::replace_char_with_string,
             raw_string::make_raw_string,
             //
             extract_variable::extract_variable,

--- a/crates/ide_assists/src/tests/generated.rs
+++ b/crates/ide_assists/src/tests/generated.rs
@@ -1332,6 +1332,23 @@ impl Foo for Bar {
 }
 
 #[test]
+fn doctest_replace_char_with_string() {
+    check_doc_test(
+        "replace_char_with_string",
+        r#####"
+fn main() {
+    find('{$0');
+}
+"#####,
+        r#####"
+fn main() {
+    find("{");
+}
+"#####,
+    )
+}
+
+#[test]
 fn doctest_replace_derive_with_manual_impl() {
     check_doc_test(
         "replace_derive_with_manual_impl",


### PR DESCRIPTION
Adds the counterpart for the `replace_string_with_char` assist and fixes the assist not escaping the `'` in the string `"'"` when transforming that to a char.
bors r+