### PR TITLE
fix: Resolve private fields in type inference

### DIFF
--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -13,8 +13,8 @@
 //! to certain types. To record this, we use the union-find implementation from
 //! the `ena` crate, which is extracted from rustc.
 
-use std::ops::Index;
 use std::sync::Arc;
+use std::{collections::hash_map::Entry, ops::Index};
 
 use chalk_ir::{cast::Cast, DebruijnIndex, Mutability, Safety, Scalar, TypeFlags};
 use hir_def::{
@@ -457,6 +457,12 @@ impl<'a> InferenceContext<'a> {
 
     fn write_field_resolution(&mut self, expr: ExprId, field: FieldId) {
         self.result.field_resolutions.insert(expr, field);
+    }
+
+    fn write_field_resolution_if_empty(&mut self, expr: ExprId, field: FieldId) {
+        if let Entry::Vacant(entry) = self.result.field_resolutions.entry(expr) {
+            entry.insert(field);
+        }
     }
 
     fn write_variant_resolution(&mut self, id: ExprOrPatId, variant: VariantId) {

--- a/crates/hir_ty/src/infer/expr.rs
+++ b/crates/hir_ty/src/infer/expr.rs
@@ -532,6 +532,11 @@ impl<'a> InferenceContext<'a> {
                                         .substitute(Interner, &parameters),
                                 )
                             } else {
+                                // Write down the first field resolution even if it is not visible
+                                // This aids IDE features for private fields like goto def and in
+                                // case of autoderef finding an applicable field, this will be
+                                // overwritten in a following cycle
+                                self.write_field_resolution_if_empty(tgt_expr, field);
                                 None
                             }
                         }
@@ -546,6 +551,11 @@ impl<'a> InferenceContext<'a> {
                                         .substitute(Interner, &parameters),
                                 )
                             } else {
+                                // Write down the first field resolution even if it is not visible
+                                // This aids IDE features for private fields like goto def and in
+                                // case of autoderef finding an applicable field, this will be
+                                // overwritten in a following cycle
+                                self.write_field_resolution_if_empty(tgt_expr, field);
                                 None
                             }
                         }


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/10253#issuecomment-920962927
(the same issue probably exists for method calls, but I think fixing that might be trickier)

Visibility checks were introduced in https://github.com/rust-analyzer/rust-analyzer/issues/7841 for autoderef to work properly, so now we just record the first field we find unconditionally, and then overwrite it if autoderef manages to find another field in a later cycle.