### PR TITLE
minor: Don't spam the manual with warnings

### DIFF
--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -1,3 +1,5 @@
+// IMPORTANT: the master copy of this document lives in the https://github.com/rust-analyzer/rust-analyzer repository
+
 = User Manual
 :toc: preamble
 :sectanchors:
@@ -623,7 +625,7 @@ Note that calls to `cargo check` are disabled when using `rust-project.json` by 
 { "rust-analyzer.checkOnSave.overrideCommand": ["cargo", "check", "--message-format=json"] }
 ----
 
-The `checkOnSave.overrideCommand` requires the command specified to output json error messages for rust-analyzer to consume. The `--message-format=json` flag does this for `cargo check` so whichever command you use must also output errors in this format. See the <<Configuration>> section for more information. 
+The `checkOnSave.overrideCommand` requires the command specified to output json error messages for rust-analyzer to consume. The `--message-format=json` flag does this for `cargo check` so whichever command you use must also output errors in this format. See the <<Configuration>> section for more information.
 
 == Security
 

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -45,7 +45,7 @@ impl flags::Release {
             let src = project_root().join("./docs/user/").join(adoc);
             let dst = website_root.join(adoc);
 
-            let contents = read_file(src)?.replace("\n\n===", "\n\n// IMPORTANT: master copy of this document lives in the https://github.com/rust-analyzer/rust-analyzer repository\n\n==");
+            let contents = read_file(src)?;
             write_file(dst, contents)?;
         }
 


### PR DESCRIPTION
A single warning on the first line should™ be enough. Currently we put that warning on every section, while also breaking the table of contents in the process:

![image](https://user-images.githubusercontent.com/308347/133045747-5232ce04-7856-40fd-a82f-adcefb7a6f5a.png)

Fixes #9657