### PR TITLE
Fix method resolution for inherent array impls

### DIFF
--- a/crates/hir_ty/src/method_resolution.rs
+++ b/crates/hir_ty/src/method_resolution.rs
@@ -348,6 +348,7 @@ pub fn def_crates(
         }
         TyKind::Str => lang_item_crate!("str_alloc", "str"),
         TyKind::Slice(_) => lang_item_crate!("slice_alloc", "slice"),
+        TyKind::Array(..) => lang_item_crate!("array"),
         TyKind::Raw(Mutability::Not, _) => lang_item_crate!("const_ptr"),
         TyKind::Raw(Mutability::Mut, _) => lang_item_crate!("mut_ptr"),
         TyKind::Dyn(_) => {

--- a/crates/hir_ty/src/tests/method_resolution.rs
+++ b/crates/hir_ty/src/tests/method_resolution.rs
@@ -1266,6 +1266,35 @@ fn f() {
 }
 
 #[test]
+fn resolve_const_generic_array_methods() {
+    check_types(
+        r#"
+#[lang = "array"]
+impl<T, const N: usize> [T; N] {
+    pub fn map<F, U>(self, f: F) -> [U; N]
+    where
+        F: FnMut(T) -> U,
+    { loop {} }
+}
+
+#[lang = "slice"]
+impl<T> [T] {
+    pub fn map<F, U>(self, f: F) -> &[U]
+    where
+        F: FnMut(T) -> U,
+    { loop {} }
+}
+
+fn f() {
+    let v = [1, 2].map::<_, usize>(|x| -> x * 2);
+    v;
+  //^ [usize; _]
+}
+    "#,
+    );
+}
+
+#[test]
 fn skip_array_during_method_dispatch() {
     check_types(
         r#"


### PR DESCRIPTION
I've been trying to solve #9992 on my own, even though I really don't understand the internals of `rust-analyzer` enough, but I hacked up something that *seems* to solve the issue!

As far as I can tell, the problem with resolving methods from std's (pretty recently added) impls on array, was caused by two separate issues, which are fixed by the two separate commits in this PR:
* the inherent impls on `TyKind::Array` were not registered for `TyFingerprint::Array`
* the inherent impls, when registered by `rust-analyzer`, are registered for `[T; {unknown}]`, while the receiver has a concrete len. I added the array Ty with an unknown const len as one of the targets for auto-derefing, which makes `is_valid_candidate` correctly return `true` in these cases.

So just to re-iterate, I have no idea if these changes actually make sense, but I thought opening a PR is worth a shot. :) And if not, I would love to get some pointers and keep working on this.

Thanks!