### PR TITLE
[ide_completion] render if a function is async/const/unsafe in completion details

### DIFF
--- a/crates/ide_completion/src/render/function.rs
+++ b/crates/ide_completion/src/render/function.rs
@@ -110,7 +110,19 @@ fn render(
 
 fn detail(db: &dyn HirDatabase, func: hir::Function) -> String {
     let ret_ty = func.ret_type(db);
-    let mut detail = format!("fn({})", params_display(db, func));
+    let mut detail = String::new();
+
+    if func.is_const(db) {
+        format_to!(detail, "const ");
+    }
+    if func.is_async(db) {
+        format_to!(detail, "async ");
+    }
+    if func.is_unsafe(db) {
+        format_to!(detail, "unsafe ");
+    }
+
+    format_to!(detail, "fn({})", params_display(db, func));
     if !ret_ty.is_unit() {
         format_to!(detail, " -> {}", ret_ty.display(db));
     }


### PR DESCRIPTION
this change renders in the autocomplete detail, whether a function is async/const/unsafe.

i found myself wanting to know this information at a glance, so now it renders here:

![image](https://user-images.githubusercontent.com/5489149/153089518-5419afe4-b2c6-4be8-80f7-585f5c514ff2.png)
