### PR TITLE
fix: Don't say "a reference to" for `Copy` types in the generate getter assist

### DIFF
--- a/crates/ide_assists/src/utils.rs
+++ b/crates/ide_assists/src/utils.rs
@@ -572,6 +572,10 @@ impl ReferenceConversion {
             | ReferenceConversionType::Result => format!("self.{}.as_ref()", field_name),
         }
     }
+
+    pub(crate) fn is_copy(&self) -> bool {
+        matches!(self.conversion, ReferenceConversionType::Copy)
+    }
 }
 
 // FIXME: It should return a new hir::Type, but currently constructing new types is too cumbersome


### PR DESCRIPTION
This changes the generate getter assist to not say "a reference to" in the documentation stub if the type is `Copy`, as the getter does not return a reference.

To determine whether the type is `Copy`, I have added an `is_copy` method to `ReferenceConversion`.