### PR TITLE
feat: Complete `#![recursion_limit = "N"]` instead of `#![recursion_limit = N]`

### DIFF
--- a/crates/ide_completion/src/completions/attribute.rs
+++ b/crates/ide_completion/src/completions/attribute.rs
@@ -272,8 +272,12 @@ const ATTRIBUTES: &[AttrCompletion] = &[
     attr("proc_macro", None, None),
     attr("proc_macro_attribute", None, None),
     attr("proc_macro_derive(…)", Some("proc_macro_derive"), Some("proc_macro_derive(${0:Trait})")),
-    attr("recursion_limit = …", Some("recursion_limit"), Some("recursion_limit = ${0:128}"))
-        .prefer_inner(),
+    attr(
+        r#"recursion_limit = "…""#,
+        Some("recursion_limit"),
+        Some(r#"recursion_limit = "${0:128}""#),
+    )
+    .prefer_inner(),
     attr("repr(…)", Some("repr"), Some("repr(${0:C})")),
     attr("should_panic", Some("should_panic"), Some(r#"should_panic"#)),
     attr(

--- a/crates/ide_completion/src/tests/attribute.rs
+++ b/crates/ide_completion/src/tests/attribute.rs
@@ -75,7 +75,7 @@ fn attr_on_source_file() {
             at no_implicit_prelude
             at no_main
             at no_std
-            at recursion_limit = …
+            at recursion_limit = "…"
             at type_length_limit = …
             at windows_subsystem = "…"
         "#]],


### PR DESCRIPTION
Currently ra emits `#![recursion_limit = 128]`, but this should rather be `#![recursion_limit = "128"]`