### PR TITLE
minor: Use `.into_iter()` method on array to avoid dereference

### DIFF
--- a/xtask/src/install.rs
+++ b/xtask/src/install.rs
@@ -50,8 +50,8 @@ fn fix_path_for_mac() -> Result<()> {
         };
 
         [ROOT_DIR, &home_dir]
-            .iter()
-            .map(|dir| String::from(*dir) + COMMON_APP_PATH)
+            .into_iter()
+            .map(|dir| dir.to_string() + COMMON_APP_PATH)
             .map(PathBuf::from)
             .filter(|path| path.exists())
             .collect()


### PR DESCRIPTION
Arguably it’s nicer to just use `.into_iter()` instead of iterating over references which are immediately dereferenced.

I also changed the use of `String::from` to `.to_string()` because the latter has around twenty times more usages in rust-analyzer.