### PR TITLE
Use term "method" on label for generating method impl

### DIFF
--- a/crates/ide_assists/src/handlers/generate_function.rs
+++ b/crates/ide_assists/src/handlers/generate_function.rs
@@ -138,7 +138,7 @@ fn gen_method(acc: &mut Assists, ctx: &AssistContext) -> Option<()> {
 
     acc.add(
         AssistId("generate_function", AssistKind::Generate),
-        format!("Generate `{}` function", function_builder.fn_name),
+        format!("Generate `{}` method", function_builder.fn_name),
         target,
         |builder| {
             let function_template = function_builder.render();


### PR DESCRIPTION
When showing the user the `generate_function` assist, use the term "method" when generating a method instead of the term "function" (which is correct but maybe not the most appropriate in that context). 