### PR TITLE
fix(completions): improve fn_param

### DIFF
--- a/crates/ide_completion/src/completions/fn_param.rs
+++ b/crates/ide_completion/src/completions/fn_param.rs
@@ -109,7 +109,6 @@ fn surround_with_commas(ctx: &CompletionContext, param: String) -> Option<String
 
     let trailing_comma_missing = matches!(next_token.kind(), SyntaxKind::IDENT);
     let trailing = if trailing_comma_missing { "," } else { "" };
-    dbg!(&ctx.token.next_token()?);
 
     let previous_token = if matches!(ctx.token.kind(), SyntaxKind::IDENT | SyntaxKind::WHITESPACE) {
         ctx.previous_token.as_ref()?

--- a/crates/ide_completion/src/completions/fn_param.rs
+++ b/crates/ide_completion/src/completions/fn_param.rs
@@ -98,8 +98,18 @@ fn should_add_self_completions(ctx: &CompletionContext, param_list: ast::ParamLi
 }
 
 fn surround_with_commas(ctx: &CompletionContext, param: String) -> Option<String> {
-    let end_of_param_list = matches!(ctx.token.next_token()?.kind(), SyntaxKind::R_PAREN);
-    let trailing = if end_of_param_list { "" } else { "," };
+    let next_token = {
+        let t = ctx.token.next_token()?;
+        if !matches!(t.kind(), SyntaxKind::WHITESPACE) {
+            t
+        } else {
+            t.next_token()?
+        }
+    };
+
+    let trailing_comma_missing = matches!(next_token.kind(), SyntaxKind::IDENT);
+    let trailing = if trailing_comma_missing { "," } else { "" };
+    dbg!(&ctx.token.next_token()?);
 
     let previous_token = if matches!(ctx.token.kind(), SyntaxKind::IDENT | SyntaxKind::WHITESPACE) {
         ctx.previous_token.as_ref()?

--- a/crates/ide_completion/src/tests/fn_param.rs
+++ b/crates/ide_completion/src/tests/fn_param.rs
@@ -46,7 +46,20 @@ fn bar(file_id: usize) {}
 fn baz(file$0 id: u32) {}
 "#,
         expect![[r#"
-            bn file_id: usize
+            bn file_id: usize,
+            kw mut
+        "#]],
+    );
+}
+
+#[test]
+fn repeated_param_name() {
+    check(
+        r#"
+fn foo(file_id: usize) {}
+fn bar(file_id: u32, $0) {}
+"#,
+        expect![[r#"
             kw mut
         "#]],
     );
@@ -126,7 +139,6 @@ impl A {
 
 #[test]
 fn in_impl_after_self() {
-    // FIXME: self completions should not be here
     check(
         r#"
 struct A {}
@@ -137,10 +149,6 @@ impl A {
 }
 "#,
         expect![[r#"
-            bn self
-            bn &self
-            bn mut self
-            bn &mut self
             bn file_id: usize
             kw mut
             sp Self


### PR DESCRIPTION
- insert commas around when necessary
- only suggest `self` completions when param list is empty
- stop suggesting completions for identifiers which are already on the param list

Closes #11085 