### PR TITLE
fix two vulneabilities (moderate: 1, high: 1) by running npm audit

### DIFF
--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -2587,9 +2587,9 @@
             }
         },
         "node_modules/linkify-it": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-            "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+            "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
             "dev": true,
             "dependencies": {
                 "uc.micro": "^1.0.1"
@@ -2619,14 +2619,14 @@
             }
         },
         "node_modules/markdown-it": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
-            "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+            "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
             "dev": true,
             "dependencies": {
-                "argparse": "^1.0.7",
-                "entities": "~2.0.0",
-                "linkify-it": "^2.0.0",
+                "argparse": "^2.0.1",
+                "entities": "~2.1.0",
+                "linkify-it": "^3.0.1",
                 "mdurl": "^1.0.1",
                 "uc.micro": "^1.0.5"
             },
@@ -2634,20 +2634,14 @@
                 "markdown-it": "bin/markdown-it.js"
             }
         },
-        "node_modules/markdown-it/node_modules/argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dev": true,
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
-            }
-        },
         "node_modules/markdown-it/node_modules/entities": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
-            "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
-            "dev": true
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+            "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
         },
         "node_modules/mdurl": {
             "version": "1.0.1",
@@ -3294,9 +3288,9 @@
             ]
         },
         "node_modules/simple-get": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
-            "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+            "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
             "dev": true,
             "dependencies": {
                 "decompress-response": "^4.2.0",
@@ -3312,12 +3306,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/sprintf-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-            "dev": true
         },
         "node_modules/string_decoder": {
             "version": "1.1.1",
@@ -3653,9 +3641,9 @@
             "dev": true
         },
         "node_modules/vsce": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.6.3.tgz",
-            "integrity": "sha512-PKfvAtG9rLT1evHiKOJpBHND1hUHOOf4lL7chZFp0KGu+Bpgcx3g3T5eq0d8Hmzd08zd3KJunsaA3iaNSmTU/A==",
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.6.7.tgz",
+            "integrity": "sha512-5dEtdi/yzWQbOU7JDUSOs8lmSzzkewBR5P122BUkmXE6A/DEdFsKNsg2773NGXJTwwF1MfsOgUR6QVF3cLLJNQ==",
             "dev": true,
             "dependencies": {
                 "azure-devops-node-api": "^11.0.1",
@@ -3666,7 +3654,7 @@
                 "hosted-git-info": "^4.0.2",
                 "keytar": "^7.7.0",
                 "leven": "^3.1.0",
-                "markdown-it": "^10.0.0",
+                "markdown-it": "^12.3.2",
                 "mime": "^1.3.4",
                 "minimatch": "^3.0.3",
                 "parse-semver": "^1.1.1",
@@ -5768,9 +5756,9 @@
             }
         },
         "linkify-it": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-            "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+            "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
             "dev": true,
             "requires": {
                 "uc.micro": "^1.0.1"
@@ -5797,31 +5785,22 @@
             }
         },
         "markdown-it": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
-            "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+            "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
             "dev": true,
             "requires": {
-                "argparse": "^1.0.7",
-                "entities": "~2.0.0",
-                "linkify-it": "^2.0.0",
+                "argparse": "^2.0.1",
+                "entities": "~2.1.0",
+                "linkify-it": "^3.0.1",
                 "mdurl": "^1.0.1",
                 "uc.micro": "^1.0.5"
             },
             "dependencies": {
-                "argparse": {
-                    "version": "1.0.10",
-                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-                    "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-                    "dev": true,
-                    "requires": {
-                        "sprintf-js": "~1.0.2"
-                    }
-                },
                 "entities": {
-                    "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
-                    "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+                    "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
                     "dev": true
                 }
             }
@@ -6311,9 +6290,9 @@
             "dev": true
         },
         "simple-get": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
-            "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+            "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
             "dev": true,
             "requires": {
                 "decompress-response": "^4.2.0",
@@ -6325,12 +6304,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
             "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-            "dev": true
-        },
-        "sprintf-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
         "string_decoder": {
@@ -6600,9 +6573,9 @@
             "dev": true
         },
         "vsce": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.6.3.tgz",
-            "integrity": "sha512-PKfvAtG9rLT1evHiKOJpBHND1hUHOOf4lL7chZFp0KGu+Bpgcx3g3T5eq0d8Hmzd08zd3KJunsaA3iaNSmTU/A==",
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.6.7.tgz",
+            "integrity": "sha512-5dEtdi/yzWQbOU7JDUSOs8lmSzzkewBR5P122BUkmXE6A/DEdFsKNsg2773NGXJTwwF1MfsOgUR6QVF3cLLJNQ==",
             "dev": true,
             "requires": {
                 "azure-devops-node-api": "^11.0.1",
@@ -6613,7 +6586,7 @@
                 "hosted-git-info": "^4.0.2",
                 "keytar": "^7.7.0",
                 "leven": "^3.1.0",
-                "markdown-it": "^10.0.0",
+                "markdown-it": "^12.3.2",
                 "mime": "^1.3.4",
                 "minimatch": "^3.0.3",
                 "parse-semver": "^1.1.1",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -51,7 +51,7 @@
         "tslib": "^2.3.0",
         "typescript": "^4.5.5",
         "typescript-formatter": "^7.2.2",
-        "vsce": "^2.6.3"
+        "vsce": "^2.6.7"
     },
     "activationEvents": [
         "onLanguage:rust",


### PR DESCRIPTION
Again me getting familiar with the code base :D

I noticed npm warning about two vulnerabilities
```
markdown-it  <12.3.2
Severity: moderate
Uncontrolled Resource Consumption in markdown-it - https://github.com/advisories/GHSA-6vfc-qv3f-vr6c
fix available via `npm audit fix`
node_modules/markdown-it
  vsce  1.26.0 - 2.6.3
  Depends on vulnerable versions of markdown-it
  node_modules/vsce

simple-get  3.0.0 - 3.1.0
Severity: high
Exposure of Sensitive Information in simple-get - https://github.com/advisories/GHSA-wpg7-2c88-r8xv
fix available via `npm audit fix`
node_modules/simple-get
```

So I thought why not run `npm audit fix` 