### PR TITLE
fix: insert auto-imports after header comments

### DIFF
--- a/crates/ide_db/src/helpers/insert_use.rs
+++ b/crates/ide_db/src/helpers/insert_use.rs
@@ -401,7 +401,7 @@ fn insert_use_(
         .children_with_tokens()
         .filter(|child| match child {
             NodeOrToken::Node(node) => is_inner_attribute(node.clone()),
-            NodeOrToken::Token(token) => is_inner_comment(token.clone()),
+            NodeOrToken::Token(token) => is_comment(token.clone()),
         })
         .last()
     {
@@ -440,7 +440,6 @@ fn is_inner_attribute(node: SyntaxNode) -> bool {
     ast::Attr::cast(node).map(|attr| attr.kind()) == Some(ast::AttrKind::Inner)
 }
 
-fn is_inner_comment(token: SyntaxToken) -> bool {
-    ast::Comment::cast(token).and_then(|comment| comment.kind().doc)
-        == Some(ast::CommentPlacement::Inner)
+fn is_comment(token: SyntaxToken) -> bool {
+    ast::Comment::cast(token).is_some()
 }

--- a/crates/ide_db/src/helpers/insert_use/tests.rs
+++ b/crates/ide_db/src/helpers/insert_use/tests.rs
@@ -402,6 +402,21 @@ use foo::bar::Baz;"#,
 }
 
 #[test]
+fn inserts_after_multiple_single_line_comments() {
+    check_none(
+        "foo::bar::Baz",
+        "// Represents a possible license header and/or general module comments
+// Second single-line comment
+// Third single-line comment",
+        r#"// Represents a possible license header and/or general module comments
+// Second single-line comment
+// Third single-line comment
+
+use foo::bar::Baz;"#,
+    );
+}
+
+#[test]
 fn inserts_before_single_line_item_comments() {
     check_none(
         "foo::bar::Baz",

--- a/crates/ide_db/src/helpers/insert_use/tests.rs
+++ b/crates/ide_db/src/helpers/insert_use/tests.rs
@@ -430,6 +430,23 @@ fn foo() {}"#,
 }
 
 #[test]
+fn inserts_after_single_line_header_comments_and_before_item() {
+    check_none(
+        "foo::bar::Baz",
+        r#"// Represents a possible license header
+// Line two of possible license header
+
+fn foo() {}"#,
+        r#"// Represents a possible license header
+// Line two of possible license header
+
+use foo::bar::Baz;
+
+fn foo() {}"#,
+    );
+}
+
+#[test]
 fn inserts_after_multiline_inner_comments() {
     check_none(
         "foo::bar::Baz",

--- a/crates/ide_db/src/helpers/insert_use/tests.rs
+++ b/crates/ide_db/src/helpers/insert_use/tests.rs
@@ -391,6 +391,30 @@ use foo::bar::Baz;"#,
 }
 
 #[test]
+fn inserts_after_single_line_comments() {
+    check_none(
+        "foo::bar::Baz",
+        "// Represents a possible license header and/or general module comments",
+        r#"// Represents a possible license header and/or general module comments
+
+use foo::bar::Baz;"#,
+    );
+}
+
+#[test]
+fn inserts_before_single_line_item_comments() {
+    check_none(
+        "foo::bar::Baz",
+        r#"// Represents a comment about a function
+fn foo() {}"#,
+        r#"use foo::bar::Baz;
+
+// Represents a comment about a function
+fn foo() {}"#,
+    );
+}
+
+#[test]
 fn inserts_after_multiline_inner_comments() {
     check_none(
         "foo::bar::Baz",


### PR DESCRIPTION
Fixes #8607.

This commit changes the auto-import functionality and causes it to add imports after any leading comments, which are commonly license headers. This does not affect comments on items as they're considered part of the item itself and not separate.