### PR TITLE
minor: Use `compare_exchange_weak` in `limit::Limit::check`

### DIFF
--- a/crates/limit/src/lib.rs
+++ b/crates/limit/src/lib.rs
@@ -45,7 +45,7 @@ impl Limit {
                 }
                 if self
                     .max
-                    .compare_exchange(old_max, other, Ordering::Relaxed, Ordering::Relaxed)
+                    .compare_exchange_weak(old_max, other, Ordering::Relaxed, Ordering::Relaxed)
                     .is_ok()
                 {
                     eprintln!("new max: {}", other);


### PR DESCRIPTION
Not a big deal, but generally loops should use `_weak` version of `compare_exchange`.