### PR TITLE
minor: don't drop binders when doing autoderef

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2504,8 +2504,7 @@ impl Type {
 
     pub fn autoderef<'a>(&'a self, db: &'a dyn HirDatabase) -> impl Iterator<Item = Type> + 'a {
         // There should be no inference vars in types passed here
-        let ty = hir_ty::replace_errors_with_variables(&self.ty).value;
-        let canonical = Canonical { value: ty, binders: CanonicalVarKinds::empty(&Interner) };
+        let canonical = hir_ty::replace_errors_with_variables(&self.ty);
         let environment = self.env.env.clone();
         let ty = InEnvironment { goal: canonical, environment };
         autoderef(db, Some(self.krate), ty)


### PR DESCRIPTION
This fixes #10396 panic introduced in #10373