### PR TITLE
feat: Add toggle to disable cache priming

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -58,6 +58,9 @@ config_data! {
         /// Whether to allow import insertion to merge new imports into single path glob imports like `use std::fmt::*;`.
         assist_allowMergingIntoGlobImports: bool           = "true",
 
+        /// Warm up caches on project load.
+        cache_warmup: bool = "true",
+
         /// Show function name and docs in parameter hints.
         callInfo_full: bool                                = "true",
 
@@ -543,6 +546,10 @@ impl Config {
             self.caps.workspace.as_ref()?.did_change_watched_files.as_ref()?.dynamic_registration?,
             false
         )
+    }
+
+    pub fn prefill_caches(&self) -> bool {
+        self.data.cache_warmup
     }
 
     pub fn location_link(&self) -> bool {

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -433,7 +433,9 @@ impl GlobalState {
                 for flycheck in &self.flycheck {
                     flycheck.update();
                 }
-                self.prime_caches_queue.request_op();
+                if self.config.prefill_caches() {
+                    self.prime_caches_queue.request_op();
+                }
             }
 
             if !was_quiescent || state_changed {

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -23,6 +23,11 @@ Group inserted imports by the https://rust-analyzer.github.io/manual.html#auto-i
 --
 Whether to allow import insertion to merge new imports into single path glob imports like `use std::fmt::*;`.
 --
+[[rust-analyzer.cache.warmup]]rust-analyzer.cache.warmup (default: `true`)::
++
+--
+Warm up caches on project load.
+--
 [[rust-analyzer.callInfo.full]]rust-analyzer.callInfo.full (default: `true`)::
 +
 --

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -445,6 +445,11 @@
                     "default": true,
                     "type": "boolean"
                 },
+                "rust-analyzer.cache.warmup": {
+                    "markdownDescription": "Warm up caches on project load.",
+                    "default": true,
+                    "type": "boolean"
+                },
                 "rust-analyzer.callInfo.full": {
                     "markdownDescription": "Show function name and docs in parameter hints.",
                     "default": true,


### PR DESCRIPTION
Even if it doesn't prevent the rest of the features from working, cache priming tends to be quite CPU-intensive and can make people think that the load times are worse than they actually are.

It's also less useful in Code and `rust-tools` because the inlay hints and semantic highlighting trigger quite a bit of computation assuming you have a file open in the editor.