### PR TITLE
minor: unblock metrics

### DIFF
--- a/xtask/src/metrics.rs
+++ b/xtask/src/metrics.rs
@@ -17,7 +17,7 @@ impl flags::Metrics {
     pub(crate) fn run(self, sh: &Shell) -> anyhow::Result<()> {
         let mut metrics = Metrics::new(sh)?;
         if !self.dry_run {
-            sh.remove_path("./target/release")?;
+            let _ = sh.remove_path("./target/release");
         }
         if !Path::new("./target/rustc-perf").exists() {
             sh.create_dir("./target/rustc-perf")?;


### PR DESCRIPTION
Doesn't seem like you can inspect the error kind, so discarding the result it is
bors r+