### PR TITLE
fix: Add type variable table to InferenceTableSnapshot

### DIFF
--- a/crates/hir_ty/src/infer/unify.rs
+++ b/crates/hir_ty/src/infer/unify.rs
@@ -140,7 +140,8 @@ pub(crate) struct InferenceTable<'a> {
 
 pub(crate) struct InferenceTableSnapshot {
     var_table_snapshot: chalk_solve::infer::InferenceSnapshot<Interner>,
-    // FIXME: snapshot type_variable_table, pending_obligations?
+    // FIXME: snapshot pending_obligations?
+    type_variable_table_snapshot: Vec<TypeVariableData>,
 }
 
 impl<'a> InferenceTable<'a> {
@@ -356,12 +357,14 @@ impl<'a> InferenceTable<'a> {
     }
 
     pub(crate) fn snapshot(&mut self) -> InferenceTableSnapshot {
-        let snapshot = self.var_unification_table.snapshot();
-        InferenceTableSnapshot { var_table_snapshot: snapshot }
+        let var_table_snapshot = self.var_unification_table.snapshot();
+        let type_variable_table_snapshot = self.type_variable_table.clone();
+        InferenceTableSnapshot { var_table_snapshot, type_variable_table_snapshot }
     }
 
     pub(crate) fn rollback_to(&mut self, snapshot: InferenceTableSnapshot) {
         self.var_unification_table.rollback_to(snapshot.var_table_snapshot);
+        self.type_variable_table = snapshot.type_variable_table_snapshot;
     }
 
     /// Checks an obligation without registering it. Useful mostly to check


### PR DESCRIPTION
Fixes #11601. 

I observed that removing the `rollback` line in https://github.com/rust-analyzer/rust-analyzer/commit/6fc3d3aa4cbf637d748c60cfdbb98b5f6a040576 fixes the issue.  

Looking at the stacktrace, I believe not restoring `type_variable_table` causes `type_variable_table` and `var_unification_table` to go out of sync, then when `hir_ty::infer::unify::InferenceTable::new_var` tries to extend `type_variable_table` to be the same length as `var_unification_table`, problems will arise.

However, I cannot pinpoint exactly how or where the vector capacity overflow happens, so my understanding might not be correct after all. 