### PR TITLE
internal: Improve GitHub release action

### DIFF
--- a/.github/actions/github-release/package.json
+++ b/.github/actions/github-release/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "main": "main.js",
   "dependencies": {
-    "@actions/core": "^1.0.0",
-    "@actions/github": "^1.0.0",
+    "@actions/core": "^1.6",
+    "@actions/github": "^5.0",
     "glob": "^7.1.5"
   }
 }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,7 @@ env:
 
 jobs:
   rust:
+    if: github.repository == 'rust-analyzer/rust-analyzer'
     name: Rust
     runs-on: ${{ matrix.os }}
     env:
@@ -61,6 +62,7 @@ jobs:
 
   # Weird targets to catch non-portable code
   rust-cross:
+    if: github.repository == 'rust-analyzer/rust-analyzer'
     name: Rust Cross
     runs-on: ubuntu-latest
 
@@ -97,6 +99,7 @@ jobs:
         done
 
   typescript:
+    if: github.repository == 'rust-analyzer/rust-analyzer'
     name: TypeScript
     strategy:
       fail-fast: false

--- a/.github/workflows/metrics.yaml
+++ b/.github/workflows/metrics.yaml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   metrics:
+    if: github.repository == 'rust-analyzer/rust-analyzer'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -162,12 +162,12 @@ jobs:
       - run: npm ci
         working-directory: editors/code
 
-      - name: Publish Extension (release)
+      - name: Package Extension (release)
         if: github.ref == 'refs/heads/release'
         run: npx vsce package -o "../../dist/rust-analyzer-alpine-x64.vsix" --target alpine-x64
         working-directory: editors/code
 
-      - name: Publish Extension (nightly)
+      - name: Package Extension (nightly)
         if: github.ref != 'refs/heads/release'
         run: npx vsce package -o "../../dist/rust-analyzer-alpine-x64.vsix" --target alpine-x64 --pre-release
         working-directory: editors/code

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -247,12 +247,12 @@ jobs:
         working-directory: ./editors/code
 
       - name: Publish Extension (release)
-        if: github.ref == 'refs/heads/release'
+        if: github.ref == 'refs/heads/release' && github.repository == 'rust-analyzer/rust-analyzer'
         working-directory: ./editors/code
         # token from https://dev.azure.com/rust-analyzer/
         run: npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --packagePath ../../dist/rust-analyzer-*.vsix
 
       - name: Publish Extension (nightly)
-        if: github.ref != 'refs/heads/release'
+        if: github.ref != 'refs/heads/release' && github.repository == 'rust-analyzer/rust-analyzer'
         working-directory: ./editors/code
         run: npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --packagePath ../../dist/rust-analyzer-*.vsix --pre-release

--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   rustdoc:
+    if: github.repository == 'rust-analyzer/rust-analyzer'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Upgrade `@actions/github` to get `listReleaseAssets` and retry individual uploads in addition to the whole thing.

Also disables `ci`, `metrics` and `rustdoc` on forks to save some CPU time.

CC #11056