### PR TITLE
internal: Try to fix Code tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,7 +112,7 @@ jobs:
     - name: Install Nodejs
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
 
     - name: Install xvfb
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,6 +114,10 @@ jobs:
       with:
         node-version: 12.x
 
+    - name: Install xvfb
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo apt-get install -y xvfb
+
     - run: npm ci
       working-directory: ./editors/code
 
@@ -124,13 +128,19 @@ jobs:
     - run: npm run lint
       working-directory: ./editors/code
 
-    - name: Run vscode tests
-      uses: GabrielBB/xvfb-action@v1.6
+    - name: Run VS Code tests (Linux)
+      if: matrix.os == 'ubuntu-latest'
       env:
         VSCODE_CLI: 1
-      with:
-        run: npm test
-        working-directory: ./editors/code
+      run: xvfb-run npm test
+      working-directory: ./editors/code
+
+    - name: Run VS Code tests (Windows)
+      if: matrix.os == 'windows-latest'
+      env:
+        VSCODE_CLI: 1
+      run: npm test
+      working-directory: ./editors/code
 
     - run: npm run pretest
       working-directory: ./editors/code

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,12 +125,12 @@ jobs:
       working-directory: ./editors/code
 
     - name: Run vscode tests
-      uses: GabrielBB/xvfb-action@v1.2
+      uses: GabrielBB/xvfb-action@v1.6
       env:
         VSCODE_CLI: 1
       with:
-        run: npm --prefix ./editors/code test
-        # working-directory: ./editors/code  # does not work: https://github.com/GabrielBB/xvfb-action/issues/8
+        run: npm test
+        working-directory: ./editors/code
 
     - run: npm run pretest
       working-directory: ./editors/code

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -32,7 +32,7 @@
         "watch": "npm run build-base -- --sourcemap --watch",
         "lint": "tsfmt --verify && eslint -c .eslintrc.js --ext ts ./src ./tests",
         "fix": " tsfmt -r       && eslint -c .eslintrc.js --ext ts ./src ./tests --fix",
-        "pretest": "tsc --noEmit && npm run build",
+        "pretest": "tsc && npm run build",
         "test": "node ./out/tests/runTests.js"
     },
     "dependencies": {


### PR DESCRIPTION
It looks like `--noEmit` broke our unit tests:

![image](https://user-images.githubusercontent.com/308347/144217192-a8133a6b-880f-4852-846b-b45527485336.png)

r? @ChayimFriedman2

I suppose we might still:

 - compile stuff twice
 - not detect failing tests on CI (since we didn't notice this)