### PR TITLE
fix: Don't complete attributes with existing expressions

### DIFF
--- a/crates/ide_completion/src/completions/attribute.rs
+++ b/crates/ide_completion/src/completions/attribute.rs
@@ -56,6 +56,7 @@ pub(crate) fn complete_attribute(acc: &mut Completions, ctx: &CompletionContext)
             _ => (),
         },
         (_, Some(_)) => (),
+        (_, None) if attribute.expr().is_some() => (),
         (_, None) => complete_new_attribute(acc, ctx, attribute),
     }
     Some(())

--- a/crates/ide_completion/src/tests/attribute.rs
+++ b/crates/ide_completion/src/tests/attribute.rs
@@ -41,6 +41,19 @@ struct Foo;
 }
 
 #[test]
+fn proc_macros_on_comment() {
+    check(
+        r#"
+//- proc_macros: identity
+/// $0
+#[proc_macros::identity]
+struct Foo;
+"#,
+        expect![[r#""#]],
+    )
+}
+
+#[test]
 fn proc_macros_qualified() {
     check(
         r#"


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/11254 due to the comment being lowered to an attribute
bors r+ 