### PR TITLE
fix: Correct has_ref detection, avoiding duplicate &mut insertion on parameter completion

### DIFF
--- a/crates/ide_completion/src/context.rs
+++ b/crates/ide_completion/src/context.rs
@@ -876,7 +876,7 @@ fn path_or_use_tree_qualifier(path: &ast::Path) -> Option<(ast::Path, bool)> {
 
 fn has_ref(token: &SyntaxToken) -> bool {
     let mut token = token.clone();
-    for skip in [WHITESPACE, IDENT, T![mut]] {
+    for skip in [IDENT, WHITESPACE, T![mut]] {
         if token.kind() == skip {
             token = match token.prev_token() {
                 Some(it) => it,
@@ -991,6 +991,20 @@ fn bar(x: &u32) {}
         check_expected_type_and_name(
             r#"
 fn foo() { bar(&mut $0); }
+fn bar(x: &mut u32) {}
+"#,
+            expect![[r#"ty: u32, name: x"#]],
+        );
+        check_expected_type_and_name(
+            r#"
+fn foo() { bar(& c$0); }
+fn bar(x: &u32) {}
+        "#,
+            expect![[r#"ty: u32, name: x"#]],
+        );
+        check_expected_type_and_name(
+            r#"
+fn foo() { bar(&mut c$0); }
 fn bar(x: &mut u32) {}
 "#,
             expect![[r#"ty: u32, name: x"#]],

--- a/crates/ide_completion/src/render.rs
+++ b/crates/ide_completion/src/render.rs
@@ -1156,6 +1156,22 @@ fn main() {
                 fn foo(…) []
             "#]],
         );
+        check_relevance(
+            r#"
+struct S;
+fn foo(s: &mut S) {}
+fn main() {
+    let mut ssss = S;
+    foo(&mut s$0);
+}
+            "#,
+            expect![[r#"
+                lc ssss [type+local]
+                st S []
+                fn main() []
+                fn foo(…) []
+            "#]],
+        );
     }
 
     #[test]


### PR DESCRIPTION
The original code fails to detect there's a ref in scenarios such as `&mut s` and `& s` because `WHITESPACE` and `IDENT` got reversed.

Closes #11199.