### PR TITLE
Turbo fish assist: don't include lifetime parameters

### DIFF
--- a/crates/ide_assists/src/handlers/add_turbo_fish.rs
+++ b/crates/ide_assists/src/handlers/add_turbo_fish.rs
@@ -79,7 +79,9 @@ pub(crate) fn add_turbo_fish(acc: &mut Assists, ctx: &AssistContext) -> Option<(
 
     let number_of_arguments = generics
         .iter()
-        .filter(|param| matches!(param, hir::GenericParam::TypeParam(_) | hir::GenericParam::ConstParam(_)))
+        .filter(|param| {
+            matches!(param, hir::GenericParam::TypeParam(_) | hir::GenericParam::ConstParam(_))
+        })
         .count();
     let fish_head = std::iter::repeat("_").take(number_of_arguments).collect::<Vec<_>>().join(",");
 

--- a/crates/ide_assists/src/handlers/add_turbo_fish.rs
+++ b/crates/ide_assists/src/handlers/add_turbo_fish.rs
@@ -79,10 +79,7 @@ pub(crate) fn add_turbo_fish(acc: &mut Assists, ctx: &AssistContext) -> Option<(
 
     let number_of_arguments = generics
         .iter()
-        .filter(|param| match param {
-            hir::GenericParam::TypeParam(_) | hir::GenericParam::ConstParam(_) => true,
-            _ => false,
-        })
+        .filter(|param| matches!(param, hir::GenericParam::TypeParam(_) | hir::GenericParam::ConstParam(_)))
         .count();
     let fish_head = std::iter::repeat("_").take(number_of_arguments).collect::<Vec<_>>().join(",");
 

--- a/crates/ide_assists/src/handlers/add_turbo_fish.rs
+++ b/crates/ide_assists/src/handlers/add_turbo_fish.rs
@@ -80,7 +80,7 @@ pub(crate) fn add_turbo_fish(acc: &mut Assists, ctx: &AssistContext) -> Option<(
     let number_of_arguments = generics
         .iter()
         .filter(|param| match param {
-            hir::GenericParam::TypeParam(_) => true,
+            hir::GenericParam::TypeParam(_) | hir::GenericParam::ConstParam(_) => true,
             _ => false,
         })
         .count();
@@ -360,6 +360,25 @@ fn main() {
 fn make<'a, T, A>(t: T, a: A) {}
 fn main() {
     make::<${0:_,_}>(5, 2);
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn add_turbo_fish_function_const_parameter() {
+        check_assist(
+            add_turbo_fish,
+            r#"
+fn make<T, const N: usize>(t: T) {}
+fn main() {
+    make$0(3);
+}
+"#,
+            r#"
+fn make<T, const N: usize>(t: T) {}
+fn main() {
+    make::<${0:_,_}>(3);
 }
 "#,
         );


### PR DESCRIPTION
Fixes #11219

The issue talks about three different types of params: type, const & lifetime. I wasn't entirely sure which ones are intended to be included here so I've gone for the type & const params (i.e. exclude lifetime).

I've added a test case for both a lifetime param and a const param. I'm still making my way through the rust book (chapter 7, yay) so I'm not too sure yet what these are but my testing shows that this approach generates code that compiles.