### PR TITLE
Fix assoc type shorthand from method bounds

### DIFF
--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -239,7 +239,7 @@ impl HirDisplay for TypeParam {
             return Ok(());
         }
 
-        let bounds = f.db.generic_predicates_for_param(self.id, None);
+        let bounds = f.db.generic_predicates_for_param(self.id.parent, self.id, None);
         let substs = TyBuilder::type_params_subst(f.db, self.id.parent);
         let predicates: Vec<_> =
             bounds.iter().cloned().map(|b| b.substitute(Interner, &substs)).collect();

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2235,8 +2235,11 @@ impl TypeParam {
         Type::new_with_resolver_inner(db, krate, &resolver, ty)
     }
 
+    /// FIXME: this only lists trait bounds from the item defining the type
+    /// parameter, not additional bounds that might be added e.g. by a method if
+    /// the parameter comes from an impl!
     pub fn trait_bounds(self, db: &dyn HirDatabase) -> Vec<Trait> {
-        db.generic_predicates_for_param(self.id, None)
+        db.generic_predicates_for_param(self.id.parent, self.id, None)
             .iter()
             .filter_map(|pred| match &pred.skip_binders().skip_binders() {
                 hir_ty::WhereClause::Implemented(trait_ref) => {

--- a/crates/hir/src/source_analyzer.rs
+++ b/crates/hir/src/source_analyzer.rs
@@ -619,9 +619,15 @@ fn resolve_hir_path_(
             TypeNs::TraitId(it) => PathResolution::Def(Trait::from(it).into()),
         };
         match unresolved {
-            Some(unresolved) => res
-                .assoc_type_shorthand_candidates(db, |name, alias| {
-                    (name == unresolved.name).then(|| alias)
+            Some(unresolved) => resolver
+                .generic_def()
+                .and_then(|def| {
+                    hir_ty::associated_type_shorthand_candidates(
+                        db,
+                        def,
+                        res.in_type_ns()?,
+                        |name, _, id| (name == unresolved.name).then(|| id),
+                    )
                 })
                 .map(TypeAlias::from)
                 .map(Into::into)

--- a/crates/hir_ty/src/db.rs
+++ b/crates/hir_ty/src/db.rs
@@ -60,6 +60,7 @@ pub trait HirDatabase: DefDatabase + Upcast<dyn DefDatabase> {
     #[salsa::cycle(crate::lower::generic_predicates_for_param_recover)]
     fn generic_predicates_for_param(
         &self,
+        def: GenericDefId,
         param_id: TypeParamId,
         assoc_name: Option<Name>,
     ) -> Arc<[Binders<QuantifiedWhereClause>]>;

--- a/crates/hir_ty/src/tests/traits.rs
+++ b/crates/hir_ty/src/tests/traits.rs
@@ -393,6 +393,25 @@ fn test() {
 }
 
 #[test]
+fn associated_type_shorthand_from_method_bound() {
+    check_types(
+        r#"
+trait Iterable {
+    type Item;
+}
+struct S<T>;
+impl<T> S<T> {
+    fn foo(self) -> T::Item where T: Iterable { loop {} }
+}
+fn test<T: Iterable>() {
+    let s: S<T>;
+    s.foo();
+ // ^^^^^^^ Iterable::Item<T>
+}"#,
+    );
+}
+
+#[test]
 fn infer_associated_type_bound() {
     check_types(
         r#"

--- a/crates/hir_ty/src/utils.rs
+++ b/crates/hir_ty/src/utils.rs
@@ -83,7 +83,7 @@ fn direct_super_trait_refs(db: &dyn HirDatabase, trait_ref: &TraitRef) -> Vec<Tr
         Some(p) => TypeParamId { parent: trait_ref.hir_trait_id().into(), local_id: p },
         None => return Vec::new(),
     };
-    db.generic_predicates_for_param(trait_self, None)
+    db.generic_predicates_for_param(trait_self.parent, trait_self, None)
         .iter()
         .filter_map(|pred| {
             pred.as_ref().filter_map(|pred| match pred.skip_binders() {

--- a/crates/ide_completion/src/completions/qualified_path.rs
+++ b/crates/ide_completion/src/completions/qualified_path.rs
@@ -119,7 +119,7 @@ pub(crate) fn complete_qualified_path(acc: &mut Completions, ctx: &CompletionCon
 
     if !matches!(kind, Some(PathKind::Pat)) {
         // Add associated types on type parameters and `Self`.
-        resolution.assoc_type_shorthand_candidates(ctx.db, |_, alias| {
+        ctx.scope.assoc_type_shorthand_candidates(&resolution, |_, alias| {
             acc.add_type_alias(ctx, alias);
             None::<()>
         });


### PR DESCRIPTION
In code like this:
```rust
impl<T> Option<T> {
    fn as_deref(&self) -> T::Target where T: Deref {}
}
```

when trying to resolve the associated type `T::Target`, we were only
looking at the bounds on the impl (where the type parameter is defined),
but the method can add additional bounds that can also be used to refer
to associated types. Hence, when resolving such an associated type, it's
not enough to just know the type parameter T, we also need to know
exactly where we are currently.

This fixes #11364 (beta apparently switched some bounds around).