### PR TITLE
Fix title of User Manual page

### DIFF
--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -1,5 +1,3 @@
-// IMPORTANT: the master copy of this document lives in the https://github.com/rust-analyzer/rust-analyzer repository
-
 = User Manual
 :toc: preamble
 :sectanchors:
@@ -7,6 +5,10 @@
 :icons: font
 :source-highlighter: rouge
 :experimental:
+
+////
+IMPORTANT: the master copy of this document lives in the https://github.com/rust-analyzer/rust-analyzer repository
+////
 
 At its core, rust-analyzer is a *library* for semantic analysis of Rust code as it changes over time.
 This manual focuses on a specific usage of the library -- running it as part of a server that implements the


### PR DESCRIPTION
Asciidoc uses the first line of a doc as the title, so you can't put
comments before the heading.

---
I had an old copy of the Manual page open and I noticed that the "User Manual" heading (and page title) had disappeared in the live version:

![image](https://user-images.githubusercontent.com/2858750/134455658-3885b754-9eae-4dca-a6d4-4b1453910850.png)

With this change (and how it was a few days ago):

![image](https://user-images.githubusercontent.com/2858750/134455865-5acc7538-ccf8-4346-941f-3a5561b3181e.png)
