### PR TITLE
feat: Add config to replace specific proc-macros with dummy expanders

### DIFF
--- a/crates/hir_def/src/db.rs
+++ b/crates/hir_def/src/db.rs
@@ -55,6 +55,8 @@ pub trait InternDatabase: SourceDatabase {
 pub trait DefDatabase: InternDatabase + AstDatabase + Upcast<dyn AstDatabase> {
     #[salsa::input]
     fn enable_proc_attr_macros(&self) -> bool;
+    #[salsa::input]
+    fn enablse_proc_attr_macros(&self) -> bool;
 
     #[salsa::invoke(ItemTree::file_item_tree_query)]
     fn file_item_tree(&self, file_id: HirFileId) -> Arc<ItemTree>;

--- a/crates/hir_def/src/db.rs
+++ b/crates/hir_def/src/db.rs
@@ -55,8 +55,6 @@ pub trait InternDatabase: SourceDatabase {
 pub trait DefDatabase: InternDatabase + AstDatabase + Upcast<dyn AstDatabase> {
     #[salsa::input]
     fn enable_proc_attr_macros(&self) -> bool;
-    #[salsa::input]
-    fn enablse_proc_attr_macros(&self) -> bool;
 
     #[salsa::invoke(ItemTree::file_item_tree_query)]
     fn file_item_tree(&self, file_id: HirFileId) -> Arc<ItemTree>;

--- a/crates/project_model/src/tests.rs
+++ b/crates/project_model/src/tests.rs
@@ -88,7 +88,7 @@ fn rooted_project_json(data: ProjectJsonData) -> ProjectJson {
 }
 
 fn to_crate_graph(project_workspace: ProjectWorkspace) -> CrateGraph {
-    project_workspace.to_crate_graph(&mut |_| Vec::new(), &mut {
+    project_workspace.to_crate_graph(&Default::default(), &mut |_, _| Vec::new(), &mut {
         let mut counter = 0;
         move |_path| {
             counter += 1;

--- a/crates/rust-analyzer/src/cli/load_cargo.rs
+++ b/crates/rust-analyzer/src/cli/load_cargo.rs
@@ -66,7 +66,8 @@ pub fn load_workspace(
     };
 
     let crate_graph = ws.to_crate_graph(
-        &mut |path: &AbsPath| load_proc_macro(proc_macro_client.as_ref(), path),
+        &Default::default(),
+        &mut |path: &AbsPath, _| load_proc_macro(proc_macro_client.as_ref(), path, &[]),
         &mut |path: &AbsPath| {
             let contents = loader.load_sync(path);
             let path = vfs::VfsPath::from(path.to_path_buf());

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -301,6 +301,7 @@ config_data! {
         /// Internal config, path to proc-macro server executable (typically,
         /// this is rust-analyzer itself, but we override this in tests).
         procMacro_server: Option<PathBuf>          = "null",
+        procMacro_dummies: FxHashMap<Box<str>, Box<[Box<str>]>>          = "{}",
 
         /// Command to be executed instead of 'cargo' for runnables.
         runnables_overrideCargo: Option<String> = "null",
@@ -715,6 +716,9 @@ impl Config {
             None => AbsPathBuf::assert(std::env::current_exe().ok()?),
         };
         Some((path, vec!["proc-macro".into()]))
+    }
+    pub fn dummy_replacements(&self) -> &FxHashMap<Box<str>, Box<[Box<str>]>> {
+        &self.data.procMacro_dummies
     }
     pub fn expand_proc_attr_macros(&self) -> bool {
         self.data.experimental_procAttrMacros

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -301,9 +301,10 @@ config_data! {
         /// Internal config, path to proc-macro server executable (typically,
         /// this is rust-analyzer itself, but we override this in tests).
         procMacro_server: Option<PathBuf>          = "null",
-        /// Replaces the proc-macro expanders for the named proc-macros in the named crates with
-        /// an identity expander that outputs the input again.
-        procMacro_dummies: FxHashMap<Box<str>, Box<[Box<str>]>>          = "{}",
+        /// These proc-macros will be ignored when trying to expand them.
+        ///
+        /// This config takes a map of crate names with the exported proc-macro names to ignore as values.
+        procMacro_ignored: FxHashMap<Box<str>, Box<[Box<str>]>>          = "{}",
 
         /// Command to be executed instead of 'cargo' for runnables.
         runnables_overrideCargo: Option<String> = "null",
@@ -720,7 +721,7 @@ impl Config {
         Some((path, vec!["proc-macro".into()]))
     }
     pub fn dummy_replacements(&self) -> &FxHashMap<Box<str>, Box<[Box<str>]>> {
-        &self.data.procMacro_dummies
+        &self.data.procMacro_ignored
     }
     pub fn expand_proc_attr_macros(&self) -> bool {
         self.data.experimental_procAttrMacros

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -10,6 +10,7 @@ use ide_db::base_db::{
 };
 use proc_macro_api::{MacroDylib, ProcMacroServer};
 use project_model::{ProjectWorkspace, WorkspaceBuildScripts};
+use syntax::SmolStr;
 use vfs::{file_set::FileSetConfig, AbsPath, AbsPathBuf, ChangeKind};
 
 use crate::{
@@ -290,6 +291,9 @@ impl GlobalState {
                     }
                 },
             };
+            self.analysis_host
+                .raw_database_mut()
+                .set_enable_proc_attr_macros(self.config.expand_proc_attr_macros());
         }
 
         let watch = match files_config.watcher {
@@ -306,8 +310,9 @@ impl GlobalState {
         // Create crate graph from all the workspaces
         let crate_graph = {
             let proc_macro_client = self.proc_macro_client.as_ref();
-            let mut load_proc_macro =
-                move |path: &AbsPath| load_proc_macro(proc_macro_client, path);
+            let mut load_proc_macro = move |path: &AbsPath, dummy_replace: &_| {
+                load_proc_macro(proc_macro_client, path, dummy_replace)
+            };
 
             let vfs = &mut self.vfs.write().0;
             let loader = &mut self.loader;
@@ -328,7 +333,11 @@ impl GlobalState {
 
             let mut crate_graph = CrateGraph::default();
             for ws in self.workspaces.iter() {
-                crate_graph.extend(ws.to_crate_graph(&mut load_proc_macro, &mut load));
+                crate_graph.extend(ws.to_crate_graph(
+                    self.config.dummy_replacements(),
+                    &mut load_proc_macro,
+                    &mut load,
+                ));
             }
             crate_graph
         };
@@ -505,7 +514,11 @@ impl SourceRootConfig {
     }
 }
 
-pub(crate) fn load_proc_macro(client: Option<&ProcMacroServer>, path: &AbsPath) -> Vec<ProcMacro> {
+pub(crate) fn load_proc_macro(
+    client: Option<&ProcMacroServer>,
+    path: &AbsPath,
+    dummy_replace: &[Box<str>],
+) -> Vec<ProcMacro> {
     let dylib = match MacroDylib::new(path.to_path_buf()) {
         Ok(it) => it,
         Err(err) => {
@@ -532,17 +545,25 @@ pub(crate) fn load_proc_macro(client: Option<&ProcMacroServer>, path: &AbsPath) 
                 Vec::new()
             }
         })
-        .map(expander_to_proc_macro)
+        .map(|expander| expander_to_proc_macro(expander, dummy_replace))
         .collect();
 
-    fn expander_to_proc_macro(expander: proc_macro_api::ProcMacro) -> ProcMacro {
-        let name = expander.name().into();
+    fn expander_to_proc_macro(
+        expander: proc_macro_api::ProcMacro,
+        dummy_replace: &[Box<str>],
+    ) -> ProcMacro {
+        let name = SmolStr::from(expander.name());
         let kind = match expander.kind() {
             proc_macro_api::ProcMacroKind::CustomDerive => ProcMacroKind::CustomDerive,
             proc_macro_api::ProcMacroKind::FuncLike => ProcMacroKind::FuncLike,
             proc_macro_api::ProcMacroKind::Attr => ProcMacroKind::Attr,
         };
-        let expander = Arc::new(Expander(expander));
+        let expander: Arc<dyn ProcMacroExpander> =
+            if dummy_replace.iter().any(|replace| &**replace == name) {
+                Arc::new(DummyExpander)
+            } else {
+                Arc::new(Expander(expander))
+            };
         ProcMacro { name, kind, expander }
     }
 
@@ -562,6 +583,20 @@ pub(crate) fn load_proc_macro(client: Option<&ProcMacroServer>, path: &AbsPath) 
                 Ok(Err(err)) => Err(ProcMacroExpansionError::Panic(err.0)),
                 Err(err) => Err(ProcMacroExpansionError::System(err.to_string())),
             }
+        }
+    }
+
+    #[derive(Debug)]
+    struct DummyExpander;
+
+    impl ProcMacroExpander for DummyExpander {
+        fn expand(
+            &self,
+            subtree: &tt::Subtree,
+            _: Option<&tt::Subtree>,
+            _: &Env,
+        ) -> Result<tt::Subtree, ProcMacroExpansionError> {
+            Ok(subtree.clone())
         }
     }
 }

--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -291,9 +291,6 @@ impl GlobalState {
                     }
                 },
             };
-            self.analysis_host
-                .raw_database_mut()
-                .set_enable_proc_attr_macros(self.config.expand_proc_attr_macros());
         }
 
         let watch = match files_config.watcher {
@@ -514,6 +511,8 @@ impl SourceRootConfig {
     }
 }
 
+/// Load the proc-macros for the given lib path, replacing all expanders whose names are in `dummy_replace`
+/// with an identity dummy expander.
 pub(crate) fn load_proc_macro(
     client: Option<&ProcMacroServer>,
     path: &AbsPath,
@@ -586,6 +585,7 @@ pub(crate) fn load_proc_macro(
         }
     }
 
+    /// Dummy identity expander, used for proc-macros that are deliberately ignored by the user.
     #[derive(Debug)]
     struct DummyExpander;
 

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -455,11 +455,12 @@ Enable support for procedural macros, implies `#rust-analyzer.cargo.runBuildScri
 Internal config, path to proc-macro server executable (typically,
 this is rust-analyzer itself, but we override this in tests).
 --
-[[rust-analyzer.procMacro.dummies]]rust-analyzer.procMacro.dummies (default: `{}`)::
+[[rust-analyzer.procMacro.ignored]]rust-analyzer.procMacro.ignored (default: `{}`)::
 +
 --
-Replaces the proc-macro expanders for the named proc-macros in the named crates with
-an identity expander that outputs the input again.
+These proc-macros will be ignored when trying to expand them.
+
+This config takes a map of crate names with the exported proc-macro names to ignore as values.
 --
 [[rust-analyzer.runnables.overrideCargo]]rust-analyzer.runnables.overrideCargo (default: `null`)::
 +

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -455,6 +455,12 @@ Enable support for procedural macros, implies `#rust-analyzer.cargo.runBuildScri
 Internal config, path to proc-macro server executable (typically,
 this is rust-analyzer itself, but we override this in tests).
 --
+[[rust-analyzer.procMacro.dummies]]rust-analyzer.procMacro.dummies (default: `{}`)::
++
+--
+Replaces the proc-macro expanders for the named proc-macros in the named crates with
+an identity expander that outputs the input again.
+--
 [[rust-analyzer.runnables.overrideCargo]]rust-analyzer.runnables.overrideCargo (default: `null`)::
 +
 --

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -880,8 +880,8 @@
                         "string"
                     ]
                 },
-                "rust-analyzer.procMacro.dummies": {
-                    "markdownDescription": "Replaces the proc-macro expanders for the named proc-macros in the named crates with\nan identity expander that outputs the input again.",
+                "rust-analyzer.procMacro.ignored": {
+                    "markdownDescription": "These proc-macros will be ignored when trying to expand them.\n\nThis config takes a map of crate names with the exported proc-macro names to ignore as values.",
                     "default": {},
                     "type": "object"
                 },

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -880,6 +880,11 @@
                         "string"
                     ]
                 },
+                "rust-analyzer.procMacro.dummies": {
+                    "markdownDescription": "Replaces the proc-macro expanders for the named proc-macros in the named crates with\nan identity expander that outputs the input again.",
+                    "default": {},
+                    "type": "object"
+                },
                 "rust-analyzer.runnables.overrideCargo": {
                     "markdownDescription": "Command to be executed instead of 'cargo' for runnables.",
                     "default": null,


### PR DESCRIPTION
With this one can specify proc-macros from crates to expand into their input as a (temporary) workaround for the current completion problems with some of the bigger attribute proc-macros like `async_trait`.

This could've been done by just not expanding these macros, but that would require fiddling with nameres. I felt like this approach was simpler to pull off while also keeping the behaviour of the attributes/proc-macro in that they still expand instead of being dead syntax to us.

Fixes https://github.com/rust-analyzer/rust-analyzer/issues/11052

Usage(`async_trait` as example):
```jsonc
    "rust-analyzer.procMacro.dummies": {
        "async-trait": [ // crate name(as per its cargo.toml definition, not the dependency name)
            "async_trait" // exported proc-macro name
        ]
    },
```