### PR TITLE
internal: Disable unstable APIs for nightly releases

### DIFF
--- a/xtask/src/dist.rs
+++ b/xtask/src/dist.rs
@@ -63,9 +63,7 @@ fn dist_client(version: &str, release_tag: &str, target: &Target) -> Result<()> 
             r#""displayName": "rust-analyzer (nightly)""#,
         );
     }
-    if !nightly {
-        patch.replace(r#""enableProposedApi": true,"#, r#""#);
-    }
+    patch.replace(r#""enableProposedApi": true,"#, r#""#);
     patch.commit()?;
 
     Ok(())


### PR DESCRIPTION
bors r+

The Marketplace doesn't allow us to publish extensions using these, even as pre-release versions.