### PR TITLE
project_model: print full cargo command if cargo metadata fails to run

### DIFF
--- a/crates/project_model/src/cargo_workspace.rs
+++ b/crates/project_model/src/cargo_workspace.rs
@@ -286,9 +286,8 @@ impl CargoWorkspace {
         // unclear whether cargo itself supports it.
         progress("metadata".to_string());
 
-        let meta = meta.exec().with_context(|| {
-            format!("Failed to run `cargo metadata --manifest-path {}`", cargo_toml.display(),)
-        })?;
+        let meta =
+            meta.exec().with_context(|| format!("Failed to run `{:?}`", meta.cargo_command()))?;
 
         Ok(meta)
     }


### PR DESCRIPTION
well, `Command` implements a sensible `Debug` which *roughly* does what we want to do. Unfortunately it's got a bit of a quote situation,

So it'd output something like `"cargo" "metadata"  "--format-version" "1" "--features" "foo,bar,baz"`. 

Which although is a bit verbose with the quotes, it's at the very least, not entirely incorrect/misleading.

fixes #10797