### PR TITLE
Support "move if to guard" for if else chains

### DIFF
--- a/crates/ide_assists/src/handlers/move_guard.rs
+++ b/crates/ide_assists/src/handlers/move_guard.rs
@@ -185,7 +185,7 @@ pub(crate) fn move_arm_cond_to_match_guard(acc: &mut Assists, ctx: &AssistContex
 }
 
 // Parses an if-else-if chain to get the conditons and the then branches until we encounter an else
-// branch, an if-let branch or the end.
+// branch or the end.
 fn parse_if_chain(if_expr: IfExpr) -> Option<(Vec<(Condition, BlockExpr)>, Option<BlockExpr>)> {
     let mut conds_blocks = Vec::new();
     let mut curr_if = if_expr;

--- a/crates/ide_assists/src/handlers/move_guard.rs
+++ b/crates/ide_assists/src/handlers/move_guard.rs
@@ -96,6 +96,7 @@ pub(crate) fn move_guard_to_arm_body(acc: &mut Assists, ctx: &AssistContext) -> 
 // fn handle(action: Action) {
 //     match action {
 //         Action::Move { distance } if distance > 10 => foo(),
+//         Action::Move { distance } => {}
 //         _ => (),
 //     }
 // }
@@ -175,7 +176,9 @@ pub(crate) fn move_arm_cond_to_match_guard(acc: &mut Assists, ctx: &AssistContex
                     }
                 }
             } else {
+                // There's no else branch. Add a pattern without guard
                 cov_mark::hit!(move_guard_ifelse_notail);
+                edit.insert(then_arm_end, format!("\n{}{} => {{}}", spaces, match_pat));
             }
         },
     )
@@ -309,6 +312,7 @@ fn main() {
 fn main() {
     match 92 {
         x if x > 10 => false,
+        x => {}
         _ => true
     }
 }
@@ -336,6 +340,7 @@ fn main() {
 fn main() {
     match 92 {
         x if x > 10 => false,
+        x => {}
         _ => true
     }
 }
@@ -363,6 +368,7 @@ fn main() {
 fn main() {
     match 92 {
         x if x > 10 => false,
+        x => {}
         _ => true
     }
 }
@@ -401,6 +407,7 @@ fn main() {
 fn main() {
     match 92 {
         x if x > 10 => {  }
+        x => {}
         _ => true
     }
 }
@@ -430,6 +437,7 @@ fn main() {
             92;
             false
         }
+        x => {}
         _ => true
     }
 }
@@ -461,6 +469,7 @@ fn main() {
             92;
             false
         }
+        x => {}
         _ => true
     }
 }
@@ -881,6 +890,7 @@ fn main() {
             42;
             3
         }
+        x => {}
     }
 }
 "#,

--- a/crates/ide_assists/src/tests/generated.rs
+++ b/crates/ide_assists/src/tests/generated.rs
@@ -1403,6 +1403,7 @@ enum Action { Move { distance: u32 }, Stop }
 fn handle(action: Action) {
     match action {
         Action::Move { distance } if distance > 10 => foo(),
+        Action::Move { distance } => {}
         _ => (),
     }
 }

--- a/crates/ide_assists/src/tests/generated.rs
+++ b/crates/ide_assists/src/tests/generated.rs
@@ -1403,7 +1403,6 @@ enum Action { Move { distance: u32 }, Stop }
 fn handle(action: Action) {
     match action {
         Action::Move { distance } if distance > 10 => foo(),
-        Action::Move { distance } => {}
         _ => (),
     }
 }


### PR DESCRIPTION
The idea is to first parse the if else chain into a vector of `(Condition, BlockExpr)`s until we reach an iflet branch, an else branch, or the end (the tail). Then add the match arms with guard for the vector, and add the tail with no if guard.

Because the whole original match arm is replaced and the generated code doesn't have redundent commas, I removed redundent commas in some test cases.

Closes #11033.