### PR TITLE
Clarify where RA_LOG must be set

### DIFF
--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -437,7 +437,7 @@ If the date is more than a week ago, it's better to update rust-analyzer version
 
 The next thing to check would be panic messages in rust-analyzer's log.
 Log messages are printed to stderr, in VS Code you can see then in the `Output > Rust Analyzer Language Server` tab of the panel.
-To see more logs, set `RA_LOG=info` environmental variable.
+To see more logs, set `RA_LOG=info` environmental variable before launching VS Code.
 
 To fully capture LSP messages between the editor and the server, set `"rust-analyzer.trace.server": "verbose"` config and check
 `Output > Rust Analyzer Language Server Trace`.


### PR DESCRIPTION
I first thought maybe there is some way inside VS code to set env vars for the language server, or so, until I realized you meant to simply set this before starting VS code.