### PR TITLE
internal: Shrink `mbe::ExpandError` and `mbe::ParseError`

### DIFF
--- a/crates/hir_expand/src/builtin_fn_macro.rs
+++ b/crates/hir_expand/src/builtin_fn_macro.rs
@@ -368,7 +368,7 @@ fn compile_error_expand(
             let text = it.text.as_str();
             if text.starts_with('"') && text.ends_with('"') {
                 // FIXME: does not handle raw strings
-                mbe::ExpandError::Other(text[1..text.len() - 1].to_string())
+                mbe::ExpandError::Other(text[1..text.len() - 1].into())
             } else {
                 mbe::ExpandError::BindingError("`compile_error!` argument must be a string".into())
             }
@@ -451,12 +451,12 @@ fn relative_file(
 ) -> Result<FileId, mbe::ExpandError> {
     let call_site = call_id.as_file().original_file(db);
     let path = AnchoredPath { anchor: call_site, path: path_str };
-    let res = db
-        .resolve_path(path)
-        .ok_or_else(|| mbe::ExpandError::Other(format!("failed to load file `{}`", path_str)))?;
+    let res = db.resolve_path(path).ok_or_else(|| {
+        mbe::ExpandError::Other(format!("failed to load file `{path_str}`").into())
+    })?;
     // Prevent include itself
     if res == call_site && !allow_recursion {
-        Err(mbe::ExpandError::Other(format!("recursive inclusion of `{}`", path_str)))
+        Err(mbe::ExpandError::Other(format!("recursive inclusion of `{path_str}`").into()))
     } else {
         Ok(res)
     }

--- a/crates/hir_expand/src/db.rs
+++ b/crates/hir_expand/src/db.rs
@@ -390,7 +390,7 @@ fn macro_def(db: &dyn AstDatabase, id: MacroDefId) -> Result<Arc<TokenExpander>,
         MacroDefKind::BuiltInEager(..) => {
             // FIXME: Return a random error here just to make the types align.
             // This obviously should do something real instead.
-            Err(mbe::ParseError::UnexpectedToken("unexpected eager macro".to_string()))
+            Err(mbe::ParseError::UnexpectedToken("unexpected eager macro".into()))
         }
         MacroDefKind::ProcMacro(expander, ..) => Ok(Arc::new(TokenExpander::ProcMacro(expander))),
     }

--- a/crates/hir_expand/src/proc_macro.rs
+++ b/crates/hir_expand/src/proc_macro.rs
@@ -51,12 +51,12 @@ impl ProcMacroExpander {
                         {
                             ExpandResult {
                                 value: tt.clone(),
-                                err: Some(mbe::ExpandError::Other(text)),
+                                err: Some(mbe::ExpandError::Other(text.into())),
                             }
                         }
                         ProcMacroExpansionError::System(text)
                         | ProcMacroExpansionError::Panic(text) => {
-                            ExpandResult::only_err(mbe::ExpandError::Other(text))
+                            ExpandResult::only_err(mbe::ExpandError::Other(text.into()))
                         }
                     },
                 }

--- a/crates/mbe/src/expander/transcriber.rs
+++ b/crates/mbe/src/expander/transcriber.rs
@@ -17,34 +17,32 @@ impl Bindings {
 
     fn get(&self, name: &str, nesting: &mut [NestingState]) -> Result<&Fragment, ExpandError> {
         macro_rules! binding_err {
-            ($($arg:tt)*) => { ExpandError::BindingError(format!($($arg)*)) };
+            ($($arg:tt)*) => { ExpandError::BindingError(format!($($arg)*).into()) };
         }
 
-        let mut b: &Binding = self
-            .inner
-            .get(name)
-            .ok_or_else(|| binding_err!("could not find binding `{}`", name))?;
+        let mut b: &Binding =
+            self.inner.get(name).ok_or_else(|| binding_err!("could not find binding `{name}`"))?;
         for nesting_state in nesting.iter_mut() {
             nesting_state.hit = true;
             b = match b {
                 Binding::Fragment(_) => break,
                 Binding::Nested(bs) => bs.get(nesting_state.idx).ok_or_else(|| {
                     nesting_state.at_end = true;
-                    binding_err!("could not find nested binding `{}`", name)
+                    binding_err!("could not find nested binding `{name}`")
                 })?,
                 Binding::Empty => {
                     nesting_state.at_end = true;
-                    return Err(binding_err!("could not find empty binding `{}`", name));
+                    return Err(binding_err!("could not find empty binding `{name}`"));
                 }
             };
         }
         match b {
             Binding::Fragment(it) => Ok(it),
             Binding::Nested(_) => {
-                Err(binding_err!("expected simple binding, found nested binding `{}`", name))
+                Err(binding_err!("expected simple binding, found nested binding `{name}`"))
             }
             Binding::Empty => {
-                Err(binding_err!("expected simple binding, found empty binding `{}`", name))
+                Err(binding_err!("expected simple binding, found empty binding `{name}`"))
             }
         }
     }
@@ -180,7 +178,7 @@ fn expand_repeat(
             );
             return ExpandResult {
                 value: Fragment::Tokens(Subtree::default().into()),
-                err: Some(ExpandError::Other("Expand exceed limit".to_string())),
+                err: Some(ExpandError::Other("Expand exceed limit".into())),
             };
         }
 

--- a/crates/mbe/src/tt_iter.rs
+++ b/crates/mbe/src/tt_iter.rs
@@ -6,15 +6,6 @@ use tt::buffer::TokenBuffer;
 
 use crate::{to_parser_input::to_parser_input, ExpandError, ExpandResult};
 
-macro_rules! err {
-    () => {
-        ExpandError::BindingError(format!(""))
-    };
-    ($($tt:tt)*) => {
-        ExpandError::BindingError(format!($($tt)*))
-    };
-}
-
 #[derive(Debug, Clone)]
 pub(crate) struct TtIter<'a> {
     pub(crate) inner: std::slice::Iter<'a, tt::TokenTree>,
@@ -115,7 +106,7 @@ impl<'a> TtIter<'a> {
         }
 
         let err = if error || !cursor.is_root() {
-            Some(err!("expected {:?}", entry_point))
+            Some(ExpandError::BindingError(format!("expected {entry_point:?}").into()))
         } else {
             None
         };


### PR DESCRIPTION
Also fixes https://github.com/rust-analyzer/rust-analyzer/issues/10051, as we no longer emit an empty diagnostic in some expansion cases which seems to trip up vscode for some reason. Using `compile_error!("")` will still trigger the vscode bug.
bors r+