### PR TITLE
Link “DST” to its definition

### DIFF
--- a/docs/dev/syntax.md
+++ b/docs/dev/syntax.md
@@ -110,7 +110,7 @@ FN@0..17
 
 (significant amount of implementation work here was done by [CAD97](https://github.com/cad97)).
 
-To reduce the amount of allocations, the GreenNode is a DST, which uses a single allocation for header and children. Thus, it is only usable behind a pointer
+To reduce the amount of allocations, the GreenNode is a [DST](https://doc.rust-lang.org/reference/dynamically-sized-types.html), which uses a single allocation for header and children. Thus, it is only usable behind a pointer.
 
 ```
 *-----------+------+----------+------------+--------+--------+-----+--------*


### PR DESCRIPTION
Being new to Rust I wasn't familiar with this acronym and found it hard to guess (the context of syntax trees biased me to reading it as a D-something Syntax Tree and trying to guess what the D was), hard to google (in retrospect googling "rust dst" does the job, but I thought it was an abstract structure thing, not Rust-specific), and hard to Github-search, because `dst` is commonly short for “destination” in code.

Alternatively `<abbr title="dynamically sized type">DST</abbr>` would be about as helpful.