### PR TITLE
Allow the check command to terminate without output

### DIFF
--- a/crates/flycheck/src/lib.rs
+++ b/crates/flycheck/src/lib.rs
@@ -326,13 +326,13 @@ impl CargoActor {
         );
         match output {
             Ok(_) if read_at_least_one_message => Ok(()),
-            Ok(output) if output.status.success() => {
+            Ok(output) if output.status.success() => Ok(()),
+            Ok(output)  => {
                 Err(io::Error::new(io::ErrorKind::Other, format!(
                     "Cargo watcher failed, the command produced no valid metadata (exit code: {:?})",
                     output.status
                 )))
             }
-            Ok(_) => Err(io::Error::new(io::ErrorKind::Other, error)),
             Err(e) => Err(e),
         }
     }


### PR DESCRIPTION
Cargo will always output something on success:

```
$ cargo check --message-format=json
{"reason":"compiler-artifact", ... snipped ... }
{"reason":"build-finished","success":true}
```

However, rustc does not output anything on success:

```
$ rustc --error-format=json main.rs
$ echo $?
0
```

Restore the behaviour prior to #10517, where an exit code of 0 is
considered good even if nothing is written to stdout.

This enables custom overrideCommand values that use rustc rather than
cargo.