### PR TITLE
fix: Fix detection of macro file in inactive-code diag

### DIFF
--- a/crates/hir_expand/src/lib.rs
+++ b/crates/hir_expand/src/lib.rs
@@ -173,6 +173,10 @@ impl HirFileId {
             _ => false,
         }
     }
+
+    pub fn is_macro(self) -> bool {
+        matches!(self.0, HirFileIdRepr::MacroFile(_))
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/ide_diagnostics/src/handlers/inactive_code.rs
+++ b/crates/ide_diagnostics/src/handlers/inactive_code.rs
@@ -11,7 +11,7 @@ pub(crate) fn inactive_code(
     d: &hir::InactiveCode,
 ) -> Option<Diagnostic> {
     // If there's inactive code somewhere in a macro, don't propagate to the call-site.
-    if d.node.file_id.expansion_info(ctx.sema.db).is_some() {
+    if d.node.file_id.is_macro() {
         return None;
     }
 


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/9753

`HirFileId::expansion_info` can return `None` for builtin macros or if there's an error in the macro call or definition, so add a `HirFileId::is_macro` method that checks the right thing.

bors r+