### PR TITLE
minor: style nits

### DIFF
--- a/crates/ide_assists/src/handlers/add_turbo_fish.rs
+++ b/crates/ide_assists/src/handlers/add_turbo_fish.rs
@@ -1,5 +1,4 @@
 use ide_db::defs::{Definition, NameRefClass};
-use itertools::Itertools;
 use syntax::{ast, AstNode, SyntaxKind, T};
 
 use crate::{
@@ -79,7 +78,7 @@ pub(crate) fn add_turbo_fish(acc: &mut Assists, ctx: &AssistContext) -> Option<(
     }
 
     let number_of_arguments = generics.len();
-    let fish_head = std::iter::repeat("_").take(number_of_arguments).collect_vec().join(",");
+    let fish_head = std::iter::repeat("_").take(number_of_arguments).collect::<Vec<_>>().join(",");
 
     acc.add(
         AssistId("add_turbo_fish", AssistKind::RefactorRewrite),

--- a/crates/ide_assists/src/handlers/destructure_tuple_binding.rs
+++ b/crates/ide_assists/src/handlers/destructure_tuple_binding.rs
@@ -3,7 +3,6 @@ use ide_db::{
     defs::Definition,
     search::{FileReference, SearchScope, UsageSearchResult},
 };
-use itertools::Itertools;
 use syntax::{
     ast::{self, AstNode, FieldExpr, HasName, IdentPat, MethodCallExpr},
     TextRange,
@@ -121,7 +120,7 @@ fn collect_data(ident_pat: IdentPat, ctx: &AssistContext) -> Option<TupleData> {
 
     let field_names = (0..field_types.len())
         .map(|i| generate_name(ctx, i, &name, &ident_pat, &usages))
-        .collect_vec();
+        .collect::<Vec<_>>();
 
     Some(TupleData { ident_pat, range, ref_type, field_names, usages })
 }

--- a/crates/ide_assists/src/handlers/extract_module.rs
+++ b/crates/ide_assists/src/handlers/extract_module.rs
@@ -311,18 +311,17 @@ impl Module {
         let (body_items, mut replacements, record_field_parents, impls) =
             get_replacements_for_visibilty_change(self.body_items.clone(), false);
 
-        let impl_items = impls.into_iter().fold(Vec::new(), |mut impl_items, x| {
-            let mut this_impl_items =
-                x.syntax().descendants().fold(Vec::new(), |mut this_impl_items, x| {
-                    if let Some(item) = ast::Item::cast(x) {
-                        this_impl_items.push(item);
-                    }
-                    return this_impl_items;
-                });
+        let mut impl_items = Vec::new();
+        for impl_ in impls {
+            let mut this_impl_items = Vec::new();
+            for node in impl_.syntax().descendants() {
+                if let Some(item) = ast::Item::cast(node) {
+                    this_impl_items.push(item);
+                }
+            }
 
             impl_items.append(&mut this_impl_items);
-            return impl_items;
-        });
+        }
 
         let (_, mut impl_item_replacements, _, _) =
             get_replacements_for_visibilty_change(impl_items, true);

--- a/crates/ide_assists/src/handlers/generate_function.rs
+++ b/crates/ide_assists/src/handlers/generate_function.rs
@@ -456,10 +456,10 @@ fn fn_args(
 /// assert_eq!(names, expected);
 /// ```
 fn deduplicate_arg_names(arg_names: &mut Vec<String>) {
-    let arg_name_counts = arg_names.iter().fold(FxHashMap::default(), |mut m, name| {
-        *m.entry(name).or_insert(0) += 1;
-        m
-    });
+    let mut arg_name_counts = FxHashMap::default();
+    for name in arg_names.iter() {
+        *arg_name_counts.entry(name).or_insert(0) += 1;
+    }
     let duplicate_arg_names: FxHashSet<String> = arg_name_counts
         .into_iter()
         .filter(|(_, count)| *count >= 2)

--- a/crates/rust-analyzer/src/handlers.rs
+++ b/crates/rust-analyzer/src/handlers.rs
@@ -14,7 +14,6 @@ use ide::{
     SourceChange, TextEdit,
 };
 use ide_db::SymbolKind;
-use itertools::Itertools;
 use lsp_server::ErrorCode;
 use lsp_types::{
     CallHierarchyIncomingCall, CallHierarchyIncomingCallsParams, CallHierarchyItem,
@@ -854,7 +853,7 @@ pub(crate) fn handle_completion_resolve(
         )?
         .into_iter()
         .flat_map(|edit| edit.into_iter().map(|indel| to_proto::text_edit(&line_index, indel)))
-        .collect_vec();
+        .collect::<Vec<_>>();
 
     if !all_edits_are_disjoint(&original_completion, &additional_edits) {
         return Err(LspError::new(
@@ -1164,7 +1163,7 @@ pub(crate) fn handle_code_action_resolve(
 }
 
 fn parse_action_id(action_id: &str) -> Result<(usize, SingleResolve), String> {
-    let id_parts = action_id.split(':').collect_vec();
+    let id_parts = action_id.split(':').collect::<Vec<_>>();
     match id_parts.as_slice() {
         [assist_id_string, assist_kind_string, index_string] => {
             let assist_kind: AssistKind = assist_kind_string.parse()?;


### PR DESCRIPTION
 - avoid `fold` with a `Vec` seed which could have been a `for_each`
 - we can't drop the dependency, but avoid `Itertools::collect_vec`

bors r+