### PR TITLE
fix: Make `stringify!` insert/collapse whitespace when needed

### DIFF
--- a/crates/hir_expand/src/lib.rs
+++ b/crates/hir_expand/src/lib.rs
@@ -26,7 +26,7 @@ use base_db::{impl_intern_key, salsa, CrateId, FileId, FileRange};
 use syntax::{
     algo::skip_trivia_token,
     ast::{self, AstNode, HasAttrs},
-    Direction, SyntaxNode, SyntaxToken, TextRange, TextSize,
+    Direction, SyntaxNode, SyntaxToken, TextRange,
 };
 
 use crate::{

--- a/crates/proc_macro_srv/src/abis/abi_1_47/rustc_server.rs
+++ b/crates/proc_macro_srv/src/abis/abi_1_47/rustc_server.rs
@@ -199,44 +199,7 @@ pub mod token_stream {
 
     impl ToString for TokenStream {
         fn to_string(&self) -> String {
-            return tokentrees_to_text(&self.token_trees[..]);
-
-            fn tokentrees_to_text(tkns: &[tt::TokenTree]) -> String {
-                tkns.iter()
-                    .fold((String::new(), true), |(last, last_to_joint), tkn| {
-                        let s = [last, tokentree_to_text(tkn)].join(if last_to_joint {
-                            ""
-                        } else {
-                            " "
-                        });
-                        let mut is_joint = false;
-                        if let tt::TokenTree::Leaf(tt::Leaf::Punct(punct)) = tkn {
-                            if punct.spacing == tt::Spacing::Joint {
-                                is_joint = true;
-                            }
-                        }
-                        (s, is_joint)
-                    })
-                    .0
-            }
-
-            fn tokentree_to_text(tkn: &tt::TokenTree) -> String {
-                match tkn {
-                    tt::TokenTree::Leaf(tt::Leaf::Ident(ident)) => ident.text.clone().into(),
-                    tt::TokenTree::Leaf(tt::Leaf::Literal(literal)) => literal.text.clone().into(),
-                    tt::TokenTree::Leaf(tt::Leaf::Punct(punct)) => format!("{}", punct.char),
-                    tt::TokenTree::Subtree(subtree) => {
-                        let content = tokentrees_to_text(&subtree.token_trees);
-                        let (open, close) = match subtree.delimiter.map(|it| it.kind) {
-                            None => ("", ""),
-                            Some(tt::DelimiterKind::Brace) => ("{", "}"),
-                            Some(tt::DelimiterKind::Parenthesis) => ("(", ")"),
-                            Some(tt::DelimiterKind::Bracket) => ("[", "]"),
-                        };
-                        format!("{}{}{}", open, content, close)
-                    }
-                }
-            }
+            tt::pretty(&self.token_trees)
         }
     }
 

--- a/crates/proc_macro_srv/src/abis/abi_1_55/rustc_server.rs
+++ b/crates/proc_macro_srv/src/abis/abi_1_55/rustc_server.rs
@@ -199,44 +199,7 @@ pub mod token_stream {
 
     impl ToString for TokenStream {
         fn to_string(&self) -> String {
-            return tokentrees_to_text(&self.token_trees[..]);
-
-            fn tokentrees_to_text(tkns: &[tt::TokenTree]) -> String {
-                tkns.iter()
-                    .fold((String::new(), true), |(last, last_to_joint), tkn| {
-                        let s = [last, tokentree_to_text(tkn)].join(if last_to_joint {
-                            ""
-                        } else {
-                            " "
-                        });
-                        let mut is_joint = false;
-                        if let tt::TokenTree::Leaf(tt::Leaf::Punct(punct)) = tkn {
-                            if punct.spacing == tt::Spacing::Joint {
-                                is_joint = true;
-                            }
-                        }
-                        (s, is_joint)
-                    })
-                    .0
-            }
-
-            fn tokentree_to_text(tkn: &tt::TokenTree) -> String {
-                match tkn {
-                    tt::TokenTree::Leaf(tt::Leaf::Ident(ident)) => ident.text.clone().into(),
-                    tt::TokenTree::Leaf(tt::Leaf::Literal(literal)) => literal.text.clone().into(),
-                    tt::TokenTree::Leaf(tt::Leaf::Punct(punct)) => format!("{}", punct.char),
-                    tt::TokenTree::Subtree(subtree) => {
-                        let content = tokentrees_to_text(&subtree.token_trees);
-                        let (open, close) = match subtree.delimiter.map(|it| it.kind) {
-                            None => ("", ""),
-                            Some(tt::DelimiterKind::Brace) => ("{", "}"),
-                            Some(tt::DelimiterKind::Parenthesis) => ("(", ")"),
-                            Some(tt::DelimiterKind::Bracket) => ("[", "]"),
-                        };
-                        format!("{}{}{}", open, content, close)
-                    }
-                }
-            }
+            tt::pretty(&self.token_trees)
         }
     }
 

--- a/crates/proc_macro_srv/src/abis/abi_1_56/rustc_server.rs
+++ b/crates/proc_macro_srv/src/abis/abi_1_56/rustc_server.rs
@@ -199,44 +199,7 @@ pub mod token_stream {
 
     impl ToString for TokenStream {
         fn to_string(&self) -> String {
-            return tokentrees_to_text(&self.token_trees[..]);
-
-            fn tokentrees_to_text(tkns: &[tt::TokenTree]) -> String {
-                tkns.iter()
-                    .fold((String::new(), true), |(last, last_to_joint), tkn| {
-                        let s = [last, tokentree_to_text(tkn)].join(if last_to_joint {
-                            ""
-                        } else {
-                            " "
-                        });
-                        let mut is_joint = false;
-                        if let tt::TokenTree::Leaf(tt::Leaf::Punct(punct)) = tkn {
-                            if punct.spacing == tt::Spacing::Joint {
-                                is_joint = true;
-                            }
-                        }
-                        (s, is_joint)
-                    })
-                    .0
-            }
-
-            fn tokentree_to_text(tkn: &tt::TokenTree) -> String {
-                match tkn {
-                    tt::TokenTree::Leaf(tt::Leaf::Ident(ident)) => ident.text.clone().into(),
-                    tt::TokenTree::Leaf(tt::Leaf::Literal(literal)) => literal.text.clone().into(),
-                    tt::TokenTree::Leaf(tt::Leaf::Punct(punct)) => format!("{}", punct.char),
-                    tt::TokenTree::Subtree(subtree) => {
-                        let content = tokentrees_to_text(&subtree.token_trees);
-                        let (open, close) = match subtree.delimiter.map(|it| it.kind) {
-                            None => ("", ""),
-                            Some(tt::DelimiterKind::Brace) => ("{", "}"),
-                            Some(tt::DelimiterKind::Parenthesis) => ("(", ")"),
-                            Some(tt::DelimiterKind::Bracket) => ("[", "]"),
-                        };
-                        format!("{}{}{}", open, content, close)
-                    }
-                }
-            }
+            tt::pretty(&self.token_trees)
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/10365

Unlike rustc, we don't insert newlines, but that should be fine.

bors r+