### PR TITLE
fix: `into_iterator` not completed on `Vec<{unknown}>`

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2601,9 +2601,7 @@ impl Type {
     ) {
         // There should be no inference vars in types passed here
         // FIXME check that?
-        // FIXME replace Unknown by bound vars here
-        let canonical =
-            Canonical { value: self.ty.clone(), binders: CanonicalVarKinds::empty(&Interner) };
+        let canonical = hir_ty::replace_errors_with_variables(&self.ty);
 
         let env = self.env.clone();
         let krate = krate.id;

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2504,9 +2504,8 @@ impl Type {
 
     pub fn autoderef<'a>(&'a self, db: &'a dyn HirDatabase) -> impl Iterator<Item = Type> + 'a {
         // There should be no inference vars in types passed here
-        // FIXME check that?
-        let canonical =
-            Canonical { value: self.ty.clone(), binders: CanonicalVarKinds::empty(&Interner) };
+        let ty = hir_ty::replace_errors_with_variables(&self.ty).value;
+        let canonical = Canonical { value: ty, binders: CanonicalVarKinds::empty(&Interner) };
         let environment = self.env.env.clone();
         let ty = InEnvironment { goal: canonical, environment };
         autoderef(db, Some(self.krate), ty)
@@ -2600,7 +2599,6 @@ impl Type {
         callback: &mut dyn FnMut(&Ty, AssocItemId) -> ControlFlow<()>,
     ) {
         // There should be no inference vars in types passed here
-        // FIXME check that?
         let canonical = hir_ty::replace_errors_with_variables(&self.ty);
 
         let env = self.env.clone();

--- a/crates/ide_completion/src/completions/dot.rs
+++ b/crates/ide_completion/src/completions/dot.rs
@@ -697,4 +697,26 @@ fn f() {
             "#]],
         );
     }
+
+    #[test]
+    fn completes_method_call_when_receiver_type_has_errors_issue_10297() {
+        check(
+            r#"
+//- minicore: iterator, sized
+struct Vec<T>;
+impl<T> IntoIterator for Vec<T> {
+    type Item = ();
+    type IntoIter = ();
+    fn into_iter(self);
+}
+fn main() {
+    let x: Vec<_>;
+    x.$0;
+}
+"#,
+            expect![[r#"
+                me into_iter() (as IntoIterator) fn(self) -> <Self as IntoIterator>::IntoIter
+            "#]],
+        )
+    }
 }


### PR DESCRIPTION
Fixes  #10297 