### PR TITLE
internal: remove accidental code re-use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,7 +525,6 @@ dependencies = [
  "la-arena",
  "limit",
  "mbe",
- "parser",
  "profile",
  "rustc-hash",
  "syntax",

--- a/crates/hir_def/src/attr.rs
+++ b/crates/hir_def/src/attr.rs
@@ -695,8 +695,7 @@ impl Attr {
         hygiene: &Hygiene,
         id: AttrId,
     ) -> Option<Attr> {
-        let (parse, _) =
-            mbe::token_tree_to_syntax_node(tt, hir_expand::FragmentKind::MetaItem).ok()?;
+        let (parse, _) = mbe::token_tree_to_syntax_node(tt, mbe::FragmentKind::MetaItem).ok()?;
         let ast = ast::Meta::cast(parse.syntax_node())?;
 
         Self::from_src(db, ast, hygiene, id)

--- a/crates/hir_def/src/item_tree.rs
+++ b/crates/hir_def/src/item_tree.rs
@@ -51,7 +51,7 @@ use hir_expand::{
     ast_id_map::FileAstId,
     hygiene::Hygiene,
     name::{name, AsName, Name},
-    FragmentKind, HirFileId, InFile,
+    ExpandTo, HirFileId, InFile,
 };
 use la_arena::{Arena, Idx, RawIdx};
 use profile::Count;
@@ -739,7 +739,7 @@ pub struct MacroCall {
     /// Path to the called macro.
     pub path: Interned<ModPath>,
     pub ast_id: FileAstId<ast::MacroCall>,
-    pub fragment: FragmentKind,
+    pub expand_to: ExpandTo,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/crates/hir_def/src/item_tree/lower.rs
+++ b/crates/hir_def/src/item_tree/lower.rs
@@ -573,8 +573,8 @@ impl<'a> Ctx<'a> {
     fn lower_macro_call(&mut self, m: &ast::MacroCall) -> Option<FileItemTreeId<MacroCall>> {
         let path = Interned::new(ModPath::from_src(self.db, m.path()?, &self.hygiene)?);
         let ast_id = self.source_ast_id_map.ast_id(m);
-        let fragment = hir_expand::to_fragment_kind(m);
-        let res = MacroCall { path, ast_id, fragment };
+        let expand_to = hir_expand::ExpandTo::from_call_site(m);
+        let res = MacroCall { path, ast_id, expand_to };
         Some(id(self.data().macro_calls.alloc(res)))
     }
 

--- a/crates/hir_def/src/item_tree/pretty.rs
+++ b/crates/hir_def/src/item_tree/pretty.rs
@@ -440,7 +440,7 @@ impl<'a> Printer<'a> {
                 }
             }
             ModItem::MacroCall(it) => {
-                let MacroCall { path, ast_id: _, fragment: _ } = &self.tree[it];
+                let MacroCall { path, ast_id: _, expand_to: _ } = &self.tree[it];
                 wln!(self, "{}!(...);", path);
             }
             ModItem::MacroRules(it) => {

--- a/crates/hir_def/src/lib.rs
+++ b/crates/hir_def/src/lib.rs
@@ -61,7 +61,7 @@ use hir_expand::{
     ast_id_map::FileAstId,
     eager::{expand_eager_macro, ErrorEmitted, ErrorSink},
     hygiene::Hygiene,
-    AstId, FragmentKind, HirFileId, InFile, MacroCallId, MacroCallKind, MacroDefId, MacroDefKind,
+    AstId, ExpandTo, HirFileId, InFile, MacroCallId, MacroCallKind, MacroDefId, MacroDefKind,
 };
 use la_arena::Idx;
 use nameres::DefMap;
@@ -667,7 +667,7 @@ impl AsMacroCall for InFile<&ast::MacroCall> {
         resolver: impl Fn(path::ModPath) -> Option<MacroDefId>,
         mut error_sink: &mut dyn FnMut(mbe::ExpandError),
     ) -> Result<Result<MacroCallId, ErrorEmitted>, UnresolvedMacro> {
-        let fragment = hir_expand::to_fragment_kind(self.value);
+        let expands_to = hir_expand::ExpandTo::from_call_site(self.value);
         let ast_id = AstId::new(self.file_id, db.ast_id_map(self.file_id).ast_id(self.value));
         let h = Hygiene::new(db.upcast(), self.file_id);
         let path = self.value.path().and_then(|path| path::ModPath::from_src(db, path, &h));
@@ -683,7 +683,7 @@ impl AsMacroCall for InFile<&ast::MacroCall> {
 
         macro_call_as_call_id(
             &AstIdWithPath::new(ast_id.file_id, ast_id.value, path),
-            fragment,
+            expands_to,
             db,
             krate,
             resolver,
@@ -712,7 +712,7 @@ pub struct UnresolvedMacro {
 
 fn macro_call_as_call_id(
     call: &AstIdWithPath<ast::MacroCall>,
-    fragment: FragmentKind,
+    expand_to: ExpandTo,
     db: &dyn db::DefDatabase,
     krate: CrateId,
     resolver: impl Fn(path::ModPath) -> Option<MacroDefId>,
@@ -738,7 +738,7 @@ fn macro_call_as_call_id(
         Ok(def.as_lazy_macro(
             db.upcast(),
             krate,
-            MacroCallKind::FnLike { ast_id: call.ast_id, fragment },
+            MacroCallKind::FnLike { ast_id: call.ast_id, expand_to },
         ))
     };
     Ok(res)

--- a/crates/hir_expand/Cargo.toml
+++ b/crates/hir_expand/Cargo.toml
@@ -19,7 +19,6 @@ itertools = "0.10.0"
 base_db = { path = "../base_db", version = "0.0.0" }
 cfg = { path = "../cfg", version = "0.0.0" }
 syntax = { path = "../syntax", version = "0.0.0" }
-parser = { path = "../parser", version = "0.0.0" }
 profile = { path = "../profile", version = "0.0.0" }
 tt = { path = "../tt", version = "0.0.0" }
 mbe = { path = "../mbe", version = "0.0.0" }

--- a/crates/hir_expand/src/builtin_derive.rs
+++ b/crates/hir_expand/src/builtin_derive.rs
@@ -3,7 +3,6 @@
 use tracing::debug;
 
 use mbe::ExpandResult;
-use parser::FragmentKind;
 use syntax::{
     ast::{self, AstNode, GenericParamsOwner, ModuleItemOwner, NameOwner},
     match_ast,
@@ -73,7 +72,7 @@ struct BasicAdtInfo {
 }
 
 fn parse_adt(tt: &tt::Subtree) -> Result<BasicAdtInfo, mbe::ExpandError> {
-    let (parsed, token_map) = mbe::token_tree_to_syntax_node(tt, FragmentKind::Items)?; // FragmentKind::Items doesn't parse attrs?
+    let (parsed, token_map) = mbe::token_tree_to_syntax_node(tt, mbe::FragmentKind::Items)?; // FragmentKind::Items doesn't parse attrs?
     let macro_items = ast::MacroItems::cast(parsed.syntax_node()).ok_or_else(|| {
         debug!("derive node didn't parse");
         mbe::ExpandError::UnexpectedToken

--- a/crates/hir_expand/src/hygiene.rs
+++ b/crates/hir_expand/src/hygiene.rs
@@ -8,10 +8,9 @@ use base_db::CrateId;
 use db::TokenExpander;
 use either::Either;
 use mbe::Origin;
-use parser::SyntaxKind;
 use syntax::{
     ast::{self, AttrsOwner},
-    AstNode, SyntaxNode, TextRange, TextSize,
+    AstNode, SyntaxKind, SyntaxNode, TextRange, TextSize,
 };
 
 use crate::{

--- a/crates/mbe/src/lib.rs
+++ b/crates/mbe/src/lib.rs
@@ -18,12 +18,14 @@ mod token_map;
 
 use std::fmt;
 
-pub use tt::{Delimiter, DelimiterKind, Punct};
-
 use crate::{
     parser::{parse_pattern, parse_template, MetaTemplate, Op},
     tt_iter::TtIter,
 };
+
+// FIXME: we probably should re-think  `token_tree_to_syntax_node` interfaces
+pub use ::parser::FragmentKind;
+pub use tt::{Delimiter, DelimiterKind, Punct};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum ParseError {
@@ -39,7 +41,7 @@ pub enum ExpandError {
     UnexpectedToken,
     BindingError(String),
     ConversionError,
-    // FXME: no way mbe should know about proc macros.
+    // FIXME: no way mbe should know about proc macros.
     UnresolvedProcMacro,
     Other(String),
 }

--- a/crates/mbe/src/syntax_bridge.rs
+++ b/crates/mbe/src/syntax_bridge.rs
@@ -2,7 +2,7 @@
 
 use std::iter;
 
-use parser::{FragmentKind, ParseError, TreeSink};
+use parser::{ParseError, TreeSink};
 use rustc_hash::FxHashMap;
 use syntax::{
     ast::{self, make::tokens::doc_comment},
@@ -12,8 +12,9 @@ use syntax::{
 };
 use tt::buffer::{Cursor, TokenBuffer};
 
-use crate::{subtree_source::SubtreeTokenSource, tt_iter::TtIter};
-use crate::{ExpandError, TokenMap};
+use crate::{
+    subtree_source::SubtreeTokenSource, tt_iter::TtIter, ExpandError, FragmentKind, TokenMap,
+};
 
 /// Convert the syntax node to a `TokenTree` (what macro
 /// will consume).

--- a/crates/mbe/src/tests.rs
+++ b/crates/mbe/src/tests.rs
@@ -3,9 +3,10 @@ mod rule;
 
 use std::fmt::Write;
 
-use ::parser::FragmentKind;
 use syntax::{ast, AstNode, NodeOrToken, SyntaxNode, WalkEvent};
 use test_utils::assert_eq_text;
+
+use crate::FragmentKind;
 
 use super::*;
 

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -98,12 +98,8 @@ pub enum FragmentKind {
     Block,
     Visibility,
     MetaItem,
-
-    // These kinds are used when parsing the result of expansion
-    // FIXME: use separate fragment kinds for macro inputs and outputs?
     Items,
     Statements,
-
     Attr,
 }
 


### PR DESCRIPTION
internal: remove accidental code re-use
FragmentKind played two roles:

* entry point to the parser
* syntactic category of a macro call

These are different use-cases, and warrant different types. For example,
macro can't expand to visibility, but we have such fragment today.

This PR introduces `ExpandsTo` enum to separate this two use-cases.

I suspect we might further split `FragmentKind` into `$x:specifier` enum
specific to MBE, and a general parser entry point, but that's for
another PR!

bors r+
🤖