### PR TITLE
Extract function also extracts comments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["crates/proc_macro_test/imp"]
 [profile.dev]
 # Disabling debug info speeds up builds a bunch,
 # and we don't rely on it for debugging that much.
-debug = 0
+debug = 2
 
 [profile.dev.package]
 # These speed up local tests.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ exclude = ["crates/proc_macro_test/imp"]
 [profile.dev]
 # Disabling debug info speeds up builds a bunch,
 # and we don't rely on it for debugging that much.
-debug = 2
+debug = 0
 
 [profile.dev.package]
 # These speed up local tests.

--- a/crates/ide_assists/src/handlers/extract_function.rs
+++ b/crates/ide_assists/src/handlers/extract_function.rs
@@ -4447,7 +4447,7 @@ fn func() {
             r#"
 fn func() {
     let i = 0;
-    
+
     fun_name();
 }
 

--- a/crates/ide_assists/src/handlers/extract_function.rs
+++ b/crates/ide_assists/src/handlers/extract_function.rs
@@ -4549,6 +4549,7 @@ fn $0fun_name() {
         );
     }
 
+    // FIXME: we do want to preserve whitespace
     #[test]
     fn extract_function_does_not_preserve_whitespace() {
         check_assist(

--- a/crates/ide_assists/src/handlers/extract_function.rs
+++ b/crates/ide_assists/src/handlers/extract_function.rs
@@ -1467,6 +1467,7 @@ fn make_body(
                 .filter(|it| text_range.contains_range(it.text_range()))
                 .map(|it| match it {
                     syntax::NodeOrToken::Node(n) => {
+                        println!("Found node: {:?}", n);
                         return syntax::NodeOrToken::try_from(rewrite_body_segment(
                             ctx,
                             &fun.params,
@@ -1476,6 +1477,7 @@ fn make_body(
                         .unwrap()
                     }
                     syntax::NodeOrToken::Token(t) => {
+                        println!("Found token: {:?}", t);
                         return syntax::NodeOrToken::try_from(t).unwrap()
                     }
                 })
@@ -1487,7 +1489,11 @@ fn make_body(
                         elements.push(node);
                         None
                     })
-                }
+                },
+                Some(token) if token.as_token().is_some() && token.as_token().unwrap().kind() == COMMENT => {
+                    elements.push(token);
+                    None
+                },
                 _ => None,
             };
 

--- a/crates/ide_assists/src/handlers/extract_function.rs
+++ b/crates/ide_assists/src/handlers/extract_function.rs
@@ -4437,8 +4437,7 @@ fn $0fun_name() {
             extract_function,
             r#"
 fn func() {
-    let i = 0;
-    $0
+    let i = 0;$0
     let a = 0;
     // comment here!
     let x = 0;$0
@@ -4447,7 +4446,6 @@ fn func() {
             r#"
 fn func() {
     let i = 0;
-
     fun_name();
 }
 
@@ -4572,9 +4570,9 @@ fn $0fun_name() {
             r#"
 fn func() {
     let i = 0;
-    $0/* 
-    a 
-    comment 
+    $0/*
+    a
+    comment
     */
     let x = 0;$0
 }
@@ -4586,9 +4584,9 @@ fn func() {
 }
 
 fn $0fun_name() {
-    /* 
-    a 
-    comment 
+    /*
+    a
+    comment
     */
     let x = 0;
 }
@@ -4603,9 +4601,9 @@ fn $0fun_name() {
             r#"
 fn func() {
     let i = 0;
-    $0/* 
-    a 
-    comment 
+    $0/*
+    a
+    comment
     */
     $0let x = 0;
 }
@@ -4618,9 +4616,9 @@ fn func() {
 }
 
 fn $0fun_name() {
-    /* 
-    a 
-    comment 
+    /*
+    a
+    comment
     */
 }
 "#,

--- a/crates/ide_assists/src/handlers/extract_function.rs
+++ b/crates/ide_assists/src/handlers/extract_function.rs
@@ -1483,7 +1483,7 @@ fn make_body(
             };
 
             let body_indent = IndentLevel(1);
-            let elements: Vec<SyntaxElement> = elements
+            let elements = elements
                 .into_iter()
                 .map(|node_or_token| match &node_or_token {
                     syntax::NodeOrToken::Node(node) => match ast::Stmt::cast(node.clone()) {

--- a/crates/ide_assists/src/handlers/extract_function.rs
+++ b/crates/ide_assists/src/handlers/extract_function.rs
@@ -4600,35 +4600,4 @@ fn $0fun_name() {
 "#,
         );
     }
-
-    #[test]
-    fn extract_function_long_form_comment_multiline() {
-        check_assist(
-            extract_function,
-            r#"
-fn func() {
-    let i = 0;
-    $0/*
-    a
-    comment
-    */
-    let x = 0;$0
-}
-"#,
-            r#"
-fn func() {
-    let i = 0;
-    fun_name();
-}
-
-fn $0fun_name() {
-    /*
-    a
-    comment
-    */
-    let x = 0;
-}
-"#,
-        );
-    }
 }

--- a/crates/ide_assists/src/handlers/extract_function.rs
+++ b/crates/ide_assists/src/handlers/extract_function.rs
@@ -22,8 +22,9 @@ use syntax::{
         edit::{AstNodeEdit, IndentLevel},
         AstNode,
     },
-    match_ast, ted, SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken, TextRange, TextSize,
-    TokenAtOffset, WalkEvent, T,
+    match_ast, ted, SyntaxElement,
+    SyntaxKind::{self, COMMENT},
+    SyntaxNode, SyntaxToken, TextRange, TextSize, TokenAtOffset, WalkEvent, T,
 };
 
 use crate::{
@@ -64,7 +65,13 @@ pub(crate) fn extract_function(acc: &mut Assists, ctx: &AssistContext) -> Option
         return None;
     }
 
-    let node = match ctx.covering_element() {
+    let node = ctx.covering_element();
+    if node.kind() == COMMENT {
+        cov_mark::hit!(extract_function_in_comment_is_not_applicable);
+        return None;
+    }
+
+    let node = match node {
         syntax::NodeOrToken::Node(n) => n,
         syntax::NodeOrToken::Token(t) => t.parent()?,
     };
@@ -2200,6 +2207,12 @@ fn $0fun_name(n: u32) -> u32 {
 }
 "#,
         )
+    }
+
+    #[test]
+    fn in_comment_is_not_applicable() {
+        cov_mark::check!(extract_function_in_comment_is_not_applicable);
+        check_assist_not_applicable(extract_function, r"fn main() { 1 + /* $0comment$0 */ 1; }");
     }
 
     #[test]
@@ -4589,37 +4602,6 @@ fn $0fun_name() {
     comment
     */
     let x = 0;
-}
-"#,
-        );
-    }
-
-    #[test]
-    fn extract_function_long_form_comment_multiline_alone() {
-        check_assist(
-            extract_function,
-            r#"
-fn func() {
-    let i = 0;
-    $0/*
-    a
-    comment
-    */
-    $0let x = 0;
-}
-"#,
-            r#"
-fn func() {
-    let i = 0;
-    fun_name();
-    let x = 0;
-}
-
-fn $0fun_name() {
-    /*
-    a
-    comment
-    */
 }
 "#,
         );

--- a/crates/ide_assists/src/handlers/extract_function.rs
+++ b/crates/ide_assists/src/handlers/extract_function.rs
@@ -4397,4 +4397,31 @@ fn $0fun_name(arg: &mut Foo) {
 "#,
         );
     }
+
+    #[test]
+    fn extract_function_copies_comments() {
+        check_assist(
+            extract_function,
+            r#"
+fn func() {
+    let i = 0;
+    $0
+    // comment here!
+    let x = 0;
+    $0
+}
+"#,
+            r#"
+fn func() {
+    let i = 0;
+    fun_name();
+}
+
+fn $0fun_name() {
+    // comment here!
+    let x = 0;
+}
+"#,
+        );
+    }
 }

--- a/crates/ide_assists/src/handlers/extract_function.rs
+++ b/crates/ide_assists/src/handlers/extract_function.rs
@@ -1451,7 +1451,7 @@ fn make_body(
                     syntax::NodeOrToken::Node(n) => syntax::NodeOrToken::Node(
                         rewrite_body_segment(ctx, &fun.params, &handler, &n),
                     ),
-                    syntax::NodeOrToken::Token(_) => it,
+                    _ => it,
                 })
                 .collect();
 
@@ -1462,7 +1462,7 @@ fn make_body(
                     }
                     _ => None,
                 },
-                None => None,
+                _ => None,
             };
 
             match tail_expr {
@@ -1492,7 +1492,7 @@ fn make_body(
                             let ast_node = indented.syntax().clone_subtree();
                             syntax::NodeOrToken::Node(ast_node)
                         }
-                        None => node_or_token,
+                        _ => node_or_token,
                     },
                     _ => node_or_token,
                 })

--- a/crates/ide_assists/src/handlers/extract_function.rs
+++ b/crates/ide_assists/src/handlers/extract_function.rs
@@ -1524,9 +1524,7 @@ fn make_body(
                 println!("element: {:?}", element);
             }
 
-            make::block_expr_full(elements, tail_expr)
-
-            // make::block_expr(parent.statements().into_iter(), tail_expr)
+            make::hacky_block_expr_with_comments(elements, tail_expr)
         }
     };
 

--- a/crates/ide_assists/src/handlers/extract_function.rs
+++ b/crates/ide_assists/src/handlers/extract_function.rs
@@ -482,9 +482,7 @@ impl FunctionBody {
         let full_body = parent.syntax().children_with_tokens();
 
         let mut text_range = full_body
-            .filter(|it| {
-                matches!(it.kind().is_punct() || it.kind() == SyntaxKind::WHITESPACE, false)
-            })
+            .filter(|it| ast::Stmt::can_cast(it.kind()) || it.kind() == COMMENT)
             .map(|element| element.text_range())
             .filter(|&range| selected.intersect(range).filter(|it| !it.is_empty()).is_some())
             .reduce(|acc, stmt| acc.cover(stmt));

--- a/crates/ide_assists/src/handlers/extract_function.rs
+++ b/crates/ide_assists/src/handlers/extract_function.rs
@@ -1459,12 +1459,9 @@ fn make_body(
                 .collect();
 
             let mut tail_expr = match &elements.last() {
-                Some(element) => match element {
-                    syntax::NodeOrToken::Node(node) if ast::Expr::can_cast(node.kind()) => {
-                        ast::Expr::cast(node.clone())
-                    }
-                    _ => None,
-                },
+                Some(syntax::NodeOrToken::Node(node)) if ast::Expr::can_cast(node.kind()) => {
+                    ast::Expr::cast(node.clone())
+                }
                 _ => None,
             };
 

--- a/crates/ide_assists/src/handlers/extract_function.rs
+++ b/crates/ide_assists/src/handlers/extract_function.rs
@@ -33,12 +33,13 @@ use crate::{
 
 // Assist: extract_function
 //
-// Extracts selected statements into new function.
+// Extracts selected statements and comments into new function.
 //
 // ```
 // fn main() {
 //     let n = 1;
 //     $0let m = n + 2;
+//     // calculate
 //     let k = m + n;$0
 //     let g = 3;
 // }
@@ -53,6 +54,7 @@ use crate::{
 //
 // fn $0fun_name(n: i32) {
 //     let m = n + 2;
+//     // calculate
 //     let k = m + n;
 // }
 // ```

--- a/crates/ide_assists/src/tests/generated.rs
+++ b/crates/ide_assists/src/tests/generated.rs
@@ -507,6 +507,7 @@ fn doctest_extract_function() {
 fn main() {
     let n = 1;
     $0let m = n + 2;
+    // calculate
     let k = m + n;$0
     let g = 3;
 }
@@ -520,6 +521,7 @@ fn main() {
 
 fn $0fun_name(n: i32) {
     let m = n + 2;
+    // calculate
     let k = m + n;
 }
 "#####,

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -331,7 +331,7 @@ pub fn block_expr(
 
 /// Ideally this function wouldn't exist since it involves manual indenting.
 /// It differs from `make::block_expr` by also supporting comments.
-/// 
+///
 /// FIXME: replace usages of this with the mutable syntax tree API
 pub fn hacky_block_expr_with_comments(
     elements: impl IntoIterator<Item = crate::SyntaxElement>,

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -335,14 +335,15 @@ pub fn block_expr_full(
 ) -> ast::BlockExpr {
     let mut buf = "{\n".to_string();
     for stmt in stmts.into_iter() {
-        
         match stmt {
             rowan::NodeOrToken::Node(n) => {
                 println!("Node: {:?}", n.text());
                 format_to!(buf, "    {}\n", n)
-            },
-            rowan::NodeOrToken::Token(t) if t.kind() == SyntaxKind::COMMENT => format_to!(buf, "    {}\n", t),
-            _ => ()
+            }
+            rowan::NodeOrToken::Token(t) if t.kind() == SyntaxKind::COMMENT => {
+                format_to!(buf, "    {}\n", t)
+            }
+            _ => (),
         }
     }
     if let Some(tail_expr) = tail_expr {

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -329,6 +329,29 @@ pub fn block_expr(
     ast_from_text(&format!("fn f() {}", buf))
 }
 
+pub fn block_expr_full(
+    stmts: impl IntoIterator<Item = crate::SyntaxElement>,
+    tail_expr: Option<ast::Expr>,
+) -> ast::BlockExpr {
+    let mut buf = "{\n".to_string();
+    for stmt in stmts.into_iter() {
+        
+        match stmt {
+            rowan::NodeOrToken::Node(n) => {
+                println!("Node: {:?}", n.text());
+                format_to!(buf, "    {}\n", n)
+            },
+            rowan::NodeOrToken::Token(t) if t.kind() == SyntaxKind::COMMENT => format_to!(buf, "    {}\n", t),
+            _ => ()
+        }
+    }
+    if let Some(tail_expr) = tail_expr {
+        format_to!(buf, "    {}\n", tail_expr);
+    }
+    buf += "}";
+    ast_from_text(&format!("fn f() {}", buf))
+}
+
 pub fn expr_unit() -> ast::Expr {
     expr_from_text("()")
 }

--- a/crates/syntax/src/ast/make.rs
+++ b/crates/syntax/src/ast/make.rs
@@ -329,17 +329,18 @@ pub fn block_expr(
     ast_from_text(&format!("fn f() {}", buf))
 }
 
-pub fn block_expr_full(
-    stmts: impl IntoIterator<Item = crate::SyntaxElement>,
+/// Ideally this function wouldn't exist since it involves manual indenting.
+/// It differs from `make::block_expr` by also supporting comments.
+/// 
+/// FIXME: replace usages of this with the mutable syntax tree API
+pub fn hacky_block_expr_with_comments(
+    elements: impl IntoIterator<Item = crate::SyntaxElement>,
     tail_expr: Option<ast::Expr>,
 ) -> ast::BlockExpr {
     let mut buf = "{\n".to_string();
-    for stmt in stmts.into_iter() {
-        match stmt {
-            rowan::NodeOrToken::Node(n) => {
-                println!("Node: {:?}", n.text());
-                format_to!(buf, "    {}\n", n)
-            }
+    for node_or_token in elements.into_iter() {
+        match node_or_token {
+            rowan::NodeOrToken::Node(n) => format_to!(buf, "    {}\n", n),
             rowan::NodeOrToken::Token(t) if t.kind() == SyntaxKind::COMMENT => {
                 format_to!(buf, "    {}\n", t)
             }


### PR DESCRIPTION
Fixes #9011

The difficulty I came across is that the original assist works from the concept of a `ast::StmtList`, a node, but that does not allow me to (easily) represent comments, which are tokens. To combat this, I do a whole bunch of roundtrips: from the `ast::StmtList` I retrieve the `NodeOrToken`s it encompasses. 

I then cast all `Node` ones back to a `Stmt` so I can apply indentation to it, after which it is again parsed as a `NodeOrToken`.

Lastly, I add a new `make::` api that accepts `NodeOrToken` rather than `StmtList` so we can write the comment tokens.