### PR TITLE
fix: Treat path dependencies like workspace members

### DIFF
--- a/crates/project_model/src/cargo_workspace.rs
+++ b/crates/project_model/src/cargo_workspace.rs
@@ -135,8 +135,8 @@ pub struct PackageData {
     pub manifest: ManifestPath,
     /// Targets provided by the crate (lib, bin, example, test, ...)
     pub targets: Vec<Target>,
-    /// Is this package a member of the current workspace
-    pub is_member: bool,
+    /// Does this package come from the local filesystem (and is editable)?
+    pub is_local: bool,
     /// List of packages this package depends on
     pub dependencies: Vec<PackageDependency>,
     /// Rust edition for this package
@@ -308,7 +308,7 @@ impl CargoWorkspace {
             });
             // We treat packages without source as "local" packages. That includes all members of
             // the current workspace, as well as any path dependency outside the workspace.
-            let is_member = meta_pkg.source.is_none();
+            let is_local = meta_pkg.source.is_none();
 
             let pkg = packages.alloc(PackageData {
                 id: id.repr.clone(),
@@ -316,7 +316,7 @@ impl CargoWorkspace {
                 version: version.clone(),
                 manifest: AbsPathBuf::assert(PathBuf::from(&manifest_path)).try_into().unwrap(),
                 targets: Vec::new(),
-                is_member,
+                is_local,
                 edition,
                 dependencies: Vec::new(),
                 features: meta_pkg.features.clone().into_iter().collect(),

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -294,7 +294,7 @@ impl GlobalState {
                         .workspaces
                         .iter()
                         .flat_map(|ws| ws.to_roots())
-                        .filter(|it| it.is_member)
+                        .filter(|it| it.is_local)
                         .flat_map(|root| {
                             root.include.into_iter().flat_map(|it| {
                                 [
@@ -514,12 +514,12 @@ impl ProjectFolders {
                 vfs::loader::Entry::Directories(dirs)
             };
 
-            if root.is_member {
+            if root.is_local {
                 res.watch.push(res.load.len());
             }
             res.load.push(entry);
 
-            if root.is_member {
+            if root.is_local {
                 local_filesets.push(fsc.len());
             }
             fsc.add_file_set(file_set_roots)


### PR DESCRIPTION
Closes https://github.com/rust-analyzer/rust-analyzer/issues/9070

Fixes diagnostics not showing up in path dependencies.