### PR TITLE
feat: Include suggested replacement in diagnostics

### DIFF
--- a/crates/rust-analyzer/src/diagnostics/test_data/clippy_pass_by_ref.txt
+++ b/crates/rust-analyzer/src/diagnostics/test_data/clippy_pass_by_ref.txt
@@ -107,7 +107,7 @@
                                 },
                             },
                         },
-                        message: "consider passing by value instead",
+                        message: "consider passing by value instead: `self`",
                     },
                 ],
             ),
@@ -262,7 +262,7 @@
             source: Some(
                 "clippy",
             ),
-            message: "consider passing by value instead",
+            message: "consider passing by value instead: `self`",
             related_information: Some(
                 [
                     DiagnosticRelatedInformation {
@@ -298,7 +298,7 @@
         },
         fixes: [
             CodeAction {
-                title: "consider passing by value instead",
+                title: "consider passing by value instead: `self`",
                 group: None,
                 kind: Some(
                     CodeActionKind(

--- a/crates/rust-analyzer/src/diagnostics/test_data/rustc_unused_variable.txt
+++ b/crates/rust-analyzer/src/diagnostics/test_data/rustc_unused_variable.txt
@@ -61,7 +61,7 @@
                                 },
                             },
                         },
-                        message: "consider prefixing with an underscore",
+                        message: "consider prefixing with an underscore: `_foo`",
                     },
                 ],
             ),
@@ -109,7 +109,7 @@
             source: Some(
                 "rustc",
             ),
-            message: "consider prefixing with an underscore",
+            message: "consider prefixing with an underscore: `_foo`",
             related_information: Some(
                 [
                     DiagnosticRelatedInformation {
@@ -145,7 +145,7 @@
         },
         fixes: [
             CodeAction {
-                title: "consider prefixing with an underscore",
+                title: "consider prefixing with an underscore: `_foo`",
                 group: None,
                 kind: Some(
                     CodeActionKind(

--- a/crates/rust-analyzer/src/diagnostics/test_data/rustc_unused_variable_as_hint.txt
+++ b/crates/rust-analyzer/src/diagnostics/test_data/rustc_unused_variable_as_hint.txt
@@ -61,7 +61,7 @@
                                 },
                             },
                         },
-                        message: "consider prefixing with an underscore",
+                        message: "consider prefixing with an underscore: `_foo`",
                     },
                 ],
             ),
@@ -109,7 +109,7 @@
             source: Some(
                 "rustc",
             ),
-            message: "consider prefixing with an underscore",
+            message: "consider prefixing with an underscore: `_foo`",
             related_information: Some(
                 [
                     DiagnosticRelatedInformation {
@@ -145,7 +145,7 @@
         },
         fixes: [
             CodeAction {
-                title: "consider prefixing with an underscore",
+                title: "consider prefixing with an underscore: `_foo`",
                 group: None,
                 kind: Some(
                     CodeActionKind(

--- a/crates/rust-analyzer/src/diagnostics/test_data/rustc_unused_variable_as_info.txt
+++ b/crates/rust-analyzer/src/diagnostics/test_data/rustc_unused_variable_as_info.txt
@@ -61,7 +61,7 @@
                                 },
                             },
                         },
-                        message: "consider prefixing with an underscore",
+                        message: "consider prefixing with an underscore: `_foo`",
                     },
                 ],
             ),
@@ -109,7 +109,7 @@
             source: Some(
                 "rustc",
             ),
-            message: "consider prefixing with an underscore",
+            message: "consider prefixing with an underscore: `_foo`",
             related_information: Some(
                 [
                     DiagnosticRelatedInformation {
@@ -145,7 +145,7 @@
         },
         fixes: [
             CodeAction {
-                title: "consider prefixing with an underscore",
+                title: "consider prefixing with an underscore: `_foo`",
                 group: None,
                 kind: Some(
                     CodeActionKind(

--- a/crates/rust-analyzer/src/diagnostics/test_data/snap_multi_line_fix.txt
+++ b/crates/rust-analyzer/src/diagnostics/test_data/snap_multi_line_fix.txt
@@ -107,7 +107,7 @@
                                 },
                             },
                         },
-                        message: "return the expression directly",
+                        message: "return the expression directly: `(0..10).collect()`",
                     },
                 ],
             ),
@@ -262,7 +262,7 @@
             source: Some(
                 "clippy",
             ),
-            message: "return the expression directly",
+            message: "return the expression directly: `(0..10).collect()`",
             related_information: Some(
                 [
                     DiagnosticRelatedInformation {
@@ -298,7 +298,7 @@
         },
         fixes: [
             CodeAction {
-                title: "return the expression directly",
+                title: "return the expression directly: `(0..10).collect()`",
                 group: None,
                 kind: Some(
                     CodeActionKind(

--- a/crates/rust-analyzer/src/diagnostics/to_proto.rs
+++ b/crates/rust-analyzer/src/diagnostics/to_proto.rs
@@ -138,7 +138,9 @@ fn map_rust_child_diagnostic(
     let mut suggested_replacements = Vec::new();
     for &span in &spans {
         if let Some(suggested_replacement) = &span.suggested_replacement {
-            suggested_replacements.push(suggested_replacement);
+            if !suggested_replacement.is_empty() {
+                suggested_replacements.push(suggested_replacement);
+            }
             let location = location(config, workspace_root, span);
             let edit = lsp_types::TextEdit::new(location.range, suggested_replacement.clone());
             edit_map.entry(location.uri).or_default().push(edit);

--- a/crates/rust-analyzer/src/diagnostics/to_proto.rs
+++ b/crates/rust-analyzer/src/diagnostics/to_proto.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 
 use flycheck::{DiagnosticLevel, DiagnosticSpan};
+use itertools::Itertools;
 use stdx::format_to;
 use vfs::{AbsPath, AbsPathBuf};
 
@@ -134,19 +135,31 @@ fn map_rust_child_diagnostic(
     }
 
     let mut edit_map: HashMap<lsp_types::Url, Vec<lsp_types::TextEdit>> = HashMap::new();
+    let mut suggested_replacements = Vec::new();
     for &span in &spans {
         if let Some(suggested_replacement) = &span.suggested_replacement {
+            suggested_replacements.push(suggested_replacement);
             let location = location(config, workspace_root, span);
             let edit = lsp_types::TextEdit::new(location.range, suggested_replacement.clone());
             edit_map.entry(location.uri).or_default().push(edit);
         }
     }
 
+    // rustc renders suggestion diagnostics by appending the suggested replacement, so do the same
+    // here, otherwise the diagnostic text is missing useful information.
+    let mut message = rd.message.clone();
+    if !suggested_replacements.is_empty() {
+        message.push_str(": ");
+        let suggestions =
+            suggested_replacements.iter().map(|suggestion| format!("`{}`", suggestion)).join(", ");
+        message.push_str(&suggestions);
+    }
+
     if edit_map.is_empty() {
         MappedRustChildDiagnostic::SubDiagnostic(SubDiagnostic {
             related: lsp_types::DiagnosticRelatedInformation {
                 location: location(config, workspace_root, spans[0]),
-                message: rd.message.clone(),
+                message,
             },
             suggested_fix: None,
         })
@@ -154,10 +167,10 @@ fn map_rust_child_diagnostic(
         MappedRustChildDiagnostic::SubDiagnostic(SubDiagnostic {
             related: lsp_types::DiagnosticRelatedInformation {
                 location: location(config, workspace_root, spans[0]),
-                message: rd.message.clone(),
+                message: message.clone(),
             },
             suggested_fix: Some(lsp_ext::CodeAction {
-                title: rd.message.clone(),
+                title: message,
                 group: None,
                 kind: Some(lsp_types::CodeActionKind::QUICKFIX),
                 edit: Some(lsp_ext::SnippetWorkspaceEdit {


### PR DESCRIPTION
rustc renders the diagnostic text for suggestions by including the suggested replacement at the end (`` help: a function with a similar name exists: `boo` ``), but the emitted JSON diagnostic does not include this in the message. This causes our diagnostics to lack some useful info, so this PR fixes that by appending any suggested replacements to the message.

Fixes https://github.com/rust-analyzer/rust-analyzer/issues/9797

Before:
![screenshot-2021-08-06-15:54:19](https://user-images.githubusercontent.com/1786438/128521003-105a43a3-e386-4afc-9d5c-7806631f53d7.png)

After:
![screenshot-2021-08-06-15:53:16](https://user-images.githubusercontent.com/1786438/128521022-c16e0967-6cc6-410d-917d-5db5cfbb96be.png)

bors r+