### PR TITLE
configure colorizedBracketPairs

### DIFF
--- a/editors/code/language-configuration.json
+++ b/editors/code/language-configuration.json
@@ -9,6 +9,11 @@
         ["(", ")"],
         ["<", ">"]
     ],
+    "colorizedBracketPairs": [
+		["{", "}"],
+		["[", "]"],
+		["(", ")"]
+	],
     "autoClosingPairs": [
         { "open": "{", "close": "}" },
         { "open": "[", "close": "]" },


### PR DESCRIPTION
The new bracket pair colorization feature of vscode colorizes all brackets no matter the language. In the context of rust colorizing the '<' and  '>' brackets doesn't make sense most of the time, especially in match statements with math like the following screenshot.

![image](https://user-images.githubusercontent.com/8348954/132622418-2edb7580-dc72-42df-894d-682d2882c7e3.png)

Currently this configuration is only possible on a language server level which is why this PR is necessary.

See https://github.com/microsoft/vscode/issues/132175 and https://github.com/microsoft/vscode/issues/132476 for more information on the issue in vscode