### PR TITLE
fix: Allow inherent impls for arrays

### DIFF
--- a/crates/hir_ty/src/method_resolution.rs
+++ b/crates/hir_ty/src/method_resolution.rs
@@ -348,6 +348,7 @@ pub fn def_crates(
         }
         TyKind::Str => lang_item_crate!("str_alloc", "str"),
         TyKind::Slice(_) => lang_item_crate!("slice_alloc", "slice"),
+        TyKind::Array(..) => lang_item_crate!("array"),
         TyKind::Raw(Mutability::Not, _) => lang_item_crate!("const_ptr"),
         TyKind::Raw(Mutability::Mut, _) => lang_item_crate!("mut_ptr"),
         TyKind::Dyn(_) => {

--- a/crates/hir_ty/src/tests/method_resolution.rs
+++ b/crates/hir_ty/src/tests/method_resolution.rs
@@ -37,6 +37,24 @@ fn infer_slice_method() {
 }
 
 #[test]
+fn infer_array_inherent_impl() {
+    check_types(
+        r#"
+        #[lang = "array"]
+        impl<T, const N: usize> [T; N] {
+            fn foo(&self) -> T {
+                loop {}
+            }
+        }
+        fn test(x: &[u8; 0]) {
+            <[_; 0]>::foo(x);
+          //^^^^^^^^^^^^^^^^ u8
+        }
+        "#,
+    );
+}
+
+#[test]
 fn infer_associated_method_struct() {
     check_infer(
         r#"


### PR DESCRIPTION
Part of https://github.com/rust-analyzer/rust-analyzer/issues/9992 (method resolution of these methods still does not work)

bors r+