### PR TITLE
Make `LoadCargoConfig`, `fn load_workspace_at` & `fn load_workspace` public again

### DIFF
--- a/crates/rust-analyzer/src/cli.rs
+++ b/crates/rust-analyzer/src/cli.rs
@@ -1,6 +1,6 @@
 //! Various batch processing tasks, intended primarily for debugging.
 
-pub(crate) mod load_cargo;
+pub mod load_cargo;
 mod analysis_stats;
 mod diagnostics;
 mod progress_report;

--- a/crates/rust-analyzer/src/cli/load_cargo.rs
+++ b/crates/rust-analyzer/src/cli/load_cargo.rs
@@ -14,13 +14,17 @@ use vfs::{loader::Handle, AbsPath, AbsPathBuf};
 
 use crate::reload::{ProjectFolders, SourceRootConfig};
 
-pub(crate) struct LoadCargoConfig {
-    pub(crate) load_out_dirs_from_check: bool,
-    pub(crate) with_proc_macro: bool,
-    pub(crate) prefill_caches: bool,
+// Note: Since this type is used by external tools that use rust-analyzer as a library
+// what otherwise would be `pub(crate)` has to be `pub` here instead.
+pub struct LoadCargoConfig {
+    pub load_out_dirs_from_check: bool,
+    pub with_proc_macro: bool,
+    pub prefill_caches: bool,
 }
 
-pub(crate) fn load_workspace_at(
+// Note: Since this function is used by external tools that use rust-analyzer as a library
+// what otherwise would be `pub(crate)` has to be `pub` here instead.
+pub fn load_workspace_at(
     root: &Path,
     cargo_config: &CargoConfig,
     load_config: &LoadCargoConfig,
@@ -33,7 +37,12 @@ pub(crate) fn load_workspace_at(
     load_workspace(workspace, cargo_config, load_config, progress)
 }
 
-fn load_workspace(
+// Note: Since this function is used by external tools that use rust-analyzer as a library
+// what otherwise would be `pub(crate)` has to be `pub` here instead.
+//
+// The reason both, `load_workspace_at` and `load_workspace` are `pub` is that some of
+// these tools need access to `ProjectWorkspace`, too, which `load_workspace_at` hides.
+pub fn load_workspace(
     mut ws: ProjectWorkspace,
     cargo_config: &CargoConfig,
     load_config: &LoadCargoConfig,


### PR DESCRIPTION
This [commit](https://github.com/rust-analyzer/rust-analyzer/commit/b24f816c0d8aaa37fbc0b33f90dd67afbf28adaa) which restricted the visibility of `LoadCargoConfig`, `fn load_workspace_at` & `fn load_workspace` unfortunately effectively rendered every crate/tool that uses rust-analyzer as a library dead in the water.

On of such tools is [cargo-modules](https://github.com/regexident/cargo-modules), a tool for generating tree/graph visualizations of one's Rust project and is powered by rust-analyzer as a library.

For more context see the PRs that introduced those types/functions and made them `pub`:

- https://github.com/rust-analyzer/rust-analyzer/pull/7595
- https://github.com/rust-analyzer/rust-analyzer/pull/7690

If kept as is rust-analyzer would effectively no longer be usable as a library.

cc @SomeoneToIgnore 