### PR TITLE
fix: Change the global setting when toggling inlay hints

### DIFF
--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -292,7 +292,7 @@ export function toggleInlayHints(ctx: Ctx): Cmd {
         await vscode
             .workspace
             .getConfiguration(`${ctx.config.rootSection}.inlayHints`)
-            .update('enable', !ctx.config.inlayHints.enable, vscode.ConfigurationTarget.Workspace);
+            .update('enable', !ctx.config.inlayHints.enable, vscode.ConfigurationTarget.Global);
     };
 }
 


### PR DESCRIPTION
Closes #10318