### PR TITLE
fix: documentation of SsrParams

### DIFF
--- a/docs/dev/lsp-extensions.md
+++ b/docs/dev/lsp-extensions.md
@@ -278,6 +278,8 @@ interface SsrParams {
     textDocument: TextDocumentIdentifier;
     /// Position where SSR was invoked.
     position: Position;
+    /// Current selections. Search/replace will be restricted to these if non-empty.
+    selections: Range[];
 }
 ```
 


### PR DESCRIPTION
Fix #11429 by extending the documentation of SsrParms with the
mandatory field 'selections'.  Copy its description from lsp_ext.rs.