### PR TITLE
Add wrap_string_in_format assist

### DIFF
--- a/crates/ide_assists/src/handlers/wrap_string_in_format.rs
+++ b/crates/ide_assists/src/handlers/wrap_string_in_format.rs
@@ -1,0 +1,70 @@
+use syntax::{ast, AstToken};
+
+use crate::{AssistContext, AssistId, AssistKind, Assists};
+
+// Assist: wrap_string_in_format
+//
+// Wraps a plain string literal in a format! macro.
+//
+// ```
+// fn main() {
+//     "Hello,$0 World!";
+// }
+// ```
+// ->
+// ```
+// fn main() {
+//     format!("Hello, World!");
+// }
+// ```
+pub(crate) fn wrap_string_in_format(acc: &mut Assists, ctx: &AssistContext) -> Option<()> {
+    let token = ctx.find_token_at_offset::<ast::String>()?;
+    let target = token.syntax().text_range();
+
+    acc.add(
+        AssistId("wrap_string_in_format", AssistKind::RefactorRewrite),
+        "Wrap in format!()",
+        target,
+        |edit| {
+            edit.insert(token.syntax().text_range().start(), "format!(");
+            edit.insert(token.syntax().text_range().end(), ")");
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::{check_assist, check_assist_target};
+
+    use super::*;
+
+    #[test]
+    fn wrap_string_in_format_target() {
+        check_assist_target(
+            wrap_string_in_format,
+            r#"
+            fn f() {
+                let s = $0"foo";
+            }
+            "#,
+            r#""foo""#,
+        );
+    }
+
+    #[test]
+    fn wrap_string_in_format_works() {
+        check_assist(
+            wrap_string_in_format,
+            r#"
+            fn f() {
+                $0"foo";
+            }
+            "#,
+            r#"
+            fn f() {
+                format!("foo");
+            }
+            "#,
+        )
+    }
+}

--- a/crates/ide_assists/src/lib.rs
+++ b/crates/ide_assists/src/lib.rs
@@ -114,6 +114,7 @@ mod handlers {
     mod unmerge_use;
     mod unwrap_block;
     mod wrap_return_type_in_result;
+    mod wrap_string_in_format;
 
     pub(crate) fn all() -> &'static [Handler] {
         &[
@@ -186,6 +187,7 @@ mod handlers {
             unmerge_use::unmerge_use,
             unwrap_block::unwrap_block,
             wrap_return_type_in_result::wrap_return_type_in_result,
+            wrap_string_in_format::wrap_string_in_format,
             // These are manually sorted for better priorities. By default,
             // priority is determined by the size of the target range (smaller
             // target wins). If the ranges are equal, position in this list is

--- a/crates/ide_assists/src/tests/generated.rs
+++ b/crates/ide_assists/src/tests/generated.rs
@@ -1602,3 +1602,20 @@ fn foo() -> Result<i32, ${0:_}> { Ok(42i32) }
 "#####,
     )
 }
+
+#[test]
+fn doctest_wrap_string_in_format() {
+    check_doc_test(
+        "wrap_string_in_format",
+        r#####"
+fn main() {
+    "Hello,$0 World!";
+}
+"#####,
+        r#####"
+fn main() {
+    format!("Hello, World!");
+}
+"#####,
+    )
+}


### PR DESCRIPTION
This PR adds a new ide-assist: `wrap_string_in_format`.
This assist simply allows to wrap a string-literal in the `format!` macro.

I've noticed myself manually doing this enough times for me to think this would be very helpful, so I thought I'd file a PR!

![Peek 2021-08-03 22-22](https://user-images.githubusercontent.com/5300871/128081019-e070fb28-cb97-4633-afad-5954d0f532f0.gif)



In the future, it would be fitting to maybe add a "remove format!" macro, too. Additionally, I could see some other "wrap in xyz" assists be useful, for example a "wrap value in `Some`" or "wrap type in `Option` assist.