### PR TITLE
fix: Don't ascribe types in pattern completion for param patterns twice

### DIFF
--- a/crates/ide_completion/src/context.rs
+++ b/crates/ide_completion/src/context.rs
@@ -598,7 +598,8 @@ impl<'a> CompletionContext<'a> {
                             .map(|c| (Some(c.return_type()), None))
                             .unwrap_or((None, None))
                     },
-                    ast::Stmt(_it) => (None, None),
+                    ast::ParamList(__) => (None, None),
+                    ast::Stmt(__) => (None, None),
                     ast::Item(__) => (None, None),
                     _ => {
                         match node.parent() {
@@ -1172,6 +1173,25 @@ fn foo() {
 }
 "#,
             expect![[r#"ty: Foo, name: ?"#]],
+        );
+    }
+
+    #[test]
+    fn expected_type_param_pat() {
+        check_expected_type_and_name(
+            r#"
+struct Foo { field: u32 }
+fn foo(a$0: Foo) {}
+"#,
+            expect![[r#"ty: Foo, name: ?"#]],
+        );
+        check_expected_type_and_name(
+            r#"
+struct Foo { field: u32 }
+fn foo($0: Foo) {}
+"#,
+            // FIXME make this work, currently fails due to pattern recovery eating the `:`
+            expect![[r#"ty: ?, name: ?"#]],
         );
     }
 }

--- a/crates/ide_completion/src/render/pattern.rs
+++ b/crates/ide_completion/src/render/pattern.rs
@@ -85,7 +85,11 @@ fn render_pat(
 
     if matches!(
         ctx.completion.pattern_ctx,
-        Some(PatternContext { is_param: Some(ParamKind::Function), .. })
+        Some(PatternContext {
+            is_param: Some(ParamKind::Function),
+            has_type_ascription: false,
+            ..
+        })
     ) {
         pat.push(':');
         pat.push(' ');

--- a/crates/ide_completion/src/tests/pattern.rs
+++ b/crates/ide_completion/src/tests/pattern.rs
@@ -163,6 +163,21 @@ fn foo(a$0) {
             ma makro!(…) #[macro_export] macro_rules! makro
         "##]],
     );
+    check(
+        r#"
+fn foo(a$0: Tuple) {
+}
+"#,
+        expect![[r##"
+            kw mut
+            bn Record    Record { field$1 }$0
+            st Record
+            bn Tuple     Tuple($1)$0
+            st Tuple
+            st Unit
+            ma makro!(…) #[macro_export] macro_rules! makro
+        "##]],
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes #10323
bors r+