### PR TITLE
fix: renaming modules does not change references by super

### DIFF
--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -1109,6 +1109,31 @@ pub mod foo$0;
     }
 
     #[test]
+    fn test_rename_mod_ref_by_super() {
+        check(
+            "baz",
+            r#"
+        mod $0foo {
+        struct X;
+
+        mod bar {
+            use super::X;
+        }
+    }
+            "#,
+            r#"
+        mod baz {
+        struct X;
+
+        mod bar {
+            use super::X;
+        }
+    }
+            "#,
+        )
+    }
+
+    #[test]
     fn test_enum_variant_from_module_1() {
         cov_mark::check!(rename_non_local);
         check(

--- a/crates/ide_db/src/rename.rs
+++ b/crates/ide_db/src/rename.rs
@@ -343,6 +343,10 @@ fn source_edit_from_name_ref(
     new_name: &str,
     def: Definition,
 ) -> bool {
+    if name_ref.super_token().is_some() {
+        return true;
+    }
+
     if let Some(record_field) = ast::RecordExprField::for_name_ref(name_ref) {
         let rcf_name_ref = record_field.name_ref();
         let rcf_expr = record_field.expr();


### PR DESCRIPTION
Fixes #11289.