### PR TITLE
fix: show custom check-command

### DIFF
--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -407,16 +407,7 @@ impl GlobalState {
                             // the title, or the editor complains. Note that this is a user-facing string.
                             let title = if self.flycheck.len() == 1 {
                                 match self.config.flycheck() {
-                                    Some(flycheck::FlycheckConfig::CargoCommand {
-                                        command,
-                                        ..
-                                    }) => {
-                                        format!("cargo {}", command)
-                                    }
-                                    Some(flycheck::FlycheckConfig::CustomCommand {
-                                        command,
-                                        ..
-                                    }) => command,
+                                    Some(config) => format!("{}", config),
                                     None => "cargo check".to_string(),
                                 }
                             } else {


### PR DESCRIPTION
just realized this is a lot cleaner and actually shows something on a custom command,
also debugged it this time.