### PR TITLE
Remove unwrap in doc path resolution

### DIFF
--- a/crates/hir/src/attrs.rs
+++ b/crates/hir/src/attrs.rs
@@ -147,7 +147,7 @@ fn resolve_doc_path(
         AttrDefId::MacroDefId(_) => return None,
     };
     let path = ast::Path::parse(link).ok()?;
-    let modpath = ModPath::from_src(db.upcast(), path, &Hygiene::new_unhygienic()).unwrap();
+    let modpath = ModPath::from_src(db.upcast(), path, &Hygiene::new_unhygienic())?;
     let resolved = resolver.resolve_module_path_in_items(db.upcast(), &modpath);
     let resolved = if resolved == PerNs::none() {
         resolver.resolve_module_path_in_trait_assoc_items(db.upcast(), &modpath)?


### PR DESCRIPTION
I keep hitting this constantly in my project, and I haven't dug very deep into the root cause. But seeing as the project otherwise compiles it appears to be something unsupported is being incorrectly parsed in rust-analyzer which for other cases is handled by returning `None`.