### PR TITLE
fix: use the right `HirFileId` when expanding macros in fn parameters

### DIFF
--- a/crates/hir_def/src/generics.rs
+++ b/crates/hir_def/src/generics.rs
@@ -299,7 +299,7 @@ impl GenericParams {
                 let macro_call = mc.to_node(db.upcast());
                 match expander.enter_expand::<ast::Type>(db, macro_call) {
                     Ok(ExpandResult { value: Some((mark, expanded)), .. }) => {
-                        let ctx = LowerCtx::new(db, mc.file_id);
+                        let ctx = LowerCtx::new(db, expander.current_file_id());
                         let type_ref = TypeRef::from_ast(&ctx, expanded);
                         self.fill_implicit_impl_trait_args(db, expander, &type_ref);
                         expander.exit(db, mark);

--- a/crates/hir_ty/src/tests/regression.rs
+++ b/crates/hir_ty/src/tests/regression.rs
@@ -1198,3 +1198,26 @@ fn bar() {
     "#,
     )
 }
+
+#[test]
+fn nested_macro_in_fn_params() {
+    check_no_mismatches(
+        r#"
+macro_rules! U32Inner {
+    () => {
+        u32
+    };
+}
+
+macro_rules! U32 {
+    () => {
+        U32Inner!()
+    };
+}
+
+fn mamba(a: U32!(), p: u32) -> u32 {
+    a
+}
+    "#,
+    )
+}


### PR DESCRIPTION
Fixes #10388