### PR TITLE
ide: parallel prime caches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,7 +578,6 @@ dependencies = [
  "cfg",
  "cov-mark",
  "crossbeam-channel",
- "crossbeam-utils",
  "dot",
  "either",
  "expect-test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,6 +577,8 @@ version = "0.0.0"
 dependencies = [
  "cfg",
  "cov-mark",
+ "crossbeam-channel",
+ "crossbeam-utils",
  "dot",
  "either",
  "expect-test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,9 +1013,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -1349,6 +1349,7 @@ dependencies = [
  "lsp-types",
  "mbe",
  "mimalloc",
+ "num_cpus",
  "oorandom",
  "parking_lot",
  "proc_macro_api",

--- a/crates/ide/Cargo.toml
+++ b/crates/ide/Cargo.toml
@@ -12,7 +12,6 @@ doctest = false
 [dependencies]
 cov-mark = "2.0.0-pre.1"
 crossbeam-channel = "0.5.0"
-crossbeam-utils = "0.8.5"
 either = "1.5.3"
 itertools = "0.10.0"
 tracing = "0.1"

--- a/crates/ide/Cargo.toml
+++ b/crates/ide/Cargo.toml
@@ -11,6 +11,8 @@ doctest = false
 
 [dependencies]
 cov-mark = "2.0.0-pre.1"
+crossbeam-channel = "0.5.0"
+crossbeam-utils = "0.8.5"
 either = "1.5.3"
 itertools = "0.10.0"
 tracing = "0.1"

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -87,7 +87,7 @@ pub use crate::{
     moniker::{MonikerKind, MonikerResult, PackageInformation},
     move_item::Direction,
     navigation_target::NavigationTarget,
-    prime_caches::{ParallelPrimeCachesProgress, PrimeCachesProgress},
+    prime_caches::ParallelPrimeCachesProgress,
     references::ReferenceSearchResult,
     rename::RenameError,
     runnables::{Runnable, RunnableKind, TestId},
@@ -242,13 +242,6 @@ impl Analysis {
     /// Debug info about the current state of the analysis.
     pub fn status(&self, file_id: Option<FileId>) -> Cancellable<String> {
         self.with_db(|db| status::status(&*db, file_id))
-    }
-
-    pub fn prime_caches<F>(&self, cb: F) -> Cancellable<()>
-    where
-        F: Fn(PrimeCachesProgress) + Sync + std::panic::UnwindSafe,
-    {
-        self.with_db(move |db| prime_caches::prime_caches(db, &cb))
     }
 
     pub fn parallel_prime_caches<F>(&self, num_worker_threads: u8, cb: F) -> Cancellable<()>

--- a/crates/ide/src/lib.rs
+++ b/crates/ide/src/lib.rs
@@ -87,7 +87,7 @@ pub use crate::{
     moniker::{MonikerKind, MonikerResult, PackageInformation},
     move_item::Direction,
     navigation_target::NavigationTarget,
-    prime_caches::PrimeCachesProgress,
+    prime_caches::{ParallelPrimeCachesProgress, PrimeCachesProgress},
     references::ReferenceSearchResult,
     rename::RenameError,
     runnables::{Runnable, RunnableKind, TestId},
@@ -249,6 +249,13 @@ impl Analysis {
         F: Fn(PrimeCachesProgress) + Sync + std::panic::UnwindSafe,
     {
         self.with_db(move |db| prime_caches::prime_caches(db, &cb))
+    }
+
+    pub fn parallel_prime_caches<F>(&self, num_worker_threads: u8, cb: F) -> Cancellable<()>
+    where
+        F: Fn(ParallelPrimeCachesProgress) + Sync + std::panic::UnwindSafe,
+    {
+        self.with_db(move |db| prime_caches::parallel_prime_caches(db, num_worker_threads, &cb))
     }
 
     /// Gets the text of the source file.

--- a/crates/ide/src/prime_caches.rs
+++ b/crates/ide/src/prime_caches.rs
@@ -12,7 +12,7 @@ use ide_db::{
     },
     FxIndexMap,
 };
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 
 use crate::RootDatabase;
 

--- a/crates/ide/src/prime_caches.rs
+++ b/crates/ide/src/prime_caches.rs
@@ -2,10 +2,14 @@
 //! sometimes is counter productive when, for example, the first goto definition
 //! request takes longer to compute. This modules implemented prepopulation of
 //! various caches, it's not really advanced at the moment.
+mod topologic_sort;
 
 use hir::db::DefDatabase;
-use ide_db::base_db::{SourceDatabase, SourceDatabaseExt};
-use rustc_hash::FxHashSet;
+use ide_db::base_db::{
+    salsa::{Database, ParallelDatabase, Snapshot},
+    Cancelled, CrateGraph, CrateId, SourceDatabase, SourceDatabaseExt,
+};
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::RootDatabase;
 
@@ -20,23 +24,8 @@ pub struct PrimeCachesProgress {
 pub(crate) fn prime_caches(db: &RootDatabase, cb: &(dyn Fn(PrimeCachesProgress) + Sync)) {
     let _p = profile::span("prime_caches");
     let graph = db.crate_graph();
-    // We're only interested in the workspace crates and the `ImportMap`s of their direct
-    // dependencies, though in practice the latter also compute the `DefMap`s.
-    // We don't prime transitive dependencies because they're generally not visible in
-    // the current workspace.
-    let to_prime: FxHashSet<_> = graph
-        .iter()
-        .filter(|&id| {
-            let file_id = graph[id].root_file_id;
-            let root_id = db.file_source_root(file_id);
-            !db.source_root(root_id).is_library
-        })
-        .flat_map(|id| graph[id].dependencies.iter().map(|krate| krate.crate_id))
-        .collect();
+    let to_prime = compute_crates_to_prime(db, &graph);
 
-    // FIXME: This would be easy to parallelize, since it's in the ideal ordering for that.
-    // Unfortunately rayon prevents panics from propagation out of a `scope`, which breaks
-    // cancellation, so we cannot use rayon.
     let n_total = to_prime.len();
     for (n_done, &crate_id) in to_prime.iter().enumerate() {
         let crate_name = graph[crate_id].display_name.as_deref().unwrap_or_default().to_string();
@@ -45,4 +34,140 @@ pub(crate) fn prime_caches(db: &RootDatabase, cb: &(dyn Fn(PrimeCachesProgress) 
         // This also computes the DefMap
         db.import_map(crate_id);
     }
+}
+
+/// We're indexing many crates.
+#[derive(Debug)]
+pub struct ParallelPrimeCachesProgress {
+    /// the crates that we are currently priming.
+    pub crates_currently_indexing: Vec<String>,
+    /// the total number of crates we want to prime.
+    pub crates_total: usize,
+    /// the total number of crates that have finished priming
+    pub crates_done: usize,
+}
+
+pub(crate) fn parallel_prime_caches<F>(db: &RootDatabase, num_worker_threads: u8, cb: &F)
+where
+    F: Fn(ParallelPrimeCachesProgress) + Sync + std::panic::UnwindSafe,
+{
+    let _p = profile::span("prime_caches");
+
+    let graph = db.crate_graph();
+    let mut crates_to_prime = {
+        let crate_ids = compute_crates_to_prime(db, &graph);
+
+        let mut builder = topologic_sort::TopologicalSortIter::builder();
+
+        for &crate_id in &crate_ids {
+            let crate_data = &graph[crate_id];
+            let dependencies = crate_data
+                .dependencies
+                .iter()
+                .map(|d| d.crate_id)
+                .filter(|i| crate_ids.contains(i));
+
+            builder.add(crate_id, dependencies);
+        }
+
+        builder.build()
+    };
+
+    crossbeam_utils::thread::scope(move |s| {
+        let (work_sender, work_receiver) = crossbeam_channel::unbounded();
+        let (progress_sender, progress_receiver) = crossbeam_channel::unbounded();
+
+        enum ParallelPrimeCacheWorkerProgress {
+            BeginCrate { crate_id: CrateId, crate_name: String },
+            EndCrate { crate_id: CrateId, cancelled: bool },
+        }
+
+        let prime_caches_worker = move |db: Snapshot<RootDatabase>| {
+            while let Ok((crate_id, crate_name)) = work_receiver.recv() {
+                progress_sender
+                    .send(ParallelPrimeCacheWorkerProgress::BeginCrate { crate_id, crate_name })?;
+
+                let cancelled = Cancelled::catch(|| {
+                    // This also computes the DefMap
+                    db.import_map(crate_id);
+                })
+                .is_err();
+
+                progress_sender
+                    .send(ParallelPrimeCacheWorkerProgress::EndCrate { crate_id, cancelled })?;
+
+                if cancelled {
+                    break;
+                }
+            }
+
+            Ok::<_, crossbeam_channel::SendError<_>>(())
+        };
+
+        for _ in 0..num_worker_threads {
+            let worker = prime_caches_worker.clone();
+            let db = db.snapshot();
+            s.spawn(move |_| worker(db));
+        }
+
+        let crates_total = crates_to_prime.len();
+        let mut crates_done = 0;
+
+        let mut is_cancelled = false;
+        let mut crates_currently_indexing =
+            FxHashMap::with_capacity_and_hasher(num_worker_threads as _, Default::default());
+
+        while !crates_to_prime.is_empty() && !is_cancelled {
+            for crate_id in &mut crates_to_prime {
+                work_sender
+                    .send((
+                        crate_id,
+                        graph[crate_id].display_name.as_deref().unwrap_or_default().to_string(),
+                    ))
+                    .ok();
+            }
+
+            let worker_progress = match progress_receiver.recv() {
+                Ok(p) => p,
+                Err(_) => break,
+            };
+            match worker_progress {
+                ParallelPrimeCacheWorkerProgress::BeginCrate { crate_id, crate_name } => {
+                    crates_currently_indexing.insert(crate_id, crate_name);
+                }
+                ParallelPrimeCacheWorkerProgress::EndCrate { crate_id, cancelled } => {
+                    crates_currently_indexing.remove(&crate_id);
+                    crates_to_prime.mark_done(crate_id);
+                    crates_done += 1;
+                    is_cancelled = cancelled;
+                }
+            };
+
+            let progress = ParallelPrimeCachesProgress {
+                crates_currently_indexing: crates_currently_indexing.values().cloned().collect(),
+                crates_done,
+                crates_total,
+            };
+
+            cb(progress);
+            db.unwind_if_cancelled();
+        }
+    })
+    .unwrap();
+}
+
+fn compute_crates_to_prime(db: &RootDatabase, graph: &CrateGraph) -> FxHashSet<CrateId> {
+    // We're only interested in the workspace crates and the `ImportMap`s of their direct
+    // dependencies, though in practice the latter also compute the `DefMap`s.
+    // We don't prime transitive dependencies because they're generally not visible in
+    // the current workspace.
+    graph
+        .iter()
+        .filter(|&id| {
+            let file_id = graph[id].root_file_id;
+            let root_id = db.file_source_root(file_id);
+            !db.source_root(root_id).is_library
+        })
+        .flat_map(|id| graph[id].dependencies.iter().map(|krate| krate.crate_id))
+        .collect()
 }

--- a/crates/ide/src/prime_caches.rs
+++ b/crates/ide/src/prime_caches.rs
@@ -7,7 +7,7 @@ mod topologic_sort;
 use hir::db::DefDatabase;
 use ide_db::base_db::{
     salsa::{Database, ParallelDatabase, Snapshot},
-    Cancelled, CrateGraph, CrateId, SourceDatabase, SourceDatabaseExt,
+    CrateGraph, CrateId, SourceDatabase, SourceDatabaseExt,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -104,7 +104,6 @@ where
 
         let crates_total = crates_to_prime.len();
         let mut crates_done = 0;
-
         let mut crates_currently_indexing =
             FxHashMap::with_capacity_and_hasher(num_worker_threads as _, Default::default());
 

--- a/crates/ide/src/prime_caches.rs
+++ b/crates/ide/src/prime_caches.rs
@@ -16,29 +16,6 @@ use rustc_hash::FxHashSet;
 
 use crate::RootDatabase;
 
-/// We started indexing a crate.
-#[derive(Debug)]
-pub struct PrimeCachesProgress {
-    pub on_crate: String,
-    pub n_done: usize,
-    pub n_total: usize,
-}
-
-pub(crate) fn prime_caches(db: &RootDatabase, cb: &(dyn Fn(PrimeCachesProgress) + Sync)) {
-    let _p = profile::span("prime_caches");
-    let graph = db.crate_graph();
-    let to_prime = compute_crates_to_prime(db, &graph);
-
-    let n_total = to_prime.len();
-    for (n_done, &crate_id) in to_prime.iter().enumerate() {
-        let crate_name = graph[crate_id].display_name.as_deref().unwrap_or_default().to_string();
-
-        cb(PrimeCachesProgress { on_crate: crate_name, n_done, n_total });
-        // This also computes the DefMap
-        db.import_map(crate_id);
-    }
-}
-
 /// We're indexing many crates.
 #[derive(Debug)]
 pub struct ParallelPrimeCachesProgress {

--- a/crates/ide/src/prime_caches.rs
+++ b/crates/ide/src/prime_caches.rs
@@ -108,7 +108,8 @@ pub(crate) fn parallel_prime_caches(
         }
 
         // recv_timeout is somewhat a hack, we need a way to from this thread check to see if the current salsa revision
-        // is cancelled.
+        // is cancelled on a regular basis. workers will only exit if they are processing a task that is cancelled, or
+        // if this thread exits, and closes the work channel.
         let worker_progress = match progress_receiver.recv_timeout(Duration::from_millis(10)) {
             Ok(p) => p,
             Err(crossbeam_channel::RecvTimeoutError::Timeout) => {

--- a/crates/ide/src/prime_caches.rs
+++ b/crates/ide/src/prime_caches.rs
@@ -47,10 +47,11 @@ pub struct ParallelPrimeCachesProgress {
     pub crates_done: usize,
 }
 
-pub(crate) fn parallel_prime_caches<F>(db: &RootDatabase, num_worker_threads: u8, cb: &F)
-where
-    F: Fn(ParallelPrimeCachesProgress) + Sync + std::panic::UnwindSafe,
-{
+pub(crate) fn parallel_prime_caches(
+    db: &RootDatabase,
+    num_worker_threads: u8,
+    cb: &(dyn Fn(ParallelPrimeCachesProgress) + Sync),
+) {
     let _p = profile::span("prime_caches");
 
     let graph = db.crate_graph();

--- a/crates/ide/src/prime_caches/topologic_sort.rs
+++ b/crates/ide/src/prime_caches/topologic_sort.rs
@@ -2,7 +2,7 @@ use std::{collections::VecDeque, hash::Hash};
 
 use rustc_hash::FxHashMap;
 
-pub struct TopologicSortIterBuilder<T> {
+pub(crate) struct TopologicSortIterBuilder<T> {
     nodes: FxHashMap<T, Entry<T>>,
 }
 
@@ -18,7 +18,7 @@ where
         self.nodes.entry(item).or_default()
     }
 
-    pub fn add(&mut self, item: T, predecessors: impl IntoIterator<Item = T>) {
+    pub(crate) fn add(&mut self, item: T, predecessors: impl IntoIterator<Item = T>) {
         let mut num_predecessors = 0;
 
         for predecessor in predecessors.into_iter() {
@@ -30,7 +30,7 @@ where
         entry.num_predecessors += num_predecessors;
     }
 
-    pub fn build(self) -> TopologicalSortIter<T> {
+    pub(crate) fn build(self) -> TopologicalSortIter<T> {
         let ready = self
             .nodes
             .iter()
@@ -43,7 +43,7 @@ where
     }
 }
 
-pub struct TopologicalSortIter<T> {
+pub(crate) struct TopologicalSortIter<T> {
     ready: VecDeque<T>,
     nodes: FxHashMap<T, Entry<T>>,
 }
@@ -52,19 +52,19 @@ impl<T> TopologicalSortIter<T>
 where
     T: Copy + Eq + PartialEq + Hash,
 {
-    pub fn builder() -> TopologicSortIterBuilder<T> {
+    pub(crate) fn builder() -> TopologicSortIterBuilder<T> {
         TopologicSortIterBuilder::new()
     }
 
-    pub fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         self.nodes.len()
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
-    pub fn mark_done(&mut self, item: T) {
+    pub(crate) fn mark_done(&mut self, item: T) {
         let entry = self.nodes.remove(&item).expect("invariant: unknown item marked as done");
 
         for successor in entry.successors {

--- a/crates/ide/src/prime_caches/topologic_sort.rs
+++ b/crates/ide/src/prime_caches/topologic_sort.rs
@@ -56,12 +56,12 @@ where
         TopologicSortIterBuilder::new()
     }
 
-    pub(crate) fn len(&self) -> usize {
+    pub(crate) fn pending(&self) -> usize {
         self.nodes.len()
     }
 
     pub(crate) fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.nodes.len() == 0 && self.ready.len() == 0
     }
 
     pub(crate) fn mark_done(&mut self, item: T) {

--- a/crates/ide/src/prime_caches/topologic_sort.rs
+++ b/crates/ide/src/prime_caches/topologic_sort.rs
@@ -60,10 +60,6 @@ where
         self.nodes.len()
     }
 
-    pub(crate) fn is_empty(&self) -> bool {
-        self.nodes.len() == 0 && self.ready.len() == 0
-    }
-
     pub(crate) fn mark_done(&mut self, item: T) {
         let entry = self.nodes.remove(&item).expect("invariant: unknown item marked as done");
 

--- a/crates/ide/src/prime_caches/topologic_sort.rs
+++ b/crates/ide/src/prime_caches/topologic_sort.rs
@@ -1,3 +1,4 @@
+//! helper data structure to schedule work for parallel prime caches.
 use std::{collections::VecDeque, hash::Hash};
 
 use rustc_hash::FxHashMap;

--- a/crates/ide/src/prime_caches/topologic_sort.rs
+++ b/crates/ide/src/prime_caches/topologic_sort.rs
@@ -1,0 +1,101 @@
+use std::{collections::VecDeque, hash::Hash};
+
+use rustc_hash::FxHashMap;
+
+pub struct TopologicSortIterBuilder<T> {
+    nodes: FxHashMap<T, Entry<T>>,
+}
+
+impl<T> TopologicSortIterBuilder<T>
+where
+    T: Copy + Eq + PartialEq + Hash,
+{
+    fn new() -> Self {
+        Self { nodes: Default::default() }
+    }
+
+    fn get_or_create_entry(&mut self, item: T) -> &mut Entry<T> {
+        self.nodes.entry(item).or_default()
+    }
+
+    pub fn add(&mut self, item: T, predecessors: impl IntoIterator<Item = T>) {
+        let mut num_predecessors = 0;
+
+        for predecessor in predecessors.into_iter() {
+            self.get_or_create_entry(predecessor).successors.push(item);
+            num_predecessors += 1;
+        }
+
+        let entry = self.get_or_create_entry(item);
+        entry.num_predecessors += num_predecessors;
+    }
+
+    pub fn build(self) -> TopologicalSortIter<T> {
+        let ready = self
+            .nodes
+            .iter()
+            .filter_map(
+                |(item, entry)| if entry.num_predecessors == 0 { Some(*item) } else { None },
+            )
+            .collect();
+
+        TopologicalSortIter { nodes: self.nodes, ready }
+    }
+}
+
+pub struct TopologicalSortIter<T> {
+    ready: VecDeque<T>,
+    nodes: FxHashMap<T, Entry<T>>,
+}
+
+impl<T> TopologicalSortIter<T>
+where
+    T: Copy + Eq + PartialEq + Hash,
+{
+    pub fn builder() -> TopologicSortIterBuilder<T> {
+        TopologicSortIterBuilder::new()
+    }
+
+    pub fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn mark_done(&mut self, item: T) {
+        let entry = self.nodes.remove(&item).expect("invariant: unknown item marked as done");
+
+        for successor in entry.successors {
+            let succ_entry = self
+                .nodes
+                .get_mut(&successor)
+                .expect("invariant: unknown successor referenced by entry");
+
+            succ_entry.num_predecessors -= 1;
+            if succ_entry.num_predecessors == 0 {
+                self.ready.push_back(successor);
+            }
+        }
+    }
+}
+
+impl<T> Iterator for TopologicalSortIter<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.ready.pop_front()
+    }
+}
+
+struct Entry<T> {
+    successors: Vec<T>,
+    num_predecessors: usize,
+}
+
+impl<T> Default for Entry<T> {
+    fn default() -> Self {
+        Self { successors: Default::default(), num_predecessors: 0 }
+    }
+}

--- a/crates/rust-analyzer/Cargo.toml
+++ b/crates/rust-analyzer/Cargo.toml
@@ -31,6 +31,7 @@ serde = { version = "1.0.106", features = ["derive"] }
 serde_json = { version = "1.0.48", features = ["preserve_order"] }
 threadpool = "1.7.1"
 rayon = "1.5"
+num_cpus = "1.13.1"
 mimalloc = { version = "0.1.19", default-features = false, optional = true }
 lsp-server = "0.5.1"
 tracing = "0.1"

--- a/crates/rust-analyzer/src/cli/load_cargo.rs
+++ b/crates/rust-analyzer/src/cli/load_cargo.rs
@@ -88,7 +88,7 @@ pub fn load_workspace(
         load_crate_graph(crate_graph, project_folders.source_root_config, &mut vfs, &receiver);
 
     if load_config.prefill_caches {
-        host.analysis().prime_caches(|_| {})?;
+        host.analysis().parallel_prime_caches(1, |_| {})?;
     }
     Ok((host, vfs, proc_macro_client))
 }

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -509,10 +509,13 @@ impl GlobalState {
                 let analysis = self.snapshot().analysis;
                 move |sender| {
                     sender.send(Task::PrimeCaches(PrimeCachesProgress::Begin)).unwrap();
-                    let res = analysis.parallel_prime_caches(32, |progress| {
-                        let report = PrimeCachesProgress::Report(progress);
-                        sender.send(Task::PrimeCaches(report)).unwrap();
-                    });
+                    let res = analysis.parallel_prime_caches(
+                        num_cpus::get_physical().try_into().unwrap_or(u8::MAX),
+                        |progress| {
+                            let report = PrimeCachesProgress::Report(progress);
+                            sender.send(Task::PrimeCaches(report)).unwrap();
+                        },
+                    );
                     sender
                         .send(Task::PrimeCaches(PrimeCachesProgress::End {
                             cancelled: res.is_err(),

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -454,6 +454,11 @@ Number of syntax trees rust-analyzer keeps in memory. Defaults to 128.
 --
 Whether to show `can't find Cargo.toml` error message.
 --
+[[rust-analyzer.primeCaches.numThreads]]rust-analyzer.primeCaches.numThreads (default: `0`)::
++
+--
+How many worker threads to to handle priming caches. The default `0` means to pick automatically.
+--
 [[rust-analyzer.procMacro.enable]]rust-analyzer.procMacro.enable (default: `true`)::
 +
 --

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -880,6 +880,13 @@
                     "default": true,
                     "type": "boolean"
                 },
+                "rust-analyzer.primeCaches.numThreads": {
+                    "markdownDescription": "How many worker threads to to handle priming caches. The default `0` means to pick automatically.",
+                    "default": 0,
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 255
+                },
                 "rust-analyzer.procMacro.enable": {
                     "markdownDescription": "Enable support for procedural macros, implies `#rust-analyzer.cargo.runBuildScripts#`.",
                     "default": true,


### PR DESCRIPTION
cache priming goes brrrr... the successor to #10149

---

this PR implements a parallel cache priming strategy that uses a topological work queue to feed a pool of worker threads the crates to index in parallel.

## todo
- [x] should we keep the old prime caches?
- [x] we should use num_cpus to detect how many cpus to use to prime caches. should we also expose a config for # of worker CPU threads to use?
- [x] something is wonky with cancellation, need to figure it out before this can merge. 