### PR TITLE
fix: fix type mismatches with `unreachable!` macro in Rust 1.59

### DIFF
--- a/crates/hir_expand/src/name.rs
+++ b/crates/hir_expand/src/name.rs
@@ -253,6 +253,7 @@ pub mod known {
         std_panic,
         stringify,
         trace_macros,
+        unreachable,
         // Builtin derives
         Copy,
         Clone,


### PR DESCRIPTION
should fix https://github.com/rust-analyzer/rust-analyzer/issues/11551

bors r+