### PR TITLE
feat: Show the type of what is being dereferenced in a deref expression.

### DIFF
--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -377,12 +377,12 @@ fn hover_deref_expr(
         let inner = inner_ty.display(sema.db).to_string();
         let type_len = "Type: ".len();
         let coerced_len = "Coerced to: ".len();
-        let deref_len = "Derefenced from: ".len();
+        let deref_len = "Dereferenced from: ".len();
         let max_len = (original.len() + type_len)
             .max(adjusted.len() + coerced_len)
             .max(inner.len() + deref_len);
         format!(
-            "{bt_start}Type: {:>apad$}\nCoerced to: {:>opad$}\nDerefenced from: {:>ipad$}\n{bt_end}",
+            "{bt_start}Type: {:>apad$}\nCoerced to: {:>opad$}\nDereferenced from: {:>ipad$}\n{bt_end}",
             original,
             adjusted,
             inner,
@@ -397,10 +397,10 @@ fn hover_deref_expr(
         let original = original.display(sema.db).to_string();
         let inner = inner_ty.display(sema.db).to_string();
         let type_len = "Type: ".len();
-        let deref_len = "Derefenced from: ".len();
+        let deref_len = "Dereferenced from: ".len();
         let max_len = (original.len() + type_len).max(inner.len() + deref_len);
         format!(
-            "{bt_start}Type: {:>apad$}\nDerefenced from: {:>ipad$}\n{bt_end}",
+            "{bt_start}Type: {:>apad$}\nDereferenced from: {:>ipad$}\n{bt_end}",
             original,
             inner,
             apad = max_len - type_len,
@@ -4543,7 +4543,7 @@ fn foo() {
             expect![[r#"
                 ```text
                 Type:                          i32
-                Derefenced from: DerefExample<i32>
+                Dereferenced from: DerefExample<i32>
                 ```
             "#]],
         );
@@ -4577,7 +4577,7 @@ fn foo() {
                 ```text
                 Type:                          &&&&&i32
                 Coerced to:                        &i32
-                Derefenced from: DerefExample<&&&&&i32>
+                Dereferenced from: DerefExample<&&&&&i32>
                 ```
             "#]],
         );

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -4542,7 +4542,7 @@ fn foo() {
 "#,
             expect![[r#"
                 ```text
-                Type:                          i32
+                Type:                            i32
                 Dereferenced from: DerefExample<i32>
                 ```
             "#]],
@@ -4575,8 +4575,8 @@ fn foo() {
 "#,
             expect![[r#"
                 ```text
-                Type:                          &&&&&i32
-                Coerced to:                        &i32
+                Type:                            &&&&&i32
+                Coerced to:                          &i32
                 Dereferenced from: DerefExample<&&&&&i32>
                 ```
             "#]],

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -375,20 +375,20 @@ fn hover_deref_expr(
         let original = original.display(sema.db).to_string();
         let adjusted = adjusted_ty.display(sema.db).to_string();
         let inner = inner_ty.display(sema.db).to_string();
-        let type_len = "Type: ".len();
+        let type_len = "To type: ".len();
         let coerced_len = "Coerced to: ".len();
         let deref_len = "Dereferenced from: ".len();
         let max_len = (original.len() + type_len)
             .max(adjusted.len() + coerced_len)
             .max(inner.len() + deref_len);
         format!(
-            "{bt_start}Type: {:>apad$}\nCoerced to: {:>opad$}\nDereferenced from: {:>ipad$}\n{bt_end}",
+            "{bt_start}Dereferenced from: {:>ipad$}\nTo type: {:>apad$}\nCoerced to: {:>opad$}\n{bt_end}",
+            inner,
             original,
             adjusted,
-            inner,
+            ipad = max_len - deref_len,
             apad = max_len - type_len,
             opad = max_len - coerced_len,
-            ipad = max_len - deref_len,
             bt_start = if config.markdown() { "```text\n" } else { "" },
             bt_end = if config.markdown() { "```\n" } else { "" }
         )
@@ -396,15 +396,15 @@ fn hover_deref_expr(
     } else {
         let original = original.display(sema.db).to_string();
         let inner = inner_ty.display(sema.db).to_string();
-        let type_len = "Type: ".len();
+        let type_len = "To type: ".len();
         let deref_len = "Dereferenced from: ".len();
         let max_len = (original.len() + type_len).max(inner.len() + deref_len);
         format!(
-            "{bt_start}Type: {:>apad$}\nDereferenced from: {:>ipad$}\n{bt_end}",
-            original,
+            "{bt_start}Dereferenced from: {:>ipad$}\nTo type: {:>apad$}\n{bt_end}",
             inner,
-            apad = max_len - type_len,
+            original,
             ipad = max_len - deref_len,
+            apad = max_len - type_len,
             bt_start = if config.markdown() { "```text\n" } else { "" },
             bt_end = if config.markdown() { "```\n" } else { "" }
         )
@@ -4542,8 +4542,8 @@ fn foo() {
 "#,
             expect![[r#"
                 ```text
-                Type:                            i32
                 Dereferenced from: DerefExample<i32>
+                To type:                         i32
                 ```
             "#]],
         );
@@ -4575,9 +4575,9 @@ fn foo() {
 "#,
             expect![[r#"
                 ```text
-                Type:                            &&&&&i32
-                Coerced to:                          &i32
                 Dereferenced from: DerefExample<&&&&&i32>
+                To type:                         &&&&&i32
+                Coerced to:                          &i32
                 ```
             "#]],
         );

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -243,7 +243,9 @@ fn hover_ranged(
     })?;
     let res = match &expr_or_pat {
         Either::Left(ast::Expr::TryExpr(try_expr)) => hover_try_expr(sema, config, try_expr),
-        Either::Left(ast::Expr::PrefixExpr(prefix_expr)) if prefix_expr.op_kind() == Some(ast::UnaryOp::Deref) => {
+        Either::Left(ast::Expr::PrefixExpr(prefix_expr))
+            if prefix_expr.op_kind() == Some(ast::UnaryOp::Deref) =>
+        {
             hover_deref_expr(sema, config, prefix_expr)
         }
         _ => None,
@@ -355,7 +357,8 @@ fn hover_deref_expr(
     deref_expr: &ast::PrefixExpr,
 ) -> Option<HoverResult> {
     let inner_ty = sema.type_of_expr(&deref_expr.expr()?)?.original;
-    let TypeInfo { original, adjusted } = sema.type_of_expr(&ast::Expr::from(deref_expr.clone()))?;
+    let TypeInfo { original, adjusted } =
+        sema.type_of_expr(&ast::Expr::from(deref_expr.clone()))?;
 
     let mut res = HoverResult::default();
     let mut targets: Vec<hir::ModuleDef> = Vec::new();
@@ -366,7 +369,7 @@ fn hover_deref_expr(
     };
     walk_and_push_ty(sema.db, &inner_ty, &mut push_new_def);
     walk_and_push_ty(sema.db, &original, &mut push_new_def);
-    
+
     res.markup = if let Some(adjusted_ty) = adjusted {
         walk_and_push_ty(sema.db, &adjusted_ty, &mut push_new_def);
         let original = original.display(sema.db).to_string();
@@ -375,7 +378,9 @@ fn hover_deref_expr(
         let type_len = "Type: ".len();
         let coerced_len = "Coerced to: ".len();
         let deref_len = "Derefenced from: ".len();
-        let max_len = (original.len() + type_len).max(adjusted.len() + coerced_len).max(inner.len() + deref_len);
+        let max_len = (original.len() + type_len)
+            .max(adjusted.len() + coerced_len)
+            .max(inner.len() + deref_len);
         format!(
             "{bt_start}Type: {:>apad$}\nCoerced to: {:>opad$}\nDerefenced from: {:>ipad$}\n{bt_end}",
             original,
@@ -4511,12 +4516,13 @@ fn foo() -> Option<()> {
         );
     }
 
-
     #[test]
     fn hover_deref_expr() {
         check_hover_range(
             r#"
-//- minicore: deref 
+//- minicore: deref
+use core::ops::Deref;
+
 struct DerefExample<T> {
     value: T
 }
@@ -4547,19 +4553,21 @@ fn foo() {
     fn hover_deref_expr_with_coercion() {
         check_hover_range(
             r#"
-//- minicore: deref 
+//- minicore: deref
+use core::ops::Deref;
+
 struct DerefExample<T> {
     value: T
 }
- 
+
 impl<T> Deref for DerefExample<T> {
     type Target = T;
- 
+
     fn deref(&self) -> &Self::Target {
         &self.value
     }
 }
- 
+
 fn foo() {
     let x = DerefExample { value: &&&&&0 };
     let y: &i32 = $0*x$0;

--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -4510,4 +4510,68 @@ fn foo() -> Option<()> {
                 ```"#]],
         );
     }
+
+
+    #[test]
+    fn hover_deref_expr() {
+        check_hover_range(
+            r#"
+//- minicore: deref 
+struct DerefExample<T> {
+    value: T
+}
+
+impl<T> Deref for DerefExample<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+fn foo() {
+    let x = DerefExample { value: 0 };
+    let y: i32 = $0*x$0;
+}
+"#,
+            expect![[r#"
+                ```text
+                Type:                          i32
+                Derefenced from: DerefExample<i32>
+                ```
+            "#]],
+        );
+    }
+
+    #[test]
+    fn hover_deref_expr_with_coercion() {
+        check_hover_range(
+            r#"
+//- minicore: deref 
+struct DerefExample<T> {
+    value: T
+}
+ 
+impl<T> Deref for DerefExample<T> {
+    type Target = T;
+ 
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+ 
+fn foo() {
+    let x = DerefExample { value: &&&&&0 };
+    let y: &i32 = $0*x$0;
+}
+"#,
+            expect![[r#"
+                ```text
+                Type:                          &&&&&i32
+                Coerced to:                        &i32
+                Derefenced from: DerefExample<&&&&&i32>
+                ```
+            "#]],
+        );
+    }
 }


### PR DESCRIPTION
Addresses issue #10106.

In-progress - I'm trying to figure out why `hover_deref_expr_with_coercion` is failing.