### PR TITLE
Give better error message when the rust-analyzer binary path was set in the user's config but the binary is invalid

### DIFF
--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -252,7 +252,12 @@ async function bootstrapServer(config: Config, state: PersistentState): Promise<
     log.info("Using server binary at", path);
 
     if (!isValidExecutable(path)) {
-        throw new Error(`Failed to execute ${path} --version`);
+        if (config.serverPath) {
+            throw new Error(`Failed to execute ${path} --version. \`config.server.path\` or \`config.serverPath\` has been set explicitly.\
+            Consider removing this config or making a valid server binary available at that path.`);
+        } else {
+            throw new Error(`Failed to execute ${path} --version`);
+        }
     }
 
     return path;


### PR DESCRIPTION
@yoshuawuyts and I ran into an issue where my rust-analyzer binary path was set in my extension config (which I didn't realize), but the path set in the config was invalid (it simply wasn't on my path). Having an error message that hinted that the binary's path was explicitly set in the config would have considerably shortened the debug time. 

Thanks! 