### PR TITLE
fix: Fix item-level macro errors (eg. `compile_error!`)

### DIFF
--- a/crates/hir_def/src/lib.rs
+++ b/crates/hir_def/src/lib.rs
@@ -733,7 +733,6 @@ fn macro_call_as_call_id(
             &|path: ast::Path| resolver(path::ModPath::from_src(db, path, &hygiene)?),
             error_sink,
         )
-        .map(MacroCallId::from)
     } else {
         Ok(def.as_lazy_macro(
             db.upcast(),

--- a/crates/hir_def/src/nameres/collector.rs
+++ b/crates/hir_def/src/nameres/collector.rs
@@ -1939,17 +1939,22 @@ impl ModCollector<'_, '_> {
                     self.macro_depth + 1,
                 );
 
+                if let Some(err) = error {
+                    self.def_collector.def_map.diagnostics.push(DefDiagnostic::macro_error(
+                        self.module_id,
+                        MacroCallKind::FnLike { ast_id: ast_id.ast_id, expand_to: mac.expand_to },
+                        err.to_string(),
+                    ));
+                }
+
                 return;
             }
             Ok(Err(_)) => {
                 // Built-in macro failed eager expansion.
 
-                // FIXME: don't parse the file here
-                let macro_call = ast_id.ast_id.to_node(self.def_collector.db.upcast());
-                let expand_to = hir_expand::ExpandTo::from_call_site(&macro_call);
                 self.def_collector.def_map.diagnostics.push(DefDiagnostic::macro_error(
                     self.module_id,
-                    MacroCallKind::FnLike { ast_id: ast_id.ast_id, expand_to },
+                    MacroCallKind::FnLike { ast_id: ast_id.ast_id, expand_to: mac.expand_to },
                     error.unwrap().to_string(),
                 ));
                 return;

--- a/crates/ide_diagnostics/src/handlers/macro_error.rs
+++ b/crates/ide_diagnostics/src/handlers/macro_error.rs
@@ -26,8 +26,14 @@ mod tests {
 #[rustc_builtin_macro]
 macro_rules! include { () => {} }
 
+#[rustc_builtin_macro]
+macro_rules! compile_error { () => {} }
+
   include!("doesntexist");
 //^^^^^^^^^^^^^^^^^^^^^^^^ error: failed to load file `doesntexist`
+
+  compile_error!("compile_error macro works");
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: compile_error macro works
             "#,
         );
     }


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/8459

bors r+