### PR TITLE
fix: keyword hover works on non-keyword tokens if expanded to keyword

### DIFF
--- a/crates/ide/src/hover.rs
+++ b/crates/ide/src/hover.rs
@@ -94,11 +94,10 @@ pub(crate) fn hover(
     let sema = &hir::Semantics::new(db);
     let file = sema.parse(file_id).syntax().clone();
 
-    let offset = if !range.is_empty() {
+    if !range.is_empty() {
         return hover_ranged(&file, range, sema, config);
-    } else {
-        range.start()
-    };
+    }
+    let offset = range.start();
 
     let original_token = pick_best_token(file.token_at_offset(offset), |kind| match kind {
         IDENT | INT_NUMBER | LIFETIME_IDENT | T![self] | T![super] | T![crate] => 3,
@@ -118,10 +117,11 @@ pub(crate) fn hover(
     let descended = sema.descend_into_macros(original_token.clone());
 
     // FIXME: Definition should include known lints and the like instead of having this special case here
-    if let Some(res) = descended.iter().find_map(|token| {
+    let hovered_lint = descended.iter().find_map(|token| {
         let attr = token.ancestors().find_map(ast::Attr::cast)?;
         render::try_for_lint(&attr, token)
-    }) {
+    });
+    if let Some(res) = hovered_lint {
         return Some(RangeInfo::new(original_token.text_range(), res));
     }
 
@@ -143,7 +143,9 @@ pub(crate) fn hover(
 
     if result.is_none() {
         // fallbacks, show keywords or types
-        if let Some(res) = render::keyword(sema, config, &original_token) {
+
+        let res = descended.iter().find_map(|token| render::keyword(sema, config, &token));
+        if let Some(res) = res {
             return Some(RangeInfo::new(original_token.text_range(), res));
         }
         let res = descended
@@ -199,6 +201,7 @@ fn hover_ranged(
     sema: &Semantics<RootDatabase>,
     config: &HoverConfig,
 ) -> Option<RangeInfo<HoverResult>> {
+    // FIXME: make this work in attributes
     let expr_or_pat = file.covering_element(range).ancestors().find_map(|it| {
         match_ast! {
             match it {


### PR DESCRIPTION
bors r+