### PR TITLE
Considers crates of workspace projects

### DIFF
--- a/crates/project_model/src/cargo_workspace.rs
+++ b/crates/project_model/src/cargo_workspace.rs
@@ -484,11 +484,13 @@ fn cargo_config_build_target(cargo_toml: &ManifestPath) -> Option<String> {
         .env("RUSTC_BOOTSTRAP", "1");
     // if successful we receive `build.target = "target-triple"`
     tracing::debug!("Discovering cargo config target by {:?}", cargo_config);
-    match utf8_stdout(cargo_config) {
+    let r = match utf8_stdout(cargo_config) {
         Ok(stdout) => stdout
             .strip_prefix("build.target = \"")
             .and_then(|stdout| stdout.strip_suffix('"'))
             .map(ToOwned::to_owned),
         Err(_) => None,
-    }
+    };
+    eprintln!("cargo_config_build_target for {:?} yields a target of {:?}", cargo_toml, r);
+    r
 }

--- a/crates/project_model/src/lib.rs
+++ b/crates/project_model/src/lib.rs
@@ -141,7 +141,7 @@ impl ProjectManifest {
             .collect::<FxHashSet<_>>()
             .into_iter()
             .collect::<Vec<_>>();
-        res.sort();
+        res.sort_by(|a, b| b.cmp(a));
         res
     }
 }

--- a/crates/project_model/src/lib.rs
+++ b/crates/project_model/src/lib.rs
@@ -69,18 +69,17 @@ impl ProjectManifest {
     }
 
     pub fn discover_single(path: &AbsPath) -> Result<ProjectManifest> {
-        let mut candidates = ProjectManifest::discover(path)?;
-        let res = match candidates.pop() {
+        let candidates = ProjectManifest::discover(path)?;
+        let res = match candidates.last() {
             None => bail!("no projects"),
-            Some(it) => it,
+            Some(it) => it.clone(),
         };
-
-        if !candidates.is_empty() {
-            bail!("more than one project")
-        }
         Ok(res)
     }
 
+    /// Discover project manifests. The outer most manifest is guaranteed to be
+    /// returned as the last element. Inner manifests are those discovered
+    /// immediately below the given path.
     pub fn discover(path: &AbsPath) -> io::Result<Vec<ProjectManifest>> {
         if let Some(project_json) = find_in_parent_dirs(path, "rust-project.json") {
             return Ok(vec![ProjectManifest::ProjectJson(project_json)]);


### PR DESCRIPTION
Background info: https://github.com/rust-analyzer/rust-analyzer/issues/11268

This is presently yielding the following during discovery:

```
DISCOVERED: [ManifestPath { file: AbsPathBuf("/Users/huntc/Projects/titanclass/embassy-start/client/app/Cargo.toml") }, ManifestPath { file: AbsPathBuf("/Users/huntc/Projects/titanclass/embassy-start/client/embedded-app/Cargo.toml") }, ManifestPath { file: AbsPathBuf("/Users/huntc/Projects/titanclass/embassy-start/client/Cargo.toml") }]
DISCOVERED: [ManifestPath { file: AbsPathBuf("/Users/huntc/Projects/titanclass/embassy-start/network-protocol/Cargo.toml") }]
DISCOVERED: [ManifestPath { file: AbsPathBuf("/Users/huntc/Projects/titanclass/embassy-start/server/app/Cargo.toml") }, ManifestPath { file: AbsPathBuf("/Users/huntc/Projects/titanclass/embassy-start/server/embedded-app/Cargo.toml") }, ManifestPath { file: AbsPathBuf("/Users/huntc/Projects/titanclass/embassy-start/server/Cargo.toml") }]
```

...which looks right.

Then, later on, the targets appear to be resolved correctly:

```
cargo_config_build_target for ManifestPath { file: AbsPathBuf("/Users/huntc/Projects/titanclass/embassy-start/client/Cargo.toml") } yields a target of None
cargo_config_build_target for ManifestPath { file: AbsPathBuf("/Users/huntc/Projects/titanclass/embassy-start/client/app/Cargo.toml") } yields a target of None
cargo_config_build_target for ManifestPath { file: AbsPathBuf("/Users/huntc/Projects/titanclass/embassy-start/client/embedded-app/Cargo.toml") } yields a target of Some("thumbv7em-none-eabihf")
cargo_config_build_target for ManifestPath { file: AbsPathBuf("/Users/huntc/Projects/titanclass/embassy-start/network-protocol/Cargo.toml") } yields a target of None
cargo_config_build_target for ManifestPath { file: AbsPathBuf("/Users/huntc/Projects/titanclass/embassy-start/server/Cargo.toml") } yields a target of None
cargo_config_build_target for ManifestPath { file: AbsPathBuf("/Users/huntc/Projects/titanclass/embassy-start/server/app/Cargo.toml") } yields a target of None
cargo_config_build_target for ManifestPath { file: AbsPathBuf("/Users/huntc/Projects/titanclass/embassy-start/server/embedded-app/Cargo.toml") } yields a target of Some("thumbv7em-none-eabihf")
<snip - repeated a few times>
```

...however, when applying to my project I'm not seeing that `interrupt::take!` macro resolved correctly still. More digging required.
