### PR TITLE
minor: Set `MACOSX_DEPLOYMENT_TARGET` to 10.15 to improve compat

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,7 @@ env:
   RUSTFLAGS: "-D warnings -W unreachable-pub"
   RUSTUP_MAX_RETRIES: 10
   FETCH_DEPTH: 0 # pull in the tags for the version string
+  MACOSX_DEPLOYMENT_TARGET: 10.15
 
 jobs:
   dist:


### PR DESCRIPTION
Since GitHub (and also us, explicitly) switched the `macos-latest` runners to 11, let's try to bring back support for 10.15.