### PR TITLE
Give rustfmt spawn error context.

### DIFF
--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -7,6 +7,7 @@ use std::{
     process::{self, Stdio},
 };
 
+use anyhow::Context;
 use ide::{
     AnnotationConfig, AssistKind, AssistResolveStrategy, FileId, FilePosition, FileRange,
     HoverAction, HoverGotoTypeData, Query, RangeInfo, Runnable, RunnableKind, SingleResolve,
@@ -1696,8 +1697,12 @@ fn run_rustfmt(
         }
     };
 
-    let mut rustfmt =
-        rustfmt.stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::piped()).spawn()?;
+    let mut rustfmt = rustfmt
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context(format!("Failed to spawn {:?}", rustfmt))?;
 
     rustfmt.stdin.as_mut().unwrap().write_all(file.as_bytes())?;
 


### PR DESCRIPTION
This mean if you misconfigure to

```json
{
    "rust-analyzer.rustfmt.overrideCommand": [
        "./nonono"
    ]
}
```

The error message is

```
[Error - 17:54:33] Request textDocument/formatting failed.
  Message: Failed to spawn "./nonono"
  Code: -32603 
```

instead of

```
[Error - 17:56:12] Request textDocument/formatting failed.
  Message: No such file or directory (os error 2)
  Code: -32603 
```

I'm not sure how to test this, or if it needs a test.