### PR TITLE
internal: Use basic `NonEmptyVec` in mbe::syntax_bridge

### DIFF
--- a/crates/stdx/src/lib.rs
+++ b/crates/stdx/src/lib.rs
@@ -5,6 +5,7 @@ use std::{cmp::Ordering, ops, time::Instant};
 mod macros;
 pub mod process;
 pub mod panic_context;
+pub mod non_empty_vec;
 
 pub use always_assert::{always, never};
 

--- a/crates/stdx/src/non_empty_vec.rs
+++ b/crates/stdx/src/non_empty_vec.rs
@@ -1,0 +1,45 @@
+//! A [`Vec`] that is guaranteed to at least contain one element.
+
+pub struct NonEmptyVec<T>(Vec<T>);
+
+impl<T> NonEmptyVec<T> {
+    #[inline]
+    pub fn new(initial: T) -> Self {
+        NonEmptyVec(vec![initial])
+    }
+
+    #[inline]
+    pub fn last_mut(&mut self) -> &mut T {
+        match self.0.last_mut() {
+            Some(it) => it,
+            None => unreachable!(),
+        }
+    }
+
+    #[inline]
+    pub fn pop(&mut self) -> Option<T> {
+        if self.0.len() <= 1 {
+            None
+        } else {
+            self.0.pop()
+        }
+    }
+
+    #[inline]
+    pub fn push(&mut self, value: T) {
+        self.0.push(value)
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    #[inline]
+    pub fn into_first(mut self) -> T {
+        match self.0.pop() {
+            Some(it) => it,
+            None => unreachable!(),
+        }
+    }
+}


### PR DESCRIPTION
There are some places in the ide crates where this can be used as well if memory serves right.
bors r+