### PR TITLE
fix: fix names generation in `Generate function`

### DIFF
--- a/crates/syntax/src/token_text.rs
+++ b/crates/syntax/src/token_text.rs
@@ -21,9 +21,9 @@ impl<'a> TokenText<'a> {
     }
 
     pub fn as_str(&self) -> &str {
-        match self.0 {
-            Repr::Borrowed(it) => it,
-            Repr::Owned(ref green) => green.text(),
+        match &self.0 {
+            &Repr::Borrowed(it) => it,
+            Repr::Owned(green) => green.text(),
         }
     }
 }


### PR DESCRIPTION
- Improve fn name computation (close #10176).
- Handle tuple indexing expressions in argument position (should close  #10241)