### PR TITLE
internal: Make CompletionItem `label` and `lookup` fields `SmolStr`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,9 +1500,12 @@ checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "smol_str"
-version = "0.1.18"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b203e79e90905594272c1c97c7af701533d42adaab0beb3859018e477d54a3b0"
+checksum = "61d15c83e300cce35b7c8cd39ff567c1ef42dde6d4a1a38dbdbf9a59902261bd"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "snap"

--- a/crates/cfg/src/lib.rs
+++ b/crates/cfg/src/lib.rs
@@ -66,24 +66,21 @@ impl CfgOptions {
         }
     }
 
-    pub fn get_cfg_keys(&self) -> Vec<&SmolStr> {
-        self.enabled
-            .iter()
-            .map(|x| match x {
-                CfgAtom::Flag(key) => key,
-                CfgAtom::KeyValue { key, .. } => key,
-            })
-            .collect()
+    pub fn get_cfg_keys(&self) -> impl Iterator<Item = &SmolStr> {
+        self.enabled.iter().map(|x| match x {
+            CfgAtom::Flag(key) => key,
+            CfgAtom::KeyValue { key, .. } => key,
+        })
     }
 
-    pub fn get_cfg_values(&self, cfg_key: &str) -> Vec<&SmolStr> {
-        self.enabled
-            .iter()
-            .filter_map(|x| match x {
-                CfgAtom::KeyValue { key, value } if cfg_key == key => Some(value),
-                _ => None,
-            })
-            .collect()
+    pub fn get_cfg_values<'a>(
+        &'a self,
+        cfg_key: &'a str,
+    ) -> impl Iterator<Item = &'a SmolStr> + 'a {
+        self.enabled.iter().filter_map(move |x| match x {
+            CfgAtom::KeyValue { key, value } if cfg_key == key => Some(value),
+            _ => None,
+        })
     }
 }
 

--- a/crates/ide_completion/src/completions/attribute.rs
+++ b/crates/ide_completion/src/completions/attribute.rs
@@ -104,7 +104,7 @@ fn complete_new_attribute(acc: &mut Completions, ctx: &CompletionContext, attrib
                 let mut item = CompletionItem::new(
                     CompletionItemKind::Attribute,
                     ctx.source_range(),
-                    name.to_string(),
+                    name.to_smol_str(),
                 );
                 if let Some(docs) = mac.docs(ctx.sema.db) {
                     item.documentation(docs);

--- a/crates/ide_completion/src/completions/attribute/cfg.rs
+++ b/crates/ide_completion/src/completions/attribute/cfg.rs
@@ -31,13 +31,11 @@ pub(crate) fn complete_cfg(acc: &mut Completions, ctx: &CompletionContext) {
         Some("target_endian") => ["little", "big"].into_iter().for_each(add_completion),
         Some(name) => {
             if let Some(krate) = ctx.krate {
-                krate.potential_cfg(ctx.db).get_cfg_values(&name).iter().for_each(|s| {
-                    let mut item = CompletionItem::new(
-                        CompletionItemKind::Attribute,
-                        ctx.source_range(),
-                        s.as_str(),
-                    );
-                    item.insert_text(format!(r#""{}""#, s));
+                krate.potential_cfg(ctx.db).get_cfg_values(&name).cloned().for_each(|s| {
+                    let insert_text = format!(r#""{}""#, s);
+                    let mut item =
+                        CompletionItem::new(CompletionItemKind::Attribute, ctx.source_range(), s);
+                    item.insert_text(insert_text);
 
                     acc.add(item.build());
                 })
@@ -45,12 +43,9 @@ pub(crate) fn complete_cfg(acc: &mut Completions, ctx: &CompletionContext) {
         }
         None => {
             if let Some(krate) = ctx.krate {
-                krate.potential_cfg(ctx.db).get_cfg_keys().iter().for_each(|s| {
-                    let item = CompletionItem::new(
-                        CompletionItemKind::Attribute,
-                        ctx.source_range(),
-                        s.as_str(),
-                    );
+                krate.potential_cfg(ctx.db).get_cfg_keys().cloned().for_each(|s| {
+                    let item =
+                        CompletionItem::new(CompletionItemKind::Attribute, ctx.source_range(), s);
                     acc.add(item.build());
                 })
             }

--- a/crates/ide_completion/src/completions/fn_param.rs
+++ b/crates/ide_completion/src/completions/fn_param.rs
@@ -30,6 +30,7 @@ pub(crate) fn complete_fn_param(acc: &mut Completions, ctx: &CompletionContext) 
         }
         func.param_list().into_iter().flat_map(|it| it.params()).for_each(|param| {
             if let Some(pat) = param.pat() {
+                // FIXME: We should be able to turn these into SmolStr without having to allocate a String
                 let text = param.syntax().text().to_string();
                 let lookup = pat.syntax().text().to_string();
                 params.entry(text).or_insert(lookup);
@@ -59,7 +60,7 @@ pub(crate) fn complete_fn_param(acc: &mut Completions, ctx: &CompletionContext) 
 
     let self_completion_items = ["self", "&self", "mut self", "&mut self"];
     if ctx.impl_def.is_some() && me?.param_list()?.params().next().is_none() {
-        self_completion_items.iter().for_each(|self_item| {
+        self_completion_items.into_iter().for_each(|self_item| {
             add_new_item_to_acc(ctx, acc, self_item.to_string(), self_item.to_string())
         });
     }

--- a/crates/ide_completion/src/completions/keyword.rs
+++ b/crates/ide_completion/src/completions/keyword.rs
@@ -27,7 +27,7 @@ pub(crate) fn complete_expr_keyword(acc: &mut Completions, ctx: &CompletionConte
         return;
     }
 
-    let mut add_keyword = |kw, snippet| add_keyword(ctx, acc, kw, snippet);
+    let mut add_keyword = |kw, snippet| add_keyword(acc, ctx, kw, snippet);
 
     let expects_assoc_item = ctx.expects_assoc_item();
     let has_block_expr_parent = ctx.has_block_expr_parent();
@@ -157,7 +157,7 @@ pub(crate) fn complete_expr_keyword(acc: &mut Completions, ctx: &CompletionConte
     )
 }
 
-fn add_keyword(ctx: &CompletionContext, acc: &mut Completions, kw: &str, snippet: &str) {
+fn add_keyword(acc: &mut Completions, ctx: &CompletionContext, kw: &str, snippet: &str) {
     let mut item = CompletionItem::new(CompletionItemKind::Keyword, ctx.source_range(), kw);
 
     match ctx.config.snippet_cap {

--- a/crates/ide_completion/src/completions/qualified_path.rs
+++ b/crates/ide_completion/src/completions/qualified_path.rs
@@ -93,7 +93,7 @@ pub(crate) fn complete_qualified_path(acc: &mut Completions, ctx: &CompletionCon
                 if ctx.in_use_tree() {
                     if let hir::ScopeDef::Unknown = def {
                         if let Some(ast::NameLike::NameRef(name_ref)) = ctx.name_syntax.as_ref() {
-                            if name_ref.syntax().text() == name.to_string().as_str() {
+                            if name_ref.syntax().text() == name.to_smol_str().as_str() {
                                 // for `use self::foo$0`, don't suggest `foo` as a completion
                                 cov_mark::hit!(dont_complete_current_use);
                                 continue;

--- a/crates/ide_completion/src/completions/trait_impl.rs
+++ b/crates/ide_completion/src/completions/trait_impl.rs
@@ -133,7 +133,7 @@ fn add_function_impl(
     func: hir::Function,
     impl_def: hir::Impl,
 ) {
-    let fn_name = func.name(ctx.db).to_string();
+    let fn_name = func.name(ctx.db).to_smol_str();
 
     let label = if func.assoc_fn_params(ctx.db).is_empty() {
         format!("fn {}()", fn_name)
@@ -205,12 +205,12 @@ fn add_type_alias_impl(
     ctx: &CompletionContext,
     type_alias: hir::TypeAlias,
 ) {
-    let alias_name = type_alias.name(ctx.db).to_string();
+    let alias_name = type_alias.name(ctx.db).to_smol_str();
 
     let snippet = format!("type {} = ", alias_name);
 
     let range = replacement_range(ctx, type_def_node);
-    let mut item = CompletionItem::new(SymbolKind::TypeAlias, ctx.source_range(), snippet.clone());
+    let mut item = CompletionItem::new(SymbolKind::TypeAlias, ctx.source_range(), &snippet);
     item.text_edit(TextEdit::replace(range, snippet))
         .lookup_by(alias_name)
         .set_documentation(type_alias.docs(ctx.db));
@@ -224,7 +224,7 @@ fn add_const_impl(
     const_: hir::Const,
     impl_def: hir::Impl,
 ) {
-    let const_name = const_.name(ctx.db).map(|n| n.to_string());
+    let const_name = const_.name(ctx.db).map(|n| n.to_smol_str());
 
     if let Some(const_name) = const_name {
         if let Some(source) = const_.source(ctx.db) {
@@ -238,8 +238,7 @@ fn add_const_impl(
                 let snippet = make_const_compl_syntax(&transformed_const);
 
                 let range = replacement_range(ctx, const_def_node);
-                let mut item =
-                    CompletionItem::new(SymbolKind::Const, ctx.source_range(), snippet.clone());
+                let mut item = CompletionItem::new(SymbolKind::Const, ctx.source_range(), &snippet);
                 item.text_edit(TextEdit::replace(range, snippet))
                     .lookup_by(const_name)
                     .set_documentation(const_.docs(ctx.db));

--- a/crates/ide_completion/src/render.rs
+++ b/crates/ide_completion/src/render.rs
@@ -83,11 +83,11 @@ pub(crate) fn render_field(
     ty: &hir::Type,
 ) -> CompletionItem {
     let is_deprecated = ctx.is_deprecated(field);
-    let name = field.name(ctx.db()).to_string();
+    let name = field.name(ctx.db()).to_smol_str();
     let mut item = CompletionItem::new(
         SymbolKind::Field,
         ctx.source_range(),
-        receiver.map_or_else(|| name.clone(), |receiver| format!("{}.{}", receiver, name)),
+        receiver.map_or_else(|| name.clone(), |receiver| format!("{}.{}", receiver, name).into()),
     );
     item.set_relevance(CompletionRelevance {
         type_match: compute_type_match(ctx.completion, ty),
@@ -97,7 +97,7 @@ pub(crate) fn render_field(
     item.detail(ty.display(ctx.db()).to_string())
         .set_documentation(field.docs(ctx.db()))
         .set_deprecated(is_deprecated)
-        .lookup_by(name.as_str());
+        .lookup_by(name.clone());
     let is_keyword = SyntaxKind::from_keyword(name.as_str()).is_some();
     if is_keyword && !matches!(name.as_str(), "self" | "crate" | "super" | "Self") {
         item.insert_text(format!("r#{}", name));
@@ -199,7 +199,7 @@ fn render_resolution_(
             let mut item = CompletionItem::new(
                 CompletionItemKind::UnresolvedReference,
                 ctx.source_range(),
-                local_name.to_string(),
+                local_name.to_smol_str(),
             );
             if let Some(import_to_add) = import_to_add {
                 item.add_import(import_to_add);
@@ -208,7 +208,7 @@ fn render_resolution_(
         }
     };
 
-    let local_name = local_name.to_string();
+    let local_name = local_name.to_smol_str();
     let mut item = CompletionItem::new(kind, ctx.source_range(), local_name.clone());
     if let hir::ScopeDef::Local(local) = resolution {
         let ty = local.ty(ctx.db());

--- a/crates/ide_completion/src/render/const_.rs
+++ b/crates/ide_completion/src/render/const_.rs
@@ -2,10 +2,7 @@
 
 use hir::{AsAssocItem, HasSource};
 use ide_db::SymbolKind;
-use syntax::{
-    ast::{Const, HasName},
-    display::const_label,
-};
+use syntax::{ast::Const, display::const_label};
 
 use crate::{item::CompletionItem, render::RenderContext};
 
@@ -27,7 +24,7 @@ impl<'a> ConstRender<'a> {
     }
 
     fn render(self) -> Option<CompletionItem> {
-        let name = self.name()?;
+        let name = self.const_.name(self.ctx.db())?.to_smol_str();
         let detail = self.detail();
 
         let mut item =
@@ -42,16 +39,12 @@ impl<'a> ConstRender<'a> {
         let db = self.ctx.db();
         if let Some(actm) = self.const_.as_assoc_item(db) {
             if let Some(trt) = actm.containing_trait_or_trait_impl(db) {
-                item.trait_name(trt.name(db).to_string());
+                item.trait_name(trt.name(db).to_smol_str());
                 item.insert_text(name);
             }
         }
 
         Some(item.build())
-    }
-
-    fn name(&self) -> Option<String> {
-        self.ast_node.name().map(|name| name.text().to_string())
     }
 
     fn detail(&self) -> String {

--- a/crates/ide_completion/src/render/pattern.rs
+++ b/crates/ide_completion/src/render/pattern.rs
@@ -3,6 +3,7 @@
 use hir::{db::HirDatabase, HasAttrs, HasVisibility, Name, StructKind};
 use ide_db::helpers::SnippetCap;
 use itertools::Itertools;
+use syntax::SmolStr;
 
 use crate::{
     context::{ParamKind, PatternContext},
@@ -25,7 +26,7 @@ pub(crate) fn render_struct_pat(
         return None;
     }
 
-    let name = local_name.unwrap_or_else(|| strukt.name(ctx.db())).to_string();
+    let name = local_name.unwrap_or_else(|| strukt.name(ctx.db())).to_smol_str();
     let pat = render_pat(&ctx, &name, strukt.kind(ctx.db()), &visible_fields, fields_omitted)?;
 
     Some(build_completion(ctx, name, pat, strukt))
@@ -43,8 +44,8 @@ pub(crate) fn render_variant_pat(
     let (visible_fields, fields_omitted) = visible_fields(&ctx, &fields, variant)?;
 
     let name = match &path {
-        Some(path) => path.to_string(),
-        None => local_name.unwrap_or_else(|| variant.name(ctx.db())).to_string(),
+        Some(path) => path.to_string().into(),
+        None => local_name.unwrap_or_else(|| variant.name(ctx.db())).to_smol_str(),
     };
     let pat = render_pat(&ctx, &name, variant.kind(ctx.db()), &visible_fields, fields_omitted)?;
 
@@ -53,7 +54,7 @@ pub(crate) fn render_variant_pat(
 
 fn build_completion(
     ctx: RenderContext<'_>,
-    name: String,
+    name: SmolStr,
     pat: String,
     def: impl HasAttrs + Copy,
 ) -> CompletionItem {

--- a/crates/ide_completion/src/render/type_alias.rs
+++ b/crates/ide_completion/src/render/type_alias.rs
@@ -58,7 +58,7 @@ impl<'a> TypeAliasRender<'a> {
         let db = self.ctx.db();
         if let Some(actm) = self.type_alias.as_assoc_item(db) {
             if let Some(trt) = actm.containing_trait_or_trait_impl(db) {
-                item.trait_name(trt.name(db).to_string());
+                item.trait_name(trt.name(db).to_smol_str());
                 item.insert_text(name);
             }
         }

--- a/crates/syntax/Cargo.toml
+++ b/crates/syntax/Cargo.toml
@@ -18,7 +18,7 @@ rustc_lexer = { version = "725.0.0", package = "rustc-ap-rustc_lexer" }
 rustc-hash = "1.1.0"
 once_cell = "1.3.1"
 indexmap = "1.4.0"
-smol_str = "0.1.15"
+smol_str = "0.1.21"
 
 stdx = { path = "../stdx", version = "0.0.0" }
 text_edit = { path = "../text_edit", version = "0.0.0" }


### PR DESCRIPTION
This replaces a bunch of String clones with SmolStr clones, though also makes a few parts a bit more expensive(mainly things involving `format!`ted strings as labels).
