### PR TITLE
update to tracing-tree 0.1.10, which does not pull in syn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1749,14 +1749,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-tree"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1712b40907f8d9bc2bc66763ab61dec914b7123d7149e59feb0d4e2a95fc4967"
+checksum = "4d850f81a21b3877d4360a079c35b7b78f2674f2dafa5c9d381c53c65acebea3"
 dependencies = [
  "ansi_term",
  "atty",
  "termcolor",
- "tracing",
+ "tracing-core",
  "tracing-log",
  "tracing-subscriber",
 ]

--- a/crates/hir_ty/Cargo.toml
+++ b/crates/hir_ty/Cargo.toml
@@ -39,5 +39,5 @@ tracing-subscriber = { version = "0.2", default-features = false, features = [
     "env-filter",
     "registry",
 ] }
-tracing-tree = { version = "0.1.4" }
+tracing-tree = { version = "0.1.10" }
 once_cell = { version = "1.5.0", features = ["unstable"] }

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -36,7 +36,7 @@ lsp-server = "0.5.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.2", default-features = false, features = ["env-filter", "registry", "fmt", "tracing-log"] }
 tracing-log = "0.1.2"
-tracing-tree = { version = "0.1.4" }
+tracing-tree = { version = "0.1.10" }
 always-assert = "0.1"
 
 stdx = { path = "../stdx", version = "0.0.0" }


### PR DESCRIPTION
I've updated tracing-tree to 0.1.10, which does not pull in syn and proc-macro2 (thanks for [the PR](https://github.com/davidbarsky/tracing-tree/pull/32), @matklad!).

It took a little bit more work than I expected to land https://github.com/davidbarsky/tracing-tree/issues/33, but I should get that done this week. However, I didn't want to keep y'all waiting, so here's _some_ of the changes that should hopefully improve your compile times.