### PR TITLE
internal: Remove `InFile` wrapping from `DynMap` keys

### DIFF
--- a/crates/hir/src/semantics/source_to_def.rs
+++ b/crates/hir/src/semantics/source_to_def.rs
@@ -242,7 +242,7 @@ impl SourceToDefCtx<'_, '_> {
 
     pub(super) fn item_to_macro_call(&mut self, src: InFile<ast::Item>) -> Option<MacroCallId> {
         let map = self.dyn_map(src.as_ref())?;
-        map[keys::ATTR_MACRO_CALL].get(&src).copied()
+        map[keys::ATTR_MACRO_CALL].get(&src.value).copied()
     }
 
     pub(super) fn attr_to_derive_macro_call(
@@ -251,7 +251,7 @@ impl SourceToDefCtx<'_, '_> {
         src: InFile<ast::Attr>,
     ) -> Option<(AttrId, &[Option<MacroCallId>])> {
         let map = self.dyn_map(item)?;
-        map[keys::DERIVE_MACRO_CALL].get(&src).map(|(id, ids)| (*id, &**ids))
+        map[keys::DERIVE_MACRO_CALL].get(&src.value).map(|(id, ids)| (*id, &**ids))
     }
 
     fn to_def<Ast: AstNode + 'static, ID: Copy + 'static>(
@@ -259,7 +259,7 @@ impl SourceToDefCtx<'_, '_> {
         src: InFile<Ast>,
         key: Key<Ast, ID>,
     ) -> Option<ID> {
-        self.dyn_map(src.as_ref())?[key].get(&src).copied()
+        self.dyn_map(src.as_ref())?[key].get(&src.value).copied()
     }
 
     fn dyn_map<Ast: AstNode + 'static>(&mut self, src: InFile<&Ast>) -> Option<&DynMap> {
@@ -277,7 +277,7 @@ impl SourceToDefCtx<'_, '_> {
     pub(super) fn type_param_to_def(&mut self, src: InFile<ast::TypeParam>) -> Option<TypeParamId> {
         let container: ChildContainer = self.find_generic_param_container(src.syntax())?.into();
         let dyn_map = self.cache_for(container, src.file_id);
-        dyn_map[keys::TYPE_PARAM].get(&src).copied()
+        dyn_map[keys::TYPE_PARAM].get(&src.value).copied()
     }
 
     pub(super) fn lifetime_param_to_def(
@@ -286,7 +286,7 @@ impl SourceToDefCtx<'_, '_> {
     ) -> Option<LifetimeParamId> {
         let container: ChildContainer = self.find_generic_param_container(src.syntax())?.into();
         let dyn_map = self.cache_for(container, src.file_id);
-        dyn_map[keys::LIFETIME_PARAM].get(&src).copied()
+        dyn_map[keys::LIFETIME_PARAM].get(&src.value).copied()
     }
 
     pub(super) fn const_param_to_def(
@@ -295,7 +295,7 @@ impl SourceToDefCtx<'_, '_> {
     ) -> Option<ConstParamId> {
         let container: ChildContainer = self.find_generic_param_container(src.syntax())?.into();
         let dyn_map = self.cache_for(container, src.file_id);
-        dyn_map[keys::CONST_PARAM].get(&src).copied()
+        dyn_map[keys::CONST_PARAM].get(&src.value).copied()
     }
 
     pub(super) fn generic_param_to_def(
@@ -316,9 +316,9 @@ impl SourceToDefCtx<'_, '_> {
     }
 
     pub(super) fn macro_to_def(&mut self, src: InFile<ast::Macro>) -> Option<MacroDefId> {
-        let makro = self.dyn_map(src.as_ref()).and_then(|it| it[keys::MACRO].get(&src).copied());
-        if let res @ Some(_) = makro {
-            return res;
+        let makro = self.dyn_map(src.as_ref()).and_then(|it| it[keys::MACRO].get(&src.value));
+        if let Some(&makro) = makro {
+            return Some(makro);
         }
 
         // Not all macros are recorded in the dyn map, only the ones behaving like items, so fall back

--- a/crates/hir_def/src/child_by_source.rs
+++ b/crates/hir_def/src/child_by_source.rs
@@ -33,12 +33,11 @@ impl ChildBySource for TraitId {
 
         data.attribute_calls().filter(|(ast_id, _)| ast_id.file_id == file_id).for_each(
             |(ast_id, call_id)| {
-                let item = ast_id.with_value(ast_id.to_node(db.upcast()));
-                res[keys::ATTR_MACRO_CALL].insert(item, call_id);
+                res[keys::ATTR_MACRO_CALL].insert(ast_id.to_node(db.upcast()), call_id);
             },
         );
         data.items.iter().for_each(|&(_, item)| {
-            child_by_source_assoc_items(db, res, file_id, item);
+            add_assoc_item(db, res, file_id, item);
         });
     }
 }
@@ -48,42 +47,33 @@ impl ChildBySource for ImplId {
         let data = db.impl_data(*self);
         data.attribute_calls().filter(|(ast_id, _)| ast_id.file_id == file_id).for_each(
             |(ast_id, call_id)| {
-                let item = ast_id.with_value(ast_id.to_node(db.upcast()));
-                res[keys::ATTR_MACRO_CALL].insert(item, call_id);
+                res[keys::ATTR_MACRO_CALL].insert(ast_id.to_node(db.upcast()), call_id);
             },
         );
         data.items.iter().for_each(|&item| {
-            child_by_source_assoc_items(db, res, file_id, item);
+            add_assoc_item(db, res, file_id, item);
         });
     }
 }
 
-fn child_by_source_assoc_items(
-    db: &dyn DefDatabase,
-    res: &mut DynMap,
-    file_id: HirFileId,
-    item: AssocItemId,
-) {
+fn add_assoc_item(db: &dyn DefDatabase, res: &mut DynMap, file_id: HirFileId, item: AssocItemId) {
     match item {
         AssocItemId::FunctionId(func) => {
             let loc = func.lookup(db);
             if loc.id.file_id() == file_id {
-                let src = loc.source(db);
-                res[keys::FUNCTION].insert(src, func)
+                res[keys::FUNCTION].insert(loc.source(db).value, func)
             }
         }
         AssocItemId::ConstId(konst) => {
             let loc = konst.lookup(db);
             if loc.id.file_id() == file_id {
-                let src = loc.source(db);
-                res[keys::CONST].insert(src, konst)
+                res[keys::CONST].insert(loc.source(db).value, konst)
             }
         }
         AssocItemId::TypeAliasId(ty) => {
             let loc = ty.lookup(db);
             if loc.id.file_id() == file_id {
-                let src = loc.source(db);
-                res[keys::TYPE_ALIAS].insert(src, ty)
+                res[keys::TYPE_ALIAS].insert(loc.source(db).value, ty)
             }
         }
     }
@@ -99,120 +89,75 @@ impl ChildBySource for ModuleId {
 
 impl ChildBySource for ItemScope {
     fn child_by_source_to(&self, db: &dyn DefDatabase, res: &mut DynMap, file_id: HirFileId) {
-        self.declarations().for_each(|item| add_module_def(db, file_id, res, item));
+        self.declarations().for_each(|item| add_module_def(db, res, file_id, item));
+        self.impls().for_each(|imp| add_impl(db, res, file_id, imp));
+        self.unnamed_consts().for_each(|konst| {
+            let loc = konst.lookup(db);
+            if loc.id.file_id() == file_id {
+                res[keys::CONST].insert(loc.source(db).value, konst);
+            }
+        });
         self.macros().for_each(|(_, makro)| {
             let ast_id = makro.ast_id();
             if ast_id.either(|it| it.file_id, |it| it.file_id) == file_id {
                 let src = match ast_id {
-                    Either::Left(ast_id) => ast_id.with_value(ast_id.to_node(db.upcast())),
+                    Either::Left(ast_id) => ast_id.to_node(db.upcast()),
                     // FIXME: Do we need to add proc-macros into a PROCMACRO dynmap here?
                     Either::Right(_fn) => return,
                 };
                 res[keys::MACRO].insert(src, makro);
             }
         });
-        self.unnamed_consts().for_each(|konst| {
-            let loc = konst.lookup(db);
-            if loc.id.file_id() == file_id {
-                let src = loc.source(db);
-                res[keys::CONST].insert(src, konst);
-            }
-        });
-        self.impls().for_each(|imp| add_impl(db, file_id, res, imp));
-        self.attr_macro_invocs().for_each(|(ast_id, call_id)| {
-            if ast_id.file_id == file_id {
-                let item = ast_id.with_value(ast_id.to_node(db.upcast()));
-                res[keys::ATTR_MACRO_CALL].insert(item, call_id);
-            }
-        });
-        self.derive_macro_invocs().for_each(|(ast_id, calls)| {
-            if ast_id.file_id != file_id {
-                return;
-            }
-            let adt = ast_id.to_node(db.upcast());
-            for (attr_id, calls) in calls {
-                if let Some(Either::Right(attr)) =
-                    adt.doc_comments_and_attrs().nth(attr_id.ast_index as usize)
-                {
-                    res[keys::DERIVE_MACRO_CALL]
-                        .insert(ast_id.with_value(attr), (attr_id, calls.into()));
-                }
-            }
-        });
+        self.attr_macro_invocs().filter(|(id, _)| id.file_id == file_id).for_each(
+            |(ast_id, call_id)| {
+                res[keys::ATTR_MACRO_CALL].insert(ast_id.to_node(db.upcast()), call_id);
+            },
+        );
+        self.derive_macro_invocs().filter(|(id, _)| id.file_id == file_id).for_each(
+            |(ast_id, calls)| {
+                let adt = ast_id.to_node(db.upcast());
+                calls.for_each(|(attr_id, calls)| {
+                    if let Some(Either::Right(attr)) =
+                        adt.doc_comments_and_attrs().nth(attr_id.ast_index as usize)
+                    {
+                        res[keys::DERIVE_MACRO_CALL].insert(attr, (attr_id, calls.into()));
+                    }
+                });
+            },
+        );
 
         fn add_module_def(
             db: &dyn DefDatabase,
-            file_id: HirFileId,
             map: &mut DynMap,
+            file_id: HirFileId,
             item: ModuleDefId,
         ) {
+            macro_rules! insert {
+                ($map:ident[$key:path].$insert:ident($id:ident)) => {{
+                    let loc = $id.lookup(db);
+                    if loc.id.file_id() == file_id {
+                        $map[$key].$insert(loc.source(db).value, $id)
+                    }
+                }};
+            }
             match item {
-                ModuleDefId::FunctionId(func) => {
-                    let loc = func.lookup(db);
-                    if loc.id.file_id() == file_id {
-                        let src = loc.source(db);
-                        map[keys::FUNCTION].insert(src, func)
-                    }
-                }
-                ModuleDefId::ConstId(konst) => {
-                    let loc = konst.lookup(db);
-                    if loc.id.file_id() == file_id {
-                        let src = loc.source(db);
-                        map[keys::CONST].insert(src, konst)
-                    }
-                }
-                ModuleDefId::StaticId(statik) => {
-                    let loc = statik.lookup(db);
-                    if loc.id.file_id() == file_id {
-                        let src = loc.source(db);
-                        map[keys::STATIC].insert(src, statik)
-                    }
-                }
-                ModuleDefId::TypeAliasId(ty) => {
-                    let loc = ty.lookup(db);
-                    if loc.id.file_id() == file_id {
-                        let src = loc.source(db);
-                        map[keys::TYPE_ALIAS].insert(src, ty)
-                    }
-                }
-                ModuleDefId::TraitId(trait_) => {
-                    let loc = trait_.lookup(db);
-                    if loc.id.file_id() == file_id {
-                        let src = loc.source(db);
-                        map[keys::TRAIT].insert(src, trait_)
-                    }
-                }
+                ModuleDefId::FunctionId(id) => insert!(map[keys::FUNCTION].insert(id)),
+                ModuleDefId::ConstId(id) => insert!(map[keys::CONST].insert(id)),
+                ModuleDefId::StaticId(id) => insert!(map[keys::STATIC].insert(id)),
+                ModuleDefId::TypeAliasId(id) => insert!(map[keys::TYPE_ALIAS].insert(id)),
+                ModuleDefId::TraitId(id) => insert!(map[keys::TRAIT].insert(id)),
                 ModuleDefId::AdtId(adt) => match adt {
-                    AdtId::StructId(strukt) => {
-                        let loc = strukt.lookup(db);
-                        if loc.id.file_id() == file_id {
-                            let src = loc.source(db);
-                            map[keys::STRUCT].insert(src, strukt)
-                        }
-                    }
-                    AdtId::UnionId(union_) => {
-                        let loc = union_.lookup(db);
-                        if loc.id.file_id() == file_id {
-                            let src = loc.source(db);
-                            map[keys::UNION].insert(src, union_)
-                        }
-                    }
-                    AdtId::EnumId(enum_) => {
-                        let loc = enum_.lookup(db);
-                        if loc.id.file_id() == file_id {
-                            let src = loc.source(db);
-                            map[keys::ENUM].insert(src, enum_)
-                        }
-                    }
+                    AdtId::StructId(id) => insert!(map[keys::STRUCT].insert(id)),
+                    AdtId::UnionId(id) => insert!(map[keys::UNION].insert(id)),
+                    AdtId::EnumId(id) => insert!(map[keys::ENUM].insert(id)),
                 },
                 _ => (),
             }
         }
-        fn add_impl(db: &dyn DefDatabase, file_id: HirFileId, map: &mut DynMap, imp: ImplId) {
+        fn add_impl(db: &dyn DefDatabase, map: &mut DynMap, file_id: HirFileId, imp: ImplId) {
             let loc = imp.lookup(db);
             if loc.id.file_id() == file_id {
-                let src = loc.source(db);
-                map[keys::IMPL].insert(src, imp)
+                map[keys::IMPL].insert(loc.source(db).value, imp)
             }
         }
     }
@@ -226,12 +171,8 @@ impl ChildBySource for VariantId {
         for (local_id, source) in arena_map.value.iter() {
             let id = FieldId { parent, local_id };
             match source.clone() {
-                Either::Left(source) => {
-                    res[keys::TUPLE_FIELD].insert(arena_map.with_value(source), id)
-                }
-                Either::Right(source) => {
-                    res[keys::RECORD_FIELD].insert(arena_map.with_value(source), id)
-                }
+                Either::Left(source) => res[keys::TUPLE_FIELD].insert(source, id),
+                Either::Right(source) => res[keys::RECORD_FIELD].insert(source, id),
             }
         }
     }
@@ -243,7 +184,7 @@ impl ChildBySource for EnumId {
         let arena_map = arena_map.as_ref();
         for (local_id, source) in arena_map.value.iter() {
             let id = EnumVariantId { parent: *self, local_id };
-            res[keys::VARIANT].insert(arena_map.with_value(source.clone()), id)
+            res[keys::VARIANT].insert(source.clone(), id)
         }
     }
 }

--- a/crates/hir_def/src/generics.rs
+++ b/crates/hir_def/src/generics.rs
@@ -473,15 +473,15 @@ impl ChildBySource for GenericDefId {
         if let Some(generic_params_list) = generic_params_list {
             for (local_id, ast_param) in types_idx_iter.zip(generic_params_list.type_params()) {
                 let id = TypeParamId { parent: *self, local_id };
-                res[keys::TYPE_PARAM].insert(InFile::new(gfile_id, ast_param), id);
+                res[keys::TYPE_PARAM].insert(ast_param, id);
             }
             for (local_id, ast_param) in lts_idx_iter.zip(generic_params_list.lifetime_params()) {
                 let id = LifetimeParamId { parent: *self, local_id };
-                res[keys::LIFETIME_PARAM].insert(InFile::new(gfile_id, ast_param), id);
+                res[keys::LIFETIME_PARAM].insert(ast_param, id);
             }
             for (local_id, ast_param) in consts_idx_iter.zip(generic_params_list.const_params()) {
                 let id = ConstParamId { parent: *self, local_id };
-                res[keys::CONST_PARAM].insert(InFile::new(gfile_id, ast_param), id);
+                res[keys::CONST_PARAM].insert(ast_param, id);
             }
         }
     }

--- a/crates/hir_def/src/generics.rs
+++ b/crates/hir_def/src/generics.rs
@@ -454,13 +454,16 @@ impl HasChildSource<LocalConstParamId> for GenericDefId {
 }
 
 impl ChildBySource for GenericDefId {
-    fn child_by_source_to(&self, db: &dyn DefDatabase, res: &mut DynMap, _: HirFileId) {
+    fn child_by_source_to(&self, db: &dyn DefDatabase, res: &mut DynMap, file_id: HirFileId) {
+        let (gfile_id, generic_params_list) = file_id_and_params_of(*self, db);
+        if gfile_id != file_id {
+            return;
+        }
+
         let generic_params = db.generic_params(*self);
         let mut types_idx_iter = generic_params.types.iter().map(|(idx, _)| idx);
         let lts_idx_iter = generic_params.lifetimes.iter().map(|(idx, _)| idx);
         let consts_idx_iter = generic_params.consts.iter().map(|(idx, _)| idx);
-
-        let (file_id, generic_params_list) = file_id_and_params_of(*self, db);
 
         // For traits the first type index is `Self`, skip it.
         if let GenericDefId::TraitId(_) = *self {
@@ -470,15 +473,15 @@ impl ChildBySource for GenericDefId {
         if let Some(generic_params_list) = generic_params_list {
             for (local_id, ast_param) in types_idx_iter.zip(generic_params_list.type_params()) {
                 let id = TypeParamId { parent: *self, local_id };
-                res[keys::TYPE_PARAM].insert(InFile::new(file_id, ast_param), id);
+                res[keys::TYPE_PARAM].insert(InFile::new(gfile_id, ast_param), id);
             }
             for (local_id, ast_param) in lts_idx_iter.zip(generic_params_list.lifetime_params()) {
                 let id = LifetimeParamId { parent: *self, local_id };
-                res[keys::LIFETIME_PARAM].insert(InFile::new(file_id, ast_param), id);
+                res[keys::LIFETIME_PARAM].insert(InFile::new(gfile_id, ast_param), id);
             }
             for (local_id, ast_param) in consts_idx_iter.zip(generic_params_list.const_params()) {
                 let id = ConstParamId { parent: *self, local_id };
-                res[keys::CONST_PARAM].insert(InFile::new(file_id, ast_param), id);
+                res[keys::CONST_PARAM].insert(InFile::new(gfile_id, ast_param), id);
             }
         }
     }


### PR DESCRIPTION
We already store a `DynMap` per `(Container, HirFileId)` pair, so the `InFile` keys are already guruanteed to always be of the same file id
bors r+