### PR TITLE
Correctly pass through reference modifiers when extracting a variable

### DIFF
--- a/crates/ide_assists/src/handlers/extract_variable.rs
+++ b/crates/ide_assists/src/handlers/extract_variable.rs
@@ -52,16 +52,10 @@ pub(crate) fn extract_variable(acc: &mut Assists, ctx: &AssistContext) -> Option
         }
     }
 
-    let ref_kind: RefKind = if let Some(receiver_type) = get_receiver_type(&ctx, &to_extract) {
-        if receiver_type.is_mutable_reference() {
-            RefKind::MutRef
-        } else if receiver_type.is_reference() {
-            RefKind::Ref
-        } else {
-            RefKind::None
-        }
-    } else {
-        RefKind::None
+    let ref_kind = match get_receiver_type(&ctx, &to_extract) {
+        Some(receiver_type) if receiver_type.is_mutable_reference() => RefKind::MutRef,
+        Some(receiver_type) if receiver_type.is_reference() => RefKind::Ref,
+        _ => RefKind::None,
     };
 
     let anchor = Anchor::from(&to_extract)?;

--- a/crates/ide_assists/src/handlers/extract_variable.rs
+++ b/crates/ide_assists/src/handlers/extract_variable.rs
@@ -52,10 +52,10 @@ pub(crate) fn extract_variable(acc: &mut Assists, ctx: &AssistContext) -> Option
         }
     }
 
-    let ref_kind = match get_receiver_type(&ctx, &to_extract) {
-        Some(receiver_type) if receiver_type.is_mutable_reference() => RefKind::MutRef,
-        Some(receiver_type) if receiver_type.is_reference() => RefKind::Ref,
-        _ => RefKind::None,
+    let reference_modifier = match get_receiver_type(&ctx, &to_extract) {
+        Some(receiver_type) if receiver_type.is_mutable_reference() => "&mut ",
+        Some(receiver_type) if receiver_type.is_reference() => "&",
+        _ => "",
     };
 
     let anchor = Anchor::from(&to_extract)?;
@@ -81,12 +81,6 @@ pub(crate) fn extract_variable(acc: &mut Assists, ctx: &AssistContext) -> Option
             let expr_range = match &field_shorthand {
                 Some(it) => it.syntax().text_range().cover(to_extract.syntax().text_range()),
                 None => to_extract.syntax().text_range(),
-            };
-
-            let reference_modifier = match ref_kind {
-                RefKind::MutRef => "&mut ",
-                RefKind::Ref => "&",
-                RefKind::None => "",
             };
 
             match anchor {
@@ -174,13 +168,6 @@ fn get_receiver(expression: ast::Expr) -> Option<ast::Expr> {
         }
         _ => Some(expression),
     }
-}
-
-#[derive(Debug)]
-enum RefKind {
-    Ref,
-    MutRef,
-    None,
 }
 
 #[derive(Debug)]

--- a/crates/ide_assists/src/handlers/extract_variable.rs
+++ b/crates/ide_assists/src/handlers/extract_variable.rs
@@ -161,7 +161,7 @@ fn valid_target_expr(node: SyntaxNode) -> Option<ast::Expr> {
 }
 
 fn get_receiver_type(ctx: &AssistContext, expression: &ast::Expr) -> Option<hir::Type> {
-    let receiver = get_receiver(expression.to_owned())?;
+    let receiver = get_receiver(expression.clone())?;
     Some(ctx.sema.type_of_expr(&receiver)?.original())
 }
 

--- a/crates/ide_assists/src/handlers/extract_variable.rs
+++ b/crates/ide_assists/src/handlers/extract_variable.rs
@@ -172,8 +172,7 @@ fn get_receiver(expression: ast::Expr) -> Option<ast::Expr> {
             let nested_expression = &field.expr()?;
             get_receiver(nested_expression.to_owned())
         }
-        ast::Expr::PathExpr(_) => Some(expression),
-        _ => None,
+        _ => Some(expression),
     }
 }
 

--- a/crates/ide_assists/src/handlers/extract_variable.rs
+++ b/crates/ide_assists/src/handlers/extract_variable.rs
@@ -1152,7 +1152,7 @@ struct S {
 
 impl S {
     fn new() -> S {
-        S { 
+        S {
             sub: X::new()
         }
     }
@@ -1181,7 +1181,7 @@ struct S {
 
 impl S {
     fn new() -> S {
-        S { 
+        S {
             sub: X::new()
         }
     }
@@ -1218,7 +1218,7 @@ struct S {
 
 impl S {
     fn new() -> S {
-        S { 
+        S {
             sub: X::new()
         }
     }
@@ -1247,7 +1247,7 @@ struct S {
 
 impl S {
     fn new() -> S {
-        S { 
+        S {
             sub: X::new()
         }
     }

--- a/crates/ide_assists/src/handlers/extract_variable.rs
+++ b/crates/ide_assists/src/handlers/extract_variable.rs
@@ -171,6 +171,7 @@ fn get_receiver_type(ctx: &AssistContext, expression: &ast::Expr) -> Option<hir:
     Some(ctx.sema.type_of_expr(&receiver)?.original())
 }
 
+/// In the expression `a.b.c.x()`, find `a`
 fn get_receiver(expression: ast::Expr) -> Option<ast::Expr> {
     match expression {
         ast::Expr::FieldExpr(field) if field.expr().is_some() => {

--- a/crates/ide_assists/src/handlers/extract_variable.rs
+++ b/crates/ide_assists/src/handlers/extract_variable.rs
@@ -1137,4 +1137,70 @@ fn foo(s: S) {
 }"#,
         );
     }
+
+    #[test]
+    fn test_extract_var_reference_local() {
+        check_assist(
+            extract_variable,
+            r#"
+struct X;
+
+struct S {
+    sub: X
+}
+
+impl S {
+    fn new() -> S {
+        S { 
+            sub: X::new()
+        }
+    }
+}
+
+impl X {
+    fn new() -> X {
+        X { }
+    }
+    fn do_thing(&self) {
+
+    }
+}
+
+
+fn foo() {
+    let local = &mut S::new();
+    $0local.sub$0.do_thing();
+}"#,
+            r#"
+struct X;
+
+struct S {
+    sub: X
+}
+
+impl S {
+    fn new() -> S {
+        S { 
+            sub: X::new()
+        }
+    }
+}
+
+impl X {
+    fn new() -> X {
+        X { }
+    }
+    fn do_thing(&self) {
+
+    }
+}
+
+
+fn foo() {
+    let local = &mut S::new();
+    let $0x = local.sub;
+    x.do_thing();
+}"#,
+        );
+    }
 }

--- a/crates/ide_assists/src/handlers/extract_variable.rs
+++ b/crates/ide_assists/src/handlers/extract_variable.rs
@@ -1139,7 +1139,7 @@ fn foo(s: S) {
     }
 
     #[test]
-    fn test_extract_var_reference_local() {
+    fn test_extract_var_mutable_reference_local() {
         check_assist(
             extract_variable,
             r#"
@@ -1198,7 +1198,73 @@ impl X {
 
 fn foo() {
     let local = &mut S::new();
-    let $0x = local.sub;
+    let $0x = &mut local.sub;
+    x.do_thing();
+}"#,
+        );
+    }
+
+    #[test]
+    fn test_extract_var_reference_local() {
+        check_assist(
+            extract_variable,
+            r#"
+struct X;
+
+struct S {
+    sub: X
+}
+
+impl S {
+    fn new() -> S {
+        S { 
+            sub: X::new()
+        }
+    }
+}
+
+impl X {
+    fn new() -> X {
+        X { }
+    }
+    fn do_thing(&self) {
+
+    }
+}
+
+
+fn foo() {
+    let local = &S::new();
+    $0local.sub$0.do_thing();
+}"#,
+            r#"
+struct X;
+
+struct S {
+    sub: X
+}
+
+impl S {
+    fn new() -> S {
+        S { 
+            sub: X::new()
+        }
+    }
+}
+
+impl X {
+    fn new() -> X {
+        X { }
+    }
+    fn do_thing(&self) {
+
+    }
+}
+
+
+fn foo() {
+    let local = &S::new();
+    let $0x = &local.sub;
     x.do_thing();
 }"#,
         );


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/10034

This will parse the field expression and look at whether it is marked `&` or `&mut` and include a modifier if appropriate. The original issue only mentions `&mut params` but I've found that this issue also occurs for `&mut locals` as well as `&params` and `&locals` so I've also added tests for them.

I'd definitely be interested in hearing where I can make my code more idiomatic for Rust.