### PR TITLE
feat: Expand derive macros under cursor in `Expand Macro Recursively`

### DIFF
--- a/crates/hir/src/semantics/source_to_def.rs
+++ b/crates/hir/src/semantics/source_to_def.rs
@@ -242,6 +242,15 @@ impl SourceToDefCtx<'_, '_> {
         map[keys::ATTR_MACRO].get(&src).copied()
     }
 
+    pub(super) fn attr_to_derive_macro_call(
+        &mut self,
+        item: InFile<&ast::Item>,
+        src: InFile<ast::Attr>,
+    ) -> Option<MacroCallId> {
+        let map = self.dyn_map(item)?;
+        map[keys::DERIVE_MACRO].get(&src).copied()
+    }
+
     fn to_def<Ast: AstNode + 'static, ID: Copy + 'static>(
         &mut self,
         src: InFile<Ast>,

--- a/crates/hir_def/src/child_by_source.rs
+++ b/crates/hir_def/src/child_by_source.rs
@@ -6,6 +6,7 @@
 
 use either::Either;
 use hir_expand::HirFileId;
+use syntax::ast::AttrsOwner;
 
 use crate::{
     db::DefDatabase,
@@ -107,6 +108,12 @@ impl ChildBySource for ItemScope {
         self.attr_macro_invocs().for_each(|(ast_id, call_id)| {
             let item = ast_id.with_value(ast_id.to_node(db.upcast()));
             res[keys::ATTR_MACRO].insert(item, call_id);
+        });
+        self.derive_macro_invocs().for_each(|(ast_id, (attr_id, call_id))| {
+            let item = ast_id.to_node(db.upcast());
+            if let Some(attr) = item.attrs().nth(attr_id.ast_index as usize) {
+                res[keys::DERIVE_MACRO].insert(ast_id.with_value(attr), call_id);
+            }
         });
 
         fn add_module_def(

--- a/crates/hir_def/src/item_scope.rs
+++ b/crates/hir_def/src/item_scope.rs
@@ -12,8 +12,8 @@ use stdx::format_to;
 use syntax::ast;
 
 use crate::{
-    db::DefDatabase, per_ns::PerNs, visibility::Visibility, AdtId, BuiltinType, ConstId, ImplId,
-    LocalModuleId, MacroDefId, ModuleDefId, ModuleId, TraitId,
+    attr::AttrId, db::DefDatabase, per_ns::PerNs, visibility::Visibility, AdtId, BuiltinType,
+    ConstId, ImplId, LocalModuleId, MacroDefId, ModuleDefId, ModuleId, TraitId,
 };
 
 #[derive(Copy, Clone)]
@@ -61,6 +61,7 @@ pub struct ItemScope {
     // be all resolved to the last one defined if shadowing happens.
     legacy_macros: FxHashMap<Name, MacroDefId>,
     attr_macros: FxHashMap<AstId<ast::Item>, MacroCallId>,
+    derive_macros: FxHashMap<AstId<ast::Item>, (AttrId, MacroCallId)>,
 }
 
 pub(crate) static BUILTIN_SCOPE: Lazy<FxHashMap<Name, PerNs>> = Lazy::new(|| {
@@ -180,6 +181,21 @@ impl ItemScope {
         &self,
     ) -> impl Iterator<Item = (AstId<ast::Item>, MacroCallId)> + '_ {
         self.attr_macros.iter().map(|(k, v)| (*k, *v))
+    }
+
+    pub(crate) fn add_derive_macro_invoc(
+        &mut self,
+        item: AstId<ast::Item>,
+        call: MacroCallId,
+        attr_id: AttrId,
+    ) {
+        self.derive_macros.insert(item, (attr_id, call));
+    }
+
+    pub(crate) fn derive_macro_invocs(
+        &self,
+    ) -> impl Iterator<Item = (AstId<ast::Item>, (AttrId, MacroCallId))> + '_ {
+        self.derive_macros.iter().map(|(k, v)| (*k, *v))
     }
 
     pub(crate) fn unnamed_trait_vis(&self, tr: TraitId) -> Option<Visibility> {
@@ -320,6 +336,7 @@ impl ItemScope {
             unnamed_trait_imports,
             legacy_macros,
             attr_macros,
+            derive_macros,
         } = self;
         types.shrink_to_fit();
         values.shrink_to_fit();
@@ -331,6 +348,7 @@ impl ItemScope {
         unnamed_trait_imports.shrink_to_fit();
         legacy_macros.shrink_to_fit();
         attr_macros.shrink_to_fit();
+        derive_macros.shrink_to_fit();
     }
 }
 

--- a/crates/hir_def/src/keys.rs
+++ b/crates/hir_def/src/keys.rs
@@ -33,6 +33,7 @@ pub const CONST_PARAM: Key<ast::ConstParam, ConstParamId> = Key::new();
 
 pub const MACRO: Key<ast::MacroCall, MacroDefId> = Key::new();
 pub const ATTR_MACRO: Key<ast::Item, MacroCallId> = Key::new();
+pub const DERIVE_MACRO: Key<ast::Attr, MacroCallId> = Key::new();
 
 /// XXX: AST Nodes and SyntaxNodes have identity equality semantics: nodes are
 /// equal if they point to exactly the same object.

--- a/crates/hir_def/src/nameres/collector.rs
+++ b/crates/hir_def/src/nameres/collector.rs
@@ -1047,6 +1047,12 @@ impl DefCollector<'_> {
                         &resolver,
                     ) {
                         Ok(call_id) => {
+                            self.def_map.modules[directive.module_id].scope.add_derive_macro_invoc(
+                                ast_id.ast_id,
+                                call_id,
+                                *derive_attr,
+                            );
+
                             resolved.push((directive.module_id, call_id, directive.depth));
                             res = ReachedFixedPoint::No;
                             return false;


### PR DESCRIPTION
Expands the derive attribtue under the cursor.

This probably does not work with items that have attributes ***and*** derives since we don't descend the cursor token into macro invocations first, for obvious reasons(we could do this to check for derives first to fix this).

(Note that we do not expand built-ins to what rustc usually expands as we only really need the impl for analysis)
![Code_QgFebdit18](https://user-images.githubusercontent.com/3757771/130638252-5125d41f-2cc0-48fa-af77-9a7f85016438.png)
![Code_QsKOvhgI1r](https://user-images.githubusercontent.com/3757771/130638250-debe0a1a-2584-426a-8377-72d6d46276eb.png)

Closes https://github.com/rust-analyzer/rust-analyzer/issues/4005