### PR TITLE
ide: show go to for function hover return type

### DIFF
--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -314,6 +314,7 @@ fn goto_type_action_for_def(db: &RootDatabase, def: Definition) -> Option<HoverA
             Definition::Local(it) => it.ty(db),
             Definition::GenericParam(hir::GenericParam::ConstParam(it)) => it.ty(db),
             Definition::Field(field) => field.ty(db),
+            Definition::Function(function) => function.ret_type(db),
             _ => return None,
         };
 

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -1718,40 +1718,43 @@ fn test_hover_test_has_action() {
 fn foo_$0test() {}
 "#,
         expect![[r#"
-                [
-                    Reference(
-                        FilePosition {
+            [
+                Reference(
+                    FilePosition {
+                        file_id: FileId(
+                            0,
+                        ),
+                        offset: 11,
+                    },
+                ),
+                Runnable(
+                    Runnable {
+                        use_name_in_title: false,
+                        nav: NavigationTarget {
                             file_id: FileId(
                                 0,
                             ),
-                            offset: 11,
+                            full_range: 0..24,
+                            focus_range: 11..19,
+                            name: "foo_test",
+                            kind: Function,
                         },
-                    ),
-                    Runnable(
-                        Runnable {
-                            use_name_in_title: false,
-                            nav: NavigationTarget {
-                                file_id: FileId(
-                                    0,
-                                ),
-                                full_range: 0..24,
-                                focus_range: 11..19,
-                                name: "foo_test",
-                                kind: Function,
+                        kind: Test {
+                            test_id: Path(
+                                "foo_test",
+                            ),
+                            attr: TestAttr {
+                                ignore: false,
                             },
-                            kind: Test {
-                                test_id: Path(
-                                    "foo_test",
-                                ),
-                                attr: TestAttr {
-                                    ignore: false,
-                                },
-                            },
-                            cfg: None,
                         },
-                    ),
-                ]
-            "#]],
+                        cfg: None,
+                    },
+                ),
+                GoToType(
+                    [],
+                ),
+            ]
+        "#]],
     );
 }
 


### PR DESCRIPTION
I've found myself wanting this...  adds to the hover quick go-to for a function's return type:

![image](https://user-images.githubusercontent.com/5489149/142375722-4a385216-494b-45a4-be1c-59664213b8d6.png)

This is particularly useful when you are hovering over a function in a long chain, like:

```rust
foo.bar().b$0az().some_trait_fn();
```

where `baz`'s return type is not immediately obvious, but the chain is not long enough to trigger chain inlay hints... 

i guess I could just select `foo.bar().baz()` too to get the types too... 