### PR TITLE
Adding println and debug postfix

### DIFF
--- a/crates/ide_completion/src/snippet.rs
+++ b/crates/ide_completion/src/snippet.rs
@@ -60,6 +60,13 @@ use std::ops::Deref;
 // [source,json]
 // ----
 // {
+//     "Println": {
+//         "postfix": "print",
+//         "body": "println!(\"{}\", ${receiver});",
+//         "requires": "std::fmt::Display",
+//         "description": "Wraps the current variable in a println macro",
+//         "scope": "expr"
+//     },
 //     "Arc::new": {
 //         "postfix": "arc",
 //         "body": "Arc::new(${receiver})",

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -120,6 +120,13 @@ config_data! {
         /// Custom completion snippets.
         // NOTE: Keep this list in sync with the feature docs of user snippets.
         completion_snippets: FxHashMap<String, SnippetDef> = r#"{
+            "Println": {
+                "postfix": "print",
+                "body": "println!(\"{}\", ${receiver});",
+                "requires": "std::fmt::Display",
+                "description": "Wraps the current expression in a println macro",
+                "scope": "expr"
+            },
             "Arc::new": {
                 "postfix": "arc",
                 "body": "Arc::new(${receiver})",

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -152,6 +152,13 @@ Whether to add parenthesis when completing functions.
 Default:
 ----
 {
+            "Println": {
+                "postfix": "print",
+                "body": "println!(\"{}\", ${receiver});",
+                "requires": "std::fmt::Display",
+                "description": "Wraps the current expression in a println macro",
+                "scope": "expr"
+            },
             "Arc::new": {
                 "postfix": "arc",
                 "body": "Arc::new(${receiver})",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -586,6 +586,13 @@
                 "rust-analyzer.completion.snippets": {
                     "markdownDescription": "Custom completion snippets.",
                     "default": {
+                        "Println": {
+                            "postfix": "print",
+                            "body": "println!(\"{}\", ${receiver});",
+                            "requires": "std::fmt::Display",
+                            "description": "Wraps the current expression in a println macro",
+                            "scope": "expr"
+                        },
                         "Arc::new": {
                             "postfix": "arc",
                             "body": "Arc::new(${receiver})",


### PR DESCRIPTION
I use these `postfix`'s all the time and it saves a lot of typing, I'd like to be able to show people when teaching that they can do this with `rust-analyzer`, so would be nice if they were default. For your consideration 🙂

went for 
```
println!(\"{}\", ${receiver});
```
instead of
```
println!(\"{receiver}\");
```

Because it makes it easier to access fields if required