### PR TITLE
feat: Visualize compiler inserted reborrows via inlay hints

### DIFF
--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -50,7 +50,9 @@ use crate::{db::HirDatabase, utils::generics};
 pub use autoderef::autoderef;
 pub use builder::{ParamKind, TyBuilder};
 pub use chalk_ext::*;
-pub use infer::{could_unify, InferenceDiagnostic, InferenceResult};
+pub use infer::{
+    could_unify, Adjust, Adjustment, AutoBorrow, InferenceDiagnostic, InferenceResult,
+};
 pub use interner::Interner;
 pub use lower::{
     associated_type_shorthand_candidates, callable_item_sig, CallableDefId, ImplTraitLoweringMode,

--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -67,10 +67,7 @@ pub struct InlayHint {
 //
 // * return types of closure expressions with blocks
 // * elided lifetimes
-//
-// **Note:** VS Code does not have native support for inlay hints https://github.com/microsoft/vscode/issues/16221[yet] and the hints are implemented using decorations.
-// This approach has limitations, the caret movement and bracket highlighting near the edges of the hint may be weird:
-// https://github.com/rust-analyzer/rust-analyzer/issues/1623[1], https://github.com/rust-analyzer/rust-analyzer/issues/3453[2].
+// * compiler inserted reborrows
 //
 // |===
 // | Editor  | Action Name

--- a/crates/ide/src/inlay_hints.rs
+++ b/crates/ide/src/inlay_hints.rs
@@ -19,6 +19,7 @@ pub struct InlayHintsConfig {
     pub type_hints: bool,
     pub parameter_hints: bool,
     pub chaining_hints: bool,
+    pub reborrow_hints: bool,
     pub closure_return_type_hints: bool,
     pub lifetime_elision_hints: LifetimeElisionHints,
     pub param_names_for_lifetime_elision_hints: bool,
@@ -35,6 +36,7 @@ pub enum LifetimeElisionHints {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum InlayKind {
+    ImplicitReborrow,
     TypeHint,
     ParameterHint,
     ClosureReturnTypeHint,
@@ -116,17 +118,16 @@ fn hints(
     if let Some(expr) = ast::Expr::cast(node.clone()) {
         chaining_hints(hints, sema, &famous_defs, config, &expr);
         match expr {
-            ast::Expr::CallExpr(it) => {
-                param_name_hints(hints, sema, config, ast::Expr::from(it));
-            }
+            ast::Expr::CallExpr(it) => param_name_hints(hints, sema, config, ast::Expr::from(it)),
             ast::Expr::MethodCallExpr(it) => {
-                param_name_hints(hints, sema, config, ast::Expr::from(it));
+                param_name_hints(hints, sema, config, ast::Expr::from(it))
             }
-            ast::Expr::ClosureExpr(it) => {
-                closure_ret_hints(hints, sema, &famous_defs, config, it);
-            }
-            _ => (),
-        }
+            ast::Expr::ClosureExpr(it) => closure_ret_hints(hints, sema, &famous_defs, config, it),
+            // We could show reborrows for all expressions, but usually that is just noise to the user
+            // and the main point here is to show why "moving" a mutable reference doesn't necessarily move it
+            ast::Expr::PathExpr(_) => reborrow_hints(hints, sema, config, &expr),
+            _ => None,
+        };
     } else if let Some(it) = ast::IdentPat::cast(node.clone()) {
         bind_pat_hints(hints, sema, config, &it);
     } else if let Some(it) = ast::Fn::cast(node) {
@@ -361,6 +362,28 @@ fn closure_ret_hints(
         kind: InlayKind::ClosureReturnTypeHint,
         label: hint_iterator(sema, &famous_defs, config, &ty)
             .unwrap_or_else(|| ty.display_truncated(sema.db, config.max_length).to_string().into()),
+    });
+    Some(())
+}
+
+fn reborrow_hints(
+    acc: &mut Vec<InlayHint>,
+    sema: &Semantics<RootDatabase>,
+    config: &InlayHintsConfig,
+    expr: &ast::Expr,
+) -> Option<()> {
+    if !config.reborrow_hints {
+        return None;
+    }
+
+    let mutability = sema.is_implicit_reborrow(expr)?;
+    acc.push(InlayHint {
+        range: expr.syntax().text_range(),
+        kind: InlayKind::ImplicitReborrow,
+        label: match mutability {
+            hir::Mutability::Shared => SmolStr::new_inline("&*"),
+            hir::Mutability::Mut => SmolStr::new_inline("&mut *"),
+        },
     });
     Some(())
 }
@@ -834,6 +857,7 @@ mod tests {
         lifetime_elision_hints: LifetimeElisionHints::Never,
         hide_named_constructor_hints: false,
         closure_return_type_hints: false,
+        reborrow_hints: false,
         param_names_for_lifetime_elision_hints: false,
         max_length: None,
     };
@@ -841,6 +865,7 @@ mod tests {
         type_hints: true,
         parameter_hints: true,
         chaining_hints: true,
+        reborrow_hints: true,
         closure_return_type_hints: true,
         lifetime_elision_hints: LifetimeElisionHints::Always,
         ..DISABLED_CONFIG
@@ -2114,6 +2139,41 @@ impl () {
     fn foo(&self, a: &()) -> &() {}
     // ^^^<'0, '1>
         // ^'0       ^'1     ^'0
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn hints_implicit_reborrow() {
+        check_with_config(
+            InlayHintsConfig { reborrow_hints: true, ..DISABLED_CONFIG },
+            r#"
+fn __() {
+    let unique = &mut ();
+    let r_mov = unique;
+    let foo: &mut _ = unique;
+                    //^^^^^^ &mut *
+    ref_mut_id(unique);
+             //^^^^^^ &mut *
+    let shared = ref_id(unique);
+                      //^^^^^^ &*
+    let mov = shared;
+    let r_mov: &_ = shared;
+    ref_id(shared);
+
+    identity(unique);
+    identity(shared);
+}
+fn identity<T>(t: T) -> T {
+    t
+}
+fn ref_mut_id(x: &mut ()) -> &mut () {
+    x
+  //^ &mut *
+}
+fn ref_id(x: &()) -> &() {
+    x
 }
 "#,
         );

--- a/crates/ide/src/static_index.rs
+++ b/crates/ide/src/static_index.rs
@@ -114,6 +114,7 @@ impl StaticIndex<'_> {
                     chaining_hints: true,
                     closure_return_type_hints: true,
                     lifetime_elision_hints: LifetimeElisionHints::Never,
+                    reborrow_hints: false,
                     hide_named_constructor_hints: false,
                     param_names_for_lifetime_elision_hints: false,
                     max_length: Some(25),

--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -256,6 +256,8 @@ config_data! {
         inlayHints_chainingHints: bool                      = "true",
         /// Whether to show inlay type hints for return types of closures with blocks.
         inlayHints_closureReturnTypeHints: bool             = "false",
+        /// Whether to show inlay type hints for compiler inserted reborrows.
+        inlayHints_reborrowHints: bool                      = "false",
         /// Whether to show inlay type hints for elided lifetimes in function signatures.
         inlayHints_lifetimeElisionHints: LifetimeElisionDef = "\"never\"",
         /// Whether to prefer using parameter names as the name for elided lifetime hints if possible.
@@ -866,6 +868,7 @@ impl Config {
                 LifetimeElisionDef::SkipTrivial => LifetimeElisionHints::SkipTrivial,
             },
             hide_named_constructor_hints: self.data.inlayHints_hideNamedConstructorHints,
+            reborrow_hints: self.data.inlayHints_reborrowHints,
             param_names_for_lifetime_elision_hints: self
                 .data
                 .inlayHints_lifetimeElisionHints_useParameterNames,

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -426,7 +426,11 @@ pub(crate) fn inlay_hint(
             _ => inlay_hint.label.to_string(),
         }),
         position: match inlay_hint.kind {
-            InlayKind::ParameterHint => position(line_index, inlay_hint.range.start()),
+            // before annotated thing
+            InlayKind::ParameterHint | InlayKind::ImplicitReborrow => {
+                position(line_index, inlay_hint.range.start())
+            }
+            // after annotated thing
             InlayKind::ClosureReturnTypeHint
             | InlayKind::TypeHint
             | InlayKind::ChainingHint
@@ -438,7 +442,9 @@ pub(crate) fn inlay_hint(
             InlayKind::ClosureReturnTypeHint | InlayKind::TypeHint | InlayKind::ChainingHint => {
                 Some(lsp_ext::InlayHintKind::TYPE)
             }
-            InlayKind::GenericParamListHint | InlayKind::LifetimeHint => None,
+            InlayKind::GenericParamListHint
+            | InlayKind::LifetimeHint
+            | InlayKind::ImplicitReborrow => None,
         },
         tooltip: None,
         padding_left: Some(match inlay_hint.kind {
@@ -447,6 +453,7 @@ pub(crate) fn inlay_hint(
             InlayKind::ChainingHint => true,
             InlayKind::GenericParamListHint => false,
             InlayKind::LifetimeHint => false,
+            InlayKind::ImplicitReborrow => false,
         }),
         padding_right: Some(match inlay_hint.kind {
             InlayKind::TypeHint | InlayKind::ChainingHint | InlayKind::ClosureReturnTypeHint => {
@@ -455,6 +462,7 @@ pub(crate) fn inlay_hint(
             InlayKind::ParameterHint => true,
             InlayKind::LifetimeHint => true,
             InlayKind::GenericParamListHint => false,
+            InlayKind::ImplicitReborrow => false,
         }),
     }
 }

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -378,6 +378,11 @@ Whether to show inlay type hints for method chains.
 --
 Whether to show inlay type hints for return types of closures with blocks.
 --
+[[rust-analyzer.inlayHints.reborrowHints]]rust-analyzer.inlayHints.reborrowHints (default: `false`)::
++
+--
+Whether to show inlay type hints for compiler inserted reborrows.
+--
 [[rust-analyzer.inlayHints.lifetimeElisionHints]]rust-analyzer.inlayHints.lifetimeElisionHints (default: `"never"`)::
 +
 --

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -800,6 +800,11 @@
                     "default": false,
                     "type": "boolean"
                 },
+                "rust-analyzer.inlayHints.reborrowHints": {
+                    "markdownDescription": "Whether to show inlay type hints for compiler inserted reborrows.",
+                    "default": false,
+                    "type": "boolean"
+                },
                 "rust-analyzer.inlayHints.lifetimeElisionHints": {
                     "markdownDescription": "Whether to show inlay type hints for elided lifetimes in function signatures.",
                     "default": "never",


### PR DESCRIPTION
Disabled by default.

![image](https://user-images.githubusercontent.com/3757771/159165178-baaf968a-4381-468e-933f-5326ca1b203d.png)

Closes https://github.com/rust-analyzer/rust-analyzer/issues/11275
