### PR TITLE
internal: Check for derive attributes by item path, not `derive` identifier

### DIFF
--- a/crates/hir_def/src/lib.rs
+++ b/crates/hir_def/src/lib.rs
@@ -776,13 +776,10 @@ fn attr_macro_as_call_id(
     macro_attr: &Attr,
     db: &dyn db::DefDatabase,
     krate: CrateId,
-    resolver: impl Fn(path::ModPath) -> Option<MacroDefId>,
+    def: Option<MacroDefId>,
 ) -> Result<MacroCallId, UnresolvedMacro> {
     let attr_path = &item_attr.path;
-
-    let def = resolver(attr_path.clone())
-        .filter(MacroDefId::is_attribute)
-        .ok_or_else(|| UnresolvedMacro { path: attr_path.clone() })?;
+    let def = def.ok_or_else(|| UnresolvedMacro { path: attr_path.clone() })?;
     let last_segment =
         attr_path.segments().last().ok_or_else(|| UnresolvedMacro { path: attr_path.clone() })?;
     let mut arg = match macro_attr.input.as_deref() {

--- a/crates/hir_def/src/macro_expansion_tests/builtin_derive_macro.rs
+++ b/crates/hir_def/src/macro_expansion_tests/builtin_derive_macro.rs
@@ -26,11 +26,15 @@ fn test_copy_expand_in_core() {
     check(
         r#"
 #[rustc_builtin_macro]
+macro derive {}
+#[rustc_builtin_macro]
 macro Copy {}
 #[derive(Copy)]
 struct Foo;
 "#,
         expect![[r##"
+#[rustc_builtin_macro]
+macro derive {}
 #[rustc_builtin_macro]
 macro Copy {}
 #[derive(Copy)]

--- a/crates/hir_def/src/macro_expansion_tests/proc_macros.rs
+++ b/crates/hir_def/src/macro_expansion_tests/proc_macros.rs
@@ -31,6 +31,7 @@ fn derive_censoring() {
     check(
         r#"
 //- proc_macros: derive_identity
+//- minicore:derive
 #[attr1]
 #[derive(Foo)]
 #[derive(proc_macros::DeriveIdentity)]

--- a/crates/hir_expand/src/builtin_attr_macro.rs
+++ b/crates/hir_expand/src/builtin_attr_macro.rs
@@ -36,6 +36,18 @@ macro_rules! register_builtin {
     };
 }
 
+impl BuiltinAttrExpander {
+    pub fn is_derive(self) -> bool {
+        matches!(self, BuiltinAttrExpander::Derive)
+    }
+    pub fn is_test(self) -> bool {
+        matches!(self, BuiltinAttrExpander::Test)
+    }
+    pub fn is_bench(self) -> bool {
+        matches!(self, BuiltinAttrExpander::Bench)
+    }
+}
+
 register_builtin! {
     (bench, Bench) => dummy_attr_expand,
     (cfg_accessible, CfgAccessible) => dummy_attr_expand,
@@ -44,16 +56,6 @@ register_builtin! {
     (global_allocator, GlobalAllocator) => dummy_attr_expand,
     (test, Test) => dummy_attr_expand,
     (test_case, TestCase) => dummy_attr_expand
-}
-
-pub fn is_builtin_test_or_bench_attr(makro: MacroDefId) -> bool {
-    match makro.kind {
-        MacroDefKind::BuiltInAttr(expander, ..) => {
-            BuiltinAttrExpander::find_by_name(&name!(test)) == Some(expander)
-                || BuiltinAttrExpander::find_by_name(&name!(bench)) == Some(expander)
-        }
-        _ => false,
-    }
 }
 
 pub fn find_builtin_attr(

--- a/crates/hir_ty/src/tests/macros.rs
+++ b/crates/hir_ty/src/tests/macros.rs
@@ -974,58 +974,9 @@ fn infer_builtin_macros_env() {
 fn infer_derive_clone_simple() {
     check_types(
         r#"
-//- /main.rs crate:main deps:core
+//- minicore: derive, clone
 #[derive(Clone)]
 struct S;
-fn test() {
-    S.clone();
-} //^^^^^^^^^ S
-
-//- /lib.rs crate:core
-pub mod prelude {
-    pub mod rust_2018 {
-        #[rustc_builtin_macro]
-        pub macro Clone {}
-        pub use crate::clone::Clone;
-    }
-}
-
-pub mod clone {
-    pub trait Clone {
-        fn clone(&self) -> Self;
-    }
-}
-"#,
-    );
-}
-
-#[test]
-fn infer_derive_clone_in_core() {
-    check_types(
-        r#"
-//- /lib.rs crate:core
-#[prelude_import]
-use prelude::rust_2018::*;
-
-pub mod prelude {
-    pub mod rust_2018 {
-        #[rustc_builtin_macro]
-        pub macro Clone {}
-        pub use crate::clone::Clone;
-    }
-}
-
-pub mod clone {
-    pub trait Clone {
-        fn clone(&self) -> Self;
-    }
-}
-
-#[derive(Clone)]
-pub struct S;
-
-//- /main.rs crate:main deps:core
-use core::S;
 fn test() {
     S.clone();
 } //^^^^^^^^^ S
@@ -1037,7 +988,7 @@ fn test() {
 fn infer_derive_clone_with_params() {
     check_types(
         r#"
-//- /main.rs crate:main deps:core
+//- minicore: clone, derive
 #[derive(Clone)]
 struct S;
 #[derive(Clone)]
@@ -1048,21 +999,6 @@ fn test() {
     x;
   //^ (Wrapper<S>, {unknown})
 }
-
-//- /lib.rs crate:core
-pub mod prelude {
-    pub mod rust_2018 {
-        #[rustc_builtin_macro]
-        pub macro Clone {}
-        pub use crate::clone::Clone;
-    }
-}
-
-pub mod clone {
-    pub trait Clone {
-        fn clone(&self) -> Self;
-    }
-}
 "#,
     );
 }
@@ -1072,7 +1008,7 @@ fn infer_custom_derive_simple() {
     // FIXME: this test current now do nothing
     check_types(
         r#"
-//- /main.rs crate:main
+//- minicore: derive
 use foo::Foo;
 
 #[derive(Foo)]

--- a/crates/ide/src/expand_macro.rs
+++ b/crates/ide/src/expand_macro.rs
@@ -367,9 +367,7 @@ fn main() {
         check(
             r#"
 //- proc_macros: identity
-
-#[rustc_builtin_macro]
-pub macro Clone {}
+//- minicore: clone, derive
 
 #[proc_macros::identity]
 #[derive(C$0lone)]
@@ -377,7 +375,7 @@ struct Foo {}
 "#,
             expect![[r#"
                 Clone
-                impl< >crate::clone::Clone for Foo< >{}
+                impl< >core::clone::Clone for Foo< >{}
 
             "#]],
         );
@@ -387,10 +385,7 @@ struct Foo {}
     fn macro_expand_derive2() {
         check(
             r#"
-#[rustc_builtin_macro]
-pub macro Clone {}
-#[rustc_builtin_macro]
-pub macro Copy {}
+//- minicore: copy, clone, derive
 
 #[derive(Cop$0y)]
 #[derive(Clone)]
@@ -398,7 +393,7 @@ struct Foo {}
 "#,
             expect![[r#"
                 Copy
-                impl< >crate::marker::Copy for Foo< >{}
+                impl< >core::marker::Copy for Foo< >{}
 
             "#]],
         );
@@ -408,19 +403,16 @@ struct Foo {}
     fn macro_expand_derive_multi() {
         check(
             r#"
-#[rustc_builtin_macro]
-pub macro Clone {}
-#[rustc_builtin_macro]
-pub macro Copy {}
+//- minicore: copy, clone, derive
 
 #[derive(Cop$0y, Clone)]
 struct Foo {}
 "#,
             expect![[r#"
                 Copy, Clone
-                impl< >crate::marker::Copy for Foo< >{}
+                impl< >core::marker::Copy for Foo< >{}
 
-                impl< >crate::clone::Clone for Foo< >{}
+                impl< >core::clone::Clone for Foo< >{}
 
             "#]],
         );

--- a/crates/rust-analyzer/tests/slow-tests/main.rs
+++ b/crates/rust-analyzer/tests/slow-tests/main.rs
@@ -878,7 +878,7 @@ pub fn foo(_input: TokenStream) -> TokenStream {
     let res = server.send_request::<HoverRequest>(HoverParams {
         text_document_position_params: TextDocumentPositionParams::new(
             server.doc_id("foo/src/main.rs"),
-            Position::new(7, 9),
+            Position::new(10, 9),
         ),
         work_done_progress_params: Default::default(),
     });

--- a/crates/rust-analyzer/tests/slow-tests/main.rs
+++ b/crates/rust-analyzer/tests/slow-tests/main.rs
@@ -805,6 +805,9 @@ bar = {path = "../bar"}
 
 //- /foo/src/main.rs
 use bar::Bar;
+
+#[rustc_builtin_macro]
+macro derive($item:item) {}
 trait Bar {
   fn bar();
 }


### PR DESCRIPTION
Prior we only checked if an attribute is the exact `derive` identifier and nothing else to collect derive attributes. That means when we encounter the following:
```rs
#[::core::macros::builtin::derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
pub struct ModPath {
    pub kind: PathKind,
    segments: Vec<Name>,
}
```
We won't actually expand the derive attributes, but instead we just expand the `derive` attribute with our dummy identity expander.

The changes here make it so we actually lookup the attribute path, check if it is the derive attribute and then collect the derives.
