### PR TITLE
Fix resolution for inherent array methods

### DIFF
--- a/crates/hir_ty/src/tests/method_resolution.rs
+++ b/crates/hir_ty/src/tests/method_resolution.rs
@@ -1284,6 +1284,35 @@ fn f() {
 }
 
 #[test]
+fn resolve_const_generic_array_methods() {
+    check_types(
+        r#"
+#[lang = "array"]
+impl<T, const N: usize> [T; N] {
+    pub fn map<F, U>(self, f: F) -> [U; N]
+    where
+        F: FnMut(T) -> U,
+    { loop {} }
+}
+
+#[lang = "slice"]
+impl<T> [T] {
+    pub fn map<F, U>(self, f: F) -> &[U]
+    where
+        F: FnMut(T) -> U,
+    { loop {} }
+}
+
+fn f() {
+    let v = [1, 2].map::<_, usize>(|x| -> x * 2);
+    v;
+  //^ [usize; _]
+}
+    "#,
+    );
+}
+
+#[test]
 fn skip_array_during_method_dispatch() {
     check_types(
         r#"


### PR DESCRIPTION
My second attempt at fixing #9992 , previous attempt was here: #10017 , but the logic was broken.

I know that this is not an ideal solution.... that would require, IIUC, a pretty big overhaul of the const generics handling in `rust-analyzer`. But, given that some of the array methods were/are being stabilized (e.g. https://github.com/rust-lang/rust/pull/87174 ), I think it'll be very beneficial to `rust-analyzer` users to have some preliminary support for them. (I know it's something I've been running into quite a lot lately :) )

As far as my limited understanding of this project's architecture goes, I think this isn't the worst hack in the world, and shouldn't be too much of a hassle to undo if/when const generics become better supported. If the maintainers deem this approach viable, I'll want to add some comments, emphasizing the purpose of this code, and that it should be removed at some point in the future.