### PR TITLE
fix: shrink the span of errors from attribute macros and derives

### DIFF
--- a/crates/proc_macro_srv/src/abis/abi_1_56/mod.rs
+++ b/crates/proc_macro_srv/src/abis/abi_1_56/mod.rs
@@ -51,7 +51,7 @@ impl Abi {
                         &proc_macro::bridge::server::SameThread,
                         rustc_server::Rustc::default(),
                         parsed_body,
-                        false,
+                        true,
                     );
                     return res.map(|it| it.into_subtree()).map_err(PanicMessage::from);
                 }
@@ -62,7 +62,7 @@ impl Abi {
                         &proc_macro::bridge::server::SameThread,
                         rustc_server::Rustc::default(),
                         parsed_body,
-                        false,
+                        true,
                     );
                     return res.map(|it| it.into_subtree()).map_err(PanicMessage::from);
                 }
@@ -74,7 +74,7 @@ impl Abi {
                         rustc_server::Rustc::default(),
                         parsed_attributes,
                         parsed_body,
-                        false,
+                        true,
                     );
                     return res.map(|it| it.into_subtree()).map_err(PanicMessage::from);
                 }

--- a/crates/proc_macro_srv/src/abis/abi_1_58/mod.rs
+++ b/crates/proc_macro_srv/src/abis/abi_1_58/mod.rs
@@ -51,7 +51,7 @@ impl Abi {
                         &proc_macro::bridge::server::SameThread,
                         rustc_server::Rustc::default(),
                         parsed_body,
-                        false,
+                        true,
                     );
                     return res.map(|it| it.into_subtree()).map_err(PanicMessage::from);
                 }
@@ -62,7 +62,7 @@ impl Abi {
                         &proc_macro::bridge::server::SameThread,
                         rustc_server::Rustc::default(),
                         parsed_body,
-                        false,
+                        true,
                     );
                     return res.map(|it| it.into_subtree()).map_err(PanicMessage::from);
                 }
@@ -74,7 +74,7 @@ impl Abi {
                         rustc_server::Rustc::default(),
                         parsed_attributes,
                         parsed_body,
-                        false,
+                        true,
                     );
                     return res.map(|it| it.into_subtree()).map_err(PanicMessage::from);
                 }

--- a/crates/syntax/src/ast/generated/nodes.rs
+++ b/crates/syntax/src/ast/generated/nodes.rs
@@ -162,6 +162,7 @@ pub struct MacroCall {
     pub(crate) syntax: SyntaxNode,
 }
 impl ast::HasAttrs for MacroCall {}
+impl ast::HasDocComments for MacroCall {}
 impl MacroCall {
     pub fn path(&self) -> Option<Path> { support::child(&self.syntax) }
     pub fn excl_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![!]) }
@@ -259,6 +260,7 @@ pub struct ExternBlock {
     pub(crate) syntax: SyntaxNode,
 }
 impl ast::HasAttrs for ExternBlock {}
+impl ast::HasDocComments for ExternBlock {}
 impl ExternBlock {
     pub fn abi(&self) -> Option<Abi> { support::child(&self.syntax) }
     pub fn extern_item_list(&self) -> Option<ExternItemList> { support::child(&self.syntax) }
@@ -270,6 +272,7 @@ pub struct ExternCrate {
 }
 impl ast::HasAttrs for ExternCrate {}
 impl ast::HasVisibility for ExternCrate {}
+impl ast::HasDocComments for ExternCrate {}
 impl ExternCrate {
     pub fn extern_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![extern]) }
     pub fn crate_token(&self) -> Option<SyntaxToken> { support::token(&self.syntax, T![crate]) }
@@ -1543,6 +1546,7 @@ pub enum Item {
     Use(Use),
 }
 impl ast::HasAttrs for Item {}
+impl ast::HasDocComments for Item {}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Stmt {
@@ -1597,6 +1601,7 @@ pub enum AssocItem {
     TypeAlias(TypeAlias),
 }
 impl ast::HasAttrs for AssocItem {}
+impl ast::HasDocComments for AssocItem {}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ExternItem {
@@ -1606,6 +1611,7 @@ pub enum ExternItem {
     TypeAlias(TypeAlias),
 }
 impl ast::HasAttrs for ExternItem {}
+impl ast::HasDocComments for ExternItem {}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum GenericParam {
@@ -3902,10 +3908,9 @@ impl AnyHasDocComments {
 impl AstNode for AnyHasDocComments {
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
-            SOURCE_FILE | CONST | ENUM | FN | IMPL | MACRO_RULES | MACRO_DEF | MODULE | STATIC
-            | STRUCT | TRAIT | TYPE_ALIAS | UNION | USE | RECORD_FIELD | TUPLE_FIELD | VARIANT => {
-                true
-            }
+            MACRO_CALL | SOURCE_FILE | CONST | ENUM | EXTERN_BLOCK | EXTERN_CRATE | FN | IMPL
+            | MACRO_RULES | MACRO_DEF | MODULE | STATIC | STRUCT | TRAIT | TYPE_ALIAS | UNION
+            | USE | RECORD_FIELD | TUPLE_FIELD | VARIANT => true,
             _ => false,
         }
     }

--- a/crates/syntax/src/ast/node_ext.rs
+++ b/crates/syntax/src/ast/node_ext.rs
@@ -772,7 +772,6 @@ impl ast::HasLoopBody for ast::ForExpr {
 }
 
 impl ast::HasAttrs for ast::AnyHasDocComments {}
-impl ast::HasDocComments for ast::Item {}
 
 impl From<ast::Adt> for ast::Item {
     fn from(it: ast::Adt) -> Self {

--- a/crates/syntax/src/tests/sourcegen_ast.rs
+++ b/crates/syntax/src/tests/sourcegen_ast.rs
@@ -793,9 +793,11 @@ fn extract_struct_traits(ast: &mut AstSrc) {
         "Const",
         "TypeAlias",
         "Impl",
+        "ExternBlock",
+        "ExternCrate",
+        "MacroCall",
         "MacroRules",
         "MacroDef",
-        "Macro",
         "Use",
     ];
 


### PR DESCRIPTION
Some procedural macros tend to get very large invocations, for example RTIC's, leading to issues like https://github.com/rtic-rs/cortex-m-rtic/issues/582, where almost the entire screen is underlined while editing incomplete code in the macro.

This PR shrinks the spans of errors from attribute macros and derives to point only at the attribute, which also matches rustc more closely.

bors r+