### PR TITLE
Generate default impl when converting `#[derive(Debug)]` to manual impl

### DIFF
--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -2732,8 +2732,8 @@ fn foo() {
                                     file_id: FileId(
                                         1,
                                     ),
-                                    full_range: 251..433,
-                                    focus_range: 290..296,
+                                    full_range: 252..434,
+                                    focus_range: 291..297,
                                     name: "Future",
                                     kind: Trait,
                                     description: "pub trait Future",

--- a/crates/ide_assists/src/handlers/replace_derive_with_manual_impl.rs
+++ b/crates/ide_assists/src/handlers/replace_derive_with_manual_impl.rs
@@ -205,7 +205,7 @@ fn gen_debug_impl(adt: &ast::Adt, func: &ast::Fn, annotated_name: &ast::Name) {
 
                 // => match self { ... }
                 let f_path = make::expr_path(make::ext::ident_path("self"));
-                let list = make::match_arm_list(arms);
+                let list = make::match_arm_list(arms).indent(ast::edit::IndentLevel(1));
                 let expr = make::expr_match(f_path, list);
 
                 let body = make::block_expr(None, Some(expr)).indent(ast::edit::IndentLevel(1));
@@ -454,8 +454,8 @@ enum Foo {
 impl fmt::Debug for Foo {
     $0fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-        Self::Bar => write!(f, "Bar"),
-        Self::Baz => write!(f, "Baz"),
+            Self::Bar => write!(f, "Bar"),
+            Self::Baz => write!(f, "Baz"),
         }
     }
 }

--- a/crates/ide_assists/src/handlers/replace_derive_with_manual_impl.rs
+++ b/crates/ide_assists/src/handlers/replace_derive_with_manual_impl.rs
@@ -171,7 +171,7 @@ fn impl_def_from_trait(
     if let ast::AssocItem::Fn(func) = &first_assoc_item {
         match trait_path.segment().unwrap().name_ref().unwrap().text().as_str() {
             "Debug" => gen_debug_impl(adt, func, annotated_name),
-            _ => {} // => If we don't know about the trait, the function body is left as `todo!`.
+            _ => {}
         };
     }
     Some((impl_def, first_assoc_item))

--- a/crates/ide_assists/src/handlers/replace_derive_with_manual_impl.rs
+++ b/crates/ide_assists/src/handlers/replace_derive_with_manual_impl.rs
@@ -170,18 +170,18 @@ fn impl_def_from_trait(
     let (impl_def, first_assoc_item) =
         add_trait_assoc_items_to_impl(sema, trait_items, trait_, impl_def, target_scope);
 
-    if let ast::AssocItem::Fn(fn_) = &first_assoc_item {
+    if let ast::AssocItem::Fn(func) = &first_assoc_item {
         if trait_path.segment().unwrap().name_ref().unwrap().text() == "Debug" {
-            gen_debug_impl(adt, fn_, annotated_name);
+            gen_debug_impl(adt, func, annotated_name);
         }
     }
     Some((impl_def, first_assoc_item))
 }
 
-fn gen_debug_impl(adt: &ast::Adt, fn_: &ast::Fn, annotated_name: &ast::Name) {
+fn gen_debug_impl(adt: &ast::Adt, func: &ast::Fn, annotated_name: &ast::Name) {
     match adt {
         ast::Adt::Union(_) => {} // `Debug` cannot be derived for unions, so no default impl can be provided.
-        ast::Adt::Enum(_) => {}  // TODO
+        ast::Adt::Enum(enum_) => {} // TODO
         ast::Adt::Struct(strukt) => match strukt.field_list() {
             Some(ast::FieldList::RecordFieldList(field_list)) => {
                 let name = format!("\"{}\"", annotated_name);
@@ -200,7 +200,7 @@ fn gen_debug_impl(adt: &ast::Adt, fn_: &ast::Fn, annotated_name: &ast::Name) {
                 }
                 let expr = make::expr_method_call(expr, "finish", make::arg_list(None));
                 let body = make::block_expr(None, Some(expr)).indent(ast::edit::IndentLevel(1));
-                ted::replace(fn_.body().unwrap().syntax(), body.clone_for_update().syntax());
+                ted::replace(func.body().unwrap().syntax(), body.clone_for_update().syntax());
             }
             Some(ast::FieldList::TupleFieldList(field_list)) => {
                 let name = format!("\"{}\"", annotated_name);
@@ -216,7 +216,7 @@ fn gen_debug_impl(adt: &ast::Adt, fn_: &ast::Fn, annotated_name: &ast::Name) {
                 }
                 let expr = make::expr_method_call(expr, "finish", make::arg_list(None));
                 let body = make::block_expr(None, Some(expr)).indent(ast::edit::IndentLevel(1));
-                ted::replace(fn_.body().unwrap().syntax(), body.clone_for_update().syntax());
+                ted::replace(func.body().unwrap().syntax(), body.clone_for_update().syntax());
             }
             None => {
                 let name = format!("\"{}\"", annotated_name);
@@ -225,7 +225,7 @@ fn gen_debug_impl(adt: &ast::Adt, fn_: &ast::Fn, annotated_name: &ast::Name) {
                 let expr = make::expr_method_call(target, "debug_struct", args);
                 let expr = make::expr_method_call(expr, "finish", make::arg_list(None));
                 let body = make::block_expr(None, Some(expr)).indent(ast::edit::IndentLevel(1));
-                ted::replace(fn_.body().unwrap().syntax(), body.clone_for_update().syntax());
+                ted::replace(func.body().unwrap().syntax(), body.clone_for_update().syntax());
             }
         },
     }

--- a/crates/ide_assists/src/handlers/replace_derive_with_manual_impl.rs
+++ b/crates/ide_assists/src/handlers/replace_derive_with_manual_impl.rs
@@ -304,36 +304,19 @@ mod tests {
         check_assist(
             replace_derive_with_manual_impl,
             r#"
-mod fmt {
-    pub struct Error;
-    pub type Result = Result<(), Error>;
-    pub struct Formatter<'a>;
-    pub trait Debug {
-        fn fmt(&self, f: &mut Formatter<'_>) -> Result;
-    }
-}
-
+//- minicore: fmt
 #[derive(Debu$0g)]
 struct Foo {
     bar: String,
 }
 "#,
             r#"
-mod fmt {
-    pub struct Error;
-    pub type Result = Result<(), Error>;
-    pub struct Formatter<'a>;
-    pub trait Debug {
-        fn fmt(&self, f: &mut Formatter<'_>) -> Result;
-    }
-}
-
 struct Foo {
     bar: String,
 }
 
-impl fmt::Debug for Foo {
-    $0fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl core::fmt::Debug for Foo {
+    $0fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Foo").field("bar", &self.bar).finish()
     }
 }
@@ -345,32 +328,14 @@ impl fmt::Debug for Foo {
         check_assist(
             replace_derive_with_manual_impl,
             r#"
-mod fmt {
-    pub struct Error;
-    pub type Result = Result<(), Error>;
-    pub struct Formatter<'a>;
-    pub trait Debug {
-        fn fmt(&self, f: &mut Formatter<'_>) -> Result;
-    }
-}
-
+//- minicore: fmt
 #[derive(Debu$0g)]
 struct Foo(String, usize);
 "#,
-            r#"
-mod fmt {
-    pub struct Error;
-    pub type Result = Result<(), Error>;
-    pub struct Formatter<'a>;
-    pub trait Debug {
-        fn fmt(&self, f: &mut Formatter<'_>) -> Result;
-    }
-}
+            r#"struct Foo(String, usize);
 
-struct Foo(String, usize);
-
-impl fmt::Debug for Foo {
-    $0fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl core::fmt::Debug for Foo {
+    $0fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_tuple("Foo").field(&self.0).field(&self.1).finish()
     }
 }
@@ -382,32 +347,15 @@ impl fmt::Debug for Foo {
         check_assist(
             replace_derive_with_manual_impl,
             r#"
-mod fmt {
-    pub struct Error;
-    pub type Result = Result<(), Error>;
-    pub struct Formatter<'a>;
-    pub trait Debug {
-        fn fmt(&self, f: &mut Formatter<'_>) -> Result;
-    }
-}
-
+//- minicore: fmt
 #[derive(Debu$0g)]
 struct Foo;
 "#,
             r#"
-mod fmt {
-    pub struct Error;
-    pub type Result = Result<(), Error>;
-    pub struct Formatter<'a>;
-    pub trait Debug {
-        fn fmt(&self, f: &mut Formatter<'_>) -> Result;
-    }
-}
-
 struct Foo;
 
-impl fmt::Debug for Foo {
-    $0fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl core::fmt::Debug for Foo {
+    $0fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Foo").finish()
     }
 }
@@ -419,15 +367,7 @@ impl fmt::Debug for Foo {
         check_assist(
             replace_derive_with_manual_impl,
             r#"
-mod fmt {
-    pub struct Error;
-    pub type Result = Result<(), Error>;
-    pub struct Formatter<'a>;
-    pub trait Debug {
-        fn fmt(&self, f: &mut Formatter<'_>) -> Result;
-    }
-}
-
+//- minicore: fmt
 #[derive(Debu$0g)]
 enum Foo {
     Bar,
@@ -435,22 +375,13 @@ enum Foo {
 }
 "#,
             r#"
-mod fmt {
-    pub struct Error;
-    pub type Result = Result<(), Error>;
-    pub struct Formatter<'a>;
-    pub trait Debug {
-        fn fmt(&self, f: &mut Formatter<'_>) -> Result;
-    }
-}
-
 enum Foo {
     Bar,
     Baz,
 }
 
-impl fmt::Debug for Foo {
-    $0fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl core::fmt::Debug for Foo {
+    $0fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Bar => write!(f, "Bar"),
             Self::Baz => write!(f, "Baz"),

--- a/crates/ide_assists/src/tests/generated.rs
+++ b/crates/ide_assists/src/tests/generated.rs
@@ -1364,7 +1364,7 @@ struct S;
 
 impl Debug for S {
     $0fn fmt(&self, f: &mut Formatter) -> Result<()> {
-        f.debug_struct(S)
+        f.debug_struct("S").finish()
     }
 }
 "#####,

--- a/crates/ide_assists/src/tests/generated.rs
+++ b/crates/ide_assists/src/tests/generated.rs
@@ -1363,8 +1363,8 @@ trait Debug { fn fmt(&self, f: &mut Formatter) -> Result<()>; }
 struct S;
 
 impl Debug for S {
-    fn fmt(&self, f: &mut Formatter) -> Result<()> {
-        ${0:todo!()}
+    $0fn fmt(&self, f: &mut Formatter) -> Result<()> {
+        f.debug_struct(S)
     }
 }
 "#####,

--- a/crates/rust-analyzer/tests/slow-tests/tidy.rs
+++ b/crates/rust-analyzer/tests/slow-tests/tidy.rs
@@ -274,11 +274,13 @@ fn check_todo(path: &Path, text: &str) {
         "handlers/add_turbo_fish.rs",
         "handlers/generate_function.rs",
         "handlers/fill_match_arms.rs",
+        "handlers/replace_derive_with_manual_impl.rs",
         // To support generating `todo!()` in assists, we have `expr_todo()` in
         // `ast::make`.
         "ast/make.rs",
         // The documentation in string literals may contain anything for its own purposes
         "ide_db/src/helpers/generated_lints.rs",
+        "ide_assists/src/tests/generated.rs",
     ];
     if need_todo.iter().any(|p| path.ends_with(p)) {
         return;

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -318,6 +318,9 @@ pub fn expr_closure(pats: impl IntoIterator<Item = ast::Param>, expr: ast::Expr)
     let params = pats.into_iter().join(", ");
     expr_from_text(&format!("|{}| {}", params, expr))
 }
+pub fn expr_field(receiver: ast::Expr, field: &str) -> ast::Expr {
+    expr_from_text(&format!("{}.{}", receiver, field))
+}
 pub fn expr_paren(expr: ast::Expr) -> ast::Expr {
     expr_from_text(&format!("({})", expr))
 }

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -311,6 +311,9 @@ pub fn expr_method_call(
 ) -> ast::Expr {
     expr_from_text(&format!("{}.{}{}", receiver, method, arg_list))
 }
+pub fn expr_macro_call(f: ast::Expr, arg_list: ast::ArgList) -> ast::Expr {
+    expr_from_text(&format!("{}!{}", f, arg_list))
+}
 pub fn expr_ref(expr: ast::Expr, exclusive: bool) -> ast::Expr {
     expr_from_text(&if exclusive { format!("&mut {}", expr) } else { format!("&{}", expr) })
 }

--- a/crates/test_utils/src/minicore.rs
+++ b/crates/test_utils/src/minicore.rs
@@ -31,6 +31,7 @@
 //!     eq: sized
 //!     ord: eq, option
 //!     derive:
+//!     fmt:
 
 pub mod marker {
     // region:sized
@@ -333,6 +334,17 @@ pub mod cmp {
     // endregion:ord
 }
 // endregion:eq
+
+// region:fmt
+pub mod fmt {
+    pub struct Error;
+    pub type Result = Result<(), Error>;
+    pub struct Formatter<'a>;
+    pub trait Debug {
+        fn fmt(&self, f: &mut Formatter<'_>) -> Result;
+    }
+}
+// endregion:fmt
 
 // region:slice
 pub mod slice {

--- a/crates/test_utils/src/minicore.rs
+++ b/crates/test_utils/src/minicore.rs
@@ -31,7 +31,7 @@
 //!     eq: sized
 //!     ord: eq, option
 //!     derive:
-//!     fmt:
+//!     fmt: result
 
 pub mod marker {
     // region:sized


### PR DESCRIPTION
This patch makes it so when you convert `#[derive(Debug)]` to a manual impl, a default body is provided that's equivalent to the original output of `#[derive(Debug)]`. This should make it drastically easier to write custom `Debug` impls, especially when all you want to do is quickly omit a single field which is `!Debug`.

This is implemented for enums, record structs, tuple structs, empty structs - and it sets us up to implement variations on this in the future for other traits (like `PartialEq` and `Hash`).

Thanks!

## Codegen diff
This is the difference in codegen for record structs with this patch:
```diff
struct Foo {
    bar: String,
}

impl fmt::Debug for Foo {
    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!();
+        f.debug_struct("Foo").field("bar", &self.bar).finish()
    }
}
```