### PR TITLE
show variadic args in hover function signature

### DIFF
--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -86,6 +86,11 @@ impl HirDisplay for Function {
             // The former will ignore lifetime arguments currently.
             type_ref.hir_fmt(f)?;
         }
+
+        if data.is_varargs() {
+            write!(f, ", ...")?;
+        }
+
         write!(f, ")")?;
 
         // `FunctionData::ret_type` will be `::core::future::Future<Output = ...>` for async fns.

--- a/crates/ide/src/hover/tests.rs
+++ b/crates/ide/src/hover/tests.rs
@@ -1758,6 +1758,30 @@ fn foo() { let bar = Bar; bar.fo$0o(); }
 }
 
 #[test]
+fn test_hover_variadic_function() {
+    check(
+        r#"
+extern "C" {
+    pub fn foo(bar: i32, ...) -> i32;
+}
+
+fn main() { let foo_test = unsafe { fo$0o(1, 2, 3); } }
+"#,
+        expect![[r#"
+            *foo*
+
+            ```rust
+            test
+            ```
+
+            ```rust
+            pub unsafe fn foo(bar: i32, ...) -> i32
+            ```
+        "#]],
+    );
+}
+
+#[test]
 fn test_hover_trait_has_impl_action() {
     check_actions(
         r#"trait foo$0() {}"#,


### PR DESCRIPTION
The current behavior is to ignore the ellipsis.