### PR TITLE
minor: Fix typos “a”→“an”

### DIFF
--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -203,7 +203,7 @@ impl<'db, DB: HirDatabase> Semantics<'db, DB> {
         self.imp.ancestors_at_offset_with_macros(node, offset)
     }
 
-    /// Find a AstNode by offset inside SyntaxNode, if it is inside *Macrofile*,
+    /// Find an AstNode by offset inside SyntaxNode, if it is inside *Macrofile*,
     /// search up until it is of the target AstNode type
     pub fn find_node_at_offset_with_macros<N: AstNode>(
         &self,
@@ -213,7 +213,7 @@ impl<'db, DB: HirDatabase> Semantics<'db, DB> {
         self.imp.ancestors_at_offset_with_macros(node, offset).find_map(N::cast)
     }
 
-    /// Find a AstNode by offset inside SyntaxNode, if it is inside *MacroCall*,
+    /// Find an AstNode by offset inside SyntaxNode, if it is inside *MacroCall*,
     /// descend it and find again
     pub fn find_node_at_offset_with_descend<N: AstNode>(
         &self,

--- a/crates/hir_ty/src/diagnostics/expr.rs
+++ b/crates/hir_ty/src/diagnostics/expr.rs
@@ -280,7 +280,7 @@ impl ExprValidator {
         for arm in arms {
             if let Some(pat_ty) = infer.type_of_pat.get(arm.pat) {
                 // We only include patterns whose type matches the type
-                // of the match expression. If we had a InvalidMatchArmPattern
+                // of the match expression. If we had an InvalidMatchArmPattern
                 // diagnostic or similar we could raise that in an else
                 // block here.
                 //

--- a/crates/ide_completion/src/completions/trait_impl.rs
+++ b/crates/ide_completion/src/completions/trait_impl.rs
@@ -1,7 +1,7 @@
 //! Completion for associated items in a trait implementation.
 //!
 //! This module adds the completion items related to implementing associated
-//! items within a `impl Trait for Struct` block. The current context node
+//! items within an `impl Trait for Struct` block. The current context node
 //! must be within either a `FN`, `TYPE_ALIAS`, or `CONST` node
 //! and an direct child of an `IMPL`.
 //!

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -98,7 +98,7 @@ impl AbsPathBuf {
             .unwrap_or_else(|path| panic!("expected absolute path, got {}", path.display()))
     }
 
-    /// Coerces to a `AbsPath` slice.
+    /// Coerces to an `AbsPath` slice.
     ///
     /// Equivalent of [`PathBuf::as_path`] for `AbsPathBuf`.
     pub fn as_path(&self) -> &AbsPath {


### PR DESCRIPTION
See rust-lang/rust#88230