### PR TITLE
fix: fix incorrect mismatched argument count diagnostic with `std::arch` functions

### DIFF
--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -1286,7 +1286,11 @@ fn fn_sig_for_fn(db: &dyn HirDatabase, def: FunctionId) -> PolyFnSig {
         .with_type_param_mode(TypeParamLoweringMode::Variable);
     let ret = ctx_ret.lower_ty(&data.ret_type);
     let generics = generics(db.upcast(), def.into());
-    make_binders(&generics, CallableSig::from_params_and_return(params, ret, data.is_varargs()))
+    let mut sig = CallableSig::from_params_and_return(params, ret, data.is_varargs());
+    if !data.legacy_const_generics_indices.is_empty() {
+        sig.set_legacy_const_generics_indices(&data.legacy_const_generics_indices);
+    }
+    make_binders(&generics, sig)
 }
 
 /// Build the declared type of a function. This should not need to look at the

--- a/crates/ide_diagnostics/src/handlers/mismatched_arg_count.rs
+++ b/crates/ide_diagnostics/src/handlers/mismatched_arg_count.rs
@@ -309,4 +309,36 @@ fn main() {
             "#,
         )
     }
+
+    #[test]
+    fn legacy_const_generics() {
+        check_diagnostics(
+            r#"
+#[rustc_legacy_const_generics(1, 3)]
+fn mixed<const N1: &'static str, const N2: bool>(
+    a: u8,
+    b: i8,
+) {}
+
+fn f() {
+    mixed(0, "", -1, true);
+    mixed::<"", true>(0, -1);
+}
+
+#[rustc_legacy_const_generics(1, 3)]
+fn b<const N1: u8, const N2: u8>(
+    a: u8,
+    b: u8,
+) {}
+
+fn g() {
+    b(0, 1, 2, 3);
+    b::<1, 3>(0, 2);
+
+    b(0, 1, 2);
+           //^ error: expected 4 arguments, found 3
+}
+            "#,
+        )
+    }
 }


### PR DESCRIPTION
Adds basic support for `#[rustc_legacy_const_generics]`.

Fixes https://github.com/rust-analyzer/rust-analyzer/issues/10009

Full support would involve actually checking call arguments against the right expected types.

bors r+