### PR TITLE
Handle pub tuple fields in tuple structs

### DIFF
--- a/crates/parser/src/grammar/items.rs
+++ b/crates/parser/src/grammar/items.rs
@@ -87,7 +87,7 @@ pub(super) fn item_or_macro(p: &mut Parser, stop_on_r_curly: bool) {
 pub(super) fn opt_item(p: &mut Parser, m: Marker) -> Result<(), Marker> {
     // test_err pub_expr
     // fn foo() { pub 92; }
-    let has_visibility = opt_visibility(p);
+    let has_visibility = opt_visibility(p, false);
 
     let m = match opt_item_without_modifiers(p, m) {
         Ok(()) => return Ok(()),

--- a/crates/parser/src/grammar/items/adt.rs
+++ b/crates/parser/src/grammar/items/adt.rs
@@ -128,7 +128,7 @@ pub(crate) fn record_field_list(p: &mut Parser) {
         // test record_field_attrs
         // struct S { #[attr] f: f32 }
         attributes::outer_attrs(p);
-        opt_visibility(p);
+        opt_visibility(p, false);
         if p.at(IDENT) {
             name(p);
             p.expect(T![:]);
@@ -150,7 +150,7 @@ fn tuple_field_list(p: &mut Parser) {
         // test tuple_field_attrs
         // struct S (#[attr] f32);
         attributes::outer_attrs(p);
-        opt_visibility(p);
+        opt_visibility(p, true);
         if !p.at_ts(types::TYPE_FIRST) {
             p.error("expected a type");
             m.complete(p, ERROR);

--- a/crates/syntax/test_data/parser/inline/ok/0196_pub_tuple_field.rast
+++ b/crates/syntax/test_data/parser/inline/ok/0196_pub_tuple_field.rast
@@ -1,0 +1,30 @@
+SOURCE_FILE@0..33
+  STRUCT@0..32
+    STRUCT_KW@0..6 "struct"
+    WHITESPACE@6..7 " "
+    NAME@7..15
+      IDENT@7..15 "MyStruct"
+    TUPLE_FIELD_LIST@15..31
+      L_PAREN@15..16 "("
+      TUPLE_FIELD@16..30
+        VISIBILITY@16..19
+          PUB_KW@16..19 "pub"
+        WHITESPACE@19..20 " "
+        TUPLE_TYPE@20..30
+          L_PAREN@20..21 "("
+          PATH_TYPE@21..24
+            PATH@21..24
+              PATH_SEGMENT@21..24
+                NAME_REF@21..24
+                  IDENT@21..24 "u32"
+          COMMA@24..25 ","
+          WHITESPACE@25..26 " "
+          PATH_TYPE@26..29
+            PATH@26..29
+              PATH_SEGMENT@26..29
+                NAME_REF@26..29
+                  IDENT@26..29 "u32"
+          R_PAREN@29..30 ")"
+      R_PAREN@30..31 ")"
+    SEMICOLON@31..32 ";"
+  WHITESPACE@32..33 "\n"

--- a/crates/syntax/test_data/parser/inline/ok/0196_pub_tuple_field.rs
+++ b/crates/syntax/test_data/parser/inline/ok/0196_pub_tuple_field.rs
@@ -1,0 +1,1 @@
+struct MyStruct(pub (u32, u32));


### PR DESCRIPTION
The current implementation will throw a parser error for tuple structs
that contain a pub tuple field. For example,
```rust
struct Foo(pub (u32, u32));
```
is valid Rust, but rust-analyzer will throw a parser error.  This is
because the parens after `pub` is treated as a visibility context.
Allowing a tuple type to follow `pub` in the special case when we are
defining fields in a tuple struct can fix the issue.

I guess this is a really minor case because there's not much reason
for having a tuple type within a struct tuple, but it is valid rust syntax...