### PR TITLE
Minor: replace old name `CrateDefMap` in comments

### DIFF
--- a/crates/hir_def/src/nameres.rs
+++ b/crates/hir_def/src/nameres.rs
@@ -1,14 +1,14 @@
 //! This module implements import-resolution/macro expansion algorithm.
 //!
-//! The result of this module is `CrateDefMap`: a data structure which contains:
+//! The result of this module is `DefMap`: a data structure which contains:
 //!
 //!   * a tree of modules for the crate
 //!   * for each module, a set of items visible in the module (directly declared
 //!     or imported)
 //!
-//! Note that `CrateDefMap` contains fully macro expanded code.
+//! Note that `DefMap` contains fully macro expanded code.
 //!
-//! Computing `CrateDefMap` can be partitioned into several logically
+//! Computing `DefMap` can be partitioned into several logically
 //! independent "phases". The phases are mutually recursive though, there's no
 //! strict ordering.
 //!

--- a/crates/ide_db/src/symbol_index.rs
+++ b/crates/ide_db/src/symbol_index.rs
@@ -198,7 +198,7 @@ pub fn world_symbols(db: &RootDatabase, query: Query) -> Vec<FileSymbol> {
 
 pub fn crate_symbols(db: &RootDatabase, krate: CrateId, query: Query) -> Vec<FileSymbol> {
     let _p = profile::span("crate_symbols").detail(|| format!("{:?}", query));
-    // FIXME(#4842): This now depends on CrateDefMap, why not build the entire symbol index from
+    // FIXME(#4842): This now depends on DefMap, why not build the entire symbol index from
     // that instead?
 
     let def_map = db.crate_def_map(krate);


### PR DESCRIPTION
This PR replaces the old name `CrateDefMap` in comments with the new name `DefMap`. The renaming was done in [57a82fb0](https://github.com/rust-analyzer/rust-analyzer/commit/57a82fb0) (Jan 2021).

I didn't touch the working code ([CrateDefMapQueryQuery][QQ]). Thank you.

[QQ]: https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/ide_db/src/apply_change.rs#L126
