### PR TITLE
fix: properly display `$crate` in hovers

### DIFF
--- a/crates/hir_ty/src/display.rs
+++ b/crates/hir_ty/src/display.rs
@@ -1189,7 +1189,18 @@ impl HirDisplay for Path {
                     write!(f, "super")?;
                 }
             }
-            (_, PathKind::DollarCrate(_)) => write!(f, "{{extern_crate}}")?,
+            (_, PathKind::DollarCrate(id)) => {
+                // Resolve `$crate` to the crate's display name.
+                // FIXME: should use the dependency name instead if available, but that depends on
+                // the crate invoking `HirDisplay`
+                let crate_graph = f.db.crate_graph();
+                let name = crate_graph[*id]
+                    .display_name
+                    .as_ref()
+                    .map(|name| name.canonical_name())
+                    .unwrap_or("$crate");
+                write!(f, "{name}")?
+            }
         }
 
         for (seg_idx, segment) in self.segments().iter().enumerate() {

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -4583,3 +4583,33 @@ pub struct Foo;
         "##]],
     );
 }
+
+#[test]
+fn hover_dollar_crate() {
+    // $crate should be resolved to the right crate name.
+
+    check(
+        r#"
+//- /main.rs crate:main deps:dep
+dep::m!(KONST$0);
+//- /dep.rs crate:dep
+#[macro_export]
+macro_rules! m {
+    ( $name:ident ) => { const $name: $crate::Type = $crate::Type; };
+}
+
+pub struct Type;
+"#,
+        expect![[r#"
+            *KONST*
+
+            ```rust
+            main
+            ```
+
+            ```rust
+            const KONST: dep::Type = $crate::Type
+            ```
+        "#]],
+    );
+}


### PR DESCRIPTION
We used to print it as `{extern_crate}`, this PR resolves it to the crate's name, or falls back to `$crate` if the crate has no name.

bors r+