### PR TITLE
Mark large benchmark data files as binary to filter greps

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,6 @@
 * text=auto eol=lf
+# git grep shouldn't match entries in this benchmark data
+bench_data/** binary
 crates/syntax/test_data/** -text eof=LF
 # Older git versions try to fix line endings on images, this prevents it.
 *.png binary


### PR DESCRIPTION
When doing a git grep (of rust-analyzer or of rust-lang/rust with
--recurse-submodules), if the grep happens to match within the large
benchmark data files, the resulting long single lines can cause a text
pager or editor to slow down and distract from more useful matches.

These test data files aren't formatted for human consumption, so mark
them as binary, which causes git grep to instead just state that they
match without printing the matching "line".