### PR TITLE
fix: Always add implicit `proc_macro` dependency

### DIFF
--- a/crates/project_model/src/workspace.rs
+++ b/crates/project_model/src/workspace.rs
@@ -533,15 +533,13 @@ fn cargo_to_crate_graph(
                     lib_tgt = Some((crate_id, cargo[tgt].name.clone()));
                     pkg_to_lib_crate.insert(pkg, crate_id);
                 }
-                if cargo[tgt].is_proc_macro {
-                    if let Some(proc_macro) = libproc_macro {
-                        add_dep(
-                            &mut crate_graph,
-                            crate_id,
-                            CrateName::new("proc_macro").unwrap(),
-                            proc_macro,
-                        );
-                    }
+                if let Some(proc_macro) = libproc_macro {
+                    add_dep(
+                        &mut crate_graph,
+                        crate_id,
+                        CrateName::new("proc_macro").unwrap(),
+                        proc_macro,
+                    );
                 }
 
                 pkg_crates.entry(pkg).or_insert_with(Vec::new).push((crate_id, cargo[tgt].kind));


### PR DESCRIPTION
Even crates that don't set `proc-macro = true` are allowed to depend on `proc_macro` (just none of the APIs work when called outside of a proc macro).

Fixes https://github.com/rust-analyzer/rust-analyzer/issues/9857

bors r+