### PR TITLE
 editors/code: fix crash due to missing ID= field

### DIFF
--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -269,8 +269,8 @@ function serverPath(config: Config): string | null {
 async function isNixOs(): Promise<boolean> {
     try {
         const contents = (await vscode.workspace.fs.readFile(vscode.Uri.file("/etc/os-release"))).toString();
-        const idString = contents.split('\n').find((a) => a.startsWith("ID="));
-        return idString?.toLowerCase()?.indexOf("nixos") !== -1;
+        const idString = contents.split('\n').find((a) => a.startsWith("ID=")) || "ID=linux";
+        return idString.indexOf("nixos") !== -1;
     } catch {
         return false;
     }


### PR DESCRIPTION
Assuming ID=linux by default.
Also removed toLowerCase — it really shouldn't be needed.
Fixes #11709