### PR TITLE
Fix codegen for is_method documentation

### DIFF
--- a/crates/ide_assists/src/tests/generated.rs
+++ b/crates/ide_assists/src/tests/generated.rs
@@ -723,6 +723,8 @@ enum Version {
 
 impl Version {
     /// Returns `true` if the version is [`Minor`].
+    ///
+    /// [`Minor`]: Version::Minor
     fn is_minor(&self) -> bool {
         matches!(self, Self::Minor)
     }


### PR DESCRIPTION
While authoring https://github.com/rust-lang/rust/pull/88154 I realized that the codegen for the `enum_generate_is_method` assist currently generates invalid paths, and used snake case instead of spaces for the docs description. This fixes both issues. Thanks!