### PR TITLE
fix: Mark chaining hints as types

### DIFF
--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -432,8 +432,7 @@ pub(crate) fn inlay_hint(
         },
         kind: match inlay_hint.kind {
             InlayKind::ParameterHint => Some(lsp_ext::InlayHintKind::PARAMETER),
-            InlayKind::TypeHint => Some(lsp_ext::InlayHintKind::TYPE),
-            InlayKind::ChainingHint => None,
+            InlayKind::TypeHint | InlayKind::ChainingHint => Some(lsp_ext::InlayHintKind::TYPE),
         },
         tooltip: None,
         padding_left: Some(match inlay_hint.kind {


### PR DESCRIPTION
CC https://github.com/rust-analyzer/rust-analyzer/pull/11445#discussion_r826863321