### PR TITLE
minor: Rename intern_macro -> intern_macro_call

### DIFF
--- a/crates/hir/src/db.rs
+++ b/crates/hir/src/db.rs
@@ -5,7 +5,7 @@
 //! But we need this for at least LRU caching at the query level.
 pub use hir_def::db::*;
 pub use hir_expand::db::{
-    AstDatabase, AstDatabaseStorage, AstIdMapQuery, HygieneFrameQuery, InternMacroQuery,
+    AstDatabase, AstDatabaseStorage, AstIdMapQuery, HygieneFrameQuery, InternMacroCallQuery,
     MacroArgTextQuery, MacroDefQuery, MacroExpandQuery, ParseMacroExpansionQuery,
 };
 pub use hir_ty::db::*;

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -842,7 +842,7 @@ impl<'db> SemanticsImpl<'db> {
     fn resolve_attr_macro_call(&self, item: &ast::Item) -> Option<MacroDef> {
         let item_in_file = self.find_file(item.syntax().clone()).with_value(item.clone());
         let macro_call_id = self.with_ctx(|ctx| ctx.item_to_macro_call(item_in_file))?;
-        Some(MacroDef { id: self.db.lookup_intern_macro(macro_call_id).def })
+        Some(MacroDef { id: self.db.lookup_intern_macro_call(macro_call_id).def })
     }
 
     fn resolve_path(&self, path: &ast::Path) -> Option<PathResolution> {

--- a/crates/hir_def/src/nameres/collector.rs
+++ b/crates/hir_def/src/nameres/collector.rs
@@ -1141,7 +1141,7 @@ impl DefCollector<'_> {
                         &resolver,
                     ) {
                         Ok(call_id) => {
-                            let loc: MacroCallLoc = self.db.lookup_intern_macro(call_id);
+                            let loc: MacroCallLoc = self.db.lookup_intern_macro_call(call_id);
                             if let MacroDefKind::ProcMacro(exp, ..) = &loc.def.kind {
                                 if exp.is_dummy() {
                                     // Proc macros that cannot be expanded are treated as not
@@ -1214,7 +1214,7 @@ impl DefCollector<'_> {
         // First, fetch the raw expansion result for purposes of error reporting. This goes through
         // `macro_expand_error` to avoid depending on the full expansion result (to improve
         // incrementality).
-        let loc: MacroCallLoc = self.db.lookup_intern_macro(macro_call_id);
+        let loc: MacroCallLoc = self.db.lookup_intern_macro_call(macro_call_id);
         let err = self.db.macro_expand_error(macro_call_id);
         if let Some(err) = err {
             let diag = match err {

--- a/crates/hir_expand/src/builtin_derive_macro.rs
+++ b/crates/hir_expand/src/builtin_derive_macro.rs
@@ -168,7 +168,7 @@ fn find_builtin_crate(db: &dyn AstDatabase, id: MacroCallId) -> tt::TokenTree {
     // FIXME: make hygiene works for builtin derive macro
     // such that $crate can be used here.
     let cg = db.crate_graph();
-    let krate = db.lookup_intern_macro(id).krate;
+    let krate = db.lookup_intern_macro_call(id).krate;
 
     // XXX
     //  All crates except core itself should have a dependency on core,

--- a/crates/hir_expand/src/builtin_fn_macro.rs
+++ b/crates/hir_expand/src/builtin_fn_macro.rs
@@ -326,7 +326,7 @@ fn cfg_expand(
     id: MacroCallId,
     tt: &tt::Subtree,
 ) -> ExpandResult<tt::Subtree> {
-    let loc = db.lookup_intern_macro(id);
+    let loc = db.lookup_intern_macro_call(id);
     let expr = CfgExpr::parse(tt);
     let enabled = db.crate_graph()[loc.krate].cfg_options.check(&expr) != Some(false);
     let expanded = if enabled { quote!(true) } else { quote!(false) };
@@ -338,7 +338,7 @@ fn panic_expand(
     id: MacroCallId,
     tt: &tt::Subtree,
 ) -> ExpandResult<tt::Subtree> {
-    let loc: MacroCallLoc = db.lookup_intern_macro(id);
+    let loc: MacroCallLoc = db.lookup_intern_macro_call(id);
     // Expand to a macro call `$crate::panic::panic_{edition}`
     let krate = tt::Ident { text: "$crate".into(), id: tt::TokenId::unspecified() };
     let mut call = if db.crate_graph()[loc.krate].edition == Edition::Edition2021 {
@@ -531,7 +531,7 @@ fn include_str_expand(
 }
 
 fn get_env_inner(db: &dyn AstDatabase, arg_id: MacroCallId, key: &str) -> Option<String> {
-    let krate = db.lookup_intern_macro(arg_id).krate;
+    let krate = db.lookup_intern_macro_call(arg_id).krate;
     db.crate_graph()[krate].env.get(key)
 }
 

--- a/crates/hir_expand/src/eager.rs
+++ b/crates/hir_expand/src/eager.rs
@@ -119,7 +119,7 @@ pub fn expand_eager_macro(
     // When `lazy_expand` is called, its *parent* file must be already exists.
     // Here we store an eager macro id for the argument expanded subtree here
     // for that purpose.
-    let arg_id = db.intern_macro(MacroCallLoc {
+    let arg_id = db.intern_macro_call(MacroCallLoc {
         def,
         krate,
         eager: Some(EagerCallInfo {
@@ -157,7 +157,7 @@ pub fn expand_eager_macro(
             kind: MacroCallKind::FnLike { ast_id: call_id, expand_to },
         };
 
-        Ok(db.intern_macro(loc))
+        Ok(db.intern_macro_call(loc))
     } else {
         panic!("called `expand_eager_macro` on non-eager macro def {:?}", def);
     }

--- a/crates/hir_expand/src/hygiene.rs
+++ b/crates/hir_expand/src/hygiene.rs
@@ -141,7 +141,7 @@ impl HygieneInfo {
         let token_id = self.exp_map.token_by_range(token)?;
         let (mut token_id, origin) = self.macro_def.map_id_up(token_id);
 
-        let loc = db.lookup_intern_macro(self.file.macro_call_id);
+        let loc = db.lookup_intern_macro_call(self.file.macro_call_id);
 
         let (token_map, tt) = match &loc.kind {
             MacroCallKind::Attr { attr_args, .. } => match self.macro_arg_shift.unshift(token_id) {
@@ -213,7 +213,7 @@ impl HygieneFrame {
         let (info, krate, local_inner) = match file_id.0 {
             HirFileIdRepr::FileId(_) => (None, None, false),
             HirFileIdRepr::MacroFile(macro_file) => {
-                let loc = db.lookup_intern_macro(macro_file.macro_call_id);
+                let loc = db.lookup_intern_macro_call(macro_file.macro_call_id);
                 let info =
                     make_hygiene_info(db, macro_file, &loc).map(|info| (loc.kind.file_id(), info));
                 match loc.def.kind {

--- a/crates/hir_expand/src/lib.rs
+++ b/crates/hir_expand/src/lib.rs
@@ -148,7 +148,7 @@ impl HirFileId {
         match self.0 {
             HirFileIdRepr::FileId(file_id) => file_id,
             HirFileIdRepr::MacroFile(macro_file) => {
-                let loc: MacroCallLoc = db.lookup_intern_macro(macro_file.macro_call_id);
+                let loc: MacroCallLoc = db.lookup_intern_macro_call(macro_file.macro_call_id);
                 let file_id = match &loc.eager {
                     Some(EagerCallInfo { included_file: Some(file), .. }) => (*file).into(),
                     _ => loc.kind.file_id(),
@@ -162,7 +162,7 @@ impl HirFileId {
         let mut level = 0;
         let mut curr = self;
         while let HirFileIdRepr::MacroFile(macro_file) = curr.0 {
-            let loc: MacroCallLoc = db.lookup_intern_macro(macro_file.macro_call_id);
+            let loc: MacroCallLoc = db.lookup_intern_macro_call(macro_file.macro_call_id);
 
             level += 1;
             curr = loc.kind.file_id();
@@ -175,7 +175,7 @@ impl HirFileId {
         match self.0 {
             HirFileIdRepr::FileId(_) => None,
             HirFileIdRepr::MacroFile(macro_file) => {
-                let loc: MacroCallLoc = db.lookup_intern_macro(macro_file.macro_call_id);
+                let loc: MacroCallLoc = db.lookup_intern_macro_call(macro_file.macro_call_id);
                 Some(loc.kind.to_node(db))
             }
         }
@@ -186,7 +186,7 @@ impl HirFileId {
         match self.0 {
             HirFileIdRepr::FileId(_) => None,
             HirFileIdRepr::MacroFile(macro_file) => {
-                let loc: MacroCallLoc = db.lookup_intern_macro(macro_file.macro_call_id);
+                let loc: MacroCallLoc = db.lookup_intern_macro_call(macro_file.macro_call_id);
 
                 let arg_tt = loc.kind.arg(db)?;
 
@@ -231,7 +231,7 @@ impl HirFileId {
         match self.0 {
             HirFileIdRepr::FileId(_) => None,
             HirFileIdRepr::MacroFile(macro_file) => {
-                let loc: MacroCallLoc = db.lookup_intern_macro(macro_file.macro_call_id);
+                let loc: MacroCallLoc = db.lookup_intern_macro_call(macro_file.macro_call_id);
                 let item = match loc.def.kind {
                     MacroDefKind::BuiltInDerive(..) => loc.kind.to_node(db),
                     _ => return None,
@@ -245,7 +245,7 @@ impl HirFileId {
         match self.0 {
             HirFileIdRepr::FileId(_) => false,
             HirFileIdRepr::MacroFile(macro_file) => {
-                let loc: MacroCallLoc = db.lookup_intern_macro(macro_file.macro_call_id);
+                let loc: MacroCallLoc = db.lookup_intern_macro_call(macro_file.macro_call_id);
                 match loc.def.kind {
                     MacroDefKind::ProcMacro(_, ProcMacroKind::CustomDerive, _) => true,
                     _ => false,
@@ -258,7 +258,7 @@ impl HirFileId {
     pub fn is_include_macro(&self, db: &dyn db::AstDatabase) -> bool {
         match self.0 {
             HirFileIdRepr::MacroFile(macro_file) => {
-                let loc: MacroCallLoc = db.lookup_intern_macro(macro_file.macro_call_id);
+                let loc: MacroCallLoc = db.lookup_intern_macro_call(macro_file.macro_call_id);
                 matches!(loc.eager, Some(EagerCallInfo { included_file: Some(_), .. }))
             }
             _ => false,
@@ -269,7 +269,7 @@ impl HirFileId {
     pub fn is_attr_macro(&self, db: &dyn db::AstDatabase) -> bool {
         match self.0 {
             HirFileIdRepr::MacroFile(macro_file) => {
-                let loc: MacroCallLoc = db.lookup_intern_macro(macro_file.macro_call_id);
+                let loc: MacroCallLoc = db.lookup_intern_macro_call(macro_file.macro_call_id);
                 matches!(loc.kind, MacroCallKind::Attr { .. })
             }
             _ => false,
@@ -288,7 +288,7 @@ impl MacroDefId {
         krate: CrateId,
         kind: MacroCallKind,
     ) -> MacroCallId {
-        db.intern_macro(MacroCallLoc { def: self, krate, eager: None, kind })
+        db.intern_macro_call(MacroCallLoc { def: self, krate, eager: None, kind })
     }
 
     pub fn ast_id(&self) -> Either<AstId<ast::Macro>, AstId<ast::Fn>> {
@@ -402,7 +402,7 @@ impl ExpansionInfo {
                 HirFileIdRepr::FileId(_) => return None,
                 HirFileIdRepr::MacroFile(macro_file) => macro_file.macro_call_id,
             };
-            let loc = db.lookup_intern_macro(call_id);
+            let loc = db.lookup_intern_macro_call(call_id);
 
             let token_range = token.value.text_range();
             match &loc.kind {
@@ -458,7 +458,7 @@ impl ExpansionInfo {
             HirFileIdRepr::FileId(_) => return None,
             HirFileIdRepr::MacroFile(macro_file) => macro_file.macro_call_id,
         };
-        let loc = db.lookup_intern_macro(call_id);
+        let loc = db.lookup_intern_macro_call(call_id);
 
         let (token_map, tt) = match &loc.kind {
             MacroCallKind::Attr { attr_args, .. } => match self.macro_arg_shift.unshift(token_id) {

--- a/crates/ide_db/src/apply_change.rs
+++ b/crates/ide_db/src/apply_change.rs
@@ -78,7 +78,7 @@ impl RootDatabase {
             hir::db::ParseMacroExpansionQuery
             hir::db::MacroExpandQuery
             hir::db::HygieneFrameQuery
-            hir::db::InternMacroQuery
+            hir::db::InternMacroCallQuery
 
             // DefDatabase
             hir::db::FileItemTreeQuery


### PR DESCRIPTION
We potentially want to intern macro definitions so the names would probably collide
bors r+