### PR TITLE
internal: introduce in-place indenting API

### DIFF
--- a/crates/ide_assists/src/handlers/convert_iter_for_each_to_for.rs
+++ b/crates/ide_assists/src/handlers/convert_iter_for_each_to_for.rs
@@ -46,7 +46,7 @@ pub(crate) fn convert_iter_for_each_to_for(acc: &mut Assists, ctx: &AssistContex
     let body = closure.body()?;
 
     let stmt = method.syntax().parent().and_then(ast::ExprStmt::cast);
-    let range = stmt.as_ref().map_or_else(|| method.syntax(), AstNode::syntax).text_range();
+    let range = stmt.as_ref().map_or(method.syntax(), AstNode::syntax).text_range();
 
     acc.add(
         AssistId("convert_iter_for_each_to_for", AssistKind::RefactorRewrite),
@@ -61,7 +61,8 @@ pub(crate) fn convert_iter_for_each_to_for(acc: &mut Assists, ctx: &AssistContex
                 _ => make::block_expr(Vec::new(), Some(body)),
             }
             .clone_for_update();
-            block.reset_indent().indent(indent);
+            block.reset_indent();
+            block.indent(indent);
 
             let expr_for_loop = make::expr_for_loop(param, receiver, block);
             builder.replace(range, expr_for_loop.to_string())

--- a/crates/syntax/src/ast/edit.rs
+++ b/crates/syntax/src/ast/edit.rs
@@ -117,7 +117,7 @@ impl IndentLevel {
     /// }
     /// ```
     /// if you indent the block, the `{` token would stay put.
-    pub(in super) fn increase_indent(self, node: &SyntaxNode) {
+    pub(super) fn increase_indent(self, node: &SyntaxNode) {
         let tokens = node.preorder_with_tokens().filter_map(|event| match event {
             rowan::WalkEvent::Leave(NodeOrToken::Token(it)) => Some(it),
             _ => None,
@@ -132,7 +132,7 @@ impl IndentLevel {
         }
     }
 
-    pub(in super) fn decrease_indent(self, node: &SyntaxNode) {
+    pub(super) fn decrease_indent(self, node: &SyntaxNode) {
         let tokens = node.preorder_with_tokens().filter_map(|event| match event {
             rowan::WalkEvent::Leave(NodeOrToken::Token(it)) => Some(it),
             _ => None,

--- a/crates/syntax/src/ast/edit_in_place.rs
+++ b/crates/syntax/src/ast/edit_in_place.rs
@@ -487,17 +487,15 @@ pub trait Indent: AstNode + Clone + Sized {
     fn indent_level(&self) -> IndentLevel {
         IndentLevel::from_node(self.syntax())
     }
-    fn indent(&self, level: IndentLevel) -> &Self {
+    fn indent(&self, level: IndentLevel) {
         level.increase_indent(self.syntax());
-        self
     }
-    fn dedent(&self, level: IndentLevel) -> &Self {
+    fn dedent(&self, level: IndentLevel) {
         level.decrease_indent(self.syntax());
-        self
     }
-    fn reset_indent(&self) -> &Self {
+    fn reset_indent(&self) {
         let level = IndentLevel::from_node(self.syntax());
-        self.dedent(level)
+        self.dedent(level);
     }
 }
 


### PR DESCRIPTION
Introduce `edit_in_place::Indent` that uses mutable tree API and intended to replace `edit::AstNodeEdit`.

Closes #9903 