### PR TITLE
fix: Fix proc macro ABI version checks

### DIFF
--- a/crates/proc_macro_srv/src/abis/mod.rs
+++ b/crates/proc_macro_srv/src/abis/mod.rs
@@ -69,22 +69,26 @@ impl Abi {
         symbol_name: String,
         info: RustCInfo,
     ) -> Result<Abi, LoadProcMacroDylibError> {
-        if info.version.0 != 1 {
-            Err(LoadProcMacroDylibError::UnsupportedABI)
-        } else if info.version.1 < 47 {
-            Err(LoadProcMacroDylibError::UnsupportedABI)
-        } else if info.version.1 < 54 {
-            let inner = unsafe { Abi_1_47::from_lib(lib, symbol_name) }?;
-            Ok(Abi::Abi1_47(inner))
-        } else if info.version.1 < 56 {
-            let inner = unsafe { Abi_1_55::from_lib(lib, symbol_name) }?;
-            Ok(Abi::Abi1_55(inner))
-        } else if info.version.1 < 57 {
-            let inner = unsafe { Abi_1_56::from_lib(lib, symbol_name) }?;
-            Ok(Abi::Abi1_56(inner))
-        } else {
-            let inner = unsafe { Abi_1_58::from_lib(lib, symbol_name) }?;
-            Ok(Abi::Abi1_58(inner))
+        // FIXME: this should use exclusive ranges when they're stable
+        // https://github.com/rust-lang/rust/issues/37854
+        match (info.version.0, info.version.1) {
+            (1, 47..=54) => {
+                let inner = unsafe { Abi_1_47::from_lib(lib, symbol_name) }?;
+                Ok(Abi::Abi1_47(inner))
+            }
+            (1, 55..=55) => {
+                let inner = unsafe { Abi_1_55::from_lib(lib, symbol_name) }?;
+                Ok(Abi::Abi1_55(inner))
+            }
+            (1, 56..=57) => {
+                let inner = unsafe { Abi_1_56::from_lib(lib, symbol_name) }?;
+                Ok(Abi::Abi1_56(inner))
+            }
+            (1, 58..) => {
+                let inner = unsafe { Abi_1_58::from_lib(lib, symbol_name) }?;
+                Ok(Abi::Abi1_58(inner))
+            }
+            _ => Err(LoadProcMacroDylibError::UnsupportedABI),
         }
     }
 


### PR DESCRIPTION
If I'm reading this right, we used to pick `Abi1_55` for `1.54` and `Abi_1_58` for `1.57`.

CC @alexjg (just in case I'm misinterpreting the code), CC #10772.

bors r+