### PR TITLE
ide: hack to make self not unresolved reference in async trait wrapped impl's

### DIFF
--- a/crates/ide/src/syntax_highlighting/highlight.rs
+++ b/crates/ide/src/syntax_highlighting/highlight.rs
@@ -286,7 +286,7 @@ fn highlight_name_ref(
                     // within a function with a self param, pretend to still be `self`, rather than
                     // an unresolved reference.
                     if name_ref.self_token().is_some() && is_in_fn_with_self_param(&name_ref) {
-                        HlTag::Symbol(SymbolKind::SelfParam).into()
+                        SymbolKind::SelfParam.into()
                     } else {
                         HlTag::UnresolvedReference.into()
                     }

--- a/crates/ide/src/syntax_highlighting/highlight.rs
+++ b/crates/ide/src/syntax_highlighting/highlight.rs
@@ -281,6 +281,8 @@ fn highlight_name_ref(
                 return if syntactic_name_ref_highlighting {
                     highlight_name_ref_by_syntax(name_ref, sema, krate)
                 } else {
+                    // FIXME: Workaround for https://github.com/rust-analyzer/rust-analyzer/issues/10708
+                    //
                     // Some popular proc macros (namely async_trait) will rewrite `self` in such a way that it no
                     // longer resolves via NameRefClass. If we can't be resolved, but we know we're a self token,
                     // within a function with a self param, pretend to still be `self`, rather than


### PR DESCRIPTION
fixes #10708 

this is a bit hacky, but it "works". 

i'm not sure how to even write a test for this though, but i've confirmed it works via manual testing...