### PR TITLE
fix: Fix parsing of `#[derive]` paths

### DIFF
--- a/crates/hir_def/src/attr.rs
+++ b/crates/hir_def/src/attr.rs
@@ -737,6 +737,7 @@ impl Attr {
                 matches!(tt, tt::TokenTree::Leaf(tt::Leaf::Punct(Punct { char: ',', .. })))
             })
             .into_iter()
+            .filter(|(comma, _)| !*comma)
             .map(|(_, tts)| {
                 let segments = tts.filter_map(|tt| match tt {
                     tt::TokenTree::Leaf(tt::Leaf::Ident(id)) => Some(id.as_name()),


### PR DESCRIPTION
Currently this code produces an empty derive path for every `,`, which makes the IDE layer resolve derive paths to the wrong derive macro in the list. Skip `,`s to fix that. (nameres just ignored them, so it didn't cause problems there)

bors r+