### PR TITLE
Support <code> blocks from Rust docs in vscode hover

### DIFF
--- a/editors/code/src/client.ts
+++ b/editors/code/src/client.ts
@@ -155,6 +155,9 @@ export function createClient(serverPath: string, workspace: Workspace, extraEnv:
                 );
             }
 
+        },
+        markdown: {
+            supportHtml: true,
         }
     };
 


### PR DESCRIPTION
Set `"supportHtml": true` to support rendering `<code>` blocks in hovers.

e.g.  https://github.com/rust-lang/rust/blob/1bd4fdc943513e1004f498bbf289279c9784fc6f/library/std/src/fs.rs#L109