### PR TITLE
fix: rust-analyzer spamming overly error message when workspace not being loaded

### DIFF
--- a/crates/ide_assists/src/handlers/expand_glob_import.rs
+++ b/crates/ide_assists/src/handlers/expand_glob_import.rs
@@ -226,9 +226,7 @@ fn find_imported_defs(ctx: &AssistContext, star: SyntaxToken) -> Option<Vec<Defi
             .flat_map(|n| n.descendants().filter_map(ast::NameRef::cast))
             .filter_map(|r| match NameRefClass::classify(&ctx.sema, &r)? {
                 NameRefClass::Definition(
-                    def
-                    @
-                    (Definition::Macro(_)
+                    def @ (Definition::Macro(_)
                     | Definition::Module(_)
                     | Definition::Function(_)
                     | Definition::Adt(_)

--- a/crates/ide_completion/src/completions/qualified_path.rs
+++ b/crates/ide_completion/src/completions/qualified_path.rs
@@ -171,9 +171,7 @@ pub(crate) fn complete_qualified_path(acc: &mut Completions, ctx: &CompletionCon
             }
         }
         hir::PathResolution::Def(
-            def
-            @
-            (hir::ModuleDef::Adt(_)
+            def @ (hir::ModuleDef::Adt(_)
             | hir::ModuleDef::TypeAlias(_)
             | hir::ModuleDef::BuiltinType(_)),
         ) => {

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -524,7 +524,7 @@ impl GlobalState {
         }
 
         let loop_duration = loop_start.elapsed();
-        if loop_duration > Duration::from_millis(100) {
+        if loop_duration > Duration::from_millis(100) && was_quiescent {
             tracing::warn!("overly long loop turn: {:?}", loop_duration);
             self.poke_rust_analyzer_developer(format!(
                 "overly long loop turn: {:?}",


### PR DESCRIPTION
Fixes #10120