### PR TITLE
fix: Don't call deprecated `compile` regex method

### DIFF
--- a/editors/code/src/toolchain.ts
+++ b/editors/code/src/toolchain.ts
@@ -133,7 +133,7 @@ export async function getRustcId(dir: string): Promise<string> {
 
     // do not memoize the result because the toolchain may change between runs
     const data = await execute(`${rustcPath} -V -v`, { cwd: dir });
-    const rx = /commit-hash:\s(.*)$/m.compile();
+    const rx = /commit-hash:\s(.*)$/m;
 
     return rx.exec(data)![1];
 }


### PR DESCRIPTION
Fixes #9872

It looks like `compile` expects to be called like `RegExp.compile("foo", "m")`, so calling `.compile()` on an existing regex replaces it with an empty one.