### PR TITLE
Refactor autoderef/method resolution

### DIFF
--- a/crates/hir/src/semantics.rs
+++ b/crates/hir/src/semantics.rs
@@ -1230,6 +1230,10 @@ impl<'a> SemanticsScope<'a> {
         Some(Crate { id: self.resolver.krate()? })
     }
 
+    pub(crate) fn resolver(&self) -> &Resolver {
+        &self.resolver
+    }
+
     /// Note: `FxHashSet<TraitId>` should be treated as an opaque type, passed into `Type
     pub fn visible_traits(&self) -> FxHashSet<TraitId> {
         let resolver = &self.resolver;

--- a/crates/hir_ty/src/autoderef.rs
+++ b/crates/hir_ty/src/autoderef.rs
@@ -23,7 +23,7 @@ pub(crate) enum AutoderefKind {
 }
 
 pub(crate) struct Autoderef<'a, 'db> {
-    pub table: &'a mut InferenceTable<'db>,
+    pub(crate) table: &'a mut InferenceTable<'db>,
     ty: Ty,
     at_start: bool,
     steps: Vec<(AutoderefKind, Ty)>,

--- a/crates/hir_ty/src/autoderef.rs
+++ b/crates/hir_ty/src/autoderef.rs
@@ -3,20 +3,16 @@
 //! reference to a type with the field `bar`. This is an approximation of the
 //! logic in rustc (which lives in librustc_typeck/check/autoderef.rs).
 
-use std::iter::successors;
+use std::sync::Arc;
 
-use base_db::CrateId;
-use chalk_ir::{cast::Cast, fold::Fold, interner::HasInterner, VariableKind};
-use hir_def::lang_item::LangItemTarget;
+use chalk_ir::cast::Cast;
 use hir_expand::name::name;
 use limit::Limit;
 use syntax::SmolStr;
-use tracing::{info, warn};
 
 use crate::{
-    db::HirDatabase, static_lifetime, AliasEq, AliasTy, BoundVar, Canonical, CanonicalVarKinds,
-    ConstrainedSubst, DebruijnIndex, Environment, Guidance, InEnvironment, Interner,
-    ProjectionTyExt, Solution, Substitution, Ty, TyBuilder, TyKind,
+    db::HirDatabase, infer::unify::InferenceTable, Canonical, Goal, Interner, ProjectionTyExt,
+    TraitEnvironment, Ty, TyBuilder, TyKind,
 };
 
 static AUTODEREF_RECURSION_LIMIT: Limit = Limit::new(10);
@@ -26,40 +22,34 @@ pub(crate) enum AutoderefKind {
     Overloaded,
 }
 
-pub(crate) struct Autoderef<'db> {
-    db: &'db dyn HirDatabase,
-    ty: Canonical<Ty>,
+pub(crate) struct Autoderef<'a, 'db> {
+    pub table: &'a mut InferenceTable<'db>,
+    ty: Ty,
     at_start: bool,
-    krate: Option<CrateId>,
-    environment: Environment,
     steps: Vec<(AutoderefKind, Ty)>,
 }
 
-impl<'db> Autoderef<'db> {
-    pub(crate) fn new(
-        db: &'db dyn HirDatabase,
-        krate: Option<CrateId>,
-        ty: InEnvironment<Canonical<Ty>>,
-    ) -> Self {
-        let InEnvironment { goal: ty, environment } = ty;
-        Autoderef { db, ty, at_start: true, environment, krate, steps: Vec::new() }
+impl<'a, 'db> Autoderef<'a, 'db> {
+    pub(crate) fn new(table: &'a mut InferenceTable<'db>, ty: Ty) -> Self {
+        let ty = table.resolve_ty_shallow(&ty);
+        Autoderef { table, ty, at_start: true, steps: Vec::new() }
     }
 
     pub(crate) fn step_count(&self) -> usize {
         self.steps.len()
     }
 
-    pub(crate) fn steps(&self) -> &[(AutoderefKind, chalk_ir::Ty<Interner>)] {
+    pub(crate) fn steps(&self) -> &[(AutoderefKind, Ty)] {
         &self.steps
     }
 
     pub(crate) fn final_ty(&self) -> Ty {
-        self.ty.value.clone()
+        self.ty.clone()
     }
 }
 
-impl Iterator for Autoderef<'_> {
-    type Item = (Canonical<Ty>, usize);
+impl Iterator for Autoderef<'_, '_> {
+    type Item = (Ty, usize);
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.at_start {
@@ -71,54 +61,42 @@ impl Iterator for Autoderef<'_> {
             return None;
         }
 
-        let (kind, new_ty) = if let Some(derefed) = builtin_deref(&self.ty.value) {
-            (
-                AutoderefKind::Builtin,
-                Canonical { value: derefed.clone(), binders: self.ty.binders.clone() },
-            )
-        } else {
-            (
-                AutoderefKind::Overloaded,
-                deref_by_trait(
-                    self.db,
-                    self.krate?,
-                    InEnvironment { goal: &self.ty, environment: self.environment.clone() },
-                )?,
-            )
-        };
+        let (kind, new_ty) = autoderef_step(self.table, self.ty.clone())?;
 
-        self.steps.push((kind, self.ty.value.clone()));
+        self.steps.push((kind, self.ty.clone()));
         self.ty = new_ty;
 
         Some((self.ty.clone(), self.step_count()))
     }
 }
 
+pub(crate) fn autoderef_step(table: &mut InferenceTable, ty: Ty) -> Option<(AutoderefKind, Ty)> {
+    if let Some(derefed) = builtin_deref(&ty) {
+        Some((AutoderefKind::Builtin, table.resolve_ty_shallow(derefed)))
+    } else {
+        Some((AutoderefKind::Overloaded, deref_by_trait(table, ty)?))
+    }
+}
+
 // FIXME: replace uses of this with Autoderef above
 pub fn autoderef<'a>(
     db: &'a dyn HirDatabase,
-    krate: Option<CrateId>,
-    ty: InEnvironment<Canonical<Ty>>,
+    env: Arc<TraitEnvironment>,
+    ty: Canonical<Ty>,
 ) -> impl Iterator<Item = Canonical<Ty>> + 'a {
-    let InEnvironment { goal: ty, environment } = ty;
-    successors(Some(ty), move |ty| {
-        deref(db, krate?, InEnvironment { goal: ty, environment: environment.clone() })
-    })
-    .take(AUTODEREF_RECURSION_LIMIT.inner())
+    let mut table = InferenceTable::new(db, env);
+    let ty = table.instantiate_canonical(ty);
+    let mut autoderef = Autoderef::new(&mut table, ty);
+    let mut v = Vec::new();
+    while let Some((ty, _steps)) = autoderef.next() {
+        v.push(autoderef.table.canonicalize(ty).value);
+    }
+    v.into_iter()
 }
 
-pub(crate) fn deref(
-    db: &dyn HirDatabase,
-    krate: CrateId,
-    ty: InEnvironment<&Canonical<Ty>>,
-) -> Option<Canonical<Ty>> {
+pub(crate) fn deref(table: &mut InferenceTable, ty: Ty) -> Option<Ty> {
     let _p = profile::span("deref");
-    match builtin_deref(&ty.goal.value) {
-        Some(derefed) => {
-            Some(Canonical { value: derefed.clone(), binders: ty.goal.binders.clone() })
-        }
-        None => deref_by_trait(db, krate, ty),
-    }
+    autoderef_step(table, ty).map(|(_, ty)| ty)
 }
 
 fn builtin_deref(ty: &Ty) -> Option<&Ty> {
@@ -129,16 +107,12 @@ fn builtin_deref(ty: &Ty) -> Option<&Ty> {
     }
 }
 
-fn deref_by_trait(
-    db: &dyn HirDatabase,
-    krate: CrateId,
-    ty: InEnvironment<&Canonical<Ty>>,
-) -> Option<Canonical<Ty>> {
+fn deref_by_trait(table: &mut InferenceTable, ty: Ty) -> Option<Ty> {
+    let db = table.db;
     let _p = profile::span("deref_by_trait");
-    let deref_trait = match db.lang_item(krate, SmolStr::new_inline("deref"))? {
-        LangItemTarget::TraitId(it) => it,
-        _ => return None,
-    };
+    let deref_trait = db
+        .lang_item(table.trait_env.krate, SmolStr::new_inline("deref"))
+        .and_then(|l| l.as_trait())?;
     let target = db.trait_data(deref_trait).associated_type_by_name(&name![Target])?;
 
     let projection = {
@@ -148,114 +122,16 @@ fn deref_by_trait(
             // namely Deref's Self type
             return None;
         }
-        b.push(ty.goal.value.clone()).build()
+        b.push(ty).build()
     };
-
-    // FIXME make the Canonical / bound var handling nicer
 
     // Check that the type implements Deref at all
     let trait_ref = projection.trait_ref(db);
-    let implements_goal = Canonical {
-        binders: ty.goal.binders.clone(),
-        value: InEnvironment {
-            goal: trait_ref.cast(Interner),
-            environment: ty.environment.clone(),
-        },
-    };
-    if db.trait_solve(krate, implements_goal).is_none() {
-        return None;
-    }
+    let implements_goal: Goal = trait_ref.cast(Interner);
+    table.try_obligation(implements_goal.clone())?;
 
-    // Now do the assoc type projection
-    let alias_eq = AliasEq {
-        alias: AliasTy::Projection(projection),
-        ty: TyKind::BoundVar(BoundVar::new(
-            DebruijnIndex::INNERMOST,
-            ty.goal.binders.len(Interner),
-        ))
-        .intern(Interner),
-    };
+    table.register_obligation(implements_goal);
 
-    let in_env = InEnvironment { goal: alias_eq.cast(Interner), environment: ty.environment };
-
-    let canonical = Canonical {
-        value: in_env,
-        binders: CanonicalVarKinds::from_iter(
-            Interner,
-            ty.goal.binders.iter(Interner).cloned().chain(Some(chalk_ir::WithKind::new(
-                VariableKind::Ty(chalk_ir::TyVariableKind::General),
-                chalk_ir::UniverseIndex::ROOT,
-            ))),
-        ),
-    };
-
-    let solution = db.trait_solve(krate, canonical)?;
-
-    match &solution {
-        Solution::Unique(Canonical { value: ConstrainedSubst { subst, .. }, binders })
-        | Solution::Ambig(Guidance::Definite(Canonical { value: subst, binders })) => {
-            // FIXME: vars may contain solutions for any inference variables
-            // that happened to be inside ty. To correctly handle these, we
-            // would have to pass the solution up to the inference context, but
-            // that requires a larger refactoring (especially if the deref
-            // happens during method resolution). So for the moment, we just
-            // check that we're not in the situation where we would actually
-            // need to handle the values of the additional variables, i.e.
-            // they're just being 'passed through'. In the 'standard' case where
-            // we have `impl<T> Deref for Foo<T> { Target = T }`, that should be
-            // the case.
-
-            // FIXME: if the trait solver decides to truncate the type, these
-            // assumptions will be broken. We would need to properly introduce
-            // new variables in that case
-
-            for i in 1..binders.len(Interner) {
-                if subst.at(Interner, i - 1).assert_ty_ref(Interner).kind(Interner)
-                    != &TyKind::BoundVar(BoundVar::new(DebruijnIndex::INNERMOST, i - 1))
-                {
-                    warn!("complex solution for derefing {:?}: {:?}, ignoring", ty.goal, solution);
-                    return None;
-                }
-            }
-            // FIXME: we remove lifetime variables here since they can confuse
-            // the method resolution code later
-            Some(fixup_lifetime_variables(Canonical {
-                value: subst.at(Interner, subst.len(Interner) - 1).assert_ty_ref(Interner).clone(),
-                binders: binders.clone(),
-            }))
-        }
-        Solution::Ambig(_) => {
-            info!("Ambiguous solution for derefing {:?}: {:?}", ty.goal, solution);
-            None
-        }
-    }
-}
-
-fn fixup_lifetime_variables<T: Fold<Interner, Result = T> + HasInterner<Interner = Interner>>(
-    c: Canonical<T>,
-) -> Canonical<T> {
-    // Removes lifetime variables from the Canonical, replacing them by static lifetimes.
-    let mut i = 0;
-    let subst = Substitution::from_iter(
-        Interner,
-        c.binders.iter(Interner).map(|vk| match vk.kind {
-            VariableKind::Ty(_) => {
-                let index = i;
-                i += 1;
-                BoundVar::new(DebruijnIndex::INNERMOST, index).to_ty(Interner).cast(Interner)
-            }
-            VariableKind::Lifetime => static_lifetime().cast(Interner),
-            VariableKind::Const(_) => unimplemented!(),
-        }),
-    );
-    let binders = CanonicalVarKinds::from_iter(
-        Interner,
-        c.binders.iter(Interner).filter(|vk| match vk.kind {
-            VariableKind::Ty(_) => true,
-            VariableKind::Lifetime => false,
-            VariableKind::Const(_) => true,
-        }),
-    );
-    let value = subst.apply(c.value, Interner);
-    Canonical { binders, value }
+    let result = table.normalize_projection_ty(projection);
+    Some(table.resolve_ty_shallow(&result))
 }

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -13,8 +13,8 @@
 //! to certain types. To record this, we use the union-find implementation from
 //! the `ena` crate, which is extracted from rustc.
 
+use std::ops::Index;
 use std::sync::Arc;
-use std::{collections::hash_map::Entry, ops::Index};
 
 use chalk_ir::{cast::Cast, DebruijnIndex, Mutability, Safety, Scalar, TypeFlags};
 use hir_def::{
@@ -46,7 +46,7 @@ use crate::{
 pub use unify::could_unify;
 pub(crate) use unify::unify;
 
-mod unify;
+pub(crate) mod unify;
 mod path;
 mod expr;
 mod pat;
@@ -228,7 +228,7 @@ pub enum Adjust {
 /// The target type is `U` in both cases, with the region and mutability
 /// being those shared by both the receiver and the returned reference.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct OverloadedDeref(Mutability);
+pub struct OverloadedDeref(pub Mutability);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum AutoBorrow {
@@ -453,16 +453,6 @@ impl<'a> InferenceContext<'a> {
 
     fn write_method_resolution(&mut self, expr: ExprId, func: FunctionId, subst: Substitution) {
         self.result.method_resolutions.insert(expr, (func, subst));
-    }
-
-    fn write_field_resolution(&mut self, expr: ExprId, field: FieldId) {
-        self.result.field_resolutions.insert(expr, field);
-    }
-
-    fn write_field_resolution_if_empty(&mut self, expr: ExprId, field: FieldId) {
-        if let Entry::Vacant(entry) = self.result.field_resolutions.entry(expr) {
-            entry.insert(field);
-        }
     }
 
     fn write_variant_resolution(&mut self, id: ExprOrPatId, variant: VariantId) {

--- a/crates/hir_ty/src/infer/coerce.rs
+++ b/crates/hir_ty/src/infer/coerce.rs
@@ -259,6 +259,8 @@ impl<'a> InferenceContext<'a> {
         // details of coercion errors though, so I think it's useful to leave
         // the structure like it is.
 
+        let snapshot = self.table.snapshot();
+
         let mut autoderef = Autoderef::new(&mut self.table, from_ty.clone());
         let mut first_error = None;
         let mut found = None;
@@ -315,6 +317,7 @@ impl<'a> InferenceContext<'a> {
         let InferOk { value: ty, goals } = match found {
             Some(d) => d,
             None => {
+                self.table.rollback_to(snapshot);
                 let err = first_error.expect("coerce_borrowed_pointer had no error");
                 return Err(err);
             }

--- a/crates/hir_ty/src/infer/path.rs
+++ b/crates/hir_ty/src/infer/path.rs
@@ -218,14 +218,12 @@ impl<'a> InferenceContext<'a> {
         }
 
         let canonical_ty = self.canonicalize(ty.clone());
-        let krate = self.resolver.krate()?;
         let traits_in_scope = self.resolver.traits_in_scope(self.db.upcast());
 
         method_resolution::iterate_method_candidates(
             &canonical_ty.value,
             self.db,
             self.table.trait_env.clone(),
-            krate,
             &traits_in_scope,
             self.resolver.module().into(),
             Some(name),

--- a/crates/hir_ty/src/infer/unify.rs
+++ b/crates/hir_ty/src/infer/unify.rs
@@ -1,6 +1,6 @@
 //! Unification and canonicalization logic.
 
-use std::{fmt, mem, sync::Arc};
+use std::{fmt, iter, mem, sync::Arc};
 
 use chalk_ir::{
     cast::Cast, fold::Fold, interner::HasInterner, zip::Zip, FloatTy, IntTy, NoSolution,
@@ -8,12 +8,14 @@ use chalk_ir::{
 };
 use chalk_solve::infer::ParameterEnaVariableExt;
 use ena::unify::UnifyKey;
+use hir_expand::name;
 
 use super::{InferOk, InferResult, InferenceContext, TypeError};
 use crate::{
-    db::HirDatabase, fold_tys, static_lifetime, AliasEq, AliasTy, BoundVar, Canonical, Const,
-    DebruijnIndex, GenericArg, Goal, Guidance, InEnvironment, InferenceVar, Interner, Lifetime,
-    ProjectionTy, Scalar, Solution, Substitution, TraitEnvironment, Ty, TyKind, VariableKind,
+    db::HirDatabase, fold_tys, static_lifetime, traits::FnTrait, AliasEq, AliasTy, BoundVar,
+    Canonical, Const, DebruijnIndex, GenericArg, Goal, Guidance, InEnvironment, InferenceVar,
+    Interner, Lifetime, ProjectionTy, ProjectionTyExt, Scalar, Solution, Substitution,
+    TraitEnvironment, Ty, TyBuilder, TyExt, TyKind, VariableKind,
 };
 
 impl<'a> InferenceContext<'a> {
@@ -24,32 +26,20 @@ impl<'a> InferenceContext<'a> {
     where
         T::Result: HasInterner<Interner = Interner>,
     {
-        // try to resolve obligations before canonicalizing, since this might
-        // result in new knowledge about variables
-        self.resolve_obligations_as_possible();
         self.table.canonicalize(t)
     }
 }
 
 #[derive(Debug, Clone)]
-pub(super) struct Canonicalized<T>
+pub(crate) struct Canonicalized<T>
 where
     T: HasInterner<Interner = Interner>,
 {
-    pub(super) value: Canonical<T>,
+    pub(crate) value: Canonical<T>,
     free_vars: Vec<GenericArg>,
 }
 
 impl<T: HasInterner<Interner = Interner>> Canonicalized<T> {
-    /// this method is wrong and shouldn't exist
-    pub(super) fn decanonicalize_ty(&self, table: &mut InferenceTable, ty: Canonical<Ty>) -> Ty {
-        let mut vars = self.free_vars.clone();
-        while ty.binders.len(Interner) > vars.len() {
-            vars.push(table.new_type_var().cast(Interner));
-        }
-        chalk_ir::Substitute::apply(&vars, ty.value, Interner)
-    }
-
     pub(super) fn apply_solution(
         &self,
         ctx: &mut InferenceTable,
@@ -203,13 +193,16 @@ impl<'a> InferenceTable<'a> {
         .intern(Interner)
     }
 
-    pub(super) fn canonicalize<T: Fold<Interner> + HasInterner<Interner = Interner>>(
+    pub(crate) fn canonicalize<T: Fold<Interner> + HasInterner<Interner = Interner>>(
         &mut self,
         t: T,
     ) -> Canonicalized<T::Result>
     where
         T::Result: HasInterner<Interner = Interner>,
     {
+        // try to resolve obligations before canonicalizing, since this might
+        // result in new knowledge about variables
+        self.resolve_obligations_as_possible();
         let result = self.var_unification_table.canonicalize(Interner, t);
         let free_vars = result
             .free_vars
@@ -225,7 +218,7 @@ impl<'a> InferenceTable<'a> {
     /// type annotation (e.g. from a let type annotation, field type or function
     /// call). `make_ty` handles this already, but e.g. for field types we need
     /// to do it as well.
-    pub(super) fn normalize_associated_types_in(&mut self, ty: Ty) -> Ty {
+    pub(crate) fn normalize_associated_types_in(&mut self, ty: Ty) -> Ty {
         fold_tys(
             ty,
             |ty, _| match ty.kind(Interner) {
@@ -238,7 +231,7 @@ impl<'a> InferenceTable<'a> {
         )
     }
 
-    pub(super) fn normalize_projection_ty(&mut self, proj_ty: ProjectionTy) -> Ty {
+    pub(crate) fn normalize_projection_ty(&mut self, proj_ty: ProjectionTy) -> Ty {
         let var = self.new_type_var();
         let alias_eq = AliasEq { alias: AliasTy::Projection(proj_ty), ty: var.clone() };
         let obligation = alias_eq.cast(Interner);
@@ -299,6 +292,13 @@ impl<'a> InferenceTable<'a> {
         self.resolve_with_fallback_inner(&mut Vec::new(), t, &fallback)
     }
 
+    pub(crate) fn instantiate_canonical<T>(&mut self, canonical: Canonical<T>) -> T::Result
+    where
+        T: HasInterner<Interner = Interner> + Fold<Interner> + std::fmt::Debug,
+    {
+        self.var_unification_table.instantiate_canonical(Interner, canonical)
+    }
+
     fn resolve_with_fallback_inner<T>(
         &mut self,
         var_stack: &mut Vec<InferenceVar>,
@@ -351,6 +351,7 @@ impl<'a> InferenceTable<'a> {
     /// If `ty` is a type variable with known type, returns that type;
     /// otherwise, return ty.
     pub(crate) fn resolve_ty_shallow(&mut self, ty: &Ty) -> Ty {
+        self.resolve_obligations_as_possible();
         self.var_unification_table.normalize_ty_shallow(Interner, ty).unwrap_or_else(|| ty.clone())
     }
 
@@ -361,6 +362,16 @@ impl<'a> InferenceTable<'a> {
 
     pub(crate) fn rollback_to(&mut self, snapshot: InferenceTableSnapshot) {
         self.var_unification_table.rollback_to(snapshot.var_table_snapshot);
+    }
+
+    /// Checks an obligation without registering it. Useful mostly to check
+    /// whether a trait *might* be implemented before deciding to 'lock in' the
+    /// choice (during e.g. method resolution or deref).
+    pub(crate) fn try_obligation(&mut self, goal: Goal) -> Option<Solution> {
+        let in_env = InEnvironment::new(&self.trait_env.env, goal);
+        let canonicalized = self.canonicalize(in_env);
+        let solution = self.db.trait_solve(self.trait_env.krate, canonicalized.value);
+        solution
     }
 
     pub(crate) fn register_obligation(&mut self, goal: Goal) {
@@ -520,6 +531,51 @@ impl<'a> InferenceTable<'a> {
                 // FIXME obligation cannot be fulfilled => diagnostic
                 true
             }
+        }
+    }
+
+    pub(crate) fn callable_sig(&mut self, ty: &Ty, num_args: usize) -> Option<(Vec<Ty>, Ty)> {
+        match ty.callable_sig(self.db) {
+            Some(sig) => Some((sig.params().to_vec(), sig.ret().clone())),
+            None => self.callable_sig_from_fn_trait(ty, num_args),
+        }
+    }
+
+    fn callable_sig_from_fn_trait(&mut self, ty: &Ty, num_args: usize) -> Option<(Vec<Ty>, Ty)> {
+        let krate = self.trait_env.krate;
+        let fn_once_trait = FnTrait::FnOnce.get_id(self.db, krate)?;
+        let output_assoc_type =
+            self.db.trait_data(fn_once_trait).associated_type_by_name(&name![Output])?;
+
+        let mut arg_tys = vec![];
+        let arg_ty = TyBuilder::tuple(num_args)
+            .fill(iter::repeat_with(|| {
+                let arg = self.new_type_var();
+                arg_tys.push(arg.clone());
+                arg
+            }))
+            .build();
+
+        let projection = {
+            let b = TyBuilder::assoc_type_projection(self.db, output_assoc_type);
+            if b.remaining() != 2 {
+                return None;
+            }
+            b.push(ty.clone()).push(arg_ty).build()
+        };
+
+        let trait_env = self.trait_env.env.clone();
+        let obligation = InEnvironment {
+            goal: projection.trait_ref(self.db).cast(Interner),
+            environment: trait_env,
+        };
+        let canonical = self.canonicalize(obligation.clone());
+        if self.db.trait_solve(krate, canonical.value.cast(Interner)).is_some() {
+            self.register_obligation(obligation.goal);
+            let return_ty = self.normalize_projection_ty(projection);
+            Some((arg_tys, return_ty))
+        } else {
+            None
         }
     }
 }

--- a/crates/hir_ty/src/tests.rs
+++ b/crates/hir_ty/src/tests.rs
@@ -100,6 +100,7 @@ fn check_impl(ra_fixture: &str, allow_none: bool, only_types: bool, display_sour
                         .trim_start_matches("adjustments: ")
                         .split(',')
                         .map(|it| it.trim().to_string())
+                        .filter(|it| !it.is_empty())
                         .collect(),
                 );
             } else {

--- a/crates/hir_ty/src/tests/coercion.rs
+++ b/crates/hir_ty/src/tests/coercion.rs
@@ -243,6 +243,45 @@ fn test() {
 }
 
 #[test]
+fn coerce_autoderef_implication_1() {
+    check_no_mismatches(
+        r"
+//- minicore: deref
+struct Foo<T>;
+impl core::ops::Deref for Foo<u32> { type Target = (); }
+
+fn takes_ref_foo<T>(x: &Foo<T>) {}
+fn test() {
+    let foo = Foo;
+      //^^^ type: Foo<{unknown}>
+    takes_ref_foo(&foo);
+
+    let foo = Foo;
+      //^^^ type: Foo<u32>
+    let _: &() = &foo;
+}",
+    );
+}
+
+#[test]
+fn coerce_autoderef_implication_2() {
+    check(
+        r"
+//- minicore: deref
+struct Foo<T>;
+impl core::ops::Deref for Foo<u32> { type Target = (); }
+
+fn takes_ref_foo<T>(x: &Foo<T>) {}
+fn test() {
+    let foo = Foo;
+      //^^^ type: Foo<{unknown}>
+    let _: &u32 = &Foo;
+                //^^^^ expected &u32, got &Foo<{unknown}>
+}",
+    );
+}
+
+#[test]
 fn closure_return_coerce() {
     check_no_mismatches(
         r"

--- a/crates/hir_ty/src/tests/method_resolution.rs
+++ b/crates/hir_ty/src/tests/method_resolution.rs
@@ -1463,7 +1463,8 @@ fn main() {
 
 #[test]
 fn deref_fun_1() {
-    check_types(r#"
+    check_types(
+        r#"
 //- minicore: deref
 
 struct A<T, U>(T, U);
@@ -1497,12 +1498,14 @@ fn test() {
     a2;
   //^^ A<B<isize>, u32>
 }
-"#);
+"#,
+    );
 }
 
 #[test]
 fn deref_fun_2() {
-    check_types(r#"
+    check_types(
+        r#"
 //- minicore: deref
 
 struct A<T, U>(T, U);
@@ -1540,5 +1543,38 @@ fn test() {
     a2;
   //^^ A<C<&str>, i32>
 }
-"#);
+"#,
+    );
+}
+
+#[test]
+fn receiver_adjustment_autoref() {
+    check(
+        r#"
+struct Foo;
+impl Foo {
+    fn foo(&self) {}
+}
+fn test() {
+    Foo.foo();
+  //^^^ adjustments: Borrow(Ref(Not))
+    (&Foo).foo();
+  // ^^^^ adjustments: ,
+}
+"#,
+    );
+}
+
+#[test]
+fn receiver_adjustment_unsize_array() {
+    // FIXME not quite correct
+    check(
+        r#"
+//- minicore: slice
+fn test() {
+    let a = [1, 2, 3];
+    a.len();
+} //^ adjustments: Pointer(Unsize), Borrow(Ref(Not))
+"#,
+    );
 }

--- a/crates/hir_ty/src/tests/traits.rs
+++ b/crates/hir_ty/src/tests/traits.rs
@@ -541,6 +541,52 @@ fn test() {
 }
 
 #[test]
+fn infer_ops_index_field() {
+    check_types(
+        r#"
+//- minicore: index
+struct Bar;
+struct Foo {
+    field: u32;
+}
+
+impl core::ops::Index<u32> for Bar {
+    type Output = Foo;
+}
+
+fn test() {
+    let a = Bar;
+    let b = a[1u32].field;
+    b;
+} //^ u32
+"#,
+    );
+}
+
+#[test]
+fn infer_ops_index_field_autoderef() {
+    check_types(
+        r#"
+//- minicore: index
+struct Bar;
+struct Foo {
+    field: u32;
+}
+
+impl core::ops::Index<u32> for Bar {
+    type Output = Foo;
+}
+
+fn test() {
+    let a = Bar;
+    let b = (&a[1u32]).field;
+    b;
+} //^ u32
+"#,
+    );
+}
+
+#[test]
 fn infer_ops_index_int() {
     check_types(
         r#"

--- a/crates/hir_ty/src/traits.rs
+++ b/crates/hir_ty/src/traits.rs
@@ -40,8 +40,7 @@ fn create_chalk_solver() -> chalk_recursive::RecursiveSolver<Interner> {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TraitEnvironment {
     pub krate: CrateId,
-    // When we're using Chalk's Ty we can make this a BTreeMap since it's Ord,
-    // but for now it's too annoying...
+    // FIXME make this a BTreeMap
     pub(crate) traits_from_clauses: Vec<(Ty, TraitId)>,
     pub env: chalk_ir::Environment<Interner>,
 }

--- a/crates/ide_assists/src/handlers/convert_iter_for_each_to_for.rs
+++ b/crates/ide_assists/src/handlers/convert_iter_for_each_to_for.rs
@@ -154,11 +154,11 @@ fn is_ref_and_impls_iter_method(
     let has_wanted_method = ty
         .iterate_method_candidates(
             sema.db,
-            krate,
+            &scope,
             &traits_in_scope,
             None,
             Some(&wanted_method),
-            |_, func| {
+            |func| {
                 if func.ret_type(sema.db).impls_trait(sema.db, iter_trait, &[]) {
                     return Some(());
                 }

--- a/crates/ide_assists/src/handlers/destructure_tuple_binding.rs
+++ b/crates/ide_assists/src/handlers/destructure_tuple_binding.rs
@@ -371,7 +371,7 @@ fn handle_ref_field_usage(ctx: &AssistContext, field_expr: &FieldExpr) -> RefDat
             fn is_auto_ref(ctx: &AssistContext, call_expr: &MethodCallExpr) -> bool {
                 fn impl_(ctx: &AssistContext, call_expr: &MethodCallExpr) -> Option<bool> {
                     let rec = call_expr.receiver()?;
-                    let rec_ty = ctx.sema.type_of_expr(&rec)?.adjusted();
+                    let rec_ty = ctx.sema.type_of_expr(&rec)?.original();
                     // input must be actual value
                     if rec_ty.is_reference() {
                         return Some(false);

--- a/crates/ide_assists/src/handlers/generate_is_empty_from_len.rs
+++ b/crates/ide_assists/src/handlers/generate_is_empty_from_len.rs
@@ -90,10 +90,9 @@ fn get_impl_method(
     let impl_def: hir::Impl = ctx.sema.to_def(impl_)?;
 
     let scope = ctx.sema.scope(impl_.syntax());
-    let krate = impl_def.module(db).krate();
     let ty = impl_def.self_ty(db);
     let traits_in_scope = scope.visible_traits();
-    ty.iterate_method_candidates(db, krate, &traits_in_scope, None, Some(fn_name), |_, func| {
+    ty.iterate_method_candidates(db, &scope, &traits_in_scope, None, Some(fn_name), |func| {
         Some(func)
     })
 }

--- a/crates/ide_ssr/src/resolving.rs
+++ b/crates/ide_ssr/src/resolving.rs
@@ -222,11 +222,11 @@ impl<'db> ResolutionScope<'db> {
             let module = self.scope.module()?;
             adt.ty(self.scope.db).iterate_path_candidates(
                 self.scope.db,
-                module.krate(),
+                &self.scope,
                 &self.scope.visible_traits(),
                 Some(module),
                 None,
-                |_ty, assoc_item| {
+                |assoc_item| {
                     let item_name = assoc_item.name(self.scope.db)?;
                     if item_name.to_smol_str().as_str() == name.text() {
                         Some(hir::PathResolution::AssocItem(assoc_item))


### PR DESCRIPTION
- don't return the receiver type from method resolution; instead just
 return the autorefs/autoderefs that happened and repeat them. This
 ensures all the effects like trait obligations and whatever we learned
 about type variables from derefing them are actually applied. Also, it
 allows us to get rid of `decanonicalize_ty`, which was just wrong in
 principle.

 - Autoderef itself now directly works with an inference table. Sadly
 this has the effect of making it harder to use as an iterator, often
 requiring manual `while let` loops. (rustc works around this by using
 inner mutability in the inference context, so that things like unifying
 types don't require a unique reference.)

 - We now record the adjustments (autoref/deref) for method receivers
 and index expressions, which we didn't before.

 - Removed the redundant crate parameter from method resolution, since
 the trait_env contains the crate as well.

 - in the HIR API, the methods now take a scope to determine the trait env.
 `Type` carries a trait env, but I think that's probably a bad decision
 because it's easy to create it with the wrong env, e.g. by using
 `Adt::ty`. This mostly didn't matter so far because
 `iterate_method_candidates` took a crate parameter and ignored
 `self.krate`, but the trait env would still have been wrong in those
 cases, which I think would give some wrong results in some edge cases.

Fixes #10058.