### PR TITLE
fix: fill_match_arms doesn't add wildcard pat for local enums

### DIFF
--- a/crates/ide_assists/src/handlers/add_missing_match_arms.rs
+++ b/crates/ide_assists/src/handlers/add_missing_match_arms.rs
@@ -303,7 +303,9 @@ fn lift_enum(e: hir::Enum) -> ExtendedEnum {
 impl ExtendedEnum {
     fn is_non_exhaustive(self, db: &RootDatabase, krate: Crate) -> bool {
         match self {
-            ExtendedEnum::Enum(e) => e.attrs(db).by_key("non_exhaustive").exists() && e.module(db).krate() != krate,
+            ExtendedEnum::Enum(e) => {
+                e.attrs(db).by_key("non_exhaustive").exists() && e.module(db).krate() != krate
+            }
             _ => false,
         }
     }


### PR DESCRIPTION
Fix #11783 

This adds similar logic to non_exhaustive as is currently on doc(hidden)