### PR TITLE
internal: Remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,6 @@ dependencies = [
  "profile",
  "rustc-hash",
  "salsa",
- "stdx",
  "syntax",
  "test_utils",
  "tt",
@@ -471,7 +470,6 @@ dependencies = [
  "hir_def",
  "hir_expand",
  "hir_ty",
- "indexmap",
  "itertools",
  "once_cell",
  "profile",
@@ -641,7 +639,6 @@ dependencies = [
  "syntax",
  "test_utils",
  "text_edit",
- "tracing",
  "xshell",
 ]
 
@@ -1127,8 +1124,6 @@ dependencies = [
 name = "proc_macro_api"
 version = "0.0.0"
 dependencies = [
- "crossbeam-channel",
- "jod-thread",
  "memmap2",
  "object",
  "paths",
@@ -1344,7 +1339,6 @@ dependencies = [
  "stdx",
  "syntax",
  "test_utils",
- "text_edit",
  "threadpool",
  "tikv-jemallocator",
  "toolchain",
@@ -1561,7 +1555,6 @@ dependencies = [
 name = "syntax"
 version = "0.0.0"
 dependencies = [
- "arrayvec",
  "cov-mark",
  "expect-test",
  "indexmap",
@@ -1848,7 +1841,6 @@ dependencies = [
  "jod-thread",
  "notify",
  "paths",
- "rustc-hash",
  "tracing",
  "vfs",
  "walkdir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,7 +526,6 @@ dependencies = [
  "profile",
  "rustc-hash",
  "syntax",
- "test_utils",
  "tracing",
  "tt",
 ]
@@ -895,7 +894,6 @@ dependencies = [
  "cov-mark",
  "expect-test",
  "parser",
- "profile",
  "rustc-hash",
  "smallvec",
  "stdx",
@@ -1140,7 +1138,6 @@ dependencies = [
 name = "proc_macro_srv"
 version = "0.0.0"
 dependencies = [
- "cargo_metadata",
  "expect-test",
  "libloading",
  "mbe",
@@ -1149,8 +1146,6 @@ dependencies = [
  "paths",
  "proc_macro_api",
  "proc_macro_test",
- "test_utils",
- "toolchain",
  "tt",
 ]
 

--- a/crates/base_db/Cargo.toml
+++ b/crates/base_db/Cargo.toml
@@ -18,4 +18,3 @@ profile = { path = "../profile", version = "0.0.0" }
 tt = { path = "../tt", version = "0.0.0" }
 test_utils = { path = "../test_utils", version = "0.0.0" }
 vfs = { path = "../vfs", version = "0.0.0" }
-stdx = { path = "../stdx", version = "0.0.0" }

--- a/crates/hir/Cargo.toml
+++ b/crates/hir/Cargo.toml
@@ -15,7 +15,6 @@ arrayvec = "0.7"
 itertools = "0.10.0"
 smallvec = "1.4.0"
 once_cell = "1"
-indexmap = "1.7"
 
 stdx = { path = "../stdx", version = "0.0.0" }
 syntax = { path = "../syntax", version = "0.0.0" }

--- a/crates/hir_expand/Cargo.toml
+++ b/crates/hir_expand/Cargo.toml
@@ -25,5 +25,4 @@ mbe = { path = "../mbe", version = "0.0.0" }
 limit = { path = "../limit", version = "0.0.0" }
 
 [dev-dependencies]
-test_utils = { path = "../test_utils" }
 expect-test = "1.1"

--- a/crates/hir_ty/Cargo.toml
+++ b/crates/hir_ty/Cargo.toml
@@ -40,4 +40,3 @@ tracing-subscriber = { version = "0.2", default-features = false, features = [
     "registry",
 ] }
 tracing-tree = { version = "0.1.10" }
-once_cell = { version = "1.5.0", features = ["unstable"] }

--- a/crates/ide_completion/Cargo.toml
+++ b/crates/ide_completion/Cargo.toml
@@ -11,7 +11,6 @@ doctest = false
 [dependencies]
 cov-mark = "2.0.0-pre.1"
 itertools = "0.10.0"
-tracing = "0.1"
 rustc-hash = "1.1.0"
 either = "1.6.1"
 once_cell = "1.7"

--- a/crates/mbe/Cargo.toml
+++ b/crates/mbe/Cargo.toml
@@ -21,5 +21,4 @@ tt = { path = "../tt", version = "0.0.0" }
 stdx = { path = "../stdx", version = "0.0.0" }
 
 [dev-dependencies]
-profile = { path = "../profile" }
 test_utils = { path = "../test_utils" }

--- a/crates/proc_macro_api/Cargo.toml
+++ b/crates/proc_macro_api/Cargo.toml
@@ -12,8 +12,6 @@ doctest = false
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["unbounded_depth"] }
 tracing = "0.1"
-crossbeam-channel = "0.5.0"
-jod-thread = "0.1.1"
 memmap2 = "0.3.0"
 snap = "1.0"
 

--- a/crates/proc_macro_srv/Cargo.toml
+++ b/crates/proc_macro_srv/Cargo.toml
@@ -25,9 +25,6 @@ paths = { path = "../paths", version = "0.0.0" }
 proc_macro_api = { path = "../proc_macro_api", version = "0.0.0" }
 
 [dev-dependencies]
-test_utils = { path = "../test_utils" }
-toolchain = { path = "../toolchain" }
-cargo_metadata = "0.14"
 expect-test = "1.1.0"
 
 # used as proc macro test targets

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -46,7 +46,6 @@ ide_db = { path = "../ide_db", version = "0.0.0" }
 profile = { path = "../profile", version = "0.0.0" }
 project_model = { path = "../project_model", version = "0.0.0" }
 syntax = { path = "../syntax", version = "0.0.0" }
-text_edit = { path = "../text_edit", version = "0.0.0" }
 vfs = { path = "../vfs", version = "0.0.0" }
 vfs-notify = { path = "../vfs-notify", version = "0.0.0" }
 cfg = { path = "../cfg", version = "0.0.0" }

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -73,7 +73,6 @@ xshell = "0.1"
 test_utils = { path = "../test_utils" }
 sourcegen = { path = "../sourcegen" }
 mbe = { path = "../mbe" }
-tt = { path = "../tt" }
 
 [features]
 jemalloc = ["jemallocator", "profile/jemalloc"]

--- a/crates/syntax/Cargo.toml
+++ b/crates/syntax/Cargo.toml
@@ -15,7 +15,6 @@ itertools = "0.10.0"
 rowan = "0.13.0"
 rustc_lexer = { version = "725.0.0", package = "rustc-ap-rustc_lexer" }
 rustc-hash = "1.1.0"
-arrayvec = "0.7"
 once_cell = "1.3.1"
 indexmap = "1.4.0"
 smol_str = "0.1.15"

--- a/crates/vfs-notify/Cargo.toml
+++ b/crates/vfs-notify/Cargo.toml
@@ -10,7 +10,6 @@ doctest = false
 
 [dependencies]
 tracing = "0.1"
-rustc-hash = "1.0"
 jod-thread = "0.1.0"
 walkdir = "2.3.1"
 crossbeam-channel = "0.5.0"


### PR DESCRIPTION
cargo check --all-targets compiles cleanly without these dependencies for me.