### PR TITLE
feat: Fix up syntax errors in attribute macro inputs to make completion work more often

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,6 +526,7 @@ dependencies = [
  "cfg",
  "cov-mark",
  "either",
+ "expect-test",
  "hashbrown 0.12.0",
  "itertools",
  "la-arena",

--- a/crates/hir_def/src/macro_expansion_tests.rs
+++ b/crates/hir_def/src/macro_expansion_tests.rs
@@ -345,6 +345,7 @@ impl base_db::ProcMacroExpander for IdentityWhenValidProcMacroExpander {
         if parse.errors().is_empty() {
             Ok(subtree.clone())
         } else {
+            eprintln!("parse errors: {:?}", parse.errors());
             use tt::{Delimiter, DelimiterKind, Ident, Leaf, Literal, Punct, TokenTree};
             let mut subtree = Subtree::default();
             subtree.token_trees.push(TokenTree::Leaf(

--- a/crates/hir_def/src/macro_expansion_tests.rs
+++ b/crates/hir_def/src/macro_expansion_tests.rs
@@ -186,7 +186,7 @@ pub fn identity_when_valid(_attr: TokenStream, item: TokenStream) -> TokenStream
         let range: Range<usize> = range.into();
 
         if show_token_ids {
-            if let Some((tree, map)) = arg.as_deref() {
+            if let Some((tree, map, _)) = arg.as_deref() {
                 let tt_range = call.token_tree().unwrap().syntax().text_range();
                 let mut ranges = Vec::new();
                 extract_id_ranges(&mut ranges, &map, &tree);

--- a/crates/hir_def/src/macro_expansion_tests.rs
+++ b/crates/hir_def/src/macro_expansion_tests.rs
@@ -345,23 +345,7 @@ impl base_db::ProcMacroExpander for IdentityWhenValidProcMacroExpander {
         if parse.errors().is_empty() {
             Ok(subtree.clone())
         } else {
-            eprintln!("parse errors: {:?}", parse.errors());
-            use tt::{Delimiter, DelimiterKind, Ident, Leaf, Literal, Punct, TokenTree};
-            let mut subtree = Subtree::default();
-            subtree.token_trees.push(TokenTree::Leaf(
-                Ident { text: "compile_error!".into(), id: TokenId(0) }.into(),
-            ));
-            subtree.token_trees.push(TokenTree::Subtree(Subtree {
-                delimiter: Some(Delimiter { id: TokenId(2), kind: DelimiterKind::Parenthesis }),
-                token_trees: vec![TokenTree::Leaf(Leaf::Literal(Literal {
-                    text: r#""parse error""#.into(),
-                    id: TokenId::unspecified(),
-                }))],
-            }));
-            subtree.token_trees.push(TokenTree::Leaf(
-                Punct { char: ';', spacing: tt::Spacing::Alone, id: TokenId::unspecified() }.into(),
-            ));
-            Ok(subtree)
+            panic!("got invalid macro input: {:?}", parse.errors());
         }
     }
 }

--- a/crates/hir_def/src/macro_expansion_tests.rs
+++ b/crates/hir_def/src/macro_expansion_tests.rs
@@ -14,10 +14,10 @@ mod builtin_fn_macro;
 mod builtin_derive_macro;
 mod proc_macros;
 
-use std::{iter, ops::Range};
+use std::{iter, ops::Range, sync::Arc};
 
 use ::mbe::TokenMap;
-use base_db::{fixture::WithFixture, SourceDatabase};
+use base_db::{fixture::WithFixture, ProcMacro, SourceDatabase};
 use expect_test::Expect;
 use hir_expand::{
     db::{AstDatabase, TokenExpander},
@@ -39,7 +39,21 @@ use crate::{
 
 #[track_caller]
 fn check(ra_fixture: &str, mut expect: Expect) {
-    let db = TestDB::with_files(ra_fixture);
+    let extra_proc_macros = vec![(
+        r#"
+#[proc_macro_attribute]
+pub fn identity_when_valid(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    item
+}
+"#
+        .into(),
+        ProcMacro {
+            name: "identity_when_valid".into(),
+            kind: base_db::ProcMacroKind::Attr,
+            expander: Arc::new(IdentityWhenValidProcMacroExpander),
+        },
+    )];
+    let db = TestDB::with_files_extra_proc_macros(ra_fixture, extra_proc_macros);
     let krate = db.crate_graph().iter().next().unwrap();
     let def_map = db.crate_def_map(krate);
     let local_id = def_map.root();
@@ -201,10 +215,19 @@ fn check(ra_fixture: &str, mut expect: Expect) {
     }
 
     for decl_id in def_map[local_id].scope.declarations() {
-        if let ModuleDefId::AdtId(AdtId::StructId(struct_id)) = decl_id {
-            let src = struct_id.lookup(&db).source(&db);
+        // FIXME: I'm sure there's already better way to do this
+        let src = match decl_id {
+            ModuleDefId::AdtId(AdtId::StructId(struct_id)) => {
+                Some(struct_id.lookup(&db).source(&db).syntax().cloned())
+            }
+            ModuleDefId::FunctionId(function_id) => {
+                Some(function_id.lookup(&db).source(&db).syntax().cloned())
+            }
+            _ => None,
+        };
+        if let Some(src) = src {
             if src.file_id.is_attr_macro(&db) || src.file_id.is_custom_derive(&db) {
-                let pp = pretty_print_macro_expansion(src.value.syntax().clone(), None);
+                let pp = pretty_print_macro_expansion(src.value, None);
                 format_to!(expanded_text, "\n{}", pp)
             }
         }
@@ -303,4 +326,41 @@ fn pretty_print_macro_expansion(expn: SyntaxNode, map: Option<&TokenMap>) -> Str
         }
     }
     res
+}
+
+// Identity mapping, but only works when the input is syntactically valid. This
+// simulates common proc macros that unnecessarily parse their input and return
+// compile errors.
+#[derive(Debug)]
+struct IdentityWhenValidProcMacroExpander;
+impl base_db::ProcMacroExpander for IdentityWhenValidProcMacroExpander {
+    fn expand(
+        &self,
+        subtree: &Subtree,
+        _: Option<&Subtree>,
+        _: &base_db::Env,
+    ) -> Result<Subtree, base_db::ProcMacroExpansionError> {
+        let (parse, _) =
+            ::mbe::token_tree_to_syntax_node(subtree, ::mbe::TopEntryPoint::MacroItems);
+        if parse.errors().is_empty() {
+            Ok(subtree.clone())
+        } else {
+            use tt::{Delimiter, DelimiterKind, Ident, Leaf, Literal, Punct, TokenTree};
+            let mut subtree = Subtree::default();
+            subtree.token_trees.push(TokenTree::Leaf(
+                Ident { text: "compile_error!".into(), id: TokenId(0) }.into(),
+            ));
+            subtree.token_trees.push(TokenTree::Subtree(Subtree {
+                delimiter: Some(Delimiter { id: TokenId(2), kind: DelimiterKind::Parenthesis }),
+                token_trees: vec![TokenTree::Leaf(Leaf::Literal(Literal {
+                    text: r#""parse error""#.into(),
+                    id: TokenId::unspecified(),
+                }))],
+            }));
+            subtree.token_trees.push(TokenTree::Leaf(
+                Punct { char: ';', spacing: tt::Spacing::Alone, id: TokenId::unspecified() }.into(),
+            ));
+            Ok(subtree)
+        }
+    }
 }

--- a/crates/hir_def/src/macro_expansion_tests/proc_macros.rs
+++ b/crates/hir_def/src/macro_expansion_tests/proc_macros.rs
@@ -76,7 +76,6 @@ fn foo() {
 #[test]
 fn attribute_macro_syntax_completion_2() {
     // common case of dot completion while typing
-    // right now not working
     check(
         r#"
 //- proc_macros: identity_when_valid
@@ -88,7 +87,7 @@ fn foo() { bar.; blub }
 fn foo() { bar.; blub }
 
 fn foo() {
-    bar.;
+    bar. ;
     blub
 }"##]],
     );

--- a/crates/hir_def/src/macro_expansion_tests/proc_macros.rs
+++ b/crates/hir_def/src/macro_expansion_tests/proc_macros.rs
@@ -52,3 +52,40 @@ struct S;
 #[attr2] struct S;"##]],
     );
 }
+
+#[test]
+fn attribute_macro_syntax_completion_1() {
+    // this is just the case where the input is actually valid
+    check(
+        r#"
+//- proc_macros: identity_when_valid
+#[proc_macros::identity_when_valid]
+fn foo() { bar.baz(); blub }
+"#,
+        expect![[r##"
+#[proc_macros::identity_when_valid]
+fn foo() { bar.baz(); blub }
+
+fn foo() {
+    bar.baz();
+    blub
+}"##]],
+    );
+}
+
+#[test]
+fn attribute_macro_syntax_completion_2() {
+    // common case of dot completion while typing
+    // right now not working
+    check(
+        r#"
+//- proc_macros: identity_when_valid
+#[proc_macros::identity_when_valid]
+fn foo() { bar.; blub }
+"#,
+        expect![[r##"
+#[proc_macros::identity_when_valid]
+fn foo() { bar.; blub }
+"##]],
+    );
+}

--- a/crates/hir_def/src/macro_expansion_tests/proc_macros.rs
+++ b/crates/hir_def/src/macro_expansion_tests/proc_macros.rs
@@ -86,6 +86,10 @@ fn foo() { bar.; blub }
         expect![[r##"
 #[proc_macros::identity_when_valid]
 fn foo() { bar.; blub }
-"##]],
+
+fn foo() {
+    bar.;
+    blub
+}"##]],
     );
 }

--- a/crates/hir_expand/Cargo.toml
+++ b/crates/hir_expand/Cargo.toml
@@ -27,3 +27,6 @@ profile = { path = "../profile", version = "0.0.0" }
 tt = { path = "../tt", version = "0.0.0" }
 mbe = { path = "../mbe", version = "0.0.0" }
 limit = { path = "../limit", version = "0.0.0" }
+
+[dev-dependencies]
+expect-test = "1.2.0-pre.1"

--- a/crates/hir_expand/src/db.rs
+++ b/crates/hir_expand/src/db.rs
@@ -430,7 +430,7 @@ fn macro_expand(db: &dyn AstDatabase, id: MacroCallId) -> ExpandResult<Option<Ar
         // be reported at the definition site (when we construct a def map).
         Err(err) => return ExpandResult::str_err(format!("invalid macro definition: {}", err)),
     };
-    let ExpandResult { value: tt, err } = expander.expand(db, id, &macro_arg.0);
+    let ExpandResult { value: mut tt, err } = expander.expand(db, id, &macro_arg.0);
     // Set a hard limit for the expanded tt
     let count = tt.count();
     // XXX: Make ExpandResult a real error and use .map_err instead?
@@ -441,6 +441,8 @@ fn macro_expand(db: &dyn AstDatabase, id: MacroCallId) -> ExpandResult<Option<Ar
             TOKEN_LIMIT.inner(),
         ));
     }
+
+    fixup::reverse_fixups(&mut tt);
 
     ExpandResult { value: Some(Arc::new(tt)), err }
 }

--- a/crates/hir_expand/src/db.rs
+++ b/crates/hir_expand/src/db.rs
@@ -151,8 +151,11 @@ pub fn expand_speculative(
     let censor = censor_for_macro_input(&loc, &speculative_args);
     let mut fixups = fixup::fixup_syntax(&speculative_args);
     fixups.replace.extend(censor.into_iter().map(|node| (node, Vec::new())));
-    let (mut tt, spec_args_tmap) =
-        mbe::syntax_node_to_token_tree_censored(&speculative_args, fixups.replace, fixups.append);
+    let (mut tt, spec_args_tmap) = mbe::syntax_node_to_token_tree_with_modifications(
+        &speculative_args,
+        fixups.replace,
+        fixups.append,
+    );
 
     let (attr_arg, token_id) = match loc.kind {
         MacroCallKind::Attr { invoc_attr_index, .. } => {
@@ -303,11 +306,10 @@ fn macro_arg(
 
     let node = SyntaxNode::new_root(arg);
     let censor = censor_for_macro_input(&loc, &node);
-    // TODO only fixup for attribute macro input
     let mut fixups = fixup::fixup_syntax(&node);
     fixups.replace.extend(censor.into_iter().map(|node| (node, Vec::new())));
     let (mut tt, tmap) =
-        mbe::syntax_node_to_token_tree_censored(&node, fixups.replace, fixups.append);
+        mbe::syntax_node_to_token_tree_with_modifications(&node, fixups.replace, fixups.append);
 
     if loc.def.is_proc_macro() {
         // proc macros expect their inputs without parentheses, MBEs expect it with them included

--- a/crates/hir_expand/src/db.rs
+++ b/crates/hir_expand/src/db.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use base_db::{salsa, SourceDatabase};
 use either::Either;
 use limit::Limit;
-use mbe::{syntax_node_to_token_tree, ExpandError, ExpandResult, SyntheticToken};
-use rustc_hash::{FxHashMap, FxHashSet};
+use mbe::{syntax_node_to_token_tree, ExpandError, ExpandResult};
+use rustc_hash::FxHashSet;
 use syntax::{
     algo::diff,
     ast::{self, HasAttrs, HasDocComments},
@@ -442,7 +442,7 @@ fn macro_expand(db: &dyn AstDatabase, id: MacroCallId) -> ExpandResult<Option<Ar
         ));
     }
 
-    fixup::reverse_fixups(&mut tt);
+    fixup::reverse_fixups(&mut tt, &macro_arg.1);
 
     ExpandResult { value: Some(Arc::new(tt)), err }
 }

--- a/crates/hir_expand/src/fixup.rs
+++ b/crates/hir_expand/src/fixup.rs
@@ -123,7 +123,7 @@ mod tests {
         let parsed = syntax::SourceFile::parse(ra_fixture);
         eprintln!("parse: {:#?}", parsed.syntax_node());
         let fixups = super::fixup_syntax(&parsed.syntax_node());
-        let (mut tt, tmap) = mbe::syntax_node_to_token_tree_censored(
+        let (mut tt, tmap) = mbe::syntax_node_to_token_tree_with_modifications(
             &parsed.syntax_node(),
             fixups.replace,
             fixups.append,

--- a/crates/hir_expand/src/fixup.rs
+++ b/crates/hir_expand/src/fixup.rs
@@ -150,7 +150,6 @@ mod tests {
     #[track_caller]
     fn check(ra_fixture: &str, mut expect: Expect) {
         let parsed = syntax::SourceFile::parse(ra_fixture);
-        eprintln!("parse: {:#?}", parsed.syntax_node());
         let fixups = super::fixup_syntax(&parsed.syntax_node());
         let (mut tt, tmap, _) = mbe::syntax_node_to_token_tree_with_modifications(
             &parsed.syntax_node(),

--- a/crates/hir_expand/src/fixup.rs
+++ b/crates/hir_expand/src/fixup.rs
@@ -14,12 +14,12 @@ use tt::Subtree;
 /// (appending to and replacing nodes), the information that is needed to
 /// reverse those changes afterwards, and a token map.
 #[derive(Debug)]
-pub struct SyntaxFixups {
-    pub append: FxHashMap<SyntaxNode, Vec<SyntheticToken>>,
-    pub replace: FxHashMap<SyntaxNode, Vec<SyntheticToken>>,
-    pub undo_info: SyntaxFixupUndoInfo,
-    pub token_map: TokenMap,
-    pub next_id: u32,
+pub(crate) struct SyntaxFixups {
+    pub(crate) append: FxHashMap<SyntaxNode, Vec<SyntheticToken>>,
+    pub(crate) replace: FxHashMap<SyntaxNode, Vec<SyntheticToken>>,
+    pub(crate) undo_info: SyntaxFixupUndoInfo,
+    pub(crate) token_map: TokenMap,
+    pub(crate) next_id: u32,
 }
 
 /// This is the information needed to reverse the fixups.
@@ -30,7 +30,7 @@ pub struct SyntaxFixupUndoInfo {
 
 const EMPTY_ID: SyntheticTokenId = SyntheticTokenId(!0);
 
-pub fn fixup_syntax(node: &SyntaxNode) -> SyntaxFixups {
+pub(crate) fn fixup_syntax(node: &SyntaxNode) -> SyntaxFixups {
     let mut append = FxHashMap::default();
     let mut replace = FxHashMap::default();
     let mut preorder = node.preorder();
@@ -122,7 +122,7 @@ fn has_error_to_handle(node: &SyntaxNode) -> bool {
     has_error(node) || node.children().any(|c| !can_handle_error(&c) && has_error_to_handle(&c))
 }
 
-pub fn reverse_fixups(tt: &mut Subtree, token_map: &TokenMap, undo_info: &SyntaxFixupUndoInfo) {
+pub(crate) fn reverse_fixups(tt: &mut Subtree, token_map: &TokenMap, undo_info: &SyntaxFixupUndoInfo) {
     tt.token_trees.retain(|tt| match tt {
         tt::TokenTree::Leaf(leaf) => {
             token_map.synthetic_token_id(leaf.id()).is_none()

--- a/crates/hir_expand/src/fixup.rs
+++ b/crates/hir_expand/src/fixup.rs
@@ -122,7 +122,11 @@ fn has_error_to_handle(node: &SyntaxNode) -> bool {
     has_error(node) || node.children().any(|c| !can_handle_error(&c) && has_error_to_handle(&c))
 }
 
-pub(crate) fn reverse_fixups(tt: &mut Subtree, token_map: &TokenMap, undo_info: &SyntaxFixupUndoInfo) {
+pub(crate) fn reverse_fixups(
+    tt: &mut Subtree,
+    token_map: &TokenMap,
+    undo_info: &SyntaxFixupUndoInfo,
+) {
     tt.token_trees.retain(|tt| match tt {
         tt::TokenTree::Leaf(leaf) => {
             token_map.synthetic_token_id(leaf.id()).is_none()

--- a/crates/hir_expand/src/fixup.rs
+++ b/crates/hir_expand/src/fixup.rs
@@ -1,0 +1,136 @@
+use mbe::SyntheticToken;
+use rustc_hash::FxHashMap;
+use syntax::{
+    ast::{self, AstNode},
+    match_ast, SyntaxKind, SyntaxNode, SyntaxToken,
+};
+use tt::{Leaf, Subtree};
+
+#[derive(Debug)]
+pub struct SyntaxFixups {
+    pub append: FxHashMap<SyntaxNode, Vec<SyntheticToken>>,
+    pub replace: FxHashMap<SyntaxNode, Vec<SyntheticToken>>,
+}
+
+pub fn fixup_syntax(node: &SyntaxNode) -> SyntaxFixups {
+    let mut append = FxHashMap::default();
+    let mut replace = FxHashMap::default();
+    let mut preorder = node.preorder();
+    while let Some(event) = preorder.next() {
+        let node = match event {
+            syntax::WalkEvent::Enter(node) => node,
+            syntax::WalkEvent::Leave(_) => continue,
+        };
+        if node.kind() == SyntaxKind::ERROR {
+            // TODO this might not be helpful
+            replace.insert(node, Vec::new());
+            preorder.skip_subtree();
+            continue;
+        }
+        match_ast! {
+            match node {
+                ast::FieldExpr(it) => {
+                    if it.name_ref().is_none() {
+                        // incomplete field access: some_expr.|
+                        append.insert(node.clone(), vec![(SyntaxKind::IDENT, "__ra_fixup".into())]);
+                    }
+                },
+                _ => (),
+            }
+        }
+    }
+    SyntaxFixups { append, replace }
+}
+
+pub fn reverse_fixups(tt: &mut Subtree) {
+    tt.token_trees.retain(|tt| match tt {
+        tt::TokenTree::Leaf(Leaf::Ident(ident)) => ident.text != "__ra_fixup",
+        _ => true,
+    });
+    tt.token_trees.iter_mut().for_each(|tt| match tt {
+        tt::TokenTree::Subtree(tt) => reverse_fixups(tt),
+        _ => {}
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use expect_test::{Expect, expect};
+
+    use super::reverse_fixups;
+
+    #[track_caller]
+    fn check(ra_fixture: &str, mut expect: Expect) {
+        let parsed = syntax::SourceFile::parse(ra_fixture);
+        let fixups = super::fixup_syntax(&parsed.syntax_node());
+        let (mut tt, _tmap) = mbe::syntax_node_to_token_tree_censored(
+            &parsed.syntax_node(),
+            fixups.replace,
+            fixups.append,
+        );
+
+        let mut actual = tt.to_string();
+        actual.push_str("\n");
+
+        expect.indent(false);
+        expect.assert_eq(&actual);
+
+        // the fixed-up tree should be syntactically valid
+        let (parse, _) = mbe::token_tree_to_syntax_node(&tt, ::mbe::TopEntryPoint::MacroItems);
+        assert_eq!(parse.errors(), &[], "parse has syntax errors. parse tree:\n{:#?}", parse.syntax_node());
+
+        reverse_fixups(&mut tt);
+
+        // the fixed-up + reversed version should be equivalent to the original input
+        // (but token IDs don't matter)
+        let (original_as_tt, _) = mbe::syntax_node_to_token_tree(&parsed.syntax_node());
+        assert_eq!(tt.to_string(), original_as_tt.to_string());
+    }
+
+    #[test]
+    fn incomplete_field_expr_1() {
+        check(r#"
+fn foo() {
+    a.
+}
+"#, expect![[r#"
+fn foo () {a . __ra_fixup}
+"#]])
+    }
+
+    #[test]
+    fn incomplete_field_expr_2() {
+        check(r#"
+fn foo() {
+    a. ;
+}
+"#, expect![[r#"
+fn foo () {a . __ra_fixup ;}
+"#]])
+    }
+
+    #[test]
+    fn incomplete_field_expr_3() {
+        check(r#"
+fn foo() {
+    a. ;
+    bar();
+}
+"#, expect![[r#"
+fn foo () {a . __ra_fixup ; bar () ;}
+"#]])
+    }
+
+    #[test]
+    fn field_expr_before_call() {
+        // another case that easily happens while typing
+        check(r#"
+fn foo() {
+    a.b
+    bar();
+}
+"#, expect![[r#"
+fn foo () {a . b bar () ;}
+"#]])
+    }
+}

--- a/crates/hir_expand/src/fixup.rs
+++ b/crates/hir_expand/src/fixup.rs
@@ -1,10 +1,10 @@
-use mbe::SyntheticToken;
+use mbe::{SyntheticToken, SyntheticTokenId, TokenMap};
 use rustc_hash::FxHashMap;
 use syntax::{
     ast::{self, AstNode},
-    match_ast, SyntaxKind, SyntaxNode, SyntaxToken,
+    match_ast, SyntaxKind, SyntaxNode, TextRange,
 };
-use tt::{Leaf, Subtree};
+use tt::Subtree;
 
 #[derive(Debug)]
 pub struct SyntaxFixups {
@@ -16,6 +16,7 @@ pub fn fixup_syntax(node: &SyntaxNode) -> SyntaxFixups {
     let mut append = FxHashMap::default();
     let mut replace = FxHashMap::default();
     let mut preorder = node.preorder();
+    let empty_id = SyntheticTokenId(0);
     while let Some(event) = preorder.next() {
         let node = match event {
             syntax::WalkEvent::Enter(node) => node,
@@ -27,12 +28,32 @@ pub fn fixup_syntax(node: &SyntaxNode) -> SyntaxFixups {
             preorder.skip_subtree();
             continue;
         }
+        let end_range = TextRange::empty(node.text_range().end());
         match_ast! {
             match node {
                 ast::FieldExpr(it) => {
                     if it.name_ref().is_none() {
                         // incomplete field access: some_expr.|
-                        append.insert(node.clone(), vec![(SyntaxKind::IDENT, "__ra_fixup".into())]);
+                        append.insert(node.clone(), vec![
+                            SyntheticToken {
+                                kind: SyntaxKind::IDENT,
+                                text: "__ra_fixup".into(),
+                                range: end_range,
+                                id: empty_id,
+                            },
+                        ]);
+                    }
+                },
+                ast::ExprStmt(it) => {
+                    if it.semicolon_token().is_none() {
+                        append.insert(node.clone(), vec![
+                            SyntheticToken {
+                                kind: SyntaxKind::SEMICOLON,
+                                text: ";".into(),
+                                range: end_range,
+                                id: empty_id,
+                            },
+                        ]);
                     }
                 },
                 _ => (),
@@ -42,20 +63,21 @@ pub fn fixup_syntax(node: &SyntaxNode) -> SyntaxFixups {
     SyntaxFixups { append, replace }
 }
 
-pub fn reverse_fixups(tt: &mut Subtree) {
+pub fn reverse_fixups(tt: &mut Subtree, token_map: &TokenMap) {
+    eprintln!("token_map: {:?}", token_map);
     tt.token_trees.retain(|tt| match tt {
-        tt::TokenTree::Leaf(Leaf::Ident(ident)) => ident.text != "__ra_fixup",
+        tt::TokenTree::Leaf(leaf) => token_map.synthetic_token_id(leaf.id()).is_none(),
         _ => true,
     });
     tt.token_trees.iter_mut().for_each(|tt| match tt {
-        tt::TokenTree::Subtree(tt) => reverse_fixups(tt),
+        tt::TokenTree::Subtree(tt) => reverse_fixups(tt, token_map),
         _ => {}
     });
 }
 
 #[cfg(test)]
 mod tests {
-    use expect_test::{Expect, expect};
+    use expect_test::{expect, Expect};
 
     use super::reverse_fixups;
 
@@ -63,7 +85,7 @@ mod tests {
     fn check(ra_fixture: &str, mut expect: Expect) {
         let parsed = syntax::SourceFile::parse(ra_fixture);
         let fixups = super::fixup_syntax(&parsed.syntax_node());
-        let (mut tt, _tmap) = mbe::syntax_node_to_token_tree_censored(
+        let (mut tt, tmap) = mbe::syntax_node_to_token_tree_censored(
             &parsed.syntax_node(),
             fixups.replace,
             fixups.append,
@@ -77,9 +99,14 @@ mod tests {
 
         // the fixed-up tree should be syntactically valid
         let (parse, _) = mbe::token_tree_to_syntax_node(&tt, ::mbe::TopEntryPoint::MacroItems);
-        assert_eq!(parse.errors(), &[], "parse has syntax errors. parse tree:\n{:#?}", parse.syntax_node());
+        assert_eq!(
+            parse.errors(),
+            &[],
+            "parse has syntax errors. parse tree:\n{:#?}",
+            parse.syntax_node()
+        );
 
-        reverse_fixups(&mut tt);
+        reverse_fixups(&mut tt, &tmap);
 
         // the fixed-up + reversed version should be equivalent to the original input
         // (but token IDs don't matter)
@@ -89,48 +116,60 @@ mod tests {
 
     #[test]
     fn incomplete_field_expr_1() {
-        check(r#"
+        check(
+            r#"
 fn foo() {
     a.
 }
-"#, expect![[r#"
+"#,
+            expect![[r#"
 fn foo () {a . __ra_fixup}
-"#]])
+"#]],
+        )
     }
 
     #[test]
     fn incomplete_field_expr_2() {
-        check(r#"
+        check(
+            r#"
 fn foo() {
     a. ;
 }
-"#, expect![[r#"
+"#,
+            expect![[r#"
 fn foo () {a . __ra_fixup ;}
-"#]])
+"#]],
+        )
     }
 
     #[test]
     fn incomplete_field_expr_3() {
-        check(r#"
+        check(
+            r#"
 fn foo() {
     a. ;
     bar();
 }
-"#, expect![[r#"
+"#,
+            expect![[r#"
 fn foo () {a . __ra_fixup ; bar () ;}
-"#]])
+"#]],
+        )
     }
 
     #[test]
     fn field_expr_before_call() {
         // another case that easily happens while typing
-        check(r#"
+        check(
+            r#"
 fn foo() {
     a.b
     bar();
 }
-"#, expect![[r#"
-fn foo () {a . b bar () ;}
-"#]])
+"#,
+            expect![[r#"
+fn foo () {a . b ; bar () ;}
+"#]],
+        )
     }
 }

--- a/crates/hir_expand/src/hygiene.rs
+++ b/crates/hir_expand/src/hygiene.rs
@@ -15,6 +15,7 @@ use syntax::{
 
 use crate::{
     db::{self, AstDatabase},
+    fixup,
     name::{AsName, Name},
     HirFileId, HirFileIdRepr, InFile, MacroCallKind, MacroCallLoc, MacroDefKind, MacroFile,
 };
@@ -127,7 +128,7 @@ struct HygieneInfo {
     attr_input_or_mac_def_start: Option<InFile<TextSize>>,
 
     macro_def: Arc<TokenExpander>,
-    macro_arg: Arc<(tt::Subtree, mbe::TokenMap)>,
+    macro_arg: Arc<(tt::Subtree, mbe::TokenMap, fixup::SyntaxFixupMap)>,
     macro_arg_shift: mbe::Shift,
     exp_map: Arc<mbe::TokenMap>,
 }

--- a/crates/hir_expand/src/hygiene.rs
+++ b/crates/hir_expand/src/hygiene.rs
@@ -128,7 +128,7 @@ struct HygieneInfo {
     attr_input_or_mac_def_start: Option<InFile<TextSize>>,
 
     macro_def: Arc<TokenExpander>,
-    macro_arg: Arc<(tt::Subtree, mbe::TokenMap, fixup::SyntaxFixupMap)>,
+    macro_arg: Arc<(tt::Subtree, mbe::TokenMap, fixup::SyntaxFixupUndoInfo)>,
     macro_arg_shift: mbe::Shift,
     exp_map: Arc<mbe::TokenMap>,
 }

--- a/crates/hir_expand/src/lib.rs
+++ b/crates/hir_expand/src/lib.rs
@@ -427,7 +427,7 @@ pub struct ExpansionInfo {
     attr_input_or_mac_def: Option<InFile<ast::TokenTree>>,
 
     macro_def: Arc<TokenExpander>,
-    macro_arg: Arc<(tt::Subtree, mbe::TokenMap)>,
+    macro_arg: Arc<(tt::Subtree, mbe::TokenMap, fixup::SyntaxFixupMap)>,
     /// A shift built from `macro_arg`'s subtree, relevant for attributes as the item is the macro arg
     /// and as such we need to shift tokens if they are part of an attributes input instead of their item.
     macro_arg_shift: mbe::Shift,

--- a/crates/hir_expand/src/lib.rs
+++ b/crates/hir_expand/src/lib.rs
@@ -427,7 +427,7 @@ pub struct ExpansionInfo {
     attr_input_or_mac_def: Option<InFile<ast::TokenTree>>,
 
     macro_def: Arc<TokenExpander>,
-    macro_arg: Arc<(tt::Subtree, mbe::TokenMap, fixup::SyntaxFixupMap)>,
+    macro_arg: Arc<(tt::Subtree, mbe::TokenMap, fixup::SyntaxFixupUndoInfo)>,
     /// A shift built from `macro_arg`'s subtree, relevant for attributes as the item is the macro arg
     /// and as such we need to shift tokens if they are part of an attributes input instead of their item.
     macro_arg_shift: mbe::Shift,

--- a/crates/hir_expand/src/lib.rs
+++ b/crates/hir_expand/src/lib.rs
@@ -15,6 +15,7 @@ pub mod proc_macro;
 pub mod quote;
 pub mod eager;
 pub mod mod_path;
+mod fixup;
 
 pub use mbe::{ExpandError, ExpandResult, Origin};
 

--- a/crates/ide_completion/src/tests/attribute.rs
+++ b/crates/ide_completion/src/tests/attribute.rs
@@ -62,8 +62,7 @@ fn proc_macros_qualified() {
 struct Foo;
 "#,
         expect![[r#"
-            at input_replace pub macro input_replace
-            at identity      pub macro identity
+            at identity pub macro identity
         "#]],
     )
 }

--- a/crates/mbe/src/lib.rs
+++ b/crates/mbe/src/lib.rs
@@ -31,6 +31,7 @@ pub use crate::{
     syntax_bridge::{
         parse_exprs_with_sep, parse_to_token_tree, syntax_node_to_token_tree,
         syntax_node_to_token_tree_censored, token_tree_to_syntax_node, SyntheticToken,
+        SyntheticTokenId,
     },
     token_map::TokenMap,
 };

--- a/crates/mbe/src/lib.rs
+++ b/crates/mbe/src/lib.rs
@@ -30,7 +30,7 @@ pub use tt::{Delimiter, DelimiterKind, Punct};
 pub use crate::{
     syntax_bridge::{
         parse_exprs_with_sep, parse_to_token_tree, syntax_node_to_token_tree,
-        syntax_node_to_token_tree_censored, token_tree_to_syntax_node,
+        syntax_node_to_token_tree_censored, token_tree_to_syntax_node, SyntheticToken,
     },
     token_map::TokenMap,
 };

--- a/crates/mbe/src/lib.rs
+++ b/crates/mbe/src/lib.rs
@@ -30,7 +30,7 @@ pub use tt::{Delimiter, DelimiterKind, Punct};
 pub use crate::{
     syntax_bridge::{
         parse_exprs_with_sep, parse_to_token_tree, syntax_node_to_token_tree,
-        syntax_node_to_token_tree_censored, token_tree_to_syntax_node, SyntheticToken,
+        syntax_node_to_token_tree_with_modifications, token_tree_to_syntax_node, SyntheticToken,
         SyntheticTokenId,
     },
     token_map::TokenMap,

--- a/crates/mbe/src/syntax_bridge.rs
+++ b/crates/mbe/src/syntax_bridge.rs
@@ -1,7 +1,7 @@
 //! Conversions between [`SyntaxNode`] and [`tt::TokenTree`].
 
 use rustc_hash::{FxHashMap, FxHashSet};
-use stdx::non_empty_vec::NonEmptyVec;
+use stdx::{non_empty_vec::NonEmptyVec, always};
 use syntax::{
     ast::{self, make::tokens::doc_comment},
     AstToken, Parse, PreorderWithTokens, SmolStr, SyntaxElement, SyntaxKind,
@@ -30,6 +30,8 @@ pub fn syntax_node_to_token_tree_censored(
     let mut c = Convertor::new(node, global_offset, replace, append);
     let subtree = convert_tokens(&mut c);
     c.id_alloc.map.shrink_to_fit();
+    always!(c.replace.is_empty());
+    always!(c.append.is_empty());
     (subtree, c.id_alloc.map)
 }
 

--- a/crates/mbe/src/syntax_bridge.rs
+++ b/crates/mbe/src/syntax_bridge.rs
@@ -192,7 +192,9 @@ fn convert_tokens<C: TokenConvertor>(conv: &mut C) -> tt::Subtree {
             continue;
         }
         let tt = if kind.is_punct() && kind != UNDERSCORE {
-            // assert_eq!(range.len(), TextSize::of('.'));
+            if synth_id.is_none() {
+                assert_eq!(range.len(), TextSize::of('.'));
+            }
 
             if let Some(delim) = subtree.delimiter {
                 let expected = match delim.kind {

--- a/crates/mbe/src/syntax_bridge.rs
+++ b/crates/mbe/src/syntax_bridge.rs
@@ -15,13 +15,12 @@ use crate::{to_parser_input::to_parser_input, tt_iter::TtIter, TokenMap};
 /// Convert the syntax node to a `TokenTree` (what macro
 /// will consume).
 pub fn syntax_node_to_token_tree(node: &SyntaxNode) -> (tt::Subtree, TokenMap) {
-    syntax_node_to_token_tree_censored(node, Default::default(), Default::default())
+    syntax_node_to_token_tree_with_modifications(node, Default::default(), Default::default())
 }
 
-// TODO rename
 /// Convert the syntax node to a `TokenTree` (what macro will consume)
 /// with the censored range excluded.
-pub fn syntax_node_to_token_tree_censored(
+pub fn syntax_node_to_token_tree_with_modifications(
     node: &SyntaxNode,
     replace: FxHashMap<SyntaxNode, Vec<SyntheticToken>>,
     append: FxHashMap<SyntaxNode, Vec<SyntheticToken>>,

--- a/crates/mbe/src/syntax_bridge.rs
+++ b/crates/mbe/src/syntax_bridge.rs
@@ -1,7 +1,7 @@
 //! Conversions between [`SyntaxNode`] and [`tt::TokenTree`].
 
 use rustc_hash::{FxHashMap, FxHashSet};
-use stdx::{non_empty_vec::NonEmptyVec, always};
+use stdx::{always, non_empty_vec::NonEmptyVec};
 use syntax::{
     ast::{self, make::tokens::doc_comment},
     AstToken, Parse, PreorderWithTokens, SmolStr, SyntaxElement, SyntaxKind,

--- a/crates/mbe/src/token_map.rs
+++ b/crates/mbe/src/token_map.rs
@@ -5,6 +5,8 @@ use std::hash::Hash;
 use parser::{SyntaxKind, T};
 use syntax::{TextRange, TextSize};
 
+use crate::syntax_bridge::SyntheticTokenId;
+
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 enum TokenTextRange {
     Token(TextRange),
@@ -31,6 +33,7 @@ impl TokenTextRange {
 pub struct TokenMap {
     /// Maps `tt::TokenId` to the *relative* source range.
     entries: Vec<(tt::TokenId, TokenTextRange)>,
+    pub synthetic_entries: Vec<(tt::TokenId, SyntheticTokenId)>,
 }
 
 impl TokenMap {
@@ -57,6 +60,10 @@ impl TokenMap {
             .filter_map(move |(_, range)| range.by_kind(kind))
     }
 
+    pub fn synthetic_token_id(&self, token_id: tt::TokenId) -> Option<SyntheticTokenId> {
+        self.synthetic_entries.iter().find(|(tid, _)| *tid == token_id).map(|(_, id)| *id)
+    }
+
     pub fn first_range_by_token(
         &self,
         token_id: tt::TokenId,
@@ -71,6 +78,10 @@ impl TokenMap {
 
     pub(crate) fn insert(&mut self, token_id: tt::TokenId, relative_range: TextRange) {
         self.entries.push((token_id, TokenTextRange::Token(relative_range)));
+    }
+
+    pub(crate) fn insert_synthetic(&mut self, token_id: tt::TokenId, id: SyntheticTokenId) {
+        self.synthetic_entries.push((token_id, id));
     }
 
     pub(crate) fn insert_delim(

--- a/crates/mbe/src/token_map.rs
+++ b/crates/mbe/src/token_map.rs
@@ -74,6 +74,7 @@ impl TokenMap {
 
     pub(crate) fn shrink_to_fit(&mut self) {
         self.entries.shrink_to_fit();
+        self.synthetic_entries.shrink_to_fit();
     }
 
     pub(crate) fn insert(&mut self, token_id: tt::TokenId, relative_range: TextRange) {

--- a/crates/tt/src/lib.rs
+++ b/crates/tt/src/lib.rs
@@ -87,6 +87,16 @@ pub struct Ident {
     pub id: TokenId,
 }
 
+impl Leaf {
+    pub fn id(&self) -> TokenId {
+        match self {
+            Leaf::Literal(l) => l.id,
+            Leaf::Punct(p) => p.id,
+            Leaf::Ident(i) => i.id,
+        }
+    }
+}
+
 fn print_debug_subtree(f: &mut fmt::Formatter<'_>, subtree: &Subtree, level: usize) -> fmt::Result {
     let align = "  ".repeat(level);
 


### PR DESCRIPTION
This implements the "fix up syntax nodes" workaround mentioned in #11014. It isn't much more than a proof of concept; I have only implemented a few cases, but it already helps quite a bit.

Some notes:
 - I'm not super happy about how much the fixup procedure needs to interact with the syntax node -> token tree conversion code (e.g. needing to share the token map). This could maybe be simplified with some refactoring of that code.
 - It would maybe be nice to have the fixup procedure reuse or share information with the parser, though I'm not really sure how much that would actually help.