### PR TITLE
Fix minor mispelling

### DIFF
--- a/crates/ide_diagnostics/src/handlers/replace_filter_map_next_with_find_map.rs
+++ b/crates/ide_diagnostics/src/handlers/replace_filter_map_next_with_find_map.rs
@@ -113,7 +113,7 @@ fn foo() {
     }
 
     #[test]
-    fn replace_with_wind_map() {
+    fn replace_with_find_map() {
         check_fix(
             r#"
 //- minicore: iterators


### PR DESCRIPTION
`find_map` misspelt as `wind_map` in test identifier. 