### PR TITLE
fix: Add `abort` to safe intrinsics list

### DIFF
--- a/crates/hir_def/src/item_tree/lower.rs
+++ b/crates/hir_def/src/item_tree/lower.rs
@@ -702,6 +702,7 @@ enum GenericsOwner<'a> {
 fn is_intrinsic_fn_unsafe(name: &Name) -> bool {
     // Should be kept in sync with https://github.com/rust-lang/rust/blob/532d2b14c05f9bc20b2d27cbb5f4550d28343a36/compiler/rustc_typeck/src/check/intrinsic.rs#L72-L106
     ![
+        known::abort,
         known::add_with_overflow,
         known::bitreverse,
         known::black_box,


### PR DESCRIPTION
Closes #11611

bors r+