### PR TITLE
feat: Complete assoc const patterns on builtin types

### DIFF
--- a/crates/ide_completion/src/completions/pattern.rs
+++ b/crates/ide_completion/src/completions/pattern.rs
@@ -141,7 +141,8 @@ fn pattern_path_completion(
                 | hir::PathResolution::SelfType(_)
                 | hir::PathResolution::Def(hir::ModuleDef::Adt(hir::Adt::Struct(_)))
                 | hir::PathResolution::Def(hir::ModuleDef::Adt(hir::Adt::Enum(_)))
-                | hir::PathResolution::Def(hir::ModuleDef::Adt(hir::Adt::Union(_)))) => {
+                | hir::PathResolution::Def(hir::ModuleDef::Adt(hir::Adt::Union(_)))
+                | hir::PathResolution::Def(hir::ModuleDef::BuiltinType(_))) => {
                     let ty = match res {
                         hir::PathResolution::TypeParam(param) => param.ty(ctx.db),
                         hir::PathResolution::SelfType(impl_def) => impl_def.self_ty(ctx.db),
@@ -157,6 +158,13 @@ fn pattern_path_completion(
                         }
                         hir::PathResolution::Def(hir::ModuleDef::Adt(hir::Adt::Union(u))) => {
                             u.ty(ctx.db)
+                        }
+                        hir::PathResolution::Def(hir::ModuleDef::BuiltinType(ty)) => {
+                            let module = match ctx.module {
+                                Some(m) => m,
+                                None => return,
+                            };
+                            ty.ty(ctx.db, module)
                         }
                         _ => return,
                     };

--- a/crates/ide_completion/src/tests/pattern.rs
+++ b/crates/ide_completion/src/tests/pattern.rs
@@ -493,7 +493,6 @@ fn f(e: MyEnum) {
 
     check_empty(
         r#"
-#[repr(C)]
 union U {
     i: i32,
     f: f32,
@@ -515,5 +514,23 @@ fn f(u: U) {
             ct C pub const C: i32
             ct D pub const D: i32
         "#]],
-    )
+    );
+
+    check_empty(
+        r#"
+#[lang = "u32"]
+impl u32 {
+    pub const MIN: Self = 0;
+}
+
+fn f(v: u32) {
+    match v {
+        u32::$0
+    }
+}
+        "#,
+        expect![[r#"
+            ct MIN pub const MIN: Self
+        "#]],
+    );
 }


### PR DESCRIPTION
followup to https://github.com/rust-analyzer/rust-analyzer/pull/11713

bors r+