### PR TITLE
fix: Fix `cfg_attr` invalidating derive identifier IDE functionalities

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -664,7 +664,7 @@ fn emit_def_diagnostic(db: &dyn HirDatabase, acc: &mut Vec<AnyDiagnostic>, diag:
                     let attr = node
                         .doc_comments_and_attrs()
                         .nth((*invoc_attr_index) as usize)
-                        .and_then(Either::right)
+                        .and_then(Either::left)
                         .unwrap_or_else(|| panic!("cannot find attribute #{}", invoc_attr_index));
                     (
                         ast_id.with_value(SyntaxNodePtr::from(AstPtr::new(&attr))),

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -364,9 +364,6 @@ impl<'db, DB: HirDatabase> Semantics<'db, DB> {
         self.imp.resolve_derive_ident(derive, ident)
     }
 
-    // FIXME: use this instead?
-    // pub fn resolve_name_ref(&self, name_ref: &ast::NameRef) -> Option<???>;
-
     pub fn record_literal_missing_fields(&self, literal: &ast::RecordExpr) -> Vec<(Field, Type)> {
         self.imp.record_literal_missing_fields(literal)
     }
@@ -931,7 +928,6 @@ impl<'db> SemanticsImpl<'db> {
                 file.with_value(derive.clone()),
             )?;
             let attrs = adt_def.attrs(self.db);
-            // FIXME: https://github.com/rust-analyzer/rust-analyzer/issues/11298
             let mut derive_paths = attrs.get(attr_id)?.parse_path_comma_token_tree()?;
 
             let derive_idx = tt

--- a/crates/hir_def/src/attr.rs
+++ b/crates/hir_def/src/attr.rs
@@ -73,8 +73,8 @@ impl ops::Deref for RawAttrs {
     }
 }
 impl Attrs {
-    pub fn get(&self, AttrId { ast_index, .. }: AttrId) -> Option<&Attr> {
-        (**self).get(ast_index as usize)
+    pub fn get(&self, id: AttrId) -> Option<&Attr> {
+        (**self).iter().find(|attr| attr.id == id)
     }
 }
 
@@ -86,14 +86,6 @@ impl ops::Deref for Attrs {
             Some(it) => &*it,
             None => &[],
         }
-    }
-}
-
-impl ops::Index<AttrId> for Attrs {
-    type Output = Attr;
-
-    fn index(&self, AttrId { ast_index, .. }: AttrId) -> &Self::Output {
-        &(**self)[ast_index as usize]
     }
 }
 
@@ -110,7 +102,7 @@ impl RawAttrs {
 
     pub(crate) fn new(db: &dyn DefDatabase, owner: &dyn ast::HasAttrs, hygiene: &Hygiene) -> Self {
         let entries = collect_attrs(owner)
-            .flat_map(|(id, attr)| match attr {
+            .filter_map(|(id, attr)| match attr {
                 Either::Left(attr) => {
                     attr.meta().and_then(|meta| Attr::from_src(db, meta, hygiene, id))
                 }

--- a/crates/hir_def/src/child_by_source.rs
+++ b/crates/hir_def/src/child_by_source.rs
@@ -117,7 +117,7 @@ impl ChildBySource for ItemScope {
             |(ast_id, calls)| {
                 let adt = ast_id.to_node(db.upcast());
                 calls.for_each(|(attr_id, calls)| {
-                    if let Some(Either::Right(attr)) =
+                    if let Some(Either::Left(attr)) =
                         adt.doc_comments_and_attrs().nth(attr_id.ast_index as usize)
                     {
                         res[keys::DERIVE_MACRO_CALL].insert(attr, (attr_id, calls.into()));

--- a/crates/hir_expand/src/db.rs
+++ b/crates/hir_expand/src/db.rs
@@ -157,7 +157,7 @@ pub fn expand_speculative(
             let attr = item
                 .doc_comments_and_attrs()
                 .nth(invoc_attr_index as usize)
-                .and_then(Either::right)?;
+                .and_then(Either::left)?;
             match attr.token_tree() {
                 Some(token_tree) => {
                     let (mut tree, map) = syntax_node_to_token_tree(attr.token_tree()?.syntax());
@@ -323,7 +323,7 @@ fn censor_for_macro_input(loc: &MacroCallLoc, node: &SyntaxNode) -> FxHashSet<Sy
                 ast::Item::cast(node.clone())?
                     .doc_comments_and_attrs()
                     .nth(invoc_attr_index as usize)
-                    .and_then(Either::right)
+                    .and_then(Either::left)
                     .map(|attr| attr.syntax().clone())
                     .into_iter()
                     .collect()

--- a/crates/hir_expand/src/hygiene.rs
+++ b/crates/hir_expand/src/hygiene.rs
@@ -191,7 +191,7 @@ fn make_hygiene_info(
                 .to_node(db)
                 .doc_comments_and_attrs()
                 .nth(invoc_attr_index as usize)
-                .and_then(Either::right)?
+                .and_then(Either::left)?
                 .token_tree()?;
             Some(InFile::new(ast_id.file_id, tt))
         }

--- a/crates/hir_expand/src/lib.rs
+++ b/crates/hir_expand/src/lib.rs
@@ -205,7 +205,7 @@ impl HirFileId {
                             .to_node(db)
                             .doc_comments_and_attrs()
                             .nth(invoc_attr_index as usize)
-                            .and_then(Either::right)?
+                            .and_then(Either::left)?
                             .token_tree()?;
                         Some(InFile::new(ast_id.file_id, tt))
                     }
@@ -382,7 +382,7 @@ impl MacroCallKind {
                     .doc_comments_and_attrs()
                     .nth(derive_attr_index as usize)
                     .expect("missing derive")
-                    .expect_right("derive is a doc comment?")
+                    .expect_left("derive is a doc comment?")
                     .syntax()
                     .text_range()
             }
@@ -391,7 +391,7 @@ impl MacroCallKind {
                 .doc_comments_and_attrs()
                 .nth(invoc_attr_index as usize)
                 .expect("missing attribute")
-                .expect_right("attribute macro is a doc comment?")
+                .expect_left("attribute macro is a doc comment?")
                 .syntax()
                 .text_range(),
         };
@@ -483,7 +483,7 @@ impl ExpansionInfo {
                     let attr = item
                         .doc_comments_and_attrs()
                         .nth(*invoc_attr_index as usize)
-                        .and_then(Either::right)?;
+                        .and_then(Either::left)?;
                     match attr.token_tree() {
                         Some(token_tree)
                             if token_tree.syntax().text_range().contains_range(token_range) =>

--- a/crates/ide/src/goto_definition.rs
+++ b/crates/ide/src/goto_definition.rs
@@ -1364,10 +1364,21 @@ impl Twait for Stwuct {
     fn goto_def_derive_input() {
         check(
             r#"
+        //- minicore:derive
+        #[rustc_builtin_macro]
+        pub macro Copy {}
+               // ^^^^
+        #[derive(Copy$0)]
+        struct Foo;
+                    "#,
+        );
+        check(
+            r#"
 //- minicore:derive
 #[rustc_builtin_macro]
 pub macro Copy {}
        // ^^^^
+#[cfg_attr(feature = "false", derive)]
 #[derive(Copy$0)]
 struct Foo;
             "#,

--- a/crates/syntax/src/ast.rs
+++ b/crates/syntax/src/ast.rs
@@ -27,8 +27,8 @@ pub use self::{
     operators::{ArithOp, BinaryOp, CmpOp, LogicOp, Ordering, RangeOp, UnaryOp},
     token_ext::{CommentKind, CommentPlacement, CommentShape, IsString, QuoteOffsets, Radix},
     traits::{
-        DocCommentIter, HasArgList, HasAttrs, HasDocComments, HasGenericParams, HasLoopBody,
-        HasModuleItem, HasName, HasTypeBounds, HasVisibility,
+        AttrDocCommentIter, DocCommentIter, HasArgList, HasAttrs, HasDocComments, HasGenericParams,
+        HasLoopBody, HasModuleItem, HasName, HasTypeBounds, HasVisibility,
     },
 };
 

--- a/crates/syntax/src/ast/node_ext.rs
+++ b/crates/syntax/src/ast/node_ext.rs
@@ -160,14 +160,9 @@ impl ast::Attr {
     }
 
     pub fn kind(&self) -> AttrKind {
-        let first_token = self.syntax().first_token();
-        let first_token_kind = first_token.as_ref().map(SyntaxToken::kind);
-        let second_token_kind =
-            first_token.and_then(|token| token.next_token()).as_ref().map(SyntaxToken::kind);
-
-        match (first_token_kind, second_token_kind) {
-            (Some(T![#]), Some(T![!])) => AttrKind::Inner,
-            _ => AttrKind::Outer,
+        match self.excl_token() {
+            Some(_) => AttrKind::Inner,
+            None => AttrKind::Outer,
         }
     }
 


### PR DESCRIPTION
Proper fix for https://github.com/rust-analyzer/rust-analyzer/issues/11298
bors r+