### PR TITLE
fix: Limit depth to 1 when searching for `Cargo.toml`

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -65,7 +65,8 @@
         "onCommand:rust-analyzer.analyzerStatus",
         "onCommand:rust-analyzer.memoryUsage",
         "onCommand:rust-analyzer.reloadWorkspace",
-        "workspaceContains:**/Cargo.toml"
+        "workspaceContains:*/Cargo.toml",
+        "workspaceContains:*/rust-project.json"
     ],
     "main": "./out/main",
     "contributes": {


### PR DESCRIPTION
...and add `rust-project.json`.

More or less fixes #7268