### PR TITLE
inlay hints: add the option to always show constructor inlay hints

### DIFF
--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -540,7 +540,7 @@ mod tests {
         type_hints: true,
         parameter_hints: true,
         chaining_hints: true,
-        hide_named_constructor_hints: true,
+        hide_named_constructor_hints: false,
         max_length: None,
     };
 
@@ -556,7 +556,7 @@ mod tests {
                 parameter_hints: true,
                 type_hints: false,
                 chaining_hints: false,
-                hide_named_constructor_hints: true,
+                hide_named_constructor_hints: false,
                 max_length: None,
             },
             ra_fixture,
@@ -570,7 +570,7 @@ mod tests {
                 parameter_hints: false,
                 type_hints: true,
                 chaining_hints: false,
-                hide_named_constructor_hints: true,
+                hide_named_constructor_hints: false,
                 max_length: None,
             },
             ra_fixture,
@@ -584,7 +584,7 @@ mod tests {
                 parameter_hints: false,
                 type_hints: false,
                 chaining_hints: true,
-                hide_named_constructor_hints: true,
+                hide_named_constructor_hints: false,
                 max_length: None,
             },
             ra_fixture,
@@ -615,7 +615,7 @@ mod tests {
                 type_hints: false,
                 parameter_hints: false,
                 chaining_hints: false,
-                hide_named_constructor_hints: true,
+                hide_named_constructor_hints: false,
                 max_length: None,
             },
             r#"
@@ -1321,7 +1321,14 @@ fn main() {
 
     #[test]
     fn skip_constructor_type_hints() {
-        check_types(
+        check_with_config(
+            InlayHintsConfig {
+                type_hints: true,
+                parameter_hints: true,
+                chaining_hints: true,
+                hide_named_constructor_hints: true,
+                max_length: None,
+            },
             r#"
 //- minicore: try
 use core::ops::ControlFlow;
@@ -1363,14 +1370,7 @@ fn fallible() -> ControlFlow<()> {
 
     #[test]
     fn shows_constructor_type_hints_when_enabled() {
-        check_with_config(
-            InlayHintsConfig {
-                type_hints: true,
-                parameter_hints: true,
-                chaining_hints: true,
-                hide_named_constructor_hints: false,
-                max_length: None,
-            },
+        check_types(
             r#"
 //- minicore: try
 use core::ops::ControlFlow;
@@ -1470,7 +1470,7 @@ fn main() {
                 parameter_hints: false,
                 type_hints: false,
                 chaining_hints: true,
-                hide_named_constructor_hints: true,
+                hide_named_constructor_hints: false,
                 max_length: None,
             },
             r#"
@@ -1527,7 +1527,7 @@ fn main() {
                 parameter_hints: false,
                 type_hints: false,
                 chaining_hints: true,
-                hide_named_constructor_hints: true,
+                hide_named_constructor_hints: false,
                 max_length: None,
             },
             r#"
@@ -1572,7 +1572,7 @@ fn main() {
                 parameter_hints: false,
                 type_hints: false,
                 chaining_hints: true,
-                hide_named_constructor_hints: true,
+                hide_named_constructor_hints: false,
                 max_length: None,
             },
             r#"
@@ -1618,7 +1618,7 @@ fn main() {
                 parameter_hints: false,
                 type_hints: false,
                 chaining_hints: true,
-                hide_named_constructor_hints: true,
+                hide_named_constructor_hints: false,
                 max_length: None,
             },
             r#"

--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -16,6 +16,7 @@ pub struct InlayHintsConfig {
     pub type_hints: bool,
     pub parameter_hints: bool,
     pub chaining_hints: bool,
+    pub hide_named_constructor_hints: bool,
     pub max_length: Option<usize>,
 }
 
@@ -213,7 +214,9 @@ fn get_bind_pat_hints(
         Some(label) => label,
         None => {
             let ty_name = ty.display_truncated(sema.db, config.max_length).to_string();
-            if is_named_constructor(sema, pat, &ty_name).is_some() {
+            if config.hide_named_constructor_hints
+                && is_named_constructor(sema, pat, &ty_name).is_some()
+            {
                 return None;
             }
             ty_name.into()
@@ -537,6 +540,7 @@ mod tests {
         type_hints: true,
         parameter_hints: true,
         chaining_hints: true,
+        hide_named_constructor_hints: true,
         max_length: None,
     };
 
@@ -552,6 +556,7 @@ mod tests {
                 parameter_hints: true,
                 type_hints: false,
                 chaining_hints: false,
+                hide_named_constructor_hints: true,
                 max_length: None,
             },
             ra_fixture,
@@ -565,6 +570,7 @@ mod tests {
                 parameter_hints: false,
                 type_hints: true,
                 chaining_hints: false,
+                hide_named_constructor_hints: true,
                 max_length: None,
             },
             ra_fixture,
@@ -578,6 +584,7 @@ mod tests {
                 parameter_hints: false,
                 type_hints: false,
                 chaining_hints: true,
+                hide_named_constructor_hints: true,
                 max_length: None,
             },
             ra_fixture,
@@ -608,6 +615,7 @@ mod tests {
                 type_hints: false,
                 parameter_hints: false,
                 chaining_hints: false,
+                hide_named_constructor_hints: true,
                 max_length: None,
             },
             r#"
@@ -1354,6 +1362,60 @@ fn fallible() -> ControlFlow<()> {
     }
 
     #[test]
+    fn shows_constructor_type_hints_when_enabled() {
+        check_with_config(
+            InlayHintsConfig {
+                type_hints: true,
+                parameter_hints: true,
+                chaining_hints: true,
+                hide_named_constructor_hints: false,
+                max_length: None,
+            },
+            r#"
+//- minicore: try
+use core::ops::ControlFlow;
+
+struct Struct;
+struct TupleStruct();
+
+impl Struct {
+    fn new() -> Self {
+        Struct
+    }
+    fn try_new() -> ControlFlow<(), Self> {
+        ControlFlow::Continue(Struct)
+    }
+}
+
+struct Generic<T>(T);
+impl Generic<i32> {
+    fn new() -> Self {
+        Generic(0)
+    }
+}
+
+fn main() {
+    let strukt = Struct::new();
+     // ^^^^^^ Struct
+    let tuple_struct = TupleStruct();
+     // ^^^^^^^^^^^^ TupleStruct
+    let generic0 = Generic::new();
+     // ^^^^^^^^ Generic<i32>
+    let generic1 = Generic::<i32>::new();
+     // ^^^^^^^^ Generic<i32>
+    let generic2 = <Generic<i32>>::new();
+     // ^^^^^^^^ Generic<i32>
+}
+
+fn fallible() -> ControlFlow<()> {
+    let strukt = Struct::try_new()?;
+     // ^^^^^^ Struct
+}
+"#,
+        );
+    }
+
+    #[test]
     fn closures() {
         check(
             r#"
@@ -1408,6 +1470,7 @@ fn main() {
                 parameter_hints: false,
                 type_hints: false,
                 chaining_hints: true,
+                hide_named_constructor_hints: true,
                 max_length: None,
             },
             r#"
@@ -1464,6 +1527,7 @@ fn main() {
                 parameter_hints: false,
                 type_hints: false,
                 chaining_hints: true,
+                hide_named_constructor_hints: true,
                 max_length: None,
             },
             r#"
@@ -1508,6 +1572,7 @@ fn main() {
                 parameter_hints: false,
                 type_hints: false,
                 chaining_hints: true,
+                hide_named_constructor_hints: true,
                 max_length: None,
             },
             r#"
@@ -1553,6 +1618,7 @@ fn main() {
                 parameter_hints: false,
                 type_hints: false,
                 chaining_hints: true,
+                hide_named_constructor_hints: true,
                 max_length: None,
             },
             r#"

--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -106,6 +106,7 @@ impl StaticIndex<'_> {
                     type_hints: true,
                     parameter_hints: true,
                     chaining_hints: true,
+                    hide_named_constructor_hints: false,
                     max_length: Some(25),
                 },
                 file_id,

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -204,7 +204,7 @@ config_data! {
         /// Whether to show inlay type hints for variables.
         inlayHints_typeHints: bool                  = "true",
         /// Whether to hide inlay hints for constructors.
-        inlayHints_hideNamedConstructorHints: bool  = "true",
+        inlayHints_hideNamedConstructorHints: bool  = "false",
 
         /// Join lines inserts else between consecutive ifs.
         joinLines_joinElseIf: bool = "true",

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -195,14 +195,16 @@ config_data! {
         hoverActions_run: bool             = "true",
 
         /// Whether to show inlay type hints for method chains.
-        inlayHints_chainingHints: bool      = "true",
+        inlayHints_chainingHints: bool              = "true",
         /// Maximum length for inlay hints. Set to null to have an unlimited length.
-        inlayHints_maxLength: Option<usize> = "25",
+        inlayHints_maxLength: Option<usize>         = "25",
         /// Whether to show function parameter name inlay hints at the call
         /// site.
-        inlayHints_parameterHints: bool     = "true",
+        inlayHints_parameterHints: bool             = "true",
         /// Whether to show inlay type hints for variables.
-        inlayHints_typeHints: bool          = "true",
+        inlayHints_typeHints: bool                  = "true",
+        /// Whether to hide inlay hints for constructors.
+        inlayHints_hideNamedConstructorHints: bool  = "true",
 
         /// Join lines inserts else between consecutive ifs.
         joinLines_joinElseIf: bool = "true",
@@ -768,6 +770,7 @@ impl Config {
             type_hints: self.data.inlayHints_typeHints,
             parameter_hints: self.data.inlayHints_parameterHints,
             chaining_hints: self.data.inlayHints_chainingHints,
+            hide_named_constructor_hints: self.data.inlayHints_hideNamedConstructorHints,
             max_length: self.data.inlayHints_maxLength,
         }
     }

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -308,6 +308,11 @@ site.
 --
 Whether to show inlay type hints for variables.
 --
+[[rust-analyzer.inlayHints.hideNamedConstructorHints]]rust-analyzer.inlayHints.hideNamedConstructorHints (default: `true`)::
++
+--
+Whether to hide inlay hints for constructors.
+--
 [[rust-analyzer.joinLines.joinElseIf]]rust-analyzer.joinLines.joinElseIf (default: `true`)::
 +
 --

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -308,7 +308,7 @@ site.
 --
 Whether to show inlay type hints for variables.
 --
-[[rust-analyzer.inlayHints.hideNamedConstructorHints]]rust-analyzer.inlayHints.hideNamedConstructorHints (default: `true`)::
+[[rust-analyzer.inlayHints.hideNamedConstructorHints]]rust-analyzer.inlayHints.hideNamedConstructorHints (default: `false`)::
 +
 --
 Whether to hide inlay hints for constructors.

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -752,6 +752,11 @@
                     "default": true,
                     "type": "boolean"
                 },
+                "rust-analyzer.inlayHints.hideNamedConstructorHints": {
+                    "markdownDescription": "Whether to hide inlay hints for constructors.",
+                    "default": true,
+                    "type": "boolean"
+                },
                 "rust-analyzer.joinLines.joinElseIf": {
                     "markdownDescription": "Join lines inserts else between consecutive ifs.",
                     "default": true,

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -754,7 +754,7 @@
                 },
                 "rust-analyzer.inlayHints.hideNamedConstructorHints": {
                     "markdownDescription": "Whether to hide inlay hints for constructors.",
-                    "default": true,
+                    "default": false,
                     "type": "boolean"
                 },
                 "rust-analyzer.joinLines.joinElseIf": {

--- a/editors/code/src/config.ts
+++ b/editors/code/src/config.ts
@@ -114,6 +114,7 @@ export class Config {
             typeHints: this.get<boolean>("inlayHints.typeHints"),
             parameterHints: this.get<boolean>("inlayHints.parameterHints"),
             chainingHints: this.get<boolean>("inlayHints.chainingHints"),
+            hideNamedConstructorHints: this.get<boolean>("inlayHints.hideNamedConstructorHints"),
             smallerHints: this.get<boolean>("inlayHints.smallerHints"),
             maxLength: this.get<null | number>("inlayHints.maxLength"),
         };


### PR DESCRIPTION
This PR adds a config to *disable* the functionality in #10441 - _and makes that functionality disabled by default._

I actually *really* like inlay hints always showing up, and it helps a lot as a teaching tool too, and also it's quite reassuring to know that r-a indeed understands the code I've written. This PR adds the option `rust-analyzer.inlayHints.hideNamedConstructorHints` (i can also invert this to be `rust-analyzer.inlayHints.showNamedConstructorHints`, just let me know.)


