### PR TITLE
fix: Do not replace items annotated with builtin attrs with the attr input

### DIFF
--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -173,6 +173,10 @@ impl<'db, DB: HirDatabase> Semantics<'db, DB> {
         self.imp.descend_node_at_offset(node, offset).find_map(N::cast)
     }
 
+    pub fn hir_file_for(&self, syntax_node: &SyntaxNode) -> HirFileId {
+        self.imp.find_file(syntax_node.clone()).file_id
+    }
+
     pub fn original_range(&self, node: &SyntaxNode) -> FileRange {
         self.imp.original_range(node)
     }

--- a/crates/hir_def/src/builtin_attr.rs
+++ b/crates/hir_def/src/builtin_attr.rs
@@ -34,9 +34,6 @@ macro_rules! rustc_attr {
     };
 }
 
-/// Built-in macro-like attributes.
-pub const EXTRA_ATTRIBUTES: &[BuiltinAttribute] = &["test", "bench"];
-
 /// "Inert" built-in attributes that have a special meaning to rustc or rustdoc.
 #[rustfmt::skip]
 pub const INERT_ATTRIBUTES: &[BuiltinAttribute] = &[

--- a/crates/hir_def/src/nameres/collector.rs
+++ b/crates/hir_def/src/nameres/collector.rs
@@ -1712,27 +1712,24 @@ impl ModCollector<'_, '_> {
         if path.kind == PathKind::Plain {
             if let Some(tool_module) = path.segments().first() {
                 let tool_module = tool_module.to_string();
-                if builtin_attr::TOOL_MODULES
+                let is_tool = builtin_attr::TOOL_MODULES
                     .iter()
                     .copied()
-                    .chain(self.def_collector.registered_tools.iter().map(|s| &**s))
-                    .any(|m| tool_module == *m)
-                {
+                    .chain(self.def_collector.registered_tools.iter().map(AsRef::as_ref))
+                    .any(|m| tool_module == *m);
+                if is_tool {
                     return true;
                 }
             }
 
             if let Some(name) = path.as_ident() {
                 let name = name.to_string();
-                if builtin_attr::INERT_ATTRIBUTES
+                let is_inert = builtin_attr::INERT_ATTRIBUTES
                     .iter()
-                    .chain(builtin_attr::EXTRA_ATTRIBUTES)
                     .copied()
-                    .chain(self.def_collector.registered_attrs.iter().map(|s| &**s))
-                    .any(|attr| name == *attr)
-                {
-                    return true;
-                }
+                    .chain(self.def_collector.registered_attrs.iter().map(AsRef::as_ref))
+                    .any(|attr| name == *attr);
+                return is_inert;
             }
         }
 

--- a/crates/hir_expand/src/builtin_attr.rs
+++ b/crates/hir_expand/src/builtin_attr.rs
@@ -17,11 +17,12 @@ macro_rules! register_builtin {
                 db: &dyn AstDatabase,
                 id: MacroCallId,
                 tt: &tt::Subtree,
+                item: &tt::Subtree,
             ) -> Result<tt::Subtree, mbe::ExpandError> {
                 let expander = match *self {
                     $( BuiltinAttrExpander::$variant => $expand, )*
                 };
-                expander(db, id, tt)
+                expander(db, id, tt, item)
             }
 
             fn find_by_name(name: &name::Name) -> Option<Self> {
@@ -61,7 +62,8 @@ pub fn find_builtin_attr(
 fn dummy_attr_expand(
     _db: &dyn AstDatabase,
     _id: MacroCallId,
-    tt: &tt::Subtree,
+    _tt: &tt::Subtree,
+    item: &tt::Subtree,
 ) -> Result<tt::Subtree, mbe::ExpandError> {
-    Ok(tt.clone())
+    Ok(item.clone())
 }

--- a/crates/hir_expand/src/db.rs
+++ b/crates/hir_expand/src/db.rs
@@ -54,18 +54,12 @@ impl TokenExpander {
             TokenExpander::MacroDef { mac, .. } => mac.expand(tt),
             TokenExpander::Builtin(it) => it.expand(db, id, tt),
             // FIXME switch these to ExpandResult as well
-            TokenExpander::BuiltinAttr(it) => {
-                let macro_arg = match db.macro_arg(id) {
-                    Some(it) => it,
-                    None => {
-                        return mbe::ExpandResult::only_err(
-                            mbe::ExpandError::Other("No item argument for attribute".to_string())
-                                .into(),
-                        );
-                    }
-                };
-                it.expand(db, id, tt, &macro_arg.0).into()
-            }
+            TokenExpander::BuiltinAttr(it) => match db.macro_arg(id) {
+                Some(macro_arg) => it.expand(db, id, tt, &macro_arg.0).into(),
+                None => mbe::ExpandResult::only_err(
+                    mbe::ExpandError::Other("No item argument for attribute".to_string()).into(),
+                ),
+            },
             TokenExpander::BuiltinDerive(it) => it.expand(db, id, tt).into(),
             TokenExpander::ProcMacro(_) => {
                 // We store the result in salsa db to prevent non-deterministic behavior in

--- a/crates/hir_expand/src/lib.rs
+++ b/crates/hir_expand/src/lib.rs
@@ -22,7 +22,7 @@ use either::Either;
 pub use mbe::{ExpandError, ExpandResult};
 pub use parser::FragmentKind;
 
-use std::{hash::Hash, sync::Arc};
+use std::{hash::Hash, iter, sync::Arc};
 
 use base_db::{impl_intern_key, salsa, CrateId, FileId, FileRange};
 use syntax::{
@@ -454,7 +454,7 @@ impl InFile<SyntaxNode> {
         self,
         db: &dyn db::AstDatabase,
     ) -> impl Iterator<Item = InFile<SyntaxNode>> + '_ {
-        std::iter::successors(Some(self), move |node| match node.value.parent() {
+        iter::successors(Some(self), move |node| match node.value.parent() {
             Some(parent) => Some(node.with_value(parent)),
             None => {
                 let parent_node = node.file_id.call_node(db)?;
@@ -570,19 +570,14 @@ impl<N: AstNode> InFile<N> {
     where
         N: 'db,
     {
-        std::iter::successors(Some(self), move |node| {
+        iter::successors(Some(self), move |node| {
             let InFile { file_id, value } = node.file_id.call_node(db)?;
             N::cast(value).map(|n| InFile::new(file_id, n))
         })
     }
 
     pub fn node_with_attributes(self, db: &dyn db::AstDatabase) -> InFile<N> {
-        std::iter::successors(Some(self), move |node| {
-            let InFile { file_id, value } = node.file_id.call_node(db)?;
-            N::cast(value).map(|n| InFile::new(file_id, n))
-        })
-        .last()
-        .unwrap()
+        self.nodes_with_attributes(db).last().unwrap()
     }
 }
 


### PR DESCRIPTION
This causes runnables to work for paths that actually resolve to the `test` attribute now.
![Code_aUhX1KQfw3](https://user-images.githubusercontent.com/3757771/129917168-bd9ed3f8-3a08-49d2-930a-4b93efaa8acf.png)

Prior to this we replaced items annotated with builtin attributes by the attribute input instead of the item in our dummy expansion which is why the fully written path didn't work as we actually discarded the item while `test` was just ignored.

Fixes #9935