### PR TITLE
doc: state that only the latest stable toolchain is supported

### DIFF
--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -40,6 +40,20 @@ To add the sources manually, run the following command:
 $ rustup component add rust-src
 ```
 
+=== Toolchain
+
+Rust Analyzer only officially supports using the latest stable toolchain.
+If you are using an older toolchain or have an override set, Rust Analyzer may fail to understand the Rust source.
+You will either need to update your toolchain or use an older version of Rust Analyzer that is compatible with your toolchain.
+
+If you are using an override in your project, you can still force Rust Analyzer to use the stable toolchain via the environment variable `RUSTUP_TOOLCHAIN`.
+For example, with VS Code or coc-rust-analyzer:
+
+[source,json]
+----
+{ "rust-analyzer.server.extraEnv": { "RUSTUP_TOOLCHAIN": "stable" } }
+----
+
 === VS Code
 
 This is the best supported editor at the moment.

--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -42,11 +42,11 @@ $ rustup component add rust-src
 
 === Toolchain
 
-Rust Analyzer only officially supports using the latest stable toolchain.
-If you are using an older toolchain or have an override set, Rust Analyzer may fail to understand the Rust source.
-You will either need to update your toolchain or use an older version of Rust Analyzer that is compatible with your toolchain.
+Only the latest stable standard library source is officially supported for use with rust-analyzer.
+If you are using an older toolchain or have an override set, rust-analyzer may fail to understand the Rust source.
+You will either need to update your toolchain or use an older version of rust-analyzer that is compatible with your toolchain.
 
-If you are using an override in your project, you can still force Rust Analyzer to use the stable toolchain via the environment variable `RUSTUP_TOOLCHAIN`.
+If you are using an override in your project, you can still force rust-analyzer to use the stable toolchain via the environment variable `RUSTUP_TOOLCHAIN`.
 For example, with VS Code or coc-rust-analyzer:
 
 [source,json]


### PR DESCRIPTION
This closes #11226. The content seemed to make more sense in the
installation section as opposed to the Troubleshooting section.