### PR TITLE
feat: upgrade ubuntu builders

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -85,7 +85,7 @@ jobs:
 
   dist-x86_64-unknown-linux-gnu:
     name: dist (x86_64-unknown-linux-gnu)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       RA_TARGET: x86_64-unknown-linux-gnu
 
@@ -125,7 +125,7 @@ jobs:
 
   dist-x86_64-unknown-linux-musl:
     name: dist (x86_64-unknown-linux-musl)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       RA_TARGET: x86_64-unknown-linux-musl
       # For some reason `-crt-static` is not working for clang without lld
@@ -155,7 +155,7 @@ jobs:
 
   dist-aarch64-unknown-linux-gnu:
     name: dist (aarch64-unknown-linux-gnu)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       RA_TARGET: aarch64-unknown-linux-gnu
       CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
@@ -256,7 +256,7 @@ jobs:
 
   publish:
     name: publish
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: ['dist-x86_64-pc-windows-msvc', 'dist-aarch64-pc-windows-msvc', 'dist-x86_64-unknown-linux-gnu', 'dist-x86_64-unknown-linux-musl', 'dist-aarch64-unknown-linux-gnu', 'dist-x86_64-apple-darwin', 'dist-aarch64-apple-darwin']
     steps:
     - name: Install Nodejs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -123,36 +123,6 @@ jobs:
         name: dist-x86_64-unknown-linux-gnu
         path: ./dist
 
-  dist-x86_64-unknown-linux-musl:
-    name: dist (x86_64-unknown-linux-musl)
-    runs-on: ubuntu-latest
-    env:
-      RA_TARGET: x86_64-unknown-linux-musl
-      # For some reason `-crt-static` is not working for clang without lld
-      RUSTFLAGS: "-C link-arg=-fuse-ld=lld -C target-feature=-crt-static"
-    container:
-      image: rust:alpine
-      volumes:
-      - /usr/local/cargo/registry
-
-    steps:
-    - name: Install dependencies
-      run: apk add --no-cache git clang lld musl-dev
-
-    - name: Checkout repository
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: ${{ env.FETCH_DEPTH }}
-
-    - name: Dist
-      run: cargo xtask dist
-
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v1
-      with:
-        name: dist-x86_64-unknown-linux-musl
-        path: ./dist
-
   dist-aarch64-unknown-linux-gnu:
     name: dist (aarch64-unknown-linux-gnu)
     runs-on: ubuntu-20.04
@@ -187,6 +157,36 @@ jobs:
       uses: actions/upload-artifact@v1
       with:
         name: dist-aarch64-unknown-linux-gnu
+        path: ./dist
+
+  dist-x86_64-unknown-linux-musl:
+    name: dist (x86_64-unknown-linux-musl)
+    runs-on: ubuntu-latest
+    env:
+      RA_TARGET: x86_64-unknown-linux-musl
+      # For some reason `-crt-static` is not working for clang without lld
+      RUSTFLAGS: "-C link-arg=-fuse-ld=lld -C target-feature=-crt-static"
+    container:
+      image: rust:alpine
+      volumes:
+      - /usr/local/cargo/registry
+
+    steps:
+    - name: Install dependencies
+      run: apk add --no-cache git clang lld musl-dev
+
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: ${{ env.FETCH_DEPTH }}
+
+    - name: Dist
+      run: cargo xtask dist
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v1
+      with:
+        name: dist-x86_64-unknown-linux-musl
         path: ./dist
 
   dist-x86_64-apple-darwin:


### PR DESCRIPTION
For `-gnu` triples, use 20.04, the current LTS. This upgrades the
required version of glibc. For musl, just use `latest` as, presumably,
we don't care about glibc version in that case.

Hopefully, this unbreaks nightly publishing!

bors r+
🤖