### PR TITLE
internal: Decrease PartialOrd and PartialEq trait methods completion relevance

### DIFF
--- a/crates/ide_completion/src/context.rs
+++ b/crates/ide_completion/src/context.rs
@@ -940,6 +940,7 @@ const OP_TRAIT_LANG_NAMES: &[&str] = &[
     "deref",
     "div_assign",
     "div",
+    "eq",
     "fn_mut",
     "fn_once",
     "fn",
@@ -949,13 +950,13 @@ const OP_TRAIT_LANG_NAMES: &[&str] = &[
     "mul",
     "neg",
     "not",
+    "partial_ord",
     "rem_assign",
     "rem",
     "shl_assign",
     "shl",
     "shr_assign",
     "shr",
-    "sub",
     "sub",
 ];
 #[cfg(test)]

--- a/crates/ide_completion/src/item.rs
+++ b/crates/ide_completion/src/item.rs
@@ -139,7 +139,7 @@ pub struct CompletionRelevance {
     /// }
     /// ```
     pub is_local: bool,
-    /// Set for method completions of the `core::ops` family.
+    /// Set for method completions of the `core::ops` and `core::cmp` family.
     pub is_op_method: bool,
     /// This is set in cases like these:
     ///


### PR DESCRIPTION

Fixes https://github.com/rust-analyzer/rust-analyzer/issues/10245
bors r+