### PR TITLE
internal: Set server status to warning when proc-macro sources change

### DIFF
--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -561,7 +561,7 @@ impl GlobalState {
                 s.shutdown_requested = true;
                 Ok(())
             })?
-            .on_sync_mut::<lsp_ext::MemoryUsage>(|s, p| handlers::handle_memory_usage(s, p))?
+            .on_sync_mut::<lsp_ext::MemoryUsage>(handlers::handle_memory_usage)?
             .on_sync::<lsp_ext::JoinLines>(handlers::handle_join_lines)?
             .on_sync::<lsp_ext::OnEnter>(handlers::handle_on_enter)?
             .on_sync::<lsp_types::request::SelectionRangeRequest>(handlers::handle_selection_range)?

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -66,6 +66,11 @@ impl GlobalState {
             message: None,
         };
 
+        if self.proc_macro_changed {
+            status.health = lsp_ext::Health::Warning;
+            status.message =
+                Some("Reload required due to source changes of a procedural macro.".into())
+        }
         if let Some(error) = self.fetch_build_data_error() {
             status.health = lsp_ext::Health::Warning;
             status.message = Some(error)


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/10027
![image](https://user-images.githubusercontent.com/3757771/138102552-208d3edf-a843-49e6-9f48-1e911f54a4ba.png)

It feels wrong using the database in this part of the code, but this was the only way to figure out whether a file belongs to a proc-macro that I could think of.
