### PR TITLE
Add support for new `where` clause location in associated types.

### DIFF
--- a/crates/parser/src/grammar/items.rs
+++ b/crates/parser/src/grammar/items.rs
@@ -290,12 +290,17 @@ fn type_alias(p: &mut Parser, m: Marker) {
         generic_params::bounds(p);
     }
 
-    // test type_item_where_clause
+    // test type_item_where_clause_deprecated
     // type Foo where Foo: Copy = ();
     generic_params::opt_where_clause(p);
     if p.eat(T![=]) {
         types::type_(p);
     }
+
+    // test type_item_where_clause
+    // type Foo = () where Foo: Copy;
+    generic_params::opt_where_clause(p);
+
     p.expect(T![;]);
     m.complete(p, TYPE_ALIAS);
 }

--- a/crates/parser/test_data/parser/inline/ok/0012_type_item_where_clause.rs
+++ b/crates/parser/test_data/parser/inline/ok/0012_type_item_where_clause.rs
@@ -1,1 +1,1 @@
-type Foo where Foo: Copy = ();
+type Foo = () where Foo: Copy;

--- a/crates/parser/test_data/parser/inline/ok/0199_type_item_where_clause_deprecated.rast
+++ b/crates/parser/test_data/parser/inline/ok/0199_type_item_where_clause_deprecated.rast
@@ -5,12 +5,6 @@ SOURCE_FILE
     NAME
       IDENT "Foo"
     WHITESPACE " "
-    EQ "="
-    WHITESPACE " "
-    TUPLE_TYPE
-      L_PAREN "("
-      R_PAREN ")"
-    WHITESPACE " "
     WHERE_CLAUSE
       WHERE_KW "where"
       WHITESPACE " "
@@ -29,5 +23,11 @@ SOURCE_FILE
                 PATH_SEGMENT
                   NAME_REF
                     IDENT "Copy"
+    WHITESPACE " "
+    EQ "="
+    WHITESPACE " "
+    TUPLE_TYPE
+      L_PAREN "("
+      R_PAREN ")"
     SEMICOLON ";"
   WHITESPACE "\n"

--- a/crates/parser/test_data/parser/inline/ok/0199_type_item_where_clause_deprecated.rs
+++ b/crates/parser/test_data/parser/inline/ok/0199_type_item_where_clause_deprecated.rs
@@ -1,0 +1,1 @@
+type Foo where Foo: Copy = ();


### PR DESCRIPTION
A recent Rust nightly changed it: https://github.com/rust-lang/rust/issues/89122

This allows both the old and new location.

Fixes #11651