### PR TITLE
Always put a space after dyn in macro pretty-printing

### DIFF
--- a/crates/ide_assists/src/handlers/add_missing_impl_members.rs
+++ b/crates/ide_assists/src/handlers/add_missing_impl_members.rs
@@ -942,4 +942,45 @@ impl FooB for Foo {
 "#,
         )
     }
+
+    #[test]
+    fn macro_trait_dyn_absolute_path() {
+        // https://github.com/rust-analyzer/rust-analyzer/issues/11100
+        check_assist(
+            add_missing_impl_members,
+            r#"
+macro_rules! foo {
+    () => {
+        trait MacroTrait {
+            fn trait_method(_: &dyn ::core::marker::Sized);
+        }
+    }
+}
+foo!();
+struct Foo;
+
+impl MacroTrait for Foo {
+    $0
+}
+"#,
+            r#"
+macro_rules! foo {
+    () => {
+        trait MacroTrait {
+            fn trait_method(_: &dyn ::core::marker::Sized);
+        }
+    }
+}
+foo!();
+struct Foo;
+
+impl MacroTrait for Foo {
+    fn trait_method(_: &dyn ::core::marker::Sized) {
+        ${0:todo!()}
+    }
+
+}
+"#,
+        )
+    }
 }

--- a/crates/ide_db/src/helpers/insert_whitespace_into_node.rs
+++ b/crates/ide_db/src/helpers/insert_whitespace_into_node.rs
@@ -88,7 +88,7 @@ pub fn insert_ws_into(syn: SyntaxNode) -> SyntaxNode {
             LIFETIME_IDENT if is_next(|it| is_text(it), true) => {
                 mods.push(do_ws(after, tok));
             }
-            AS_KW => {
+            AS_KW | DYN_KW => {
                 mods.push(do_ws(after, tok));
             }
             T![;] => {


### PR DESCRIPTION
Fixes #11100.