### PR TITLE
fix: Don't use uncached syntax nodes in `generate_function` for sema lookups

### DIFF
--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -884,6 +884,7 @@ to_def_impls![
     (crate::Local, ast::IdentPat, bind_pat_to_def),
     (crate::Local, ast::SelfParam, self_param_to_def),
     (crate::Label, ast::Label, label_to_def),
+    (crate::Adt, ast::Adt, adt_to_def),
 ];
 
 fn find_root(node: &SyntaxNode) -> SyntaxNode {

--- a/crates/hir/src/semantics/source_to_def.rs
+++ b/crates/hir/src/semantics/source_to_def.rs
@@ -91,9 +91,9 @@ use hir_def::{
     dyn_map::DynMap,
     expr::{LabelId, PatId},
     keys::{self, Key},
-    ConstId, ConstParamId, DefWithBodyId, EnumId, EnumVariantId, FieldId, FunctionId, GenericDefId,
-    ImplId, LifetimeParamId, ModuleId, StaticId, StructId, TraitId, TypeAliasId, TypeParamId,
-    UnionId, VariantId,
+    AdtId, ConstId, ConstParamId, DefWithBodyId, EnumId, EnumVariantId, FieldId, FunctionId,
+    GenericDefId, ImplId, LifetimeParamId, ModuleId, StaticId, StructId, TraitId, TypeAliasId,
+    TypeParamId, UnionId, VariantId,
 };
 use hir_expand::{name::AsName, AstId, MacroCallId, MacroDefId, MacroDefKind};
 use rustc_hash::FxHashMap;
@@ -200,6 +200,18 @@ impl SourceToDefCtx<'_, '_> {
         src: InFile<ast::Variant>,
     ) -> Option<EnumVariantId> {
         self.to_def(src, keys::VARIANT)
+    }
+    pub(super) fn adt_to_def(
+        &mut self,
+        InFile { file_id, value }: InFile<ast::Adt>,
+    ) -> Option<AdtId> {
+        match value {
+            ast::Adt::Enum(it) => self.enum_to_def(InFile::new(file_id, it)).map(AdtId::EnumId),
+            ast::Adt::Struct(it) => {
+                self.struct_to_def(InFile::new(file_id, it)).map(AdtId::StructId)
+            }
+            ast::Adt::Union(it) => self.union_to_def(InFile::new(file_id, it)).map(AdtId::UnionId),
+        }
     }
     pub(super) fn bind_pat_to_def(
         &mut self,


### PR DESCRIPTION
Fixes the crash in the comment here https://github.com/rust-analyzer/rust-analyzer/issues/9382#issuecomment-896101298
Couldn't make out a repro test for this unfortunately
still not idea about the original issue