### PR TITLE
fix: show the right check-command

### DIFF
--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -406,7 +406,19 @@ impl GlobalState {
                             // When we're running multiple flychecks, we have to include a disambiguator in
                             // the title, or the editor complains. Note that this is a user-facing string.
                             let title = if self.flycheck.len() == 1 {
-                                "cargo check".to_string()
+                                match self.config.flycheck() {
+                                    Some(flycheck::FlycheckConfig::CargoCommand {
+                                        command,
+                                        ..
+                                    }) => {
+                                        format!("cargo {}", command)
+                                    }
+                                    Some(flycheck::FlycheckConfig::CustomCommand {
+                                        command,
+                                        ..
+                                    }) => command,
+                                    None => "cargo check".to_string(),
+                                }
                             } else {
                                 format!("cargo check (#{})", id + 1)
                             };


### PR DESCRIPTION
Currenty r.a. only shows this:
![image](https://user-images.githubusercontent.com/65456722/140977478-e6bc8a45-7c25-4578-9406-fb34f1eb0792.png)
even if another command was specified

There might be a better way to do this, I tried.