### PR TITLE
Exclude `rust-analyzer.server.path` from VS Code's sync feature

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -326,6 +326,7 @@
                         "null",
                         "string"
                     ],
+                    "scope": "machine-overridable",
                     "default": null,
                     "markdownDescription": "Path to rust-analyzer executable (points to bundled binary by default). If this is set, then `#rust-analyzer.updates.channel#` setting is not used"
                 },


### PR DESCRIPTION
By changing the scope of this configuration to `machine-overridible`, this setting becomes fully local for the VS Code instance the user is running.

Having this setting excluded from syncing should help avoid inconveniences for users who have VS Code installed on two different operating systems, where the paths to the language server binary would very likely mismatch.