### PR TITLE
assists: Promote module to folder

### DIFF
--- a/crates/ide_assists/src/assist_context.rs
+++ b/crates/ide_assists/src/assist_context.rs
@@ -294,6 +294,10 @@ impl AssistBuilder {
         let file_system_edit = FileSystemEdit::CreateFile { dst, initial_contents: content.into() };
         self.source_change.push_file_system_edit(file_system_edit);
     }
+    pub(crate) fn move_file(&mut self, src: FileId, dst: AnchoredPathBuf) {
+        let file_system_edit = FileSystemEdit::MoveFile { src, dst };
+        self.source_change.push_file_system_edit(file_system_edit);
+    }
 
     fn finish(mut self) -> SourceChange {
         self.commit();

--- a/crates/ide_assists/src/handlers/promote_mod_file.rs
+++ b/crates/ide_assists/src/handlers/promote_mod_file.rs
@@ -9,6 +9,19 @@ use syntax::{
 
 use crate::assist_context::{AssistContext, Assists};
 
+// Assist: promote_mod_file
+//
+// Moves inline module's contents to a separate file.
+//
+// ```
+// // a.rs
+// $0fn t() {}
+// ```
+// ->
+// ```
+// // /a/mod.rs
+// fn t() {}
+// ```
 pub(crate) fn promote_mod_file(acc: &mut Assists, ctx: &AssistContext) -> Option<()> {
     let source_file = ctx.find_node_at_offset::<ast::SourceFile>()?;
     let module = ctx.sema.to_module_def(ctx.frange.file_id)?;

--- a/crates/ide_assists/src/handlers/promote_mod_file.rs
+++ b/crates/ide_assists/src/handlers/promote_mod_file.rs
@@ -14,12 +14,13 @@ use crate::assist_context::{AssistContext, Assists};
 // Moves inline module's contents to a separate file.
 //
 // ```
-// // a.rs
+// //- /main.rs
+// mod a;
+// //- /a.rs
 // $0fn t() {}
 // ```
 // ->
 // ```
-// // /a/mod.rs
 // fn t() {}
 // ```
 pub(crate) fn promote_mod_file(acc: &mut Assists, ctx: &AssistContext) -> Option<()> {

--- a/crates/ide_assists/src/handlers/promote_mod_file.rs
+++ b/crates/ide_assists/src/handlers/promote_mod_file.rs
@@ -1,0 +1,148 @@
+use ide_db::{
+    assists::{AssistId, AssistKind},
+    base_db::AnchoredPathBuf,
+};
+use syntax::{
+    ast::{self},
+    AstNode, TextRange,
+};
+
+use crate::assist_context::{AssistContext, Assists};
+
+pub(crate) fn promote_mod_file(acc: &mut Assists, ctx: &AssistContext) -> Option<()> {
+    let source_file = ctx.find_node_at_offset::<ast::SourceFile>()?;
+    let module = ctx.sema.to_module_def(ctx.frange.file_id)?;
+    if module.is_mod_rs(ctx.db()) {
+        return None;
+    }
+    let target = TextRange::new(
+        source_file.syntax().text_range().start(),
+        source_file.syntax().text_range().end(),
+    );
+    let path = format!("./{}/mod.rs", module.name(ctx.db())?.to_string());
+    let dst = AnchoredPathBuf { anchor: ctx.frange.file_id, path };
+    acc.add(
+        AssistId("promote_mod_file", AssistKind::Refactor),
+        "Promote Module to directory",
+        target,
+        |builder| {
+            builder.move_file(ctx.frange.file_id, dst);
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::{check_assist, check_assist_not_applicable};
+
+    use super::*;
+
+    #[test]
+    fn trivial() {
+        check_assist(
+            promote_mod_file,
+            r#"
+//- /main.rs
+mod a;
+//- /a.rs
+$0fn t() {}
+"#,
+            r#"
+//- /a/mod.rs
+fn t() {}
+"#,
+        );
+    }
+
+    #[test]
+    fn cursor_can_be_putted_anywhere() {
+        check_assist(
+            promote_mod_file,
+            r#"
+//- /main.rs
+mod a;
+//- /a.rs
+fn t() {}$0
+"#,
+            r#"
+//- /a/mod.rs
+fn t() {}
+"#,
+        );
+        check_assist(
+            promote_mod_file,
+            r#"
+//- /main.rs
+mod a;
+//- /a.rs
+fn t()$0 {}
+"#,
+            r#"
+//- /a/mod.rs
+fn t() {}
+"#,
+        );
+        check_assist(
+            promote_mod_file,
+            r#"
+//- /main.rs
+mod a;
+//- /a.rs
+fn t($0) {}
+"#,
+            r#"
+//- /a/mod.rs
+fn t() {}
+"#,
+        );
+    }
+
+    #[test]
+    fn cannot_promote_mod_rs() {
+        check_assist_not_applicable(
+            promote_mod_file,
+            r#"//- /main.rs
+mod a;
+//- /a/mod.rs
+$0fn t() {}
+"#,
+        );
+    }
+
+    #[test]
+    fn cannot_promote_main_and_lib_rs() {
+        check_assist_not_applicable(
+            promote_mod_file,
+            r#"//- /main.rs
+$0fn t() {}
+"#,
+        );
+        check_assist_not_applicable(
+            promote_mod_file,
+            r#"//- /lib.rs
+$0fn t() {}
+"#,
+        );
+    }
+
+    #[test]
+    fn works_in_mod() {
+        // note: /a/b.rs remains untouched
+        check_assist(
+            promote_mod_file,
+            r#"//- /main.rs
+mod a;
+//- /a.rs
+mod b;
+$0fn t() {}
+//- /a/b.rs
+fn t1() {}
+"#,
+            r#"
+//- /a/mod.rs
+mod b;
+fn t() {}
+"#,
+        );
+    }
+}

--- a/crates/ide_assists/src/lib.rs
+++ b/crates/ide_assists/src/lib.rs
@@ -96,6 +96,7 @@ mod handlers {
     mod move_bounds;
     mod move_guard;
     mod move_module_to_file;
+    mod promote_mod_file;
     mod pull_assignment_up;
     mod qualify_path;
     mod raw_string;
@@ -167,6 +168,7 @@ mod handlers {
             move_guard::move_arm_cond_to_match_guard,
             move_guard::move_guard_to_arm_body,
             move_module_to_file::move_module_to_file,
+            promote_mod_file::promote_mod_file,
             pull_assignment_up::pull_assignment_up,
             qualify_path::qualify_path,
             raw_string::add_hash,

--- a/crates/ide_assists/src/lib.rs
+++ b/crates/ide_assists/src/lib.rs
@@ -96,7 +96,7 @@ mod handlers {
     mod move_bounds;
     mod move_guard;
     mod move_module_to_file;
-    mod promote_mod_file;
+    mod move_to_mod_rs;
     mod pull_assignment_up;
     mod qualify_path;
     mod raw_string;
@@ -168,7 +168,7 @@ mod handlers {
             move_guard::move_arm_cond_to_match_guard,
             move_guard::move_guard_to_arm_body,
             move_module_to_file::move_module_to_file,
-            promote_mod_file::promote_mod_file,
+            move_to_mod_rs::move_to_mod_rs,
             pull_assignment_up::pull_assignment_up,
             qualify_path::qualify_path,
             raw_string::add_hash,

--- a/crates/ide_assists/src/tests/generated.rs
+++ b/crates/ide_assists/src/tests/generated.rs
@@ -1227,6 +1227,22 @@ mod foo;
 }
 
 #[test]
+fn doctest_promote_mod_file() {
+    check_doc_test(
+        "promote_mod_file",
+        r#####"
+//- /main.rs
+mod a;
+//- /a.rs
+$0fn t() {}
+"#####,
+        r#####"
+fn t() {}
+"#####,
+    )
+}
+
+#[test]
 fn doctest_pull_assignment_up() {
     check_doc_test(
         "pull_assignment_up",

--- a/crates/ide_assists/src/tests/generated.rs
+++ b/crates/ide_assists/src/tests/generated.rs
@@ -1227,9 +1227,9 @@ mod foo;
 }
 
 #[test]
-fn doctest_promote_mod_file() {
+fn doctest_move_to_mod_rs() {
     check_doc_test(
-        "promote_mod_file",
+        "move_to_mod_rs",
         r#####"
 //- /main.rs
 mod a;

--- a/crates/ide_assists/src/tests/generated.rs
+++ b/crates/ide_assists/src/tests/generated.rs
@@ -1234,7 +1234,7 @@ fn doctest_promote_mod_file() {
 //- /main.rs
 mod a;
 //- /a.rs
-$0fn t() {}
+$0fn t() {}$0
 "#####,
         r#####"
 fn t() {}


### PR DESCRIPTION
Close part of #10143.

This PR adds a assist to promote module to directory, which means make a .rs file module into a directory style module with the same name.

![未命名(1)](https://user-images.githubusercontent.com/13777628/132958377-14555d6f-a64a-4b9b-9154-90a3b86fd685.gif)
