### PR TITLE
no sending notification about failure of loaded workspace when loading new one

### DIFF
--- a/crates/rust-analyzer/src/reload.rs
+++ b/crates/rust-analyzer/src/reload.rs
@@ -83,8 +83,10 @@ impl GlobalState {
             status.health = lsp_ext::Health::Warning;
             status.message = Some("Workspace reload required".to_string())
         }
-
-        if let Some(error) = self.fetch_workspace_error() {
+        if self.fetch_workspaces_queue.op_in_progress() {
+            status.health = lsp_ext::Health::Warning;
+            status.message = Some("Workspace reloading".to_string())
+        } else if let Some(error) = self.fetch_workspace_error() {
             status.health = lsp_ext::Health::Error;
             status.message = Some(error)
         }


### PR DESCRIPTION
Change is about current_status.
If workspace is loading, don't send error status to ide instantly.