### PR TITLE
internal: Update `InferenceContext::infer_pat`

### DIFF
--- a/crates/hir_ty/src/infer/pat.rs
+++ b/crates/hir_ty/src/infer/pat.rs
@@ -134,15 +134,10 @@ impl<'a> InferenceContext<'a> {
                     .intern(&Interner)
             }
             Pat::Or(pats) => {
-                if let Some((first_pat, rest)) = pats.split_first() {
-                    let ty = self.infer_pat(*first_pat, &expected, default_bm);
-                    for pat in rest {
-                        self.infer_pat(*pat, &expected, default_bm);
-                    }
-                    ty
-                } else {
-                    self.err_ty()
+                for &pat in pats.iter() {
+                    self.infer_pat(pat, &expected, default_bm);
                 }
+                expected.clone()
             }
             Pat::Ref { pat, mutability } => {
                 let mutability = lower_to_chalk_mutability(*mutability);

--- a/crates/hir_ty/src/tests/patterns.rs
+++ b/crates/hir_ty/src/tests/patterns.rs
@@ -205,7 +205,6 @@ fn infer_pattern_match_ergonomics() {
 
 #[test]
 fn infer_pattern_match_ergonomics_ref() {
-    cov_mark::check!(match_ergonomics_ref);
     check_infer(
         r#"
         fn test() {

--- a/crates/hir_ty/src/tests/patterns.rs
+++ b/crates/hir_ty/src/tests/patterns.rs
@@ -175,6 +175,31 @@ fn infer_range_pattern() {
 }
 
 #[test]
+fn match_ergonomics_with_binding_modes_interaction() {
+    check_infer_with_mismatches(
+        r"
+enum E{ A, B }
+fn foo() {
+    match &E::A {
+        b @ (x @ E::A | x) => {}
+    }
+}",
+        expect![[r#"
+            24..84 '{     ...   } }': ()
+            30..82 'match ...     }': ()
+            36..41 '&E::A': &E
+            37..41 'E::A': E
+            52..70 'b @ (x...A | x)': &E
+            57..65 'x @ E::A': &E
+            57..69 'x @ E::A | x': &E
+            61..65 'E::A': E
+            68..69 'x': &E
+            74..76 '{}': ()
+        "#]],
+    );
+}
+
+#[test]
 fn infer_pattern_match_ergonomics() {
     check_infer(
         r#"
@@ -861,9 +886,9 @@ fn main() {
             42..51 'true | ()': bool
             49..51 '()': ()
             57..59 '{}': ()
-            68..80 '(() | true,)': ((),)
+            68..80 '(() | true,)': (bool,)
             69..71 '()': ()
-            69..78 '() | true': ()
+            69..78 '() | true': bool
             74..78 'true': bool
             74..78 'true': bool
             84..86 '{}': ()
@@ -872,19 +897,15 @@ fn main() {
             96..102 '_ | ()': bool
             100..102 '()': ()
             108..110 '{}': ()
-            119..128 '(() | _,)': ((),)
+            119..128 '(() | _,)': (bool,)
             120..122 '()': ()
-            120..126 '() | _': ()
+            120..126 '() | _': bool
             125..126 '_': bool
             132..134 '{}': ()
             49..51: expected bool, got ()
-            68..80: expected (bool,), got ((),)
             69..71: expected bool, got ()
-            69..78: expected bool, got ()
             100..102: expected bool, got ()
-            119..128: expected (bool,), got ((),)
             120..122: expected bool, got ()
-            120..126: expected bool, got ()
         "#]],
     );
 }


### PR DESCRIPTION
Been looking into https://github.com/rust-analyzer/rust-analyzer/issues/10989 a bit, and figured it would be a good idea to bring this part more into line with how rustc does it first https://github.com/rust-lang/rust/blob/8b09ba6a5d5c644fe0f1c27c7f9c80b334241707/compiler/rustc_typeck/src/check/pat.rs
Fixes #10989