### PR TITLE
fix(rename): Use text range of a mod name after macro expansion

### DIFF
--- a/crates/ide/src/rename.rs
+++ b/crates/ide/src/rename.rs
@@ -1134,6 +1134,34 @@ pub mod foo$0;
     }
 
     #[test]
+    fn test_rename_mod_in_macro() {
+        check(
+            "bar",
+            r#"
+//- /foo.rs
+
+//- /lib.rs
+macro_rules! submodule {
+    ($name:ident) => {
+        mod $name;
+    };
+}
+
+submodule!($0foo);
+"#,
+            r#"
+macro_rules! submodule {
+    ($name:ident) => {
+        mod $name;
+    };
+}
+
+submodule!(bar);
+"#,
+        )
+    }
+
+    #[test]
     fn test_enum_variant_from_module_1() {
         cov_mark::check!(rename_non_local);
         check(


### PR DESCRIPTION
Fixes #11417. 