### PR TITLE
Add section on configuring compilation errors when using `rust-project.json`

### DIFF
--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -616,23 +616,11 @@ See https://github.com/rust-analyzer/rust-project.json-example for a small examp
 
 You can set `RA_LOG` environmental variable to `rust_analyzer=info` to inspect how rust-analyzer handles config and project loading.
 
-Note that calls to `cargo check` are disabled when using `rust-project.json` by default, so compilation errors and warnings will no longer be sent to your LSP client. To enable these compilation errors you will need to specify explicitly what command rust-analyzer should run to perform the checks using the `checkOnSave.overrideCommand` configuration. The following example, explicitly enables calls to `cargo check` in neovim's configuration:
+Note that calls to `cargo check` are disabled when using `rust-project.json` by default, so compilation errors and warnings will no longer be sent to your LSP client. To enable these compilation errors you will need to specify explicitly what command rust-analyzer should run to perform the checks using the `checkOnSave.overrideCommand` configuration. As an example, the following configuration explicitly sets `cargo check` as the `checkOnSave` command.
 
-[source,vim]
+[source,json]
 ----
-lua << EOF
-nvim_lsp['rust_analyzer'].setup {
-  on_attach = on_attach,
-  settings = {
-    ["rust-analyzer"] = {
-      checkOnSave = {
-        overrideCommand = {"cargo", "check", "--message-format=json"},
-        enable = true,
-      }
-    }
-  }
-}
-EOF
+{ "rust-analyzer.checkOnSave.overrideCommand": ["cargo", "check", "--message-format=json"] }
 ----
 
 The `checkOnSave.overrideCommand` requires the command specified to output json error messages for rust-analyzer to consume. The `--message-format=json` flag does this for `cargo check` so whichever command you use must also output errors in this format. See the <<Configuration>> section for more information. 

--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -616,6 +616,27 @@ See https://github.com/rust-analyzer/rust-project.json-example for a small examp
 
 You can set `RA_LOG` environmental variable to `rust_analyzer=info` to inspect how rust-analyzer handles config and project loading.
 
+Note that calls to `cargo check` are disabled when using `rust-project.json` by default, so compilation errors and warnings will no longer be sent to your LSP client. To enable these compilation errors you will need to specify explicitly what command rust-analyzer should run to perform the checks using the `checkOnSave.overrideCommand` configuration. The following example, explicitly enables calls to `cargo check` in neovim's configuration:
+
+[source,vim]
+----
+lua << EOF
+nvim_lsp['rust_analyzer'].setup {
+  on_attach = on_attach,
+  settings = {
+    ["rust-analyzer"] = {
+      checkOnSave = {
+        overrideCommand = {"cargo", "check", "--message-format=json"},
+        enable = true,
+      }
+    }
+  }
+}
+EOF
+----
+
+The `checkOnSave.overrideCommand` requires the command specified to output json error messages for rust-analyzer to consume. The `--message-format=json` flag does this for `cargo check` so whichever command you use must also output errors in this format. See the <<Configuration>> section for more information. 
+
 == Security
 
 At the moment, rust-analyzer assumes that all code is trusted.


### PR DESCRIPTION
When using `rust-project.json` to specify the project workspace, flychecks are disabled. It is not mentioned that they can be re-enabled by specifying a custom checking command using the `checkOnSave.overrideCommand` configuration. This additional section makes it clear that using `rust-project.json` disables flychecks and how to enable them either using `cargo check` (as an example) or (more likely) a custom command which emits json error messages.

Further information can be found at this forum thread:

https://users.rust-lang.org/t/rust-analyzer-doesnt-show-cargo-check-compilation-errors-warnings-when-using-rust-project-json/64412