### PR TITLE
fix: Don't show flyimport completions in use renames

### DIFF
--- a/crates/ide_completion/src/completions/flyimport.rs
+++ b/crates/ide_completion/src/completions/flyimport.rs
@@ -1220,4 +1220,17 @@ fn function() {
             "#]],
         );
     }
+
+    #[test]
+    fn flyimport_rename() {
+        check(
+            r#"
+mod module {
+    pub struct Struct;
+}
+use self as Str$0;
+    "#,
+            expect![[r#""#]],
+        );
+    }
 }

--- a/crates/ide_completion/src/context.rs
+++ b/crates/ide_completion/src/context.rs
@@ -383,6 +383,7 @@ impl<'a> CompletionContext<'a> {
                         | ImmediateLocation::ModDeclaration(_)
                         | ImmediateLocation::RecordPat(_)
                         | ImmediateLocation::RecordExpr(_)
+                        | ImmediateLocation::Rename
                 )
             )
     }

--- a/crates/ide_completion/src/patterns.rs
+++ b/crates/ide_completion/src/patterns.rs
@@ -32,6 +32,7 @@ pub(crate) enum ImmediatePrevSibling {
 pub(crate) enum ImmediateLocation {
     Use,
     UseTree,
+    Rename,
     Impl,
     Trait,
     RecordField,
@@ -201,6 +202,7 @@ pub(crate) fn determine_location(
             ast::Use(_it) => ImmediateLocation::Use,
             ast::UseTree(_it) => ImmediateLocation::UseTree,
             ast::UseTreeList(_it) => ImmediateLocation::UseTree,
+            ast::Rename(_it) => ImmediateLocation::Rename,
             ast::StmtList(_it) => ImmediateLocation::StmtList,
             ast::SourceFile(_it) => ImmediateLocation::ItemList,
             ast::ItemList(_it) => ImmediateLocation::ItemList,


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/10367
bors r+