### PR TITLE
fix: fix `concat!` with captured expression

### DIFF
--- a/crates/hir_def/src/macro_expansion_tests/builtin_fn_macro.rs
+++ b/crates/hir_def/src/macro_expansion_tests/builtin_fn_macro.rs
@@ -314,6 +314,40 @@ fn main() { "foor0bar\nfalse"; }
 }
 
 #[test]
+fn test_concat_with_captured_expr() {
+    check(
+        r##"
+#[rustc_builtin_macro]
+macro_rules! concat {}
+
+macro_rules! surprise {
+    () => { "s" };
+}
+
+macro_rules! stuff {
+    ($string:expr) => { concat!($string) };
+}
+
+fn main() { concat!(surprise!()); }
+"##,
+        expect![[r##"
+#[rustc_builtin_macro]
+macro_rules! concat {}
+
+macro_rules! surprise {
+    () => { "s" };
+}
+
+macro_rules! stuff {
+    ($string:expr) => { concat!($string) };
+}
+
+fn main() { "s"; }
+"##]],
+    );
+}
+
+#[test]
 fn test_concat_idents_expand() {
     check(
         r##"


### PR DESCRIPTION
Adds another hack on top of https://github.com/rust-analyzer/rust-analyzer/pull/10623 to fix `concat!`.

Fixes https://github.com/rust-analyzer/rust-analyzer/issues/10721

bors r+