### PR TITLE
fix: Don't bail on parse errors in macro input for builtin expansion

### DIFF
--- a/crates/hir_expand/src/builtin_macro.rs
+++ b/crates/hir_expand/src/builtin_macro.rs
@@ -793,6 +793,23 @@ mod tests {
     }
 
     #[test]
+    fn test_format_args_expand_with_broken_member_access() {
+        check_expansion(
+            r#"
+            #[rustc_builtin_macro]
+            macro_rules! format_args {
+                ($fmt:expr) => ({ /* compiler built-in */ });
+                ($fmt:expr, $($args:tt)*) => ({ /* compiler built-in */ })
+            }
+            format_args!("{} {:?}", a.);
+            "#,
+            expect![[
+                r#"unsafe{std::fmt::Arguments::new_v1(&[], &[std::fmt::ArgumentV1::new(&(a.),std::fmt::Display::fmt),])}"#
+            ]],
+        );
+    }
+
+    #[test]
     fn test_include_bytes_expand() {
         check_expansion(
             r#"

--- a/crates/mbe/src/syntax_bridge.rs
+++ b/crates/mbe/src/syntax_bridge.rs
@@ -90,7 +90,7 @@ pub fn parse_to_token_tree(text: &str) -> Option<(tt::Subtree, TokenMap)> {
     Some((subtree, conv.id_alloc.map))
 }
 
-/// Split token tree with seperate expr: $($e:expr)SEP*
+/// Split token tree with separate expr: $($e:expr)SEP*
 pub fn parse_exprs_with_sep(tt: &tt::Subtree, sep: char) -> Vec<tt::Subtree> {
     if tt.token_trees.is_empty() {
         return Vec::new();
@@ -101,9 +101,6 @@ pub fn parse_exprs_with_sep(tt: &tt::Subtree, sep: char) -> Vec<tt::Subtree> {
 
     while iter.peek_n(0).is_some() {
         let expanded = iter.expect_fragment(ParserEntryPoint::Expr);
-        if expanded.err.is_some() {
-            break;
-        }
 
         res.push(match expanded.value {
             None => break,


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/8158