### PR TITLE
Print a single ellipsis for any number of omitted types

### DIFF
--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -151,6 +151,12 @@ impl<'a> HirFormatter<'a> {
                 write!(self, "{}", sep)?;
             }
             first = false;
+
+            // Abbreviate multiple omitted types with a single ellipsis.
+            if self.should_truncate() {
+                return write!(self, "{}", TYPE_HINT_TRUNCATION);
+            }
+
             e.hir_fmt(self)?;
         }
         Ok(())


### PR DESCRIPTION
Helps a little bit with https://github.com/rust-analyzer/rust-analyzer/issues/11240

bors r+