### PR TITLE
minor: Allow overwriting RUST_BACKTRACE for the server manually

### DIFF
--- a/crates/rust-analyzer/src/bin/main.rs
+++ b/crates/rust-analyzer/src/bin/main.rs
@@ -92,7 +92,9 @@ fn try_main() -> Result<()> {
 }
 
 fn setup_logging(log_file: Option<&Path>) -> Result<()> {
-    env::set_var("RUST_BACKTRACE", "short");
+    if env::var("RUST_BACKTRACE").is_err() {
+        env::set_var("RUST_BACKTRACE", "short");
+    }
 
     let log_file = match log_file {
         Some(path) => {


### PR DESCRIPTION
Trying to figure out why we aren't getting backtraces for windows builds from CI, this let's one set the backtraces to `FULL`
Might be cc https://github.com/rust-lang/rust/issues/87481
bors r+