### PR TITLE
docs: add note about `vscode-vim` in `on_enter`

### DIFF
--- a/crates/ide/src/typing/on_enter.rs
+++ b/crates/ide/src/typing/on_enter.rs
@@ -36,6 +36,16 @@ use text_edit::TextEdit;
 // }
 // ----
 //
+// When using the Vim plugin:
+// [source,json]
+// ----
+// {
+//   "key": "Enter",
+//   "command": "rust-analyzer.onEnter",
+//   "when": "editorTextFocus && !suggestWidgetVisible && editorLangId == rust && vim.mode == 'Insert'"
+// }
+// ----
+//
 // image::https://user-images.githubusercontent.com/48062697/113065578-04c21800-91b1-11eb-82b8-22b8c481e645.gif[]
 pub(crate) fn on_enter(db: &RootDatabase, position: FilePosition) -> Option<TextEdit> {
     let parse = db.parse(position.file_id);


### PR DESCRIPTION
I found myself search for this, so building off of #3013 and #3308, I
hope this note is useful.
