### PR TITLE
feat: enable completions inside macros after `.`

### DIFF
--- a/crates/ide_completion/src/completions/dot.rs
+++ b/crates/ide_completion/src/completions/dot.rs
@@ -672,4 +672,29 @@ impl Foo { fn foo(&mut self) { $0 } }"#,
             "#]],
         );
     }
+
+    #[test]
+    fn macro_completion_after_dot() {
+        check(
+            r#"
+macro_rules! m {
+    ($e:expr) => { $e };
+}
+
+struct Completable;
+
+impl Completable {
+    fn method(&self) {}
+}
+
+fn f() {
+    let c = Completable;
+    m!(c.$0);
+}
+    "#,
+            expect![[r#"
+                me method() fn(&self)
+            "#]],
+        );
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/8158
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/10039

This issue was not caused by us not being able to expand the macro (we can do that just fine). Instead, body lowering deliberately aborted lowering of a statement macro expansion when the expansion causes errors, citing some hygiene-related issue with recovery (@edwin0cheng if you remember what exactly the issue was I'd be happy to take a look).

Simply removing that code path doesn't cause any tests to fail, and makes completions in macros work better ("completion after `.`" is not the only thing that now works better, we also get better highlighting in incomplete macro calls).

Just to be sure, lets merge this after tomorrow's release.