### PR TITLE
feat: Implement custom user snippets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,6 +633,7 @@ dependencies = [
  "once_cell",
  "profile",
  "rustc-hash",
+ "smallvec",
  "sourcegen",
  "stdx",
  "syntax",

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -99,7 +99,7 @@ pub use ide_assists::{
 };
 pub use ide_completion::{
     CompletionConfig, CompletionItem, CompletionItemKind, CompletionRelevance, ImportEdit,
-    PostfixSnippet,
+    PostfixSnippet, PostfixSnippetScope, Snippet, SnippetScope,
 };
 pub use ide_db::{
     base_db::{

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -98,8 +98,8 @@ pub use ide_assists::{
     Assist, AssistConfig, AssistId, AssistKind, AssistResolveStrategy, SingleResolve,
 };
 pub use ide_completion::{
-    CompletionConfig, CompletionItem, CompletionItemKind, CompletionRelevance, ImportEdit,
-    PostfixSnippet, PostfixSnippetScope, Snippet, SnippetScope,
+    CompletionConfig, CompletionItem, CompletionItemKind, CompletionRelevance, ImportEdit, Snippet,
+    SnippetScope,
 };
 pub use ide_db::{
     base_db::{

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -533,19 +533,10 @@ impl Analysis {
         &self,
         config: &CompletionConfig,
         position: FilePosition,
-        full_import_path: &str,
-        imported_name: String,
+        imports: impl IntoIterator<Item = (String, String)> + std::panic::UnwindSafe,
     ) -> Cancellable<Vec<TextEdit>> {
         Ok(self
-            .with_db(|db| {
-                ide_completion::resolve_completion_edits(
-                    db,
-                    config,
-                    position,
-                    full_import_path,
-                    imported_name,
-                )
-            })?
+            .with_db(|db| ide_completion::resolve_completion_edits(db, config, position, imports))?
             .unwrap_or_default())
     }
 

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -99,6 +99,7 @@ pub use ide_assists::{
 };
 pub use ide_completion::{
     CompletionConfig, CompletionItem, CompletionItemKind, CompletionRelevance, ImportEdit,
+    PostfixSnippet,
 };
 pub use ide_db::{
     base_db::{

--- a/crates/ide_completion/Cargo.toml
+++ b/crates/ide_completion/Cargo.toml
@@ -14,6 +14,7 @@ itertools = "0.10.0"
 rustc-hash = "1.1.0"
 either = "1.6.1"
 once_cell = "1.7"
+smallvec = "1.4"
 
 stdx = { path = "../stdx", version = "0.0.0" }
 syntax = { path = "../syntax", version = "0.0.0" }

--- a/crates/ide_completion/src/completions/postfix.rs
+++ b/crates/ide_completion/src/completions/postfix.rs
@@ -2,6 +2,7 @@
 
 mod format_like;
 
+use hir::Documentation;
 use ide_db::{
     helpers::{insert_use::ImportScope, FamousDefs, SnippetCap},
     ty_filter::TryEnum,
@@ -236,11 +237,10 @@ fn add_custom_postfix_completions(
                 Some(imports) => imports,
                 None => return,
             };
-            let mut builder = postfix_snippet(
-                trigger,
-                snippet.description.as_deref().unwrap_or_default(),
-                &snippet.postfix_snippet(&receiver_text),
-            );
+            let body = snippet.postfix_snippet(&receiver_text);
+            let mut builder =
+                postfix_snippet(trigger, snippet.description.as_deref().unwrap_or_default(), &body);
+            builder.documentation(Documentation::new(format!("```rust\n{}\n```", body)));
             for import in imports.into_iter() {
                 builder.add_import(import);
             }
@@ -481,7 +481,7 @@ fn main() {
                 snippets: vec![Snippet::new(
                     &[],
                     &["break".into()],
-                    &["ControlFlow::Break($receiver)".into()],
+                    &["ControlFlow::Break(${receiver})".into()],
                     "",
                     &["core::ops::ControlFlow".into()],
                     crate::SnippetScope::Expr,

--- a/crates/ide_completion/src/completions/postfix.rs
+++ b/crates/ide_completion/src/completions/postfix.rs
@@ -232,8 +232,8 @@ fn add_custom_postfix_completions(
         ImportScope::find_insert_use_container_with_macros(&ctx.token.parent()?, &ctx.sema)?;
     ctx.config.postfix_snippets.iter().for_each(|snippet| {
         let imports = match snippet.imports(ctx, &import_scope) {
-            Ok(imports) => imports,
-            Err(_) => return,
+            Some(imports) => imports,
+            None => return,
         };
         let mut builder = postfix_snippet(
             &snippet.label,

--- a/crates/ide_completion/src/completions/snippet.rs
+++ b/crates/ide_completion/src/completions/snippet.rs
@@ -105,8 +105,8 @@ fn add_custom_completions(
         ImportScope::find_insert_use_container_with_macros(&ctx.token.parent()?, &ctx.sema)?;
     ctx.config.snippets.iter().filter(|snip| snip.scope == scope).for_each(|snip| {
         let imports = match snip.imports(ctx, &import_scope) {
-            Ok(imports) => imports,
-            Err(_) => return,
+            Some(imports) => imports,
+            None => return,
         };
         let mut builder = snippet(ctx, cap, &snip.label, &snip.snippet);
         for import in imports.into_iter() {

--- a/crates/ide_completion/src/completions/snippet.rs
+++ b/crates/ide_completion/src/completions/snippet.rs
@@ -1,11 +1,11 @@
 //! This file provides snippet completions, like `pd` => `eprintln!(...)`.
 
-use ide_db::helpers::SnippetCap;
+use ide_db::helpers::{insert_use::ImportScope, SnippetCap};
 use syntax::T;
 
 use crate::{
     context::PathCompletionContext, item::Builder, CompletionContext, CompletionItem,
-    CompletionItemKind, CompletionKind, Completions,
+    CompletionItemKind, CompletionKind, Completions, SnippetScope,
 };
 
 fn snippet(ctx: &CompletionContext, cap: SnippetCap, label: &str, snippet: &str) -> Builder {
@@ -29,6 +29,10 @@ pub(crate) fn complete_expr_snippet(acc: &mut Completions, ctx: &CompletionConte
         None => return,
     };
 
+    if !ctx.config.snippets.is_empty() {
+        add_custom_completions(acc, ctx, cap, SnippetScope::Expr);
+    }
+
     if can_be_stmt {
         snippet(ctx, cap, "pd", "eprintln!(\"$0 = {:?}\", $0);").add_to(acc);
         snippet(ctx, cap, "ppd", "eprintln!(\"$0 = {:#?}\", $0);").add_to(acc);
@@ -51,6 +55,10 @@ pub(crate) fn complete_item_snippet(acc: &mut Completions, ctx: &CompletionConte
         Some(it) => it,
         None => return,
     };
+
+    if !ctx.config.snippets.is_empty() {
+        add_custom_completions(acc, ctx, cap, SnippetScope::Item);
+    }
 
     let mut item = snippet(
         ctx,
@@ -85,4 +93,60 @@ fn ${1:feature}() {
 
     let item = snippet(ctx, cap, "macro_rules", "macro_rules! $1 {\n\t($2) => {\n\t\t$0\n\t};\n}");
     item.add_to(acc);
+}
+
+fn add_custom_completions(
+    acc: &mut Completions,
+    ctx: &CompletionContext,
+    cap: SnippetCap,
+    scope: SnippetScope,
+) -> Option<()> {
+    let import_scope =
+        ImportScope::find_insert_use_container_with_macros(&ctx.token.parent()?, &ctx.sema)?;
+    ctx.config.snippets.iter().filter(|snip| snip.scope == scope).for_each(|snip| {
+        // FIXME: Support multiple imports
+        let import = match snip.imports(ctx, &import_scope) {
+            Ok(mut imports) => imports.pop(),
+            Err(_) => return,
+        };
+        let mut builder = snippet(ctx, cap, &snip.label, &snip.snippet);
+        builder.add_import(import).detail(snip.description.as_deref().unwrap_or_default());
+        builder.add_to(acc);
+    });
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        tests::{check_edit_with_config, TEST_CONFIG},
+        CompletionConfig, Snippet,
+    };
+
+    #[test]
+    fn custom_snippet_completion() {
+        check_edit_with_config(
+            CompletionConfig {
+                snippets: vec![Snippet::new(
+                    "break".into(),
+                    &["ControlFlow::Break(())".into()],
+                    &[],
+                    &["core::ops::ControlFlow".into()],
+                    None,
+                )
+                .unwrap()],
+                ..TEST_CONFIG
+            },
+            "break",
+            r#"
+//- minicore: try
+fn main() { $0 }
+"#,
+            r#"
+use core::ops::ControlFlow;
+
+fn main() { ControlFlow::Break(()) }
+"#,
+        );
+    }
 }

--- a/crates/ide_completion/src/completions/snippet.rs
+++ b/crates/ide_completion/src/completions/snippet.rs
@@ -1,5 +1,6 @@
 //! This file provides snippet completions, like `pd` => `eprintln!(...)`.
 
+use hir::Documentation;
 use ide_db::helpers::{insert_use::ImportScope, SnippetCap};
 use syntax::T;
 
@@ -109,7 +110,9 @@ fn add_custom_completions(
                 Some(imports) => imports,
                 None => return,
             };
-            let mut builder = snippet(ctx, cap, &trigger, &snip.snippet());
+            let body = snip.snippet();
+            let mut builder = snippet(ctx, cap, &trigger, &body);
+            builder.documentation(Documentation::new(format!("```rust\n{}\n```", body)));
             for import in imports.into_iter() {
                 builder.add_import(import);
             }

--- a/crates/ide_completion/src/config.rs
+++ b/crates/ide_completion/src/config.rs
@@ -6,7 +6,7 @@
 
 use ide_db::helpers::{insert_use::InsertUseConfig, SnippetCap};
 
-use crate::snippet::{PostfixSnippet, Snippet};
+use crate::snippet::Snippet;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CompletionConfig {
@@ -17,6 +17,18 @@ pub struct CompletionConfig {
     pub add_call_argument_snippets: bool,
     pub snippet_cap: Option<SnippetCap>,
     pub insert_use: InsertUseConfig,
-    pub postfix_snippets: Vec<PostfixSnippet>,
     pub snippets: Vec<Snippet>,
+}
+
+impl CompletionConfig {
+    pub fn postfix_snippets(&self) -> impl Iterator<Item = (&str, &Snippet)> {
+        self.snippets.iter().flat_map(|snip| {
+            snip.postfix_triggers.iter().map(move |trigger| (trigger.as_str(), snip))
+        })
+    }
+    pub fn prefix_snippets(&self) -> impl Iterator<Item = (&str, &Snippet)> {
+        self.snippets.iter().flat_map(|snip| {
+            snip.prefix_triggers.iter().map(move |trigger| (trigger.as_str(), snip))
+        })
+    }
 }

--- a/crates/ide_completion/src/config.rs
+++ b/crates/ide_completion/src/config.rs
@@ -5,6 +5,8 @@
 //! completions if we are allowed to.
 
 use ide_db::helpers::{insert_use::InsertUseConfig, SnippetCap};
+use itertools::Itertools;
+use syntax::ast;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CompletionConfig {
@@ -15,4 +17,46 @@ pub struct CompletionConfig {
     pub add_call_argument_snippets: bool,
     pub snippet_cap: Option<SnippetCap>,
     pub insert_use: InsertUseConfig,
+    pub postfix_snippets: Vec<PostfixSnippet>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PostfixSnippet {
+    pub label: String,
+    snippet: String,
+    pub description: Option<String>,
+    pub requires: Box<[String]>,
+}
+
+impl PostfixSnippet {
+    pub fn new(
+        label: String,
+        snippet: &[String],
+        description: &[String],
+        requires: &[String],
+    ) -> Option<Self> {
+        // validate that these are indeed simple paths
+        if requires.iter().any(|path| match ast::Path::parse(path) {
+            Ok(path) => path.segments().any(|seg| {
+                !matches!(seg.kind(), Some(ast::PathSegmentKind::Name(_)))
+                    || seg.generic_arg_list().is_some()
+            }),
+            Err(_) => true,
+        }) {
+            return None;
+        }
+        let snippet = snippet.iter().join("\n");
+        let description = description.iter().join("\n");
+        let description = if description.is_empty() { None } else { Some(description) };
+        Some(PostfixSnippet {
+            label,
+            snippet,
+            description,
+            requires: requires.iter().cloned().collect(), // Box::into doesn't work as that has a Copy bound 😒
+        })
+    }
+
+    pub fn snippet(&self, receiver: &str) -> String {
+        self.snippet.replace("$receiver", receiver)
+    }
 }

--- a/crates/ide_completion/src/context.rs
+++ b/crates/ide_completion/src/context.rs
@@ -869,7 +869,8 @@ mod tests {
 
     fn check_expected_type_and_name(ra_fixture: &str, expect: Expect) {
         let (db, pos) = position(ra_fixture);
-        let completion_context = CompletionContext::new(&db, pos, &TEST_CONFIG).unwrap();
+        let config = TEST_CONFIG;
+        let completion_context = CompletionContext::new(&db, pos, &config).unwrap();
 
         let ty = completion_context
             .expected_type

--- a/crates/ide_completion/src/lib.rs
+++ b/crates/ide_completion/src/lib.rs
@@ -9,6 +9,7 @@ mod render;
 
 #[cfg(test)]
 mod tests;
+mod snippet;
 
 use completions::flyimport::position_for_import;
 use ide_db::{
@@ -24,8 +25,9 @@ use text_edit::TextEdit;
 use crate::{completions::Completions, context::CompletionContext, item::CompletionKind};
 
 pub use crate::{
-    config::{CompletionConfig, PostfixSnippet},
+    config::CompletionConfig,
     item::{CompletionItem, CompletionItemKind, CompletionRelevance, ImportEdit},
+    snippet::{PostfixSnippet, PostfixSnippetScope, Snippet, SnippetScope},
 };
 
 //FIXME: split the following feature into fine-grained features.

--- a/crates/ide_completion/src/lib.rs
+++ b/crates/ide_completion/src/lib.rs
@@ -24,7 +24,7 @@ use text_edit::TextEdit;
 use crate::{completions::Completions, context::CompletionContext, item::CompletionKind};
 
 pub use crate::{
-    config::CompletionConfig,
+    config::{CompletionConfig, PostfixSnippet},
     item::{CompletionItem, CompletionItemKind, CompletionRelevance, ImportEdit},
 };
 

--- a/crates/ide_completion/src/lib.rs
+++ b/crates/ide_completion/src/lib.rs
@@ -15,11 +15,13 @@ use completions::flyimport::position_for_import;
 use ide_db::{
     base_db::FilePosition,
     helpers::{
-        import_assets::{LocatedImport, NameToImport},
-        insert_use::ImportScope,
+        import_assets::NameToImport,
+        insert_use::{self, ImportScope},
+        mod_path_to_ast,
     },
     items_locator, RootDatabase,
 };
+use syntax::algo;
 use text_edit::TextEdit;
 
 use crate::{completions::Completions, context::CompletionContext, item::CompletionKind};
@@ -177,41 +179,35 @@ pub fn resolve_completion_edits(
     position: FilePosition,
     imports: impl IntoIterator<Item = (String, String)>,
 ) -> Option<Vec<TextEdit>> {
+    let _p = profile::span("resolve_completion_edits");
     let ctx = CompletionContext::new(db, position, config)?;
     let position_for_import = position_for_import(&ctx, None)?;
     let scope = ImportScope::find_insert_use_container_with_macros(position_for_import, &ctx.sema)?;
 
     let current_module = ctx.sema.scope(position_for_import).module()?;
     let current_crate = current_module.krate();
+    let new_ast = scope.clone_for_update();
+    let mut import_insert = TextEdit::builder();
 
-    Some(
-        imports
-            .into_iter()
-            .filter_map(|(full_import_path, imported_name)| {
-                let (import_path, item_to_import) = items_locator::items_with_name(
-                    &ctx.sema,
-                    current_crate,
-                    NameToImport::Exact(imported_name),
-                    items_locator::AssocItemSearch::Include,
-                    Some(items_locator::DEFAULT_QUERY_SEARCH_LIMIT.inner()),
-                )
-                .filter_map(|candidate| {
-                    current_module
-                        .find_use_path_prefixed(db, candidate, config.insert_use.prefix_kind)
-                        .zip(Some(candidate))
-                })
-                .find(|(mod_path, _)| mod_path.to_string() == full_import_path)?;
-                let import = LocatedImport::new(
-                    import_path.clone(),
-                    item_to_import,
-                    item_to_import,
-                    Some(import_path),
-                );
-
-                ImportEdit { import, scope: scope.clone() }
-                    .to_text_edit(config.insert_use)
-                    .map(|edit| edit)
+    // FIXME: lift out and make some tests here, this is ImportEdit::to_text_edit but changed to work with multiple edits
+    imports.into_iter().for_each(|(full_import_path, imported_name)| {
+        let items_with_name = items_locator::items_with_name(
+            &ctx.sema,
+            current_crate,
+            NameToImport::Exact(imported_name),
+            items_locator::AssocItemSearch::Include,
+            Some(items_locator::DEFAULT_QUERY_SEARCH_LIMIT.inner()),
+        );
+        let import = items_with_name
+            .filter_map(|candidate| {
+                current_module.find_use_path_prefixed(db, candidate, config.insert_use.prefix_kind)
             })
-            .collect(),
-    )
+            .find(|mod_path| mod_path.to_string() == full_import_path);
+        if let Some(import_path) = import {
+            insert_use::insert_use(&new_ast, mod_path_to_ast(&import_path), &config.insert_use);
+        }
+    });
+
+    algo::diff(scope.as_syntax_node(), new_ast.as_syntax_node()).into_text_edit(&mut import_insert);
+    Some(vec![import_insert.finish()])
 }

--- a/crates/ide_completion/src/lib.rs
+++ b/crates/ide_completion/src/lib.rs
@@ -29,7 +29,7 @@ use crate::{completions::Completions, context::CompletionContext, item::Completi
 pub use crate::{
     config::CompletionConfig,
     item::{CompletionItem, CompletionItemKind, CompletionRelevance, ImportEdit},
-    snippet::{PostfixSnippet, PostfixSnippetScope, Snippet, SnippetScope},
+    snippet::{Snippet, SnippetScope},
 };
 
 //FIXME: split the following feature into fine-grained features.

--- a/crates/ide_completion/src/render.rs
+++ b/crates/ide_completion/src/render.rs
@@ -212,7 +212,10 @@ fn render_resolution_(
                 ctx.source_range(),
                 local_name.to_string(),
             );
-            item.kind(CompletionItemKind::UnresolvedReference).add_import(import_to_add);
+            item.kind(CompletionItemKind::UnresolvedReference);
+            if let Some(import_to_add) = import_to_add {
+                item.add_import(import_to_add);
+            }
             return Some(item.build());
         }
     };
@@ -258,9 +261,12 @@ fn render_resolution_(
         }
     }
     item.kind(kind)
-        .add_import(import_to_add)
         .set_documentation(scope_def_docs(ctx.db(), resolution))
         .set_deprecated(scope_def_is_deprecated(&ctx, resolution));
+
+    if let Some(import_to_add) = import_to_add {
+        item.add_import(import_to_add);
+    }
     Some(item.build())
 }
 

--- a/crates/ide_completion/src/render/enum_variant.rs
+++ b/crates/ide_completion/src/render/enum_variant.rs
@@ -68,8 +68,11 @@ impl<'a> EnumRender<'a> {
         item.kind(SymbolKind::Variant)
             .set_documentation(self.variant.docs(self.ctx.db()))
             .set_deprecated(self.ctx.is_deprecated(self.variant))
-            .add_import(import_to_add)
             .detail(self.detail());
+
+        if let Some(import_to_add) = import_to_add {
+            item.add_import(import_to_add);
+        }
 
         if self.variant_kind == hir::StructKind::Tuple {
             cov_mark::hit!(inserts_parens_for_tuple_enums);

--- a/crates/ide_completion/src/render/function.rs
+++ b/crates/ide_completion/src/render/function.rs
@@ -98,7 +98,10 @@ impl<'a> FunctionRender<'a> {
             }
         }
 
-        item.add_import(import_to_add).lookup_by(self.name);
+        if let Some(import_to_add) = import_to_add {
+            item.add_import(import_to_add);
+        }
+        item.lookup_by(self.name);
 
         let ret_type = self.func.ret_type(self.ctx.db());
         item.set_relevance(CompletionRelevance {

--- a/crates/ide_completion/src/render/macro_.rs
+++ b/crates/ide_completion/src/render/macro_.rs
@@ -51,8 +51,11 @@ impl<'a> MacroRender<'a> {
         item.kind(SymbolKind::Macro)
             .set_documentation(self.docs.clone())
             .set_deprecated(self.ctx.is_deprecated(self.macro_))
-            .add_import(import_to_add)
             .set_detail(self.detail());
+
+        if let Some(import_to_add) = import_to_add {
+            item.add_import(import_to_add);
+        }
 
         let needs_bang = !(self.ctx.completion.in_use_tree()
             || matches!(self.ctx.completion.path_call_kind(), Some(CallKind::Mac)));

--- a/crates/ide_completion/src/snippet.rs
+++ b/crates/ide_completion/src/snippet.rs
@@ -1,6 +1,57 @@
 //! User (postfix)-snippet definitions.
 //!
 //! Actual logic is implemented in [`crate::completions::postfix`] and [`crate::completions::snippet`].
+
+// Feature: User Snippet Completions
+//
+// rust-analyzer allows the user to define custom (postfix)-snippets that may depend on items to be accessible for the current scope to be applicable.
+//
+// A custom snippet can be defined by adding it to the `rust-analyzer.completion.snippets` object respectively.
+//
+// [source,json]
+// ----
+// {
+//   "rust-analyzer.completion.snippets": {
+//     "thread spawn": {
+//       "prefix": ["spawn", "tspawn"],
+//       "body": [
+//         "thread::spawn(move || {",
+//         "\t$0",
+//         ")};",
+//       ],
+//       "description": "Insert a thread::spawn call",
+//       "requires": "std::thread",
+//       "scope": "expr",
+//     }
+//   }
+// }
+// ----
+//
+// In the example above:
+//
+// * `"thread spawn"` is the name of the snippet.
+//
+// * `prefix` defines one or more trigger words that will trigger the snippets completion.
+// Using `postfix` will instead create a postfix snippet.
+//
+// * `body` is one or more lines of content joined via newlines for the final output.
+//
+// * `description` is an optional description of the snippet, if unset the snippet name will be used.
+//
+// * `requires` is an optional list of item paths that have to be resolvable in the current crate where the completion is rendered.
+// On failure of resolution the snippet won't be applicable, otherwise the snippet will insert an import for the items on insertion if
+// the items aren't yet in scope.
+//
+// * `scope` is an optional filter for when the snippet should be applicable. Possible values are:
+// ** for Snippet-Scopes: `expr`, `item` (default: `item`)
+// ** for Postfix-Snippet-Scopes: `expr`, `type` (default: `expr`)
+//
+// The `body` field also has access to placeholders as visible in the example as `$0`.
+// These placeholders take the form of `$number` or `${number:placeholder_text}` which can be traversed as tabstop in ascending order starting from 1,
+// with `$0` being a special case that always comes last.
+//
+// There is also a special placeholder, `${receiver}`, which will be replaced by the receiver expression for postfix snippets, or nothing in case of normal snippets.
+// It does not act as a tabstop.
 use ide_db::helpers::{import_assets::LocatedImport, insert_use::ImportScope};
 use itertools::Itertools;
 use syntax::ast;
@@ -8,50 +59,40 @@ use syntax::ast;
 use crate::{context::CompletionContext, ImportEdit};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum PostfixSnippetScope {
+pub enum SnippetScope {
+    Item,
     Expr,
     Type,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum SnippetScope {
-    Item,
-    Expr,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct PostfixSnippet {
-    pub scope: PostfixSnippetScope,
-    pub label: String,
+pub struct Snippet {
+    pub postfix_triggers: Box<[String]>,
+    pub prefix_triggers: Box<[String]>,
+    pub scope: SnippetScope,
     snippet: String,
     pub description: Option<String>,
     pub requires: Box<[String]>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct Snippet {
-    pub scope: SnippetScope,
-    pub label: String,
-    pub snippet: String,
-    pub description: Option<String>,
-    pub requires: Box<[String]>,
-}
 impl Snippet {
     pub fn new(
-        label: String,
+        prefix_triggers: &[String],
+        postfix_triggers: &[String],
         snippet: &[String],
-        description: &[String],
+        description: &str,
         requires: &[String],
         scope: SnippetScope,
     ) -> Option<Self> {
         let (snippet, description) = validate_snippet(snippet, description, requires)?;
         Some(Snippet {
+            // Box::into doesn't work as that has a Copy bound 😒
+            postfix_triggers: postfix_triggers.iter().cloned().collect(),
+            prefix_triggers: prefix_triggers.iter().cloned().collect(),
             scope,
-            label,
             snippet,
             description,
-            requires: requires.iter().cloned().collect(), // Box::into doesn't work as that has a Copy bound 😒
+            requires: requires.iter().cloned().collect(),
         })
     }
 
@@ -62,6 +103,14 @@ impl Snippet {
         import_scope: &ImportScope,
     ) -> Option<Vec<ImportEdit>> {
         import_edits(ctx, import_scope, &self.requires)
+    }
+
+    pub fn snippet(&self) -> String {
+        self.snippet.replace("${receiver}", "")
+    }
+
+    pub fn postfix_snippet(&self, receiver: &str) -> String {
+        self.snippet.replace("${receiver}", receiver)
     }
 
     pub fn is_item(&self) -> bool {
@@ -70,46 +119,6 @@ impl Snippet {
 
     pub fn is_expr(&self) -> bool {
         self.scope == SnippetScope::Expr
-    }
-}
-
-impl PostfixSnippet {
-    pub fn new(
-        label: String,
-        snippet: &[String],
-        description: &[String],
-        requires: &[String],
-        scope: PostfixSnippetScope,
-    ) -> Option<Self> {
-        let (snippet, description) = validate_snippet(snippet, description, requires)?;
-        Some(PostfixSnippet {
-            scope,
-            label,
-            snippet,
-            description,
-            requires: requires.iter().cloned().collect(), // Box::into doesn't work as that has a Copy bound 😒
-        })
-    }
-
-    /// Returns None if the required items do not resolve.
-    pub(crate) fn imports(
-        &self,
-        ctx: &CompletionContext,
-        import_scope: &ImportScope,
-    ) -> Option<Vec<ImportEdit>> {
-        import_edits(ctx, import_scope, &self.requires)
-    }
-
-    pub fn snippet(&self, receiver: &str) -> String {
-        self.snippet.replace("$receiver", receiver)
-    }
-
-    pub fn is_item(&self) -> bool {
-        self.scope == PostfixSnippetScope::Type
-    }
-
-    pub fn is_expr(&self) -> bool {
-        self.scope == PostfixSnippetScope::Expr
     }
 }
 
@@ -147,7 +156,7 @@ fn import_edits(
 
 fn validate_snippet(
     snippet: &[String],
-    description: &[String],
+    description: &str,
     requires: &[String],
 ) -> Option<(String, Option<String>)> {
     // validate that these are indeed simple paths
@@ -162,7 +171,6 @@ fn validate_snippet(
         return None;
     }
     let snippet = snippet.iter().join("\n");
-    let description = description.iter().join("\n");
-    let description = if description.is_empty() { None } else { Some(description) };
+    let description = if description.is_empty() { None } else { Some(description.to_owned()) };
     Some((snippet, description))
 }

--- a/crates/ide_completion/src/snippet.rs
+++ b/crates/ide_completion/src/snippet.rs
@@ -41,7 +41,7 @@ impl Snippet {
         snippet: &[String],
         description: &[String],
         requires: &[String],
-        scope: Option<SnippetScope>,
+        scope: SnippetScope,
     ) -> Option<Self> {
         // validate that these are indeed simple paths
         if requires.iter().any(|path| match ast::Path::parse(path) {
@@ -57,7 +57,7 @@ impl Snippet {
         let description = description.iter().join("\n");
         let description = if description.is_empty() { None } else { Some(description) };
         Some(Snippet {
-            scope: scope.unwrap_or(SnippetScope::Expr),
+            scope,
             label,
             snippet,
             description,
@@ -89,7 +89,7 @@ impl PostfixSnippet {
         snippet: &[String],
         description: &[String],
         requires: &[String],
-        scope: Option<PostfixSnippetScope>,
+        scope: PostfixSnippetScope,
     ) -> Option<Self> {
         // validate that these are indeed simple paths
         if requires.iter().any(|path| match ast::Path::parse(path) {
@@ -105,7 +105,7 @@ impl PostfixSnippet {
         let description = description.iter().join("\n");
         let description = if description.is_empty() { None } else { Some(description) };
         Some(PostfixSnippet {
-            scope: scope.unwrap_or(PostfixSnippetScope::Expr),
+            scope,
             label,
             snippet,
             description,

--- a/crates/ide_completion/src/snippet.rs
+++ b/crates/ide_completion/src/snippet.rs
@@ -1,3 +1,6 @@
+//! User (postfix)-snippet definitions.
+//!
+//! Actual logic is implemented in [`crate::completions::postfix`] and [`crate::completions::snippet`].
 use ide_db::helpers::{import_assets::LocatedImport, insert_use::ImportScope};
 use itertools::Itertools;
 use syntax::ast;

--- a/crates/ide_completion/src/snippet.rs
+++ b/crates/ide_completion/src/snippet.rs
@@ -1,0 +1,170 @@
+use ide_db::helpers::{import_assets::LocatedImport, insert_use::ImportScope};
+use itertools::Itertools;
+use syntax::ast;
+
+use crate::{context::CompletionContext, ImportEdit};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PostfixSnippetScope {
+    Expr,
+    Type,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SnippetScope {
+    Item,
+    Expr,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PostfixSnippet {
+    pub scope: PostfixSnippetScope,
+    pub label: String,
+    snippet: String,
+    pub description: Option<String>,
+    pub requires: Box<[String]>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Snippet {
+    pub scope: SnippetScope,
+    pub label: String,
+    pub snippet: String,
+    pub description: Option<String>,
+    pub requires: Box<[String]>,
+}
+
+impl Snippet {
+    pub fn new(
+        label: String,
+        snippet: &[String],
+        description: &[String],
+        requires: &[String],
+        scope: Option<SnippetScope>,
+    ) -> Option<Self> {
+        // validate that these are indeed simple paths
+        if requires.iter().any(|path| match ast::Path::parse(path) {
+            Ok(path) => path.segments().any(|seg| {
+                !matches!(seg.kind(), Some(ast::PathSegmentKind::Name(_)))
+                    || seg.generic_arg_list().is_some()
+            }),
+            Err(_) => true,
+        }) {
+            return None;
+        }
+        let snippet = snippet.iter().join("\n");
+        let description = description.iter().join("\n");
+        let description = if description.is_empty() { None } else { Some(description) };
+        Some(Snippet {
+            scope: scope.unwrap_or(SnippetScope::Expr),
+            label,
+            snippet,
+            description,
+            requires: requires.iter().cloned().collect(), // Box::into doesn't work as that has a Copy bound 😒
+        })
+    }
+
+    // FIXME: This shouldn't be fallible
+    pub(crate) fn imports(
+        &self,
+        ctx: &CompletionContext,
+        import_scope: &ImportScope,
+    ) -> Result<Vec<ImportEdit>, ()> {
+        import_edits(ctx, import_scope, &self.requires)
+    }
+
+    pub fn is_item(&self) -> bool {
+        self.scope == SnippetScope::Item
+    }
+
+    pub fn is_expr(&self) -> bool {
+        self.scope == SnippetScope::Expr
+    }
+}
+
+impl PostfixSnippet {
+    pub fn new(
+        label: String,
+        snippet: &[String],
+        description: &[String],
+        requires: &[String],
+        scope: Option<PostfixSnippetScope>,
+    ) -> Option<Self> {
+        // validate that these are indeed simple paths
+        if requires.iter().any(|path| match ast::Path::parse(path) {
+            Ok(path) => path.segments().any(|seg| {
+                !matches!(seg.kind(), Some(ast::PathSegmentKind::Name(_)))
+                    || seg.generic_arg_list().is_some()
+            }),
+            Err(_) => true,
+        }) {
+            return None;
+        }
+        let snippet = snippet.iter().join("\n");
+        let description = description.iter().join("\n");
+        let description = if description.is_empty() { None } else { Some(description) };
+        Some(PostfixSnippet {
+            scope: scope.unwrap_or(PostfixSnippetScope::Expr),
+            label,
+            snippet,
+            description,
+            requires: requires.iter().cloned().collect(), // Box::into doesn't work as that has a Copy bound 😒
+        })
+    }
+
+    // FIXME: This shouldn't be fallible
+    pub(crate) fn imports(
+        &self,
+        ctx: &CompletionContext,
+        import_scope: &ImportScope,
+    ) -> Result<Vec<ImportEdit>, ()> {
+        import_edits(ctx, import_scope, &self.requires)
+    }
+
+    pub fn snippet(&self, receiver: &str) -> String {
+        self.snippet.replace("$receiver", receiver)
+    }
+
+    pub fn is_item(&self) -> bool {
+        self.scope == PostfixSnippetScope::Type
+    }
+
+    pub fn is_expr(&self) -> bool {
+        self.scope == PostfixSnippetScope::Expr
+    }
+}
+
+fn import_edits(
+    ctx: &CompletionContext,
+    import_scope: &ImportScope,
+    requires: &[String],
+) -> Result<Vec<ImportEdit>, ()> {
+    let resolve = |import| {
+        let path = ast::Path::parse(import).ok()?;
+        match ctx.scope.speculative_resolve(&path)? {
+            hir::PathResolution::Macro(_) => None,
+            hir::PathResolution::Def(def) => {
+                let item = def.into();
+                let path = ctx.scope.module()?.find_use_path_prefixed(
+                    ctx.db,
+                    item,
+                    ctx.config.insert_use.prefix_kind,
+                )?;
+                Some((path.len() > 1).then(|| ImportEdit {
+                    import: LocatedImport::new(path.clone(), item, item, None),
+                    scope: import_scope.clone(),
+                }))
+            }
+            _ => None,
+        }
+    };
+    let mut res = Vec::with_capacity(requires.len());
+    for import in requires {
+        match resolve(import) {
+            Some(first) => res.extend(first),
+            None => return Err(()),
+        }
+    }
+    Ok(res)
+}

--- a/crates/ide_completion/src/tests.rs
+++ b/crates/ide_completion/src/tests.rs
@@ -74,7 +74,6 @@ pub(crate) const TEST_CONFIG: CompletionConfig = CompletionConfig {
         group: true,
         skip_glob_imports: true,
     },
-    postfix_snippets: Vec::new(),
     snippets: Vec::new(),
 };
 

--- a/crates/ide_completion/src/tests.rs
+++ b/crates/ide_completion/src/tests.rs
@@ -74,6 +74,7 @@ pub(crate) const TEST_CONFIG: CompletionConfig = CompletionConfig {
         group: true,
         skip_glob_imports: true,
     },
+    postfix_snippets: Vec::new(),
 };
 
 pub(crate) fn completion_list(ra_fixture: &str) -> String {

--- a/crates/ide_completion/src/tests.rs
+++ b/crates/ide_completion/src/tests.rs
@@ -75,6 +75,7 @@ pub(crate) const TEST_CONFIG: CompletionConfig = CompletionConfig {
         skip_glob_imports: true,
     },
     postfix_snippets: Vec::new(),
+    snippets: Vec::new(),
 };
 
 pub(crate) fn completion_list(ra_fixture: &str) -> String {

--- a/crates/ide_completion/src/tests.rs
+++ b/crates/ide_completion/src/tests.rs
@@ -183,13 +183,15 @@ pub(crate) fn check_edit_with_config(
     let mut actual = db.file_text(position.file_id).to_string();
 
     let mut combined_edit = completion.text_edit().to_owned();
-    if let Some(import_text_edit) =
-        completion.import_to_add().and_then(|edit| edit.to_text_edit(config.insert_use))
-    {
-        combined_edit.union(import_text_edit).expect(
-            "Failed to apply completion resolve changes: change ranges overlap, but should not",
-        )
-    }
+    completion
+        .imports_to_add()
+        .iter()
+        .filter_map(|edit| edit.to_text_edit(config.insert_use))
+        .for_each(|text_edit| {
+            combined_edit.union(text_edit).expect(
+                "Failed to apply completion resolve changes: change ranges overlap, but should not",
+            )
+        });
 
     combined_edit.apply(&mut actual);
     assert_eq_text!(&ra_fixture_after, &actual)

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -282,9 +282,9 @@ config_data! {
         rustfmt_enableRangeFormatting: bool = "false",
 
         /// Workspace symbol search scope.
-        workspace_symbol_search_scope: WorskpaceSymbolSearchScopeDef = "\"workspace\"",
+        workspace_symbol_search_scope: WorkspaceSymbolSearchScopeDef = "\"workspace\"",
         /// Workspace symbol search kind.
-        workspace_symbol_search_kind: WorskpaceSymbolSearchKindDef = "\"only_types\"",
+        workspace_symbol_search_kind: WorkspaceSymbolSearchKindDef = "\"only_types\"",
     }
 }
 
@@ -893,14 +893,14 @@ impl Config {
     pub fn workspace_symbol(&self) -> WorkspaceSymbolConfig {
         WorkspaceSymbolConfig {
             search_scope: match self.data.workspace_symbol_search_scope {
-                WorskpaceSymbolSearchScopeDef::Workspace => WorkspaceSymbolSearchScope::Workspace,
-                WorskpaceSymbolSearchScopeDef::WorkspaceAndDependencies => {
+                WorkspaceSymbolSearchScopeDef::Workspace => WorkspaceSymbolSearchScope::Workspace,
+                WorkspaceSymbolSearchScopeDef::WorkspaceAndDependencies => {
                     WorkspaceSymbolSearchScope::WorkspaceAndDependencies
                 }
             },
             search_kind: match self.data.workspace_symbol_search_kind {
-                WorskpaceSymbolSearchKindDef::OnlyTypes => WorkspaceSymbolSearchKind::OnlyTypes,
-                WorskpaceSymbolSearchKindDef::AllSymbols => WorkspaceSymbolSearchKind::AllSymbols,
+                WorkspaceSymbolSearchKindDef::OnlyTypes => WorkspaceSymbolSearchKind::OnlyTypes,
+                WorkspaceSymbolSearchKindDef::AllSymbols => WorkspaceSymbolSearchKind::AllSymbols,
             },
         }
     }
@@ -1065,14 +1065,14 @@ enum ImportPrefixDef {
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "snake_case")]
-enum WorskpaceSymbolSearchScopeDef {
+enum WorkspaceSymbolSearchScopeDef {
     Workspace,
     WorkspaceAndDependencies,
 }
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "snake_case")]
-enum WorskpaceSymbolSearchKindDef {
+enum WorkspaceSymbolSearchKindDef {
     OnlyTypes,
     AllSymbols,
 }
@@ -1203,6 +1203,12 @@ fn field_props(field: &str, ty: &str, doc: &[&str], default: &str) -> serde_json
             "items": { "type": "string" },
             "uniqueItems": true,
         },
+        "FxHashMap<String, PostfixSnippetDef>" => set! {
+            "type": "object",
+        },
+        "FxHashMap<String, SnippetDef>" => set! {
+            "type": "object",
+        },
         "FxHashMap<String, String>" => set! {
             "type": "object",
         },
@@ -1259,7 +1265,7 @@ fn field_props(field: &str, ty: &str, doc: &[&str], default: &str) -> serde_json
             "type": "array",
             "items": { "type": ["string", "object"] },
         },
-        "WorskpaceSymbolSearchScopeDef" => set! {
+        "WorkspaceSymbolSearchScopeDef" => set! {
             "type": "string",
             "enum": ["workspace", "workspace_and_dependencies"],
             "enumDescriptions": [
@@ -1267,7 +1273,7 @@ fn field_props(field: &str, ty: &str, doc: &[&str], default: &str) -> serde_json
                 "Search in current workspace and dependencies"
             ],
         },
-        "WorskpaceSymbolSearchKindDef" => set! {
+        "WorkspaceSymbolSearchKindDef" => set! {
             "type": "string",
             "enum": ["only_types", "all_symbols"],
             "enumDescriptions": [

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -462,10 +462,10 @@ impl Config {
                     &desc.snippet,
                     &desc.description,
                     &desc.requires,
-                    desc.scope.map(|scope| match scope {
+                    match desc.scope {
                         PostfixSnippetScopeDef::Expr => PostfixSnippetScope::Expr,
                         PostfixSnippetScopeDef::Type => PostfixSnippetScope::Type,
-                    }),
+                    },
                 )
             })
             .collect();
@@ -479,10 +479,10 @@ impl Config {
                     &desc.snippet,
                     &desc.description,
                     &desc.requires,
-                    desc.scope.map(|scope| match scope {
+                    match desc.scope {
                         SnippetScopeDef::Expr => SnippetScope::Expr,
                         SnippetScopeDef::Item => SnippetScope::Item,
-                    }),
+                    },
                 )
             })
             .collect();
@@ -954,15 +954,29 @@ impl Config {
 }
 
 #[derive(Deserialize, Debug, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
 enum PostfixSnippetScopeDef {
     Expr,
     Type,
 }
 
+impl Default for PostfixSnippetScopeDef {
+    fn default() -> Self {
+        PostfixSnippetScopeDef::Expr
+    }
+}
+
 #[derive(Deserialize, Debug, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
 enum SnippetScopeDef {
     Expr,
     Item,
+}
+
+impl Default for SnippetScopeDef {
+    fn default() -> Self {
+        SnippetScopeDef::Expr
+    }
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -973,7 +987,8 @@ struct PostfixSnippetDef {
     snippet: Vec<String>,
     #[serde(deserialize_with = "single_or_array")]
     requires: Vec<String>,
-    scope: Option<PostfixSnippetScopeDef>,
+    #[serde(default)]
+    scope: PostfixSnippetScopeDef,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -984,7 +999,8 @@ struct SnippetDef {
     snippet: Vec<String>,
     #[serde(deserialize_with = "single_or_array")]
     requires: Vec<String>,
-    scope: Option<SnippetScopeDef>,
+    #[serde(default)]
+    scope: SnippetScopeDef,
 }
 
 fn single_or_array<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -787,8 +787,10 @@ pub(crate) fn handle_completion_resolve(
         .resolve_completion_edits(
             &snap.config.completion(),
             FilePosition { file_id, offset },
-            &resolve_data.full_import_path,
-            resolve_data.imported_name,
+            resolve_data
+                .imports
+                .into_iter()
+                .map(|import| (import.full_import_path, import.imported_name)),
         )?
         .into_iter()
         .flat_map(|edit| edit.into_iter().map(|indel| to_proto::text_edit(&line_index, indel)))

--- a/crates/rust-analyzer/src/integrated_benchmarks.rs
+++ b/crates/rust-analyzer/src/integrated_benchmarks.rs
@@ -144,6 +144,7 @@ fn integrated_completion_benchmark() {
                 group: true,
                 skip_glob_imports: true,
             },
+            postfix_snippets: Vec::new(),
         };
         let position =
             FilePosition { file_id, offset: TextSize::try_from(completion_offset).unwrap() };
@@ -180,6 +181,7 @@ fn integrated_completion_benchmark() {
                 group: true,
                 skip_glob_imports: true,
             },
+            postfix_snippets: Vec::new(),
         };
         let position =
             FilePosition { file_id, offset: TextSize::try_from(completion_offset).unwrap() };

--- a/crates/rust-analyzer/src/integrated_benchmarks.rs
+++ b/crates/rust-analyzer/src/integrated_benchmarks.rs
@@ -144,7 +144,6 @@ fn integrated_completion_benchmark() {
                 group: true,
                 skip_glob_imports: true,
             },
-            postfix_snippets: Vec::new(),
             snippets: Vec::new(),
         };
         let position =
@@ -182,7 +181,6 @@ fn integrated_completion_benchmark() {
                 group: true,
                 skip_glob_imports: true,
             },
-            postfix_snippets: Vec::new(),
             snippets: Vec::new(),
         };
         let position =

--- a/crates/rust-analyzer/src/integrated_benchmarks.rs
+++ b/crates/rust-analyzer/src/integrated_benchmarks.rs
@@ -145,6 +145,7 @@ fn integrated_completion_benchmark() {
                 skip_glob_imports: true,
             },
             postfix_snippets: Vec::new(),
+            snippets: Vec::new(),
         };
         let position =
             FilePosition { file_id, offset: TextSize::try_from(completion_offset).unwrap() };
@@ -182,6 +183,7 @@ fn integrated_completion_benchmark() {
                 skip_glob_imports: true,
             },
             postfix_snippets: Vec::new(),
+            snippets: Vec::new(),
         };
         let position =
             FilePosition { file_id, offset: TextSize::try_from(completion_offset).unwrap() };

--- a/crates/rust-analyzer/src/lsp_ext.rs
+++ b/crates/rust-analyzer/src/lsp_ext.rs
@@ -520,6 +520,11 @@ pub enum WorkspaceSymbolSearchKind {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CompletionResolveData {
     pub position: lsp_types::TextDocumentPositionParams,
+    pub imports: Vec<CompletionImport>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CompletionImport {
     pub full_import_path: String,
     pub imported_name: String,
 }

--- a/docs/dev/lsp-extensions.md
+++ b/docs/dev/lsp-extensions.md
@@ -1,5 +1,5 @@
 <!---
-lsp_ext.rs hash: ad52054176909945
+lsp_ext.rs hash: c6568e4035333f3a
 
 If you need to change the above hash to make the test pass, please check if you
 need to adjust this doc as well and ping this issue:

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -146,11 +146,6 @@ Custom completion snippets.
 --
 Whether to show postfix snippets like `dbg`, `if`, `not`, etc.
 --
-[[rust-analyzer.completion.postfix.snippets]]rust-analyzer.completion.postfix.snippets (default: `{}`)::
-+
---
-Custom postfix completion snippets.
---
 [[rust-analyzer.completion.autoimport.enable]]rust-analyzer.completion.autoimport.enable (default: `true`)::
 +
 --

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -136,10 +136,20 @@ Only applies when `#rust-analyzer.completion.addCallParenthesis#` is set.
 --
 Whether to add parenthesis when completing functions.
 --
+[[rust-analyzer.completion.snippets]]rust-analyzer.completion.snippets (default: `{}`)::
++
+--
+Custom completion snippets.
+--
 [[rust-analyzer.completion.postfix.enable]]rust-analyzer.completion.postfix.enable (default: `true`)::
 +
 --
 Whether to show postfix snippets like `dbg`, `if`, `not`, etc.
+--
+[[rust-analyzer.completion.postfix.snippets]]rust-analyzer.completion.postfix.snippets (default: `{}`)::
++
+--
+Custom postfix completion snippets.
 --
 [[rust-analyzer.completion.autoimport.enable]]rust-analyzer.completion.autoimport.enable (default: `true`)::
 +

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -585,10 +585,20 @@
                     "default": true,
                     "type": "boolean"
                 },
+                "rust-analyzer.completion.snippets": {
+                    "markdownDescription": "Custom completion snippets.",
+                    "default": {},
+                    "type": "object"
+                },
                 "rust-analyzer.completion.postfix.enable": {
                     "markdownDescription": "Whether to show postfix snippets like `dbg`, `if`, `not`, etc.",
                     "default": true,
                     "type": "boolean"
+                },
+                "rust-analyzer.completion.postfix.snippets": {
+                    "markdownDescription": "Custom postfix completion snippets.",
+                    "default": {},
+                    "type": "object"
                 },
                 "rust-analyzer.completion.autoimport.enable": {
                     "markdownDescription": "Toggles the additional completions that automatically add imports when completed.\nNote that your client must specify the `additionalTextEdits` LSP client capability to truly have this feature enabled.",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -595,11 +595,6 @@
                     "default": true,
                     "type": "boolean"
                 },
-                "rust-analyzer.completion.postfix.snippets": {
-                    "markdownDescription": "Custom postfix completion snippets.",
-                    "default": {},
-                    "type": "object"
-                },
                 "rust-analyzer.completion.autoimport.enable": {
                     "markdownDescription": "Toggles the additional completions that automatically add imports when completed.\nNote that your client must specify the `additionalTextEdits` LSP client capability to truly have this feature enabled.",
                     "default": true,


### PR DESCRIPTION
![Y24dX7fOWX](https://user-images.githubusercontent.com/3757771/136059454-ceccfc2c-2c90-46da-8ad1-bac9c2e83ec1.gif)

Allows us to address the following issues:
    - `.arc / .rc / .pin, similar to .box?` https://github.com/rust-analyzer/rust-analyzer/issues/7033
    - `Add unsafe snippet` https://github.com/rust-analyzer/rust-analyzer/issues/10392, would allow users to have this without the diagnostic)
    - `.ok() postfix snippet is annoying` https://github.com/rust-analyzer/rust-analyzer/issues/9636, allows us to get rid of the `ok` postfix and similar ones
    - `Postfix vec completion` https://github.com/rust-analyzer/rust-analyzer/issues/7773

cc https://github.com/rust-analyzer/rust-analyzer/issues/772

Zulipd discussion: https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Frust-analyzer/topic/Custom.20Postfix.20snippets