### PR TITLE
Set esbuild target as node14

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -27,7 +27,7 @@
     "scripts": {
         "vscode:prepublish": "npm run build-base -- --minify",
         "package": "vsce package -o rust-analyzer.vsix",
-        "build-base": "esbuild ./src/main.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node",
+        "build-base": "esbuild ./src/main.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node --target=node14",
         "build": "npm run build-base -- --sourcemap",
         "watch": "npm run build-base -- --sourcemap --watch",
         "lint": "tsfmt --verify && eslint -c .eslintrc.js --ext ts ./src ./tests",


### PR DESCRIPTION
ref: https://github.com/rust-analyzer/rust-analyzer/pull/10061

Currently, target version is not specified so it's esnext.

https://esbuild.github.io/api/#target

VSCode uses node 14 since version 1.56.

https://github.com/rust-analyzer/rust-analyzer/issues/3167#issuecomment-907058367