### PR TITLE
internal: fix and force-disable block validation ;-(

### DIFF
--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -162,10 +162,6 @@ impl SourceFile {
         let (green, mut errors) = parsing::parse_text(text);
         let root = SyntaxNode::new_root(green.clone());
 
-        if cfg!(debug_assertions) {
-            validation::validate_block_structure(&root);
-        }
-
         errors.extend(validation::validate(&root));
 
         assert_eq!(root.kind(), SyntaxKind::SOURCE_FILE);

--- a/crates/syntax/src/syntax_node.rs
+++ b/crates/syntax/src/syntax_node.rs
@@ -47,7 +47,7 @@ impl SyntaxTreeBuilder {
 
     pub fn finish(self) -> Parse<SyntaxNode> {
         let (green, errors) = self.finish_raw();
-        if cfg!(debug_assertions) {
+        if cfg!(debug_assertions) && false {
             let node = SyntaxNode::new_root(green.clone());
             crate::validation::validate_block_structure(&node);
         }

--- a/crates/syntax/src/validation.rs
+++ b/crates/syntax/src/validation.rs
@@ -170,7 +170,7 @@ fn validate_literal(literal: ast::Literal, acc: &mut Vec<SyntaxError>) {
 
 pub(crate) fn validate_block_structure(root: &SyntaxNode) {
     let mut stack = Vec::new();
-    for node in root.descendants() {
+    for node in root.descendants_with_tokens() {
         match node.kind() {
             T!['{'] => stack.push(node),
             T!['}'] => {
@@ -183,11 +183,12 @@ pub(crate) fn validate_block_structure(root: &SyntaxNode) {
                         root,
                     );
                     assert!(
-                        node.next_sibling().is_none() && pair.prev_sibling().is_none(),
+                        node.next_sibling_or_token().is_none()
+                            && pair.prev_sibling_or_token().is_none(),
                         "\nfloating curlys at {:?}\nfile:\n{}\nerror:\n{}\n",
                         node,
                         root.text(),
-                        node.text(),
+                        node,
                     );
                 }
             }


### PR DESCRIPTION
Originally we tried to maintain the invariant that `{}` always match.
That is, that in the parse tree the pair of corresponding `{}` is always
first and last tokens of some nodes.

We had the code to validate that, but apparently it's been broken for
**years** since we introduced tokens/nodes split. Fixing it now makes
some tests fail.

It's unclear if we want to keep this invariant: there's a strong
motivation for breaking it in the following case:

```
use std::{ // unclosed paren

fn main() {

}

} // don't actually want to pair up this with the one from `use`
```

So let's fix the code, but disable it for the time being

bors r+
🤖