### PR TITLE
Implicit `Sized` bounds

### DIFF
--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -239,7 +239,8 @@ impl HirDisplay for TypeParam {
         let predicates =
             bounds.iter().cloned().map(|b| b.substitute(&Interner, &substs)).collect::<Vec<_>>();
         if !(predicates.is_empty() || f.omit_verbose_types()) {
-            write_bounds_like_dyn_trait_with_prefix(":", &predicates, SizedByDefault::Sized, f)?;
+            let default_sized = SizedByDefault::Sized { anchor: self.module(f.db).krate().id };
+            write_bounds_like_dyn_trait_with_prefix(":", &predicates, default_sized, f)?;
         }
         Ok(())
     }

--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -93,7 +93,7 @@ impl HirDisplay for Function {
         } else {
             match &*data.ret_type {
                 TypeRef::ImplTrait(bounds) => match bounds[0].as_ref() {
-                    TypeBound::Path(path) => {
+                    TypeBound::Path(path, _) => {
                         path.segments().iter().last().unwrap().args_and_bindings.unwrap().bindings
                             [0]
                         .type_ref

--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -7,7 +7,7 @@ use hir_def::{
 };
 use hir_ty::display::{
     write_bounds_like_dyn_trait_with_prefix, write_visibility, HirDisplay, HirDisplayError,
-    HirFormatter,
+    HirFormatter, SizedByDefault,
 };
 use hir_ty::Interner;
 use syntax::ast::{self, NameOwner};
@@ -239,7 +239,7 @@ impl HirDisplay for TypeParam {
         let predicates =
             bounds.iter().cloned().map(|b| b.substitute(&Interner, &substs)).collect::<Vec<_>>();
         if !(predicates.is_empty() || f.omit_verbose_types()) {
-            write_bounds_like_dyn_trait_with_prefix(":", &predicates, f)?;
+            write_bounds_like_dyn_trait_with_prefix(":", &predicates, SizedByDefault::Sized, f)?;
         }
         Ok(())
     }

--- a/crates/hir_def/src/generics.rs
+++ b/crates/hir_def/src/generics.rs
@@ -338,10 +338,6 @@ impl GenericParams {
         hrtb_lifetimes: Option<&Box<[Name]>>,
         target: Either<TypeRef, LifetimeRef>,
     ) {
-        if bound.question_mark_token().is_some() {
-            // FIXME: remove this bound
-            return;
-        }
         let bound = TypeBound::from_ast(lower_ctx, bound);
         let predicate = match (target, bound) {
             (Either::Left(type_ref), bound) => match hrtb_lifetimes {

--- a/crates/hir_def/src/item_tree/lower.rs
+++ b/crates/hir_def/src/item_tree/lower.rs
@@ -10,7 +10,7 @@ use syntax::{
 
 use crate::{
     generics::{GenericParams, TypeParamData, TypeParamProvenance},
-    type_ref::{LifetimeRef, TraitRef},
+    type_ref::{LifetimeRef, TraitBoundModifier, TraitRef},
 };
 
 use super::*;
@@ -369,7 +369,7 @@ impl<'a> Ctx<'a> {
         let (ret_type, async_ret_type) = if func.async_token().is_some() {
             let async_ret_type = ret_type.clone();
             let future_impl = desugar_future_path(ret_type);
-            let ty_bound = Interned::new(TypeBound::Path(future_impl));
+            let ty_bound = Interned::new(TypeBound::Path(future_impl, TraitBoundModifier::None));
             (TypeRef::ImplTrait(vec![ty_bound]), Some(async_ret_type))
         } else {
             (ret_type, None)

--- a/crates/hir_def/src/item_tree/pretty.rs
+++ b/crates/hir_def/src/item_tree/pretty.rs
@@ -8,6 +8,7 @@ use crate::{
     attr::RawAttrs,
     generics::{WherePredicate, WherePredicateTypeTarget},
     path::GenericArg,
+    type_ref::TraitBoundModifier,
     visibility::RawVisibility,
 };
 
@@ -543,7 +544,13 @@ impl<'a> Printer<'a> {
             }
 
             match bound.as_ref() {
-                TypeBound::Path(path) => self.print_path(path),
+                TypeBound::Path(path, modifier) => {
+                    match modifier {
+                        TraitBoundModifier::None => (),
+                        TraitBoundModifier::Maybe => w!(self, "?"),
+                    }
+                    self.print_path(path)
+                }
                 TypeBound::ForLifetime(lifetimes, path) => {
                     w!(self, "for<{}> ", lifetimes.iter().format(", "));
                     self.print_path(path);

--- a/crates/hir_def/src/item_tree/tests.rs
+++ b/crates/hir_def/src/item_tree/tests.rs
@@ -304,7 +304,7 @@ struct S<'a, 'b: 'a, T: Copy + 'a + 'b, const K: u8 = 0> {
     field: &'a &'b T,
 }
 
-struct Tuple<T: Copy>(T);
+struct Tuple<T: Copy, U: ?Sized>(T, U);
 
 impl<'a, 'b: 'a, T: Copy + 'a + 'b, const K: u8 = 0> S<'a, 'b, T, K> {
     fn f<G: 'a>(arg: impl Copy) -> impl Copy {}
@@ -325,11 +325,13 @@ trait Tr<'a, T: 'a>: Super where Self: for<'a> Tr<'a, T> {}
                 pub(self) field: &'a &'b T,
             }
 
-            pub(self) struct Tuple<T>(
+            pub(self) struct Tuple<T, U>(
                 pub(self) 0: T,
+                pub(self) 1: U,
             )
             where
-                T: Copy;
+                T: Copy,
+                U: ?Sized;
 
             impl<'a, 'b, T, const K: u8> S<'a, 'b, T, K>
             where

--- a/crates/hir_def/src/type_ref.rs
+++ b/crates/hir_def/src/type_ref.rs
@@ -118,10 +118,18 @@ impl LifetimeRef {
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub enum TypeBound {
-    Path(Path),
+    Path(Path, TraitBoundModifier),
     ForLifetime(Box<[Name]>, Path),
     Lifetime(LifetimeRef),
     Error,
+}
+
+/// A modifier on a bound, currently this is only used for `?Sized`, where the
+/// modifier is `Maybe`.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub enum TraitBoundModifier {
+    None,
+    Maybe,
 }
 
 impl TypeRef {
@@ -233,7 +241,7 @@ impl TypeRef {
                 TypeRef::ImplTrait(bounds) | TypeRef::DynTrait(bounds) => {
                     for bound in bounds {
                         match bound.as_ref() {
-                            TypeBound::Path(path) | TypeBound::ForLifetime(_, path) => {
+                            TypeBound::Path(path, _) | TypeBound::ForLifetime(_, path) => {
                                 go_path(path, f)
                             }
                             TypeBound::Lifetime(_) | TypeBound::Error => (),
@@ -265,7 +273,7 @@ impl TypeRef {
                         }
                         for bound in &binding.bounds {
                             match bound.as_ref() {
-                                TypeBound::Path(path) | TypeBound::ForLifetime(_, path) => {
+                                TypeBound::Path(path, _) | TypeBound::ForLifetime(_, path) => {
                                     go_path(path, f)
                                 }
                                 TypeBound::Lifetime(_) | TypeBound::Error => (),
@@ -295,7 +303,11 @@ impl TypeBound {
 
         match node.kind() {
             ast::TypeBoundKind::PathType(path_type) => {
-                lower_path_type(path_type).map(TypeBound::Path).unwrap_or(TypeBound::Error)
+                let m = match node.question_mark_token() {
+                    Some(_) => TraitBoundModifier::Maybe,
+                    None => TraitBoundModifier::None,
+                };
+                lower_path_type(path_type).map(|p| TypeBound::Path(p, m)).unwrap_or(TypeBound::Error)
             }
             ast::TypeBoundKind::ForType(for_type) => {
                 let lt_refs = match for_type.generic_param_list() {
@@ -322,7 +334,7 @@ impl TypeBound {
 
     pub fn as_path(&self) -> Option<&Path> {
         match self {
-            TypeBound::Path(p) | TypeBound::ForLifetime(_, p) => Some(p),
+            TypeBound::Path(p, _) | TypeBound::ForLifetime(_, p) => Some(p),
             TypeBound::Lifetime(_) | TypeBound::Error => None,
         }
     }

--- a/crates/hir_def/src/type_ref.rs
+++ b/crates/hir_def/src/type_ref.rs
@@ -307,7 +307,9 @@ impl TypeBound {
                     Some(_) => TraitBoundModifier::Maybe,
                     None => TraitBoundModifier::None,
                 };
-                lower_path_type(path_type).map(|p| TypeBound::Path(p, m)).unwrap_or(TypeBound::Error)
+                lower_path_type(path_type)
+                    .map(|p| TypeBound::Path(p, m))
+                    .unwrap_or(TypeBound::Error)
             }
             ast::TypeBoundKind::ForType(for_type) => {
                 let lt_refs = match for_type.generic_param_list() {

--- a/crates/hir_def/src/type_ref.rs
+++ b/crates/hir_def/src/type_ref.rs
@@ -332,9 +332,10 @@ impl TypeBound {
         }
     }
 
-    pub fn as_path(&self) -> Option<&Path> {
+    pub fn as_path(&self) -> Option<(&Path, &TraitBoundModifier)> {
         match self {
-            TypeBound::Path(p, _) | TypeBound::ForLifetime(_, p) => Some(p),
+            TypeBound::Path(p, m) => Some((p, m)),
+            TypeBound::ForLifetime(_, p) => Some((p, &TraitBoundModifier::None)),
             TypeBound::Lifetime(_) | TypeBound::Error => None,
         }
     }

--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -377,7 +377,7 @@ impl HirDisplay for Ty {
                 }
 
                 // FIXME: all this just to decide whether to use parentheses...
-                let conains_impl_fn = |bounds: &[QuantifiedWhereClause]| {
+                let contains_impl_fn = |bounds: &[QuantifiedWhereClause]| {
                     bounds.iter().any(|bound| {
                         if let WhereClause::Implemented(trait_ref) = bound.skip_binders() {
                             let trait_ = trait_ref.hir_trait_id();
@@ -390,7 +390,7 @@ impl HirDisplay for Ty {
                 let (preds_to_print, has_impl_fn_pred) = match t.kind(&Interner) {
                     TyKind::Dyn(dyn_ty) if dyn_ty.bounds.skip_binders().interned().len() > 1 => {
                         let bounds = dyn_ty.bounds.skip_binders().interned();
-                        (bounds.len(), conains_impl_fn(bounds))
+                        (bounds.len(), contains_impl_fn(bounds))
                     }
                     TyKind::Alias(AliasTy::Opaque(OpaqueTy {
                         opaque_ty_id,
@@ -435,7 +435,7 @@ impl HirDisplay for Ty {
                                 }
                             }
 
-                            (len, conains_impl_fn(bounds.skip_binders()))
+                            (len, contains_impl_fn(bounds.skip_binders()))
                         } else {
                             (0, false)
                         }

--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -13,7 +13,7 @@ use hir_def::{
     intern::{Internable, Interned},
     item_scope::ItemInNs,
     path::{Path, PathKind},
-    type_ref::{TypeBound, TypeRef},
+    type_ref::{TraitBoundModifier, TypeBound, TypeRef},
     visibility::Visibility,
     AssocContainerId, Lookup, ModuleId, TraitId,
 };
@@ -1026,7 +1026,14 @@ impl HirDisplay for TypeRef {
 impl HirDisplay for TypeBound {
     fn hir_fmt(&self, f: &mut HirFormatter) -> Result<(), HirDisplayError> {
         match self {
-            TypeBound::Path(path) => path.hir_fmt(f),
+            TypeBound::Path(path, modifier) => {
+                // todo don't print implicit Sized; implicit ?Sized on Self of a trait
+                match modifier {
+                    TraitBoundModifier::None => (),
+                    TraitBoundModifier::Maybe => write!(f, "?")?,
+                }
+                path.hir_fmt(f)
+            }
             TypeBound::Lifetime(lifetime) => write!(f, "{}", lifetime.name),
             TypeBound::ForLifetime(lifetimes, path) => {
                 write!(f, "for<{}> ", lifetimes.iter().format(", "))?;

--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -791,10 +791,10 @@ fn write_bounds_like_dyn_trait(
                 if default_sized.is_sized_trait(trait_, f.db.upcast()) {
                     is_sized = true;
                     if matches!(default_sized, SizedByDefault::Sized { .. }) {
-                            // Don't print +Sized, but rather +?Sized if absent.
-                            continue;
-                        }
+                        // Don't print +Sized, but rather +?Sized if absent.
+                        continue;
                     }
+                }
                 if !is_fn_trait {
                     is_fn_trait = fn_traits(f.db.upcast(), trait_).any(|it| it == trait_);
                 }

--- a/crates/hir_ty/src/infer/coerce.rs
+++ b/crates/hir_ty/src/infer/coerce.rs
@@ -578,7 +578,6 @@ impl<'a> InferenceContext<'a> {
             Solution::Ambig(Guidance::Definite(subst)) => {
                 canonicalized.apply_solution(&mut self.table, subst)
             }
-            // FIXME: should we accept ambiguous results here?
             _ => return Err(TypeError),
         };
         let unsize =

--- a/crates/hir_ty/src/infer/coerce.rs
+++ b/crates/hir_ty/src/infer/coerce.rs
@@ -575,11 +575,11 @@ impl<'a> InferenceContext<'a> {
                     },
                 );
             }
-            Solution::Ambig(guidance) => {
-                if let Guidance::Definite(subst) = guidance {
-                    canonicalized.apply_solution(&mut self.table, subst);
-                }
+            Solution::Ambig(Guidance::Definite(subst)) => {
+                canonicalized.apply_solution(&mut self.table, subst)
             }
+            // FIXME: should we accept ambiguous results here?
+            _ => return Err(TypeError),
         };
         let unsize =
             Adjustment { kind: Adjust::Pointer(PointerCast::Unsize), target: to_ty.clone() };

--- a/crates/hir_ty/src/infer/coerce.rs
+++ b/crates/hir_ty/src/infer/coerce.rs
@@ -17,8 +17,8 @@ use crate::{
         Adjust, Adjustment, AutoBorrow, InferOk, InferResult, InferenceContext, OverloadedDeref,
         PointerCast, TypeError, TypeMismatch,
     },
-    static_lifetime, Canonical, DomainGoal, FnPointer, FnSig, InEnvironment, Interner, Solution,
-    Substitution, Ty, TyBuilder, TyExt, TyKind,
+    static_lifetime, Canonical, DomainGoal, FnPointer, FnSig, Guidance, InEnvironment, Interner,
+    Solution, Substitution, Ty, TyBuilder, TyExt, TyKind,
 };
 
 pub(crate) type CoerceResult = Result<InferOk<(Vec<Adjustment>, Ty)>, TypeError>;
@@ -541,7 +541,7 @@ impl<'a> InferenceContext<'a> {
             _ => return Err(TypeError),
         };
 
-        let trait_ref = {
+        let coerce_unsized_tref = {
             let b = TyBuilder::trait_ref(self.db, coerce_unsized_trait);
             if b.remaining() != 2 {
                 // The CoerceUnsized trait should have two generic params: Self and T.
@@ -551,7 +551,7 @@ impl<'a> InferenceContext<'a> {
         };
 
         let goal: InEnvironment<DomainGoal> =
-            InEnvironment::new(&self.trait_env.env, trait_ref.cast(&Interner));
+            InEnvironment::new(&self.trait_env.env, coerce_unsized_tref.cast(&Interner));
 
         let canonicalized = self.canonicalize(goal);
 
@@ -575,8 +575,11 @@ impl<'a> InferenceContext<'a> {
                     },
                 );
             }
-            // FIXME: should we accept ambiguous results here?
-            _ => return Err(TypeError),
+            Solution::Ambig(guidance) => {
+                if let Guidance::Definite(subst) = guidance {
+                    canonicalized.apply_solution(&mut self.table, subst);
+                }
+            }
         };
         let unsize =
             Adjustment { kind: Adjust::Pointer(PointerCast::Unsize), target: to_ty.clone() };

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -881,8 +881,6 @@ impl<'a> TyLoweringContext<'a> {
         cov_mark::hit!(lower_rpit);
         let self_ty =
             TyKind::BoundVar(BoundVar::new(DebruijnIndex::INNERMOST, 0)).intern(&Interner);
-        // XXX(iDawer): Can shifting mess with unsized_types? For now I better reinsure.
-        let outer_unsized_types = self.unsized_types.replace(Default::default());
         let predicates = self.with_shifted_in(DebruijnIndex::ONE, |ctx| {
             let mut predicates: Vec<_> = bounds
                 .iter()
@@ -907,7 +905,6 @@ impl<'a> TyLoweringContext<'a> {
             }
             predicates
         });
-        self.unsized_types.replace(outer_unsized_types);
 
         ReturnTypeImplTrait { bounds: crate::make_only_type_binders(1, predicates) }
     }

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -828,7 +828,9 @@ impl<'a> TyLoweringContext<'a> {
         trait_ref: TraitRef,
     ) -> impl Iterator<Item = QuantifiedWhereClause> + 'a {
         let last_segment = match bound {
-            TypeBound::Path(path, TraitBoundModifier::None) | TypeBound::ForLifetime(_, path) => path.segments().last(),
+            TypeBound::Path(path, TraitBoundModifier::None) | TypeBound::ForLifetime(_, path) => {
+                path.segments().last()
+            }
             TypeBound::Path(_, TraitBoundModifier::Maybe)
             | TypeBound::Error
             | TypeBound::Lifetime(_) => None,

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -66,8 +66,8 @@ pub struct TyLoweringContext<'a> {
     /// Splitting this up would be a possible fix.
     opaque_type_data: RefCell<Vec<ReturnTypeImplTrait>>,
     expander: RefCell<Option<Expander>>,
-    /// Keeps tracking types with explicit `?Sized` bounds.
-    unsized_types: RefCell<FxHashSet<Ty>>,
+    /// Tracks types with explicit `?Sized` bounds.
+    pub(crate) unsized_types: RefCell<FxHashSet<Ty>>,
 }
 
 impl<'a> TyLoweringContext<'a> {
@@ -796,7 +796,7 @@ impl<'a> TyLoweringContext<'a> {
                     .and_then(|krate| self.db.lang_item(krate, "sized".into()))
                     .and_then(|lang_item| lang_item.as_trait());
                 // Don't lower associated type bindings as the only possible relaxed trait bound
-                // `?Sized` has none of them.
+                // `?Sized` has no of them.
                 // If we got another trait here ignore the bound completely.
                 let trait_id = self
                     .lower_trait_ref_from_path(path, Some(self_ty.clone()))
@@ -996,7 +996,6 @@ pub(crate) fn generic_predicates_for_param_query(
     let ctx =
         TyLoweringContext::new(db, &resolver).with_type_param_mode(TypeParamLoweringMode::Variable);
     let generics = generics(db.upcast(), param_id.parent);
-    // TODO(iDawer): add implicitly sized clauses?
     resolver
         .where_predicates_in_scope()
         // we have to filter out all other predicates *first*, before attempting to lower them

--- a/crates/hir_ty/src/tests/coercion.rs
+++ b/crates/hir_ty/src/tests/coercion.rs
@@ -559,3 +559,16 @@ fn test() {
         "#,
     );
 }
+
+#[test]
+fn coerce_type_var() {
+    check_types(
+        r#"
+//- minicore: from, coerce_unsized
+fn test() {
+    let x = ();
+    let _: &() = &x.into();
+}               //^^^^^^^^ ()
+"#,
+    )
+}

--- a/crates/hir_ty/src/tests/coercion.rs
+++ b/crates/hir_ty/src/tests/coercion.rs
@@ -406,7 +406,7 @@ trait Foo {}
 fn test(f: impl Foo, g: &(impl Foo + ?Sized)) {
     let _: &dyn Foo = &f;
     let _: &dyn Foo = g;
-                    //^ expected &dyn Foo, got &impl Foo
+                    //^ expected &dyn Foo, got &impl Foo + ?Sized
 }
         "#,
     );

--- a/crates/hir_ty/src/tests/coercion.rs
+++ b/crates/hir_ty/src/tests/coercion.rs
@@ -398,15 +398,15 @@ fn test() {
 
 #[test]
 fn coerce_unsize_apit() {
-    // FIXME: #8984
     check(
         r#"
 //- minicore: coerce_unsized
 trait Foo {}
 
-fn test(f: impl Foo) {
+fn test(f: impl Foo, g: &(impl Foo + ?Sized)) {
     let _: &dyn Foo = &f;
-                    //^^ expected &dyn Foo, got &impl Foo
+    let _: &dyn Foo = g;
+                    //^ expected &dyn Foo, got &impl Foo
 }
         "#,
     );

--- a/crates/hir_ty/src/tests/display_source_code.rs
+++ b/crates/hir_ty/src/tests/display_source_code.rs
@@ -42,15 +42,16 @@ fn main() {
 
 #[test]
 fn render_raw_ptr_impl_ty() {
+    // FIXME: remove parens, they apper because there is an implicit Sized bound
     check_types_source_code(
         r#"
-trait Sized {}
+#[lang = "sized"] trait Sized {}
 trait Unpin {}
-fn foo() -> *const (impl Unpin + Sized) { loop {} }
+fn foo() -> *const impl Unpin { loop {} }
 fn main() {
     let foo = foo();
     foo;
-} //^^^ *const (impl Unpin + Sized)
+} //^^^ *const (impl Unpin)
 "#,
     );
 }
@@ -72,8 +73,7 @@ fn foo(foo: &dyn for<'a> Foo<'a>) {}
 fn sized_bounds_apit() {
     check_types_source_code(
         r#"
-#[lang = "sized"]
-pub trait Sized {}
+#[lang = "sized"] trait Sized {}
 
 trait Foo {}
 trait Bar<T> {}
@@ -83,7 +83,7 @@ fn test(
     b: impl Foo + Sized,
     c: &(impl Foo + ?Sized),
     d: S<impl Foo>,
-    e: impl Bar<impl Foo>,
+    ref_any: &impl ?Sized,
     empty: impl,
 ) {
     a;
@@ -94,8 +94,8 @@ fn test(
   //^ &impl Foo + ?Sized
     d;
   //^ S<impl Foo>
-    e;
-  //^ impl Bar<impl Foo>
+    ref_any;
+  //^ &impl ?Sized
     empty;
 } //^ impl Sized
 "#,
@@ -106,8 +106,7 @@ fn test(
 fn sized_bounds_rpit() {
     check_types_source_code(
         r#"
-#[lang = "sized"]
-pub trait Sized {}
+#[lang = "sized"] trait Sized {}
 
 trait Foo {}
 fn foo() -> impl Foo { loop {} }
@@ -123,8 +122,7 @@ fn test<T: Foo>() {
 fn sized_bounds_impl_traits_in_fn_signature() {
     check_types_source_code(
         r#"
-#[lang = "sized"]
-pub trait Sized {}
+#[lang = "sized"] trait Sized {}
 
 trait Foo {}
 fn test(

--- a/crates/hir_ty/src/tests/display_source_code.rs
+++ b/crates/hir_ty/src/tests/display_source_code.rs
@@ -45,7 +45,7 @@ fn render_raw_ptr_impl_ty() {
     // FIXME: remove parens, they apper because there is an implicit Sized bound
     check_types_source_code(
         r#"
-#[lang = "sized"] trait Sized {}
+//- minicore: sized
 trait Unpin {}
 fn foo() -> *const impl Unpin { loop {} }
 fn main() {
@@ -73,8 +73,7 @@ fn foo(foo: &dyn for<'a> Foo<'a>) {}
 fn sized_bounds_apit() {
     check_types_source_code(
         r#"
-#[lang = "sized"] trait Sized {}
-
+//- minicore: sized
 trait Foo {}
 trait Bar<T> {}
 struct S<T>;
@@ -106,8 +105,7 @@ fn test(
 fn sized_bounds_rpit() {
     check_types_source_code(
         r#"
-#[lang = "sized"] trait Sized {}
-
+//- minicore: sized
 trait Foo {}
 fn foo() -> impl Foo { loop {} }
 fn test<T: Foo>() {
@@ -122,8 +120,7 @@ fn test<T: Foo>() {
 fn sized_bounds_impl_traits_in_fn_signature() {
     check_types_source_code(
         r#"
-#[lang = "sized"] trait Sized {}
-
+//- minicore: sized
 trait Foo {}
 fn test(
     a: fn(impl Foo) -> impl Foo,

--- a/crates/hir_ty/src/tests/method_resolution.rs
+++ b/crates/hir_ty/src/tests/method_resolution.rs
@@ -1312,3 +1312,31 @@ impl<'a, T> IntoIterator for &'a [T] {
     "#,
     );
 }
+
+#[test]
+fn sized_blanket_impl() {
+    check_infer(
+        r#"
+#[lang = "sized"]
+pub trait Sized {}
+
+trait Foo { fn foo() -> u8; }
+impl<T: Sized> Foo for T {}
+fn f<S: Sized, T, U: ?Sized>() {
+    u32::foo;
+    S::foo;
+    T::foo;
+    U::foo;
+    <[u32]>::foo;
+}
+"#,
+        expect![[r#"
+            127..198 '{     ...foo; }': ()
+            133..141 'u32::foo': fn foo<u32>() -> u8
+            147..153 'S::foo': fn foo<S>() -> u8
+            159..165 'T::foo': fn foo<T>() -> u8
+            171..177 'U::foo': {unknown}
+            183..195 '<[u32]>::foo': {unknown}
+        "#]],
+    );
+}

--- a/crates/hir_ty/src/tests/method_resolution.rs
+++ b/crates/hir_ty/src/tests/method_resolution.rs
@@ -922,7 +922,7 @@ fn test() { foo.call(); }
 fn super_trait_impl_return_trait_method_resolution() {
     check_infer(
         r#"
-        #[lang = "sized"] trait Sized {}
+        //- minicore: sized
         trait Base {
             fn foo(self) -> usize;
         }
@@ -940,26 +940,26 @@ fn super_trait_impl_return_trait_method_resolution() {
         }
         "#,
         expect![[r#"
-            57..61 'self': Self
-            123..134 '{ loop {} }': !
-            125..132 'loop {}': !
-            130..132 '{}': ()
-            161..172 '{ loop {} }': !
-            163..170 'loop {}': !
-            168..170 '{}': ()
-            182..187 'base2': impl Base
-            200..206 'super2': impl Super
-            220..297 '{     ...o(); }': ()
-            226..231 'base1': fn base1() -> impl Base
-            226..233 'base1()': impl Base
-            226..239 'base1().foo()': usize
-            245..251 'super1': fn super1() -> impl Super
-            245..253 'super1()': impl Super
-            245..259 'super1().foo()': usize
-            265..270 'base2': impl Base
-            265..276 'base2.foo()': usize
-            282..288 'super2': impl Super
-            282..294 'super2.foo()': usize
+            24..28 'self': Self
+            90..101 '{ loop {} }': !
+            92..99 'loop {}': !
+            97..99 '{}': ()
+            128..139 '{ loop {} }': !
+            130..137 'loop {}': !
+            135..137 '{}': ()
+            149..154 'base2': impl Base
+            167..173 'super2': impl Super
+            187..264 '{     ...o(); }': ()
+            193..198 'base1': fn base1() -> impl Base
+            193..200 'base1()': impl Base
+            193..206 'base1().foo()': usize
+            212..218 'super1': fn super1() -> impl Super
+            212..220 'super1()': impl Super
+            212..226 'super1().foo()': usize
+            232..237 'base2': impl Base
+            232..243 'base2.foo()': usize
+            249..255 'super2': impl Super
+            249..261 'super2.foo()': usize
         "#]],
     );
 }
@@ -1318,9 +1318,7 @@ impl<'a, T> IntoIterator for &'a [T] {
 fn sized_blanket_impl() {
     check_infer(
         r#"
-#[lang = "sized"]
-pub trait Sized {}
-
+//- minicore: sized
 trait Foo { fn foo() -> u8; }
 impl<T: Sized> Foo for T {}
 fn f<S: Sized, T, U: ?Sized>() {
@@ -1332,12 +1330,12 @@ fn f<S: Sized, T, U: ?Sized>() {
 }
 "#,
         expect![[r#"
-            127..198 '{     ...foo; }': ()
-            133..141 'u32::foo': fn foo<u32>() -> u8
-            147..153 'S::foo': fn foo<S>() -> u8
-            159..165 'T::foo': fn foo<T>() -> u8
-            171..177 'U::foo': {unknown}
-            183..195 '<[u32]>::foo': {unknown}
+            89..160 '{     ...foo; }': ()
+            95..103 'u32::foo': fn foo<u32>() -> u8
+            109..115 'S::foo': fn foo<S>() -> u8
+            121..127 'T::foo': fn foo<T>() -> u8
+            133..139 'U::foo': {unknown}
+            145..157 '<[u32]>::foo': {unknown}
         "#]],
     );
 }

--- a/crates/hir_ty/src/tests/method_resolution.rs
+++ b/crates/hir_ty/src/tests/method_resolution.rs
@@ -922,6 +922,7 @@ fn test() { foo.call(); }
 fn super_trait_impl_return_trait_method_resolution() {
     check_infer(
         r#"
+        #[lang = "sized"] trait Sized {}
         trait Base {
             fn foo(self) -> usize;
         }
@@ -939,26 +940,26 @@ fn super_trait_impl_return_trait_method_resolution() {
         }
         "#,
         expect![[r#"
-            24..28 'self': Self
-            90..101 '{ loop {} }': !
-            92..99 'loop {}': !
-            97..99 '{}': ()
-            128..139 '{ loop {} }': !
-            130..137 'loop {}': !
-            135..137 '{}': ()
-            149..154 'base2': impl Base
-            167..173 'super2': impl Super
-            187..264 '{     ...o(); }': ()
-            193..198 'base1': fn base1() -> impl Base
-            193..200 'base1()': impl Base
-            193..206 'base1().foo()': usize
-            212..218 'super1': fn super1() -> impl Super
-            212..220 'super1()': impl Super
-            212..226 'super1().foo()': usize
-            232..237 'base2': impl Base
-            232..243 'base2.foo()': usize
-            249..255 'super2': impl Super
-            249..261 'super2.foo()': usize
+            57..61 'self': Self
+            123..134 '{ loop {} }': !
+            125..132 'loop {}': !
+            130..132 '{}': ()
+            161..172 '{ loop {} }': !
+            163..170 'loop {}': !
+            168..170 '{}': ()
+            182..187 'base2': impl Base
+            200..206 'super2': impl Super
+            220..297 '{     ...o(); }': ()
+            226..231 'base1': fn base1() -> impl Base
+            226..233 'base1()': impl Base
+            226..239 'base1().foo()': usize
+            245..251 'super1': fn super1() -> impl Super
+            245..253 'super1()': impl Super
+            245..259 'super1().foo()': usize
+            265..270 'base2': impl Base
+            265..276 'base2.foo()': usize
+            282..288 'super2': impl Super
+            282..294 'super2.foo()': usize
         "#]],
     );
 }

--- a/crates/hir_ty/src/tests/regression.rs
+++ b/crates/hir_ty/src/tests/regression.rs
@@ -944,7 +944,7 @@ fn lifetime_from_chalk_during_deref() {
         r#"
 //- minicore: deref
 struct Box<T: ?Sized> {}
-impl<T> core::ops::Deref for Box<T> {
+impl<T: ?Sized> core::ops::Deref for Box<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -1063,6 +1063,7 @@ fn cfg_tail() {
 fn impl_trait_in_option_9530() {
     check_types(
         r#"
+//- minicore: sized
 struct Option<T>;
 impl<T> Option<T> {
     fn unwrap(self) -> T { loop {} }

--- a/crates/hir_ty/src/tests/traits.rs
+++ b/crates/hir_ty/src/tests/traits.rs
@@ -3515,3 +3515,35 @@ fn test() {
 "#,
     );
 }
+
+#[test]
+fn associated_type_sized_bounds() {
+    check_infer(
+        r#"
+#[lang = "sized"]
+pub trait Sized {}
+
+struct Yes;
+trait IsSized { const IS_SIZED: Yes; }
+impl<T: Sized> IsSized for T { const IS_SIZED: Yes = Yes; }
+
+trait Foo {
+    type Explicit: Sized;
+    type Implicit;
+    type Relaxed: ?Sized;
+}
+fn f<F: Foo>() {
+    F::Explicit::IS_SIZED;
+    F::Implicit::IS_SIZED;
+    F::Relaxed::IS_SIZED;
+}
+"#,
+        expect![[r#"
+            142..145 'Yes': Yes
+            250..333 '{     ...ZED; }': ()
+            256..277 'F::Exp..._SIZED': Yes
+            283..304 'F::Imp..._SIZED': Yes
+            310..330 'F::Rel..._SIZED': {unknown}
+        "#]],
+    );
+}

--- a/crates/hir_ty/src/tests/traits.rs
+++ b/crates/hir_ty/src/tests/traits.rs
@@ -147,7 +147,7 @@ mod ops {
     pub use self::try_trait::Try;
 }
 
-mov convert {
+mod convert {
     pub trait From<T> {}
     impl<T> From<T> for T {}
 }
@@ -567,8 +567,8 @@ fn deref_trait() {
     check_types(
         r#"
 //- minicore: deref
-struct Arc<T>;
-impl<T> core::ops::Deref for Arc<T> {
+struct Arc<T: ?Sized>;
+impl<T: ?Sized> core::ops::Deref for Arc<T> {
     type Target = T;
 }
 
@@ -589,9 +589,9 @@ fn deref_trait_with_inference_var() {
     check_types(
         r#"
 //- minicore: deref
-struct Arc<T>;
-fn new_arc<T>() -> Arc<T> { Arc }
-impl<T> core::ops::Deref for Arc<T> {
+struct Arc<T: ?Sized>;
+fn new_arc<T: ?Sized>() -> Arc<T> { Arc }
+impl<T: ?Sized> core::ops::Deref for Arc<T> {
     type Target = T;
 }
 
@@ -631,7 +631,7 @@ fn deref_trait_with_question_mark_size() {
     check_types(
         r#"
 //- minicore: deref
-struct Arc<T>;
+struct Arc<T: ?Sized>;
 impl<T: ?Sized> core::ops::Deref for Arc<T> {
     type Target = T;
 }
@@ -2431,8 +2431,8 @@ fn dyn_trait_through_chalk() {
     check_types(
         r#"
 //- minicore: deref
-struct Box<T> {}
-impl<T> core::ops::Deref for Box<T> {
+struct Box<T: ?Sized> {}
+impl<T: ?Sized> core::ops::Deref for Box<T> {
     type Target = T;
 }
 trait Trait {

--- a/crates/hir_ty/src/tests/traits.rs
+++ b/crates/hir_ty/src/tests/traits.rs
@@ -845,6 +845,7 @@ fn test<T: ApplyL>(t: T) {
 fn argument_impl_trait() {
     check_infer_with_mismatches(
         r#"
+#[lang = "sized"] trait Sized {}
 trait Trait<T> {
     fn foo(&self) -> T;
     fn foo2(&self) -> i64;
@@ -866,34 +867,34 @@ fn test(x: impl Trait<u64>, y: &impl Trait<u32>) {
     z.foo2();
 }"#,
         expect![[r#"
-            29..33 'self': &Self
-            54..58 'self': &Self
-            77..78 'x': impl Trait<u16>
-            97..99 '{}': ()
-            154..155 'x': impl Trait<u64>
-            174..175 'y': &impl Trait<u32>
-            195..323 '{     ...2(); }': ()
-            201..202 'x': impl Trait<u64>
-            208..209 'y': &impl Trait<u32>
-            219..220 'z': S<u16>
-            223..224 'S': S<u16>(u16) -> S<u16>
-            223..227 'S(1)': S<u16>
-            225..226 '1': u16
-            233..236 'bar': fn bar(S<u16>)
-            233..239 'bar(z)': ()
-            237..238 'z': S<u16>
-            245..246 'x': impl Trait<u64>
-            245..252 'x.foo()': u64
-            258..259 'y': &impl Trait<u32>
-            258..265 'y.foo()': u32
-            271..272 'z': S<u16>
-            271..278 'z.foo()': u16
-            284..285 'x': impl Trait<u64>
-            284..292 'x.foo2()': i64
-            298..299 'y': &impl Trait<u32>
-            298..306 'y.foo2()': i64
-            312..313 'z': S<u16>
-            312..320 'z.foo2()': i64
+            62..66 'self': &Self
+            87..91 'self': &Self
+            110..111 'x': impl Trait<u16>
+            130..132 '{}': ()
+            187..188 'x': impl Trait<u64>
+            207..208 'y': &impl Trait<u32>
+            228..356 '{     ...2(); }': ()
+            234..235 'x': impl Trait<u64>
+            241..242 'y': &impl Trait<u32>
+            252..253 'z': S<u16>
+            256..257 'S': S<u16>(u16) -> S<u16>
+            256..260 'S(1)': S<u16>
+            258..259 '1': u16
+            266..269 'bar': fn bar(S<u16>)
+            266..272 'bar(z)': ()
+            270..271 'z': S<u16>
+            278..279 'x': impl Trait<u64>
+            278..285 'x.foo()': u64
+            291..292 'y': &impl Trait<u32>
+            291..298 'y.foo()': u32
+            304..305 'z': S<u16>
+            304..311 'z.foo()': u16
+            317..318 'x': impl Trait<u64>
+            317..325 'x.foo2()': i64
+            331..332 'y': &impl Trait<u32>
+            331..339 'y.foo2()': i64
+            345..346 'z': S<u16>
+            345..353 'z.foo2()': i64
         "#]],
     );
 }
@@ -902,6 +903,7 @@ fn test(x: impl Trait<u64>, y: &impl Trait<u32>) {
 fn argument_impl_trait_type_args_1() {
     check_infer_with_mismatches(
         r#"
+#[lang = "sized"] trait Sized {}
 trait Trait {}
 trait Foo {
     // this function has an implicit Self param, an explicit type param,
@@ -926,39 +928,39 @@ fn test() {
     foo::<u32, i32>(S); // we should ignore the extraneous i32
 }"#,
         expect![[r#"
-            155..156 'x': impl Trait
-            175..186 '{ loop {} }': T
-            177..184 'loop {}': !
-            182..184 '{}': ()
-            199..200 'x': impl Trait
-            219..230 '{ loop {} }': T
-            221..228 'loop {}': !
-            226..228 '{}': ()
-            300..509 '{     ... i32 }': ()
-            306..314 'Foo::bar': fn bar<{unknown}, {unknown}>(S) -> {unknown}
-            306..317 'Foo::bar(S)': {unknown}
-            315..316 'S': S
-            323..338 '<F as Foo>::bar': fn bar<F, {unknown}>(S) -> {unknown}
-            323..341 '<F as ...bar(S)': {unknown}
-            339..340 'S': S
-            347..353 'F::bar': fn bar<F, {unknown}>(S) -> {unknown}
-            347..356 'F::bar(S)': {unknown}
-            354..355 'S': S
-            362..377 'Foo::bar::<u32>': fn bar<{unknown}, u32>(S) -> u32
-            362..380 'Foo::b...32>(S)': u32
-            378..379 'S': S
-            386..408 '<F as ...:<u32>': fn bar<F, u32>(S) -> u32
-            386..411 '<F as ...32>(S)': u32
-            409..410 'S': S
-            418..421 'foo': fn foo<{unknown}>(S) -> {unknown}
-            418..424 'foo(S)': {unknown}
-            422..423 'S': S
-            430..440 'foo::<u32>': fn foo<u32>(S) -> u32
-            430..443 'foo::<u32>(S)': u32
-            441..442 'S': S
-            449..464 'foo::<u32, i32>': fn foo<u32>(S) -> u32
-            449..467 'foo::<...32>(S)': u32
-            465..466 'S': S
+            188..189 'x': impl Trait
+            208..219 '{ loop {} }': T
+            210..217 'loop {}': !
+            215..217 '{}': ()
+            232..233 'x': impl Trait
+            252..263 '{ loop {} }': T
+            254..261 'loop {}': !
+            259..261 '{}': ()
+            333..542 '{     ... i32 }': ()
+            339..347 'Foo::bar': fn bar<{unknown}, {unknown}>(S) -> {unknown}
+            339..350 'Foo::bar(S)': {unknown}
+            348..349 'S': S
+            356..371 '<F as Foo>::bar': fn bar<F, {unknown}>(S) -> {unknown}
+            356..374 '<F as ...bar(S)': {unknown}
+            372..373 'S': S
+            380..386 'F::bar': fn bar<F, {unknown}>(S) -> {unknown}
+            380..389 'F::bar(S)': {unknown}
+            387..388 'S': S
+            395..410 'Foo::bar::<u32>': fn bar<{unknown}, u32>(S) -> u32
+            395..413 'Foo::b...32>(S)': u32
+            411..412 'S': S
+            419..441 '<F as ...:<u32>': fn bar<F, u32>(S) -> u32
+            419..444 '<F as ...32>(S)': u32
+            442..443 'S': S
+            451..454 'foo': fn foo<{unknown}>(S) -> {unknown}
+            451..457 'foo(S)': {unknown}
+            455..456 'S': S
+            463..473 'foo::<u32>': fn foo<u32>(S) -> u32
+            463..476 'foo::<u32>(S)': u32
+            474..475 'S': S
+            482..497 'foo::<u32, i32>': fn foo<u32>(S) -> u32
+            482..500 'foo::<...32>(S)': u32
+            498..499 'S': S
         "#]],
     );
 }
@@ -967,6 +969,7 @@ fn test() {
 fn argument_impl_trait_type_args_2() {
     check_infer_with_mismatches(
         r#"
+#[lang = "sized"] trait Sized {}
 trait Trait {}
 struct S;
 impl Trait for S {}
@@ -982,24 +985,24 @@ fn test() {
     F::<u32>.foo::<i32, u32>(S); // extraneous argument should be ignored
 }"#,
         expect![[r#"
-            87..91 'self': F<T>
-            93..94 'x': impl Trait
-            118..129 '{ loop {} }': (T, U)
-            120..127 'loop {}': !
-            125..127 '{}': ()
-            143..283 '{     ...ored }': ()
-            149..150 'F': F<{unknown}>
-            149..157 'F.foo(S)': ({unknown}, {unknown})
-            155..156 'S': S
-            163..171 'F::<u32>': F<u32>
-            163..178 'F::<u32>.foo(S)': (u32, {unknown})
-            176..177 'S': S
-            184..192 'F::<u32>': F<u32>
-            184..206 'F::<u3...32>(S)': (u32, i32)
-            204..205 'S': S
-            212..220 'F::<u32>': F<u32>
-            212..239 'F::<u3...32>(S)': (u32, i32)
+            120..124 'self': F<T>
+            126..127 'x': impl Trait
+            151..162 '{ loop {} }': (T, U)
+            153..160 'loop {}': !
+            158..160 '{}': ()
+            176..316 '{     ...ored }': ()
+            182..183 'F': F<{unknown}>
+            182..190 'F.foo(S)': ({unknown}, {unknown})
+            188..189 'S': S
+            196..204 'F::<u32>': F<u32>
+            196..211 'F::<u32>.foo(S)': (u32, {unknown})
+            209..210 'S': S
+            217..225 'F::<u32>': F<u32>
+            217..239 'F::<u3...32>(S)': (u32, i32)
             237..238 'S': S
+            245..253 'F::<u32>': F<u32>
+            245..272 'F::<u3...32>(S)': (u32, i32)
+            270..271 'S': S
         "#]],
     );
 }
@@ -1008,6 +1011,7 @@ fn test() {
 fn argument_impl_trait_to_fn_pointer() {
     check_infer_with_mismatches(
         r#"
+#[lang = "sized"] trait Sized {}
 trait Trait {}
 fn foo(x: impl Trait) { loop {} }
 struct S;
@@ -1017,13 +1021,13 @@ fn test() {
     let f: fn(S) -> () = foo;
 }"#,
         expect![[r#"
-            22..23 'x': impl Trait
-            37..48 '{ loop {} }': ()
-            39..46 'loop {}': !
-            44..46 '{}': ()
-            90..123 '{     ...foo; }': ()
-            100..101 'f': fn(S)
-            117..120 'foo': fn foo(S)
+            55..56 'x': impl Trait
+            70..81 '{ loop {} }': ()
+            72..79 'loop {}': !
+            77..79 '{}': ()
+            123..156 '{     ...foo; }': ()
+            133..134 'f': fn(S)
+            150..153 'foo': fn foo(S)
         "#]],
     );
 }
@@ -1032,6 +1036,7 @@ fn test() {
 fn impl_trait() {
     check_infer(
         r#"
+#[lang = "sized"] trait Sized {}
 trait Trait<T> {
     fn foo(&self) -> T;
     fn foo2(&self) -> i64;
@@ -1050,29 +1055,29 @@ fn test(x: impl Trait<u64>, y: &impl Trait<u64>) {
     z.foo2();
 }"#,
         expect![[r#"
-            29..33 'self': &Self
-            54..58 'self': &Self
-            98..100 '{}': ()
-            110..111 'x': impl Trait<u64>
-            130..131 'y': &impl Trait<u64>
-            151..268 '{     ...2(); }': ()
-            157..158 'x': impl Trait<u64>
-            164..165 'y': &impl Trait<u64>
-            175..176 'z': impl Trait<u64>
-            179..182 'bar': fn bar() -> impl Trait<u64>
-            179..184 'bar()': impl Trait<u64>
+            62..66 'self': &Self
+            87..91 'self': &Self
+            131..133 '{}': ()
+            143..144 'x': impl Trait<u64>
+            163..164 'y': &impl Trait<u64>
+            184..301 '{     ...2(); }': ()
             190..191 'x': impl Trait<u64>
-            190..197 'x.foo()': u64
-            203..204 'y': &impl Trait<u64>
-            203..210 'y.foo()': u64
-            216..217 'z': impl Trait<u64>
-            216..223 'z.foo()': u64
-            229..230 'x': impl Trait<u64>
-            229..237 'x.foo2()': i64
-            243..244 'y': &impl Trait<u64>
-            243..251 'y.foo2()': i64
-            257..258 'z': impl Trait<u64>
-            257..265 'z.foo2()': i64
+            197..198 'y': &impl Trait<u64>
+            208..209 'z': impl Trait<u64>
+            212..215 'bar': fn bar() -> impl Trait<u64>
+            212..217 'bar()': impl Trait<u64>
+            223..224 'x': impl Trait<u64>
+            223..230 'x.foo()': u64
+            236..237 'y': &impl Trait<u64>
+            236..243 'y.foo()': u64
+            249..250 'z': impl Trait<u64>
+            249..256 'z.foo()': u64
+            262..263 'x': impl Trait<u64>
+            262..270 'x.foo2()': i64
+            276..277 'y': &impl Trait<u64>
+            276..284 'y.foo2()': i64
+            290..291 'z': impl Trait<u64>
+            290..298 'z.foo2()': i64
         "#]],
     );
 }
@@ -1082,6 +1087,7 @@ fn simple_return_pos_impl_trait() {
     cov_mark::check!(lower_rpit);
     check_infer(
         r#"
+#[lang = "sized"] trait Sized {}
 trait Trait<T> {
     fn foo(&self) -> T;
 }
@@ -1092,16 +1098,16 @@ fn test() {
     a.foo();
 }"#,
         expect![[r#"
-            29..33 'self': &Self
-            71..82 '{ loop {} }': !
-            73..80 'loop {}': !
-            78..80 '{}': ()
-            94..129 '{     ...o(); }': ()
-            104..105 'a': impl Trait<u64>
-            108..111 'bar': fn bar() -> impl Trait<u64>
-            108..113 'bar()': impl Trait<u64>
-            119..120 'a': impl Trait<u64>
-            119..126 'a.foo()': u64
+            62..66 'self': &Self
+            104..115 '{ loop {} }': !
+            106..113 'loop {}': !
+            111..113 '{}': ()
+            127..162 '{     ...o(); }': ()
+            137..138 'a': impl Trait<u64>
+            141..144 'bar': fn bar() -> impl Trait<u64>
+            141..146 'bar()': impl Trait<u64>
+            152..153 'a': impl Trait<u64>
+            152..159 'a.foo()': u64
         "#]],
     );
 }
@@ -1110,6 +1116,7 @@ fn test() {
 fn more_return_pos_impl_trait() {
     check_infer(
         r#"
+#[lang = "sized"] trait Sized {}
 trait Iterator {
     type Item;
     fn next(&mut self) -> Self::Item;
@@ -1129,37 +1136,37 @@ fn test() {
     d.foo();
 }"#,
         expect![[r#"
-            49..53 'self': &mut Self
-            101..105 'self': &Self
-            184..195 '{ loop {} }': ({unknown}, {unknown})
-            186..193 'loop {}': !
-            191..193 '{}': ()
-            206..207 't': T
-            268..279 '{ loop {} }': ({unknown}, {unknown})
-            270..277 'loop {}': !
-            275..277 '{}': ()
-            291..413 '{     ...o(); }': ()
-            301..307 '(a, b)': (impl Iterator<Item = impl Trait<u32>>, impl Trait<u64>)
-            302..303 'a': impl Iterator<Item = impl Trait<u32>>
-            305..306 'b': impl Trait<u64>
-            310..313 'bar': fn bar() -> (impl Iterator<Item = impl Trait<u32>>, impl Trait<u64>)
-            310..315 'bar()': (impl Iterator<Item = impl Trait<u32>>, impl Trait<u64>)
-            321..322 'a': impl Iterator<Item = impl Trait<u32>>
-            321..329 'a.next()': impl Trait<u32>
-            321..335 'a.next().foo()': u32
-            341..342 'b': impl Trait<u64>
-            341..348 'b.foo()': u64
-            358..364 '(c, d)': (impl Iterator<Item = impl Trait<u128>>, impl Trait<u128>)
-            359..360 'c': impl Iterator<Item = impl Trait<u128>>
-            362..363 'd': impl Trait<u128>
-            367..370 'baz': fn baz<u128>(u128) -> (impl Iterator<Item = impl Trait<u128>>, impl Trait<u128>)
-            367..377 'baz(1u128)': (impl Iterator<Item = impl Trait<u128>>, impl Trait<u128>)
-            371..376 '1u128': u128
-            383..384 'c': impl Iterator<Item = impl Trait<u128>>
-            383..391 'c.next()': impl Trait<u128>
-            383..397 'c.next().foo()': u128
-            403..404 'd': impl Trait<u128>
-            403..410 'd.foo()': u128
+            82..86 'self': &mut Self
+            134..138 'self': &Self
+            217..228 '{ loop {} }': ({unknown}, {unknown})
+            219..226 'loop {}': !
+            224..226 '{}': ()
+            239..240 't': T
+            301..312 '{ loop {} }': ({unknown}, {unknown})
+            303..310 'loop {}': !
+            308..310 '{}': ()
+            324..446 '{     ...o(); }': ()
+            334..340 '(a, b)': (impl Iterator<Item = impl Trait<u32>>, impl Trait<u64>)
+            335..336 'a': impl Iterator<Item = impl Trait<u32>>
+            338..339 'b': impl Trait<u64>
+            343..346 'bar': fn bar() -> (impl Iterator<Item = impl Trait<u32>>, impl Trait<u64>)
+            343..348 'bar()': (impl Iterator<Item = impl Trait<u32>>, impl Trait<u64>)
+            354..355 'a': impl Iterator<Item = impl Trait<u32>>
+            354..362 'a.next()': impl Trait<u32>
+            354..368 'a.next().foo()': u32
+            374..375 'b': impl Trait<u64>
+            374..381 'b.foo()': u64
+            391..397 '(c, d)': (impl Iterator<Item = impl Trait<u128>>, impl Trait<u128>)
+            392..393 'c': impl Iterator<Item = impl Trait<u128>>
+            395..396 'd': impl Trait<u128>
+            400..403 'baz': fn baz<u128>(u128) -> (impl Iterator<Item = impl Trait<u128>>, impl Trait<u128>)
+            400..410 'baz(1u128)': (impl Iterator<Item = impl Trait<u128>>, impl Trait<u128>)
+            404..409 '1u128': u128
+            416..417 'c': impl Iterator<Item = impl Trait<u128>>
+            416..424 'c.next()': impl Trait<u128>
+            416..430 'c.next().foo()': u128
+            436..437 'd': impl Trait<u128>
+            436..443 'd.foo()': u128
         "#]],
     );
 }
@@ -1168,6 +1175,7 @@ fn test() {
 fn dyn_trait() {
     check_infer(
         r#"
+#[lang = "sized"] trait Sized {}
 trait Trait<T> {
     fn foo(&self) -> T;
     fn foo2(&self) -> i64;
@@ -1186,29 +1194,29 @@ fn test(x: dyn Trait<u64>, y: &dyn Trait<u64>) {
     z.foo2();
 }"#,
         expect![[r#"
-            29..33 'self': &Self
-            54..58 'self': &Self
-            97..99 '{}': ()
-            109..110 'x': dyn Trait<u64>
-            128..129 'y': &dyn Trait<u64>
-            148..265 '{     ...2(); }': ()
-            154..155 'x': dyn Trait<u64>
+            62..66 'self': &Self
+            87..91 'self': &Self
+            130..132 '{}': ()
+            142..143 'x': dyn Trait<u64>
             161..162 'y': &dyn Trait<u64>
-            172..173 'z': dyn Trait<u64>
-            176..179 'bar': fn bar() -> dyn Trait<u64>
-            176..181 'bar()': dyn Trait<u64>
+            181..298 '{     ...2(); }': ()
             187..188 'x': dyn Trait<u64>
-            187..194 'x.foo()': u64
-            200..201 'y': &dyn Trait<u64>
-            200..207 'y.foo()': u64
-            213..214 'z': dyn Trait<u64>
-            213..220 'z.foo()': u64
-            226..227 'x': dyn Trait<u64>
-            226..234 'x.foo2()': i64
-            240..241 'y': &dyn Trait<u64>
-            240..248 'y.foo2()': i64
-            254..255 'z': dyn Trait<u64>
-            254..262 'z.foo2()': i64
+            194..195 'y': &dyn Trait<u64>
+            205..206 'z': dyn Trait<u64>
+            209..212 'bar': fn bar() -> dyn Trait<u64>
+            209..214 'bar()': dyn Trait<u64>
+            220..221 'x': dyn Trait<u64>
+            220..227 'x.foo()': u64
+            233..234 'y': &dyn Trait<u64>
+            233..240 'y.foo()': u64
+            246..247 'z': dyn Trait<u64>
+            246..253 'z.foo()': u64
+            259..260 'x': dyn Trait<u64>
+            259..267 'x.foo2()': i64
+            273..274 'y': &dyn Trait<u64>
+            273..281 'y.foo2()': i64
+            287..288 'z': dyn Trait<u64>
+            287..295 'z.foo2()': i64
         "#]],
     );
 }
@@ -1217,6 +1225,7 @@ fn test(x: dyn Trait<u64>, y: &dyn Trait<u64>) {
 fn dyn_trait_in_impl() {
     check_infer(
         r#"
+#[lang = "sized"] trait Sized {}
 trait Trait<T, U> {
     fn foo(&self) -> (T, U);
 }
@@ -1233,17 +1242,17 @@ fn test(s: S<u32, i32>) {
     s.bar().baz();
 }"#,
         expect![[r#"
-            32..36 'self': &Self
-            102..106 'self': &S<T, U>
-            128..139 '{ loop {} }': &dyn Trait<T, U>
-            130..137 'loop {}': !
-            135..137 '{}': ()
-            175..179 'self': &Self
-            251..252 's': S<u32, i32>
-            267..289 '{     ...z(); }': ()
-            273..274 's': S<u32, i32>
-            273..280 's.bar()': &dyn Trait<u32, i32>
-            273..286 's.bar().baz()': (u32, i32)
+            65..69 'self': &Self
+            135..139 'self': &S<T, U>
+            161..172 '{ loop {} }': &dyn Trait<T, U>
+            163..170 'loop {}': !
+            168..170 '{}': ()
+            208..212 'self': &Self
+            284..285 's': S<u32, i32>
+            300..322 '{     ...z(); }': ()
+            306..307 's': S<u32, i32>
+            306..313 's.bar()': &dyn Trait<u32, i32>
+            306..319 's.bar().baz()': (u32, i32)
         "#]],
     );
 }
@@ -1252,6 +1261,7 @@ fn test(s: S<u32, i32>) {
 fn dyn_trait_bare() {
     check_infer(
         r#"
+#[lang = "sized"] trait Sized {}
 trait Trait {
     fn foo(&self) -> u64;
 }
@@ -1266,22 +1276,22 @@ fn test(x: Trait, y: &Trait) -> u64 {
     z.foo();
 }"#,
         expect![[r#"
-            26..30 'self': &Self
-            60..62 '{}': ()
-            72..73 'x': dyn Trait
-            82..83 'y': &dyn Trait
-            100..175 '{     ...o(); }': ()
-            106..107 'x': dyn Trait
-            113..114 'y': &dyn Trait
-            124..125 'z': dyn Trait
-            128..131 'bar': fn bar() -> dyn Trait
-            128..133 'bar()': dyn Trait
+            59..63 'self': &Self
+            93..95 '{}': ()
+            105..106 'x': dyn Trait
+            115..116 'y': &dyn Trait
+            133..208 '{     ...o(); }': ()
             139..140 'x': dyn Trait
-            139..146 'x.foo()': u64
-            152..153 'y': &dyn Trait
-            152..159 'y.foo()': u64
-            165..166 'z': dyn Trait
-            165..172 'z.foo()': u64
+            146..147 'y': &dyn Trait
+            157..158 'z': dyn Trait
+            161..164 'bar': fn bar() -> dyn Trait
+            161..166 'bar()': dyn Trait
+            172..173 'x': dyn Trait
+            172..179 'x.foo()': u64
+            185..186 'y': &dyn Trait
+            185..192 'y.foo()': u64
+            198..199 'z': dyn Trait
+            198..205 'z.foo()': u64
         "#]],
     );
 }
@@ -1290,6 +1300,7 @@ fn test(x: Trait, y: &Trait) -> u64 {
 fn weird_bounds() {
     check_infer(
         r#"
+#[lang = "sized"] trait Sized {}
 trait Trait {}
 fn test(
     a: impl Trait + 'lifetime,
@@ -1301,13 +1312,13 @@ fn test(
 ) {}
 "#,
         expect![[r#"
-            28..29 'a': impl Trait
-            59..60 'b': impl
-            82..83 'c': impl Trait
-            103..104 'd': impl
-            128..129 'e': impl
-            148..149 'f': impl Trait
-            173..175 '{}': ()
+            61..62 'a': impl Trait
+            92..93 'b': impl Sized
+            115..116 'c': impl Trait
+            136..137 'd': impl Sized
+            161..162 'e': impl ?Sized
+            181..182 'f': impl Trait + ?Sized
+            206..208 '{}': ()
         "#]],
     );
 }
@@ -1331,6 +1342,7 @@ fn test(x: (impl Trait + UnknownTrait)) {
 fn assoc_type_bindings() {
     check_infer(
         r#"
+#[lang = "sized"] trait Sized {}
 trait Trait {
     type Type;
 }
@@ -1352,41 +1364,41 @@ fn test<T: Trait<Type = u32>>(x: T, y: impl Trait<Type = i64>) {
     get2(S::<str>);
 }"#,
         expect![[r#"
-            49..50 't': T
-            77..79 '{}': ()
-            111..112 't': T
-            122..124 '{}': ()
-            154..155 't': T
-            165..168 '{t}': T
-            166..167 't': T
-            256..257 'x': T
-            262..263 'y': impl Trait<Type = i64>
-            289..397 '{     ...r>); }': ()
-            295..298 'get': fn get<T>(T) -> <T as Trait>::Type
-            295..301 'get(x)': u32
-            299..300 'x': T
-            307..311 'get2': fn get2<u32, T>(T) -> u32
-            307..314 'get2(x)': u32
-            312..313 'x': T
-            320..323 'get': fn get<impl Trait<Type = i64>>(impl Trait<Type = i64>) -> <impl Trait<Type = i64> as Trait>::Type
-            320..326 'get(y)': i64
-            324..325 'y': impl Trait<Type = i64>
-            332..336 'get2': fn get2<i64, impl Trait<Type = i64>>(impl Trait<Type = i64>) -> i64
-            332..339 'get2(y)': i64
-            337..338 'y': impl Trait<Type = i64>
-            345..348 'get': fn get<S<u64>>(S<u64>) -> <S<u64> as Trait>::Type
-            345..356 'get(set(S))': u64
-            349..352 'set': fn set<S<u64>>(S<u64>) -> S<u64>
-            349..355 'set(S)': S<u64>
-            353..354 'S': S<u64>
-            362..366 'get2': fn get2<u64, S<u64>>(S<u64>) -> u64
-            362..374 'get2(set(S))': u64
-            367..370 'set': fn set<S<u64>>(S<u64>) -> S<u64>
-            367..373 'set(S)': S<u64>
-            371..372 'S': S<u64>
-            380..384 'get2': fn get2<str, S<str>>(S<str>) -> str
-            380..394 'get2(S::<str>)': str
-            385..393 'S::<str>': S<str>
+            82..83 't': T
+            110..112 '{}': ()
+            144..145 't': T
+            155..157 '{}': ()
+            187..188 't': T
+            198..201 '{t}': T
+            199..200 't': T
+            289..290 'x': T
+            295..296 'y': impl Trait<Type = i64>
+            322..430 '{     ...r>); }': ()
+            328..331 'get': fn get<T>(T) -> <T as Trait>::Type
+            328..334 'get(x)': u32
+            332..333 'x': T
+            340..344 'get2': fn get2<u32, T>(T) -> u32
+            340..347 'get2(x)': u32
+            345..346 'x': T
+            353..356 'get': fn get<impl Trait<Type = i64>>(impl Trait<Type = i64>) -> <impl Trait<Type = i64> as Trait>::Type
+            353..359 'get(y)': i64
+            357..358 'y': impl Trait<Type = i64>
+            365..369 'get2': fn get2<i64, impl Trait<Type = i64>>(impl Trait<Type = i64>) -> i64
+            365..372 'get2(y)': i64
+            370..371 'y': impl Trait<Type = i64>
+            378..381 'get': fn get<S<u64>>(S<u64>) -> <S<u64> as Trait>::Type
+            378..389 'get(set(S))': u64
+            382..385 'set': fn set<S<u64>>(S<u64>) -> S<u64>
+            382..388 'set(S)': S<u64>
+            386..387 'S': S<u64>
+            395..399 'get2': fn get2<u64, S<u64>>(S<u64>) -> u64
+            395..407 'get2(set(S))': u64
+            400..403 'set': fn set<S<u64>>(S<u64>) -> S<u64>
+            400..406 'set(S)': S<u64>
+            404..405 'S': S<u64>
+            413..417 'get2': fn get2<str, S<str>>(S<str>) -> str
+            413..427 'get2(S::<str>)': str
+            418..426 'S::<str>': S<str>
         "#]],
     );
 }
@@ -1495,6 +1507,7 @@ fn test<T: Trait1, U: Trait2>(x: T, y: U) {
 fn super_trait_impl_trait_method_resolution() {
     check_infer(
         r#"
+#[lang = "sized"] trait Sized {}
 mod foo {
     trait SuperTrait {
         fn foo(&self) -> u32 {}
@@ -1506,12 +1519,12 @@ fn test(x: &impl Trait1) {
     x.foo();
 }"#,
         expect![[r#"
-            49..53 'self': &Self
-            62..64 '{}': ()
-            115..116 'x': &impl Trait1
-            132..148 '{     ...o(); }': ()
-            138..139 'x': &impl Trait1
-            138..145 'x.foo()': u32
+            82..86 'self': &Self
+            95..97 '{}': ()
+            148..149 'x': &impl Trait1
+            165..181 '{     ...o(); }': ()
+            171..172 'x': &impl Trait1
+            171..178 'x.foo()': u32
         "#]],
     );
 }
@@ -2299,6 +2312,7 @@ impl TokenStream for Rustc {
 fn unify_impl_trait() {
     check_infer_with_mismatches(
         r#"
+#[lang = "sized"] trait Sized {}
 trait Trait<T> {}
 
 fn foo(x: impl Trait<u32>) { loop {} }
@@ -2316,37 +2330,37 @@ fn test() -> impl Trait<i32> {
     S(default())
 }"#,
         expect![[r#"
-            26..27 'x': impl Trait<u32>
-            46..57 '{ loop {} }': ()
-            48..55 'loop {}': !
-            53..55 '{}': ()
-            68..69 'x': impl Trait<T>
-            91..102 '{ loop {} }': T
-            93..100 'loop {}': !
-            98..100 '{}': ()
-            171..182 '{ loop {} }': T
-            173..180 'loop {}': !
-            178..180 '{}': ()
-            213..309 '{     ...t()) }': S<{unknown}>
-            223..225 's1': S<u32>
-            228..229 'S': S<u32>(u32) -> S<u32>
-            228..240 'S(default())': S<u32>
-            230..237 'default': fn default<u32>() -> u32
-            230..239 'default()': u32
-            246..249 'foo': fn foo(S<u32>)
-            246..253 'foo(s1)': ()
-            250..252 's1': S<u32>
-            263..264 'x': i32
-            272..275 'bar': fn bar<i32>(S<i32>) -> i32
-            272..289 'bar(S(...lt()))': i32
-            276..277 'S': S<i32>(i32) -> S<i32>
-            276..288 'S(default())': S<i32>
-            278..285 'default': fn default<i32>() -> i32
-            278..287 'default()': i32
-            295..296 'S': S<{unknown}>({unknown}) -> S<{unknown}>
-            295..307 'S(default())': S<{unknown}>
-            297..304 'default': fn default<{unknown}>() -> {unknown}
-            297..306 'default()': {unknown}
+            59..60 'x': impl Trait<u32>
+            79..90 '{ loop {} }': ()
+            81..88 'loop {}': !
+            86..88 '{}': ()
+            101..102 'x': impl Trait<T>
+            124..135 '{ loop {} }': T
+            126..133 'loop {}': !
+            131..133 '{}': ()
+            204..215 '{ loop {} }': T
+            206..213 'loop {}': !
+            211..213 '{}': ()
+            246..342 '{     ...t()) }': S<{unknown}>
+            256..258 's1': S<u32>
+            261..262 'S': S<u32>(u32) -> S<u32>
+            261..273 'S(default())': S<u32>
+            263..270 'default': fn default<u32>() -> u32
+            263..272 'default()': u32
+            279..282 'foo': fn foo(S<u32>)
+            279..286 'foo(s1)': ()
+            283..285 's1': S<u32>
+            296..297 'x': i32
+            305..308 'bar': fn bar<i32>(S<i32>) -> i32
+            305..322 'bar(S(...lt()))': i32
+            309..310 'S': S<i32>(i32) -> S<i32>
+            309..321 'S(default())': S<i32>
+            311..318 'default': fn default<i32>() -> i32
+            311..320 'default()': i32
+            328..329 'S': S<{unknown}>({unknown}) -> S<{unknown}>
+            328..340 'S(default())': S<{unknown}>
+            330..337 'default': fn default<{unknown}>() -> {unknown}
+            330..339 'default()': {unknown}
         "#]],
     );
 }

--- a/crates/hir_ty/src/tests/traits.rs
+++ b/crates/hir_ty/src/tests/traits.rs
@@ -3534,9 +3534,7 @@ fn test() {
 fn associated_type_sized_bounds() {
     check_infer(
         r#"
-#[lang = "sized"]
-pub trait Sized {}
-
+//- minicore: sized
 struct Yes;
 trait IsSized { const IS_SIZED: Yes; }
 impl<T: Sized> IsSized for T { const IS_SIZED: Yes = Yes; }
@@ -3553,11 +3551,11 @@ fn f<F: Foo>() {
 }
 "#,
         expect![[r#"
-            142..145 'Yes': Yes
-            250..333 '{     ...ZED; }': ()
-            256..277 'F::Exp..._SIZED': Yes
-            283..304 'F::Imp..._SIZED': Yes
-            310..330 'F::Rel..._SIZED': {unknown}
+            104..107 'Yes': Yes
+            212..295 '{     ...ZED; }': ()
+            218..239 'F::Exp..._SIZED': Yes
+            245..266 'F::Imp..._SIZED': Yes
+            272..292 'F::Rel..._SIZED': {unknown}
         "#]],
     );
 }

--- a/crates/hir_ty/src/tests/traits.rs
+++ b/crates/hir_ty/src/tests/traits.rs
@@ -649,6 +649,25 @@ fn test(s: Arc<S>) {
 }
 
 #[test]
+fn deref_trait_with_implicit_sized_requirement_on_inference_var() {
+    check_types(
+        r#"
+//- minicore: deref
+struct Foo<T>;
+impl<T> core::ops::Deref for Foo<T> {
+    type Target = ();
+}
+fn test() {
+    let foo = Foo;
+    *foo;
+  //^^^^ ()
+    let _: Foo<u8> = foo;
+}
+"#,
+    )
+}
+
+#[test]
 fn obligation_from_function_clause() {
     check_types(
         r#"

--- a/crates/hir_ty/src/tests/traits.rs
+++ b/crates/hir_ty/src/tests/traits.rs
@@ -43,7 +43,7 @@ fn test() {
 fn infer_desugar_async() {
     check_types(
         r#"
-//- minicore: future
+//- minicore: future, sized
 async fn foo() -> u64 { 128 }
 
 fn test() {
@@ -845,7 +845,7 @@ fn test<T: ApplyL>(t: T) {
 fn argument_impl_trait() {
     check_infer_with_mismatches(
         r#"
-#[lang = "sized"] trait Sized {}
+//- minicore: sized
 trait Trait<T> {
     fn foo(&self) -> T;
     fn foo2(&self) -> i64;
@@ -867,34 +867,34 @@ fn test(x: impl Trait<u64>, y: &impl Trait<u32>) {
     z.foo2();
 }"#,
         expect![[r#"
-            62..66 'self': &Self
-            87..91 'self': &Self
-            110..111 'x': impl Trait<u16>
-            130..132 '{}': ()
-            187..188 'x': impl Trait<u64>
-            207..208 'y': &impl Trait<u32>
-            228..356 '{     ...2(); }': ()
-            234..235 'x': impl Trait<u64>
-            241..242 'y': &impl Trait<u32>
-            252..253 'z': S<u16>
-            256..257 'S': S<u16>(u16) -> S<u16>
-            256..260 'S(1)': S<u16>
-            258..259 '1': u16
-            266..269 'bar': fn bar(S<u16>)
-            266..272 'bar(z)': ()
-            270..271 'z': S<u16>
-            278..279 'x': impl Trait<u64>
-            278..285 'x.foo()': u64
-            291..292 'y': &impl Trait<u32>
-            291..298 'y.foo()': u32
-            304..305 'z': S<u16>
-            304..311 'z.foo()': u16
-            317..318 'x': impl Trait<u64>
-            317..325 'x.foo2()': i64
-            331..332 'y': &impl Trait<u32>
-            331..339 'y.foo2()': i64
-            345..346 'z': S<u16>
-            345..353 'z.foo2()': i64
+            29..33 'self': &Self
+            54..58 'self': &Self
+            77..78 'x': impl Trait<u16>
+            97..99 '{}': ()
+            154..155 'x': impl Trait<u64>
+            174..175 'y': &impl Trait<u32>
+            195..323 '{     ...2(); }': ()
+            201..202 'x': impl Trait<u64>
+            208..209 'y': &impl Trait<u32>
+            219..220 'z': S<u16>
+            223..224 'S': S<u16>(u16) -> S<u16>
+            223..227 'S(1)': S<u16>
+            225..226 '1': u16
+            233..236 'bar': fn bar(S<u16>)
+            233..239 'bar(z)': ()
+            237..238 'z': S<u16>
+            245..246 'x': impl Trait<u64>
+            245..252 'x.foo()': u64
+            258..259 'y': &impl Trait<u32>
+            258..265 'y.foo()': u32
+            271..272 'z': S<u16>
+            271..278 'z.foo()': u16
+            284..285 'x': impl Trait<u64>
+            284..292 'x.foo2()': i64
+            298..299 'y': &impl Trait<u32>
+            298..306 'y.foo2()': i64
+            312..313 'z': S<u16>
+            312..320 'z.foo2()': i64
         "#]],
     );
 }
@@ -903,7 +903,7 @@ fn test(x: impl Trait<u64>, y: &impl Trait<u32>) {
 fn argument_impl_trait_type_args_1() {
     check_infer_with_mismatches(
         r#"
-#[lang = "sized"] trait Sized {}
+//- minicore: sized
 trait Trait {}
 trait Foo {
     // this function has an implicit Self param, an explicit type param,
@@ -928,39 +928,39 @@ fn test() {
     foo::<u32, i32>(S); // we should ignore the extraneous i32
 }"#,
         expect![[r#"
-            188..189 'x': impl Trait
-            208..219 '{ loop {} }': T
-            210..217 'loop {}': !
-            215..217 '{}': ()
-            232..233 'x': impl Trait
-            252..263 '{ loop {} }': T
-            254..261 'loop {}': !
-            259..261 '{}': ()
-            333..542 '{     ... i32 }': ()
-            339..347 'Foo::bar': fn bar<{unknown}, {unknown}>(S) -> {unknown}
-            339..350 'Foo::bar(S)': {unknown}
-            348..349 'S': S
-            356..371 '<F as Foo>::bar': fn bar<F, {unknown}>(S) -> {unknown}
-            356..374 '<F as ...bar(S)': {unknown}
-            372..373 'S': S
-            380..386 'F::bar': fn bar<F, {unknown}>(S) -> {unknown}
-            380..389 'F::bar(S)': {unknown}
-            387..388 'S': S
-            395..410 'Foo::bar::<u32>': fn bar<{unknown}, u32>(S) -> u32
-            395..413 'Foo::b...32>(S)': u32
-            411..412 'S': S
-            419..441 '<F as ...:<u32>': fn bar<F, u32>(S) -> u32
-            419..444 '<F as ...32>(S)': u32
-            442..443 'S': S
-            451..454 'foo': fn foo<{unknown}>(S) -> {unknown}
-            451..457 'foo(S)': {unknown}
-            455..456 'S': S
-            463..473 'foo::<u32>': fn foo<u32>(S) -> u32
-            463..476 'foo::<u32>(S)': u32
-            474..475 'S': S
-            482..497 'foo::<u32, i32>': fn foo<u32>(S) -> u32
-            482..500 'foo::<...32>(S)': u32
-            498..499 'S': S
+            155..156 'x': impl Trait
+            175..186 '{ loop {} }': T
+            177..184 'loop {}': !
+            182..184 '{}': ()
+            199..200 'x': impl Trait
+            219..230 '{ loop {} }': T
+            221..228 'loop {}': !
+            226..228 '{}': ()
+            300..509 '{     ... i32 }': ()
+            306..314 'Foo::bar': fn bar<{unknown}, {unknown}>(S) -> {unknown}
+            306..317 'Foo::bar(S)': {unknown}
+            315..316 'S': S
+            323..338 '<F as Foo>::bar': fn bar<F, {unknown}>(S) -> {unknown}
+            323..341 '<F as ...bar(S)': {unknown}
+            339..340 'S': S
+            347..353 'F::bar': fn bar<F, {unknown}>(S) -> {unknown}
+            347..356 'F::bar(S)': {unknown}
+            354..355 'S': S
+            362..377 'Foo::bar::<u32>': fn bar<{unknown}, u32>(S) -> u32
+            362..380 'Foo::b...32>(S)': u32
+            378..379 'S': S
+            386..408 '<F as ...:<u32>': fn bar<F, u32>(S) -> u32
+            386..411 '<F as ...32>(S)': u32
+            409..410 'S': S
+            418..421 'foo': fn foo<{unknown}>(S) -> {unknown}
+            418..424 'foo(S)': {unknown}
+            422..423 'S': S
+            430..440 'foo::<u32>': fn foo<u32>(S) -> u32
+            430..443 'foo::<u32>(S)': u32
+            441..442 'S': S
+            449..464 'foo::<u32, i32>': fn foo<u32>(S) -> u32
+            449..467 'foo::<...32>(S)': u32
+            465..466 'S': S
         "#]],
     );
 }
@@ -969,7 +969,7 @@ fn test() {
 fn argument_impl_trait_type_args_2() {
     check_infer_with_mismatches(
         r#"
-#[lang = "sized"] trait Sized {}
+//- minicore: sized
 trait Trait {}
 struct S;
 impl Trait for S {}
@@ -985,24 +985,24 @@ fn test() {
     F::<u32>.foo::<i32, u32>(S); // extraneous argument should be ignored
 }"#,
         expect![[r#"
-            120..124 'self': F<T>
-            126..127 'x': impl Trait
-            151..162 '{ loop {} }': (T, U)
-            153..160 'loop {}': !
-            158..160 '{}': ()
-            176..316 '{     ...ored }': ()
-            182..183 'F': F<{unknown}>
-            182..190 'F.foo(S)': ({unknown}, {unknown})
-            188..189 'S': S
-            196..204 'F::<u32>': F<u32>
-            196..211 'F::<u32>.foo(S)': (u32, {unknown})
-            209..210 'S': S
-            217..225 'F::<u32>': F<u32>
-            217..239 'F::<u3...32>(S)': (u32, i32)
+            87..91 'self': F<T>
+            93..94 'x': impl Trait
+            118..129 '{ loop {} }': (T, U)
+            120..127 'loop {}': !
+            125..127 '{}': ()
+            143..283 '{     ...ored }': ()
+            149..150 'F': F<{unknown}>
+            149..157 'F.foo(S)': ({unknown}, {unknown})
+            155..156 'S': S
+            163..171 'F::<u32>': F<u32>
+            163..178 'F::<u32>.foo(S)': (u32, {unknown})
+            176..177 'S': S
+            184..192 'F::<u32>': F<u32>
+            184..206 'F::<u3...32>(S)': (u32, i32)
+            204..205 'S': S
+            212..220 'F::<u32>': F<u32>
+            212..239 'F::<u3...32>(S)': (u32, i32)
             237..238 'S': S
-            245..253 'F::<u32>': F<u32>
-            245..272 'F::<u3...32>(S)': (u32, i32)
-            270..271 'S': S
         "#]],
     );
 }
@@ -1011,7 +1011,7 @@ fn test() {
 fn argument_impl_trait_to_fn_pointer() {
     check_infer_with_mismatches(
         r#"
-#[lang = "sized"] trait Sized {}
+//- minicore: sized
 trait Trait {}
 fn foo(x: impl Trait) { loop {} }
 struct S;
@@ -1021,13 +1021,13 @@ fn test() {
     let f: fn(S) -> () = foo;
 }"#,
         expect![[r#"
-            55..56 'x': impl Trait
-            70..81 '{ loop {} }': ()
-            72..79 'loop {}': !
-            77..79 '{}': ()
-            123..156 '{     ...foo; }': ()
-            133..134 'f': fn(S)
-            150..153 'foo': fn foo(S)
+            22..23 'x': impl Trait
+            37..48 '{ loop {} }': ()
+            39..46 'loop {}': !
+            44..46 '{}': ()
+            90..123 '{     ...foo; }': ()
+            100..101 'f': fn(S)
+            117..120 'foo': fn foo(S)
         "#]],
     );
 }
@@ -1036,7 +1036,7 @@ fn test() {
 fn impl_trait() {
     check_infer(
         r#"
-#[lang = "sized"] trait Sized {}
+//- minicore: sized
 trait Trait<T> {
     fn foo(&self) -> T;
     fn foo2(&self) -> i64;
@@ -1055,29 +1055,29 @@ fn test(x: impl Trait<u64>, y: &impl Trait<u64>) {
     z.foo2();
 }"#,
         expect![[r#"
-            62..66 'self': &Self
-            87..91 'self': &Self
-            131..133 '{}': ()
-            143..144 'x': impl Trait<u64>
-            163..164 'y': &impl Trait<u64>
-            184..301 '{     ...2(); }': ()
+            29..33 'self': &Self
+            54..58 'self': &Self
+            98..100 '{}': ()
+            110..111 'x': impl Trait<u64>
+            130..131 'y': &impl Trait<u64>
+            151..268 '{     ...2(); }': ()
+            157..158 'x': impl Trait<u64>
+            164..165 'y': &impl Trait<u64>
+            175..176 'z': impl Trait<u64>
+            179..182 'bar': fn bar() -> impl Trait<u64>
+            179..184 'bar()': impl Trait<u64>
             190..191 'x': impl Trait<u64>
-            197..198 'y': &impl Trait<u64>
-            208..209 'z': impl Trait<u64>
-            212..215 'bar': fn bar() -> impl Trait<u64>
-            212..217 'bar()': impl Trait<u64>
-            223..224 'x': impl Trait<u64>
-            223..230 'x.foo()': u64
-            236..237 'y': &impl Trait<u64>
-            236..243 'y.foo()': u64
-            249..250 'z': impl Trait<u64>
-            249..256 'z.foo()': u64
-            262..263 'x': impl Trait<u64>
-            262..270 'x.foo2()': i64
-            276..277 'y': &impl Trait<u64>
-            276..284 'y.foo2()': i64
-            290..291 'z': impl Trait<u64>
-            290..298 'z.foo2()': i64
+            190..197 'x.foo()': u64
+            203..204 'y': &impl Trait<u64>
+            203..210 'y.foo()': u64
+            216..217 'z': impl Trait<u64>
+            216..223 'z.foo()': u64
+            229..230 'x': impl Trait<u64>
+            229..237 'x.foo2()': i64
+            243..244 'y': &impl Trait<u64>
+            243..251 'y.foo2()': i64
+            257..258 'z': impl Trait<u64>
+            257..265 'z.foo2()': i64
         "#]],
     );
 }
@@ -1087,7 +1087,7 @@ fn simple_return_pos_impl_trait() {
     cov_mark::check!(lower_rpit);
     check_infer(
         r#"
-#[lang = "sized"] trait Sized {}
+//- minicore: sized
 trait Trait<T> {
     fn foo(&self) -> T;
 }
@@ -1098,16 +1098,16 @@ fn test() {
     a.foo();
 }"#,
         expect![[r#"
-            62..66 'self': &Self
-            104..115 '{ loop {} }': !
-            106..113 'loop {}': !
-            111..113 '{}': ()
-            127..162 '{     ...o(); }': ()
-            137..138 'a': impl Trait<u64>
-            141..144 'bar': fn bar() -> impl Trait<u64>
-            141..146 'bar()': impl Trait<u64>
-            152..153 'a': impl Trait<u64>
-            152..159 'a.foo()': u64
+            29..33 'self': &Self
+            71..82 '{ loop {} }': !
+            73..80 'loop {}': !
+            78..80 '{}': ()
+            94..129 '{     ...o(); }': ()
+            104..105 'a': impl Trait<u64>
+            108..111 'bar': fn bar() -> impl Trait<u64>
+            108..113 'bar()': impl Trait<u64>
+            119..120 'a': impl Trait<u64>
+            119..126 'a.foo()': u64
         "#]],
     );
 }
@@ -1116,7 +1116,7 @@ fn test() {
 fn more_return_pos_impl_trait() {
     check_infer(
         r#"
-#[lang = "sized"] trait Sized {}
+//- minicore: sized
 trait Iterator {
     type Item;
     fn next(&mut self) -> Self::Item;
@@ -1136,37 +1136,37 @@ fn test() {
     d.foo();
 }"#,
         expect![[r#"
-            82..86 'self': &mut Self
-            134..138 'self': &Self
-            217..228 '{ loop {} }': ({unknown}, {unknown})
-            219..226 'loop {}': !
-            224..226 '{}': ()
-            239..240 't': T
-            301..312 '{ loop {} }': ({unknown}, {unknown})
-            303..310 'loop {}': !
-            308..310 '{}': ()
-            324..446 '{     ...o(); }': ()
-            334..340 '(a, b)': (impl Iterator<Item = impl Trait<u32>>, impl Trait<u64>)
-            335..336 'a': impl Iterator<Item = impl Trait<u32>>
-            338..339 'b': impl Trait<u64>
-            343..346 'bar': fn bar() -> (impl Iterator<Item = impl Trait<u32>>, impl Trait<u64>)
-            343..348 'bar()': (impl Iterator<Item = impl Trait<u32>>, impl Trait<u64>)
-            354..355 'a': impl Iterator<Item = impl Trait<u32>>
-            354..362 'a.next()': impl Trait<u32>
-            354..368 'a.next().foo()': u32
-            374..375 'b': impl Trait<u64>
-            374..381 'b.foo()': u64
-            391..397 '(c, d)': (impl Iterator<Item = impl Trait<u128>>, impl Trait<u128>)
-            392..393 'c': impl Iterator<Item = impl Trait<u128>>
-            395..396 'd': impl Trait<u128>
-            400..403 'baz': fn baz<u128>(u128) -> (impl Iterator<Item = impl Trait<u128>>, impl Trait<u128>)
-            400..410 'baz(1u128)': (impl Iterator<Item = impl Trait<u128>>, impl Trait<u128>)
-            404..409 '1u128': u128
-            416..417 'c': impl Iterator<Item = impl Trait<u128>>
-            416..424 'c.next()': impl Trait<u128>
-            416..430 'c.next().foo()': u128
-            436..437 'd': impl Trait<u128>
-            436..443 'd.foo()': u128
+            49..53 'self': &mut Self
+            101..105 'self': &Self
+            184..195 '{ loop {} }': ({unknown}, {unknown})
+            186..193 'loop {}': !
+            191..193 '{}': ()
+            206..207 't': T
+            268..279 '{ loop {} }': ({unknown}, {unknown})
+            270..277 'loop {}': !
+            275..277 '{}': ()
+            291..413 '{     ...o(); }': ()
+            301..307 '(a, b)': (impl Iterator<Item = impl Trait<u32>>, impl Trait<u64>)
+            302..303 'a': impl Iterator<Item = impl Trait<u32>>
+            305..306 'b': impl Trait<u64>
+            310..313 'bar': fn bar() -> (impl Iterator<Item = impl Trait<u32>>, impl Trait<u64>)
+            310..315 'bar()': (impl Iterator<Item = impl Trait<u32>>, impl Trait<u64>)
+            321..322 'a': impl Iterator<Item = impl Trait<u32>>
+            321..329 'a.next()': impl Trait<u32>
+            321..335 'a.next().foo()': u32
+            341..342 'b': impl Trait<u64>
+            341..348 'b.foo()': u64
+            358..364 '(c, d)': (impl Iterator<Item = impl Trait<u128>>, impl Trait<u128>)
+            359..360 'c': impl Iterator<Item = impl Trait<u128>>
+            362..363 'd': impl Trait<u128>
+            367..370 'baz': fn baz<u128>(u128) -> (impl Iterator<Item = impl Trait<u128>>, impl Trait<u128>)
+            367..377 'baz(1u128)': (impl Iterator<Item = impl Trait<u128>>, impl Trait<u128>)
+            371..376 '1u128': u128
+            383..384 'c': impl Iterator<Item = impl Trait<u128>>
+            383..391 'c.next()': impl Trait<u128>
+            383..397 'c.next().foo()': u128
+            403..404 'd': impl Trait<u128>
+            403..410 'd.foo()': u128
         "#]],
     );
 }
@@ -1175,7 +1175,7 @@ fn test() {
 fn dyn_trait() {
     check_infer(
         r#"
-#[lang = "sized"] trait Sized {}
+//- minicore: sized
 trait Trait<T> {
     fn foo(&self) -> T;
     fn foo2(&self) -> i64;
@@ -1194,29 +1194,29 @@ fn test(x: dyn Trait<u64>, y: &dyn Trait<u64>) {
     z.foo2();
 }"#,
         expect![[r#"
-            62..66 'self': &Self
-            87..91 'self': &Self
-            130..132 '{}': ()
-            142..143 'x': dyn Trait<u64>
+            29..33 'self': &Self
+            54..58 'self': &Self
+            97..99 '{}': ()
+            109..110 'x': dyn Trait<u64>
+            128..129 'y': &dyn Trait<u64>
+            148..265 '{     ...2(); }': ()
+            154..155 'x': dyn Trait<u64>
             161..162 'y': &dyn Trait<u64>
-            181..298 '{     ...2(); }': ()
+            172..173 'z': dyn Trait<u64>
+            176..179 'bar': fn bar() -> dyn Trait<u64>
+            176..181 'bar()': dyn Trait<u64>
             187..188 'x': dyn Trait<u64>
-            194..195 'y': &dyn Trait<u64>
-            205..206 'z': dyn Trait<u64>
-            209..212 'bar': fn bar() -> dyn Trait<u64>
-            209..214 'bar()': dyn Trait<u64>
-            220..221 'x': dyn Trait<u64>
-            220..227 'x.foo()': u64
-            233..234 'y': &dyn Trait<u64>
-            233..240 'y.foo()': u64
-            246..247 'z': dyn Trait<u64>
-            246..253 'z.foo()': u64
-            259..260 'x': dyn Trait<u64>
-            259..267 'x.foo2()': i64
-            273..274 'y': &dyn Trait<u64>
-            273..281 'y.foo2()': i64
-            287..288 'z': dyn Trait<u64>
-            287..295 'z.foo2()': i64
+            187..194 'x.foo()': u64
+            200..201 'y': &dyn Trait<u64>
+            200..207 'y.foo()': u64
+            213..214 'z': dyn Trait<u64>
+            213..220 'z.foo()': u64
+            226..227 'x': dyn Trait<u64>
+            226..234 'x.foo2()': i64
+            240..241 'y': &dyn Trait<u64>
+            240..248 'y.foo2()': i64
+            254..255 'z': dyn Trait<u64>
+            254..262 'z.foo2()': i64
         "#]],
     );
 }
@@ -1225,7 +1225,7 @@ fn test(x: dyn Trait<u64>, y: &dyn Trait<u64>) {
 fn dyn_trait_in_impl() {
     check_infer(
         r#"
-#[lang = "sized"] trait Sized {}
+//- minicore: sized
 trait Trait<T, U> {
     fn foo(&self) -> (T, U);
 }
@@ -1242,17 +1242,17 @@ fn test(s: S<u32, i32>) {
     s.bar().baz();
 }"#,
         expect![[r#"
-            65..69 'self': &Self
-            135..139 'self': &S<T, U>
-            161..172 '{ loop {} }': &dyn Trait<T, U>
-            163..170 'loop {}': !
-            168..170 '{}': ()
-            208..212 'self': &Self
-            284..285 's': S<u32, i32>
-            300..322 '{     ...z(); }': ()
-            306..307 's': S<u32, i32>
-            306..313 's.bar()': &dyn Trait<u32, i32>
-            306..319 's.bar().baz()': (u32, i32)
+            32..36 'self': &Self
+            102..106 'self': &S<T, U>
+            128..139 '{ loop {} }': &dyn Trait<T, U>
+            130..137 'loop {}': !
+            135..137 '{}': ()
+            175..179 'self': &Self
+            251..252 's': S<u32, i32>
+            267..289 '{     ...z(); }': ()
+            273..274 's': S<u32, i32>
+            273..280 's.bar()': &dyn Trait<u32, i32>
+            273..286 's.bar().baz()': (u32, i32)
         "#]],
     );
 }
@@ -1261,7 +1261,7 @@ fn test(s: S<u32, i32>) {
 fn dyn_trait_bare() {
     check_infer(
         r#"
-#[lang = "sized"] trait Sized {}
+//- minicore: sized
 trait Trait {
     fn foo(&self) -> u64;
 }
@@ -1276,22 +1276,22 @@ fn test(x: Trait, y: &Trait) -> u64 {
     z.foo();
 }"#,
         expect![[r#"
-            59..63 'self': &Self
-            93..95 '{}': ()
-            105..106 'x': dyn Trait
-            115..116 'y': &dyn Trait
-            133..208 '{     ...o(); }': ()
+            26..30 'self': &Self
+            60..62 '{}': ()
+            72..73 'x': dyn Trait
+            82..83 'y': &dyn Trait
+            100..175 '{     ...o(); }': ()
+            106..107 'x': dyn Trait
+            113..114 'y': &dyn Trait
+            124..125 'z': dyn Trait
+            128..131 'bar': fn bar() -> dyn Trait
+            128..133 'bar()': dyn Trait
             139..140 'x': dyn Trait
-            146..147 'y': &dyn Trait
-            157..158 'z': dyn Trait
-            161..164 'bar': fn bar() -> dyn Trait
-            161..166 'bar()': dyn Trait
-            172..173 'x': dyn Trait
-            172..179 'x.foo()': u64
-            185..186 'y': &dyn Trait
-            185..192 'y.foo()': u64
-            198..199 'z': dyn Trait
-            198..205 'z.foo()': u64
+            139..146 'x.foo()': u64
+            152..153 'y': &dyn Trait
+            152..159 'y.foo()': u64
+            165..166 'z': dyn Trait
+            165..172 'z.foo()': u64
         "#]],
     );
 }
@@ -1300,7 +1300,7 @@ fn test(x: Trait, y: &Trait) -> u64 {
 fn weird_bounds() {
     check_infer(
         r#"
-#[lang = "sized"] trait Sized {}
+//- minicore: sized
 trait Trait {}
 fn test(
     a: impl Trait + 'lifetime,
@@ -1312,13 +1312,13 @@ fn test(
 ) {}
 "#,
         expect![[r#"
-            61..62 'a': impl Trait
-            92..93 'b': impl Sized
-            115..116 'c': impl Trait
-            136..137 'd': impl Sized
-            161..162 'e': impl ?Sized
-            181..182 'f': impl Trait + ?Sized
-            206..208 '{}': ()
+            28..29 'a': impl Trait
+            59..60 'b': impl Sized
+            82..83 'c': impl Trait
+            103..104 'd': impl Sized
+            128..129 'e': impl ?Sized
+            148..149 'f': impl Trait + ?Sized
+            173..175 '{}': ()
         "#]],
     );
 }
@@ -1342,7 +1342,7 @@ fn test(x: (impl Trait + UnknownTrait)) {
 fn assoc_type_bindings() {
     check_infer(
         r#"
-#[lang = "sized"] trait Sized {}
+//- minicore: sized
 trait Trait {
     type Type;
 }
@@ -1364,41 +1364,41 @@ fn test<T: Trait<Type = u32>>(x: T, y: impl Trait<Type = i64>) {
     get2(S::<str>);
 }"#,
         expect![[r#"
-            82..83 't': T
-            110..112 '{}': ()
-            144..145 't': T
-            155..157 '{}': ()
-            187..188 't': T
-            198..201 '{t}': T
-            199..200 't': T
-            289..290 'x': T
-            295..296 'y': impl Trait<Type = i64>
-            322..430 '{     ...r>); }': ()
-            328..331 'get': fn get<T>(T) -> <T as Trait>::Type
-            328..334 'get(x)': u32
-            332..333 'x': T
-            340..344 'get2': fn get2<u32, T>(T) -> u32
-            340..347 'get2(x)': u32
-            345..346 'x': T
-            353..356 'get': fn get<impl Trait<Type = i64>>(impl Trait<Type = i64>) -> <impl Trait<Type = i64> as Trait>::Type
-            353..359 'get(y)': i64
-            357..358 'y': impl Trait<Type = i64>
-            365..369 'get2': fn get2<i64, impl Trait<Type = i64>>(impl Trait<Type = i64>) -> i64
-            365..372 'get2(y)': i64
-            370..371 'y': impl Trait<Type = i64>
-            378..381 'get': fn get<S<u64>>(S<u64>) -> <S<u64> as Trait>::Type
-            378..389 'get(set(S))': u64
-            382..385 'set': fn set<S<u64>>(S<u64>) -> S<u64>
-            382..388 'set(S)': S<u64>
-            386..387 'S': S<u64>
-            395..399 'get2': fn get2<u64, S<u64>>(S<u64>) -> u64
-            395..407 'get2(set(S))': u64
-            400..403 'set': fn set<S<u64>>(S<u64>) -> S<u64>
-            400..406 'set(S)': S<u64>
-            404..405 'S': S<u64>
-            413..417 'get2': fn get2<str, S<str>>(S<str>) -> str
-            413..427 'get2(S::<str>)': str
-            418..426 'S::<str>': S<str>
+            49..50 't': T
+            77..79 '{}': ()
+            111..112 't': T
+            122..124 '{}': ()
+            154..155 't': T
+            165..168 '{t}': T
+            166..167 't': T
+            256..257 'x': T
+            262..263 'y': impl Trait<Type = i64>
+            289..397 '{     ...r>); }': ()
+            295..298 'get': fn get<T>(T) -> <T as Trait>::Type
+            295..301 'get(x)': u32
+            299..300 'x': T
+            307..311 'get2': fn get2<u32, T>(T) -> u32
+            307..314 'get2(x)': u32
+            312..313 'x': T
+            320..323 'get': fn get<impl Trait<Type = i64>>(impl Trait<Type = i64>) -> <impl Trait<Type = i64> as Trait>::Type
+            320..326 'get(y)': i64
+            324..325 'y': impl Trait<Type = i64>
+            332..336 'get2': fn get2<i64, impl Trait<Type = i64>>(impl Trait<Type = i64>) -> i64
+            332..339 'get2(y)': i64
+            337..338 'y': impl Trait<Type = i64>
+            345..348 'get': fn get<S<u64>>(S<u64>) -> <S<u64> as Trait>::Type
+            345..356 'get(set(S))': u64
+            349..352 'set': fn set<S<u64>>(S<u64>) -> S<u64>
+            349..355 'set(S)': S<u64>
+            353..354 'S': S<u64>
+            362..366 'get2': fn get2<u64, S<u64>>(S<u64>) -> u64
+            362..374 'get2(set(S))': u64
+            367..370 'set': fn set<S<u64>>(S<u64>) -> S<u64>
+            367..373 'set(S)': S<u64>
+            371..372 'S': S<u64>
+            380..384 'get2': fn get2<str, S<str>>(S<str>) -> str
+            380..394 'get2(S::<str>)': str
+            385..393 'S::<str>': S<str>
         "#]],
     );
 }
@@ -1507,7 +1507,7 @@ fn test<T: Trait1, U: Trait2>(x: T, y: U) {
 fn super_trait_impl_trait_method_resolution() {
     check_infer(
         r#"
-#[lang = "sized"] trait Sized {}
+//- minicore: sized
 mod foo {
     trait SuperTrait {
         fn foo(&self) -> u32 {}
@@ -1519,12 +1519,12 @@ fn test(x: &impl Trait1) {
     x.foo();
 }"#,
         expect![[r#"
-            82..86 'self': &Self
-            95..97 '{}': ()
-            148..149 'x': &impl Trait1
-            165..181 '{     ...o(); }': ()
-            171..172 'x': &impl Trait1
-            171..178 'x.foo()': u32
+            49..53 'self': &Self
+            62..64 '{}': ()
+            115..116 'x': &impl Trait1
+            132..148 '{     ...o(); }': ()
+            138..139 'x': &impl Trait1
+            138..145 'x.foo()': u32
         "#]],
     );
 }
@@ -2312,7 +2312,7 @@ impl TokenStream for Rustc {
 fn unify_impl_trait() {
     check_infer_with_mismatches(
         r#"
-#[lang = "sized"] trait Sized {}
+//- minicore: sized
 trait Trait<T> {}
 
 fn foo(x: impl Trait<u32>) { loop {} }
@@ -2330,37 +2330,37 @@ fn test() -> impl Trait<i32> {
     S(default())
 }"#,
         expect![[r#"
-            59..60 'x': impl Trait<u32>
-            79..90 '{ loop {} }': ()
-            81..88 'loop {}': !
-            86..88 '{}': ()
-            101..102 'x': impl Trait<T>
-            124..135 '{ loop {} }': T
-            126..133 'loop {}': !
-            131..133 '{}': ()
-            204..215 '{ loop {} }': T
-            206..213 'loop {}': !
-            211..213 '{}': ()
-            246..342 '{     ...t()) }': S<{unknown}>
-            256..258 's1': S<u32>
-            261..262 'S': S<u32>(u32) -> S<u32>
-            261..273 'S(default())': S<u32>
-            263..270 'default': fn default<u32>() -> u32
-            263..272 'default()': u32
-            279..282 'foo': fn foo(S<u32>)
-            279..286 'foo(s1)': ()
-            283..285 's1': S<u32>
-            296..297 'x': i32
-            305..308 'bar': fn bar<i32>(S<i32>) -> i32
-            305..322 'bar(S(...lt()))': i32
-            309..310 'S': S<i32>(i32) -> S<i32>
-            309..321 'S(default())': S<i32>
-            311..318 'default': fn default<i32>() -> i32
-            311..320 'default()': i32
-            328..329 'S': S<{unknown}>({unknown}) -> S<{unknown}>
-            328..340 'S(default())': S<{unknown}>
-            330..337 'default': fn default<{unknown}>() -> {unknown}
-            330..339 'default()': {unknown}
+            26..27 'x': impl Trait<u32>
+            46..57 '{ loop {} }': ()
+            48..55 'loop {}': !
+            53..55 '{}': ()
+            68..69 'x': impl Trait<T>
+            91..102 '{ loop {} }': T
+            93..100 'loop {}': !
+            98..100 '{}': ()
+            171..182 '{ loop {} }': T
+            173..180 'loop {}': !
+            178..180 '{}': ()
+            213..309 '{     ...t()) }': S<{unknown}>
+            223..225 's1': S<u32>
+            228..229 'S': S<u32>(u32) -> S<u32>
+            228..240 'S(default())': S<u32>
+            230..237 'default': fn default<u32>() -> u32
+            230..239 'default()': u32
+            246..249 'foo': fn foo(S<u32>)
+            246..253 'foo(s1)': ()
+            250..252 's1': S<u32>
+            263..264 'x': i32
+            272..275 'bar': fn bar<i32>(S<i32>) -> i32
+            272..289 'bar(S(...lt()))': i32
+            276..277 'S': S<i32>(i32) -> S<i32>
+            276..288 'S(default())': S<i32>
+            278..285 'default': fn default<i32>() -> i32
+            278..287 'default()': i32
+            295..296 'S': S<{unknown}>({unknown}) -> S<{unknown}>
+            295..307 'S(default())': S<{unknown}>
+            297..304 'default': fn default<{unknown}>() -> {unknown}
+            297..306 'default()': {unknown}
         "#]],
     );
 }

--- a/crates/hir_ty/src/utils.rs
+++ b/crates/hir_ty/src/utils.rs
@@ -13,7 +13,7 @@ use hir_def::{
     intern::Interned,
     path::Path,
     resolver::{HasResolver, TypeNs},
-    type_ref::TypeRef,
+    type_ref::{TraitBoundModifier, TypeRef},
     AssocContainerId, GenericDefId, Lookup, TraitId, TypeAliasId, TypeParamId,
 };
 use hir_expand::name::{name, Name};
@@ -57,6 +57,10 @@ fn direct_super_traits(db: &dyn DefDatabase, trait_: TraitId) -> Vec<TraitId> {
                 _ => None,
             },
             WherePredicate::Lifetime { .. } => None,
+        })
+        .filter_map(|(path, bound_modifier)| match bound_modifier {
+            TraitBoundModifier::None => Some(path),
+            TraitBoundModifier::Maybe => None,
         })
         .filter_map(|path| match resolver.resolve_path_in_type_ns_fully(db, path.mod_path()) {
             Some(TypeNs::TraitId(t)) => Some(t),

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -1189,7 +1189,9 @@ fn main() {
     #[test]
     fn hover_for_param_with_multiple_traits() {
         check(
-            r#"trait Deref {
+            r#"
+            //- minicore: sized
+            trait Deref {
                 type Target: ?Sized;
             }
             trait DerefMut {
@@ -3380,17 +3382,17 @@ fn foo() {
     fn hover_type_param() {
         check(
             r#"
+//- minicore: sized
 struct Foo<T>(T);
 trait Copy {}
 trait Clone {}
-trait Sized {}
 impl<T: Copy + Clone> Foo<T$0> where T: Sized {}
 "#,
             expect![[r#"
                 *T*
 
                 ```rust
-                T: Copy + Clone + Sized
+                T: Copy + Clone
                 ```
             "#]],
         );
@@ -3420,6 +3422,26 @@ impl<T: 'static> Foo<T$0> {}
                 T
                 ```
                 "#]],
+        );
+    }
+
+    #[test]
+    fn hover_type_param_not_sized() {
+        check(
+            r#"
+//- minicore: sized
+struct Foo<T>(T);
+trait Copy {}
+trait Clone {}
+impl<T: Copy + Clone> Foo<T$0> where T: ?Sized {}
+"#,
+            expect![[r#"
+                *T*
+
+                ```rust
+                T: Copy + Clone + ?Sized
+                ```
+            "#]],
         );
     }
 

--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -933,6 +933,50 @@ fn main() {
     }
 
     #[test]
+    fn fn_hints_ptr_rpit_fn_parentheses() {
+        check_types(
+            r#"
+//- minicore: fn, sized
+trait Trait {}
+
+fn foo1() -> *const impl Fn() { loop {} }
+fn foo2() -> *const (impl Fn() + Sized) { loop {} }
+fn foo3() -> *const (impl Fn() + ?Sized) { loop {} }
+fn foo4() -> *const (impl Sized + Fn()) { loop {} }
+fn foo5() -> *const (impl ?Sized + Fn()) { loop {} }
+fn foo6() -> *const (impl Fn() + Trait) { loop {} }
+fn foo7() -> *const (impl Fn() + Sized + Trait) { loop {} }
+fn foo8() -> *const (impl Fn() + ?Sized + Trait) { loop {} }
+fn foo9() -> *const (impl Fn() -> u8 + ?Sized) { loop {} }
+fn foo10() -> *const (impl Fn() + Sized + ?Sized) { loop {} }
+
+fn main() {
+    let foo = foo1();
+    //  ^^^ *const impl Fn()
+    let foo = foo2();
+    //  ^^^ *const impl Fn()
+    let foo = foo3();
+    //  ^^^ *const (impl Fn() + ?Sized)
+    let foo = foo4();
+    //  ^^^ *const impl Fn()
+    let foo = foo5();
+    //  ^^^ *const (impl Fn() + ?Sized)
+    let foo = foo6();
+    //  ^^^ *const (impl Fn() + Trait)
+    let foo = foo7();
+    //  ^^^ *const (impl Fn() + Trait)
+    let foo = foo8();
+    //  ^^^ *const (impl Fn() + Trait + ?Sized)
+    let foo = foo9();
+    //  ^^^ *const (impl Fn() -> u8 + ?Sized)
+    let foo = foo10();
+    //  ^^^ *const impl Fn()
+}
+"#,
+        )
+    }
+
+    #[test]
     fn unit_structs_have_no_type_hints() {
         check_types(
             r#"

--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -924,9 +924,9 @@ fn main() {
     let foo = foo5();
      // ^^^ &dyn Fn(&dyn Fn(f64, f64) -> u32, f64) -> u32
     let foo = foo6();
-     // ^^^ impl Fn(f64, f64) -> u32 + Sized
+     // ^^^ impl Fn(f64, f64) -> u32
     let foo = foo7();
-     // ^^^ *const (impl Fn(f64, f64) -> u32 + Sized)
+     // ^^^ *const impl Fn(f64, f64) -> u32
 }
 "#,
         )

--- a/crates/ide_assists/src/handlers/generate_function.rs
+++ b/crates/ide_assists/src/handlers/generate_function.rs
@@ -746,7 +746,8 @@ fn bar(worble: ()) ${0:-> ()} {
     fn add_function_with_impl_trait_arg() {
         check_assist(
             generate_function,
-            r"
+            r#"
+#[lang = "sized"] trait Sized {}
 trait Foo {}
 fn foo() -> impl Foo {
     todo!()
@@ -754,8 +755,9 @@ fn foo() -> impl Foo {
 fn baz() {
     $0bar(foo())
 }
-",
-            r"
+"#,
+            r#"
+#[lang = "sized"] trait Sized {}
 trait Foo {}
 fn foo() -> impl Foo {
     todo!()
@@ -767,7 +769,7 @@ fn baz() {
 fn bar(foo: impl Foo) ${0:-> ()} {
     todo!()
 }
-",
+"#,
         )
     }
 

--- a/crates/ide_assists/src/handlers/generate_function.rs
+++ b/crates/ide_assists/src/handlers/generate_function.rs
@@ -747,7 +747,7 @@ fn bar(worble: ()) ${0:-> ()} {
         check_assist(
             generate_function,
             r#"
-#[lang = "sized"] trait Sized {}
+//- minicore: sized
 trait Foo {}
 fn foo() -> impl Foo {
     todo!()
@@ -757,7 +757,6 @@ fn baz() {
 }
 "#,
             r#"
-#[lang = "sized"] trait Sized {}
 trait Foo {}
 fn foo() -> impl Foo {
     todo!()


### PR DESCRIPTION
This should close #8984 

`hir_ty`:
- Type parameters, associated types and `impl Trait` are `Sized` by deafault except `Self` in a trait.
- Implicit `Sized` bound is added to end of predicate list. It does not check if such bound is present already. Also it does not track the bound is implicit.
- Allowed ambiguous unsize coercion if Chalk returns definite guidance.
- Allowed ambiguous autoderef if Chalk returns definite guidance.

`hir_def`:
- `ItemTree` pretty printing shows `?Sized` bounds.

`HirDisplay`:
- `impl Trait` with weird bounds rendered correctly.
- `Sized`/`?Sized` bounds are not shown if they are default.

### Perf
`./target/rust-analyzer-baseline_8a843113 -q analysis-stats --memory-usage .`
```
Database loaded:     1.63s, 287minstr, 91mb
  crates: 38, mods: 741, decls: 15914, fns: 11835
Item Collection:     26.80s, 73ginstr, 338mb
  exprs: 318994, ??ty: 398 (0%), ?ty: 435 (0%), !ty: 174
Inference:           50.28s, 116ginstr, 516mb
Total:               77.08s, 189ginstr, 855mb
```

`./target/rust-analyzer-sized-fixed_ambig_coercion-de074fe6 -q analysis-stats --memory-usage .`
```
Database loaded:     1.63s, 287minstr, 91mb
  crates: 38, mods: 741, decls: 15914, fns: 11835
Item Collection:     26.95s, 73ginstr, 338mb
  exprs: 318994, ??ty: 398 (0%), ?ty: 435 (0%), !ty: 166
Inference:           96.39s, 234ginstr, 543mb
Total:               123.33s, 307ginstr, 881mb
```
