### PR TITLE
feat: Publish platform-specific Code VSIXes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,7 @@ env:
   RUSTUP_MAX_RETRIES: 10
   FETCH_DEPTH: 0 # pull in the tags for the version string
   MACOSX_DEPLOYMENT_TARGET: 10.15
+  CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
 
 jobs:
   dist:
@@ -25,24 +26,28 @@ jobs:
         include:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
+            code-target: win32-x64
           - os: windows-latest
             target: aarch64-pc-windows-msvc
+            code-target: win32-arm64
           - os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
+            code-target: linux-x64
           - os: ubuntu-20.04
             target: aarch64-unknown-linux-gnu
-            cross_linker: aarch64-linux-gnu-gcc
+            code-target: linux-arm64
           - os: macos-11
             target: x86_64-apple-darwin
+            code-target: darwin-x64
           - os: macos-11
             target: aarch64-apple-darwin
+            code-target: darwin-arm64
 
     name: dist (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
 
     env:
       RA_TARGET: ${{ matrix.target }}
-      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.cross_linker }}
 
     steps:
       - name: Checkout repository
@@ -77,7 +82,6 @@ jobs:
           components: rust-src
 
       - name: Install Node.js
-        if: matrix.target == 'x86_64-unknown-linux-gnu'
         uses: actions/setup-node@v1
         with:
           node-version: 14.x
@@ -90,13 +94,21 @@ jobs:
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: sudo apt-get install gcc-aarch64-linux-gnu
 
-      - name: Dist (generic)
-        if: matrix.target != 'x86_64-unknown-linux-gnu'
-        run: cargo xtask dist
+      - name: Dist
+        run: cargo xtask dist --client-patch-version ${{ github.run_number }}
 
-      - name: Dist (Linux)
-        if: matrix.target == 'x86_64-unknown-linux-gnu'
-        run: cargo xtask dist --client-patch-version $GITHUB_RUN_NUMBER
+      - run: npm ci
+        working-directory: editors/code
+
+      - run: npx vsce package -o "../../dist/rust-analyzer-${{ matrix.code-target }}.vsix" --target ${{ matrix.code-target }}
+        working-directory: editors/code
+
+      - if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: rm -rf editors/code/server
+
+      - if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: npx vsce package -o ../../dist/rust-analyzer.vsix
+        working-directory: editors/code
 
       - name: Run analysis-stats on rust-analyzer
         if: matrix.target == 'x86_64-unknown-linux-gnu'
@@ -126,7 +138,7 @@ jobs:
 
     steps:
       - name: Install dependencies
-        run: apk add --no-cache git clang lld musl-dev
+        run: apk add --no-cache git clang lld musl-dev nodejs npm
 
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -134,7 +146,15 @@ jobs:
           fetch-depth: ${{ env.FETCH_DEPTH }}
 
       - name: Dist
-        run: cargo xtask dist
+        run: cargo xtask dist --client-patch-version ${{ github.run_number }}
+
+      - run: npm ci
+        working-directory: editors/code
+
+      - run: npx vsce package -o "../../dist/rust-analyzer-alpine-x64.vsix" --target alpine-x64
+        working-directory: editors/code
+
+      - run: rm -rf editors/code/server
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
@@ -210,4 +230,4 @@ jobs:
         if: github.ref == 'refs/heads/release'
         working-directory: ./editors/code
         # token from https://dev.azure.com/rust-analyzer/
-        run: npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --packagePath ../../dist/rust-analyzer.vsix
+        run: npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --packagePath ../../dist/rust-analyzer-*.vsix

--- a/editors/code/.gitignore
+++ b/editors/code/.gitignore
@@ -1,5 +1,5 @@
 out
 node_modules
+server
 .vscode-test/
 *.vsix
-bundle

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -221,9 +221,18 @@ async function bootstrapExtension(config: Config, state: PersistentState): Promi
     );
     if (userResponse !== "Update") return;
 
-    const artifact = latestNightlyRelease.assets.find(artifact => artifact.name === "rust-analyzer.vsix");
-    assert(!!artifact, `Bad release: ${JSON.stringify(latestNightlyRelease)}`);
+    let arch = process.arch;
+    if (arch === "ia32") {
+        arch = "x64";
+    }
+    let platform = process.platform as string;
+    if (platform === "linux" && isMusl()) {
+        platform = "alpine";
+    }
+    const artifactName = `rust-analyzer-${platform}-${arch}.vsix`;
 
+    const artifact = latestNightlyRelease.assets.find(artifact => artifact.name === artifactName);
+    assert(!!artifact, `Bad release: ${JSON.stringify(latestNightlyRelease)}`);
     const dest = vscode.Uri.joinPath(config.globalStorageUri, "rust-analyzer.vsix");
 
     await downloadWithRetryDialog(state, async () => {


### PR DESCRIPTION
Closes #10483
CC #10371

Some notes:

 - we still build a plain VSIX, just in case
 - we build the extension on every platform to make the release workflow arguably cleaner
 - the Windows VSIX includes the PDB (but let's leave  #10371 open until we change the Windows stand-alone release to a ZIP file)
 - `npm` doesn't run if started from `xtask`, possibly something related to path mapping; I moved the `npm` calls outside, but..
 - the `Patch` thingy doesn't work any more, so you'll end up with a dirty `package.json` of you run `cargo xtask --client-patch-version`; I don't think we should block on this
 - there's an untested Alpine build; for better or worse, we publish `musl` builds as `alpine`
 - I tested this as much as I could, but not the publishing and nightly updates
 - you can find some sample artifacts under https://github.com/lnicola/rust-analyzer/releases
 - we can now run the server from the install location (is Code planning to switch to compressed extensions?), except on NixOS
 - Code lets you install a VSIX for the wrong platform (with the results one would expect)
 - I don't know what happens if we try to publish a VSIX without a target

This is a relatively risky, but we'll probably have to take our chances with it.

r? @rust-analyzer/review