### PR TITLE
feat: Add vscode native onEnterRules

### DIFF
--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -63,6 +63,8 @@ async function tryActivate(context: vscode.ExtensionContext) {
     activateInlayHints(ctx);
     warnAboutExtensionConflicts();
 
+    ctx.pushCleanup(configureLanguage());
+
     vscode.workspace.onDidChangeConfiguration(
         _ => ctx?.client?.sendNotification('workspace/didChangeConfiguration', { settings: "" }),
         null,
@@ -473,4 +475,55 @@ function warnAboutExtensionConflicts() {
             "both plugins to not work correctly. You should disable one of them.", "Got it")
             .then(() => { }, console.error);
     };
+}
+
+/**
+ * Sets up additional language configuration that's impossible to do via a
+ * separate language-configuration.json file. See [1] for more information.
+ *
+ * [1]: https://github.com/Microsoft/vscode/issues/11514#issuecomment-244707076
+ */
+function configureLanguage(): vscode.Disposable {
+    const indentAction = vscode.IndentAction.None;
+    return vscode.languages.setLanguageConfiguration('rust', {
+        onEnterRules: [
+            {
+                // Doc single-line comment
+                // e.g. ///|
+                beforeText: /^\s*\/{3}.*$/,
+                action: { indentAction, appendText: '/// ' },
+            },
+            {
+                // Parent doc single-line comment
+                // e.g. //!|
+                beforeText: /^\s*\/{2}\!.*$/,
+                action: { indentAction, appendText: '//! ' },
+            },
+            {
+                // Begins an auto-closed multi-line comment (standard or parent doc)
+                // e.g. /** | */ or /*! | */
+                beforeText: /^\s*\/\*(\*|\!)(?!\/)([^\*]|\*(?!\/))*$/,
+                afterText: /^\s*\*\/$/,
+                action: { indentAction: vscode.IndentAction.IndentOutdent, appendText: ' * ' },
+            },
+            {
+                // Begins a multi-line comment (standard or parent doc)
+                // e.g. /** ...| or /*! ...|
+                beforeText: /^\s*\/\*(\*|\!)(?!\/)([^\*]|\*(?!\/))*$/,
+                action: { indentAction, appendText: ' * ' },
+            },
+            {
+                // Continues a multi-line comment
+                // e.g.  * ...|
+                beforeText: /^(\ \ )*\ \*(\ ([^\*]|\*(?!\/))*)?$/,
+                action: { indentAction, appendText: '* ' },
+            },
+            {
+                // Dedents after closing a multi-line comment
+                // e.g.  */|
+                beforeText: /^(\ \ )*\ \*\/\s*$/,
+                action: { indentAction, removeText: 1 },
+            },
+        ],
+    });
 }


### PR DESCRIPTION
This PR copy onEnterRules configurations [from vscode-rust](https://github.com/rust-lang/vscode-rust/blob/master/src/extension.ts#L287) based on discussion in #6254 

I understand that the ideal way is to use parser data for this, and probably all other things that language-config do. But since it can't be enabled (or at least it isn't enabled) by default in vscode, I think this is needed (until onEnter becomes official LSP and get vscode support).

People can still configure shortcut and use the parser based onEnter, so it wouldn't harm anyone.
