### PR TITLE
fix: correctly complete macro call if cursor at `!`

### DIFF
--- a/crates/ide_completion/src/completions/unqualified_path.rs
+++ b/crates/ide_completion/src/completions/unqualified_path.rs
@@ -304,4 +304,31 @@ pub mod prelude {
             "#]],
         );
     }
+
+    #[test]
+    fn completes_macro_call_if_cursor_at_bang_token() {
+        // Regression test for https://github.com/rust-analyzer/rust-analyzer/issues/9904
+        cov_mark::check!(completes_macro_call_if_cursor_at_bang_token);
+        check_edit(
+            "foo!",
+            r#"
+macro_rules! foo {
+    () => {}
+}
+
+fn main() {
+    foo!$0
+}
+"#,
+            r#"
+macro_rules! foo {
+    () => {}
+}
+
+fn main() {
+    foo!($0)
+}
+"#,
+        );
+    }
 }

--- a/crates/ide_completion/src/completions/unqualified_path.rs
+++ b/crates/ide_completion/src/completions/unqualified_path.rs
@@ -304,31 +304,4 @@ pub mod prelude {
             "#]],
         );
     }
-
-    #[test]
-    fn completes_macro_call_if_cursor_at_bang_token() {
-        // Regression test for https://github.com/rust-analyzer/rust-analyzer/issues/9904
-        cov_mark::check!(completes_macro_call_if_cursor_at_bang_token);
-        check_edit(
-            "foo!",
-            r#"
-macro_rules! foo {
-    () => {}
-}
-
-fn main() {
-    foo!$0
-}
-"#,
-            r#"
-macro_rules! foo {
-    () => {}
-}
-
-fn main() {
-    foo!($0)
-}
-"#,
-        );
-    }
 }


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/9904