### PR TITLE
internal: Refactor completion module split

### DIFF
--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -481,7 +481,7 @@ impl HirDisplay for Module {
         // FIXME: Module doesn't have visibility saved in data.
         match self.name(f.db) {
             Some(name) => write!(f, "mod {}", name),
-            None if self.crate_root(f.db) == *self => match self.krate().display_name(f.db) {
+            None if self.is_crate_root(f.db) => match self.krate().display_name(f.db) {
                 Some(name) => write!(f, "extern crate {}", name),
                 None => write!(f, "extern crate {{unknown}}"),
             },

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -452,6 +452,11 @@ impl Module {
         Module { id: def_map.module_id(def_map.root()) }
     }
 
+    pub fn is_crate_root(self, db: &dyn HirDatabase) -> bool {
+        let def_map = db.crate_def_map(self.id.krate());
+        def_map.root() == self.id.local_id
+    }
+
     /// Iterates over all child modules.
     pub fn children(self, db: &dyn HirDatabase) -> impl Iterator<Item = Module> {
         let def_map = self.id.def_map(db.upcast());

--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -949,12 +949,15 @@ impl<'db> SemanticsImpl<'db> {
         })?;
 
         match res {
-            Either::Left(path) => resolve_hir_path(
-                self.db,
-                &self.scope(derive.syntax()).resolver,
-                &Path::from_known_path(path, []),
-            )
-            .filter(|res| matches!(res, PathResolution::Def(ModuleDef::Module(_)))),
+            Either::Left(path) => {
+                let len = path.len();
+                resolve_hir_path(
+                    self.db,
+                    &self.scope(derive.syntax()).resolver,
+                    &Path::from_known_path(path, vec![None; len]),
+                )
+                .filter(|res| matches!(res, PathResolution::Def(ModuleDef::Module(_))))
+            }
             Either::Right(derive) => derive
                 .map(|call| MacroDef { id: self.db.lookup_intern_macro_call(call).def })
                 .map(PathResolution::Macro),

--- a/crates/hir_def/src/path.rs
+++ b/crates/hir_def/src/path.rs
@@ -92,7 +92,9 @@ impl Path {
         path: ModPath,
         generic_args: impl Into<Box<[Option<Interned<GenericArgs>>]>>,
     ) -> Path {
-        Path { type_anchor: None, mod_path: Interned::new(path), generic_args: generic_args.into() }
+        let generic_args = generic_args.into();
+        assert_eq!(path.len(), generic_args.len());
+        Path { type_anchor: None, mod_path: Interned::new(path), generic_args }
     }
 
     pub fn kind(&self) -> &PathKind {

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -253,6 +253,7 @@ pub enum PointerCast {
     /// Go from a mut raw pointer to a const raw pointer.
     MutToConstPointer,
 
+    #[allow(dead_code)]
     /// Go from `*const [T; N]` to `*const T`
     ArrayToPointer,
 

--- a/crates/ide_completion/src/completions.rs
+++ b/crates/ide_completion/src/completions.rs
@@ -8,7 +8,6 @@ pub(crate) mod format_string;
 pub(crate) mod keyword;
 pub(crate) mod lifetime;
 pub(crate) mod mod_;
-pub(crate) mod use_;
 pub(crate) mod pattern;
 pub(crate) mod postfix;
 pub(crate) mod qualified_path;
@@ -16,6 +15,8 @@ pub(crate) mod record;
 pub(crate) mod snippet;
 pub(crate) mod trait_impl;
 pub(crate) mod unqualified_path;
+pub(crate) mod use_;
+pub(crate) mod vis;
 
 use std::iter;
 

--- a/crates/ide_completion/src/completions.rs
+++ b/crates/ide_completion/src/completions.rs
@@ -4,9 +4,11 @@ pub(crate) mod attribute;
 pub(crate) mod dot;
 pub(crate) mod flyimport;
 pub(crate) mod fn_param;
+pub(crate) mod format_string;
 pub(crate) mod keyword;
 pub(crate) mod lifetime;
 pub(crate) mod mod_;
+pub(crate) mod use_;
 pub(crate) mod pattern;
 pub(crate) mod postfix;
 pub(crate) mod qualified_path;
@@ -14,7 +16,6 @@ pub(crate) mod record;
 pub(crate) mod snippet;
 pub(crate) mod trait_impl;
 pub(crate) mod unqualified_path;
-pub(crate) mod format_string;
 
 use std::iter;
 

--- a/crates/ide_completion/src/completions.rs
+++ b/crates/ide_completion/src/completions.rs
@@ -99,6 +99,19 @@ impl Completions {
         item.add_to(self);
     }
 
+    pub(crate) fn add_nameref_keywords(&mut self, ctx: &CompletionContext) {
+        ["self::", "super::", "crate::"].into_iter().for_each(|kw| self.add_keyword(ctx, kw));
+    }
+
+    pub(crate) fn add_crate_roots(&mut self, ctx: &CompletionContext) {
+        ctx.process_all_names(&mut |name, res| match res {
+            ScopeDef::ModuleDef(hir::ModuleDef::Module(m)) if m.is_crate_root(ctx.db) => {
+                self.add_resolution(ctx, name, res);
+            }
+            _ => (),
+        });
+    }
+
     pub(crate) fn add_resolution(
         &mut self,
         ctx: &CompletionContext,

--- a/crates/ide_completion/src/completions/attribute.rs
+++ b/crates/ide_completion/src/completions/attribute.rs
@@ -2,7 +2,6 @@
 //!
 //! This module uses a bit of static metadata to provide completions for builtin-in attributes and lints.
 
-use hir::ScopeDef;
 use ide_db::{
     helpers::{
         generated_lints::{
@@ -103,14 +102,7 @@ pub(crate) fn complete_attribute(acc: &mut Completions, ctx: &CompletionContext)
             return;
         }
         // fresh use tree with leading colon2, only show crate roots
-        None if is_absolute_path => {
-            ctx.process_all_names(&mut |name, res| match res {
-                ScopeDef::ModuleDef(hir::ModuleDef::Module(m)) if m.is_crate_root(ctx.db) => {
-                    acc.add_resolution(ctx, name, res);
-                }
-                _ => (),
-            });
-        }
+        None if is_absolute_path => acc.add_crate_roots(ctx),
         // only show modules in a fresh UseTree
         None => {
             ctx.process_all_names(&mut |name, def| {
@@ -118,7 +110,7 @@ pub(crate) fn complete_attribute(acc: &mut Completions, ctx: &CompletionContext)
                     acc.add_resolution(ctx, name, def);
                 }
             });
-            ["self::", "super::", "crate::"].into_iter().for_each(|kw| acc.add_keyword(ctx, kw));
+            acc.add_nameref_keywords(ctx);
         }
     }
 

--- a/crates/ide_completion/src/completions/attribute.rs
+++ b/crates/ide_completion/src/completions/attribute.rs
@@ -16,62 +16,95 @@ use ide_db::{
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use rustc_hash::FxHashMap;
-use syntax::{algo::non_trivia_sibling, ast, AstNode, Direction, SyntaxKind, T};
+use syntax::{
+    ast::{self, AttrKind},
+    AstNode, SyntaxKind, T,
+};
 
-use crate::{context::CompletionContext, item::CompletionItem, Completions};
+use crate::{
+    completions::module_or_attr,
+    context::{CompletionContext, PathCompletionContext, PathKind},
+    item::CompletionItem,
+    Completions,
+};
 
 mod cfg;
 mod derive;
 mod lint;
 mod repr;
 
-pub(crate) fn complete_attribute(acc: &mut Completions, ctx: &CompletionContext) -> Option<()> {
+/// Complete inputs to known builtin attributes as well as derive attributes
+pub(crate) fn complete_known_attribute_input(
+    acc: &mut Completions,
+    ctx: &CompletionContext,
+) -> Option<()> {
     let attribute = ctx.fake_attribute_under_caret.as_ref()?;
     let name_ref = match attribute.path() {
         Some(p) => Some(p.as_single_name_ref()?),
         None => None,
     };
-    match (name_ref, attribute.token_tree()) {
-        (Some(path), Some(tt)) if tt.l_paren_token().is_some() => match path.text().as_str() {
-            "repr" => repr::complete_repr(acc, ctx, tt),
-            "derive" => derive::complete_derive(acc, ctx, ctx.attr.as_ref()?),
-            "feature" => lint::complete_lint(acc, ctx, &parse_tt_as_comma_sep_paths(tt)?, FEATURES),
-            "allow" | "warn" | "deny" | "forbid" => {
-                let existing_lints = parse_tt_as_comma_sep_paths(tt)?;
+    let (path, tt) = name_ref.zip(attribute.token_tree())?;
+    if tt.l_paren_token().is_none() {
+        return None;
+    }
 
-                let lints: Vec<Lint> = CLIPPY_LINT_GROUPS
-                    .iter()
-                    .map(|g| &g.lint)
-                    .chain(DEFAULT_LINTS.iter())
-                    .chain(CLIPPY_LINTS.iter())
-                    .chain(RUSTDOC_LINTS)
-                    .cloned()
-                    .collect();
+    match path.text().as_str() {
+        "repr" => repr::complete_repr(acc, ctx, tt),
+        "derive" => derive::complete_derive(acc, ctx, ctx.attr.as_ref()?),
+        "feature" => lint::complete_lint(acc, ctx, &parse_tt_as_comma_sep_paths(tt)?, FEATURES),
+        "allow" | "warn" | "deny" | "forbid" => {
+            let existing_lints = parse_tt_as_comma_sep_paths(tt)?;
 
-                lint::complete_lint(acc, ctx, &existing_lints, &lints);
-            }
-            "cfg" => {
-                cfg::complete_cfg(acc, ctx);
-            }
-            _ => (),
-        },
-        (_, Some(_)) => (),
-        (_, None) if attribute.expr().is_some() => (),
-        (_, None) => complete_new_attribute(acc, ctx, attribute),
+            let lints: Vec<Lint> = CLIPPY_LINT_GROUPS
+                .iter()
+                .map(|g| &g.lint)
+                .chain(DEFAULT_LINTS)
+                .chain(CLIPPY_LINTS)
+                .chain(RUSTDOC_LINTS)
+                .cloned()
+                .collect();
+
+            lint::complete_lint(acc, ctx, &existing_lints, &lints);
+        }
+        "cfg" => {
+            cfg::complete_cfg(acc, ctx);
+        }
+        _ => (),
     }
     Some(())
 }
 
-// FIXME?: Move this functionality to (un)qualified_path, make this module work solely for builtin/known attributes for their inputs?
-fn complete_new_attribute(acc: &mut Completions, ctx: &CompletionContext, attribute: &ast::Attr) {
-    let is_inner = attribute.kind() == ast::AttrKind::Inner;
-    let attribute_annotated_item_kind =
-        attribute.syntax().parent().map(|it| it.kind()).filter(|_| {
-            is_inner
-            // If we got nothing coming after the attribute it could be anything so filter it the kind out
-                || non_trivia_sibling(attribute.syntax().clone().into(), Direction::Next).is_some()
-        });
-    let attributes = attribute_annotated_item_kind.and_then(|kind| {
+pub(crate) fn complete_attribute(acc: &mut Completions, ctx: &CompletionContext) {
+    let (is_trivial_path, qualifier, is_inner, annotated_item_kind) = match ctx.path_context {
+        Some(PathCompletionContext {
+            kind: Some(PathKind::Attr { kind, annotated_item_kind }),
+            is_trivial_path,
+            ref qualifier,
+            ..
+        }) => (is_trivial_path, qualifier, kind == AttrKind::Inner, annotated_item_kind),
+        _ => return,
+    };
+
+    if !is_trivial_path {
+        return;
+    }
+
+    if let Some((_, Some(hir::PathResolution::Def(hir::ModuleDef::Module(module))))) = qualifier {
+        for (name, def) in module.scope(ctx.db, ctx.module) {
+            if let Some(def) = module_or_attr(def) {
+                acc.add_resolution(ctx, name, def);
+            }
+        }
+        return;
+    }
+
+    ctx.process_all_names(&mut |name, def| {
+        if let Some(def) = module_or_attr(def) {
+            acc.add_resolution(ctx, name, def);
+        }
+    });
+
+    let attributes = annotated_item_kind.and_then(|kind| {
         if ast::Expr::can_cast(kind) {
             Some(EXPR_ATTRIBUTES)
         } else {

--- a/crates/ide_completion/src/completions/dot.rs
+++ b/crates/ide_completion/src/completions/dot.rs
@@ -32,7 +32,7 @@ fn complete_undotted_self(acc: &mut Completions, ctx: &CompletionContext) {
     if !ctx.config.enable_self_on_the_fly {
         return;
     }
-    if !ctx.is_trivial_path() || ctx.is_path_disallowed() || !ctx.expects_expression() {
+    if ctx.is_non_trivial_path() || ctx.is_path_disallowed() || !ctx.expects_expression() {
         return;
     }
     if let Some(func) = ctx.function_def.as_ref().and_then(|fn_| ctx.sema.to_def(fn_)) {

--- a/crates/ide_completion/src/completions/flyimport.rs
+++ b/crates/ide_completion/src/completions/flyimport.rs
@@ -171,8 +171,8 @@ pub(crate) fn import_on_the_fly(acc: &mut Completions, ctx: &CompletionContext) 
             (PathKind::Type, ItemInNs::Types(_)) => true,
             (PathKind::Type, ItemInNs::Values(_)) => false,
 
-            (PathKind::Attr, ItemInNs::Macros(mac)) => mac.is_attr(),
-            (PathKind::Attr, _) => false,
+            (PathKind::Attr { .. }, ItemInNs::Macros(mac)) => mac.is_attr(),
+            (PathKind::Attr { .. }, _) => false,
         }
     };
 

--- a/crates/ide_completion/src/completions/keyword.rs
+++ b/crates/ide_completion/src/completions/keyword.rs
@@ -5,7 +5,7 @@
 use syntax::{SyntaxKind, T};
 
 use crate::{
-    context::{PathCompletionContext, PathKind},
+    context::{PathCompletionCtx, PathKind},
     patterns::ImmediateLocation,
     CompletionContext, CompletionItem, CompletionItemKind, Completions,
 };
@@ -122,9 +122,9 @@ pub(crate) fn complete_expr_keyword(acc: &mut Completions, ctx: &CompletionConte
     }
 
     let (can_be_stmt, in_loop_body) = match ctx.path_context {
-        Some(PathCompletionContext {
-            is_trivial_path: true, can_be_stmt, in_loop_body, ..
-        }) => (can_be_stmt, in_loop_body),
+        Some(PathCompletionCtx { is_absolute_path: false, can_be_stmt, in_loop_body, .. }) => {
+            (can_be_stmt, in_loop_body)
+        }
         _ => return,
     };
 

--- a/crates/ide_completion/src/completions/keyword.rs
+++ b/crates/ide_completion/src/completions/keyword.rs
@@ -34,11 +34,7 @@ pub(crate) fn complete_expr_keyword(acc: &mut Completions, ctx: &CompletionConte
     let has_block_expr_parent = ctx.has_block_expr_parent();
     let expects_item = ctx.expects_item();
 
-    if let Some(PathKind::Vis { has_in_token }) = ctx.path_kind() {
-        if !has_in_token {
-            cov_mark::hit!(kw_completion_in);
-            add_keyword("in", "in");
-        }
+    if let Some(PathKind::Vis { .. }) = ctx.path_kind() {
         return;
     }
     if ctx.has_impl_or_trait_prev_sibling() {

--- a/crates/ide_completion/src/completions/keyword.rs
+++ b/crates/ide_completion/src/completions/keyword.rs
@@ -27,6 +27,9 @@ pub(crate) fn complete_expr_keyword(acc: &mut Completions, ctx: &CompletionConte
         cov_mark::hit!(no_keyword_completion_in_non_trivial_path);
         return;
     }
+    if ctx.pattern_ctx.is_some() {
+        return;
+    }
 
     let mut add_keyword = |kw, snippet| add_keyword(acc, ctx, kw, snippet);
 
@@ -117,7 +120,7 @@ pub(crate) fn complete_expr_keyword(acc: &mut Completions, ctx: &CompletionConte
         add_keyword("else if", "else if $1 {\n    $0\n}");
     }
 
-    if ctx.expects_ident_pat_or_ref_expr() {
+    if ctx.expects_ident_ref_expr() {
         add_keyword("mut", "mut ");
     }
 

--- a/crates/ide_completion/src/completions/pattern.rs
+++ b/crates/ide_completion/src/completions/pattern.rs
@@ -1,20 +1,52 @@
 //! Completes constants and paths in unqualified patterns.
 
-use hir::db::DefDatabase;
+use hir::{db::DefDatabase, AssocItem, ScopeDef};
+use rustc_hash::FxHashSet;
+use syntax::ast::Pat;
 
 use crate::{
-    context::{PatternContext, PatternRefutability},
+    context::{PathCompletionCtx, PathQualifierCtx, PatternRefutability},
     CompletionContext, Completions,
 };
 
 /// Completes constants and paths in unqualified patterns.
 pub(crate) fn complete_pattern(acc: &mut Completions, ctx: &CompletionContext) {
-    let refutable = match ctx.pattern_ctx {
-        Some(PatternContext { refutability, .. }) if ctx.path_context.is_none() => {
-            refutability == PatternRefutability::Refutable
-        }
+    let patctx = match &ctx.pattern_ctx {
+        Some(ctx) => ctx,
         _ => return,
     };
+    let refutable = patctx.refutability == PatternRefutability::Refutable;
+
+    if let Some(path_ctx) = &ctx.path_context {
+        pattern_path_completion(acc, ctx, path_ctx);
+        return;
+    }
+
+    match patctx.parent_pat.as_ref() {
+        Some(Pat::RangePat(_) | Pat::BoxPat(_)) => (),
+        Some(Pat::RefPat(r)) => {
+            if r.mut_token().is_none() {
+                acc.add_keyword(ctx, "mut");
+            }
+        }
+        _ => {
+            let tok = ctx.token.text_range().start();
+            match (patctx.ref_token.as_ref(), patctx.mut_token.as_ref()) {
+                (None, None) => {
+                    acc.add_keyword(ctx, "ref");
+                    acc.add_keyword(ctx, "mut");
+                }
+                (None, Some(m)) if tok < m.text_range().start() => {
+                    acc.add_keyword(ctx, "ref");
+                }
+                (Some(r), None) if tok > r.text_range().end() => {
+                    acc.add_keyword(ctx, "mut");
+                }
+                _ => (),
+            }
+        }
+    }
+
     let single_variant_enum = |enum_: hir::Enum| ctx.db.enum_data(enum_.into()).variants.len() == 1;
 
     if let Some(hir::Adt::Enum(e)) =
@@ -62,4 +94,105 @@ pub(crate) fn complete_pattern(acc: &mut Completions, ctx: &CompletionContext) {
             acc.add_resolution(ctx, name, res);
         }
     });
+}
+
+fn pattern_path_completion(
+    acc: &mut Completions,
+    ctx: &CompletionContext,
+    PathCompletionCtx { qualifier, is_absolute_path, .. }: &PathCompletionCtx,
+) {
+    match qualifier {
+        Some(PathQualifierCtx { resolution, is_super_chain, .. }) => {
+            if *is_super_chain {
+                acc.add_keyword(ctx, "super::");
+            }
+
+            let resolution = match resolution {
+                Some(it) => it,
+                None => return,
+            };
+
+            match resolution {
+                hir::PathResolution::Def(hir::ModuleDef::Module(module)) => {
+                    let module_scope = module.scope(ctx.db, ctx.module);
+                    for (name, def) in module_scope {
+                        let add_resolution = match def {
+                            ScopeDef::MacroDef(m) if m.is_fn_like() => true,
+                            ScopeDef::ModuleDef(_) => true,
+                            _ => false,
+                        };
+
+                        if add_resolution {
+                            acc.add_resolution(ctx, name, def);
+                        }
+                    }
+                }
+                hir::PathResolution::Def(hir::ModuleDef::Adt(hir::Adt::Enum(e))) => {
+                    cov_mark::hit!(enum_plain_qualified_use_tree);
+                    e.variants(ctx.db)
+                        .into_iter()
+                        .for_each(|variant| acc.add_enum_variant(ctx, variant, None));
+                }
+                res @ (hir::PathResolution::TypeParam(_) | hir::PathResolution::SelfType(_)) => {
+                    if let Some(krate) = ctx.krate {
+                        let ty = match res {
+                            hir::PathResolution::TypeParam(param) => param.ty(ctx.db),
+                            hir::PathResolution::SelfType(impl_def) => impl_def.self_ty(ctx.db),
+                            _ => return,
+                        };
+
+                        // Note associated consts cannot be referenced in patterns
+                        if let Some(hir::Adt::Enum(e)) = ty.as_adt() {
+                            e.variants(ctx.db)
+                                .into_iter()
+                                .for_each(|variant| acc.add_enum_variant(ctx, variant, None));
+                        }
+
+                        let traits_in_scope = ctx.scope.visible_traits();
+                        let mut seen = FxHashSet::default();
+                        ty.iterate_path_candidates(
+                            ctx.db,
+                            krate,
+                            &traits_in_scope,
+                            ctx.module,
+                            None,
+                            |_ty, item| {
+                                // We might iterate candidates of a trait multiple times here, so deduplicate
+                                // them.
+                                if let AssocItem::TypeAlias(ta) = item {
+                                    if seen.insert(item) {
+                                        acc.add_type_alias(ctx, ta);
+                                    }
+                                }
+                                None::<()>
+                            },
+                        );
+                    }
+                }
+                _ => {}
+            }
+        }
+        // qualifier can only be none here if we are in a TuplePat or RecordPat in which case special characters have to follow the path
+        // so executing the rest of this completion doesn't make sense
+        // fresh use tree with leading colon2, only show crate roots
+        None if *is_absolute_path => {
+            cov_mark::hit!(use_tree_crate_roots_only);
+            ctx.process_all_names(&mut |name, res| match res {
+                ScopeDef::ModuleDef(hir::ModuleDef::Module(m)) if m.is_crate_root(ctx.db) => {
+                    acc.add_resolution(ctx, name, res);
+                }
+                _ => (),
+            });
+        }
+        // only show modules in a fresh UseTree
+        None => {
+            cov_mark::hit!(unqualified_path_only_modules_in_import);
+            ctx.process_all_names(&mut |name, res| {
+                if let ScopeDef::ModuleDef(hir::ModuleDef::Module(_)) = res {
+                    acc.add_resolution(ctx, name, res);
+                }
+            });
+            ["self::", "super::", "crate::"].into_iter().for_each(|kw| acc.add_keyword(ctx, kw));
+        }
+    }
 }

--- a/crates/ide_completion/src/completions/qualified_path.rs
+++ b/crates/ide_completion/src/completions/qualified_path.rs
@@ -15,6 +15,9 @@ pub(crate) fn complete_qualified_path(acc: &mut Completions, ctx: &CompletionCon
     if ctx.is_path_disallowed() || ctx.has_impl_or_trait_prev_sibling() {
         return;
     }
+    if ctx.pattern_ctx.is_some() {
+        return;
+    }
     let (qualifier, kind) = match ctx.path_context {
         // let ... else, syntax would come in really handy here right now
         Some(PathCompletionCtx { qualifier: Some(ref qualifier), kind, .. }) => (qualifier, kind),
@@ -60,10 +63,9 @@ pub(crate) fn complete_qualified_path(acc: &mut Completions, ctx: &CompletionCon
     }
 
     match kind {
-        Some(PathKind::Attr { .. } | PathKind::Vis { .. } | PathKind::Use) => {
+        Some(PathKind::Pat | PathKind::Attr { .. } | PathKind::Vis { .. } | PathKind::Use) => {
             return;
         }
-        Some(PathKind::Pat) => (),
         _ => {
             // Add associated types on type parameters and `Self`.
             ctx.scope.assoc_type_shorthand_candidates(&resolution, |_, alias| {

--- a/crates/ide_completion/src/completions/qualified_path.rs
+++ b/crates/ide_completion/src/completions/qualified_path.rs
@@ -62,26 +62,7 @@ pub(crate) fn complete_qualified_path(acc: &mut Completions, ctx: &CompletionCon
     }
 
     match kind {
-        // Complete next child module that comes after the qualified module which is still our parent
-        Some(PathKind::Vis { .. }) => {
-            if let hir::PathResolution::Def(hir::ModuleDef::Module(module)) = resolution {
-                if let Some(current_module) = ctx.module {
-                    let next_towards_current = current_module
-                        .path_to_root(ctx.db)
-                        .into_iter()
-                        .take_while(|it| it != module)
-                        .next();
-                    if let Some(next) = next_towards_current {
-                        if let Some(name) = next.name(ctx.db) {
-                            cov_mark::hit!(visibility_qualified);
-                            acc.add_resolution(ctx, name, ScopeDef::ModuleDef(next.into()));
-                        }
-                    }
-                }
-            }
-            return;
-        }
-        Some(PathKind::Attr { .. } | PathKind::Use) => {
+        Some(PathKind::Attr { .. } | PathKind::Vis { .. } | PathKind::Use) => {
             return;
         }
         Some(PathKind::Pat) => (),

--- a/crates/ide_completion/src/completions/snippet.rs
+++ b/crates/ide_completion/src/completions/snippet.rs
@@ -5,7 +5,7 @@ use ide_db::helpers::{insert_use::ImportScope, SnippetCap};
 use syntax::T;
 
 use crate::{
-    context::PathCompletionContext, item::Builder, CompletionContext, CompletionItem,
+    context::PathCompletionCtx, item::Builder, CompletionContext, CompletionItem,
     CompletionItemKind, Completions, SnippetScope,
 };
 
@@ -21,7 +21,9 @@ pub(crate) fn complete_expr_snippet(acc: &mut Completions, ctx: &CompletionConte
     }
 
     let can_be_stmt = match ctx.path_context {
-        Some(PathCompletionContext { is_trivial_path: true, can_be_stmt, .. }) => can_be_stmt,
+        Some(PathCompletionCtx {
+            is_absolute_path: false, qualifier: None, can_be_stmt, ..
+        }) => can_be_stmt,
         _ => return,
     };
 

--- a/crates/ide_completion/src/completions/unqualified_path.rs
+++ b/crates/ide_completion/src/completions/unqualified_path.rs
@@ -5,7 +5,7 @@ use syntax::{ast, AstNode};
 
 use crate::{
     completions::module_or_fn_macro,
-    context::{PathCompletionContext, PathKind},
+    context::{PathCompletionCtx, PathKind},
     patterns::ImmediateLocation,
     CompletionContext, Completions,
 };
@@ -16,11 +16,11 @@ pub(crate) fn complete_unqualified_path(acc: &mut Completions, ctx: &CompletionC
         return;
     }
     match ctx.path_context {
-        Some(PathCompletionContext {
+        Some(PathCompletionCtx {
             kind: Some(PathKind::Vis { .. } | PathKind::Attr { .. } | PathKind::Use { .. }),
             ..
         }) => return,
-        Some(PathCompletionContext { is_trivial_path: true, .. }) => (),
+        Some(PathCompletionCtx { is_absolute_path: false, qualifier: None, .. }) => (),
         _ => return,
     }
 

--- a/crates/ide_completion/src/completions/unqualified_path.rs
+++ b/crates/ide_completion/src/completions/unqualified_path.rs
@@ -4,7 +4,7 @@ use hir::ScopeDef;
 use syntax::{ast, AstNode};
 
 use crate::{
-    completions::{module_or_attr, module_or_fn_macro},
+    completions::module_or_fn_macro,
     context::{PathCompletionContext, PathKind},
     patterns::ImmediateLocation,
     CompletionContext, Completions,
@@ -36,14 +36,7 @@ pub(crate) fn complete_unqualified_path(acc: &mut Completions, ctx: &CompletionC
 
     match kind {
         Some(PathKind::Vis { .. }) => return,
-        Some(PathKind::Attr) => {
-            ctx.process_all_names(&mut |name, def| {
-                if let Some(def) = module_or_attr(def) {
-                    acc.add_resolution(ctx, name, def);
-                }
-            });
-            return;
-        }
+        Some(PathKind::Attr { .. }) => return,
         _ => (),
     }
 

--- a/crates/ide_completion/src/completions/unqualified_path.rs
+++ b/crates/ide_completion/src/completions/unqualified_path.rs
@@ -20,25 +20,11 @@ pub(crate) fn complete_unqualified_path(acc: &mut Completions, ctx: &CompletionC
         _ => return,
     };
 
-    if let Some(PathKind::Use) = kind {
-        // only show modules in a fresh UseTree
-        cov_mark::hit!(unqualified_path_only_modules_in_import);
-        ctx.process_all_names(&mut |name, res| {
-            if let ScopeDef::ModuleDef(hir::ModuleDef::Module(_)) = res {
-                acc.add_resolution(ctx, name, res);
-            }
-        });
-
-        ["self::", "super::", "crate::"].into_iter().for_each(|kw| acc.add_keyword(ctx, kw));
-        return;
-    }
-    ["self", "super", "crate"].into_iter().for_each(|kw| acc.add_keyword(ctx, kw));
-
     match kind {
-        Some(PathKind::Vis { .. }) => return,
-        Some(PathKind::Attr { .. }) => return,
+        Some(PathKind::Vis { .. } | PathKind::Attr { .. } | PathKind::Use { .. }) => return,
         _ => (),
     }
+    ["self", "super", "crate"].into_iter().for_each(|kw| acc.add_keyword(ctx, kw));
 
     match &ctx.completion_location {
         Some(ImmediateLocation::ItemList | ImmediateLocation::Trait | ImmediateLocation::Impl) => {

--- a/crates/ide_completion/src/completions/unqualified_path.rs
+++ b/crates/ide_completion/src/completions/unqualified_path.rs
@@ -17,7 +17,13 @@ pub(crate) fn complete_unqualified_path(acc: &mut Completions, ctx: &CompletionC
     }
     match ctx.path_context {
         Some(PathCompletionCtx {
-            kind: Some(PathKind::Vis { .. } | PathKind::Attr { .. } | PathKind::Use { .. }),
+            kind:
+                Some(
+                    PathKind::Vis { .. }
+                    | PathKind::Attr { .. }
+                    | PathKind::Use { .. }
+                    | PathKind::Pat,
+                ),
             ..
         }) => return,
         Some(PathCompletionCtx { is_absolute_path: false, qualifier: None, .. }) => (),

--- a/crates/ide_completion/src/completions/unqualified_path.rs
+++ b/crates/ide_completion/src/completions/unqualified_path.rs
@@ -15,15 +15,15 @@ pub(crate) fn complete_unqualified_path(acc: &mut Completions, ctx: &CompletionC
     if ctx.is_path_disallowed() || ctx.has_impl_or_trait_prev_sibling() {
         return;
     }
-    let kind = match ctx.path_context {
-        Some(PathCompletionContext { is_trivial_path: true, kind, .. }) => kind,
+    match ctx.path_context {
+        Some(PathCompletionContext {
+            kind: Some(PathKind::Vis { .. } | PathKind::Attr { .. } | PathKind::Use { .. }),
+            ..
+        }) => return,
+        Some(PathCompletionContext { is_trivial_path: true, .. }) => (),
         _ => return,
-    };
-
-    match kind {
-        Some(PathKind::Vis { .. } | PathKind::Attr { .. } | PathKind::Use { .. }) => return,
-        _ => (),
     }
+
     ["self", "super", "crate"].into_iter().for_each(|kw| acc.add_keyword(ctx, kw));
 
     match &ctx.completion_location {

--- a/crates/ide_completion/src/completions/use_.rs
+++ b/crates/ide_completion/src/completions/use_.rs
@@ -1,0 +1,109 @@
+//! Completion for use trees
+//!
+//! This module uses a bit of static metadata to provide completions
+//! for built-in attributes.
+//! Non-built-in attribute (excluding derives attributes) completions are done in [`super::unqualified_path`].
+
+use std::iter;
+
+use hir::ScopeDef;
+use syntax::{ast, AstNode};
+
+use crate::{
+    context::{CompletionContext, PathCompletionContext, PathKind},
+    Completions,
+};
+
+pub(crate) fn complete_use_tree(acc: &mut Completions, ctx: &CompletionContext) {
+    let (is_trivial_path, qualifier, use_tree_parent) = match ctx.path_context {
+        Some(PathCompletionContext {
+            kind: Some(PathKind::Use),
+            is_trivial_path,
+            use_tree_parent,
+            ref qualifier,
+            ..
+        }) => (is_trivial_path, qualifier, use_tree_parent),
+        _ => return,
+    };
+
+    match qualifier {
+        Some((path, qualifier)) => {
+            let is_super_chain = iter::successors(Some(path.clone()), |p| p.qualifier())
+                .all(|p| p.segment().and_then(|s| s.super_token()).is_some());
+            if is_super_chain {
+                acc.add_keyword(ctx, "super::");
+            }
+            // only show `self` in a new use-tree when the qualifier doesn't end in self
+            let not_preceded_by_self = use_tree_parent
+                && !matches!(
+                    path.segment().and_then(|it| it.kind()),
+                    Some(ast::PathSegmentKind::SelfKw)
+                );
+            if not_preceded_by_self {
+                acc.add_keyword(ctx, "self");
+            }
+
+            let qualifier = match qualifier {
+                Some(it) => it,
+                None => return,
+            };
+
+            match qualifier {
+                hir::PathResolution::Def(hir::ModuleDef::Module(module)) => {
+                    let module_scope = module.scope(ctx.db, ctx.module);
+                    let unknown_is_current = |name: &hir::Name| {
+                        matches!(
+                            ctx.name_syntax.as_ref(),
+                            Some(ast::NameLike::NameRef(name_ref))
+                                if name_ref.syntax().text() == name.to_smol_str().as_str()
+                        )
+                    };
+                    for (name, def) in module_scope {
+                        let add_resolution = match def {
+                            ScopeDef::Unknown if unknown_is_current(&name) => {
+                                // for `use self::foo$0`, don't suggest `foo` as a completion
+                                cov_mark::hit!(dont_complete_current_use);
+                                continue;
+                            }
+                            ScopeDef::ModuleDef(_) | ScopeDef::MacroDef(_) | ScopeDef::Unknown => {
+                                true
+                            }
+                            _ => false,
+                        };
+
+                        if add_resolution {
+                            acc.add_resolution(ctx, name, def);
+                        }
+                    }
+                }
+                hir::PathResolution::Def(hir::ModuleDef::Adt(hir::Adt::Enum(e))) => {
+                    cov_mark::hit!(enum_plain_qualified_use_tree);
+                    e.variants(ctx.db)
+                        .into_iter()
+                        .for_each(|variant| acc.add_enum_variant(ctx, variant, None));
+                }
+                _ => {}
+            }
+        }
+        // fresh use tree with leading colon2, only show crate roots
+        None if !is_trivial_path => {
+            cov_mark::hit!(use_tree_crate_roots_only);
+            ctx.process_all_names(&mut |name, res| match res {
+                ScopeDef::ModuleDef(hir::ModuleDef::Module(m)) if m.is_crate_root(ctx.db) => {
+                    acc.add_resolution(ctx, name, res);
+                }
+                _ => (),
+            });
+        }
+        // only show modules in a fresh UseTree
+        None => {
+            cov_mark::hit!(unqualified_path_only_modules_in_import);
+            ctx.process_all_names(&mut |name, res| {
+                if let ScopeDef::ModuleDef(hir::ModuleDef::Module(_)) = res {
+                    acc.add_resolution(ctx, name, res);
+                }
+            });
+            ["self::", "super::", "crate::"].into_iter().for_each(|kw| acc.add_keyword(ctx, kw));
+        }
+    }
+}

--- a/crates/ide_completion/src/completions/use_.rs
+++ b/crates/ide_completion/src/completions/use_.rs
@@ -79,12 +79,7 @@ pub(crate) fn complete_use_tree(acc: &mut Completions, ctx: &CompletionContext) 
         // fresh use tree with leading colon2, only show crate roots
         None if is_absolute_path => {
             cov_mark::hit!(use_tree_crate_roots_only);
-            ctx.process_all_names(&mut |name, res| match res {
-                ScopeDef::ModuleDef(hir::ModuleDef::Module(m)) if m.is_crate_root(ctx.db) => {
-                    acc.add_resolution(ctx, name, res);
-                }
-                _ => (),
-            });
+            acc.add_crate_roots(ctx);
         }
         // only show modules in a fresh UseTree
         None => {
@@ -94,7 +89,7 @@ pub(crate) fn complete_use_tree(acc: &mut Completions, ctx: &CompletionContext) 
                     acc.add_resolution(ctx, name, res);
                 }
             });
-            ["self::", "super::", "crate::"].into_iter().for_each(|kw| acc.add_keyword(ctx, kw));
+            acc.add_nameref_keywords(ctx);
         }
     }
 }

--- a/crates/ide_completion/src/completions/use_.rs
+++ b/crates/ide_completion/src/completions/use_.rs
@@ -1,8 +1,4 @@
 //! Completion for use trees
-//!
-//! This module uses a bit of static metadata to provide completions
-//! for built-in attributes.
-//! Non-built-in attribute (excluding derives attributes) completions are done in [`super::unqualified_path`].
 
 use std::iter;
 

--- a/crates/ide_completion/src/completions/vis.rs
+++ b/crates/ide_completion/src/completions/vis.rs
@@ -1,0 +1,56 @@
+//! Completion for visibility specifiers.
+
+use std::iter;
+
+use hir::ScopeDef;
+
+use crate::{
+    context::{CompletionContext, PathCompletionContext, PathKind},
+    Completions,
+};
+
+pub(crate) fn complete_vis(acc: &mut Completions, ctx: &CompletionContext) {
+    let (is_trivial_path, qualifier, has_in_token) = match ctx.path_context {
+        Some(PathCompletionContext {
+            kind: Some(PathKind::Vis { has_in_token }),
+            is_trivial_path,
+            ref qualifier,
+            ..
+        }) => (is_trivial_path, qualifier, has_in_token),
+        _ => return,
+    };
+
+    match qualifier {
+        Some((path, qualifier)) => {
+            if let Some(hir::PathResolution::Def(hir::ModuleDef::Module(module))) = qualifier {
+                if let Some(current_module) = ctx.module {
+                    let next_towards_current = current_module
+                        .path_to_root(ctx.db)
+                        .into_iter()
+                        .take_while(|it| it != module)
+                        .next();
+                    if let Some(next) = next_towards_current {
+                        if let Some(name) = next.name(ctx.db) {
+                            cov_mark::hit!(visibility_qualified);
+                            acc.add_resolution(ctx, name, ScopeDef::ModuleDef(next.into()));
+                        }
+                    }
+                }
+            }
+
+            let is_super_chain = iter::successors(Some(path.clone()), |p| p.qualifier())
+                .all(|p| p.segment().and_then(|s| s.super_token()).is_some());
+            if is_super_chain {
+                acc.add_keyword(ctx, "super::");
+            }
+        }
+        None if is_trivial_path => {
+            if !has_in_token {
+                cov_mark::hit!(kw_completion_in);
+                acc.add_keyword(ctx, "in");
+            }
+            ["self", "super", "crate"].into_iter().for_each(|kw| acc.add_keyword(ctx, kw));
+        }
+        _ => {}
+    }
+}

--- a/crates/ide_completion/src/completions/vis.rs
+++ b/crates/ide_completion/src/completions/vis.rs
@@ -1,28 +1,26 @@
 //! Completion for visibility specifiers.
 
-use std::iter;
-
 use hir::ScopeDef;
 
 use crate::{
-    context::{CompletionContext, PathCompletionContext, PathKind},
+    context::{CompletionContext, PathCompletionCtx, PathKind, PathQualifierCtx},
     Completions,
 };
 
 pub(crate) fn complete_vis(acc: &mut Completions, ctx: &CompletionContext) {
-    let (is_trivial_path, qualifier, has_in_token) = match ctx.path_context {
-        Some(PathCompletionContext {
+    let (is_absolute_path, qualifier, has_in_token) = match ctx.path_context {
+        Some(PathCompletionCtx {
             kind: Some(PathKind::Vis { has_in_token }),
-            is_trivial_path,
+            is_absolute_path,
             ref qualifier,
             ..
-        }) => (is_trivial_path, qualifier, has_in_token),
+        }) => (is_absolute_path, qualifier, has_in_token),
         _ => return,
     };
 
     match qualifier {
-        Some((path, qualifier)) => {
-            if let Some(hir::PathResolution::Def(hir::ModuleDef::Module(module))) = qualifier {
+        Some(PathQualifierCtx { resolution, is_super_chain, .. }) => {
+            if let Some(hir::PathResolution::Def(hir::ModuleDef::Module(module))) = resolution {
                 if let Some(current_module) = ctx.module {
                     let next_towards_current = current_module
                         .path_to_root(ctx.db)
@@ -38,13 +36,11 @@ pub(crate) fn complete_vis(acc: &mut Completions, ctx: &CompletionContext) {
                 }
             }
 
-            let is_super_chain = iter::successors(Some(path.clone()), |p| p.qualifier())
-                .all(|p| p.segment().and_then(|s| s.super_token()).is_some());
-            if is_super_chain {
+            if *is_super_chain {
                 acc.add_keyword(ctx, "super::");
             }
         }
-        None if is_trivial_path => {
+        None if !is_absolute_path => {
             if !has_in_token {
                 cov_mark::hit!(kw_completion_in);
                 acc.add_keyword(ctx, "in");

--- a/crates/ide_completion/src/context.rs
+++ b/crates/ide_completion/src/context.rs
@@ -72,12 +72,12 @@ pub(crate) struct PathCompletionCtx {
 
 #[derive(Debug)]
 pub(crate) struct PathQualifierCtx {
-    pub path: ast::Path,
-    pub resolution: Option<PathResolution>,
+    pub(crate) path: ast::Path,
+    pub(crate) resolution: Option<PathResolution>,
     /// Whether this path consists solely of `super` segments
-    pub is_super_chain: bool,
+    pub(crate) is_super_chain: bool,
     /// Whether the qualifier comes from a use tree parent or not
-    pub use_tree_parent: bool,
+    pub(crate) use_tree_parent: bool,
 }
 
 #[derive(Debug)]

--- a/crates/ide_completion/src/lib.rs
+++ b/crates/ide_completion/src/lib.rs
@@ -153,6 +153,7 @@ pub fn completions(
     let mut acc = Completions::default();
     completions::attribute::complete_known_attribute_input(&mut acc, &ctx);
     completions::attribute::complete_attribute(&mut acc, &ctx);
+    completions::use_::complete_use_tree(&mut acc, &ctx);
     completions::fn_param::complete_fn_param(&mut acc, &ctx);
     completions::keyword::complete_expr_keyword(&mut acc, &ctx);
     completions::snippet::complete_expr_snippet(&mut acc, &ctx);

--- a/crates/ide_completion/src/lib.rs
+++ b/crates/ide_completion/src/lib.rs
@@ -151,6 +151,7 @@ pub fn completions(
     }
 
     let mut acc = Completions::default();
+    completions::attribute::complete_known_attribute_input(&mut acc, &ctx);
     completions::attribute::complete_attribute(&mut acc, &ctx);
     completions::fn_param::complete_fn_param(&mut acc, &ctx);
     completions::keyword::complete_expr_keyword(&mut acc, &ctx);

--- a/crates/ide_completion/src/lib.rs
+++ b/crates/ide_completion/src/lib.rs
@@ -154,6 +154,7 @@ pub fn completions(
     completions::attribute::complete_known_attribute_input(&mut acc, &ctx);
     completions::attribute::complete_attribute(&mut acc, &ctx);
     completions::use_::complete_use_tree(&mut acc, &ctx);
+    completions::vis::complete_vis(&mut acc, &ctx);
     completions::fn_param::complete_fn_param(&mut acc, &ctx);
     completions::keyword::complete_expr_keyword(&mut acc, &ctx);
     completions::snippet::complete_expr_snippet(&mut acc, &ctx);

--- a/crates/ide_completion/src/render.rs
+++ b/crates/ide_completion/src/render.rs
@@ -19,7 +19,7 @@ use ide_db::{
 use syntax::{SmolStr, SyntaxKind, TextRange};
 
 use crate::{
-    context::{PathCompletionContext, PathKind},
+    context::{PathCompletionCtx, PathKind},
     item::{CompletionRelevanceTypeMatch, ImportEdit},
     render::{enum_variant::render_variant, function::render_fn, macro_::render_macro},
     CompletionContext, CompletionItem, CompletionItemKind, CompletionRelevance,
@@ -234,7 +234,7 @@ fn render_resolution_(
     // Add `<>` for generic types
     let type_path_no_ty_args = matches!(
         ctx.completion.path_context,
-        Some(PathCompletionContext { kind: Some(PathKind::Type), has_type_args: false, .. })
+        Some(PathCompletionCtx { kind: Some(PathKind::Type), has_type_args: false, .. })
     ) && ctx.completion.config.add_call_parenthesis;
     if type_path_no_ty_args {
         if let Some(cap) = ctx.snippet_cap() {

--- a/crates/ide_completion/src/tests/attribute.rs
+++ b/crates/ide_completion/src/tests/attribute.rs
@@ -18,6 +18,9 @@ struct Foo;
 "#,
         expect![[r#"
             md proc_macros
+            kw self::
+            kw super::
+            kw crate::
             at allow(…)
             at cfg(…)
             at cfg_attr(…)
@@ -33,9 +36,6 @@ struct Foo;
             at derive(…)
             at repr(…)
             at non_exhaustive
-            kw self
-            kw super
-            kw crate
         "#]],
     )
 }
@@ -61,7 +61,10 @@ fn proc_macros_qualified() {
 #[proc_macros::$0]
 struct Foo;
 "#,
-        expect![[r#""#]],
+        expect![[r#"
+            at input_replace pub macro input_replace
+            at identity      pub macro identity
+        "#]],
     )
 }
 
@@ -75,15 +78,15 @@ fn with_existing_attr() {
     check(
         r#"#[no_mangle] #[$0] mcall!();"#,
         expect![[r#"
+            kw self::
+            kw super::
+            kw crate::
             at allow(…)
             at cfg(…)
             at cfg_attr(…)
             at deny(…)
             at forbid(…)
             at warn(…)
-            kw self
-            kw super
-            kw crate
         "#]],
     )
 }
@@ -93,6 +96,9 @@ fn attr_on_source_file() {
     check(
         r#"#![$0]"#,
         expect![[r#"
+            kw self::
+            kw super::
+            kw crate::
             at allow(…)
             at cfg(…)
             at cfg_attr(…)
@@ -113,9 +119,6 @@ fn attr_on_source_file() {
             at recursion_limit = "…"
             at type_length_limit = …
             at windows_subsystem = "…"
-            kw self
-            kw super
-            kw crate
         "#]],
     );
 }
@@ -125,6 +128,9 @@ fn attr_on_module() {
     check(
         r#"#[$0] mod foo;"#,
         expect![[r#"
+            kw self::
+            kw super::
+            kw crate::
             at allow(…)
             at cfg(…)
             at cfg_attr(…)
@@ -139,14 +145,14 @@ fn attr_on_module() {
             at no_mangle
             at macro_use
             at path = "…"
-            kw self
-            kw super
-            kw crate
         "#]],
     );
     check(
         r#"mod foo {#![$0]}"#,
         expect![[r#"
+            kw self::
+            kw super::
+            kw crate::
             at allow(…)
             at cfg(…)
             at cfg_attr(…)
@@ -160,9 +166,6 @@ fn attr_on_module() {
             at must_use
             at no_mangle
             at no_implicit_prelude
-            kw self
-            kw super
-            kw crate
         "#]],
     );
 }
@@ -172,6 +175,9 @@ fn attr_on_macro_rules() {
     check(
         r#"#[$0] macro_rules! foo {}"#,
         expect![[r#"
+            kw self::
+            kw super::
+            kw crate::
             at allow(…)
             at cfg(…)
             at cfg_attr(…)
@@ -186,9 +192,6 @@ fn attr_on_macro_rules() {
             at no_mangle
             at macro_export
             at macro_use
-            kw self
-            kw super
-            kw crate
         "#]],
     );
 }
@@ -198,6 +201,9 @@ fn attr_on_macro_def() {
     check(
         r#"#[$0] macro foo {}"#,
         expect![[r#"
+            kw self::
+            kw super::
+            kw crate::
             at allow(…)
             at cfg(…)
             at cfg_attr(…)
@@ -210,9 +216,6 @@ fn attr_on_macro_def() {
             at doc(alias = "…")
             at must_use
             at no_mangle
-            kw self
-            kw super
-            kw crate
         "#]],
     );
 }
@@ -222,6 +225,9 @@ fn attr_on_extern_crate() {
     check(
         r#"#[$0] extern crate foo;"#,
         expect![[r#"
+            kw self::
+            kw super::
+            kw crate::
             at allow(…)
             at cfg(…)
             at cfg_attr(…)
@@ -235,9 +241,6 @@ fn attr_on_extern_crate() {
             at must_use
             at no_mangle
             at macro_use
-            kw self
-            kw super
-            kw crate
         "#]],
     );
 }
@@ -247,6 +250,9 @@ fn attr_on_use() {
     check(
         r#"#[$0] use foo;"#,
         expect![[r#"
+            kw self::
+            kw super::
+            kw crate::
             at allow(…)
             at cfg(…)
             at cfg_attr(…)
@@ -259,9 +265,6 @@ fn attr_on_use() {
             at doc(alias = "…")
             at must_use
             at no_mangle
-            kw self
-            kw super
-            kw crate
         "#]],
     );
 }
@@ -271,6 +274,9 @@ fn attr_on_type_alias() {
     check(
         r#"#[$0] type foo = ();"#,
         expect![[r#"
+            kw self::
+            kw super::
+            kw crate::
             at allow(…)
             at cfg(…)
             at cfg_attr(…)
@@ -283,9 +289,6 @@ fn attr_on_type_alias() {
             at doc(alias = "…")
             at must_use
             at no_mangle
-            kw self
-            kw super
-            kw crate
         "#]],
     );
 }
@@ -301,6 +304,9 @@ struct Foo;
         expect![[r#"
             md core
             at derive           pub macro derive
+            kw self::
+            kw super::
+            kw crate::
             at allow(…)
             at cfg(…)
             at cfg_attr(…)
@@ -316,9 +322,6 @@ struct Foo;
             at derive(…)
             at repr(…)
             at non_exhaustive
-            kw self
-            kw super
-            kw crate
         "#]],
     );
 }
@@ -328,6 +331,9 @@ fn attr_on_enum() {
     check(
         r#"#[$0] enum Foo {}"#,
         expect![[r#"
+            kw self::
+            kw super::
+            kw crate::
             at allow(…)
             at cfg(…)
             at cfg_attr(…)
@@ -343,9 +349,6 @@ fn attr_on_enum() {
             at derive(…)
             at repr(…)
             at non_exhaustive
-            kw self
-            kw super
-            kw crate
         "#]],
     );
 }
@@ -355,6 +358,9 @@ fn attr_on_const() {
     check(
         r#"#[$0] const FOO: () = ();"#,
         expect![[r#"
+            kw self::
+            kw super::
+            kw crate::
             at allow(…)
             at cfg(…)
             at cfg_attr(…)
@@ -367,9 +373,6 @@ fn attr_on_const() {
             at doc(alias = "…")
             at must_use
             at no_mangle
-            kw self
-            kw super
-            kw crate
         "#]],
     );
 }
@@ -379,6 +382,9 @@ fn attr_on_static() {
     check(
         r#"#[$0] static FOO: () = ()"#,
         expect![[r#"
+            kw self::
+            kw super::
+            kw crate::
             at allow(…)
             at cfg(…)
             at cfg_attr(…)
@@ -396,9 +402,6 @@ fn attr_on_static() {
             at link_section = "…"
             at global_allocator
             at used
-            kw self
-            kw super
-            kw crate
         "#]],
     );
 }
@@ -408,6 +411,9 @@ fn attr_on_trait() {
     check(
         r#"#[$0] trait Foo {}"#,
         expect![[r#"
+            kw self::
+            kw super::
+            kw crate::
             at allow(…)
             at cfg(…)
             at cfg_attr(…)
@@ -421,9 +427,6 @@ fn attr_on_trait() {
             at must_use
             at no_mangle
             at must_use
-            kw self
-            kw super
-            kw crate
         "#]],
     );
 }
@@ -433,6 +436,9 @@ fn attr_on_impl() {
     check(
         r#"#[$0] impl () {}"#,
         expect![[r#"
+            kw self::
+            kw super::
+            kw crate::
             at allow(…)
             at cfg(…)
             at cfg_attr(…)
@@ -446,14 +452,14 @@ fn attr_on_impl() {
             at must_use
             at no_mangle
             at automatically_derived
-            kw self
-            kw super
-            kw crate
         "#]],
     );
     check(
         r#"impl () {#![$0]}"#,
         expect![[r#"
+            kw self::
+            kw super::
+            kw crate::
             at allow(…)
             at cfg(…)
             at cfg_attr(…)
@@ -466,9 +472,6 @@ fn attr_on_impl() {
             at doc(alias = "…")
             at must_use
             at no_mangle
-            kw self
-            kw super
-            kw crate
         "#]],
     );
 }
@@ -478,6 +481,9 @@ fn attr_on_extern_block() {
     check(
         r#"#[$0] extern {}"#,
         expect![[r#"
+            kw self::
+            kw super::
+            kw crate::
             at allow(…)
             at cfg(…)
             at cfg_attr(…)
@@ -491,14 +497,14 @@ fn attr_on_extern_block() {
             at must_use
             at no_mangle
             at link
-            kw self
-            kw super
-            kw crate
         "#]],
     );
     check(
         r#"extern {#![$0]}"#,
         expect![[r#"
+            kw self::
+            kw super::
+            kw crate::
             at allow(…)
             at cfg(…)
             at cfg_attr(…)
@@ -512,9 +518,6 @@ fn attr_on_extern_block() {
             at must_use
             at no_mangle
             at link
-            kw self
-            kw super
-            kw crate
         "#]],
     );
 }
@@ -524,6 +527,9 @@ fn attr_on_variant() {
     check(
         r#"enum Foo { #[$0] Bar }"#,
         expect![[r#"
+            kw self::
+            kw super::
+            kw crate::
             at allow(…)
             at cfg(…)
             at cfg_attr(…)
@@ -531,9 +537,6 @@ fn attr_on_variant() {
             at forbid(…)
             at warn(…)
             at non_exhaustive
-            kw self
-            kw super
-            kw crate
         "#]],
     );
 }
@@ -543,6 +546,9 @@ fn attr_on_fn() {
     check(
         r#"#[$0] fn main() {}"#,
         expect![[r#"
+            kw self::
+            kw super::
+            kw crate::
             at allow(…)
             at cfg(…)
             at cfg_attr(…)
@@ -570,9 +576,6 @@ fn attr_on_fn() {
             at target_feature = "…"
             at test
             at track_caller
-            kw self
-            kw super
-            kw crate
         "#]],
     );
 }
@@ -583,15 +586,15 @@ fn attr_on_expr() {
     check(
         r#"fn main() { #[$0] foo() }"#,
         expect![[r#"
+            kw self::
+            kw super::
+            kw crate::
             at allow(…)
             at cfg(…)
             at cfg_attr(…)
             at deny(…)
             at forbid(…)
             at warn(…)
-            kw self
-            kw super
-            kw crate
         "#]],
     );
 }
@@ -601,6 +604,9 @@ fn attr_in_source_file_end() {
     check(
         r#"#[$0]"#,
         expect![[r#"
+            kw self::
+            kw super::
+            kw crate::
             at allow(…)
             at automatically_derived
             at cfg(…)
@@ -637,9 +643,6 @@ fn attr_in_source_file_end() {
             at track_caller
             at used
             at warn(…)
-            kw self
-            kw super
-            kw crate
         "#]],
     );
 }

--- a/crates/ide_completion/src/tests/attribute.rs
+++ b/crates/ide_completion/src/tests/attribute.rs
@@ -17,6 +17,7 @@ fn proc_macros() {
 struct Foo;
 "#,
         expect![[r#"
+            md proc_macros
             at allow(…)
             at cfg(…)
             at cfg_attr(…)
@@ -35,7 +36,6 @@ struct Foo;
             kw self
             kw super
             kw crate
-            md proc_macros
         "#]],
     )
 }
@@ -61,10 +61,7 @@ fn proc_macros_qualified() {
 #[proc_macros::$0]
 struct Foo;
 "#,
-        expect![[r#"
-            at input_replace pub macro input_replace
-            at identity      pub macro identity
-        "#]],
+        expect![[r#""#]],
     )
 }
 
@@ -302,6 +299,8 @@ fn attr_on_struct() {
 struct Foo;
 "#,
         expect![[r#"
+            md core
+            at derive           pub macro derive
             at allow(…)
             at cfg(…)
             at cfg_attr(…)
@@ -320,8 +319,6 @@ struct Foo;
             kw self
             kw super
             kw crate
-            md core
-            at derive           pub macro derive
         "#]],
     );
 }

--- a/crates/ide_completion/src/tests/fn_param.rs
+++ b/crates/ide_completion/src/tests/fn_param.rs
@@ -17,6 +17,7 @@ fn baz(file$0) {}
 "#,
         expect![[r#"
             bn file_id: usize
+            kw ref
             kw mut
         "#]],
     );
@@ -32,6 +33,7 @@ fn baz(foo: (), file$0) {}
 "#,
         expect![[r#"
             bn file_id: usize
+            kw ref
             kw mut
         "#]],
     );
@@ -47,6 +49,7 @@ fn baz(file$0 id: u32) {}
 "#,
         expect![[r#"
             bn file_id: usize,
+            kw ref
             kw mut
         "#]],
     );
@@ -60,6 +63,7 @@ fn foo(file_id: usize) {}
 fn bar(file_id: u32, $0) {}
 "#,
         expect![[r#"
+            kw ref
             kw mut
         "#]],
     );
@@ -76,6 +80,7 @@ pub(crate) trait SourceRoot {
 "#,
         expect![[r#"
             bn file_id: usize
+            kw ref
             kw mut
         "#]],
     );
@@ -91,6 +96,7 @@ fn outer(text: &str) {
 "#,
         expect![[r#"
             bn text: &str
+            kw ref
             kw mut
         "#]],
     )
@@ -106,6 +112,7 @@ fn foo2($0) {}
 "#,
         expect![[r#"
             bn Bar { bar }: Bar
+            kw ref
             kw mut
             bn Bar              Bar { bar$1 }: Bar$0
             st Bar
@@ -130,6 +137,7 @@ impl A {
             bn mut self
             bn &mut self
             bn file_id: usize
+            kw ref
             kw mut
             sp Self
             st A
@@ -150,6 +158,7 @@ impl A {
 "#,
         expect![[r#"
             bn file_id: usize
+            kw ref
             kw mut
             sp Self
             st A
@@ -178,6 +187,7 @@ fn outer() {
             bn foo: i32
             bn baz: i32
             bn bar: i32
+            kw ref
             kw mut
         "#]],
     )
@@ -202,6 +212,22 @@ fn outer() {
             bn baz: i32
             bn bar: i32
             bn foo: i32
+            kw ref
+            kw mut
+        "#]],
+    )
+}
+
+#[test]
+fn completes_fully_equal() {
+    check(
+        r#"
+fn foo(bar: u32) {}
+fn bar(bar$0) {}
+"#,
+        expect![[r#"
+            bn bar: u32
+            kw ref
             kw mut
         "#]],
     )

--- a/crates/ide_completion/src/tests/pattern.rs
+++ b/crates/ide_completion/src/tests/pattern.rs
@@ -22,6 +22,7 @@ fn quux() {
 }
 "#,
         expect![[r#"
+            kw ref
             kw mut
         "#]],
     );
@@ -53,16 +54,13 @@ fn quux() {
 
 #[test]
 fn ident_ref_mut_pat() {
-    // FIXME mut is already here, don't complete it again
     check_empty(
         r#"
 fn quux() {
     let ref mut en$0
 }
 "#,
-        expect![[r#"
-            kw mut
-        "#]],
+        expect![[r#""#]],
     );
     check_empty(
         r#"
@@ -70,9 +68,7 @@ fn quux() {
     let ref mut en$0 @ x
 }
 "#,
-        expect![[r#"
-            kw mut
-        "#]],
+        expect![[r#""#]],
     );
 }
 
@@ -88,16 +84,13 @@ fn quux() {
             kw mut
         "#]],
     );
-    // FIXME mut is already here, don't complete it again
     check_empty(
         r#"
 fn quux() {
     let &mut en$0
 }
 "#,
-        expect![[r#"
-            kw mut
-        "#]],
+        expect![[r#""#]],
     );
 }
 
@@ -110,6 +103,7 @@ fn foo() {
 }
 "#,
         expect![[r##"
+            kw ref
             kw mut
             en Enum
             bn Record    Record { field$1 }$0
@@ -139,6 +133,7 @@ fn foo() {
 }
 "#,
         expect![[r##"
+            kw ref
             kw mut
             bn Record            Record { field$1 }$0
             st Record
@@ -160,6 +155,7 @@ fn foo(a$0) {
 }
 "#,
         expect![[r##"
+            kw ref
             kw mut
             bn Record    Record { field$1 }: Record$0
             st Record
@@ -175,6 +171,7 @@ fn foo(a$0: Tuple) {
 }
 "#,
         expect![[r##"
+            kw ref
             kw mut
             bn Record    Record { field$1 }$0
             st Record
@@ -200,6 +197,7 @@ fn foo() {
 }
 "#,
         expect![[r#"
+            kw ref
             kw mut
             ma m!(…) macro_rules! m
         "#]],
@@ -218,6 +216,7 @@ fn foo() {
 }
 "#,
         expect![[r#"
+            kw ref
             kw mut
             ev E::X  ()
             en E
@@ -242,6 +241,7 @@ fn outer() {
 }
 "#,
         expect![[r#"
+            kw ref
             kw mut
             bn Record    Record { field$1, .. }$0
             st Record
@@ -267,6 +267,7 @@ impl Foo {
 }
     "#,
         expect![[r#"
+            kw ref
             kw mut
             bn Self Self($1)$0
             sp Self
@@ -278,7 +279,6 @@ impl Foo {
 
 #[test]
 fn enum_qualified() {
-    // FIXME: Don't show functions, they aren't patterns
     check(
         r#"
 impl Enum {
@@ -291,12 +291,9 @@ fn func() {
 }
 "#,
         expect![[r#"
-            ev TupleV(…)   (u32)
-            ev RecordV     {field: u32}
-            ev UnitV       ()
-            ct ASSOC_CONST const ASSOC_CONST: ()
-            fn assoc_fn()  fn()
-            ta AssocType   type AssocType = ()
+            ev TupleV(…) (u32)
+            ev RecordV   {field: u32}
+            ev UnitV     ()
         "#]],
     );
 }
@@ -310,6 +307,7 @@ struct Bar(u32);
 fn outer(Foo { bar: $0 }: Foo) {}
 "#,
         expect![[r#"
+            kw ref
             kw mut
             bn Foo Foo { bar$1 }$0
             st Foo
@@ -340,6 +338,7 @@ struct Bar(u32);
 fn foo($0) {}
 "#,
         expect![[r#"
+            kw ref
             kw mut
             bn Foo Foo { bar$1 }: Foo$0
             st Foo
@@ -360,25 +359,12 @@ fn foo() {
 }
 "#,
         expect![[r#"
+            kw ref
             kw mut
             bn Foo Foo { bar$1 }$0
             st Foo
             bn Bar Bar($1)$0
             st Bar
-        "#]],
-    )
-}
-
-#[test]
-fn completes_fully_equal() {
-    check_empty(
-        r#"
-fn foo(bar: u32) {}
-fn bar(bar$0) {}
-"#,
-        expect![[r#"
-            bn bar: u32
-            kw mut
         "#]],
     )
 }

--- a/crates/ide_completion/src/tests/use_tree.rs
+++ b/crates/ide_completion/src/tests/use_tree.rs
@@ -32,6 +32,25 @@ mod foo {}
 }
 
 #[test]
+fn use_tree_start_abs() {
+    cov_mark::check!(use_tree_crate_roots_only);
+    check(
+        r#"
+//- /lib.rs crate:main deps:other_crate
+use ::f$0
+
+struct Foo;
+mod foo {}
+//- /other_crate/lib.rs crate:other_crate
+// nothing here
+"#,
+        expect![[r#"
+            md other_crate
+        "#]],
+    );
+}
+
+#[test]
 fn dont_complete_current_use() {
     cov_mark::check!(dont_complete_current_use);
     check(r#"use self::foo$0;"#, expect![[r#""#]]);

--- a/crates/ide_completion/src/tests/use_tree.rs
+++ b/crates/ide_completion/src/tests/use_tree.rs
@@ -135,6 +135,25 @@ struct Bar;
 }
 
 #[test]
+fn enum_plain_qualified_use_tree() {
+    cov_mark::check!(enum_plain_qualified_use_tree);
+    check(
+        r#"
+use Foo::$0
+
+enum Foo { Variant }
+impl Foo {
+    const CONST: () = ()
+    fn func() {}
+}
+"#,
+        expect![[r#"
+            ev Variant ()
+        "#]],
+    );
+}
+
+#[test]
 fn self_qualified_use_tree() {
     check(
         r#"

--- a/crates/ide_completion/src/tests/visibility.rs
+++ b/crates/ide_completion/src/tests/visibility.rs
@@ -17,6 +17,9 @@ pub($0)
 "#,
         expect![[r#"
             kw in
+            kw self
+            kw super
+            kw crate
         "#]],
     );
 }
@@ -27,7 +30,11 @@ fn after_in_kw() {
         r#"
 pub(in $0)
 "#,
-        expect![[r#""#]],
+        expect![[r#"
+            kw self
+            kw super
+            kw crate
+        "#]],
     );
 }
 

--- a/crates/ide_completion/src/tests/visibility.rs
+++ b/crates/ide_completion/src/tests/visibility.rs
@@ -17,9 +17,6 @@ pub($0)
 "#,
         expect![[r#"
             kw in
-            kw self
-            kw super
-            kw crate
         "#]],
     );
 }
@@ -30,11 +27,7 @@ fn after_in_kw() {
         r#"
 pub(in $0)
 "#,
-        expect![[r#"
-            kw self
-            kw super
-            kw crate
-        "#]],
+        expect![[r#""#]],
     );
 }
 

--- a/crates/ide_db/src/search.rs
+++ b/crates/ide_db/src/search.rs
@@ -223,7 +223,7 @@ impl Definition {
         // def is crate root
         // FIXME: We don't do searches for crates currently, as a crate does not actually have a single name
         if let &Definition::Module(module) = self {
-            if module.crate_root(db) == module {
+            if module.is_crate_root(db) {
                 return SearchScope::reverse_dependencies(db, module.krate());
             }
         }
@@ -378,7 +378,7 @@ impl<'a> FindUsages<'a> {
 
         let name = match self.def {
             // special case crate modules as these do not have a proper name
-            Definition::Module(module) if module.crate_root(self.sema.db) == module => {
+            Definition::Module(module) if module.is_crate_root(self.sema.db) => {
                 // FIXME: This assumes the crate name is always equal to its display name when it really isn't
                 module
                     .krate()
@@ -460,7 +460,7 @@ impl<'a> FindUsages<'a> {
             Definition::Module(module) => {
                 let scope = search_scope.intersection(&SearchScope::module(self.sema.db, module));
 
-                let is_crate_root = module.crate_root(self.sema.db) == module;
+                let is_crate_root = module.is_crate_root(self.sema.db);
 
                 for (text, file_id, search_range) in scope_files(sema, &scope) {
                     let tree = Lazy::new(move || sema.parse(file_id).syntax().clone());

--- a/crates/syntax/src/ast/node_ext.rs
+++ b/crates/syntax/src/ast/node_ext.rs
@@ -119,7 +119,7 @@ impl From<ast::AssocItem> for ast::Item {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum AttrKind {
     Inner,
     Outer,


### PR DESCRIPTION
Currently our completion infra is split into several modules, each trying to do completions for something specific. This "something" is rather unstructured as it stands now, we have a module for `flyimporting path` completions, `unqualified` and `qualified path` completions, modules for `pattern position` completions that only try to complete extra things for patterns that aren't done in the path modules, `attribute` completions that again only try to add builtin attribute completions without adding the normal path completions and a bunch of other special "entity" completions like lifetimes, method call/field access, function param cloning, ... which serve a more specific purpose than the previous listed ones.

As is evident, the former mentioned ones have some decent overlap which requires extra filtering in them so that they don't collide with each other duplicating a bunch of completions(which we had happen in the past at times).

Now this overlap mostly happens with path completions(and keyword completions as well in some sense) which gives me the feeling that having `qualified` and `unqualified` path completions be separate from the rest gives us more troubles than benefits in the long run.
So this is an attempt at changing this structure to instead still go by rough entity for special cases, but when it comes to paths we instead do the module split on the "path kinds"/"locations"(think pattern, type, expr position etc) that exist. This goes hand in hand with the test refactoring I have done that moved tests to "location oriented" modules as well as the `CompletionContext` refactoring that actually already started splitting the context up for path kinds.

This PR moves some path completions out of the `qualified` and `unqualified` path modules namely attribute, visibility, use and pattern paths.