### PR TITLE
fix: status: output all crates a file belongs to

### DIFF
--- a/crates/ide/src/status.rs
+++ b/crates/ide/src/status.rs
@@ -45,23 +45,23 @@ pub(crate) fn status(db: &RootDatabase, file_id: Option<FileId>) -> String {
 
     if let Some(file_id) = file_id {
         format_to!(buf, "\nFile info:\n");
-        let krate = crate::parent_module::crate_for(db, file_id).pop();
-        match krate {
-            Some(krate) => {
-                let crate_graph = db.crate_graph();
-                let display_crate = |krate: CrateId| match &crate_graph[krate].display_name {
-                    Some(it) => format!("{}({:?})", it, krate),
-                    None => format!("{:?}", krate),
-                };
-                format_to!(buf, "Crate: {}\n", display_crate(krate));
-                let deps = crate_graph[krate]
-                    .dependencies
-                    .iter()
-                    .map(|dep| format!("{}={:?}", dep.name, dep.crate_id))
-                    .format(", ");
-                format_to!(buf, "Dependencies: {}\n", deps);
-            }
-            None => format_to!(buf, "Does not belong to any crate"),
+        let crates = crate::parent_module::crate_for(db, file_id);
+        if crates.is_empty() {
+            format_to!(buf, "Does not belong to any crate");
+        }
+        let crate_graph = db.crate_graph();
+        for krate in crates {
+            let display_crate = |krate: CrateId| match &crate_graph[krate].display_name {
+                Some(it) => format!("{}({:?})", it, krate),
+                None => format!("{:?}", krate),
+            };
+            format_to!(buf, "Crate: {}\n", display_crate(krate));
+            let deps = crate_graph[krate]
+                .dependencies
+                .iter()
+                .map(|dep| format!("{}={:?}", dep.name, dep.crate_id))
+                .format(", ");
+            format_to!(buf, "Dependencies: {}\n", deps);
         }
     }
 


### PR DESCRIPTION
While investigating https://github.com/rust-analyzer/rust-analyzer/issues/11300 I noticed that we only output the first crate, which masks the reason for that issue – the file in question is the root of multiple crates, and one is missing dependencies.

This PR makes "Rust Analyzer: Status" include *every* crate a file is part of.

bors r+