### PR TITLE
fix: Type param hover shows correct sized bounds.

### DIFF
--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -3596,6 +3596,146 @@ impl<T: Trait + ?Sized> Foo<T$0> {}
         );
     }
 
+    mod type_param_sized_bounds {
+        use super::*;
+
+        #[test]
+        fn single_implicit() {
+            check(
+                r#"
+//- minicore: sized
+fn foo<T$0>() {}
+"#,
+                expect![[r#"
+                    *T*
+
+                    ```rust
+                    T
+                    ```
+                "#]],
+            );
+        }
+
+        #[test]
+        fn single_explicit() {
+            check(
+                r#"
+//- minicore: sized
+fn foo<T$0: Sized>() {}
+"#,
+                expect![[r#"
+                    *T*
+
+                    ```rust
+                    T
+                    ```
+                "#]],
+            );
+        }
+
+        #[test]
+        fn single_relaxed() {
+            check(
+                r#"
+//- minicore: sized
+fn foo<T$0: ?Sized>() {}
+"#,
+                expect![[r#"
+                    *T*
+
+                    ```rust
+                    T: ?Sized
+                    ```
+                "#]],
+            );
+        }
+
+        #[test]
+        fn multiple_implicit() {
+            check(
+                r#"
+//- minicore: sized
+trait Trait {}
+fn foo<T$0: Trait>() {}
+"#,
+                expect![[r#"
+                    *T*
+
+                    ```rust
+                    T: Trait
+                    ```
+                "#]],
+            );
+        }
+
+        #[test]
+        fn multiple_explicit() {
+            check(
+                r#"
+//- minicore: sized
+trait Trait {}
+fn foo<T$0: Trait + Sized>() {}
+"#,
+                expect![[r#"
+                    *T*
+
+                    ```rust
+                    T: Trait
+                    ```
+                "#]],
+            );
+        }
+
+        #[test]
+        fn multiple_relaxed() {
+            check(
+                r#"
+//- minicore: sized
+trait Trait {}
+fn foo<T$0: Trait + ?Sized>() {}
+"#,
+                expect![[r#"
+                    *T*
+
+                    ```rust
+                    T: Trait + ?Sized
+                    ```
+                "#]],
+            );
+        }
+
+        #[test]
+        fn mixed() {
+            check(
+                r#"
+//- minicore: sized
+fn foo<T$0: ?Sized + Sized + Sized>() {}
+"#,
+                expect![[r#"
+                    *T*
+
+                    ```rust
+                    T
+                    ```
+                "#]],
+            );
+            check(
+                r#"
+//- minicore: sized
+trait Trait {}
+fn foo<T$0: Sized + ?Sized + Sized + Trait>() {}
+"#,
+                expect![[r#"
+                    *T*
+
+                    ```rust
+                    T: Trait
+                    ```
+                "#]],
+            );
+        }
+    }
+
     #[test]
     fn hover_const_param() {
         check(

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -3520,15 +3520,15 @@ fn foo() {
             r#"
 //- minicore: sized
 struct Foo<T>(T);
-trait Copy {}
-trait Clone {}
-impl<T: Copy + Clone> Foo<T$0> where T: Sized {}
+trait TraitA {}
+trait TraitB {}
+impl<T: TraitA + TraitB> Foo<T$0> where T: Sized {}
 "#,
             expect![[r#"
                 *T*
 
                 ```rust
-                T: Copy + Clone
+                T: TraitA + TraitB
                 ```
             "#]],
         );
@@ -3562,20 +3562,35 @@ impl<T: 'static> Foo<T$0> {}
     }
 
     #[test]
-    fn hover_type_param_not_sized() {
+    fn hover_type_param_sized_bounds() {
+        // implicit `: Sized` bound
         check(
             r#"
 //- minicore: sized
+trait Trait {}
 struct Foo<T>(T);
-trait Copy {}
-trait Clone {}
-impl<T: Copy + Clone> Foo<T$0> where T: ?Sized {}
+impl<T: Trait> Foo<T$0> {}
 "#,
             expect![[r#"
                 *T*
 
                 ```rust
-                T: Copy + Clone + ?Sized
+                T: Trait
+                ```
+            "#]],
+        );
+        check(
+            r#"
+//- minicore: sized
+trait Trait {}
+struct Foo<T>(T);
+impl<T: Trait + ?Sized> Foo<T$0> {}
+"#,
+            expect![[r#"
+                *T*
+
+                ```rust
+                T: Trait + ?Sized
                 ```
             "#]],
         );

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -3534,6 +3534,7 @@ impl<T: TraitA + TraitB> Foo<T$0> where T: Sized {}
         );
         check(
             r#"
+//- minicore: sized
 struct Foo<T>(T);
 impl<T> Foo<T$0> {}
 "#,
@@ -3548,6 +3549,7 @@ impl<T> Foo<T$0> {}
         // lifetimes bounds arent being tracked yet
         check(
             r#"
+//- minicore: sized
 struct Foo<T>(T);
 impl<T: 'static> Foo<T$0> {}
 "#,


### PR DESCRIPTION
Closes  #9949

This adds implicit `: Sized` bound to type parameters at lowering step.

Hovering on type parameter does not show it's `: Sized` bound be it set explicitly or implicitly. This is because it doesn't track that the bound was set implicitly.

### Perf

```rust
./target/rust-analyzer-baseline-3dae94bf -q analysis-stats --memory-usage .
Database loaded:     4.51s, 311minstr, 110mb (metadata 1.08s, 22minstr, 743kb; build 3.20s, 8730kinstr, -237kb)
  crates: 38, mods: 770, decls: 17173, fns: 12835
Item Collection:     29.63s, 85ginstr, 372mb
  exprs: 353460, ??ty: 364 (0%), ?ty: 232 (0%), !ty: 144
Inference:           118.25s, 284ginstr, 601mb
Total:               147.88s, 370ginstr, 973mb

./target/rust-analyzer-hover-ty-param-dfb15292 -q analysis-stats --memory-usage .
Database loaded:     4.53s, 311minstr, 110mb (metadata 1.10s, 22minstr, 743kb; build 3.20s, 8672kinstr, -189kb)
  crates: 38, mods: 770, decls: 17173, fns: 12835
Item Collection:     29.59s, 85ginstr, 372mb
  exprs: 353460, ??ty: 364 (0%), ?ty: 232 (0%), !ty: 144
Inference:           121.69s, 296ginstr, 601mb
Total:               151.28s, 382ginstr, 974mb

```