### PR TITLE
minor: remove duplicate calls

### DIFF
--- a/crates/hir_def/src/body/scope.rs
+++ b/crates/hir_def/src/body/scope.rs
@@ -151,18 +151,15 @@ fn compute_block_scopes(
         match stmt {
             Statement::Let { pat, initializer, else_branch, .. } => {
                 if let Some(expr) = initializer {
-                    scopes.set_scope(*expr, scope);
                     compute_expr_scopes(*expr, body, scopes, scope);
                 }
                 if let Some(expr) = else_branch {
-                    scopes.set_scope(*expr, scope);
                     compute_expr_scopes(*expr, body, scopes, scope);
                 }
                 scope = scopes.new_scope(scope);
                 scopes.add_bindings(body, scope, *pat);
             }
             Statement::Expr { expr, .. } => {
-                scopes.set_scope(*expr, scope);
                 compute_expr_scopes(*expr, body, scopes, scope);
             }
         }


### PR DESCRIPTION
`scopes.set_scope(*expr, scope)` is duplicate, because we always call it in `compute_expr_scopes`  https://github.com/rust-analyzer/rust-analyzer/blob/add6cccd4c923fbb5c83cc27b06aa84b2cbc9557/crates/hir_def/src/body/scope.rs#L175-L180