### PR TITLE
internal: Resolve functions as proc-macros via `FileAstId`

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1388,9 +1388,13 @@ impl Function {
         let loc = self.id.lookup(db.upcast());
         let krate = loc.krate(db);
         let def_map = db.crate_def_map(krate.into());
-        let name = &function_data.name;
+        let ast_id =
+            InFile::new(loc.id.file_id(), loc.id.item_tree(db.upcast())[loc.id.value].ast_id);
+
         let mut exported_proc_macros = def_map.exported_proc_macros();
-        exported_proc_macros.find(|(_, mac_name)| mac_name == name).map(|(id, _)| MacroDef { id })
+        exported_proc_macros
+            .find(|&(id, _)| matches!(id.kind, MacroDefKind::ProcMacro(_, _, id) if id == ast_id))
+            .map(|(id, _)| MacroDef { id })
     }
 
     /// A textual representation of the HIR of this function for debugging purposes.

--- a/crates/ide/src/references.rs
+++ b/crates/ide/src/references.rs
@@ -1536,11 +1536,13 @@ trait Trait {
         )
     }
 
+    // FIXME: import is classified as function
     #[test]
     fn attr() {
         check(
             r#"
 //- proc_macros: identity
+use proc_macros::identity;
 
 #[proc_macros::$0identity]
 fn func() {}
@@ -1548,7 +1550,7 @@ fn func() {}
             expect![[r#"
                 identity Attribute FileId(1) 1..107 32..40
 
-                FileId(0) 16..24
+                FileId(0) 43..51
             "#]],
         );
         check(
@@ -1564,12 +1566,31 @@ fn func$0() {}
         );
     }
 
+    // FIXME: import is classified as function
+    #[test]
+    fn proc_macro() {
+        check(
+            r#"
+//- proc_macros: mirror
+use proc_macros::mirror;
+
+mirror$0! {}
+"#,
+            expect![[r#"
+                mirror Macro FileId(1) 1..77 22..28
+
+                FileId(0) 26..32
+            "#]],
+        )
+    }
+
     #[test]
     fn derive() {
         check(
             r#"
 //- proc_macros: derive_identity
 //- minicore: derive
+use proc_macros::DeriveIdentity;
 
 #[derive(proc_macros::DeriveIdentity$0)]
 struct Foo;
@@ -1577,8 +1598,20 @@ struct Foo;
             expect![[r#"
                 derive_identity Derive FileId(2) 1..107 45..60
 
-                FileId(0) 23..37
+                FileId(0) 17..31
+                FileId(0) 56..70
             "#]],
-        )
+        );
+        check(
+            r#"
+#[proc_macro_derive(Derive, attributes(x))]
+pub fn deri$0ve(_stream: TokenStream) -> TokenStream {}
+"#,
+            expect![[r#"
+                derive Derive FileId(0) 0..97 51..57
+
+                (no references)
+            "#]],
+        );
     }
 }


### PR DESCRIPTION
cc https://github.com/rust-analyzer/rust-analyzer/issues/11528
bors r+