### PR TITLE
Correctly fix formatting doc tests with generics

### DIFF
--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -426,8 +426,8 @@ fn module_def_doctest(db: &RootDatabase, def: Definition) -> Option<Runnable> {
                             ty_args.format_with(", ", |ty, cb| cb(&ty.display(db)))
                         );
                     }
-                    format_to!(path, "::{}", def_name);
-                    return Some(path);
+                    format_to!(path, "::{}\"", def_name);
+                    return Some(format!("\"{}", path));
                 }
             }
         }
@@ -966,7 +966,7 @@ impl Data {
                         },
                         kind: DocTest {
                             test_id: Path(
-                                "Data::foo",
+                                "\"Data::foo\"",
                             ),
                         },
                         cfg: None,
@@ -1360,7 +1360,7 @@ impl Foo {
                         },
                         kind: DocTest {
                             test_id: Path(
-                                "foo::Foo::foo",
+                                "\"foo::Foo::foo\"",
                             ),
                         },
                         cfg: None,
@@ -2066,7 +2066,7 @@ impl<T, U> Foo<T, U> {
                         },
                         kind: DocTest {
                             test_id: Path(
-                                "Foo<T, U>::t",
+                                "\"Foo<T, U>::t\"",
                             ),
                         },
                         cfg: None,

--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -426,8 +426,7 @@ fn module_def_doctest(db: &RootDatabase, def: Definition) -> Option<Runnable> {
                             ty_args.format_with(", ", |ty, cb| cb(&ty.display(db)))
                         );
                     }
-                    format_to!(path, "::{}\"", def_name);
-                    return Some(format!("\"{}", path));
+                    return Some(format!(r#""{}::{}""#, path, def_name));
                 }
             }
         }


### PR DESCRIPTION
Before the doc_test would be outputted like this:
```zsh
"Foo<T, U>::t"
```
However, this would cause problems with shell redirection. I've changed it
so when generics are involved we simply wrap the expression under quotes as so:
```zsh
"\"Foo<T, U>::t\""
```

Note:
At the cost of adding this, I had to allocate a new string via
`format!{}`. However, I argue this is alright as this for just for
outputting the name of the doc test.

The following tests have been changed:
```
runnables::tests::doc_test_type_params
runnables::tests::test_doc_runnables_impl_mod
runnables::tests::test_runnables_doc_test_in_impl
```

Closes  https://github.com/rust-analyzer/rust-analyzer/issues/11489