### PR TITLE
editors/code: fix nixos detection

### DIFF
--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -269,7 +269,8 @@ function serverPath(config: Config): string | null {
 async function isNixOs(): Promise<boolean> {
     try {
         const contents = (await vscode.workspace.fs.readFile(vscode.Uri.file("/etc/os-release"))).toString();
-        return contents.indexOf("ID=nixos") !== -1;
+        const idString = contents.split('\n').find((a) => a.startsWith("ID="));
+        return idString?.toLowerCase()?.indexOf("nixos") !== -1;
     } catch {
         return false;
     }


### PR DESCRIPTION
Problem: NixOS started using quotes around it's id field in /etc/os-release
Solution: Parially parsing os-release, and detecting, whether `nixos` appears anywhere in "ID=" field\
See https://github.com/rust-analyzer/rust-analyzer/issues/11695

Closes #11695