### PR TITLE
internal: Update `url` to make `webrender` build when computing metrics

### DIFF
--- a/xtask/src/metrics.rs
+++ b/xtask/src/metrics.rs
@@ -32,6 +32,11 @@ impl flags::Metrics {
 
         let _env = pushenv("RA_METRICS", "1");
 
+        {
+            // https://github.com/rust-analyzer/rust-analyzer/issues/9997
+            let _d = pushd("target/rustc-perf/collector/benchmarks/webrender")?;
+            cmd!("cargo update -p url --precise 1.6.1").run()?;
+        }
         metrics.measure_build()?;
         metrics.measure_analysis_stats_self()?;
         metrics.measure_analysis_stats("ripgrep")?;


### PR DESCRIPTION
Closes #9997

This doesn't seem to affect the metrics, but I'm not sure since somehow I get different values than what shows up on CI.

With `stable`:

```
  exprs: 94151, ??ty: 96 (0%), ?ty: 25 (0%), !ty: 6
```

CI shows 16.

Also, https://github.com/rust-analyzer/rust-analyzer/pull/7250 strikes again, I can never tell what those numbers are.

r? @jonas-schievink