### PR TITLE
minor: Bump deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.26.0",
+ "object",
  "rustc-demangle",
 ]
 
@@ -1000,15 +1000,6 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38f2be3697a57b4060074ff41b44c16870d916ad7877c17696e063257482bc7"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "object"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c55827317fb4c08822499848a14237d2874d6f139828893017237e7ab93eb386"
@@ -1151,7 +1142,7 @@ dependencies = [
  "jod-thread",
  "log",
  "memmap2",
- "object 0.25.3",
+ "object",
  "paths",
  "profile",
  "serde",
@@ -1170,7 +1161,7 @@ dependencies = [
  "libloading",
  "mbe",
  "memmap2",
- "object 0.25.3",
+ "object",
  "paths",
  "proc_macro_api",
  "proc_macro_test",
@@ -1317,9 +1308,9 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "rowan"
-version = "0.13.0-pre.7"
+version = "0.13.0-pre.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9a7c0b71a45f8ba80c74d55a7d4b3ec611042d3b98ee56835b6af7b5e9f3f83"
+checksum = "9635096edc6dc0fe4a8eea7f17307229e2c4f9b8481f4949e221abe7d94ae6ee"
 dependencies = [
  "countme",
  "hashbrown",

--- a/crates/proc_macro_api/Cargo.toml
+++ b/crates/proc_macro_api/Cargo.toml
@@ -15,7 +15,13 @@ log = "0.4.8"
 crossbeam-channel = "0.5.0"
 jod-thread = "0.1.1"
 memmap2 = "0.3.0"
-object = { version = "0.25.3", default-features = false, features = ["std", "read_core", "elf", "macho", "pe"] }
+object = { version = "0.26", default-features = false, features = [
+    "std",
+    "read_core",
+    "elf",
+    "macho",
+    "pe",
+] }
 snap = "1.0"
 
 paths = { path = "../paths", version = "0.0.0" }

--- a/crates/proc_macro_srv/Cargo.toml
+++ b/crates/proc_macro_srv/Cargo.toml
@@ -9,7 +9,13 @@ edition = "2018"
 doctest = false
 
 [dependencies]
-object = { version = "0.25.3", default-features = false, features = ["std", "read_core", "elf", "macho", "pe"] }
+object = { version = "0.26", default-features = false, features = [
+    "std",
+    "read_core",
+    "elf",
+    "macho",
+    "pe",
+] }
 libloading = "0.7.0"
 memmap2 = "0.3.0"
 

--- a/crates/syntax/Cargo.toml
+++ b/crates/syntax/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 [dependencies]
 cov-mark = "2.0.0-pre.1"
 itertools = "0.10.0"
-rowan = "=0.13.0-pre.7"
+rowan = "=0.13.0-pre.8"
 rustc_lexer = { version = "725.0.0", package = "rustc-ap-rustc_lexer" }
 rustc-hash = "1.1.0"
 arrayvec = "0.7"


### PR DESCRIPTION
Upgrade `rowan` and avoid the duplicate `object` dependency.