### PR TITLE
Bump ide_db rust-version to 1.58

### DIFF
--- a/crates/ide_db/Cargo.toml
+++ b/crates/ide_db/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 description = "TBD"
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.58"
 
 [lib]
 doctest = false


### PR DESCRIPTION
ide_db/src/helpers/format_string.rs uses format strings
that are only supported in 1.58.  This change helps
alert a user to the specific problem instead of
a generic compilation issue if compiling fails.