### PR TITLE
internal: Augment panic context when resolving path

### DIFF
--- a/crates/hir_def/src/nameres/path_resolution.rs
+++ b/crates/hir_def/src/nameres/path_resolution.rs
@@ -178,6 +178,11 @@ impl DefMap {
         path: &ModPath,
         shadow: BuiltinShadowMode,
     ) -> ResolvePathResult {
+        let _cx = stdx::panic_context::enter(format!(
+            "DefMap {:?} {:?} path {}",
+            self.krate, self.block, path
+        ));
+
         let mut segments = path.segments().iter().enumerate();
         let mut curr_per_ns: PerNs = match path.kind {
             PathKind::DollarCrate(krate) => {


### PR DESCRIPTION
Should help with debugging https://github.com/rust-analyzer/rust-analyzer/issues/10084 and similar issues.

Might have a perf impact since the string is created on every function call.