### PR TITLE
internal: Wrap MacroCallKind::Attr attr_args field in an Arc

### DIFF
--- a/crates/hir_def/src/lib.rs
+++ b/crates/hir_def/src/lib.rs
@@ -787,7 +787,7 @@ fn attr_macro_as_call_id(
         MacroCallKind::Attr {
             ast_id: item_attr.ast_id,
             attr_name: last_segment.to_string().into_boxed_str(),
-            attr_args: arg,
+            attr_args: Arc::new(arg),
             invoc_attr_index: macro_attr.id.ast_index,
         },
     );


### PR DESCRIPTION
This is stored in `MacroCallLoc` which is returned from a query, so cloning should be made cheap.
bors r+