### PR TITLE
fix: Fix merge commit check for git 2.35

### DIFF
--- a/crates/rust-analyzer/tests/slow-tests/tidy.rs
+++ b/crates/rust-analyzer/tests/slow-tests/tidy.rs
@@ -139,10 +139,9 @@ fn check_cargo_toml(path: &Path, text: String) {
 
 #[test]
 fn check_merge_commits() {
-    let stdout = cmd!("git rev-list --merges --invert-grep --author 'bors\\[bot\\]' HEAD~19..")
-        .read()
-        .unwrap();
-    if !stdout.is_empty() {
+    let bors = cmd!("git rev-list --merges --author 'bors\\[bot\\]' HEAD~19..").read().unwrap();
+    let all = cmd!("git rev-list --merges HEAD~19..").read().unwrap();
+    if bors != all {
         panic!(
             "
 Merge commits are not allowed in the history.


### PR DESCRIPTION
git 2.35 introduces a [change in behavior](https://github.com/git/git/blob/89bece5c8c96f0b962cfc89e63f82d603fd60bed/Documentation/RelNotes/2.35.0.txt#L330-L333) that breaks this check.

bors r+