### PR TITLE
fix: Look for enum variants and trait assoc functions when looking for lang items

### DIFF
--- a/crates/ide_completion/src/completions/flyimport.rs
+++ b/crates/ide_completion/src/completions/flyimport.rs
@@ -696,8 +696,8 @@ fn main() {
 }
 "#,
             expect![[r#"
-                ct SPECIAL_CONST (use dep::test_mod::TestTrait) DEPRECATED
                 fn weird_function() (use dep::test_mod::TestTrait) fn() DEPRECATED
+                ct SPECIAL_CONST (use dep::test_mod::TestTrait) DEPRECATED
             "#]],
         );
     }


### PR DESCRIPTION
Examples for lang enum variants are the `Option` variants.
Assoc trait functions aren't being seen since they aren't declared in the direct module scope.