### PR TITLE
fix: fix "disjunction in conjunction" panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,9 +52,6 @@ name = "arbitrary"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "577b08a4acd7b99869f863c50011b01eb73424ccc798ecd996f2e24817adfca7"
-dependencies = [
- "derive_arbitrary",
-]
 
 [[package]]
 name = "arrayvec"
@@ -157,6 +154,7 @@ name = "cfg"
 version = "0.0.0"
 dependencies = [
  "arbitrary",
+ "derive_arbitrary",
  "expect-test",
  "mbe",
  "oorandom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33954243bd79057c2de7338850b85983a44588021f8a5fee574a8888c6de4344"
 
 [[package]]
+name = "arbitrary"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577b08a4acd7b99869f863c50011b01eb73424ccc798ecd996f2e24817adfca7"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,8 +156,10 @@ checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
 name = "cfg"
 version = "0.0.0"
 dependencies = [
+ "arbitrary",
  "expect-test",
  "mbe",
+ "oorandom",
  "rustc-hash",
  "syntax",
  "tt",
@@ -289,6 +300,17 @@ checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
 dependencies = [
  "cfg-if",
  "num_cpus",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b24629208e87a2d8b396ff43b15c4afb0a69cea3fbbaa9ed9b92b7c02f0aed73"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/cfg/Cargo.toml
+++ b/crates/cfg/Cargo.toml
@@ -17,3 +17,5 @@ tt = { path = "../tt", version = "0.0.0" }
 mbe = { path = "../mbe" }
 syntax = { path = "../syntax" }
 expect-test = "1.1"
+arbitrary = { version = "1", features = ["derive"] }
+oorandom = "11"

--- a/crates/cfg/Cargo.toml
+++ b/crates/cfg/Cargo.toml
@@ -17,5 +17,9 @@ tt = { path = "../tt", version = "0.0.0" }
 mbe = { path = "../mbe" }
 syntax = { path = "../syntax" }
 expect-test = "1.1"
-arbitrary = { version = "1", features = ["derive"] }
 oorandom = "11"
+# We depend on both individually instead of using `features = ["derive"]` to microoptimize the
+# build graph: if the feature was enabled, syn would be built early on in the graph if `smolstr`
+# supports `arbitrary`. This way, we avoid feature unification.
+arbitrary = "1"
+derive_arbitrary = "1"

--- a/crates/cfg/src/cfg_expr.rs
+++ b/crates/cfg/src/cfg_expr.rs
@@ -50,6 +50,7 @@ impl fmt::Display for CfgAtom {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(test, derive(arbitrary::Arbitrary))]
 pub enum CfgExpr {
     Invalid,
     Atom(CfgAtom),
@@ -127,4 +128,18 @@ fn next_cfg_expr(it: &mut SliceIter<tt::TokenTree>) -> Option<CfgExpr> {
         }
     }
     Some(ret)
+}
+
+#[cfg(test)]
+impl arbitrary::Arbitrary<'_> for CfgAtom {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        match u.int_in_range(0..=1)? {
+            0 => Ok(CfgAtom::Flag(String::arbitrary(u)?.into())),
+            1 => Ok(CfgAtom::KeyValue {
+                key: String::arbitrary(u)?.into(),
+                value: String::arbitrary(u)?.into(),
+            }),
+            _ => unreachable!(),
+        }
+    }
 }

--- a/crates/cfg/src/cfg_expr.rs
+++ b/crates/cfg/src/cfg_expr.rs
@@ -133,13 +133,13 @@ fn next_cfg_expr(it: &mut SliceIter<tt::TokenTree>) -> Option<CfgExpr> {
 #[cfg(test)]
 impl arbitrary::Arbitrary<'_> for CfgAtom {
     fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
-        match u.int_in_range(0..=1)? {
-            0 => Ok(CfgAtom::Flag(String::arbitrary(u)?.into())),
-            1 => Ok(CfgAtom::KeyValue {
+        if u.arbitrary()? {
+            Ok(CfgAtom::Flag(String::arbitrary(u)?.into()))
+        } else {
+            Ok(CfgAtom::KeyValue {
                 key: String::arbitrary(u)?.into(),
                 value: String::arbitrary(u)?.into(),
-            }),
-            _ => unreachable!(),
+            })
         }
     }
 }

--- a/crates/cfg/src/cfg_expr.rs
+++ b/crates/cfg/src/cfg_expr.rs
@@ -50,7 +50,7 @@ impl fmt::Display for CfgAtom {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(test, derive(arbitrary::Arbitrary))]
+#[cfg_attr(test, derive(derive_arbitrary::Arbitrary))]
 pub enum CfgExpr {
     Invalid,
     Atom(CfgAtom),


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/10073

The DNF construction code created expressions that were combined in a way that made us "forget" to make their contents valid DNF again. This PR fixes that by flattening nested `any(any())` and `all(all())` predicates. There was also a typo that led to a redundant call to `make_nnf` instead of the correct recursive call to `make_dnf` (but this didn't seem to break/fix anything).

This also adds some light property testing, though I'm not really sure this is the best way to do it.