### PR TITLE
Give defaultLibrary semantic token modifier to items from standard library

### DIFF
--- a/crates/ide/src/syntax_highlighting.rs
+++ b/crates/ide/src/syntax_highlighting.rs
@@ -134,6 +134,7 @@ pub struct HlRange {
 // consuming:: Emitted for locals that are being consumed when use in a function call.
 // controlFlow:: Emitted for control-flow related tokens, this includes the `?` operator.
 // declaration:: Emitted for names of definitions, like `foo` in `fn foo() {}`.
+// defaultLibrary:: Emitted for items from built-in crates (std, core, alloc, test and proc_macro).
 // documentation:: Emitted for documentation comments.
 // injected:: Emitted for doc-string injected highlighting like rust source blocks in documentation.
 // intraDocLink:: Emitted for intra doc links in doc-strings.

--- a/crates/ide/src/syntax_highlighting/highlight.rs
+++ b/crates/ide/src/syntax_highlighting/highlight.rs
@@ -515,7 +515,7 @@ fn highlight_def(
     });
     let is_from_other_crate = def_crate != krate;
     let is_from_builtin_crate =
-        def_crate.map_or(false, |it| famous_defs.builtin_crates().contains(&it));
+        def_crate.map_or(false, |def_crate| famous_defs.builtin_crates().any(|it| def_crate == it));
     let is_builtin_type = matches!(def, Definition::ModuleDef(hir::ModuleDef::BuiltinType(_)));
     let is_public = def.visibility(db) == Some(hir::Visibility::Public);
 
@@ -564,7 +564,7 @@ fn highlight_method_call(
     let famous_defs = FamousDefs(&sema, krate);
     let def_crate = func.module(sema.db).krate();
     let is_from_other_crate = Some(def_crate) != krate;
-    let is_from_builtin_crate = famous_defs.builtin_crates().contains(&def_crate);
+    let is_from_builtin_crate = famous_defs.builtin_crates().any(|it| def_crate == it);
     let is_public = func.visibility(sema.db) == hir::Visibility::Public;
 
     if is_from_other_crate {

--- a/crates/ide/src/syntax_highlighting/tags.rs
+++ b/crates/ide/src/syntax_highlighting/tags.rs
@@ -55,6 +55,8 @@ pub enum HlMod {
     Consuming,
     /// Used with keywords like `if` and `break`.
     ControlFlow,
+    /// Used for items from built-in crates (std, core, alloc, test and proc_macro).
+    DefaultLibrary,
     /// `foo` in `fn foo(x: i32)` is a definition, `foo` in `foo(90 + 2)` is
     /// not.
     Definition,
@@ -187,42 +189,44 @@ impl fmt::Display for HlTag {
 impl HlMod {
     const ALL: &'static [HlMod; HlMod::Unsafe as u8 as usize + 1] = &[
         HlMod::Associated,
+        HlMod::Async,
         HlMod::Attribute,
         HlMod::Callable,
         HlMod::Consuming,
         HlMod::ControlFlow,
+        HlMod::DefaultLibrary,
         HlMod::Definition,
         HlMod::Documentation,
         HlMod::Injected,
         HlMod::IntraDocLink,
+        HlMod::Library,
         HlMod::Mutable,
+        HlMod::Public,
         HlMod::Reference,
         HlMod::Static,
         HlMod::Trait,
-        HlMod::Async,
-        HlMod::Library,
-        HlMod::Public,
         HlMod::Unsafe,
     ];
 
     fn as_str(self) -> &'static str {
         match self {
             HlMod::Associated => "associated",
+            HlMod::Async => "async",
             HlMod::Attribute => "attribute",
             HlMod::Callable => "callable",
             HlMod::Consuming => "consuming",
             HlMod::ControlFlow => "control",
+            HlMod::DefaultLibrary => "default_library",
             HlMod::Definition => "declaration",
             HlMod::Documentation => "documentation",
             HlMod::Injected => "injected",
             HlMod::IntraDocLink => "intra_doc_link",
+            HlMod::Library => "library",
             HlMod::Mutable => "mutable",
+            HlMod::Public => "public",
             HlMod::Reference => "reference",
             HlMod::Static => "static",
             HlMod::Trait => "trait",
-            HlMod::Async => "async",
-            HlMod::Library => "library",
-            HlMod::Public => "public",
             HlMod::Unsafe => "unsafe",
         }
     }

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_assoc_functions.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_assoc_functions.html
@@ -45,8 +45,8 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 <span class="keyword">struct</span> <span class="struct declaration">foo</span> <span class="brace">{</span><span class="brace">}</span>
 
 <span class="keyword">impl</span> <span class="struct">foo</span> <span class="brace">{</span>
-    <span class="keyword">pub</span> <span class="keyword">fn</span> <span class="function associated declaration static public">is_static</span><span class="parenthesis">(</span><span class="parenthesis">)</span> <span class="brace">{</span><span class="brace">}</span>
-    <span class="keyword">pub</span> <span class="keyword">fn</span> <span class="function associated declaration reference public">is_not_static</span><span class="parenthesis">(</span><span class="operator">&</span><span class="self_keyword declaration reference">self</span><span class="parenthesis">)</span> <span class="brace">{</span><span class="brace">}</span>
+    <span class="keyword">pub</span> <span class="keyword">fn</span> <span class="function associated declaration public static">is_static</span><span class="parenthesis">(</span><span class="parenthesis">)</span> <span class="brace">{</span><span class="brace">}</span>
+    <span class="keyword">pub</span> <span class="keyword">fn</span> <span class="function associated declaration public reference">is_not_static</span><span class="parenthesis">(</span><span class="operator">&</span><span class="self_keyword declaration reference">self</span><span class="parenthesis">)</span> <span class="brace">{</span><span class="brace">}</span>
 <span class="brace">}</span>
 
 <span class="keyword">trait</span> <span class="trait declaration">t</span> <span class="brace">{</span>
@@ -55,7 +55,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 <span class="brace">}</span>
 
 <span class="keyword">impl</span> <span class="trait">t</span> <span class="keyword">for</span> <span class="struct">foo</span> <span class="brace">{</span>
-    <span class="keyword">pub</span> <span class="keyword">fn</span> <span class="function associated declaration static trait public">is_static</span><span class="parenthesis">(</span><span class="parenthesis">)</span> <span class="brace">{</span><span class="brace">}</span>
-    <span class="keyword">pub</span> <span class="keyword">fn</span> <span class="function associated declaration reference trait public">is_not_static</span><span class="parenthesis">(</span><span class="operator">&</span><span class="self_keyword declaration reference">self</span><span class="parenthesis">)</span> <span class="brace">{</span><span class="brace">}</span>
+    <span class="keyword">pub</span> <span class="keyword">fn</span> <span class="function associated declaration public static trait">is_static</span><span class="parenthesis">(</span><span class="parenthesis">)</span> <span class="brace">{</span><span class="brace">}</span>
+    <span class="keyword">pub</span> <span class="keyword">fn</span> <span class="function associated declaration public reference trait">is_not_static</span><span class="parenthesis">(</span><span class="operator">&</span><span class="self_keyword declaration reference">self</span><span class="parenthesis">)</span> <span class="brace">{</span><span class="brace">}</span>
 <span class="brace">}</span>
         </code></pre>

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_default_library.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_default_library.html
@@ -40,6 +40,10 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 
 .unresolved_reference { color: #FC5555; text-decoration: wavy underline; }
 </style>
-<pre><code><span class="keyword">extern</span> <span class="keyword">crate</span> <span class="module default_library library">std</span><span class="semicolon">;</span>
-<span class="keyword">extern</span> <span class="keyword">crate</span> <span class="module default_library library">alloc</span> <span class="keyword">as</span> <span class="module default_library declaration library">abc</span><span class="semicolon">;</span>
+<pre><code><span class="keyword">use</span> <span class="module default_library library">core</span><span class="operator">::</span><span class="module default_library library">iter</span><span class="semicolon">;</span>
+
+<span class="keyword">fn</span> <span class="function declaration">main</span><span class="parenthesis">(</span><span class="parenthesis">)</span> <span class="brace">{</span>
+    <span class="keyword">let</span> <span class="variable declaration">foo</span> <span class="operator">=</span> <span class="enum_variant default_library library">Some</span><span class="parenthesis">(</span><span class="numeric_literal">92</span><span class="parenthesis">)</span><span class="semicolon">;</span>
+    <span class="keyword">let</span> <span class="variable declaration">nums</span> <span class="operator">=</span> <span class="module default_library library">iter</span><span class="operator">::</span><span class="function default_library library">repeat</span><span class="parenthesis">(</span><span class="variable">foo</span><span class="operator">.</span><span class="function associated consuming default_library library">unwrap</span><span class="parenthesis">(</span><span class="parenthesis">)</span><span class="parenthesis">)</span><span class="semicolon">;</span>
+<span class="brace">}</span>
 </code></pre>

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_doctest.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_doctest.html
@@ -75,7 +75,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
     <span class="comment documentation">/// #</span><span class="none injected"> </span><span class="attribute attribute injected">#</span><span class="attribute attribute injected">!</span><span class="attribute attribute injected">[</span><span class="builtin_attr attribute injected">allow</span><span class="parenthesis attribute injected">(</span><span class="none attribute injected">unused_mut</span><span class="parenthesis attribute injected">)</span><span class="attribute attribute injected">]</span>
     <span class="comment documentation">/// </span><span class="keyword injected">let</span><span class="none injected"> </span><span class="keyword injected">mut</span><span class="none injected"> </span><span class="variable declaration injected mutable">foo</span><span class="colon injected">:</span><span class="none injected"> </span><span class="struct injected">Foo</span><span class="none injected"> </span><span class="operator injected">=</span><span class="none injected"> </span><span class="struct injected">Foo</span><span class="operator injected">::</span><span class="function injected">new</span><span class="parenthesis injected">(</span><span class="parenthesis injected">)</span><span class="semicolon injected">;</span>
     <span class="comment documentation">/// ```</span>
-    <span class="keyword">pub</span> <span class="keyword">const</span> <span class="keyword">fn</span> <span class="function associated declaration static public">new</span><span class="parenthesis">(</span><span class="parenthesis">)</span> <span class="operator">-&gt;</span> <span class="struct">Foo</span> <span class="brace">{</span>
+    <span class="keyword">pub</span> <span class="keyword">const</span> <span class="keyword">fn</span> <span class="function associated declaration public static">new</span><span class="parenthesis">(</span><span class="parenthesis">)</span> <span class="operator">-&gt;</span> <span class="struct">Foo</span> <span class="brace">{</span>
         <span class="struct">Foo</span> <span class="brace">{</span> <span class="field">bar</span><span class="colon">:</span> <span class="bool_literal">true</span> <span class="brace">}</span>
     <span class="brace">}</span>
 
@@ -109,7 +109,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
     <span class="comment documentation">/// ```sh</span>
     <span class="comment documentation">/// echo 1</span>
     <span class="comment documentation">/// ```</span>
-    <span class="keyword">pub</span> <span class="keyword">fn</span> <span class="function associated declaration reference public">foo</span><span class="parenthesis">(</span><span class="operator">&</span><span class="self_keyword declaration reference">self</span><span class="parenthesis">)</span> <span class="operator">-&gt;</span> <span class="builtin_type">bool</span> <span class="brace">{</span>
+    <span class="keyword">pub</span> <span class="keyword">fn</span> <span class="function associated declaration public reference">foo</span><span class="parenthesis">(</span><span class="operator">&</span><span class="self_keyword declaration reference">self</span><span class="parenthesis">)</span> <span class="operator">-&gt;</span> <span class="builtin_type">bool</span> <span class="brace">{</span>
         <span class="bool_literal">true</span>
     <span class="brace">}</span>
 <span class="brace">}</span>

--- a/crates/ide/src/syntax_highlighting/test_data/highlighting.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlighting.html
@@ -241,12 +241,12 @@ proc_macros::<span class="macro">mirror!</span> <span class="brace">{</span>
     <span class="brace">}</span>
 <span class="brace">}</span>
 
-<span class="keyword async">async</span> <span class="keyword">fn</span> <span class="function declaration async">learn_and_sing</span><span class="parenthesis">(</span><span class="parenthesis">)</span> <span class="brace">{</span>
-    <span class="keyword">let</span> <span class="variable declaration">song</span> <span class="operator">=</span> <span class="unresolved_reference">learn_song</span><span class="parenthesis">(</span><span class="parenthesis">)</span><span class="operator">.</span><span class="keyword control async">await</span><span class="semicolon">;</span>
-    <span class="unresolved_reference">sing_song</span><span class="parenthesis">(</span><span class="variable consuming">song</span><span class="parenthesis">)</span><span class="operator">.</span><span class="keyword control async">await</span><span class="semicolon">;</span>
+<span class="keyword async">async</span> <span class="keyword">fn</span> <span class="function async declaration">learn_and_sing</span><span class="parenthesis">(</span><span class="parenthesis">)</span> <span class="brace">{</span>
+    <span class="keyword">let</span> <span class="variable declaration">song</span> <span class="operator">=</span> <span class="unresolved_reference">learn_song</span><span class="parenthesis">(</span><span class="parenthesis">)</span><span class="operator">.</span><span class="keyword async control">await</span><span class="semicolon">;</span>
+    <span class="unresolved_reference">sing_song</span><span class="parenthesis">(</span><span class="variable consuming">song</span><span class="parenthesis">)</span><span class="operator">.</span><span class="keyword async control">await</span><span class="semicolon">;</span>
 <span class="brace">}</span>
 
-<span class="keyword async">async</span> <span class="keyword">fn</span> <span class="function declaration async">async_main</span><span class="parenthesis">(</span><span class="parenthesis">)</span> <span class="brace">{</span>
+<span class="keyword async">async</span> <span class="keyword">fn</span> <span class="function async declaration">async_main</span><span class="parenthesis">(</span><span class="parenthesis">)</span> <span class="brace">{</span>
     <span class="keyword">let</span> <span class="variable declaration">f1</span> <span class="operator">=</span> <span class="function async">learn_and_sing</span><span class="parenthesis">(</span><span class="parenthesis">)</span><span class="semicolon">;</span>
     <span class="keyword">let</span> <span class="variable declaration">f2</span> <span class="operator">=</span> <span class="unresolved_reference">dance</span><span class="parenthesis">(</span><span class="parenthesis">)</span><span class="semicolon">;</span>
     futures::<span class="macro">join!</span><span class="parenthesis">(</span>f1<span class="comma">,</span> f2<span class="parenthesis">)</span><span class="semicolon">;</span>

--- a/crates/ide/src/syntax_highlighting/tests.rs
+++ b/crates/ide/src/syntax_highlighting/tests.rs
@@ -735,6 +735,23 @@ fn test_extern_crate() {
 }
 
 #[test]
+fn test_default_library() {
+    check_highlighting(
+        r#"
+        //- minicore: option, iterators
+        use core::iter;
+
+        fn main() {
+            let foo = Some(92);
+            let nums = iter::repeat(foo.unwrap());
+        }
+        "#,
+        expect_file!["./test_data/highlight_default_library.html"],
+        false,
+    );
+}
+
+#[test]
 fn test_associated_function() {
     check_highlighting(
         r#"

--- a/crates/ide_db/src/helpers/famous_defs.rs
+++ b/crates/ide_db/src/helpers/famous_defs.rs
@@ -68,6 +68,30 @@ impl FamousDefs<'_, '_> {
         self.find_trait("core:ops:Deref")
     }
 
+    pub fn alloc(&self) -> Option<Crate> {
+        self.find_crate("alloc")
+    }
+
+    pub fn test(&self) -> Option<Crate> {
+        self.find_crate("test")
+    }
+
+    pub fn proc_macro(&self) -> Option<Crate> {
+        self.find_crate("proc_macro")
+    }
+
+    pub fn builtin_crates(&self) -> Vec<Crate> {
+        IntoIterator::into_iter([
+            self.std(),
+            self.core(),
+            self.alloc(),
+            self.test(),
+            self.proc_macro(),
+        ])
+        .filter_map(|it| it)
+        .collect()
+    }
+
     fn find_trait(&self, path: &str) -> Option<Trait> {
         match self.find_def(path)? {
             hir::ScopeDef::ModuleDef(hir::ModuleDef::Trait(it)) => Some(it),

--- a/crates/ide_db/src/helpers/famous_defs.rs
+++ b/crates/ide_db/src/helpers/famous_defs.rs
@@ -80,7 +80,7 @@ impl FamousDefs<'_, '_> {
         self.find_crate("proc_macro")
     }
 
-    pub fn builtin_crates(&self) -> Vec<Crate> {
+    pub fn builtin_crates(&self) -> impl Iterator<Item = Crate> {
         IntoIterator::into_iter([
             self.std(),
             self.core(),
@@ -89,7 +89,6 @@ impl FamousDefs<'_, '_> {
             self.proc_macro(),
         ])
         .filter_map(|it| it)
-        .collect()
     }
 
     fn find_trait(&self, path: &str) -> Option<Trait> {

--- a/crates/rust-analyzer/src/semantic_tokens.rs
+++ b/crates/rust-analyzer/src/semantic_tokens.rs
@@ -93,7 +93,6 @@ define_semantic_token_modifiers![
     (CONSTANT, "constant"),
     (CONSUMING, "consuming"),
     (CONTROL_FLOW, "controlFlow"),
-    (DEFAULT_LIBRARY, "defaultLibrary"),
     (INJECTED, "injected"),
     (INTRA_DOC_LINK, "intraDocLink"),
     (LIBRARY, "library"),

--- a/crates/rust-analyzer/src/semantic_tokens.rs
+++ b/crates/rust-analyzer/src/semantic_tokens.rs
@@ -87,20 +87,21 @@ macro_rules! define_semantic_token_modifiers {
 }
 
 define_semantic_token_modifiers![
-    (CONSTANT, "constant"),
-    (CONTROL_FLOW, "controlFlow"),
-    (INJECTED, "injected"),
-    (MUTABLE, "mutable"),
-    (CONSUMING, "consuming"),
     (ASYNC, "async"),
-    (LIBRARY, "library"),
-    (PUBLIC, "public"),
-    (UNSAFE, "unsafe"),
     (ATTRIBUTE_MODIFIER, "attribute"),
-    (TRAIT_MODIFIER, "trait"),
     (CALLABLE, "callable"),
+    (CONSTANT, "constant"),
+    (CONSUMING, "consuming"),
+    (CONTROL_FLOW, "controlFlow"),
+    (DEFAULT_LIBRARY, "defaultLibrary"),
+    (INJECTED, "injected"),
     (INTRA_DOC_LINK, "intraDocLink"),
+    (LIBRARY, "library"),
+    (MUTABLE, "mutable"),
+    (PUBLIC, "public"),
     (REFERENCE, "reference"),
+    (TRAIT_MODIFIER, "trait"),
+    (UNSAFE, "unsafe"),
 ];
 
 #[derive(Default)]

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -529,23 +529,24 @@ fn semantic_token_type_and_modifiers(
 
     for modifier in highlight.mods.iter() {
         let modifier = match modifier {
+            HlMod::Associated => continue,
+            HlMod::Async => semantic_tokens::ASYNC,
             HlMod::Attribute => semantic_tokens::ATTRIBUTE_MODIFIER,
+            HlMod::Callable => semantic_tokens::CALLABLE,
+            HlMod::Consuming => semantic_tokens::CONSUMING,
+            HlMod::ControlFlow => semantic_tokens::CONTROL_FLOW,
+            HlMod::DefaultLibrary => semantic_tokens::DEFAULT_LIBRARY,
             HlMod::Definition => lsp_types::SemanticTokenModifier::DECLARATION,
             HlMod::Documentation => lsp_types::SemanticTokenModifier::DOCUMENTATION,
             HlMod::Injected => semantic_tokens::INJECTED,
-            HlMod::ControlFlow => semantic_tokens::CONTROL_FLOW,
-            HlMod::Mutable => semantic_tokens::MUTABLE,
-            HlMod::Reference => semantic_tokens::REFERENCE,
-            HlMod::Consuming => semantic_tokens::CONSUMING,
-            HlMod::Async => semantic_tokens::ASYNC,
-            HlMod::Library => semantic_tokens::LIBRARY,
-            HlMod::Public => semantic_tokens::PUBLIC,
-            HlMod::Unsafe => semantic_tokens::UNSAFE,
-            HlMod::Callable => semantic_tokens::CALLABLE,
-            HlMod::Static => lsp_types::SemanticTokenModifier::STATIC,
             HlMod::IntraDocLink => semantic_tokens::INTRA_DOC_LINK,
+            HlMod::Library => semantic_tokens::LIBRARY,
+            HlMod::Mutable => semantic_tokens::MUTABLE,
+            HlMod::Public => semantic_tokens::PUBLIC,
+            HlMod::Reference => semantic_tokens::REFERENCE,
+            HlMod::Static => lsp_types::SemanticTokenModifier::STATIC,
             HlMod::Trait => semantic_tokens::TRAIT_MODIFIER,
-            HlMod::Associated => continue,
+            HlMod::Unsafe => semantic_tokens::UNSAFE,
         };
         mods |= modifier;
     }

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -535,7 +535,7 @@ fn semantic_token_type_and_modifiers(
             HlMod::Callable => semantic_tokens::CALLABLE,
             HlMod::Consuming => semantic_tokens::CONSUMING,
             HlMod::ControlFlow => semantic_tokens::CONTROL_FLOW,
-            HlMod::DefaultLibrary => semantic_tokens::DEFAULT_LIBRARY,
+            HlMod::DefaultLibrary => lsp_types::SemanticTokenModifier::DEFAULT_LIBRARY,
             HlMod::Definition => lsp_types::SemanticTokenModifier::DECLARATION,
             HlMod::Documentation => lsp_types::SemanticTokenModifier::DOCUMENTATION,
             HlMod::Injected => semantic_tokens::INJECTED,


### PR DESCRIPTION
Fixes #8999, fixes #2155

`builtInCrates` could be an alternate name to `defaultLibrary`, which one is better?

> P.S. I'm participating in [Hacktoberfest 2021](https://hacktoberfest.digitalocean.com/). If this PR is up to standard and merged, I'd appreciate if the `hacktoberfest-accepted` label could be added. Thanks!