### PR TITLE
add `is_slice` method to `hir::Type`

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -2507,6 +2507,10 @@ impl Type {
         matches!(self.ty.kind(Interner), TyKind::Ref(..))
     }
 
+    pub fn is_slice(&self) -> bool {
+        matches!(self.ty.kind(Interner), TyKind::Slice(..))
+    }
+
     pub fn is_usize(&self) -> bool {
         matches!(self.ty.kind(Interner), TyKind::Scalar(Scalar::Uint(UintTy::Usize)))
     }


### PR DESCRIPTION
would like to have this on `hir::Type` for a small project i am working on, unless there is another way to check if `hir::Type` is a slice primitive?