### PR TITLE
Fix a typo in server_capabilities.experimental

### DIFF
--- a/crates/rust-analyzer/src/caps.rs
+++ b/crates/rust-analyzer/src/caps.rs
@@ -117,7 +117,7 @@ pub fn server_capabilities(config: &Config) -> ServerCapabilities {
             "hoverRange": true,
             "joinLines": true,
             "matchingBrace": true,
-            "moveItems": true,
+            "moveItem": true,
             "onEnter": true,
             "openCargoToml": true,
             "parentModule": true,


### PR DESCRIPTION
Commit 27c4be6b4f68 wasn't really complex, but I still managed to make a mistake there, which this PR fixes.  Sorry.