### PR TITLE
Use correct file syntax node for `decl_access` computation in `find_all_refs`

### DIFF
--- a/crates/ide/src/references.rs
+++ b/crates/ide/src/references.rs
@@ -87,7 +87,10 @@ pub(crate) fn find_all_refs(
                 }
                 .map(|nav| {
                     let decl_range = nav.focus_or_full_range();
-                    Declaration { nav, access: decl_access(&def, &syntax, decl_range) }
+                    Declaration {
+                        access: decl_access(&def, sema.parse(nav.file_id).syntax(), decl_range),
+                        nav,
+                    }
                 });
                 if is_literal_search {
                     retain_adt_literal_usages(&mut usages, def, sema);


### PR DESCRIPTION
Defs and refs of locals only ever life in one file, this isn't true for fields though.
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/10201

bors r+