### PR TITLE
Fix eslint language server not working

### DIFF
--- a/editors/code/.eslintrc.js
+++ b/editors/code/.eslintrc.js
@@ -5,7 +5,8 @@ module.exports = {
     },
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
-        "project": "tsconfig.json",
+        "project": "tsconfig.eslint.json",
+        "tsconfigRootDir": __dirname,
         "sourceType": "module"
     },
     "plugins": [

--- a/editors/code/tsconfig.eslint.json
+++ b/editors/code/tsconfig.eslint.json
@@ -1,0 +1,11 @@
+// Special typescript project file, used by eslint only.
+{
+	"extends": "./tsconfig.json",
+	"include": [
+		// repeated from base config's "include" setting
+		"src",
+		"tests",
+		// these are the eslint-only inclusions
+		".eslintrc.js",
+	]
+}


### PR DESCRIPTION
Allows the language server for eslint to work inside VS Code.

Before change:
![image](https://user-images.githubusercontent.com/77730378/152661637-c5d90678-39dc-4018-b884-fc4b6135368e.png)

After change:
![image](https://user-images.githubusercontent.com/77730378/152661647-164c0655-aa6a-4c50-b49d-49cda112d149.png)