### PR TITLE
Always put a space after impl in macro pretty-printing

### DIFF
--- a/crates/ide/src/expand_macro.rs
+++ b/crates/ide/src/expand_macro.rs
@@ -319,7 +319,7 @@ struct Foo {}
 "#,
             expect![[r#"
                 Clone
-                impl< >core::clone::Clone for Foo< >{}
+                impl < >core::clone::Clone for Foo< >{}
 
             "#]],
         );
@@ -337,7 +337,7 @@ struct Foo {}
 "#,
             expect![[r#"
                 Copy
-                impl< >core::marker::Copy for Foo< >{}
+                impl < >core::marker::Copy for Foo< >{}
 
             "#]],
         );
@@ -354,9 +354,9 @@ struct Foo {}
 "#,
             expect![[r#"
                 Copy, Clone
-                impl< >core::marker::Copy for Foo< >{}
+                impl < >core::marker::Copy for Foo< >{}
 
-                impl< >core::clone::Clone for Foo< >{}
+                impl < >core::clone::Clone for Foo< >{}
 
             "#]],
         );

--- a/crates/ide_db/src/helpers/insert_whitespace_into_node.rs
+++ b/crates/ide_db/src/helpers/insert_whitespace_into_node.rs
@@ -88,7 +88,7 @@ pub fn insert_ws_into(syn: SyntaxNode) -> SyntaxNode {
             LIFETIME_IDENT if is_next(|it| is_text(it), true) => {
                 mods.push(do_ws(after, tok));
             }
-            AS_KW | DYN_KW => {
+            AS_KW | DYN_KW | IMPL_KW => {
                 mods.push(do_ws(after, tok));
             }
             T![;] => {


### PR DESCRIPTION
… regardless of whether the next symbol is punctuation or not.

Followup to #11200.