### PR TITLE
feat: Improve `extract_struct_from_enum_variant` output

### DIFF
--- a/crates/ide_assists/src/tests/generated.rs
+++ b/crates/ide_assists/src/tests/generated.rs
@@ -448,7 +448,7 @@ fn doctest_extract_struct_from_enum_variant() {
 enum A { $0One(u32, u32) }
 "#####,
         r#####"
-struct One(pub u32, pub u32);
+struct One(u32, u32);
 
 enum A { One(One) }
 "#####,


### PR DESCRIPTION
Improves the struct generated by `extract_struct_from_enum_variant`.

Summary of changes:

- Indent the generated struct and enum to the same indent level
- Preserve comments & attributes from the enum variant (something I missed when doing the same thing for the variant fields)
- Use enum's visibility for fields without any visibility, instead of filling it in with `pub`