### PR TITLE
fix: Remove incorrectly filtering VS Code cargo task execution resolution by scope

### DIFF
--- a/editors/code/src/tasks.ts
+++ b/editors/code/src/tasks.ts
@@ -109,26 +109,14 @@ export async function buildCargoTask(
         exec = new vscode.ProcessExecution(fullCommand[0], fullCommand.slice(1), definition);
     }
 
-    if (scope) {
-        return new vscode.Task(
-            definition,
-            scope,
-            name,
-            TASK_SOURCE,
-            exec,
-            ['$rustc']
-        );
-    }
-    else {
-        // if the original task did not provide a scope retain the original lack of scope
-        return new vscode.Task(
-            definition,
-            name,
-            TASK_SOURCE,
-            exec,
-            ['$rustc']
-        );
-    }
+    return new vscode.Task(
+        definition,
+        scope ?? vscode.TaskScope.Workspace,
+        name,
+        TASK_SOURCE,
+        exec,
+        ['$rustc']
+    );
 }
 
 export function activateTaskProvider(config: Config): vscode.Disposable {

--- a/editors/code/src/tasks.ts
+++ b/editors/code/src/tasks.ts
@@ -111,6 +111,8 @@ export async function buildCargoTask(
 
     return new vscode.Task(
         definition,
+        // scope can sometimes be undefined. in these situations we default to the workspace taskscope as
+        // recommended by the official docs: https://code.visualstudio.com/api/extension-guides/task-provider#task-provider)
         scope ?? vscode.TaskScope.Workspace,
         name,
         TASK_SOURCE,


### PR DESCRIPTION
This fixes #9093 ​introduced by #8995.

A filter was present on the function that adds the execution definition to Cargo tasks. This would mean Cargo tasks defined in workspaces (i.e. `.code-workspace` files) would not be given an execution, leading to a `There is no task provider registered for tasks of type "cargo".` error as descibed in #9093. I have made a minimum reproduction setup [here](https://github.com/oeed/ra-workspace).

This PR essentially removes that check. The `if (scope) { ... }` is to handle the case where `task.scope === undefined` using a deprecated constructor. I'm not sure if that is ever likely to occur and can remove if not needed.

There is some discussion about whether it's necessary to filter the tasks before building them. From my understanding, it shouldn't be needed as we should provide an execution for all `cargo` tasks; but I'm not overly familiar with VS Code internals so I could be wrong. For more info please see [the discussion](https://github.com/rust-analyzer/rust-analyzer/pull/8995#issuecomment-908920395) on #8995