### PR TITLE
feat: add config to use reasonable default expression instead of todo! when filling missing fields

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2695,7 +2695,7 @@ impl Type {
     // This would be nicer if it just returned an iterator, but that runs into
     // lifetime problems, because we need to borrow temp `CrateImplDefs`.
     pub fn iterate_assoc_items<T>(
-        self,
+        &self,
         db: &dyn HirDatabase,
         krate: Crate,
         mut callback: impl FnMut(AssocItem) -> Option<T>,
@@ -2709,7 +2709,7 @@ impl Type {
     }
 
     fn iterate_assoc_items_dyn(
-        self,
+        &self,
         db: &dyn HirDatabase,
         krate: Crate,
         callback: &mut dyn FnMut(AssocItemId) -> bool,
@@ -2751,6 +2751,7 @@ impl Type {
     ) -> Option<T> {
         let _p = profile::span("iterate_method_candidates");
         let mut slot = None;
+
         self.iterate_method_candidates_dyn(
             db,
             krate,

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1685,6 +1685,26 @@ impl BuiltinType {
     pub fn name(self) -> Name {
         self.inner.as_name()
     }
+
+    pub fn is_int(&self) -> bool {
+        matches!(self.inner, hir_def::builtin_type::BuiltinType::Int(_))
+    }
+
+    pub fn is_uint(&self) -> bool {
+        matches!(self.inner, hir_def::builtin_type::BuiltinType::Uint(_))
+    }
+
+    pub fn is_float(&self) -> bool {
+        matches!(self.inner, hir_def::builtin_type::BuiltinType::Float(_))
+    }
+
+    pub fn is_char(&self) -> bool {
+        matches!(self.inner, hir_def::builtin_type::BuiltinType::Char)
+    }
+
+    pub fn is_str(&self) -> bool {
+        matches!(self.inner, hir_def::builtin_type::BuiltinType::Str)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -2571,6 +2591,10 @@ impl Type {
 
     pub fn is_fn(&self) -> bool {
         matches!(&self.ty.kind(Interner), TyKind::FnDef(..) | TyKind::Function { .. })
+    }
+
+    pub fn is_array(&self) -> bool {
+        matches!(&self.ty.kind(Interner), TyKind::Array(..))
     }
 
     pub fn is_packed(&self, db: &dyn HirDatabase) -> bool {

--- a/crates/hir_expand/src/name.rs
+++ b/crates/hir_expand/src/name.rs
@@ -226,6 +226,7 @@ pub mod known {
         iter_mut,
         len,
         is_empty,
+        new,
         // Builtin macros
         asm,
         assert,

--- a/crates/hir_ty/src/method_resolution.rs
+++ b/crates/hir_ty/src/method_resolution.rs
@@ -542,6 +542,7 @@ pub fn iterate_method_candidates_dyn(
 
             let deref_chain = autoderef_method_receiver(db, krate, ty);
             let mut deref_chains = stdx::slice_tails(&deref_chain);
+
             deref_chains.try_for_each(|deref_chain| {
                 iterate_method_candidates_with_autoref(
                     deref_chain,

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -118,7 +118,7 @@ pub use ide_db::{
     symbol_index::Query,
     RootDatabase, SymbolKind,
 };
-pub use ide_diagnostics::{Diagnostic, DiagnosticsConfig, Severity};
+pub use ide_diagnostics::{Diagnostic, DiagnosticsConfig, ExprFillDefaultMode, Severity};
 pub use ide_ssr::SsrError;
 pub use syntax::{TextRange, TextSize};
 pub use text_edit::{Indel, TextEdit};

--- a/crates/ide_diagnostics/src/handlers/missing_fields.rs
+++ b/crates/ide_diagnostics/src/handlers/missing_fields.rs
@@ -73,7 +73,7 @@ fn fixes(ctx: &DiagnosticsContext<'_>, d: &hir::MissingFields) -> Option<Vec<Ass
 
     let generate_fill_expr = |ty: &Type| match ctx.config.expr_fill_default {
         crate::ExprFillDefaultMode::Todo => Some(make::ext::expr_todo()),
-        crate::ExprFillDefaultMode::DefaultImpl => {
+        crate::ExprFillDefaultMode::Default => {
             let default_constr = get_default_constructor(ctx, d, ty);
             match default_constr {
                 Some(default_constr) => Some(default_constr),
@@ -159,7 +159,6 @@ fn get_default_constructor(
             if let AssocItem::Function(func) = assoc_item {
                 if func.name(ctx.sema.db) == known::new
                     && func.assoc_fn_params(ctx.sema.db).is_empty()
-                    && func.self_param(ctx.sema.db).is_none()
                 {
                     return Some(());
                 }

--- a/crates/ide_diagnostics/src/lib.rs
+++ b/crates/ide_diagnostics/src/lib.rs
@@ -132,7 +132,7 @@ pub enum Severity {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ExprFillDefaultMode {
     Todo,
-    DefaultImpl,
+    Default,
 }
 impl Default for ExprFillDefaultMode {
     fn default() -> Self {

--- a/crates/ide_diagnostics/src/lib.rs
+++ b/crates/ide_diagnostics/src/lib.rs
@@ -129,10 +129,22 @@ pub enum Severity {
     WeakWarning,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ExprFillDefaultMode {
+    Todo,
+    DefaultImpl,
+}
+impl Default for ExprFillDefaultMode {
+    fn default() -> Self {
+        Self::Todo
+    }
+}
+
 #[derive(Default, Debug, Clone)]
 pub struct DiagnosticsConfig {
     pub disable_experimental: bool,
     pub disabled: FxHashSet<String>,
+    pub expr_fill_default: ExprFillDefaultMode,
 }
 
 struct DiagnosticsContext<'a> {

--- a/crates/ide_diagnostics/src/tests.rs
+++ b/crates/ide_diagnostics/src/tests.rs
@@ -9,7 +9,7 @@ use ide_db::{
 use stdx::trim_indent;
 use test_utils::{assert_eq_text, extract_annotations};
 
-use crate::{DiagnosticsConfig, Severity};
+use crate::{DiagnosticsConfig, ExprFillDefaultMode, Severity};
 
 /// Takes a multi-file input fixture with annotated cursor positions,
 /// and checks that:
@@ -36,14 +36,12 @@ fn check_nth_fix(nth: usize, ra_fixture_before: &str, ra_fixture_after: &str) {
     let after = trim_indent(ra_fixture_after);
 
     let (db, file_position) = RootDatabase::with_position(ra_fixture_before);
-    let diagnostic = super::diagnostics(
-        &db,
-        &DiagnosticsConfig::default(),
-        &AssistResolveStrategy::All,
-        file_position.file_id,
-    )
-    .pop()
-    .expect("no diagnostics");
+    let mut conf = DiagnosticsConfig::default();
+    conf.expr_fill_default = ExprFillDefaultMode::DefaultImpl;
+    let diagnostic =
+        super::diagnostics(&db, &conf, &AssistResolveStrategy::All, file_position.file_id)
+            .pop()
+            .expect("no diagnostics");
     let fix = &diagnostic.fixes.expect("diagnostic misses fixes")[nth];
     let actual = {
         let source_change = fix.source_change.as_ref().unwrap();

--- a/crates/ide_diagnostics/src/tests.rs
+++ b/crates/ide_diagnostics/src/tests.rs
@@ -37,7 +37,7 @@ fn check_nth_fix(nth: usize, ra_fixture_before: &str, ra_fixture_after: &str) {
 
     let (db, file_position) = RootDatabase::with_position(ra_fixture_before);
     let mut conf = DiagnosticsConfig::default();
-    conf.expr_fill_default = ExprFillDefaultMode::DefaultImpl;
+    conf.expr_fill_default = ExprFillDefaultMode::Default;
     let diagnostic =
         super::diagnostics(&db, &conf, &AssistResolveStrategy::All, file_position.file_id)
             .pop()

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -698,7 +698,7 @@ impl Config {
             disabled: self.data.diagnostics_disabled.clone(),
             expr_fill_default: match self.data.assist_exprFillDefault {
                 ExprFillDefaultDef::Todo => ExprFillDefaultMode::Todo,
-                ExprFillDefaultDef::DefaultImpl => ExprFillDefaultMode::DefaultImpl,
+                ExprFillDefaultDef::Default => ExprFillDefaultMode::Default,
             },
         }
     }
@@ -1070,8 +1070,8 @@ enum ManifestOrProjectJson {
 pub enum ExprFillDefaultDef {
     #[serde(alias = "todo")]
     Todo,
-    #[serde(alias = "defaultImpl")]
-    DefaultImpl,
+    #[serde(alias = "default")]
+    Default,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -1270,9 +1270,9 @@ fn field_props(field: &str, ty: &str, doc: &[&str], default: &str) -> serde_json
         },
         "ExprFillDefaultDef" => set! {
             "type": "string",
-            "enum": ["todo", "defaultImpl"],
+            "enum": ["todo", "default"],
             "enumDescriptions": [
-                "Fill missing elements with 'todo' macro",
+                "Fill missing expressions with the 'todo' macro",
                 "Fill missing expressions with reasonable defaults, `new` or `default` constructors."
             ],
         },

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -1273,7 +1273,7 @@ fn field_props(field: &str, ty: &str, doc: &[&str], default: &str) -> serde_json
             "enum": ["todo", "defaultImpl"],
             "enumDescriptions": [
                 "Fill missing elements with 'todo' macro",
-                "Fill missing elements with T::default()"
+                "Fill missing expressions with reasonable defaults, `new` or `default` constructors."
             ],
         },
         "ImportGranularityDef" => set! {

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -45,7 +45,7 @@ use crate::{
 // parsing the old name.
 config_data! {
     struct ConfigData {
-        /// How assists will fill missing elements in an expression.
+        /// Placeholder for missing expressions in assists.
         assist_exprFillDefault: ExprFillDefaultDef              = "\"todo\"",
         /// How imports should be grouped into use statements.
         assist_importGranularity |
@@ -1272,7 +1272,7 @@ fn field_props(field: &str, ty: &str, doc: &[&str], default: &str) -> serde_json
             "type": "string",
             "enum": ["todo", "default"],
             "enumDescriptions": [
-                "Fill missing expressions with the 'todo' macro",
+                "Fill missing expressions with the `todo` macro",
                 "Fill missing expressions with reasonable defaults, `new` or `default` constructors."
             ],
         },

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -1273,7 +1273,7 @@ fn field_props(field: &str, ty: &str, doc: &[&str], default: &str) -> serde_json
             "enum": ["todo", "defaultImpl"],
             "enumDescriptions": [
                 "Fill missing elements with 'todo' macro",
-                "Fill missing elements with Default::default()"
+                "Fill missing elements with T::default()"
             ],
         },
         "ImportGranularityDef" => set! {

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -76,7 +76,7 @@ pub mod ext {
         expr_from_text(r#""""#)
     }
     pub fn empty_char() -> ast::Expr {
-        expr_from_text("''")
+        expr_from_text("'\x00'")
     }
     pub fn default_bool() -> ast::Expr {
         expr_from_text("false")

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -59,6 +59,9 @@ pub mod ext {
     pub fn expr_todo() -> ast::Expr {
         expr_from_text("todo!()")
     }
+    pub fn expr_default() -> ast::Expr {
+        expr_from_text("Default::default()")
+    }
     pub fn empty_block_expr() -> ast::BlockExpr {
         block_expr(None, None)
     }

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -59,8 +59,27 @@ pub mod ext {
     pub fn expr_todo() -> ast::Expr {
         expr_from_text("todo!()")
     }
-    pub fn expr_default() -> ast::Expr {
-        expr_from_text("Default::default()")
+    pub fn expr_ty_default(ty: &ast::Type) -> ast::Expr {
+        expr_from_text(&format!("{}::default()", ty))
+    }
+    pub fn expr_ty_new(ty: &ast::Type) -> ast::Expr {
+        expr_from_text(&format!("{}::new()", ty))
+    }
+
+    pub fn zero_number() -> ast::Expr {
+        expr_from_text("0")
+    }
+    pub fn zero_float() -> ast::Expr {
+        expr_from_text("0.0")
+    }
+    pub fn empty_str() -> ast::Expr {
+        expr_from_text(r#""""#)
+    }
+    pub fn empty_char() -> ast::Expr {
+        expr_from_text("''")
+    }
+    pub fn default_bool() -> ast::Expr {
+        expr_from_text("false")
     }
     pub fn empty_block_expr() -> ast::BlockExpr {
         block_expr(None, None)

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -1,7 +1,7 @@
 [[rust-analyzer.assist.exprFillDefault]]rust-analyzer.assist.exprFillDefault (default: `"todo"`)::
 +
 --
-How assists will fill missing elements in an expression.
+Placeholder for missing expressions in assists.
 --
 [[rust-analyzer.assist.importGranularity]]rust-analyzer.assist.importGranularity (default: `"crate"`)::
 +

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -1,3 +1,8 @@
+[[rust-analyzer.assist.exprFillDefault]]rust-analyzer.assist.exprFillDefault (default: `"todo"`)::
++
+--
+How assists will fill missing elements in an expression.
+--
 [[rust-analyzer.assist.importGranularity]]rust-analyzer.assist.importGranularity (default: `"crate"`)::
 +
 --

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -384,11 +384,11 @@
                     "type": "string",
                     "enum": [
                         "todo",
-                        "defaultImpl"
+                        "default"
                     ],
                     "enumDescriptions": [
-                        "Fill missing elements with 'todo' macro",
-                        "Fill missing elements with T::default()"
+                        "Fill missing expressions with the 'todo' macro",
+                        "Fill missing expressions with reasonable defaults, `new` or `default` constructors."
                     ]
                 },
                 "rust-analyzer.assist.importGranularity": {

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -379,7 +379,7 @@
                 },
                 "$generated-start": {},
                 "rust-analyzer.assist.exprFillDefault": {
-                    "markdownDescription": "How assists will fill missing elements in an expression.",
+                    "markdownDescription": "Placeholder for missing expressions in assists.",
                     "default": "todo",
                     "type": "string",
                     "enum": [
@@ -387,7 +387,7 @@
                         "default"
                     ],
                     "enumDescriptions": [
-                        "Fill missing expressions with the 'todo' macro",
+                        "Fill missing expressions with the `todo` macro",
                         "Fill missing expressions with reasonable defaults, `new` or `default` constructors."
                     ]
                 },

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -388,7 +388,7 @@
                     ],
                     "enumDescriptions": [
                         "Fill missing elements with 'todo' macro",
-                        "Fill missing elements with Default::default()"
+                        "Fill missing elements with T::default()"
                     ]
                 },
                 "rust-analyzer.assist.importGranularity": {

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -378,6 +378,19 @@
                     "markdownDescription": "Optional settings passed to the debug engine. Example: `{ \"lldb\": { \"terminal\":\"external\"} }`"
                 },
                 "$generated-start": {},
+                "rust-analyzer.assist.exprFillDefault": {
+                    "markdownDescription": "How assists will fill missing elements in an expression.",
+                    "default": "todo",
+                    "type": "string",
+                    "enum": [
+                        "todo",
+                        "defaultImpl"
+                    ],
+                    "enumDescriptions": [
+                        "Fill missing elements with 'todo' macro",
+                        "Fill missing elements with Default::default()"
+                    ]
+                },
                 "rust-analyzer.assist.importGranularity": {
                     "markdownDescription": "How imports should be grouped into use statements.",
                     "default": "crate",


### PR DESCRIPTION
Use `Default::default()` in struct fields when we ask to fill it instead of putting `todo!()` for every fields

before:

```rust
pub enum Other {
    One,
    Two,
}

pub struct Test {
    text: String,
    num: usize,
    other: Other,
}

fn t_test() {
    let test = Test {<|>};
}
``` 

after: 

```rust
pub enum Other {
    One,
    Two,
}

pub struct Test {
    text: String,
    num: usize,
    other: Other,
}

fn t_test() {
    let test = Test {
        text: String::new(),
        num: 0,
        other: todo!(),
    };
}
``` 

