### PR TITLE
Fix replacing for loops over ranges with for_each.

### DIFF
--- a/crates/ide_assists/src/handlers/replace_for_loop_with_for_each.rs
+++ b/crates/ide_assists/src/handlers/replace_for_loop_with_for_each.rs
@@ -50,7 +50,7 @@ pub(crate) fn replace_for_loop_with_for_each(acc: &mut Assists, ctx: &AssistCont
                 // We have either "for x in &col" and col implements a method called iter
                 //             or "for x in &mut col" and col implements a method called iter_mut
                 format_to!(buf, "{}.{}()", expr_behind_ref, method);
-            } else if matches!(iterable, ast::Expr::RangeExpr(..)) {
+            } else if let ast::Expr::RangeExpr(..) = iterable {
                 // range expressions need to be parenthesized for the syntax to be correct
                 format_to!(buf, "({})", iterable);
             } else if impls_core_iter(&ctx.sema, &iterable) {


### PR DESCRIPTION
Previously, the assist would turn this:
```rust
for x in 0..92 {
    ...
}
```
into the syntactically incorrect code below:
```rust
0..92.for_each(|x| ...)
```

This fixes the assist by parenthesizing range expressions.