### PR TITLE
Small refactor text edit 2nd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,6 +1668,7 @@ checksum = "288cb548dbe72b652243ea797201f3d481a0609a967980fcc5b2315ea811560a"
 name = "text_edit"
 version = "0.0.0"
 dependencies = [
+ "itertools",
  "text-size",
 ]
 

--- a/crates/text_edit/Cargo.toml
+++ b/crates/text_edit/Cargo.toml
@@ -10,4 +10,5 @@ rust-version = "1.57"
 doctest = false
 
 [dependencies]
+itertools = "0.10.0"
 text-size = "1.0.0"


### PR DESCRIPTION
Some more changes to text_edit. Basic idea is to make `Indel` implement `PartialOrd` to take advantage of some sweet sweet iteration, most notably itertool's `merge`.

