### PR TITLE
fix: Avoid type inference panic on bitslice methods

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2612,7 +2612,7 @@ impl Type {
             None,
             name,
             method_resolution::LookupMode::MethodCall,
-            callback,
+            &mut |ty, id| callback(&ty.value, id),
         );
     }
 
@@ -2664,7 +2664,7 @@ impl Type {
             None,
             name,
             method_resolution::LookupMode::Path,
-            callback,
+            &mut |ty, id| callback(&ty.value, id),
         );
     }
 

--- a/crates/hir_ty/src/infer/coerce.rs
+++ b/crates/hir_ty/src/infer/coerce.rs
@@ -277,7 +277,7 @@ impl<'a> InferenceContext<'a> {
                 continue;
             }
 
-            let referent_ty = canonicalized.decanonicalize_ty(referent_ty.value);
+            let referent_ty = canonicalized.decanonicalize_ty(&mut self.table, referent_ty);
 
             // At this point, we have deref'd `a` to `referent_ty`.  So
             // imagine we are coercing from `&'a mut Vec<T>` to `&'b mut [T]`.

--- a/crates/hir_ty/src/infer/unify.rs
+++ b/crates/hir_ty/src/infer/unify.rs
@@ -41,8 +41,13 @@ where
 }
 
 impl<T: HasInterner<Interner = Interner>> Canonicalized<T> {
-    pub(super) fn decanonicalize_ty(&self, ty: Ty) -> Ty {
-        chalk_ir::Substitute::apply(&self.free_vars, ty, &Interner)
+    /// this method is wrong and shouldn't exist
+    pub(super) fn decanonicalize_ty(&self, table: &mut InferenceTable, ty: Canonical<Ty>) -> Ty {
+        let mut vars = self.free_vars.clone();
+        while ty.binders.len(&Interner) > vars.len() {
+            vars.push(table.new_type_var().cast(&Interner));
+        }
+        chalk_ir::Substitute::apply(&vars, ty.value, &Interner)
     }
 
     pub(super) fn apply_solution(

--- a/crates/hir_ty/src/tests/regression.rs
+++ b/crates/hir_ty/src/tests/regression.rs
@@ -1145,3 +1145,35 @@ impl<'a, T, DB: TypeMetadata> Output<'a, T, DB> {
         "#,
     );
 }
+
+#[test]
+fn bitslice_panic() {
+    check_no_mismatches(
+        r#"
+//- minicore: option, deref
+
+pub trait BitView {
+    type Store;
+}
+
+pub struct Lsb0;
+
+pub struct BitArray<V: BitView> { }
+
+pub struct BitSlice<T> { }
+
+impl<V: BitView> core::ops::Deref for BitArray<V> {
+    type Target = BitSlice<V::Store>;
+}
+
+impl<T> BitSlice<T> {
+    pub fn split_first(&self) -> Option<(T, &Self)> { loop {} }
+}
+
+fn multiexp_inner() {
+    let exp: &BitArray<Foo>;
+    exp.split_first();
+}
+        "#,
+    );
+}


### PR DESCRIPTION
Should fix #10090, fix #10046, and fix #10179.
This is only a workaround, but the proper fix requires some bigger
refactoring (also related to fixing #10058), and this at least prevents
the crash.