### PR TITLE
fix: Update dependency, fix Markdown references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,9 +1245,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark-to-cmark"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f94dc756ef5c50ad28ccea8428ba5de9f4dca1fff6516a26b85e0b125a70d17"
+checksum = "d1dd19382cbbcee6ce498f65d5acaa6016e41ec701c9b0aef29a689bd7062f88"
 dependencies = [
  "pulldown-cmark",
 ]

--- a/crates/ide/Cargo.toml
+++ b/crates/ide/Cargo.toml
@@ -17,7 +17,7 @@ itertools = "0.10.0"
 tracing = "0.1"
 rustc-hash = "1.1.0"
 oorandom = "11.1.2"
-pulldown-cmark-to-cmark = "9.0"
+pulldown-cmark-to-cmark = "10.0.0"
 pulldown-cmark = { version = "0.9", default-features = false }
 url = "2.1.1"
 dot = "0.1.4"

--- a/crates/ide/src/doc_links.rs
+++ b/crates/ide/src/doc_links.rs
@@ -7,7 +7,7 @@ mod intra_doc_links;
 
 use either::Either;
 use pulldown_cmark::{BrokenLink, CowStr, Event, InlineStr, LinkType, Options, Parser, Tag};
-use pulldown_cmark_to_cmark::{cmark_with_options, Options as CMarkOptions};
+use pulldown_cmark_to_cmark::{cmark_resume_with_options, Options as CMarkOptions};
 use stdx::format_to;
 use url::Url;
 
@@ -61,7 +61,7 @@ pub(crate) fn rewrite_links(db: &RootDatabase, markdown: &str, definition: Defin
         }
     });
     let mut out = String::new();
-    cmark_with_options(
+    cmark_resume_with_options(
         doc,
         &mut out,
         None,
@@ -97,7 +97,7 @@ pub(crate) fn remove_links(markdown: &str) -> String {
     });
 
     let mut out = String::new();
-    cmark_with_options(
+    cmark_resume_with_options(
         doc,
         &mut out,
         None,

--- a/crates/ide/src/doc_links/tests.rs
+++ b/crates/ide/src/doc_links/tests.rs
@@ -394,7 +394,6 @@ pub struct $0Foo;
 "#,
         expect![[r#"[my Foo](https://docs.rs/foo/*/foo/struct.Foo.html)"#]],
     );
-    // FIXME #11008
     check_rewrite(
         r#"
 //- /main.rs crate:foo
@@ -403,9 +402,6 @@ pub struct $0Foo;
 /// [`foo`]: Foo
 pub struct $0Foo;
 "#,
-        expect![[r#"
-            [`foo`]
-
-            []: https://docs.rs/foo/*/foo/struct.Foo.html"#]],
+        expect![["[`foo`]"]],
     );
 }


### PR DESCRIPTION
Stumbled across this accidentally while familiarizing myself with the code base.

Update `pulldown-cmark-to-cmark` Fix for #11008  