### PR TITLE
internal: use naming that matches intended use-case

### DIFF
--- a/crates/ide/src/highlight_related.rs
+++ b/crates/ide/src/highlight_related.rs
@@ -3,7 +3,7 @@ use ide_db::{
     base_db::FilePosition,
     defs::{Definition, NameClass, NameRefClass},
     helpers::{for_each_break_expr, for_each_tail_expr, node_ext::walk_expr, pick_best_token},
-    search::{FileReference, ReferenceAccess, SearchScope},
+    search::{FileReference, ReferenceCategory, SearchScope},
     RootDatabase,
 };
 use rustc_hash::FxHashSet;
@@ -19,7 +19,7 @@ use crate::{display::TryToNav, references, NavigationTarget};
 #[derive(PartialEq, Eq, Hash)]
 pub struct HighlightedRange {
     pub range: TextRange,
-    pub access: Option<ReferenceAccess>,
+    pub access: Option<ReferenceCategory>,
 }
 
 #[derive(Default, Clone)]
@@ -87,7 +87,7 @@ fn highlight_references(
                 .remove(&file_id)
         })
         .flatten()
-        .map(|FileReference { access, range, .. }| HighlightedRange { range, access });
+        .map(|FileReference { category: access, range, .. }| HighlightedRange { range, access });
 
     let declarations = defs.iter().flat_map(|def| {
         match def {
@@ -355,8 +355,8 @@ mod tests {
                     hl.range,
                     hl.access.map(|it| {
                         match it {
-                            ReferenceAccess::Read => "read",
-                            ReferenceAccess::Write => "write",
+                            ReferenceCategory::Read => "read",
+                            ReferenceCategory::Write => "write",
                         }
                         .to_string()
                     }),

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -108,7 +108,7 @@ pub use ide_db::{
     call_info::CallInfo,
     label::Label,
     line_index::{LineCol, LineColUtf16, LineIndex},
-    search::{ReferenceAccess, SearchScope},
+    search::{ReferenceCategory, SearchScope},
     source_change::{FileSystemEdit, SourceChange},
     symbol_index::Query,
     RootDatabase, SymbolKind,

--- a/crates/ide_assists/src/handlers/extract_function.rs
+++ b/crates/ide_assists/src/handlers/extract_function.rs
@@ -6,7 +6,7 @@ use hir::{HirDisplay, InFile, Local, Semantics, TypeInfo};
 use ide_db::{
     defs::{Definition, NameRefClass},
     helpers::node_ext::{preorder_expr, walk_expr, walk_pat, walk_patterns_in_expr},
-    search::{FileReference, ReferenceAccess, SearchScope},
+    search::{FileReference, ReferenceCategory, SearchScope},
     RootDatabase,
 };
 use itertools::Itertools;
@@ -877,7 +877,7 @@ fn reference_is_exclusive(
     ctx: &AssistContext,
 ) -> bool {
     // we directly modify variable with set: `n = 0`, `n += 1`
-    if reference.access == Some(ReferenceAccess::Write) {
+    if reference.category == Some(ReferenceCategory::Write) {
         return true;
     }
 

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -1182,9 +1182,9 @@ pub(crate) fn handle_document_highlight(
     };
     let res = refs
         .into_iter()
-        .map(|ide::HighlightedRange { range, access }| lsp_types::DocumentHighlight {
+        .map(|ide::HighlightedRange { range, category }| lsp_types::DocumentHighlight {
             range: to_proto::range(&line_index, range),
-            kind: access.map(to_proto::document_highlight_kind),
+            kind: category.map(to_proto::document_highlight_kind),
         })
         .collect();
     Ok(Some(res))

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -9,7 +9,7 @@ use ide::{
     Annotation, AnnotationKind, Assist, AssistKind, CallInfo, Cancellable, CompletionItem,
     CompletionItemKind, CompletionRelevance, Documentation, FileId, FileRange, FileSystemEdit,
     Fold, FoldKind, Highlight, HlMod, HlOperator, HlPunct, HlRange, HlTag, Indel, InlayHint,
-    InlayKind, Markup, NavigationTarget, ReferenceAccess, RenameError, Runnable, Severity,
+    InlayKind, Markup, NavigationTarget, ReferenceCategory, RenameError, Runnable, Severity,
     SourceChange, StructureNodeKind, SymbolKind, TextEdit, TextRange, TextSize,
 };
 use itertools::Itertools;
@@ -75,11 +75,11 @@ pub(crate) fn structure_node_kind(kind: StructureNodeKind) -> lsp_types::SymbolK
 }
 
 pub(crate) fn document_highlight_kind(
-    reference_access: ReferenceAccess,
+    category: ReferenceCategory,
 ) -> lsp_types::DocumentHighlightKind {
-    match reference_access {
-        ReferenceAccess::Read => lsp_types::DocumentHighlightKind::Read,
-        ReferenceAccess::Write => lsp_types::DocumentHighlightKind::Write,
+    match category {
+        ReferenceCategory::Read => lsp_types::DocumentHighlightKind::Read,
+        ReferenceCategory::Write => lsp_types::DocumentHighlightKind::Write,
     }
 }
 


### PR DESCRIPTION
bors r+
🤖