### PR TITLE
Replace write! with direct `Formatter` calls

### DIFF
--- a/crates/base_db/src/input.rs
+++ b/crates/base_db/src/input.rs
@@ -105,7 +105,7 @@ impl CrateName {
 
 impl fmt::Display for CrateName {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
+        self.0.fmt(f)
     }
 }
 
@@ -160,7 +160,7 @@ impl From<CrateName> for CrateDisplayName {
 
 impl fmt::Display for CrateDisplayName {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.crate_name)
+        self.crate_name.fmt(f)
     }
 }
 

--- a/crates/cfg/src/cfg_expr.rs
+++ b/crates/cfg/src/cfg_expr.rs
@@ -43,7 +43,7 @@ impl CfgAtom {
 impl fmt::Display for CfgAtom {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            CfgAtom::Flag(name) => write!(f, "{}", name),
+            CfgAtom::Flag(name) => name.fmt(f),
             CfgAtom::KeyValue { key, value } => write!(f, "{} = {:?}", key, value),
         }
     }

--- a/crates/cfg/src/dnf.rs
+++ b/crates/cfg/src/dnf.rs
@@ -6,7 +6,7 @@
 //!
 //! This is currently both messy and inefficient. Feel free to improve, there are unit tests.
 
-use std::fmt;
+use std::fmt::{self, Write};
 
 use rustc_hash::FxHashSet;
 
@@ -125,17 +125,17 @@ impl DnfExpr {
 impl fmt::Display for DnfExpr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.conjunctions.len() != 1 {
-            write!(f, "any(")?;
+            f.write_str("any(")?;
         }
         for (i, conj) in self.conjunctions.iter().enumerate() {
             if i != 0 {
                 f.write_str(", ")?;
             }
 
-            write!(f, "{}", conj)?;
+            conj.fmt(f)?;
         }
         if self.conjunctions.len() != 1 {
-            write!(f, ")")?;
+            f.write_char(')')?;
         }
 
         Ok(())
@@ -165,17 +165,17 @@ impl Conjunction {
 impl fmt::Display for Conjunction {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.literals.len() != 1 {
-            write!(f, "all(")?;
+            f.write_str("all(")?;
         }
         for (i, lit) in self.literals.iter().enumerate() {
             if i != 0 {
                 f.write_str(", ")?;
             }
 
-            write!(f, "{}", lit)?;
+            lit.fmt(f)?;
         }
         if self.literals.len() != 1 {
-            write!(f, ")")?;
+            f.write_str(")")?;
         }
 
         Ok(())
@@ -204,12 +204,12 @@ impl fmt::Display for Literal {
         }
 
         match &self.var {
-            Some(var) => write!(f, "{}", var)?,
+            Some(var) => var.fmt(f)?,
             None => f.write_str("<invalid>")?,
         }
 
         if self.negate {
-            write!(f, ")")?;
+            f.write_char(')')?;
         }
 
         Ok(())

--- a/crates/cfg/src/lib.rs
+++ b/crates/cfg/src/lib.rs
@@ -128,7 +128,7 @@ impl fmt::Display for CfgDiff {
                 };
                 f.write_str(sep)?;
 
-                write!(f, "{}", atom)?;
+                atom.fmt(f)?;
             }
 
             if !self.disable.is_empty() {
@@ -146,7 +146,7 @@ impl fmt::Display for CfgDiff {
                 };
                 f.write_str(sep)?;
 
-                write!(f, "{}", atom)?;
+                atom.fmt(f)?;
             }
         }
 
@@ -170,7 +170,7 @@ impl fmt::Display for InactiveReason {
                 };
                 f.write_str(sep)?;
 
-                write!(f, "{}", atom)?;
+                atom.fmt(f)?;
             }
             let is_are = if self.enabled.len() == 1 { "is" } else { "are" };
             write!(f, " {} enabled", is_are)?;
@@ -189,7 +189,7 @@ impl fmt::Display for InactiveReason {
                 };
                 f.write_str(sep)?;
 
-                write!(f, "{}", atom)?;
+                atom.fmt(f)?;
             }
             let is_are = if self.disabled.len() == 1 { "is" } else { "are" };
             write!(f, " {} disabled", is_are)?;

--- a/crates/hir_def/src/type_ref.rs
+++ b/crates/hir_def/src/type_ref.rs
@@ -5,7 +5,7 @@ use hir_expand::{
     name::{AsName, Name},
     AstId, InFile,
 };
-use std::convert::TryInto;
+use std::{convert::TryInto, fmt::Write};
 use syntax::ast::{self, HasName};
 
 use crate::{body::LowerCtx, intern::Interned, path::Path};
@@ -364,8 +364,8 @@ pub enum ConstScalarOrPath {
 impl std::fmt::Display for ConstScalarOrPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ConstScalarOrPath::Scalar(s) => write!(f, "{}", s),
-            ConstScalarOrPath::Path(n) => write!(f, "{}", n),
+            ConstScalarOrPath::Scalar(s) => s.fmt(f),
+            ConstScalarOrPath::Path(n) => n.fmt(f),
         }
     }
 }
@@ -425,10 +425,10 @@ pub enum ConstScalar {
 }
 
 impl std::fmt::Display for ConstScalar {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {
-            ConstScalar::Usize(us) => write!(fmt, "{}", us),
-            ConstScalar::Unknown => write!(fmt, "_"),
+            ConstScalar::Usize(us) => us.fmt(f),
+            ConstScalar::Unknown => f.write_char('_'),
         }
     }
 }

--- a/crates/hir_expand/src/mod_path.rs
+++ b/crates/hir_expand/src/mod_path.rs
@@ -121,7 +121,7 @@ impl Display for ModPath {
                 f.write_str("::")?;
             }
             first_segment = false;
-            write!(f, "{}", segment)?;
+            segment.fmt(f)?;
         }
         Ok(())
     }

--- a/crates/hir_ty/src/consteval.rs
+++ b/crates/hir_ty/src/consteval.rs
@@ -1,6 +1,10 @@
 //! Constant evaluation details
 
-use std::{collections::HashMap, convert::TryInto, fmt::Display};
+use std::{
+    collections::HashMap,
+    convert::TryInto,
+    fmt::{Display, Write},
+};
 
 use chalk_ir::{BoundVar, DebruijnIndex, GenericArgData, IntTy, Scalar};
 use hir_def::{
@@ -79,28 +83,29 @@ impl Display for ComputedExpr {
                     if *x >= 16 {
                         write!(f, "{} ({:#X})", x, x)
                     } else {
-                        write!(f, "{}", x)
+                        x.fmt(f)
                     }
                 }
                 Literal::Uint(x, _) => {
                     if *x >= 16 {
                         write!(f, "{} ({:#X})", x, x)
                     } else {
-                        write!(f, "{}", x)
+                        x.fmt(f)
                     }
                 }
-                Literal::Float(x, _) => write!(f, "{}", x),
-                Literal::Bool(x) => write!(f, "{}", x),
-                Literal::Char(x) => write!(f, "{:?}", x),
-                Literal::String(x) => write!(f, "{:?}", x),
-                Literal::ByteString(x) => write!(f, "{:?}", x),
+                Literal::Float(x, _) => x.fmt(f),
+                Literal::Bool(x) => x.fmt(f),
+                Literal::Char(x) => std::fmt::Debug::fmt(x, f),
+                Literal::String(x) => std::fmt::Debug::fmt(x, f),
+                Literal::ByteString(x) => std::fmt::Debug::fmt(x, f),
             },
             ComputedExpr::Tuple(t) => {
-                write!(f, "(")?;
+                f.write_char('(')?;
                 for x in &**t {
-                    write!(f, "{}, ", x)?;
+                    x.fmt(f)?;
+                    f.write_str(", ")?;
                 }
-                write!(f, ")")
+                f.write_char(')')
             }
         }
     }

--- a/crates/hir_ty/src/diagnostics/decl_check.rs
+++ b/crates/hir_ty/src/diagnostics/decl_check.rs
@@ -72,7 +72,7 @@ impl fmt::Display for CaseType {
             CaseType::UpperCamelCase => "CamelCase",
         };
 
-        write!(f, "{}", repr)
+        repr.fmt(f)
     }
 }
 
@@ -103,7 +103,7 @@ impl fmt::Display for IdentType {
             IdentType::Variant => "Variant",
         };
 
-        write!(f, "{}", repr)
+        repr.fmt(f)
     }
 }
 

--- a/crates/hir_ty/src/tls.rs
+++ b/crates/hir_ty/src/tls.rs
@@ -1,5 +1,5 @@
 //! Implementation of Chalk debug helper functions using TLS.
-use std::fmt;
+use std::fmt::{self, Display};
 
 use itertools::Itertools;
 
@@ -24,17 +24,17 @@ impl DebugContext<'_> {
             AdtId::UnionId(it) => self.0.union_data(it).name.clone(),
             AdtId::EnumId(it) => self.0.enum_data(it).name.clone(),
         };
-        write!(f, "{}", name)
+        name.fmt(f)
     }
 
     pub(crate) fn debug_trait_id(
         &self,
         id: chalk_db::TraitId,
-        fmt: &mut fmt::Formatter<'_>,
+        f: &mut fmt::Formatter<'_>,
     ) -> Result<(), fmt::Error> {
         let trait_: hir_def::TraitId = from_chalk_trait_id(id);
         let trait_data = self.0.trait_data(trait_);
-        write!(fmt, "{}", trait_data.name)
+        trait_data.name.fmt(f)
     }
 
     pub(crate) fn debug_assoc_type_id(

--- a/crates/ide/src/runnables.rs
+++ b/crates/ide/src/runnables.rs
@@ -38,8 +38,8 @@ pub enum TestId {
 impl fmt::Display for TestId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            TestId::Name(name) => write!(f, "{}", name),
-            TestId::Path(path) => write!(f, "{}", path),
+            TestId::Name(name) => name.fmt(f),
+            TestId::Path(path) => path.fmt(f),
         }
     }
 }

--- a/crates/ide/src/syntax_highlighting/tags.rs
+++ b/crates/ide/src/syntax_highlighting/tags.rs
@@ -1,7 +1,10 @@
 //! Defines token tags we use for syntax highlighting.
 //! A tag is not unlike a CSS class.
 
-use std::{fmt, ops};
+use std::{
+    fmt::{self, Write},
+    ops,
+};
 
 use ide_db::SymbolKind;
 
@@ -254,9 +257,10 @@ impl fmt::Display for HlMod {
 
 impl fmt::Display for Highlight {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.tag)?;
+        self.tag.fmt(f)?;
         for modifier in self.mods.iter() {
-            write!(f, ".{}", modifier)?
+            f.write_char('.')?;
+            modifier.fmt(f)?;
         }
         Ok(())
     }

--- a/crates/proc_macro_api/src/lib.rs
+++ b/crates/proc_macro_api/src/lib.rs
@@ -95,9 +95,10 @@ pub struct ServerError {
 
 impl fmt::Display for ServerError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.message)?;
+        self.message.fmt(f)?;
         if let Some(io) = &self.io {
-            write!(f, ": {}", io)?;
+            f.write_str(": ")?;
+            io.fmt(f)?;
         }
         Ok(())
     }

--- a/crates/profile/src/memory_usage.rs
+++ b/crates/profile/src/memory_usage.rs
@@ -11,8 +11,8 @@ pub struct MemoryUsage {
 }
 
 impl fmt::Display for MemoryUsage {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", self.allocated)
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.allocated.fmt(f)
     }
 }
 


### PR DESCRIPTION
The final executable is somehow larger (36 239 296 vs 36 238 336 bytes), but this saves us a bit of `text` and `data`:

```
   text	   data	    bss	    dec	    hex	filename
23719199	1126625	   4377	24850201	17b2f19	rust-analyzer-baseline
23716027	1126377	   4377	24846781	17b21bd	rust-analyzer-pr
```