### PR TITLE
fix: don't discard formatting of `use` lines

### DIFF
--- a/crates/ide_assists/src/handlers/merge_imports.rs
+++ b/crates/ide_assists/src/handlers/merge_imports.rs
@@ -80,7 +80,7 @@ use std::fmt$0::{Display, Debug};
 use std::fmt::{Display, Debug};
 ",
             r"
-use std::fmt::{Debug, Display};
+use std::fmt::{Display, Debug};
 ",
         )
     }
@@ -108,7 +108,7 @@ use std::fmt::Debug;
 use std::fmt$0::Display;
 ",
             r"
-use std::fmt::{Debug, Display};
+use std::fmt::{Display, Debug};
 ",
         );
     }
@@ -135,7 +135,7 @@ use std::fmt::{self, Display};
 use std::{fmt, $0fmt::Display};
 ",
             r"
-use std::{fmt::{self, Display}};
+use std::{fmt::{Display, self}};
 ",
         );
     }
@@ -247,7 +247,7 @@ use std::{fmt::{Debug, Display}};
 use std::{fmt::Debug, fmt$0::Display};
 ",
             r"
-use std::{fmt::{Debug, Display}};
+use std::{fmt::{Display, Debug}};
 ",
         );
     }
@@ -341,7 +341,9 @@ use foo::$0{
 };
 ",
             r"
-use foo::{FooBar, bar::baz};
+use foo::{
+    FooBar, bar::baz,
+};
 ",
         )
     }

--- a/crates/ide_assists/src/handlers/replace_qualified_name_with_use.rs
+++ b/crates/ide_assists/src/handlers/replace_qualified_name_with_use.rs
@@ -299,7 +299,7 @@ fn main() {
     ",
             r"
 mod std { pub mod fmt { pub trait Display {} } }
-use std::fmt::{self, Display};
+use std::fmt::{Display, self};
 
 fn main() {
     fmt;

--- a/crates/ide_db/src/helpers/insert_use/tests.rs
+++ b/crates/ide_db/src/helpers/insert_use/tests.rs
@@ -463,7 +463,7 @@ fn merge_groups_full() {
 
 #[test]
 fn merge_groups_long_full() {
-    check_crate("std::foo::bar::Baz", r"use std::foo::bar::Qux;", r"use std::foo::bar::{Baz, Qux};")
+    check_crate("std::foo::bar::Baz", r"use std::foo::bar::Qux;", r"use std::foo::bar::{Qux, Baz};")
 }
 
 #[test]
@@ -471,7 +471,7 @@ fn merge_groups_long_last() {
     check_module(
         "std::foo::bar::Baz",
         r"use std::foo::bar::Qux;",
-        r"use std::foo::bar::{Baz, Qux};",
+        r"use std::foo::bar::{Qux, Baz};",
     )
 }
 
@@ -480,7 +480,7 @@ fn merge_groups_long_full_list() {
     check_crate(
         "std::foo::bar::Baz",
         r"use std::foo::bar::{Qux, Quux};",
-        r"use std::foo::bar::{Baz, Quux, Qux};",
+        r"use std::foo::bar::{Qux, Quux, Baz};",
     )
 }
 
@@ -489,7 +489,7 @@ fn merge_groups_long_last_list() {
     check_module(
         "std::foo::bar::Baz",
         r"use std::foo::bar::{Qux, Quux};",
-        r"use std::foo::bar::{Baz, Quux, Qux};",
+        r"use std::foo::bar::{Qux, Quux, Baz};",
     )
 }
 
@@ -498,7 +498,7 @@ fn merge_groups_long_full_nested() {
     check_crate(
         "std::foo::bar::Baz",
         r"use std::foo::bar::{Qux, quux::{Fez, Fizz}};",
-        r"use std::foo::bar::{Baz, Qux, quux::{Fez, Fizz}};",
+        r"use std::foo::bar::{Qux, quux::{Fez, Fizz}, Baz};",
     )
 }
 
@@ -517,7 +517,7 @@ fn merge_groups_full_nested_deep() {
     check_crate(
         "std::foo::bar::quux::Baz",
         r"use std::foo::bar::{Qux, quux::{Fez, Fizz}};",
-        r"use std::foo::bar::{Qux, quux::{Baz, Fez, Fizz}};",
+        r"use std::foo::bar::{Qux, quux::{Fez, Fizz, Baz}};",
     )
 }
 
@@ -526,7 +526,7 @@ fn merge_groups_full_nested_long() {
     check_crate(
         "std::foo::bar::Baz",
         r"use std::{foo::bar::Qux};",
-        r"use std::{foo::bar::{Baz, Qux}};",
+        r"use std::{foo::bar::{Qux, Baz}};",
     );
 }
 
@@ -535,7 +535,7 @@ fn merge_groups_last_nested_long() {
     check_crate(
         "std::foo::bar::Baz",
         r"use std::{foo::bar::Qux};",
-        r"use std::{foo::bar::{Baz, Qux}};",
+        r"use std::{foo::bar::{Qux, Baz}};",
     );
 }
 
@@ -600,7 +600,7 @@ fn merge_mod_into_glob() {
     check_with_config(
         "token::TokenKind",
         r"use token::TokenKind::*;",
-        r"use token::TokenKind::{*, self};",
+        r"use token::TokenKind::{self, *};",
         &InsertUseConfig {
             granularity: ImportGranularity::Crate,
             enforce_granularity: true,
@@ -618,7 +618,7 @@ fn merge_self_glob() {
     check_with_config(
         "self",
         r"use self::*;",
-        r"use self::{*, self};",
+        r"use self::{self, *};",
         &InsertUseConfig {
             granularity: ImportGranularity::Crate,
             enforce_granularity: true,
@@ -637,7 +637,7 @@ fn merge_glob() {
         r"
 use syntax::{SyntaxKind::*};",
         r"
-use syntax::{SyntaxKind::{*, self}};",
+use syntax::{SyntaxKind::{self, *}};",
     )
 }
 

--- a/crates/syntax/src/ast/edit.rs
+++ b/crates/syntax/src/ast/edit.rs
@@ -4,47 +4,9 @@
 use std::{fmt, iter, ops};
 
 use crate::{
-    algo,
     ast::{self, make, AstNode},
     ted, AstToken, NodeOrToken, SyntaxElement, SyntaxNode, SyntaxToken,
 };
-
-impl ast::UseTree {
-    /// Splits off the given prefix, making it the path component of the use tree, appending the rest of the path to all UseTreeList items.
-    #[must_use]
-    pub fn split_prefix(&self, prefix: &ast::Path) -> ast::UseTree {
-        let suffix = if self.path().as_ref() == Some(prefix) && self.use_tree_list().is_none() {
-            make::path_unqualified(make::path_segment_self())
-        } else {
-            match split_path_prefix(prefix) {
-                Some(it) => it,
-                None => return self.clone(),
-            }
-        };
-
-        let use_tree = make::use_tree(
-            suffix,
-            self.use_tree_list(),
-            self.rename(),
-            self.star_token().is_some(),
-        );
-        let nested = make::use_tree_list(iter::once(use_tree));
-        return make::use_tree(prefix.clone(), Some(nested), None, false);
-
-        fn split_path_prefix(prefix: &ast::Path) -> Option<ast::Path> {
-            let parent = prefix.parent_path()?;
-            let segment = parent.segment()?;
-            if algo::has_errors(segment.syntax()) {
-                return None;
-            }
-            let mut res = make::path_unqualified(segment);
-            for p in iter::successors(parent.parent_path(), |it| it.parent_path()) {
-                res = make::path_qualified(res, p.segment()?);
-            }
-            Some(res)
-        }
-    }
-}
 
 #[derive(Debug, Clone, Copy)]
 pub struct IndentLevel(pub u8);


### PR DESCRIPTION
Use mutable syntax trees in `merge_imports`, `split_imports`. This tries to resolve #9013. But I haven't much managed to simplify code of merging.

Also resolve #9361. It reuses a use tree under the cursor so that comments+indentation are preserved. Merged trees are just appended to the end.

This touches bunch of tests. I removed the sorting of use trees as it needs a proper implementation that takes into account comments and line wrapping. I think it is rustfmt's job or at least until we get a close implementation.