### PR TITLE
feat: Suggest union literals, suggest union fields within an empty union literal

### DIFF
--- a/crates/ide_completion/src/completions.rs
+++ b/crates/ide_completion/src/completions.rs
@@ -35,6 +35,7 @@ use crate::{
         render_field, render_resolution, render_tuple_field,
         struct_literal::render_struct_literal,
         type_alias::{render_type_alias, render_type_alias_with_eq},
+        union_literal::render_union_literal,
         RenderContext,
     },
     CompletionContext, CompletionItem, CompletionItemKind,
@@ -231,6 +232,17 @@ impl Completions {
         local_name: Option<hir::Name>,
     ) {
         let item = render_struct_literal(RenderContext::new(ctx, false), strukt, path, local_name);
+        self.add_opt(item);
+    }
+
+    pub(crate) fn add_union_literal(
+        &mut self,
+        ctx: &CompletionContext,
+        un: hir::Union,
+        path: Option<hir::ModPath>,
+        local_name: Option<hir::Name>,
+    ) {
+        let item = render_union_literal(RenderContext::new(ctx, false), un, path, local_name);
         self.add_opt(item);
     }
 

--- a/crates/ide_completion/src/completions/record.rs
+++ b/crates/ide_completion/src/completions/record.rs
@@ -14,12 +14,31 @@ pub(crate) fn complete_record(acc: &mut Completions, ctx: &CompletionContext) ->
             | ImmediateLocation::RecordExprUpdate(record_expr),
         ) => {
             let ty = ctx.sema.type_of_expr(&Expr::RecordExpr(record_expr.clone()));
-            let default_trait = ctx.famous_defs().core_default_Default();
-            let impl_default_trait = default_trait.zip(ty).map_or(false, |(default_trait, ty)| {
-                ty.original.impls_trait(ctx.db, default_trait, &[])
-            });
 
-            let missing_fields = ctx.sema.record_literal_missing_fields(record_expr);
+            let default_trait = ctx.famous_defs().core_default_Default();
+            let impl_default_trait =
+                default_trait.zip(ty.as_ref()).map_or(false, |(default_trait, ty)| {
+                    ty.original.impls_trait(ctx.db, default_trait, &[])
+                });
+
+            let missing_fields = match ty.and_then(|t| t.adjusted().as_adt()) {
+                Some(hir::Adt::Union(un)) => {
+                    // ctx.sema.record_literal_missing_fields will always return
+                    // an empty Vec on a union literal. This is normally
+                    // reasonable, but here we'd like to present the full list
+                    // of fields if the literal is empty.
+                    let were_fields_specified = record_expr
+                        .record_expr_field_list()
+                        .and_then(|fl| fl.fields().next())
+                        .is_some();
+
+                    match were_fields_specified {
+                        false => un.fields(ctx.db).into_iter().map(|f| (f, f.ty(ctx.db))).collect(),
+                        true => vec![],
+                    }
+                }
+                _ => ctx.sema.record_literal_missing_fields(record_expr),
+            };
             if impl_default_trait && !missing_fields.is_empty() && ctx.path_qual().is_none() {
                 let completion_text = "..Default::default()";
                 let mut item =
@@ -62,14 +81,26 @@ pub(crate) fn complete_record_literal(
         return None;
     }
 
-    if let hir::Adt::Struct(strukt) = ctx.expected_type.as_ref()?.as_adt()? {
-        if ctx.path_qual().is_none() {
-            let module = if let Some(module) = ctx.module { module } else { strukt.module(ctx.db) };
-            let path = module.find_use_path(ctx.db, hir::ModuleDef::from(strukt));
+    match ctx.expected_type.as_ref()?.as_adt()? {
+        hir::Adt::Struct(strukt) => {
+            if ctx.path_qual().is_none() {
+                let module =
+                    if let Some(module) = ctx.module { module } else { strukt.module(ctx.db) };
+                let path = module.find_use_path(ctx.db, hir::ModuleDef::from(strukt));
 
-            acc.add_struct_literal(ctx, strukt, path, None);
+                acc.add_struct_literal(ctx, strukt, path, None);
+            }
         }
-    }
+        hir::Adt::Union(un) => {
+            if ctx.path_qual().is_none() {
+                let module = if let Some(module) = ctx.module { module } else { un.module(ctx.db) };
+                let path = module.find_use_path(ctx.db, hir::ModuleDef::from(un));
+
+                acc.add_union_literal(ctx, un, path, None);
+            }
+        }
+        _ => {}
+    };
 
     Some(())
 }

--- a/crates/ide_completion/src/render.rs
+++ b/crates/ide_completion/src/render.rs
@@ -9,6 +9,7 @@ pub(crate) mod pattern;
 pub(crate) mod type_alias;
 pub(crate) mod struct_literal;
 pub(crate) mod compound;
+pub(crate) mod union_literal;
 
 mod builder_ext;
 

--- a/crates/ide_completion/src/render/union_literal.rs
+++ b/crates/ide_completion/src/render/union_literal.rs
@@ -1,0 +1,76 @@
+//! Renderer for `union` literals.
+
+use hir::{HirDisplay, Name, StructKind};
+use itertools::Itertools;
+
+use crate::{
+    render::{
+        compound::{format_literal_label, visible_fields},
+        RenderContext,
+    },
+    CompletionItem, CompletionItemKind,
+};
+
+pub(crate) fn render_union_literal(
+    ctx: RenderContext,
+    un: hir::Union,
+    path: Option<hir::ModPath>,
+    local_name: Option<Name>,
+) -> Option<CompletionItem> {
+    let name = local_name.unwrap_or_else(|| un.name(ctx.db())).to_smol_str();
+
+    let qualified_name = match path {
+        Some(p) => p.to_string(),
+        None => name.to_string(),
+    };
+
+    let mut item = CompletionItem::new(
+        CompletionItemKind::Snippet,
+        ctx.source_range(),
+        format_literal_label(&name, StructKind::Record),
+    );
+
+    let fields = un.fields(ctx.db());
+    let (fields, fields_omitted) = visible_fields(&ctx, &fields, un)?;
+
+    if fields.is_empty() {
+        return None;
+    }
+
+    let literal = if ctx.snippet_cap().is_some() {
+        format!(
+            "{} {{ ${{1|{}|}}: ${{2:()}} }}$0",
+            qualified_name,
+            fields.iter().map(|field| field.name(ctx.db())).format(",")
+        )
+    } else {
+        format!(
+            "{} {{ {} }}",
+            qualified_name,
+            fields
+                .iter()
+                .format_with(", ", |field, f| { f(&format_args!("{}: ()", field.name(ctx.db()))) })
+        )
+    };
+
+    let detail = format!(
+        "{} {{ {}{} }}",
+        qualified_name,
+        fields.iter().format_with(", ", |field, f| {
+            f(&format_args!("{}: {}", field.name(ctx.db()), field.ty(ctx.db()).display(ctx.db())))
+        }),
+        if fields_omitted { ", .." } else { "" }
+    );
+
+    item.set_documentation(ctx.docs(un))
+        .set_deprecated(ctx.is_deprecated(un))
+        .detail(&detail)
+        .set_relevance(ctx.completion_relevance());
+
+    match ctx.snippet_cap() {
+        Some(snippet_cap) => item.insert_snippet(snippet_cap, literal),
+        None => item.insert_text(literal),
+    };
+
+    Some(item.build())
+}

--- a/crates/ide_completion/src/tests/record.rs
+++ b/crates/ide_completion/src/tests/record.rs
@@ -204,3 +204,39 @@ fn main() {
         "#]],
     );
 }
+
+#[test]
+fn empty_union_literal() {
+    check(
+        r#"
+union Union { foo: u32, bar: f32 }
+
+fn foo() {
+    let other = Union {
+        $0
+    };
+}
+        "#,
+        expect![[r#"
+            fd foo u32
+            fd bar f32
+        "#]],
+    )
+}
+
+#[test]
+fn dont_suggest_additional_union_fields() {
+    check(
+        r#"
+union Union { foo: u32, bar: f32 }
+
+fn foo() {
+    let other = Union {
+        foo: 1,
+        $0
+    };
+}
+        "#,
+        expect![[r#""#]],
+    )
+}


### PR DESCRIPTION
Adds a `Union {…}` completion in contexts where a union is expected, expanding to a choice of available fields (if snippets are supported):

![image](https://user-images.githubusercontent.com/38578268/158023335-84c03e39-daf0-4a52-b969-f40b01501cc8.png)
![image](https://user-images.githubusercontent.com/38578268/158023354-db49d0bb-034c-49d3-bc02-07414179cb61.png)

Also, adds support for listing possible fields in an empty union literal.

![image](https://user-images.githubusercontent.com/38578268/158023398-4695ae34-ce64-4f40-8494-68731a3030c6.png)
![image](https://user-images.githubusercontent.com/38578268/158023406-be96dd95-125a-47ac-9628-0bce634ca2eb.png)

Closes #11568.