### PR TITLE
Insert #[must_use] in generate_is_empty_from_len

### DIFF
--- a/crates/ide_assists/src/handlers/generate_is_empty_from_len.rs
+++ b/crates/ide_assists/src/handlers/generate_is_empty_from_len.rs
@@ -17,6 +17,7 @@ use crate::{
 // struct MyStruct { data: Vec<String> }
 //
 // impl MyStruct {
+//     #[must_use]
 //     p$0ub fn len(&self) -> usize {
 //         self.data.len()
 //     }
@@ -27,10 +28,12 @@ use crate::{
 // struct MyStruct { data: Vec<String> }
 //
 // impl MyStruct {
+//     #[must_use]
 //     pub fn len(&self) -> usize {
 //         self.data.len()
 //     }
 //
+//     #[must_use]
 //     pub fn is_empty(&self) -> bool {
 //         self.len() == 0
 //     }
@@ -72,6 +75,7 @@ pub(crate) fn generate_is_empty_from_len(acc: &mut Assists, ctx: &AssistContext)
         |builder| {
             let code = r#"
 
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }"#
@@ -129,6 +133,7 @@ impl MyStruct {
 struct MyStruct { data: Vec<String> }
 
 impl MyStruct {
+    #[must_use]
     p$0ub fn len(&self, _i: bool) -> usize {
         self.data.len()
     }
@@ -146,10 +151,12 @@ impl MyStruct {
 struct MyStruct { data: Vec<String> }
 
 impl MyStruct {
+    #[must_use]
     p$0ub fn len(&self) -> usize {
         self.data.len()
     }
 
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -167,6 +174,7 @@ impl MyStruct {
 struct MyStruct { data: Vec<String> }
 
 impl MyStruct {
+    #[must_use]
     p$0ub fn len(&self) -> u32 {
         self.data.len()
     }
@@ -183,6 +191,7 @@ impl MyStruct {
 struct MyStruct { data: Vec<String> }
 
 impl MyStruct {
+    #[must_use]
     p$0ub fn len(&self) -> usize {
         self.data.len()
     }
@@ -192,10 +201,12 @@ impl MyStruct {
 struct MyStruct { data: Vec<String> }
 
 impl MyStruct {
+    #[must_use]
     pub fn len(&self) -> usize {
         self.data.len()
     }
 
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -212,10 +223,12 @@ impl MyStruct {
 struct MyStruct { data: Vec<String> }
 
 impl MyStruct {
+    #[must_use]
     pub fn new() -> Self {
         Self { data: 0 }
     }
 
+    #[must_use]
     p$0ub fn len(&self) -> usize {
         self.data.len()
     }
@@ -229,14 +242,17 @@ impl MyStruct {
 struct MyStruct { data: Vec<String> }
 
 impl MyStruct {
+    #[must_use]
     pub fn new() -> Self {
         Self { data: 0 }
     }
 
+    #[must_use]
     pub fn len(&self) -> usize {
         self.data.len()
     }
 
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -257,12 +273,14 @@ impl MyStruct {
 struct MyStruct { data: Vec<String> }
 
 impl MyStruct {
+    #[must_use]
     p$0ub fn len(&self) -> usize {
         self.data.len()
     }
 }
 
 impl MyStruct {
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }

--- a/crates/ide_assists/src/tests/generated.rs
+++ b/crates/ide_assists/src/tests/generated.rs
@@ -1097,6 +1097,7 @@ fn doctest_generate_is_empty_from_len() {
 struct MyStruct { data: Vec<String> }
 
 impl MyStruct {
+    #[must_use]
     p$0ub fn len(&self) -> usize {
         self.data.len()
     }
@@ -1106,10 +1107,12 @@ impl MyStruct {
 struct MyStruct { data: Vec<String> }
 
 impl MyStruct {
+    #[must_use]
     pub fn len(&self) -> usize {
         self.data.len()
     }
 
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }


### PR DESCRIPTION
Inserts `#[must_use]` for the generated is_empty methods. I also added the `#[must_use]` for the `len()` methods in the documentation and tests while at it, to make sure they too encourage the use of the annotation.

From discussion in https://github.com/rust-analyzer/rust-analyzer/issues/11736 and https://github.com/rust-analyzer/rust-analyzer/pull/11738