### PR TITLE
feat: Show coerced types on type hover

### DIFF
--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -225,7 +225,7 @@ impl<'db, DB: HirDatabase> Semantics<'db, DB> {
         self.imp.type_of_pat(pat)
     }
 
-    pub fn type_of_pat_with_coercion(&self, expr: &ast::Pat) -> Option<Type> {
+    pub fn type_of_pat_with_coercion(&self, expr: &ast::Pat) -> Option<(Type, bool)> {
         self.imp.type_of_pat_with_coercion(expr)
     }
 
@@ -577,7 +577,7 @@ impl<'db> SemanticsImpl<'db> {
         self.analyze(pat.syntax()).type_of_pat(self.db, pat)
     }
 
-    fn type_of_pat_with_coercion(&self, pat: &ast::Pat) -> Option<Type> {
+    fn type_of_pat_with_coercion(&self, pat: &ast::Pat) -> Option<(Type, bool)> {
         self.analyze(pat.syntax()).type_of_pat_with_coercion(self.db, pat)
     }
 

--- a/crates/hir/src/source_analyzer.rs
+++ b/crates/hir/src/source_analyzer.rs
@@ -147,15 +147,15 @@ impl SourceAnalyzer {
         &self,
         db: &dyn HirDatabase,
         pat: &ast::Pat,
-    ) -> Option<Type> {
+    ) -> Option<(Type, bool)> {
         let pat_id = self.pat_id(pat)?;
         let infer = self.infer.as_ref()?;
-        let ty = infer
+        let (ty, coerced) = infer
             .pat_adjustments
             .get(&pat_id)
-            .and_then(|adjusts| adjusts.last().map(|adjust| &adjust.target))
-            .unwrap_or_else(|| &infer[pat_id]);
-        Type::new_with_resolver(db, &self.resolver, ty.clone())
+            .and_then(|adjusts| adjusts.last().map(|adjust| (&adjust.target, true)))
+            .unwrap_or_else(|| (&infer[pat_id], false));
+        Type::new_with_resolver(db, &self.resolver, ty.clone()).zip(Some(coerced))
     }
 
     pub(crate) fn type_of_self(


### PR DESCRIPTION
This applies to both the ranged hover request as well as the normal hover type fallback.
![image](https://user-images.githubusercontent.com/3757771/127883884-2935b624-a3e5-4f35-861a-7d6d3266d187.png)
![image](https://user-images.githubusercontent.com/3757771/127883951-4ff96b6b-7576-4886-887b-1198c1121841.png)

We unfortunately have to leave out syntax highlighting here as otherwise the `Type` and `Coerced` words in the hover will get colored.

Note that this does not show all the coercions yet(and almost no pattern coercions) as not all coercion adjustments are implemented yet.

Closes https://github.com/rust-analyzer/rust-analyzer/issues/2677