### PR TITLE
docs: make dev docs more discoverable

### DIFF
--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -462,6 +462,9 @@ $ rust-analyzer analysis-stats .
 
 It is especially useful when the `repo` doesn't use external crates or the standard library.
 
+If you want to go as far as to modify the source code to debug the problem, be sure to read the
+https://github.com/rust-analyzer/rust-analyzer/tree/master/docs/dev[dev docs]!
+
 == Configuration
 
 **Source:** https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/rust-analyzer/src/config.rs[config.rs]

--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -462,7 +462,7 @@ $ rust-analyzer analysis-stats .
 
 It is especially useful when the `repo` doesn't use external crates or the standard library.
 
-If you want to go as far as to modify the source code to debug the problem, be sure to read the
+If you want to go as far as to modify the source code to debug the problem, be sure to take a look at the
 https://github.com/rust-analyzer/rust-analyzer/tree/master/docs/dev[dev docs]!
 
 == Configuration


### PR DESCRIPTION
I *think* people might try to debug ra by using only the troubleshooting
section. Might make sense to point them to dev docs then!

bors r+
🤖