### PR TITLE
minor: Rename some assists

### DIFF
--- a/crates/ide_assists/src/handlers/add_missing_match_arms.rs
+++ b/crates/ide_assists/src/handlers/add_missing_match_arms.rs
@@ -12,7 +12,7 @@ use crate::{
     AssistContext, AssistId, AssistKind, Assists,
 };
 
-// Assist: fill_match_arms
+// Assist: add_missing_match_arms
 //
 // Adds missing clauses to a `match` expression.
 //
@@ -36,7 +36,7 @@ use crate::{
 //     }
 // }
 // ```
-pub(crate) fn fill_match_arms(acc: &mut Assists, ctx: &AssistContext) -> Option<()> {
+pub(crate) fn add_missing_match_arms(acc: &mut Assists, ctx: &AssistContext) -> Option<()> {
     let match_expr = ctx.find_node_at_offset_with_descend::<ast::MatchExpr>()?;
     let match_arm_list = match_expr.match_arm_list()?;
 
@@ -105,7 +105,7 @@ pub(crate) fn fill_match_arms(acc: &mut Assists, ctx: &AssistContext) -> Option<
         let missing_pats = variants_of_enums
             .into_iter()
             .multi_cartesian_product()
-            .inspect(|_| cov_mark::hit!(fill_match_arms_lazy_computation))
+            .inspect(|_| cov_mark::hit!(add_missing_match_arms_lazy_computation))
             .map(|variants| {
                 let patterns =
                     variants.into_iter().filter_map(|variant| build_pat(ctx.db(), module, variant));
@@ -123,7 +123,7 @@ pub(crate) fn fill_match_arms(acc: &mut Assists, ctx: &AssistContext) -> Option<
 
     let target = ctx.sema.original_range(match_expr.syntax()).range;
     acc.add(
-        AssistId("fill_match_arms", AssistKind::QuickFix),
+        AssistId("add_missing_match_arms", AssistKind::QuickFix),
         "Fill match arms",
         target,
         |builder| {
@@ -146,7 +146,7 @@ pub(crate) fn fill_match_arms(acc: &mut Assists, ctx: &AssistContext) -> Option<
                 if is_empty_expr {
                     arm.remove();
                 } else {
-                    cov_mark::hit!(fill_match_arms_empty_expr);
+                    cov_mark::hit!(add_missing_match_arms_empty_expr);
                 }
             }
             let mut first_new_arm = None;
@@ -283,12 +283,12 @@ mod tests {
         check_assist, check_assist_not_applicable, check_assist_target, check_assist_unresolved,
     };
 
-    use super::fill_match_arms;
+    use super::add_missing_match_arms;
 
     #[test]
     fn all_match_arms_provided() {
         check_assist_not_applicable(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 enum A {
     As,
@@ -309,7 +309,7 @@ fn main() {
     #[test]
     fn all_boolean_match_arms_provided() {
         check_assist_not_applicable(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 fn foo(a: bool) {
     match a$0 {
@@ -326,7 +326,7 @@ fn foo(a: bool) {
         // for now this case is not handled, although it potentially could be
         // in the future
         check_assist_not_applicable(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 fn main() {
     match (0, false)$0 {
@@ -337,9 +337,9 @@ fn main() {
     }
 
     #[test]
-    fn fill_match_arms_boolean() {
+    fn add_missing_match_arms_boolean() {
         check_assist(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 fn foo(a: bool) {
     match a$0 {
@@ -360,7 +360,7 @@ fn foo(a: bool) {
     #[test]
     fn partial_fill_boolean() {
         check_assist(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 fn foo(a: bool) {
     match a$0 {
@@ -382,7 +382,7 @@ fn foo(a: bool) {
     #[test]
     fn all_boolean_tuple_arms_provided() {
         check_assist_not_applicable(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 fn foo(a: bool) {
     match (a, a)$0 {
@@ -399,7 +399,7 @@ fn foo(a: bool) {
     #[test]
     fn fill_boolean_tuple() {
         check_assist(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 fn foo(a: bool) {
     match (a, a)$0 {
@@ -422,7 +422,7 @@ fn foo(a: bool) {
     #[test]
     fn partial_fill_boolean_tuple() {
         check_assist(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 fn foo(a: bool) {
     match (a, a)$0 {
@@ -446,7 +446,7 @@ fn foo(a: bool) {
     #[test]
     fn partial_fill_record_tuple() {
         check_assist(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 enum A {
     As,
@@ -480,7 +480,7 @@ fn main() {
     #[test]
     fn partial_fill_option() {
         check_assist(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 //- minicore: option
 fn main() {
@@ -503,7 +503,7 @@ fn main() {
     #[test]
     fn partial_fill_or_pat() {
         check_assist(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 enum A { As, Bs, Cs(Option<i32>) }
 fn main() {
@@ -527,7 +527,7 @@ fn main() {
     #[test]
     fn partial_fill() {
         check_assist(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 enum A { As, Bs, Cs, Ds(String), Es(B) }
 enum B { Xs, Ys }
@@ -558,7 +558,7 @@ fn main() {
     #[test]
     fn partial_fill_bind_pat() {
         check_assist(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 enum A { As, Bs, Cs(Option<i32>) }
 fn main() {
@@ -582,9 +582,9 @@ fn main() {
     }
 
     #[test]
-    fn fill_match_arms_empty_body() {
+    fn add_missing_match_arms_empty_body() {
         check_assist(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 enum A { As, Bs, Cs(String), Ds(String, String), Es { x: usize, y: usize } }
 
@@ -611,9 +611,9 @@ fn main() {
     }
 
     #[test]
-    fn fill_match_arms_tuple_of_enum() {
+    fn add_missing_match_arms_tuple_of_enum() {
         check_assist(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 enum A { One, Two }
 enum B { One, Two }
@@ -643,9 +643,9 @@ fn main() {
     }
 
     #[test]
-    fn fill_match_arms_tuple_of_enum_ref() {
+    fn add_missing_match_arms_tuple_of_enum_ref() {
         check_assist(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 enum A { One, Two }
 enum B { One, Two }
@@ -675,9 +675,9 @@ fn main() {
     }
 
     #[test]
-    fn fill_match_arms_tuple_of_enum_partial() {
+    fn add_missing_match_arms_tuple_of_enum_partial() {
         check_assist(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 enum A { One, Two }
 enum B { One, Two }
@@ -709,9 +709,9 @@ fn main() {
     }
 
     #[test]
-    fn fill_match_arms_tuple_of_enum_partial_with_wildcards() {
+    fn add_missing_match_arms_tuple_of_enum_partial_with_wildcards() {
         check_assist(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 //- minicore: option
 fn main() {
@@ -738,10 +738,10 @@ fn main() {
     }
 
     #[test]
-    fn fill_match_arms_partial_with_deep_pattern() {
+    fn add_missing_match_arms_partial_with_deep_pattern() {
         // Fixme: cannot handle deep patterns
         check_assist_not_applicable(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 //- minicore: option
 fn main() {
@@ -755,9 +755,9 @@ fn main() {
     }
 
     #[test]
-    fn fill_match_arms_tuple_of_enum_not_applicable() {
+    fn add_missing_match_arms_tuple_of_enum_not_applicable() {
         check_assist_not_applicable(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 enum A { One, Two }
 enum B { One, Two }
@@ -777,9 +777,9 @@ fn main() {
     }
 
     #[test]
-    fn fill_match_arms_single_element_tuple_of_enum() {
+    fn add_missing_match_arms_single_element_tuple_of_enum() {
         check_assist(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 enum A { One, Two }
 
@@ -806,7 +806,7 @@ fn main() {
     #[test]
     fn test_fill_match_arm_refs() {
         check_assist(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 enum A { As }
 
@@ -827,7 +827,7 @@ fn foo(a: &A) {
         );
 
         check_assist(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 enum A {
     Es { x: usize, y: usize }
@@ -853,9 +853,9 @@ fn foo(a: &mut A) {
     }
 
     #[test]
-    fn fill_match_arms_target() {
+    fn add_missing_match_arms_target() {
         check_assist_target(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 enum E { X, Y }
 
@@ -868,9 +868,9 @@ fn main() {
     }
 
     #[test]
-    fn fill_match_arms_trivial_arm() {
+    fn add_missing_match_arms_trivial_arm() {
         check_assist(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 enum E { X, Y }
 
@@ -894,9 +894,9 @@ fn main() {
     }
 
     #[test]
-    fn fill_match_arms_qualifies_path() {
+    fn add_missing_match_arms_qualifies_path() {
         check_assist(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 mod foo { pub enum E { X, Y } }
 use foo::E::X;
@@ -922,9 +922,9 @@ fn main() {
     }
 
     #[test]
-    fn fill_match_arms_preserves_comments() {
+    fn add_missing_match_arms_preserves_comments() {
         check_assist(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 enum A { One, Two }
 fn foo(a: A) {
@@ -950,9 +950,9 @@ fn foo(a: A) {
     }
 
     #[test]
-    fn fill_match_arms_preserves_comments_empty() {
+    fn add_missing_match_arms_preserves_comments_empty() {
         check_assist(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 enum A { One, Two }
 fn foo(a: A) {
@@ -975,9 +975,9 @@ fn foo(a: A) {
     }
 
     #[test]
-    fn fill_match_arms_placeholder() {
+    fn add_missing_match_arms_placeholder() {
         check_assist(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 enum A { One, Two, }
 fn foo(a: A) {
@@ -1002,7 +1002,7 @@ fn foo(a: A) {
     fn option_order() {
         cov_mark::check!(option_order);
         check_assist(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 //- minicore: option
 fn foo(opt: Option<i32>) {
@@ -1024,7 +1024,7 @@ fn foo(opt: Option<i32>) {
     #[test]
     fn works_inside_macro_call() {
         check_assist(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 macro_rules! m { ($expr:expr) => {$expr}}
 enum Test {
@@ -1057,9 +1057,9 @@ fn foo(t: Test) {
     #[test]
     fn lazy_computation() {
         // Computing a single missing arm is enough to determine applicability of the assist.
-        cov_mark::check_count!(fill_match_arms_lazy_computation, 1);
+        cov_mark::check_count!(add_missing_match_arms_lazy_computation, 1);
         check_assist_unresolved(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 enum A { One, Two, }
 fn foo(tuple: (A, A)) {
@@ -1072,7 +1072,7 @@ fn foo(tuple: (A, A)) {
     #[test]
     fn adds_comma_before_new_arms() {
         check_assist(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 fn foo(t: bool) {
     match $0t {
@@ -1092,7 +1092,7 @@ fn foo(t: bool) {
     #[test]
     fn does_not_add_extra_comma() {
         check_assist(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 fn foo(t: bool) {
     match $0t {
@@ -1111,9 +1111,9 @@ fn foo(t: bool) {
 
     #[test]
     fn does_not_remove_catch_all_with_non_empty_expr() {
-        cov_mark::check!(fill_match_arms_empty_expr);
+        cov_mark::check!(add_missing_match_arms_empty_expr);
         check_assist(
-            fill_match_arms,
+            add_missing_match_arms,
             r#"
 fn foo(t: bool) {
     match $0t {

--- a/crates/ide_assists/src/handlers/add_return_type.rs
+++ b/crates/ide_assists/src/handlers/add_return_type.rs
@@ -3,7 +3,7 @@ use syntax::{ast, AstNode, TextRange, TextSize};
 
 use crate::{AssistContext, AssistId, AssistKind, Assists};
 
-// Assist: infer_function_return_type
+// Assist: add_return_type
 //
 // Adds the return type to a function or closure inferred from its tail expression if it doesn't have a return
 // type specified. This assists is useable in a functions or closures tail expression or return type position.
@@ -15,7 +15,7 @@ use crate::{AssistContext, AssistId, AssistKind, Assists};
 // ```
 // fn foo() -> i32 { 42i32 }
 // ```
-pub(crate) fn infer_function_return_type(acc: &mut Assists, ctx: &AssistContext) -> Option<()> {
+pub(crate) fn add_return_type(acc: &mut Assists, ctx: &AssistContext) -> Option<()> {
     let (fn_type, tail_expr, builder_edit_pos) = extract_tail(ctx)?;
     let module = ctx.sema.scope(tail_expr.syntax()).module()?;
     let ty = ctx.sema.type_of_expr(&tail_expr)?.adjusted();
@@ -25,7 +25,7 @@ pub(crate) fn infer_function_return_type(acc: &mut Assists, ctx: &AssistContext)
     let ty = ty.display_source_code(ctx.db(), module.into()).ok()?;
 
     acc.add(
-        AssistId("infer_function_return_type", AssistKind::RefactorRewrite),
+        AssistId("add_return_type", AssistKind::RefactorRewrite),
         match fn_type {
             FnType::Function => "Add this function's return type",
             FnType::Closure { .. } => "Add this closure's return type",
@@ -129,7 +129,7 @@ mod tests {
     fn infer_return_type_specified_inferred() {
         cov_mark::check!(existing_infer_ret_type);
         check_assist(
-            infer_function_return_type,
+            add_return_type,
             r#"fn foo() -> $0_ {
     45
 }"#,
@@ -143,7 +143,7 @@ mod tests {
     fn infer_return_type_specified_inferred_closure() {
         cov_mark::check!(existing_infer_ret_type_closure);
         check_assist(
-            infer_function_return_type,
+            add_return_type,
             r#"fn foo() {
     || -> _ {$045};
 }"#,
@@ -157,7 +157,7 @@ mod tests {
     fn infer_return_type_cursor_at_return_type_pos() {
         cov_mark::check!(cursor_in_ret_position);
         check_assist(
-            infer_function_return_type,
+            add_return_type,
             r#"fn foo() $0{
     45
 }"#,
@@ -171,7 +171,7 @@ mod tests {
     fn infer_return_type_cursor_at_return_type_pos_closure() {
         cov_mark::check!(cursor_in_ret_position_closure);
         check_assist(
-            infer_function_return_type,
+            add_return_type,
             r#"fn foo() {
     || $045
 }"#,
@@ -185,7 +185,7 @@ mod tests {
     fn infer_return_type() {
         cov_mark::check!(cursor_on_tail);
         check_assist(
-            infer_function_return_type,
+            add_return_type,
             r#"fn foo() {
     45$0
 }"#,
@@ -198,7 +198,7 @@ mod tests {
     #[test]
     fn infer_return_type_nested() {
         check_assist(
-            infer_function_return_type,
+            add_return_type,
             r#"fn foo() {
     if true {
         3$0
@@ -220,7 +220,7 @@ mod tests {
     fn not_applicable_ret_type_specified() {
         cov_mark::check!(existing_ret_type);
         check_assist_not_applicable(
-            infer_function_return_type,
+            add_return_type,
             r#"fn foo() -> i32 {
     ( 45$0 + 32 ) * 123
 }"#,
@@ -230,7 +230,7 @@ mod tests {
     #[test]
     fn not_applicable_non_tail_expr() {
         check_assist_not_applicable(
-            infer_function_return_type,
+            add_return_type,
             r#"fn foo() {
     let x = $03;
     ( 45 + 32 ) * 123
@@ -241,7 +241,7 @@ mod tests {
     #[test]
     fn not_applicable_unit_return_type() {
         check_assist_not_applicable(
-            infer_function_return_type,
+            add_return_type,
             r#"fn foo() {
     ($0)
 }"#,
@@ -252,7 +252,7 @@ mod tests {
     fn infer_return_type_closure_block() {
         cov_mark::check!(cursor_on_tail_closure);
         check_assist(
-            infer_function_return_type,
+            add_return_type,
             r#"fn foo() {
     |x: i32| {
         x$0
@@ -269,7 +269,7 @@ mod tests {
     #[test]
     fn infer_return_type_closure() {
         check_assist(
-            infer_function_return_type,
+            add_return_type,
             r#"fn foo() {
     |x: i32| { x$0 };
 }"#,
@@ -283,7 +283,7 @@ mod tests {
     fn infer_return_type_closure_wrap() {
         cov_mark::check!(wrap_closure_non_block_expr);
         check_assist(
-            infer_function_return_type,
+            add_return_type,
             r#"fn foo() {
     |x: i32| x$0;
 }"#,
@@ -296,7 +296,7 @@ mod tests {
     #[test]
     fn infer_return_type_nested_closure() {
         check_assist(
-            infer_function_return_type,
+            add_return_type,
             r#"fn foo() {
     || {
         if true {
@@ -322,7 +322,7 @@ mod tests {
     fn not_applicable_ret_type_specified_closure() {
         cov_mark::check!(existing_ret_type_closure);
         check_assist_not_applicable(
-            infer_function_return_type,
+            add_return_type,
             r#"fn foo() {
     || -> i32 { 3$0 }
 }"#,
@@ -332,7 +332,7 @@ mod tests {
     #[test]
     fn not_applicable_non_tail_expr_closure() {
         check_assist_not_applicable(
-            infer_function_return_type,
+            add_return_type,
             r#"fn foo() {
     || -> i32 {
         let x = 3$0;

--- a/crates/ide_assists/src/handlers/introduce_named_generic.rs
+++ b/crates/ide_assists/src/handlers/introduce_named_generic.rs
@@ -5,7 +5,7 @@ use syntax::{
 
 use crate::{utils::suggest_name, AssistContext, AssistId, AssistKind, Assists};
 
-// Assist: replace_impl_trait_with_generic
+// Assist: introduce_named_generic
 //
 // Replaces `impl Trait` function argument with the named generic.
 //
@@ -16,10 +16,7 @@ use crate::{utils::suggest_name, AssistContext, AssistId, AssistKind, Assists};
 // ```
 // fn foo<B: Bar>(bar: B) {}
 // ```
-pub(crate) fn replace_impl_trait_with_generic(
-    acc: &mut Assists,
-    ctx: &AssistContext,
-) -> Option<()> {
+pub(crate) fn introduce_named_generic(acc: &mut Assists, ctx: &AssistContext) -> Option<()> {
     let impl_trait_type = ctx.find_node_at_offset::<ast::ImplTraitType>()?;
     let param = impl_trait_type.syntax().parent().and_then(ast::Param::cast)?;
     let fn_ = param.syntax().ancestors().find_map(ast::Fn::cast)?;
@@ -28,7 +25,7 @@ pub(crate) fn replace_impl_trait_with_generic(
 
     let target = fn_.syntax().text_range();
     acc.add(
-        AssistId("replace_impl_trait_with_generic", AssistKind::RefactorRewrite),
+        AssistId("introduce_named_generic", AssistKind::RefactorRewrite),
         "Replace impl trait with generic",
         target,
         |edit| {
@@ -54,9 +51,9 @@ mod tests {
     use crate::tests::check_assist;
 
     #[test]
-    fn replace_impl_trait_with_generic_params() {
+    fn introduce_named_generic_params() {
         check_assist(
-            replace_impl_trait_with_generic,
+            introduce_named_generic,
             r#"fn foo<G>(bar: $0impl Bar) {}"#,
             r#"fn foo<G, B: Bar>(bar: B) {}"#,
         );
@@ -65,7 +62,7 @@ mod tests {
     #[test]
     fn replace_impl_trait_without_generic_params() {
         check_assist(
-            replace_impl_trait_with_generic,
+            introduce_named_generic,
             r#"fn foo(bar: $0impl Bar) {}"#,
             r#"fn foo<B: Bar>(bar: B) {}"#,
         );
@@ -74,7 +71,7 @@ mod tests {
     #[test]
     fn replace_two_impl_trait_with_generic_params() {
         check_assist(
-            replace_impl_trait_with_generic,
+            introduce_named_generic,
             r#"fn foo<G>(foo: impl Foo, bar: $0impl Bar) {}"#,
             r#"fn foo<G, B: Bar>(foo: impl Foo, bar: B) {}"#,
         );
@@ -83,7 +80,7 @@ mod tests {
     #[test]
     fn replace_impl_trait_with_empty_generic_params() {
         check_assist(
-            replace_impl_trait_with_generic,
+            introduce_named_generic,
             r#"fn foo<>(bar: $0impl Bar) {}"#,
             r#"fn foo<B: Bar>(bar: B) {}"#,
         );
@@ -92,7 +89,7 @@ mod tests {
     #[test]
     fn replace_impl_trait_with_empty_multiline_generic_params() {
         check_assist(
-            replace_impl_trait_with_generic,
+            introduce_named_generic,
             r#"
 fn foo<
 >(bar: $0impl Bar) {}
@@ -109,7 +106,7 @@ fn foo<B: Bar
         // FIXME: This is wrong, we should pick a different name if the one we
         // want is already bound.
         check_assist(
-            replace_impl_trait_with_generic,
+            introduce_named_generic,
             r#"fn foo<B>(bar: $0impl Bar) {}"#,
             r#"fn foo<B, B: Bar>(bar: B) {}"#,
         );
@@ -118,7 +115,7 @@ fn foo<B: Bar
     #[test]
     fn replace_impl_trait_with_multiline_generic_params() {
         check_assist(
-            replace_impl_trait_with_generic,
+            introduce_named_generic,
             r#"
 fn foo<
     G: Foo,
@@ -139,7 +136,7 @@ fn foo<
     #[test]
     fn replace_impl_trait_multiple() {
         check_assist(
-            replace_impl_trait_with_generic,
+            introduce_named_generic,
             r#"fn foo(bar: $0impl Foo + Bar) {}"#,
             r#"fn foo<F: Foo + Bar>(bar: F) {}"#,
         );

--- a/crates/ide_assists/src/lib.rs
+++ b/crates/ide_assists/src/lib.rs
@@ -125,7 +125,7 @@ mod handlers {
     mod extract_struct_from_enum_variant;
     mod extract_type_alias;
     mod extract_variable;
-    mod fill_match_arms;
+    mod add_missing_match_arms;
     mod fix_visibility;
     mod flip_binexpr;
     mod flip_comma;
@@ -143,7 +143,7 @@ mod handlers {
     mod generate_is_empty_from_len;
     mod generate_new;
     mod generate_setter;
-    mod infer_function_return_type;
+    mod add_return_type;
     mod inline_call;
     mod inline_local_variable;
     mod introduce_named_lifetime;
@@ -164,7 +164,7 @@ mod handlers {
     mod replace_derive_with_manual_impl;
     mod replace_for_loop_with_for_each;
     mod replace_if_let_with_match;
-    mod replace_impl_trait_with_generic;
+    mod introduce_named_generic;
     mod replace_let_with_if_let;
     mod replace_qualified_name_with_use;
     mod replace_string_with_char;
@@ -179,7 +179,9 @@ mod handlers {
         &[
             // These are alphabetic for the foolish consistency
             add_explicit_type::add_explicit_type,
+            add_missing_match_arms::add_missing_match_arms,
             add_lifetime_to_type::add_lifetime_to_type,
+            add_return_type::add_return_type,
             add_turbo_fish::add_turbo_fish,
             apply_demorgan::apply_demorgan,
             auto_import::auto_import,
@@ -197,7 +199,6 @@ mod handlers {
             expand_glob_import::expand_glob_import,
             extract_struct_from_enum_variant::extract_struct_from_enum_variant,
             extract_type_alias::extract_type_alias,
-            fill_match_arms::fill_match_arms,
             fix_visibility::fix_visibility,
             flip_binexpr::flip_binexpr,
             flip_comma::flip_comma,
@@ -214,9 +215,9 @@ mod handlers {
             generate_impl::generate_impl,
             generate_is_empty_from_len::generate_is_empty_from_len,
             generate_new::generate_new,
-            infer_function_return_type::infer_function_return_type,
             inline_call::inline_call,
             inline_local_variable::inline_local_variable,
+            introduce_named_generic::introduce_named_generic,
             introduce_named_lifetime::introduce_named_lifetime,
             invert_if::invert_if,
             merge_imports::merge_imports,
@@ -239,7 +240,6 @@ mod handlers {
             replace_for_loop_with_for_each::replace_for_loop_with_for_each,
             replace_if_let_with_match::replace_if_let_with_match,
             replace_if_let_with_match::replace_match_with_if_let,
-            replace_impl_trait_with_generic::replace_impl_trait_with_generic,
             replace_let_with_if_let::replace_let_with_if_let,
             replace_qualified_name_with_use::replace_qualified_name_with_use,
             sort_items::sort_items,

--- a/crates/ide_assists/src/tests/generated.rs
+++ b/crates/ide_assists/src/tests/generated.rs
@@ -122,6 +122,45 @@ struct Point<'a> {
 }
 
 #[test]
+fn doctest_add_missing_match_arms() {
+    check_doc_test(
+        "add_missing_match_arms",
+        r#####"
+enum Action { Move { distance: u32 }, Stop }
+
+fn handle(action: Action) {
+    match action {
+        $0
+    }
+}
+"#####,
+        r#####"
+enum Action { Move { distance: u32 }, Stop }
+
+fn handle(action: Action) {
+    match action {
+        $0Action::Move { distance } => todo!(),
+        Action::Stop => todo!(),
+    }
+}
+"#####,
+    )
+}
+
+#[test]
+fn doctest_add_return_type() {
+    check_doc_test(
+        "add_return_type",
+        r#####"
+fn foo() { 4$02i32 }
+"#####,
+        r#####"
+fn foo() -> i32 { 42i32 }
+"#####,
+    )
+}
+
+#[test]
 fn doctest_add_turbo_fish() {
     check_doc_test(
         "add_turbo_fish",
@@ -511,32 +550,6 @@ fn main() {
 fn main() {
     let $0var_name = (1 + 2);
     var_name * 4;
-}
-"#####,
-    )
-}
-
-#[test]
-fn doctest_fill_match_arms() {
-    check_doc_test(
-        "fill_match_arms",
-        r#####"
-enum Action { Move { distance: u32 }, Stop }
-
-fn handle(action: Action) {
-    match action {
-        $0
-    }
-}
-"#####,
-        r#####"
-enum Action { Move { distance: u32 }, Stop }
-
-fn handle(action: Action) {
-    match action {
-        $0Action::Move { distance } => todo!(),
-        Action::Stop => todo!(),
-    }
 }
 "#####,
     )
@@ -995,19 +1008,6 @@ impl Person {
 }
 
 #[test]
-fn doctest_infer_function_return_type() {
-    check_doc_test(
-        "infer_function_return_type",
-        r#####"
-fn foo() { 4$02i32 }
-"#####,
-        r#####"
-fn foo() -> i32 { 42i32 }
-"#####,
-    )
-}
-
-#[test]
 fn doctest_inline_call() {
     check_doc_test(
         "inline_call",
@@ -1042,6 +1042,19 @@ fn main() {
 fn main() {
     (1 + 2) * 4;
 }
+"#####,
+    )
+}
+
+#[test]
+fn doctest_introduce_named_generic() {
+    check_doc_test(
+        "introduce_named_generic",
+        r#####"
+fn foo(bar: $0impl Bar) {}
+"#####,
+        r#####"
+fn foo<B: Bar>(bar: B) {}
 "#####,
     )
 }
@@ -1524,19 +1537,6 @@ fn handle(action: Action) {
         _ => bar(),
     }
 }
-"#####,
-    )
-}
-
-#[test]
-fn doctest_replace_impl_trait_with_generic() {
-    check_doc_test(
-        "replace_impl_trait_with_generic",
-        r#####"
-fn foo(bar: $0impl Bar) {}
-"#####,
-        r#####"
-fn foo<B: Bar>(bar: B) {}
 "#####,
     )
 }

--- a/crates/rust-analyzer/tests/slow-tests/tidy.rs
+++ b/crates/rust-analyzer/tests/slow-tests/tidy.rs
@@ -273,7 +273,7 @@ fn check_todo(path: &Path, text: &str) {
         // Some of our assists generate `todo!()`.
         "handlers/add_turbo_fish.rs",
         "handlers/generate_function.rs",
-        "handlers/fill_match_arms.rs",
+        "handlers/add_missing_match_arms.rs",
         "handlers/replace_derive_with_manual_impl.rs",
         // To support generating `todo!()` in assists, we have `expr_todo()` in
         // `ast::make`.


### PR DESCRIPTION
Trying to make our assist names a bit more uniform
`fill_match_arms` -> `add_missing_match_arms`
`infer_function_return_type` -> `add_return_type`
`replace_impl_trait_with_generic` -> `introduce_named_generic`
bors r+