### PR TITLE
Fix two more “a”/“an” typos (this time the other way)

### DIFF
--- a/crates/hir_def/src/path/lower.rs
+++ b/crates/hir_def/src/path/lower.rs
@@ -101,7 +101,7 @@ pub(super) fn lower_path(mut path: ast::Path, ctx: &LowerCtx) -> Option<Path> {
                 break;
             }
             ast::PathSegmentKind::SelfKw => {
-                // don't break out if `self` is the last segment of a path, this mean we got an
+                // don't break out if `self` is the last segment of a path, this mean we got a
                 // use tree like `foo::{self}` which we want to resolve as `foo`
                 if !segments.is_empty() {
                     kind = PathKind::Super(0);

--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -331,7 +331,7 @@ fn should_hide_param_name_hint(
     // - exact argument<->parameter match(ignoring leading underscore) or parameter is a prefix/suffix
     //   of argument with _ splitting it off
     // - param starts with `ra_fixture`
-    // - param is a well known name in an unary function
+    // - param is a well known name in a unary function
 
     let param_name = param_name.trim_start_matches('_');
     if param_name.is_empty() {
@@ -369,7 +369,7 @@ fn is_argument_similar_to_param_name(argument: &ast::Expr, param_name: &str) -> 
     argument == param_name
 }
 
-/// Hide the parameter name of an unary function if it is a `_` - prefixed suffix of the function's name, or equal.
+/// Hide the parameter name of a unary function if it is a `_` - prefixed suffix of the function's name, or equal.
 ///
 /// `fn strip_suffix(suffix)` will be hidden.
 /// `fn stripsuffix(suffix)` will not be hidden.

--- a/crates/mbe/src/expander.rs
+++ b/crates/mbe/src/expander.rs
@@ -93,7 +93,7 @@ pub(crate) fn expand_rules(
 ///
 /// In other words, `Bindings` is a *multi* mapping from `SmolStr` to
 /// `tt::TokenTree`, where the index to select a particular `TokenTree` among
-/// many is not a plain `usize`, but an `&[usize]`.
+/// many is not a plain `usize`, but a `&[usize]`.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 struct Bindings {
     inner: FxHashMap<SmolStr, Binding>,

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -182,7 +182,7 @@ impl<'t> Parser<'t> {
 
     /// Advances the parser by one token, remapping its kind.
     /// This is useful to create contextual keywords from
-    /// identifiers. For example, the lexer creates an `union`
+    /// identifiers. For example, the lexer creates a `union`
     /// *identifier* token, but the parser remaps it to the
     /// `union` keyword, and keyword is what ends up in the
     /// final tree.


### PR DESCRIPTION
Follow-up to #9987

you guys are still merging these fast :sweat_smile:

_this time I thought – for sure – that I’d get this commit into #9987 before it’s merged…_