### PR TITLE
Set esbuild target as node12

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -27,7 +27,7 @@
     "scripts": {
         "vscode:prepublish": "npm run build-base -- --minify",
         "package": "vsce package -o rust-analyzer.vsix",
-        "build-base": "esbuild ./src/main.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node",
+        "build-base": "esbuild ./src/main.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node --target=node12",
         "build": "npm run build-base -- --sourcemap",
         "watch": "npm run build-base -- --sourcemap --watch",
         "lint": "tsfmt --verify && eslint -c .eslintrc.js --ext ts ./src ./tests",


### PR DESCRIPTION
Currently, target version is not specified so it's `esnext`.

https://esbuild.github.io/api/#target

As a result, generated file is not valid for node12, the node version which is used by theia editor.

https://github.com/eclipse-theia/theia/blob/02261581de60f5221de6264fab4b011c51e5ab91/package.json#L7

```
$ wget https://github.com/rust-analyzer/rust-analyzer/releases/download/2021-08-23/rust-analyzer.vsix
$ unzip rust-analyzer.vsix -d ext
$ node --version                                                                                           
v12.22.5
$ node --check ./ext/extension/out/main.js
...
void 0;var qd=_n(),Di=Fr(),aw=kd(),Od=Nr(),cw="Content-Length: ",Id=`\r
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            

SyntaxError: Unexpected token '?'
    at wrapSafe (internal/modules/cjs/loader.js:915:16)
    at checkSyntax (internal/main/check_syntax.js:66:3)
    at internal/main/check_syntax.js:39:3
```

```
$ node --version
v14.17.5
$ node --check ext/extension/out/main.js
```