### PR TITLE
Generate default impl when converting #[derive(Default)] to manual impl

### DIFF
--- a/crates/test_utils/src/minicore.rs
+++ b/crates/test_utils/src/minicore.rs
@@ -346,14 +346,6 @@ pub mod fmt {
 }
 // endregion:fmt
 
-// region:default
-pub mod default {
-    pub trait Default {
-        fn default() -> Self;
-    }
-}
-// endregion:default
-
 // region:slice
 pub mod slice {
     #[lang = "slice"]

--- a/crates/test_utils/src/minicore.rs
+++ b/crates/test_utils/src/minicore.rs
@@ -346,6 +346,14 @@ pub mod fmt {
 }
 // endregion:fmt
 
+// region:default
+pub mod default {
+    pub trait Default {
+        fn default() -> Self;
+    }
+}
+// endregion:default
+
 // region:slice
 pub mod slice {
     #[lang = "slice"]


### PR DESCRIPTION
Similar to https://github.com/rust-analyzer/rust-analyzer/pull/9814, but for `#[derive(Default)]`. Thanks!

## Follow-up steps
I've added the tests inside `handlers/replace_derive_with_manual_impl.rs` again, but I'm planning a follow-up PR to extract these to `utils/` so we can share them between assists - and maybe even add another assist just for the purpose of testing these impls (e.g. `generate_default_trait_body`).

The step after _that_ is likely to fill out the remaining traits, so we can make it so whenever RA auto-completes a trait which also can be derived, we provide a default function body.
