### PR TITLE
fix: Fix cases where `Merge Imports` would drop imports.

### DIFF
--- a/crates/ide_assists/src/handlers/merge_imports.rs
+++ b/crates/ide_assists/src/handlers/merge_imports.rs
@@ -322,6 +322,18 @@ use foo::{bar::{self}};
     }
 
     #[test]
+    fn test_merge_nested_list_self_and_glob() {
+        check_assist(
+            merge_imports,
+            r"
+use std$0::{fmt::*};
+use std::{fmt::{self, Display}};
+",
+            r"use std::{fmt::{self, *, Display}};",
+        )
+    }
+
+    #[test]
     fn test_merge_single_wildcard_diff_prefixes() {
         check_assist(
             merge_imports,

--- a/crates/ide_assists/src/handlers/merge_imports.rs
+++ b/crates/ide_assists/src/handlers/merge_imports.rs
@@ -329,7 +329,9 @@ use foo::{bar::{self}};
 use std$0::{fmt::*};
 use std::{fmt::{self, Display}};
 ",
-            r"use std::{fmt::{self, *, Display}};",
+            r"
+use std::{fmt::{self, *, Display}};
+",
         )
     }
 

--- a/crates/ide_assists/src/handlers/merge_imports.rs
+++ b/crates/ide_assists/src/handlers/merge_imports.rs
@@ -253,6 +253,75 @@ use std::{fmt::{Display, Debug}};
     }
 
     #[test]
+    fn test_merge_with_nested_self_item() {
+        check_assist(
+            merge_imports,
+            r"
+use std$0::{fmt::{Write, Display}};
+use std::{fmt::{self, Debug}};
+",
+            r"
+use std::{fmt::{Write, Display, self, Debug}};
+",
+        );
+    }
+
+    #[test]
+    fn test_merge_with_nested_self_item2() {
+        check_assist(
+            merge_imports,
+            r"
+use std$0::{fmt::{self, Debug}};
+use std::{fmt::{Write, Display}};
+",
+            r"
+use std::{fmt::{self, Debug, Write, Display}};
+",
+        );
+    }
+
+    #[test]
+    fn test_merge_self_with_nested_self_item() {
+        check_assist(
+            merge_imports,
+            r"
+use std::{fmt$0::{self, Debug}, fmt::{Write, Display}};
+",
+            r"
+use std::{fmt::{self, Debug, Write, Display}};
+",
+        );
+    }
+
+    #[test]
+    fn test_merge_nested_self_and_empty() {
+        check_assist(
+            merge_imports,
+            r"
+use foo::$0{bar::{self}};
+use foo::{bar};
+",
+            r"
+use foo::{bar::{self}};
+",
+        )
+    }
+
+    #[test]
+    fn test_merge_nested_empty_and_self() {
+        check_assist(
+            merge_imports,
+            r"
+use foo::$0{bar};
+use foo::{bar::{self}};
+",
+            r"
+use foo::{bar::{self}};
+",
+        )
+    }
+
+    #[test]
     fn test_merge_single_wildcard_diff_prefixes() {
         check_assist(
             merge_imports,

--- a/crates/ide_db/src/helpers/merge_imports.rs
+++ b/crates/ide_db/src/helpers/merge_imports.rs
@@ -117,7 +117,7 @@ fn recursive_merge(lhs: &ast::UseTree, rhs: &ast::UseTree, merge: MergeBehavior)
                             .map(|tree_list| tree_list.use_trees().any(|it| tree_is_self(&it)))
                             // Glob imports aren't part of the use-tree lists,
                             // so they need to be handled explicitly
-                            .or_else(|| tree.star_token().is_some().then(|| false))
+                            .or_else(|| tree.star_token().map(|_| false))
                     };
                     match (tree_contains_self(lhs_t), tree_contains_self(&rhs_t)) {
                         (Some(true), None) => continue,

--- a/crates/ide_db/src/helpers/merge_imports.rs
+++ b/crates/ide_db/src/helpers/merge_imports.rs
@@ -115,6 +115,9 @@ fn recursive_merge(lhs: &ast::UseTree, rhs: &ast::UseTree, merge: MergeBehavior)
                     let tree_contains_self = |tree: &ast::UseTree| {
                         tree.use_tree_list()
                             .map(|tree_list| tree_list.use_trees().any(|it| tree_is_self(&it)))
+                            // Glob imports aren't part of the use-tree lists,
+                            // so they need to be handled explicitly
+                            .or_else(|| tree.star_token().is_some().then(|| false))
                     };
                     match (tree_contains_self(lhs_t), tree_contains_self(&rhs_t)) {
                         (Some(true), None) => continue,

--- a/crates/ide_db/src/helpers/merge_imports.rs
+++ b/crates/ide_db/src/helpers/merge_imports.rs
@@ -115,11 +115,10 @@ fn recursive_merge(lhs: &ast::UseTree, rhs: &ast::UseTree, merge: MergeBehavior)
                     let tree_contains_self = |tree: &ast::UseTree| {
                         tree.use_tree_list()
                             .map(|tree_list| tree_list.use_trees().any(|it| tree_is_self(&it)))
-                            .unwrap_or(false)
                     };
                     match (tree_contains_self(lhs_t), tree_contains_self(&rhs_t)) {
-                        (true, false) => continue,
-                        (false, true) => {
+                        (Some(true), None) => continue,
+                        (None, Some(true)) => {
                             ted::replace(lhs_t.syntax(), rhs_t.syntax());
                             *lhs_t = rhs_t;
                             continue;


### PR DESCRIPTION
Fixes #11466 