### PR TITLE
Downmap tokens to all token descendants instead of just the first

### DIFF
--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -538,6 +538,8 @@ impl<'db> SemanticsImpl<'db> {
         res
     }
 
+    // Note this return type is deliberate as [`find_nodes_at_offset_with_descend`] wants to stop
+    // traversing the inner iterator when it finds a node.
     fn descend_node_at_offset(
         &self,
         node: &SyntaxNode,

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -2,7 +2,7 @@
 
 mod source_to_def;
 
-use std::{cell::RefCell, fmt, iter::successors};
+use std::{cell::RefCell, fmt};
 
 use base_db::{FileId, FileRange};
 use hir_def::{
@@ -14,6 +14,7 @@ use hir_expand::{name::AsName, ExpansionInfo};
 use hir_ty::{associated_type_shorthand_candidates, Interner};
 use itertools::Itertools;
 use rustc_hash::{FxHashMap, FxHashSet};
+use smallvec::{smallvec, SmallVec};
 use syntax::{
     algo::find_node_at_offset,
     ast::{self, GenericParamsOwner, LoopBodyOwner},
@@ -166,6 +167,10 @@ impl<'db, DB: HirDatabase> Semantics<'db, DB> {
     }
 
     pub fn descend_into_macros(&self, token: SyntaxToken) -> SyntaxToken {
+        self.imp.descend_into_macros(token).pop().unwrap()
+    }
+
+    pub fn descend_into_macros_many(&self, token: SyntaxToken) -> SmallVec<[SyntaxToken; 1]> {
         self.imp.descend_into_macros(token)
     }
 
@@ -440,76 +445,83 @@ impl<'db> SemanticsImpl<'db> {
         )
     }
 
-    fn descend_into_macros(&self, token: SyntaxToken) -> SyntaxToken {
+    fn descend_into_macros(&self, token: SyntaxToken) -> SmallVec<[SyntaxToken; 1]> {
         let _p = profile::span("descend_into_macros");
         let parent = match token.parent() {
             Some(it) => it,
-            None => return token,
+            None => return smallvec![token],
         };
         let sa = self.analyze(&parent);
-
-        let token = successors(Some(InFile::new(sa.file_id, token)), |token| {
+        let mut queue = vec![InFile::new(sa.file_id, token)];
+        let mut res = smallvec![];
+        while let Some(token) = queue.pop() {
             self.db.unwind_if_cancelled();
 
-            for node in token.value.ancestors() {
-                match_ast! {
-                    match node {
-                        ast::MacroCall(macro_call) => {
-                            let tt = macro_call.token_tree()?;
-                            let l_delim = match tt.left_delimiter_token() {
-                                Some(it) => it.text_range().end(),
-                                None => tt.syntax().text_range().start()
-                            };
-                            let r_delim = match tt.right_delimiter_token() {
-                                Some(it) => it.text_range().start(),
-                                None => tt.syntax().text_range().end()
-                            };
-                            if !TextRange::new(l_delim, r_delim).contains_range(token.value.text_range()) {
-                                return None;
-                            }
-                            let file_id = sa.expand(self.db, token.with_value(&macro_call))?;
-                            let token = self
-                                .expansion_info_cache
-                                .borrow_mut()
-                                .entry(file_id)
-                                .or_insert_with(|| file_id.expansion_info(self.db.upcast()))
-                                .as_ref()?
-                                .map_token_down(self.db.upcast(), None, token.as_ref())?;
-
-                            if let Some(parent) = token.value.parent() {
-                                self.cache(find_root(&parent), token.file_id);
-                            }
-
-                            return Some(token);
-                        },
-                        ast::Item(item) => {
-                            if let Some(call_id) = self.with_ctx(|ctx| ctx.item_to_macro_call(token.with_value(item.clone()))) {
-                                let file_id = call_id.as_file();
-                                let token = self
-                                    .expansion_info_cache
-                                    .borrow_mut()
+            let mapped = (|| {
+                for node in token.value.ancestors() {
+                    match_ast! {
+                        match node {
+                            ast::MacroCall(macro_call) => {
+                                let tt = macro_call.token_tree()?;
+                                let l_delim = match tt.left_delimiter_token() {
+                                    Some(it) => it.text_range().end(),
+                                    None => tt.syntax().text_range().start()
+                                };
+                                let r_delim = match tt.right_delimiter_token() {
+                                    Some(it) => it.text_range().start(),
+                                    None => tt.syntax().text_range().end()
+                                };
+                                if !TextRange::new(l_delim, r_delim).contains_range(token.value.text_range()) {
+                                    return None;
+                                }
+                                let file_id = sa.expand(self.db, token.with_value(&macro_call))?;
+                                let mut cache = self.expansion_info_cache.borrow_mut();
+                                let tokens = cache
                                     .entry(file_id)
                                     .or_insert_with(|| file_id.expansion_info(self.db.upcast()))
                                     .as_ref()?
-                                    .map_token_down(self.db.upcast(), Some(item), token.as_ref())?;
+                                    .map_token_down(self.db.upcast(), None, token.as_ref())?;
 
-                                if let Some(parent) = token.value.parent() {
-                                    self.cache(find_root(&parent), token.file_id);
+                                queue.extend(tokens.inspect(|token| {
+                                    if let Some(parent) = token.value.parent() {
+                                        self.cache(find_root(&parent), token.file_id);
+                                    }
+                                }));
+                                return Some(());
+                            },
+                            ast::Item(item) => {
+                                match self.with_ctx(|ctx| ctx.item_to_macro_call(token.with_value(item))) {
+                                    Some(call_id) => {
+                                        let file_id = call_id.as_file();
+                                        let mut cache = self.expansion_info_cache.borrow_mut();
+                                        let tokens = cache
+                                            .entry(file_id)
+                                            .or_insert_with(|| file_id.expansion_info(self.db.upcast()))
+                                            .as_ref()?
+                                            .map_token_down(self.db.upcast(), None, token.as_ref())?;
+
+                                        queue.extend(tokens.inspect(|token| {
+                                            if let Some(parent) = token.value.parent() {
+                                                self.cache(find_root(&parent), token.file_id);
+                                            }
+                                        }));
+                                        return Some(());
+                                    }
+                                    None => {}
                                 }
-
-                                return Some(token);
-                            }
-                        },
-                        _ => {}
+                            },
+                            _ => {}
+                        }
                     }
                 }
+                None
+            })();
+            match mapped {
+                Some(()) => (),
+                None => res.push(token.value),
             }
-
-            None
-        })
-        .last()
-        .unwrap();
-        token.value
+        }
+        res
     }
 
     fn descend_node_at_offset(
@@ -519,8 +531,8 @@ impl<'db> SemanticsImpl<'db> {
     ) -> impl Iterator<Item = SyntaxNode> + '_ {
         // Handle macro token cases
         node.token_at_offset(offset)
-            .map(|token| self.descend_into_macros(token))
-            .map(|it| self.token_ancestors_with_macros(it))
+            .flat_map(move |token| self.descend_into_macros(token))
+            .map(move |it| self.token_ancestors_with_macros(it))
             .flatten()
     }
 

--- a/crates/hir_expand/src/db.rs
+++ b/crates/hir_expand/src/db.rs
@@ -163,7 +163,7 @@ pub fn expand_speculative(
         mbe::token_tree_to_syntax_node(&speculative_expansion.value, fragment_kind).ok()?;
 
     let token_id = macro_def.map_id_down(token_id);
-    let range = tmap_2.range_by_token(token_id, token_to_map.kind())?;
+    let range = tmap_2.first_range_by_token(token_id, token_to_map.kind())?;
     let token = node.syntax_node().covering_element(range).into_token()?;
     Some((node.syntax_node(), token))
 }

--- a/crates/hir_expand/src/hygiene.rs
+++ b/crates/hir_expand/src/hygiene.rs
@@ -171,7 +171,7 @@ impl HygieneInfo {
             },
         };
 
-        let range = token_map.range_by_token(token_id, SyntaxKind::IDENT)?;
+        let range = token_map.first_range_by_token(token_id, SyntaxKind::IDENT)?;
         Some((tt.with_value(range + tt.value), origin))
     }
 }

--- a/crates/ide/src/highlight_related.rs
+++ b/crates/ide/src/highlight_related.rs
@@ -6,6 +6,7 @@ use ide_db::{
     search::{FileReference, ReferenceAccess, SearchScope},
     RootDatabase,
 };
+use itertools::Itertools;
 use syntax::{
     ast::{self, LoopBodyOwner},
     match_ast, AstNode, SyntaxNode, SyntaxToken, TextRange, TextSize, T,
@@ -70,7 +71,7 @@ fn highlight_references(
     syntax: &SyntaxNode,
     FilePosition { offset, file_id }: FilePosition,
 ) -> Option<Vec<HighlightedRange>> {
-    let defs = find_defs(sema, syntax, offset)?;
+    let defs = find_defs(sema, syntax, offset);
     let usages = defs
         .iter()
         .flat_map(|&d| {
@@ -99,7 +100,12 @@ fn highlight_references(
         })
     });
 
-    Some(declarations.chain(usages).collect())
+    let res: Vec<_> = declarations.chain(usages).collect();
+    if res.is_empty() {
+        None
+    } else {
+        Some(res)
+    }
 }
 
 fn highlight_exit_points(
@@ -270,29 +276,41 @@ fn find_defs(
     sema: &Semantics<RootDatabase>,
     syntax: &SyntaxNode,
     offset: TextSize,
-) -> Option<Vec<Definition>> {
-    let defs = match sema.find_node_at_offset_with_descend(syntax, offset)? {
-        ast::NameLike::NameRef(name_ref) => match NameRefClass::classify(sema, &name_ref)? {
-            NameRefClass::Definition(def) => vec![def],
-            NameRefClass::FieldShorthand { local_ref, field_ref } => {
-                vec![Definition::Local(local_ref), Definition::Field(field_ref)]
-            }
-        },
-        ast::NameLike::Name(name) => match NameClass::classify(sema, &name)? {
-            NameClass::Definition(it) | NameClass::ConstReference(it) => vec![it],
-            NameClass::PatFieldShorthand { local_def, field_ref } => {
-                vec![Definition::Local(local_def), Definition::Field(field_ref)]
-            }
-        },
-        ast::NameLike::Lifetime(lifetime) => NameRefClass::classify_lifetime(sema, &lifetime)
-            .and_then(|class| match class {
-                NameRefClass::Definition(it) => Some(it),
-                _ => None,
+) -> Vec<Definition> {
+    sema.find_nodes_at_offset_with_descend(syntax, offset)
+        .flat_map(|name_like| {
+            Some(match name_like {
+                ast::NameLike::NameRef(name_ref) => {
+                    match NameRefClass::classify(sema, &name_ref)? {
+                        NameRefClass::Definition(def) => vec![def],
+                        NameRefClass::FieldShorthand { local_ref, field_ref } => {
+                            vec![Definition::Local(local_ref), Definition::Field(field_ref)]
+                        }
+                    }
+                }
+                ast::NameLike::Name(name) => match NameClass::classify(sema, &name)? {
+                    NameClass::Definition(it) | NameClass::ConstReference(it) => vec![it],
+                    NameClass::PatFieldShorthand { local_def, field_ref } => {
+                        vec![Definition::Local(local_def), Definition::Field(field_ref)]
+                    }
+                },
+                ast::NameLike::Lifetime(lifetime) => {
+                    NameRefClass::classify_lifetime(sema, &lifetime)
+                        .and_then(|class| match class {
+                            NameRefClass::Definition(it) => Some(it),
+                            _ => None,
+                        })
+                        .or_else(|| {
+                            NameClass::classify_lifetime(sema, &lifetime)
+                                .and_then(NameClass::defined)
+                        })
+                        .map(|it| vec![it])?
+                }
             })
-            .or_else(|| NameClass::classify_lifetime(sema, &lifetime).and_then(NameClass::defined))
-            .map(|it| vec![it])?,
-    };
-    Some(defs)
+        })
+        .flatten()
+        .unique()
+        .collect()
 }
 
 #[cfg(test)]
@@ -387,6 +405,46 @@ fn foo() {
          // ^^^ write
     bar$0;
  // ^^^ read
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn test_multi_macro_usage() {
+        check(
+            r#"
+macro_rules! foo {
+    ($ident:ident) => {
+        fn $ident() -> $ident { loop {} }
+        struct $ident;
+    }
+}
+
+foo!(bar$0);
+  // ^^^
+  // ^^^
+fn foo() {
+    let bar: bar = bar();
+          // ^^^
+                // ^^^
+}
+"#,
+        );
+        check(
+            r#"
+macro_rules! foo {
+    ($ident:ident) => {
+        fn $ident() -> $ident { loop {} }
+        struct $ident;
+    }
+}
+
+foo!(bar);
+  // ^^^
+fn foo() {
+    let bar: bar$0 = bar();
+          // ^^^
 }
 "#,
         );

--- a/crates/ide/src/highlight_related.rs
+++ b/crates/ide/src/highlight_related.rs
@@ -424,6 +424,7 @@ macro_rules! foo {
 foo!(bar$0);
   // ^^^
   // ^^^
+  // ^^^
 fn foo() {
     let bar: bar = bar();
           // ^^^
@@ -441,6 +442,7 @@ macro_rules! foo {
 }
 
 foo!(bar);
+  // ^^^
   // ^^^
 fn foo() {
     let bar: bar$0 = bar();

--- a/crates/ide_db/src/defs.rs
+++ b/crates/ide_db/src/defs.rs
@@ -17,7 +17,7 @@ use syntax::{
 use crate::RootDatabase;
 
 // FIXME: a more precise name would probably be `Symbol`?
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Hash)]
 pub enum Definition {
     Macro(MacroDef),
     Field(Field),

--- a/crates/ide_db/src/search.rs
+++ b/crates/ide_db/src/search.rs
@@ -61,7 +61,7 @@ pub struct FileReference {
     pub access: Option<ReferenceAccess>,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum ReferenceAccess {
     Read,
     Write,

--- a/crates/ide_db/src/search.rs
+++ b/crates/ide_db/src/search.rs
@@ -393,7 +393,7 @@ impl<'a> FindUsages<'a> {
                     continue;
                 }
 
-                if let Some(name) = sema.find_node_at_offset_with_descend(&tree, offset) {
+                for name in sema.find_nodes_at_offset_with_descend(&tree, offset) {
                     if match name {
                         ast::NameLike::NameRef(name_ref) => self.found_name_ref(&name_ref, sink),
                         ast::NameLike::Name(name) => self.found_name(&name, sink),
@@ -410,9 +410,7 @@ impl<'a> FindUsages<'a> {
                         continue;
                     }
 
-                    if let Some(ast::NameLike::NameRef(name_ref)) =
-                        sema.find_node_at_offset_with_descend(&tree, offset)
-                    {
+                    for name_ref in sema.find_nodes_at_offset_with_descend(&tree, offset) {
                         if self.found_self_ty_name_ref(self_ty, &name_ref, sink) {
                             return;
                         }

--- a/crates/mbe/src/tests/expand.rs
+++ b/crates/mbe/src/tests/expand.rs
@@ -58,8 +58,9 @@ macro_rules! foobar {
     let (node, token_map) = token_tree_to_syntax_node(&expanded, FragmentKind::Items).unwrap();
     let content = node.syntax_node().to_string();
 
-    let get_text =
-        |id, kind| -> String { content[token_map.range_by_token(id, kind).unwrap()].to_string() };
+    let get_text = |id, kind| -> String {
+        content[token_map.first_range_by_token(id, kind).unwrap()].to_string()
+    };
 
     assert_eq!(expanded.token_trees.len(), 4);
     // {($e:ident) => { fn $e() {} }}

--- a/crates/mbe/src/token_map.rs
+++ b/crates/mbe/src/token_map.rs
@@ -46,9 +46,23 @@ impl TokenMap {
         Some(token_id)
     }
 
-    pub fn range_by_token(&self, token_id: tt::TokenId, kind: SyntaxKind) -> Option<TextRange> {
-        let &(_, range) = self.entries.iter().find(|(tid, _)| *tid == token_id)?;
-        range.by_kind(kind)
+    pub fn ranges_by_token(
+        &self,
+        token_id: tt::TokenId,
+        kind: SyntaxKind,
+    ) -> impl Iterator<Item = TextRange> + '_ {
+        self.entries
+            .iter()
+            .filter(move |&&(tid, _)| tid == token_id)
+            .filter_map(move |(_, range)| range.by_kind(kind))
+    }
+
+    pub fn first_range_by_token(
+        &self,
+        token_id: tt::TokenId,
+        kind: SyntaxKind,
+    ) -> Option<TextRange> {
+        self.ranges_by_token(token_id, kind).next()
     }
 
     pub(crate) fn shrink_to_fit(&mut self) {


### PR DESCRIPTION
With this we can now resolve usages of identifiers inside (proc-)macros even if they are used for different purposes multiple times inside the expansion.
Example here being with the cursor being on the `no_send_sync_value` function causing us to still highlight the identifier in the attribute invocation correctly as we now resolve its usages in there. Prior we only saw the first usage of the identifier which is for a definition only, as such we bailed and didn't highlight it. 
![image](https://user-images.githubusercontent.com/3757771/131233056-7e645b1d-b82f-468c-bf19-d3335a2cf7c2.png)

Note that this has to be explicitly switched over for most IDE features now as pretty much everything expects a single node/token as a result from descending.