### PR TITLE
fix: qualify struct name in struct constructor completion

### DIFF
--- a/crates/ide_completion/src/completions.rs
+++ b/crates/ide_completion/src/completions.rs
@@ -191,9 +191,10 @@ impl Completions {
         &mut self,
         ctx: &CompletionContext,
         strukt: hir::Struct,
+        path: Option<hir::ModPath>,
         local_name: Option<hir::Name>,
     ) {
-        let item = render_struct_literal(RenderContext::new(ctx), strukt, local_name);
+        let item = render_struct_literal(RenderContext::new(ctx), strukt, path, local_name);
         self.add_opt(item);
     }
 

--- a/crates/ide_completion/src/render/struct_literal.rs
+++ b/crates/ide_completion/src/render/struct_literal.rs
@@ -10,6 +10,7 @@ use crate::{render::RenderContext, CompletionItem, CompletionItemKind};
 pub(crate) fn render_struct_literal(
     ctx: RenderContext<'_>,
     strukt: hir::Struct,
+    path: Option<hir::ModPath>,
     local_name: Option<Name>,
 ) -> Option<CompletionItem> {
     let _p = profile::span("render_struct_literal");
@@ -23,7 +24,8 @@ pub(crate) fn render_struct_literal(
     }
 
     let name = local_name.unwrap_or_else(|| strukt.name(ctx.db())).to_smol_str();
-    let literal = render_literal(&ctx, &name, strukt.kind(ctx.db()), &visible_fields)?;
+
+    let literal = render_literal(&ctx, path, &name, strukt.kind(ctx.db()), &visible_fields)?;
 
     Some(build_completion(ctx, name, literal, strukt))
 }
@@ -49,13 +51,20 @@ fn build_completion(
 
 fn render_literal(
     ctx: &RenderContext<'_>,
+    path: Option<hir::ModPath>,
     name: &str,
     kind: StructKind,
     fields: &[hir::Field],
 ) -> Option<String> {
+    let qualified_name = if let Some(path) = path { path.to_string() } else { name.to_string() };
+
     let mut literal = match kind {
-        StructKind::Tuple if ctx.snippet_cap().is_some() => render_tuple_as_literal(fields, name),
-        StructKind::Record => render_record_as_literal(ctx.db(), ctx.snippet_cap(), fields, name),
+        StructKind::Tuple if ctx.snippet_cap().is_some() => {
+            render_tuple_as_literal(fields, &qualified_name)
+        }
+        StructKind::Record => {
+            render_record_as_literal(ctx.db(), ctx.snippet_cap(), fields, &qualified_name)
+        }
         _ => return None,
     };
 

--- a/crates/ide_completion/src/render/struct_literal.rs
+++ b/crates/ide_completion/src/render/struct_literal.rs
@@ -56,14 +56,21 @@ fn render_literal(
     kind: StructKind,
     fields: &[hir::Field],
 ) -> Option<String> {
-    let qualified_name = if let Some(path) = path { path.to_string() } else { name.to_string() };
+    let path_string;
+
+    let qualified_name = if let Some(path) = path {
+        path_string = path.to_string();
+        &path_string
+    } else {
+        name
+    };
 
     let mut literal = match kind {
         StructKind::Tuple if ctx.snippet_cap().is_some() => {
-            render_tuple_as_literal(fields, &qualified_name)
+            render_tuple_as_literal(fields, qualified_name)
         }
         StructKind::Record => {
-            render_record_as_literal(ctx.db(), ctx.snippet_cap(), fields, &qualified_name)
+            render_record_as_literal(ctx.db(), ctx.snippet_cap(), fields, qualified_name)
         }
         _ => return None,
     };


### PR DESCRIPTION
* Alter `add_struct_literal` method signature to take an optional module path
* Update `render_literal` method to use a qualified  

Relates to issue #10771 

Side note: This is my first contribution. Any feedback is welcome!