### PR TITLE
ra: fix rustfmt custom command not using correct directory

### DIFF
--- a/crates/rust-analyzer/src/from_proto.rs
+++ b/crates/rust-analyzer/src/from_proto.rs
@@ -58,7 +58,7 @@ pub(crate) fn file_position(
 
 pub(crate) fn file_range(
     snap: &GlobalStateSnapshot,
-    text_document_identifier: lsp_types::TextDocumentIdentifier,
+    text_document_identifier: &lsp_types::TextDocumentIdentifier,
     range: lsp_types::Range,
 ) -> Result<FileRange> {
     let file_id = file_id(snap, &text_document_identifier.uri)?;


### PR DESCRIPTION
fixes #10826 

when a custom command is provided, we don't set the working directory to match that of the file we're formatting, thus removing rustfmt's ability to detect the appropriate rustfmt.toml for said file.