### PR TITLE
fix: visibility in impl items and pub(crate) to pub in extract_module

### DIFF
--- a/crates/ide_assists/src/handlers/extract_module.rs
+++ b/crates/ide_assists/src/handlers/extract_module.rs
@@ -779,12 +779,8 @@ fn get_replacements_for_visibilty_change(
             ast::Item::Enum(it) => replacements.push((it.visibility(), it.syntax().clone())),
             ast::Item::ExternCrate(it) => replacements.push((it.visibility(), it.syntax().clone())),
             ast::Item::Fn(it) => replacements.push((it.visibility(), it.syntax().clone())),
-            ast::Item::Impl(it) => {
-                //Associated item's visibility should not be changed
-                if let None = it.for_token() {
-                    impls.push(it);
-                }
-            }
+            //Associated item's visibility should not be changed
+            ast::Item::Impl(it) if it.for_token().is_none() => impls.push(it),
             ast::Item::MacroRules(it) => replacements.push((it.visibility(), it.syntax().clone())),
             ast::Item::MacroDef(it) => replacements.push((it.visibility(), it.syntax().clone())),
             ast::Item::Module(it) => replacements.push((it.visibility(), it.syntax().clone())),


### PR DESCRIPTION
Should fix #11007 and #11443

Makes following changes:

- Removes visiblity modifiers from trait items
- Respect user given visibility
- Updated tests for the same