### PR TITLE
Add a way to disable dll copying for users of proc_macro_srv library

### DIFF
--- a/crates/proc_macro_srv/src/dylib.rs
+++ b/crates/proc_macro_srv/src/dylib.rs
@@ -168,6 +168,10 @@ fn ensure_file_with_lock_free_access(path: &Path) -> io::Result<PathBuf> {
     use std::ffi::OsString;
     use std::hash::{BuildHasher, Hasher};
 
+    if std::env::var("RA_DONT_COPY_PROC_MACRO_DLL").is_ok() {
+        return Ok(path.to_path_buf());
+    }
+
     let mut to = std::env::temp_dir();
 
     let file_name = path.file_name().ok_or_else(|| {


### PR DESCRIPTION
We use `ra_ap_proc_macro_srv` library in IntelliJ Rust in order to expand proc macros. We need a way to disable [DLL copying to a temp dir on Windows](https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/proc_macro_srv/src/dylib.rs#L166) behavior because it causes issues like https://github.com/intellij-rust/intellij-rust/issues/7709. Unlike RA, file locking is not an issue for IntelliJ Rust because we copy DLLs to a temp dir before calling the expander.