### PR TITLE
minor: add missing test

### DIFF
--- a/crates/hir_def/src/macro_expansion_tests/mbe/matching.rs
+++ b/crates/hir_def/src/macro_expansion_tests/mbe/matching.rs
@@ -122,3 +122,17 @@ stringify!(.. .. ..|);
 "#]],
     );
 }
+
+#[test]
+fn trailing_vis() {
+    check(
+        r#"
+macro_rules! m { ($($i:ident)? $vis:vis) => () }
+m!(x pub);
+"#,
+        expect![[r#"
+macro_rules! m { ($($i:ident)? $vis:vis) => () }
+
+"#]],
+    )
+}


### PR DESCRIPTION
This test kills the following mutant:

diff --git a/crates/mbe/src/tt_iter.rs b/crates/mbe/src/tt_iter.rs
index 9d2b1da9a..055d9a733 100644
--- a/crates/mbe/src/tt_iter.rs
+++ b/crates/mbe/src/tt_iter.rs
@@ -134,7 +134,7 @@ impl<'a> TtIter<'a> {
         self.inner = self.inner.as_slice()[res.len()..].iter();
         let res = match res.len() {
             1 => Some(res[0].cloned()),
-            0 => None,
+            // 0 => None,
             _ => Some(tt::TokenTree::Subtree(tt::Subtree {
                 delimiter: None,
                 token_trees: res.into_iter().map(|it| it.cloned()).collect(),

bors r+
🤖