### PR TITLE
Add pub(super) along with pub(crate) and pub as a completion keyword

### DIFF
--- a/crates/ide_completion/src/completions/keyword.rs
+++ b/crates/ide_completion/src/completions/keyword.rs
@@ -64,6 +64,7 @@ pub(crate) fn complete_expr_keyword(acc: &mut Completions, ctx: &CompletionConte
         && (expects_item || ctx.expects_non_trait_assoc_item() || ctx.expect_field())
     {
         add_keyword("pub(crate)", "pub(crate)");
+        add_keyword("pub(super)", "pub(super)");
         add_keyword("pub", "pub");
     }
 

--- a/crates/ide_completion/src/tests/item.rs
+++ b/crates/ide_completion/src/tests/item.rs
@@ -87,6 +87,7 @@ fn after_struct_name() {
         r"struct Struct $0",
         expect![[r##"
             kw pub(crate)
+            kw pub(super)
             kw pub
             kw unsafe
             kw fn
@@ -120,6 +121,7 @@ fn after_fn_name() {
         r"fn func() $0",
         expect![[r##"
             kw pub(crate)
+            kw pub(super)
             kw pub
             kw unsafe
             kw fn
@@ -157,6 +159,7 @@ struct Foo {
 "#,
         expect![[r#"
             kw pub(crate)
+            kw pub(super)
             kw pub
         "#]],
     )

--- a/crates/ide_completion/src/tests/item_list.rs
+++ b/crates/ide_completion/src/tests/item_list.rs
@@ -14,6 +14,7 @@ fn in_mod_item_list() {
         r#"mod tests { $0 }"#,
         expect![[r##"
             kw pub(crate)
+            kw pub(super)
             kw pub
             kw unsafe
             kw fn
@@ -45,6 +46,7 @@ fn in_source_file_item_list() {
         r#"$0"#,
         expect![[r##"
             kw pub(crate)
+            kw pub(super)
             kw pub
             kw unsafe
             kw fn
@@ -77,6 +79,7 @@ fn in_item_list_after_attr() {
         r#"#[attr] $0"#,
         expect![[r#"
             kw pub(crate)
+            kw pub(super)
             kw pub
             kw unsafe
             kw fn
@@ -161,6 +164,7 @@ fn in_impl_assoc_item_list() {
         r#"impl Struct { $0 }"#,
         expect![[r##"
             kw pub(crate)
+            kw pub(super)
             kw pub
             kw unsafe
             kw fn
@@ -181,6 +185,7 @@ fn in_impl_assoc_item_list_after_attr() {
         r#"impl Struct { #[attr] $0 }"#,
         expect![[r#"
             kw pub(crate)
+            kw pub(super)
             kw pub
             kw unsafe
             kw fn
@@ -230,6 +235,7 @@ impl Test for () {
 "#,
         expect![[r##"
             kw pub(crate)
+            kw pub(super)
             kw pub
             kw unsafe
             kw fn

--- a/crates/ide_completion/src/tests/type_pos.rs
+++ b/crates/ide_completion/src/tests/type_pos.rs
@@ -44,6 +44,7 @@ struct Foo<'lt, T, const C: usize>(f$0);
 "#,
         expect![[r##"
             kw pub(crate)
+            kw pub(super)
             kw pub
             kw self
             kw super


### PR DESCRIPTION
I've gotten used to typing `pc` in front of items to get `pub(crate)`, but recently I needed `pub(super)`. So I tried typing `ps` and it didn't work. Now it should!