### PR TITLE
minor: Future-proof against a next edition by using `>=` and not `==`

### DIFF
--- a/crates/hir_expand/src/builtin_fn_macro.rs
+++ b/crates/hir_expand/src/builtin_fn_macro.rs
@@ -344,7 +344,7 @@ fn panic_expand(
     let loc: MacroCallLoc = db.lookup_intern_macro_call(id);
     // Expand to a macro call `$crate::panic::panic_{edition}`
     let krate = tt::Ident { text: "$crate".into(), id: tt::TokenId::unspecified() };
-    let mut call = if db.crate_graph()[loc.krate].edition == Edition::Edition2021 {
+    let mut call = if db.crate_graph()[loc.krate].edition >= Edition::Edition2021 {
         quote!(#krate::panic::panic_2021!)
     } else {
         quote!(#krate::panic::panic_2015!)
@@ -363,7 +363,7 @@ fn unreachable_expand(
     let loc: MacroCallLoc = db.lookup_intern_macro_call(id);
     // Expand to a macro call `$crate::panic::unreachable_{edition}`
     let krate = tt::Ident { text: "$crate".into(), id: tt::TokenId::unspecified() };
-    let mut call = if db.crate_graph()[loc.krate].edition == Edition::Edition2021 {
+    let mut call = if db.crate_graph()[loc.krate].edition >= Edition::Edition2021 {
         quote!(#krate::panic::unreachable_2021!)
     } else {
         quote!(#krate::panic::unreachable_2015!)


### PR DESCRIPTION
So that we won't have a strange bug when edition 2024 will land.

rustc [also does that](https://github.com/rust-lang/rust/blob/427cf81206d3b6cf41c86c1b9ce113a33f1ce860/compiler/rustc_builtin_macros/src/edition_panic.rs#L84).