### PR TITLE
Add whitespace between lifetime and mut keyword in "expand macro" command

### DIFF
--- a/crates/ide/src/expand_macro.rs
+++ b/crates/ide/src/expand_macro.rs
@@ -159,7 +159,7 @@ fn insert_whitespaces(syn: SyntaxNode) -> String {
                 res.push_str("}\n");
                 res.extend(iter::repeat(" ").take(2 * indent));
             }
-            LIFETIME_IDENT if is_next(|it| it == IDENT, true) => {
+            LIFETIME_IDENT if is_next(|it| it == IDENT || it == MUT_KW, true) => {
                 res.push_str(token.text());
                 res.push(' ');
             }


### PR DESCRIPTION
Before, we were only adding whitespace between a lifetime and the following ident, which produced invalid code for mutable references.

Before this PR:
```rust
macro_rules! foo {
    () => {
        pub struct Foo<'a> {
            foo: &'a mut str,
        }
    };
}
foo!(); // <- expand macro here
```
expanded to
```rust
pub struct Foo< 'a>{
  foo: & 'amut str,
}
```

with this PR, it expands to
```rust
pub struct Foo< 'a>{
  foo: & 'a mut str,
}
```