### PR TITLE
internal: Skip test/bench attr expansion in resolution instead of collection

### DIFF
--- a/crates/hir_def/src/builtin_attr.rs
+++ b/crates/hir_def/src/builtin_attr.rs
@@ -34,11 +34,6 @@ macro_rules! rustc_attr {
     };
 }
 
-// FIXME: We shouldn't special case these at all, but as of now expanding attributes severely degrades
-// user experience due to lacking support.
-/// Built-in macro-like attributes.
-pub const EXTRA_ATTRIBUTES: &[BuiltinAttribute] = &["test", "bench"];
-
 /// "Inert" built-in attributes that have a special meaning to rustc or rustdoc.
 #[rustfmt::skip]
 pub const INERT_ATTRIBUTES: &[BuiltinAttribute] = &[

--- a/crates/hir_expand/src/builtin_attr_macro.rs
+++ b/crates/hir_expand/src/builtin_attr_macro.rs
@@ -46,6 +46,16 @@ register_builtin! {
     (test_case, TestCase) => dummy_attr_expand
 }
 
+pub fn is_builtin_test_or_bench_attr(makro: MacroDefId) -> bool {
+    match makro.kind {
+        MacroDefKind::BuiltInAttr(expander, ..) => {
+            BuiltinAttrExpander::find_by_name(&name!(test)) == Some(expander)
+                || BuiltinAttrExpander::find_by_name(&name!(bench)) == Some(expander)
+        }
+        _ => false,
+    }
+}
+
 pub fn find_builtin_attr(
     ident: &name::Name,
     krate: CrateId,

--- a/crates/hir_expand/src/lib.rs
+++ b/crates/hir_expand/src/lib.rs
@@ -701,16 +701,6 @@ impl<N: AstNode> InFile<N> {
     }
 }
 
-impl InFile<ast::Fn> {
-    pub fn map_out_of_test_attr(self, db: &dyn db::AstDatabase) -> InFile<ast::Fn> {
-        (|| {
-            let InFile { file_id, value } = self.file_id.call_node(db)?;
-            ast::Fn::cast(value).map(|n| InFile::new(file_id, n))
-        })()
-        .unwrap_or(self)
-    }
-}
-
 /// In Rust, macros expand token trees to token trees. When we want to turn a
 /// token tree into an AST node, we need to figure out what kind of AST node we
 /// want: something like `foo` can be a type, an expression, or a pattern.

--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -237,8 +237,7 @@ fn find_related_tests(
                 .map(|f| hir::InFile::new(sema.hir_file_for(f.syntax()), f));
 
             for fn_def in functions {
-                // #[test/bench] expands to just the item causing us to lose the attribute, so recover them by going out of the attribute
-                let InFile { value: fn_def, .. } = &fn_def.map_out_of_test_attr(sema.db);
+                let InFile { value: fn_def, .. } = &fn_def;
                 if let Some(runnable) = as_test_runnable(sema, fn_def) {
                     // direct test
                     tests.insert(runnable);
@@ -294,8 +293,7 @@ fn parent_test_module(sema: &Semantics<RootDatabase>, fn_def: &ast::Fn) -> Optio
 }
 
 pub(crate) fn runnable_fn(sema: &Semantics<RootDatabase>, def: hir::Function) -> Option<Runnable> {
-    // #[test/bench] expands to just the item causing us to lose the attribute, so recover them by going out of the attribute
-    let func = def.source(sema.db)?.map_out_of_test_attr(sema.db);
+    let func = def.source(sema.db)?;
     let name_string = def.name(sema.db).to_string();
 
     let root = def.module(sema.db).krate().root_module(sema.db);
@@ -504,8 +502,6 @@ fn has_test_function_or_multiple_test_submodules(
         match item {
             hir::ModuleDef::Function(f) => {
                 if let Some(it) = f.source(sema.db) {
-                    // #[test/bench] expands to just the item causing us to lose the attribute, so recover them by going out of the attribute
-                    let it = it.map_out_of_test_attr(sema.db);
                     if test_related_attribute(&it.value).is_some() {
                         return true;
                     }


### PR DESCRIPTION
This way we skip any path resolving to the test and bench attributes instead of just the lone identifiers(which could very well point to non-builtin attributes).
bors r+