### PR TITLE
internal: replace TreeSink with a data structure 

### DIFF
--- a/crates/mbe/src/lib.rs
+++ b/crates/mbe/src/lib.rs
@@ -10,7 +10,7 @@ mod parser;
 mod expander;
 mod syntax_bridge;
 mod tt_iter;
-mod to_parser_tokens;
+mod to_parser_input;
 
 #[cfg(test)]
 mod benchmark;

--- a/crates/mbe/src/to_parser_input.rs
+++ b/crates/mbe/src/to_parser_input.rs
@@ -4,8 +4,8 @@
 use syntax::{SyntaxKind, SyntaxKind::*, T};
 use tt::buffer::TokenBuffer;
 
-pub(crate) fn to_parser_tokens(buffer: &TokenBuffer) -> parser::Tokens {
-    let mut res = parser::Tokens::default();
+pub(crate) fn to_parser_input(buffer: &TokenBuffer) -> parser::Input {
+    let mut res = parser::Input::default();
 
     let mut current = buffer.begin();
 

--- a/crates/mbe/src/tt_iter.rs
+++ b/crates/mbe/src/tt_iter.rs
@@ -3,9 +3,8 @@
 
 use crate::{to_parser_tokens::to_parser_tokens, ExpandError, ExpandResult, ParserEntryPoint};
 
-use parser::TreeSink;
 use syntax::SyntaxKind;
-use tt::buffer::{Cursor, TokenBuffer};
+use tt::buffer::TokenBuffer;
 
 macro_rules! err {
     () => {
@@ -94,34 +93,28 @@ impl<'a> TtIter<'a> {
         &mut self,
         entry_point: ParserEntryPoint,
     ) -> ExpandResult<Option<tt::TokenTree>> {
-        struct OffsetTokenSink<'a> {
-            cursor: Cursor<'a>,
-            error: bool,
-        }
-
-        impl<'a> TreeSink for OffsetTokenSink<'a> {
-            fn token(&mut self, kind: SyntaxKind, mut n_tokens: u8) {
-                if kind == SyntaxKind::LIFETIME_IDENT {
-                    n_tokens = 2;
-                }
-                for _ in 0..n_tokens {
-                    self.cursor = self.cursor.bump_subtree();
-                }
-            }
-            fn start_node(&mut self, _kind: SyntaxKind) {}
-            fn finish_node(&mut self) {}
-            fn error(&mut self, _error: parser::ParseError) {
-                self.error = true;
-            }
-        }
-
         let buffer = TokenBuffer::from_tokens(self.inner.as_slice());
         let parser_tokens = to_parser_tokens(&buffer);
-        let mut sink = OffsetTokenSink { cursor: buffer.begin(), error: false };
+        let tree_traversal = parser::parse(&parser_tokens, entry_point);
 
-        parser::parse(&parser_tokens, &mut sink, entry_point);
+        let mut cursor = buffer.begin();
+        let mut error = false;
+        for step in tree_traversal.iter() {
+            match step {
+                parser::TraversalStep::Token { kind, mut n_raw_tokens } => {
+                    if kind == SyntaxKind::LIFETIME_IDENT {
+                        n_raw_tokens = 2;
+                    }
+                    for _ in 0..n_raw_tokens {
+                        cursor = cursor.bump_subtree();
+                    }
+                }
+                parser::TraversalStep::EnterNode { .. } | parser::TraversalStep::LeaveNode => (),
+                parser::TraversalStep::Error { .. } => error = true,
+            }
+        }
 
-        let mut err = if !sink.cursor.is_root() || sink.error {
+        let mut err = if !cursor.is_root() || error {
             Some(err!("expected {:?}", entry_point))
         } else {
             None
@@ -130,8 +123,8 @@ impl<'a> TtIter<'a> {
         let mut curr = buffer.begin();
         let mut res = vec![];
 
-        if sink.cursor.is_root() {
-            while curr != sink.cursor {
+        if cursor.is_root() {
+            while curr != cursor {
                 if let Some(token) = curr.token_tree() {
                     res.push(token);
                 }

--- a/crates/parser/src/event.rs
+++ b/crates/parser/src/event.rs
@@ -10,7 +10,7 @@
 use std::mem;
 
 use crate::{
-    tree_traversal::TreeTraversal,
+    output::Output,
     SyntaxKind::{self, *},
 };
 
@@ -87,8 +87,8 @@ impl Event {
 }
 
 /// Generate the syntax tree with the control of events.
-pub(super) fn process(mut events: Vec<Event>) -> TreeTraversal {
-    let mut res = TreeTraversal::default();
+pub(super) fn process(mut events: Vec<Event>) -> Output {
+    let mut res = Output::default();
     let mut forward_parents = Vec::new();
 
     for i in 0..events.len() {

--- a/crates/parser/src/event.rs
+++ b/crates/parser/src/event.rs
@@ -10,9 +10,8 @@
 use std::mem;
 
 use crate::{
-    ParseError,
+    tree_traversal::TreeTraversal,
     SyntaxKind::{self, *},
-    TreeSink,
 };
 
 /// `Parser` produces a flat list of `Event`s.
@@ -77,7 +76,7 @@ pub(crate) enum Event {
     },
 
     Error {
-        msg: ParseError,
+        msg: String,
     },
 }
 
@@ -88,7 +87,8 @@ impl Event {
 }
 
 /// Generate the syntax tree with the control of events.
-pub(super) fn process(sink: &mut dyn TreeSink, mut events: Vec<Event>) {
+pub(super) fn process(mut events: Vec<Event>) -> TreeTraversal {
+    let mut res = TreeTraversal::default();
     let mut forward_parents = Vec::new();
 
     for i in 0..events.len() {
@@ -117,15 +117,17 @@ pub(super) fn process(sink: &mut dyn TreeSink, mut events: Vec<Event>) {
 
                 for kind in forward_parents.drain(..).rev() {
                     if kind != TOMBSTONE {
-                        sink.start_node(kind);
+                        res.enter_node(kind);
                     }
                 }
             }
-            Event::Finish => sink.finish_node(),
+            Event::Finish => res.leave_node(),
             Event::Token { kind, n_raw_tokens } => {
-                sink.token(kind, n_raw_tokens);
+                res.token(kind, n_raw_tokens);
             }
-            Event::Error { msg } => sink.error(msg),
+            Event::Error { msg } => res.error(msg),
         }
     }
+
+    res
 }

--- a/crates/parser/src/input.rs
+++ b/crates/parser/src/input.rs
@@ -1,26 +1,26 @@
-//! Input for the parser -- a sequence of tokens.
-//!
-//! As of now, parser doesn't have access to the *text* of the tokens, and makes
-//! decisions based solely on their classification. Unlike `LexerToken`, the
-//! `Tokens` doesn't include whitespace and comments.
+//! See [`Input`].
 
 use crate::SyntaxKind;
 
 #[allow(non_camel_case_types)]
 type bits = u64;
 
-/// Main input to the parser.
+/// Input for the parser -- a sequence of tokens.
 ///
-/// A sequence of tokens represented internally as a struct of arrays.
+/// As of now, parser doesn't have access to the *text* of the tokens, and makes
+/// decisions based solely on their classification. Unlike `LexerToken`, the
+/// `Tokens` doesn't include whitespace and comments. Main input to the parser.
+///
+/// Struct of arrays internally, but this shouldn't really matter.
 #[derive(Default)]
-pub struct Tokens {
+pub struct Input {
     kind: Vec<SyntaxKind>,
     joint: Vec<bits>,
     contextual_kind: Vec<SyntaxKind>,
 }
 
 /// `pub` impl used by callers to create `Tokens`.
-impl Tokens {
+impl Input {
     #[inline]
     pub fn push(&mut self, kind: SyntaxKind) {
         self.push_impl(kind, SyntaxKind::EOF)
@@ -63,7 +63,7 @@ impl Tokens {
 }
 
 /// pub(crate) impl used by the parser to consume `Tokens`.
-impl Tokens {
+impl Input {
     pub(crate) fn kind(&self, idx: usize) -> SyntaxKind {
         self.kind.get(idx).copied().unwrap_or(SyntaxKind::EOF)
     }
@@ -76,7 +76,7 @@ impl Tokens {
     }
 }
 
-impl Tokens {
+impl Input {
     fn bit_index(&self, n: usize) -> (usize, usize) {
         let idx = n / (bits::BITS as usize);
         let b_idx = n % (bits::BITS as usize);

--- a/crates/parser/src/lexed_str.rs
+++ b/crates/parser/src/lexed_str.rs
@@ -122,8 +122,8 @@ impl<'a> LexedStr<'a> {
         self.error.iter().map(|it| (it.token as usize, it.msg.as_str()))
     }
 
-    pub fn to_tokens(&self) -> crate::Tokens {
-        let mut res = crate::Tokens::default();
+    pub fn to_input(&self) -> crate::Input {
+        let mut res = crate::Input::default();
         let mut was_joint = false;
         for i in 0..self.len() {
             let kind = self.kind(i);

--- a/crates/parser/src/output.rs
+++ b/crates/parser/src/output.rs
@@ -1,43 +1,52 @@
-//! TODO
+//! See [`Output`]
+
 use crate::SyntaxKind;
 
-/// Output of the parser.
+/// Output of the parser -- a DFS traversal of a concrete syntax tree.
+///
+/// Use the [`Output::iter`] method to iterate over traversal steps and consume
+/// a syntax tree.
+///
+/// In a sense, this is just a sequence of [`SyntaxKind`]-colored parenthesis
+/// interspersed into the original [`crate::Input`]. The output is fundamentally
+/// coordinated with the input and `n_input_tokens` refers to the number of
+/// times [`crate::Input::push`] was called.
 #[derive(Default)]
-pub struct TreeTraversal {
+pub struct Output {
     /// 32-bit encoding of events. If LSB is zero, then that's an index into the
     /// error vector. Otherwise, it's one of the thee other variants, with data encoded as
     ///
-    ///     |16 bit kind|8 bit n_raw_tokens|4 bit tag|4 bit leftover|
+    ///     |16 bit kind|8 bit n_input_tokens|4 bit tag|4 bit leftover|
     ///
     event: Vec<u32>,
     error: Vec<String>,
 }
 
-pub enum TraversalStep<'a> {
-    Token { kind: SyntaxKind, n_raw_tokens: u8 },
-    EnterNode { kind: SyntaxKind },
-    LeaveNode,
+pub enum Step<'a> {
+    Token { kind: SyntaxKind, n_input_tokens: u8 },
+    Enter { kind: SyntaxKind },
+    Exit,
     Error { msg: &'a str },
 }
 
-impl TreeTraversal {
-    pub fn iter(&self) -> impl Iterator<Item = TraversalStep<'_>> {
+impl Output {
+    pub fn iter(&self) -> impl Iterator<Item = Step<'_>> {
         self.event.iter().map(|&event| {
             if event & 0b1 == 0 {
-                return TraversalStep::Error { msg: self.error[(event as usize) >> 1].as_str() };
+                return Step::Error { msg: self.error[(event as usize) >> 1].as_str() };
             }
             let tag = ((event & 0x0000_00F0) >> 4) as u8;
             match tag {
                 0 => {
                     let kind: SyntaxKind = (((event & 0xFFFF_0000) >> 16) as u16).into();
-                    let n_raw_tokens = ((event & 0x0000_FF00) >> 8) as u8;
-                    TraversalStep::Token { kind, n_raw_tokens }
+                    let n_input_tokens = ((event & 0x0000_FF00) >> 8) as u8;
+                    Step::Token { kind, n_input_tokens }
                 }
                 1 => {
                     let kind: SyntaxKind = (((event & 0xFFFF_0000) >> 16) as u16).into();
-                    TraversalStep::EnterNode { kind }
+                    Step::Enter { kind }
                 }
-                2 => TraversalStep::LeaveNode,
+                2 => Step::Exit,
                 _ => unreachable!(),
             }
         })

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -8,7 +8,6 @@ use limit::Limit;
 use crate::{
     event::Event,
     tokens::Tokens,
-    ParseError,
     SyntaxKind::{self, EOF, ERROR, TOMBSTONE},
     TokenSet, T,
 };
@@ -196,7 +195,7 @@ impl<'t> Parser<'t> {
     /// structured errors with spans and notes, like rustc
     /// does.
     pub(crate) fn error<T: Into<String>>(&mut self, message: T) {
-        let msg = ParseError(Box::new(message.into()));
+        let msg = message.into();
         self.push_event(Event::Error { msg });
     }
 

--- a/crates/parser/src/tree_traversal.rs
+++ b/crates/parser/src/tree_traversal.rs
@@ -1,0 +1,67 @@
+//! TODO
+use crate::SyntaxKind;
+
+/// Output of the parser.
+#[derive(Default)]
+pub struct TreeTraversal {
+    /// 32-bit encoding of events. If LSB is zero, then that's an index into the
+    /// error vector. Otherwise, it's one of the thee other variants, with data encoded as
+    ///
+    ///     |16 bit kind|8 bit n_raw_tokens|4 bit tag|4 bit leftover|
+    ///
+    event: Vec<u32>,
+    error: Vec<String>,
+}
+
+pub enum TraversalStep<'a> {
+    Token { kind: SyntaxKind, n_raw_tokens: u8 },
+    EnterNode { kind: SyntaxKind },
+    LeaveNode,
+    Error { msg: &'a str },
+}
+
+impl TreeTraversal {
+    pub fn iter(&self) -> impl Iterator<Item = TraversalStep<'_>> {
+        self.event.iter().map(|&event| {
+            if event & 0b1 == 0 {
+                return TraversalStep::Error { msg: self.error[(event as usize) >> 1].as_str() };
+            }
+            let tag = ((event & 0x0000_00F0) >> 4) as u8;
+            match tag {
+                0 => {
+                    let kind: SyntaxKind = (((event & 0xFFFF_0000) >> 16) as u16).into();
+                    let n_raw_tokens = ((event & 0x0000_FF00) >> 8) as u8;
+                    TraversalStep::Token { kind, n_raw_tokens }
+                }
+                1 => {
+                    let kind: SyntaxKind = (((event & 0xFFFF_0000) >> 16) as u16).into();
+                    TraversalStep::EnterNode { kind }
+                }
+                2 => TraversalStep::LeaveNode,
+                _ => unreachable!(),
+            }
+        })
+    }
+
+    pub(crate) fn token(&mut self, kind: SyntaxKind, n_tokens: u8) {
+        let e = ((kind as u16 as u32) << 16) | ((n_tokens as u32) << 8) | (0 << 4) | 1;
+        self.event.push(e)
+    }
+
+    pub(crate) fn enter_node(&mut self, kind: SyntaxKind) {
+        let e = ((kind as u16 as u32) << 16) | (1 << 4) | 1;
+        self.event.push(e)
+    }
+
+    pub(crate) fn leave_node(&mut self) {
+        let e = 2 << 4 | 1;
+        self.event.push(e)
+    }
+
+    pub(crate) fn error(&mut self, error: String) {
+        let idx = self.error.len();
+        self.error.push(error);
+        let e = (idx as u32) << 1;
+        self.event.push(e);
+    }
+}

--- a/crates/syntax/src/parsing.rs
+++ b/crates/syntax/src/parsing.rs
@@ -12,9 +12,9 @@ pub(crate) use crate::parsing::reparsing::incremental_reparse;
 
 pub(crate) fn parse_text(text: &str) -> (GreenNode, Vec<SyntaxError>) {
     let lexed = parser::LexedStr::new(text);
-    let parser_tokens = lexed.to_tokens();
-    let tree_traversal = parser::parse_source_file(&parser_tokens);
-    let (node, errors, _eof) = build_tree(lexed, tree_traversal, false);
+    let parser_input = lexed.to_input();
+    let parser_output = parser::parse_source_file(&parser_input);
+    let (node, errors, _eof) = build_tree(lexed, parser_output, false);
     (node, errors)
 }
 
@@ -27,9 +27,9 @@ pub(crate) fn parse_text_as<T: AstNode>(
     if lexed.errors().next().is_some() {
         return Err(());
     }
-    let parser_tokens = lexed.to_tokens();
-    let tree_traversal = parser::parse(&parser_tokens, entry_point);
-    let (node, errors, eof) = build_tree(lexed, tree_traversal, true);
+    let parser_input = lexed.to_input();
+    let parser_output = parser::parse(&parser_input, entry_point);
+    let (node, errors, eof) = build_tree(lexed, parser_output, true);
 
     if !errors.is_empty() || !eof {
         return Err(());

--- a/crates/syntax/src/parsing.rs
+++ b/crates/syntax/src/parsing.rs
@@ -4,24 +4,18 @@
 mod text_tree_sink;
 mod reparsing;
 
-use parser::SyntaxKind;
-use text_tree_sink::TextTreeSink;
-
-use crate::{syntax_node::GreenNode, AstNode, SyntaxError, SyntaxNode};
+use crate::{
+    parsing::text_tree_sink::build_tree, syntax_node::GreenNode, AstNode, SyntaxError, SyntaxNode,
+};
 
 pub(crate) use crate::parsing::reparsing::incremental_reparse;
 
 pub(crate) fn parse_text(text: &str) -> (GreenNode, Vec<SyntaxError>) {
     let lexed = parser::LexedStr::new(text);
     let parser_tokens = lexed.to_tokens();
-
-    let mut tree_sink = TextTreeSink::new(lexed);
-
-    parser::parse_source_file(&parser_tokens, &mut tree_sink);
-
-    let (tree, parser_errors) = tree_sink.finish();
-
-    (tree, parser_errors)
+    let tree_traversal = parser::parse_source_file(&parser_tokens);
+    let (node, errors, _eof) = build_tree(lexed, tree_traversal, false);
+    (node, errors)
 }
 
 /// Returns `text` parsed as a `T` provided there are no parse errors.
@@ -34,20 +28,12 @@ pub(crate) fn parse_text_as<T: AstNode>(
         return Err(());
     }
     let parser_tokens = lexed.to_tokens();
+    let tree_traversal = parser::parse(&parser_tokens, entry_point);
+    let (node, errors, eof) = build_tree(lexed, tree_traversal, true);
 
-    let mut tree_sink = TextTreeSink::new(lexed);
-
-    // TextTreeSink assumes that there's at least some root node to which it can attach errors and
-    // tokens. We arbitrarily give it a SourceFile.
-    use parser::TreeSink;
-    tree_sink.start_node(SyntaxKind::SOURCE_FILE);
-    parser::parse(&parser_tokens, &mut tree_sink, entry_point);
-    tree_sink.finish_node();
-
-    let (tree, parser_errors, eof) = tree_sink.finish_eof();
-    if !parser_errors.is_empty() || !eof {
+    if !errors.is_empty() || !eof {
         return Err(());
     }
 
-    SyntaxNode::new_root(tree).first_child().and_then(T::cast).ok_or(())
+    SyntaxNode::new_root(node).first_child().and_then(T::cast).ok_or(())
 }

--- a/crates/syntax/src/parsing/reparsing.rs
+++ b/crates/syntax/src/parsing/reparsing.rs
@@ -89,7 +89,7 @@ fn reparse_block(
     let text = get_text_after_edit(node.clone().into(), edit);
 
     let lexed = parser::LexedStr::new(text.as_str());
-    let parser_tokens = lexed.to_tokens();
+    let parser_input = lexed.to_input();
     if !is_balanced(&lexed) {
         return None;
     }

--- a/crates/syntax/src/parsing/reparsing.rs
+++ b/crates/syntax/src/parsing/reparsing.rs
@@ -94,7 +94,7 @@ fn reparse_block(
         return None;
     }
 
-    let tree_traversal = reparser.parse(&parser_tokens);
+    let tree_traversal = reparser.parse(&parser_input);
 
     let (green, new_parser_errors, _eof) = build_tree(lexed, tree_traversal, false);
 

--- a/crates/syntax/src/parsing/reparsing.rs
+++ b/crates/syntax/src/parsing/reparsing.rs
@@ -10,7 +10,7 @@ use parser::Reparser;
 use text_edit::Indel;
 
 use crate::{
-    parsing::text_tree_sink::TextTreeSink,
+    parsing::text_tree_sink::build_tree,
     syntax_node::{GreenNode, GreenToken, NodeOrToken, SyntaxElement, SyntaxNode},
     SyntaxError,
     SyntaxKind::*,
@@ -94,11 +94,9 @@ fn reparse_block(
         return None;
     }
 
-    let mut tree_sink = TextTreeSink::new(lexed);
+    let tree_traversal = reparser.parse(&parser_tokens);
 
-    reparser.parse(&parser_tokens, &mut tree_sink);
-
-    let (green, new_parser_errors) = tree_sink.finish();
+    let (green, new_parser_errors, _eof) = build_tree(lexed, tree_traversal, false);
 
     Some((node.replace_with(green), new_parser_errors, node.text_range()))
 }

--- a/crates/syntax/src/syntax_node.rs
+++ b/crates/syntax/src/syntax_node.rs
@@ -69,7 +69,7 @@ impl SyntaxTreeBuilder {
         self.inner.finish_node();
     }
 
-    pub fn error(&mut self, error: parser::ParseError, text_pos: TextSize) {
-        self.errors.push(SyntaxError::new_at_offset(*error.0, text_pos));
+    pub fn error(&mut self, error: String, text_pos: TextSize) {
+        self.errors.push(SyntaxError::new_at_offset(error, text_pos));
     }
 }


### PR DESCRIPTION
The general theme of this is to make parser a better independent
library.

The specific thing we do here is replacing callback based TreeSink with
a data structure. That is, rather than calling user-provided tree
construction methods, the parser now spits out a very bare-bones tree,
effectively a log of a DFS traversal.

This makes the parser usable without any *specifc* tree sink, and allows
us to, eg, move tests into this crate.

Now, it's also true that this is a distinction without a difference, as
the old and the new interface are equivalent in expressiveness. Still,
this new thing seems somewhat simpler. But yeah, I admit I don't have a
suuper strong motivation here, just a hunch that this is better.

cc #10765 