### PR TITLE
Correctly pass through mutable parameter references when extracting a function

### DIFF
--- a/crates/ide_assists/src/handlers/extract_function.rs
+++ b/crates/ide_assists/src/handlers/extract_function.rs
@@ -4346,11 +4346,9 @@ pub struct Foo {
 }
 
 pub fn testfn(arg: &mut Foo) {
-    $0arg.field = 8; // write access
-    println!("{}", arg.field); // read access$0
+    $0arg.field = 8;$0
     // Simulating access after the extracted portion
-    arg.field = 16; // write access
-    println!("{}", arg.field); // read access
+    arg.field = 16;
 }
 "#,
             r#"
@@ -4359,15 +4357,13 @@ pub struct Foo {
 }
 
 pub fn testfn(arg: &mut Foo) {
-    fun_name(arg); // read access
+    fun_name(arg);
     // Simulating access after the extracted portion
-    arg.field = 16; // write access
-    println!("{}", arg.field); // read access
+    arg.field = 16;
 }
 
 fn $0fun_name(arg: &mut Foo) {
     arg.field = 8;
-    println!("{}", arg.field);
 }
 "#,
         );
@@ -4383,8 +4379,7 @@ pub struct Foo {
 }
 
 pub fn testfn(arg: &mut Foo) {
-    $0arg.field = 8; // write access
-    println!("{}", arg.field); // read access$0
+    $0arg.field = 8;$0
 }
 "#,
             r#"
@@ -4393,12 +4388,11 @@ pub struct Foo {
 }
 
 pub fn testfn(arg: &mut Foo) {
-    fun_name(arg); // read access
+    fun_name(arg);
 }
 
 fn $0fun_name(arg: &mut Foo) {
     arg.field = 8;
-    println!("{}", arg.field);
 }
 "#,
         );

--- a/crates/ide_assists/src/handlers/extract_function.rs
+++ b/crates/ide_assists/src/handlers/extract_function.rs
@@ -4337,7 +4337,7 @@ fn $0fun_name(a: _) -> _ {
     }
 
     #[test]
-    fn test_jeroen() {
+    fn reference_mutable_param_with_further_usages() {
         check_assist(
             extract_function,
             r#"
@@ -4363,6 +4363,37 @@ pub fn testfn(arg: &mut Foo) {
     // Simulating access after the extracted portion
     arg.field = 16; // write access
     println!("{}", arg.field); // read access
+}
+
+fn $0fun_name(arg: &mut Foo) {
+    arg.field = 8;
+    println!("{}", arg.field);
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn reference_mutable_param_without_further_usages() {
+        check_assist(
+            extract_function,
+            r#"
+pub struct Foo {
+    field: u32,
+}
+
+pub fn testfn(arg: &mut Foo) {
+    $0arg.field = 8; // write access
+    println!("{}", arg.field); // read access$0
+}
+"#,
+            r#"
+pub struct Foo {
+    field: u32,
+}
+
+pub fn testfn(arg: &mut Foo) {
+    fun_name(arg); // read access
 }
 
 fn $0fun_name(arg: &mut Foo) {


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/10277

I have based this investigation based on my understanding of [the Borrowing chapter](https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html) but I wasn't able to debug the test runs or see it in action in an IDE. I'll try to figure out how to do that for future PRs but for now, the tests seem to confirm my understanding. I'll lay out my hypothesis below.

Here we define the parameters for the to-be-generated function: 

https://github.com/rust-analyzer/rust-analyzer/blob/7409880a07803c34590ad162d7854061145c6eae/crates/ide_assists/src/handlers/extract_function.rs#L882

Three values in particular are important here: `requires_mut`, `is_copy` and `move_local`. These will in turn be used here to determine the kind of parameter:

https://github.com/rust-analyzer/rust-analyzer/blob/7409880a07803c34590ad162d7854061145c6eae/crates/ide_assists/src/handlers/extract_function.rs#L374-L381

and then here to determine what transformation is needed for the calling argument:

https://github.com/rust-analyzer/rust-analyzer/blob/7409880a07803c34590ad162d7854061145c6eae/crates/ide_assists/src/handlers/extract_function.rs#L383-L390

which then gets transformed here:

https://github.com/rust-analyzer/rust-analyzer/blob/7409880a07803c34590ad162d7854061145c6eae/crates/syntax/src/ast/make.rs#L381-L383

What I believe is happening is that 
* `requires_mut` is `false` (it already is marked as mutable), 
* `is_copy` is `false` (`Foo` does not implement `Copy`), and 
* `move_local` is `false` (it has further usages)

According to the pattern matching in `fn kind()`, that would lead to `ParamKind::SharedRef` which in turn applies a transformation that prepends `&`.

However if I look at the chapter on borrowing then we only need to mark an argument as a reference if we actually own it. In this case the value is passed through as a reference parameter into the current function which means we never had ownership in the first place. By including the additional check for a reference parameter, `move_local` now becomes `true` and the resulting parameter is now `ParamKind::Value` which will avoid applying any transformations. This was further obscured by the fact that you need further usages of the variable or `move_local` would be considered `true` after all.

I didn't follow it in depth but it appears this idea applies for both the generated argument and the generated parameter.
There are existing tests that account for `&mut` values but they refer to local variables for which we do have ownership and as such they didn't expose this issue.