### PR TITLE
internal: Restructure syntax element highlighting into node and token branches

### DIFF
--- a/crates/ide/src/syntax_highlighting.rs
+++ b/crates/ide/src/syntax_highlighting.rs
@@ -309,6 +309,7 @@ fn traverse(
                     match (token.kind(), parent.kind()) {
                         (T![ident], NAME | NAME_REF) => parent.into(),
                         (T![self] | T![super] | T![crate], NAME_REF) => parent.into(),
+                        (INT_NUMBER, NAME_REF) => parent.into(),
                         _ => token.into(),
                     }
                 }

--- a/crates/ide/src/syntax_highlighting/inject.rs
+++ b/crates/ide/src/syntax_highlighting/inject.rs
@@ -12,10 +12,9 @@ use syntax::{
 
 use crate::{
     doc_links::{doc_attributes, extract_definitions_from_docs, resolve_doc_path_for_def},
+    syntax_highlighting::{highlights::Highlights, injector::Injector},
     Analysis, HlMod, HlRange, HlTag, RootDatabase,
 };
-
-use super::{highlights::Highlights, injector::Injector};
 
 pub(super) fn ra_fixture(
     hl: &mut Highlights,

--- a/crates/ide/src/syntax_highlighting/injector.rs
+++ b/crates/ide/src/syntax_highlighting/injector.rs
@@ -17,9 +17,11 @@ impl Injector {
         assert_eq!(len, source_range.len());
         self.add_impl(text, Some(source_range.start()));
     }
+
     pub(super) fn add_unmapped(&mut self, text: &str) {
         self.add_impl(text, None);
     }
+
     fn add_impl(&mut self, text: &str, source: Option<TextSize>) {
         let len = TextSize::of(text);
         let target_range = TextRange::at(TextSize::of(&self.buf), len);
@@ -30,6 +32,7 @@ impl Injector {
     pub(super) fn text(&self) -> &str {
         &self.buf
     }
+
     pub(super) fn map_range_up(&self, range: TextRange) -> impl Iterator<Item = TextRange> + '_ {
         equal_range_by(&self.ranges, |&(r, _)| TextRange::ordering(r, range)).filter_map(move |i| {
             let (target_range, delta) = self.ranges[i];


### PR DESCRIPTION
Gets rid of all the unseemly unwraps 
bors r+