### PR TITLE
Extract struct from enum variant filters generics

### DIFF
--- a/crates/ide_assists/src/handlers/extract_struct_from_enum_variant.rs
+++ b/crates/ide_assists/src/handlers/extract_struct_from_enum_variant.rs
@@ -20,6 +20,7 @@ use syntax::{
     },
     match_ast,
     ted::{self, Position},
+    SyntaxElement,
     SyntaxKind::*,
     SyntaxNode, T,
 };
@@ -222,12 +223,7 @@ fn tag_generics_in_variant(
     types: &mut [(ast::TypeParam, bool)],
     consts: &mut [(ast::ConstParam, bool)],
 ) {
-    for token in
-        ty.syntax().preorder_with_tokens().filter_map(|node_or_token| match node_or_token {
-            syntax::WalkEvent::Enter(syntax::NodeOrToken::Token(token)) => Some(token),
-            _ => None,
-        })
-    {
+    for token in ty.syntax().descendants_with_tokens().filter_map(SyntaxElement::into_token) {
         match token.kind() {
             T![lifetime_ident] => {
                 for (lt, present) in lifetimes.iter_mut() {


### PR DESCRIPTION
Fixes #11452.

This PR updates extract_struct_from_enum_variant. Extracting a struct `A` form an enum like
```rust
enum X<'a, 'b> {
    A { a: &'a () },
    B { b: &'b () },
}
```
will now be correctly generated as
```rust
struct A<'a> { a: &'a () }

enum X<'a, 'b> {
    A(A<'a>),
    B { b: &'b () },
}
```
instead of the previous
```rust
struct A<'a, 'b>{ a: &'a () } // <- should not have 'b

enum X<'a, 'b> {
    A(A<'a, 'b>),
    B { b: &'b () },
}
```

This also works for generic type parameters and const generics.

Bounds are also copied, however I have not yet implemented a filter for unneeded bounds. Extracting `B` from the following enum
```rust
enum X<'a, 'b: 'a> {
    A { a: &'a () },
    B { b: &'b () },
}
```
will be generated as 
```rust
struct B<'b: 'a> { b: &'b () } // <- should be `struct B<'b> { b: &'b () }`

enum X<'a, 'b: 'a> {
    A { a: &'a () },
    B(B<'b>),
}
```

Extracting bounds with where clauses is also still not implemented.