### PR TITLE
fix: Reimplement mapping out of test/bench attributes for runnables

### DIFF
--- a/crates/hir_expand/src/lib.rs
+++ b/crates/hir_expand/src/lib.rs
@@ -701,6 +701,16 @@ impl<N: AstNode> InFile<N> {
     }
 }
 
+impl InFile<ast::Fn> {
+    pub fn map_out_of_test_attr(self, db: &dyn db::AstDatabase) -> InFile<ast::Fn> {
+        (|| {
+            let InFile { file_id, value } = self.file_id.call_node(db)?;
+            ast::Fn::cast(value).map(|n| InFile::new(file_id, n))
+        })()
+        .unwrap_or(self)
+    }
+}
+
 /// In Rust, macros expand token trees to token trees. When we want to turn a
 /// token tree into an AST node, we need to figure out what kind of AST node we
 /// want: something like `foo` can be a type, an expression, or a pattern.


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/10768
bors r+
