### PR TITLE
fix: don't panic in semantics due to `cfg_attr` disrupting offsets

### DIFF
--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -931,7 +931,8 @@ impl<'db> SemanticsImpl<'db> {
                 file.with_value(derive.clone()),
             )?;
             let attrs = adt_def.attrs(self.db);
-            let mut derive_paths = attrs[attr_id].parse_path_comma_token_tree()?;
+            // FIXME: https://github.com/rust-analyzer/rust-analyzer/issues/11298
+            let mut derive_paths = attrs.get(attr_id)?.parse_path_comma_token_tree()?;
 
             let derive_idx = tt
                 .syntax()

--- a/crates/hir_def/src/attr.rs
+++ b/crates/hir_def/src/attr.rs
@@ -72,6 +72,11 @@ impl ops::Deref for RawAttrs {
         }
     }
 }
+impl Attrs {
+    pub fn get(&self, AttrId { ast_index, .. }: AttrId) -> Option<&Attr> {
+        (**self).get(ast_index as usize)
+    }
+}
 
 impl ops::Deref for Attrs {
     type Target = [Attr];


### PR DESCRIPTION
Reduces the panic in https://github.com/rust-analyzer/rust-analyzer/issues/11298 to an early return, that means we won't resolve these cases again for now, but this is better than constantly panicking in highlighting and hovering.
bors r+