### PR TITLE
feat: Show try operator propogated types on ranged hover 

### DIFF
--- a/crates/hir_ty/src/infer/pat.rs
+++ b/crates/hir_ty/src/infer/pat.rs
@@ -1,7 +1,6 @@
 //! Type inference for patterns.
 
-use std::iter::repeat;
-use std::sync::Arc;
+use std::{iter::repeat, sync::Arc};
 
 use chalk_ir::Mutability;
 use hir_def::{
@@ -10,9 +9,10 @@ use hir_def::{
 };
 use hir_expand::name::Name;
 
-use super::{BindingMode, Expectation, InferenceContext, TypeMismatch};
 use crate::{
-    infer::{Adjust, Adjustment, AutoBorrow},
+    infer::{
+        Adjust, Adjustment, AutoBorrow, BindingMode, Expectation, InferenceContext, TypeMismatch,
+    },
     lower::lower_to_chalk_mutability,
     static_lifetime, Interner, Substitution, Ty, TyBuilder, TyExt, TyKind,
 };

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -292,6 +292,7 @@ fn hover_try_expr(
         // special case for two options, there is no value in showing them
         if let Some(option_enum) = famous_defs.core_option_Option() {
             if inner == option_enum && body == option_enum {
+                cov_mark::hit!(hover_try_expr_opt_opt);
                 return None;
             }
         }
@@ -326,10 +327,10 @@ fn hover_try_expr(
     let body_ty = body_ty.display(sema.db).to_string();
     let ty_len_max = inner_ty.len().max(body_ty.len());
 
-    // "Propagated as: ".len() - " Type: ".len() = 8
-    let static_test_len_diff = 8 - s.len() as isize;
-    let tpad = static_test_len_diff.max(0) as usize;
-    let ppad = static_test_len_diff.min(0).abs() as usize;
+    let l = "Propagated as: ".len() - " Type: ".len();
+    let static_text_len_diff = l as isize - s.len() as isize;
+    let tpad = static_text_len_diff.max(0) as usize;
+    let ppad = static_text_len_diff.min(0).abs() as usize;
 
     res.markup = format!(
         "{bt_start}{} Type: {:>pad0$}\nPropagated as: {:>pad1$}\n{bt_end}",
@@ -368,12 +369,12 @@ fn hover_type_info(
         walk_and_push_ty(sema.db, &adjusted_ty, &mut push_new_def);
         let original = original.display(sema.db).to_string();
         let adjusted = adjusted_ty.display(sema.db).to_string();
+        let static_text_diff_len = "Coerced to: ".len() - "Type: ".len();
         format!(
             "{bt_start}Type: {:>apad$}\nCoerced to: {:>opad$}\n{bt_end}",
             original,
             adjusted,
-            // 6 base padding for difference of length of the two text prefixes
-            apad = 6 + adjusted.len().max(original.len()),
+            apad = static_text_diff_len + adjusted.len().max(original.len()),
             opad = original.len(),
             bt_start = if config.markdown() { "```text\n" } else { "" },
             bt_end = if config.markdown() { "```\n" } else { "" }
@@ -4429,6 +4430,7 @@ fn foo() -> NotResult<(), Short> {
 
     #[test]
     fn hover_try_expr_option() {
+        cov_mark::check!(hover_try_expr_opt_opt);
         check_hover_range(
             r#"
 //- minicore: option, try


### PR DESCRIPTION
Basically this just shows the type of the inner expression of the `?` expression as well as the type of the expression that the `?` returns from:
![Code_wIrCxMqLH9](https://user-images.githubusercontent.com/3757771/130111025-f7ee0742-214a-493b-947a-b4a671e4be92.png)

Unless both of these types are `core::result::Result` in which case we show the error types only.
![Code_Xruw5FCBNI](https://user-images.githubusercontent.com/3757771/130111024-f9caef82-92e4-4070-b3dd-f2ff9e5d87a9.png)

If both types are `core::option::Option` with different type params we do not show this special hover either as it would be pointless(instead fallback to default type hover)

Very much open to changes to the hover text here(I suppose we also want to show the actual type of the `?` expression, that is its output type?).

Fixes #9931