### PR TITLE
internal: Remove redundant `Option` from eager macro fns

### DIFF
--- a/crates/hir_expand/src/eager.rs
+++ b/crates/hir_expand/src/eager.rs
@@ -145,14 +145,16 @@ pub fn expand_eager_macro(
 
     if let MacroDefKind::BuiltInEager(eager, _) = def.kind {
         let res = eager.expand(db, arg_id, &subtree);
+        if let Some(err) = res.err {
+            diagnostic_sink(err);
+        }
 
-        let expanded = diagnostic_sink.expand_result_option(res)?;
         let loc = MacroCallLoc {
             def,
             krate,
             eager: Some(EagerCallInfo {
-                arg_or_expansion: Arc::new(expanded.subtree),
-                included_file: expanded.included_file,
+                arg_or_expansion: Arc::new(res.value.subtree),
+                included_file: res.value.included_file,
             }),
             kind: MacroCallKind::FnLike { ast_id: call_id, expand_to },
         };


### PR DESCRIPTION
This isn't needed since `tt::Subtree` already implements `Default`, and an empty expansion is the appropriate default here.

bors r+