### PR TITLE
Add back colons around inlay hints

### DIFF
--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -415,7 +415,11 @@ pub(crate) fn signature_help(
 
 pub(crate) fn inlay_hint(line_index: &LineIndex, inlay_hint: InlayHint) -> lsp_ext::InlayHint {
     lsp_ext::InlayHint {
-        label: inlay_hint.label.to_string(),
+        label: match inlay_hint.kind {
+            InlayKind::ParameterHint => format!("{}:", inlay_hint.label),
+            InlayKind::TypeHint => format!(": {}", inlay_hint.label),
+            InlayKind::ChainingHint => inlay_hint.label.to_string(),
+        },
         position: match inlay_hint.kind {
             InlayKind::ParameterHint => position(line_index, inlay_hint.range.start()),
             InlayKind::TypeHint | InlayKind::ChainingHint => {
@@ -429,7 +433,7 @@ pub(crate) fn inlay_hint(line_index: &LineIndex, inlay_hint: InlayHint) -> lsp_e
         },
         tooltip: None,
         padding_left: Some(match inlay_hint.kind {
-            InlayKind::TypeHint => true,
+            InlayKind::TypeHint => false,
             InlayKind::ParameterHint => false,
             InlayKind::ChainingHint => true,
         }),


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/2797#issuecomment-1061594139.

I originally thought that other extensions don't include the colons, but the TypeScript one seems to do.