### PR TITLE
Refactor: quick clean-up of iteration idioms in the `vfs` crate

### DIFF
--- a/crates/vfs/src/lib.rs
+++ b/crates/vfs/src/lib.rs
@@ -139,13 +139,12 @@ impl Vfs {
     ///
     /// This will skip deleted files.
     pub fn iter(&self) -> impl Iterator<Item = (FileId, &VfsPath)> + '_ {
-        (0..self.data.len())
-            .map(|it| FileId(it as u32))
-            .filter(move |&file_id| self.get(file_id).is_some())
-            .map(move |file_id| {
-                let path = self.interner.lookup(file_id);
-                (file_id, path)
-            })
+        (0..self.data.len()).filter_map(move |it| {
+            let file_id = FileId(it as u32);
+            let _ = self.get(file_id).as_ref()?;
+            let path = self.interner.lookup(file_id);
+            Some((file_id, path))
+        })
     }
 
     /// Update the `path` with the given `contents`. `None` means the file was deleted.

--- a/crates/vfs/src/lib.rs
+++ b/crates/vfs/src/lib.rs
@@ -111,7 +111,9 @@ impl Vfs {
 
     /// Id of the given path if it exists in the `Vfs` and is not deleted.
     pub fn file_id(&self, path: &VfsPath) -> Option<FileId> {
-        self.interner.get(path).filter(|&it| self.get(it).is_some())
+        let it = self.interner.get(path)?;
+        let _ = self.get(it).as_ref()?;
+        Some(it)
     }
 
     /// File path corresponding to the given `file_id`.

--- a/crates/vfs/src/loader.rs
+++ b/crates/vfs/src/loader.rs
@@ -137,7 +137,10 @@ impl Directories {
     /// Returns `true` if `path` is included in `self`.
     pub fn contains_file(&self, path: &AbsPath) -> bool {
         let ext = path.extension().unwrap_or_default();
-        self.extensions.iter().any(|it| it.as_str() == ext) && self.includes_path(path)
+        if self.extensions.iter().all(|it| it.as_str() != ext) {
+            return false;
+        }
+        self.includes_path(path)
     }
 
     /// Returns `true` if `path` is included in `self`.

--- a/crates/vfs/src/loader.rs
+++ b/crates/vfs/src/loader.rs
@@ -136,10 +136,13 @@ impl Entry {
 impl Directories {
     /// Returns `true` if `path` is included in `self`.
     pub fn contains_file(&self, path: &AbsPath) -> bool {
+        // First, check the file extension...
         let ext = path.extension().unwrap_or_default();
         if self.extensions.iter().all(|it| it.as_str() != ext) {
             return false;
         }
+
+        // Then, check for path inclusion...
         self.includes_path(path)
     }
 

--- a/crates/vfs/src/loader.rs
+++ b/crates/vfs/src/loader.rs
@@ -161,16 +161,15 @@ impl Directories {
     ///   - This path is longer than any element in `self.exclude` that is a prefix
     ///     of `path`. In case of equality, exclusion wins.
     fn includes_path(&self, path: &AbsPath) -> bool {
-        let include = self.include.iter().fold(None::<&AbsPathBuf>, |include, incl| {
-            if !path.starts_with(incl) {
-                return include;
+        let mut include = None::<&AbsPathBuf>;
+        for incl in &self.include {
+            if path.starts_with(incl) {
+                include = Some(match include {
+                    Some(prev) if prev.starts_with(incl) => prev,
+                    _ => incl,
+                });
             }
-
-            Some(match include {
-                Some(prev) if prev.starts_with(incl) => prev,
-                _ => incl,
-            })
-        });
+        }
 
         let include = match include {
             Some(it) => it,

--- a/crates/vfs/src/loader.rs
+++ b/crates/vfs/src/loader.rs
@@ -137,10 +137,7 @@ impl Directories {
     /// Returns `true` if `path` is included in `self`.
     pub fn contains_file(&self, path: &AbsPath) -> bool {
         let ext = path.extension().unwrap_or_default();
-        if self.extensions.iter().all(|it| it.as_str() != ext) {
-            return false;
-        }
-        self.includes_path(path)
+        self.extensions.iter().any(|it| it.as_str() == ext) && self.includes_path(path)
     }
 
     /// Returns `true` if `path` is included in `self`.

--- a/crates/vfs/src/loader.rs
+++ b/crates/vfs/src/loader.rs
@@ -155,25 +155,23 @@ impl Directories {
     ///   - This path is longer than any element in `self.exclude` that is a prefix
     ///     of `path`. In case of equality, exclusion wins.
     fn includes_path(&self, path: &AbsPath) -> bool {
-        let mut include: Option<&AbsPathBuf> = None;
-        for incl in &self.include {
-            if path.starts_with(incl) {
-                include = Some(match include {
-                    Some(prev) if prev.starts_with(incl) => prev,
-                    _ => incl,
-                })
+        let include = self.include.iter().fold(None::<&AbsPathBuf>, |include, incl| {
+            if !path.starts_with(incl) {
+                return include;
             }
-        }
+
+            Some(match include {
+                Some(prev) if prev.starts_with(incl) => prev,
+                _ => incl,
+            })
+        });
+
         let include = match include {
             Some(it) => it,
             None => return false,
         };
-        for excl in &self.exclude {
-            if path.starts_with(excl) && excl.starts_with(include) {
-                return false;
-            }
-        }
-        true
+
+        !self.exclude.iter().any(|excl| path.starts_with(excl) && excl.starts_with(include))
     }
 }
 


### PR DESCRIPTION
This PR cleans up some of the iteration idioms used in the `vfs` crate. Most of the changes simply converted `for` loops into their `std::iter::Iterator`-method counterpart. Other changes required some inversion of logic to accommodate for better short-circuiting. Overall, there should be no behavioral changes. If there are any stylistic issues, I will gladly adhere to them and adjust the PR accordingly. Thanks!