### PR TITLE
fix: Fix lifetime elision hint configuration key

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -259,7 +259,7 @@ config_data! {
         /// Whether to show inlay type hints for compiler inserted reborrows.
         inlayHints_reborrowHints: bool                      = "false",
         /// Whether to show inlay type hints for elided lifetimes in function signatures.
-        inlayHints_lifetimeElisionHints: LifetimeElisionDef = "\"never\"",
+        inlayHints_lifetimeElisionHints_enable: LifetimeElisionDef = "\"never\"",
         /// Whether to prefer using parameter names as the name for elided lifetime hints if possible.
         inlayHints_lifetimeElisionHints_useParameterNames: bool  = "false",
         /// Whether to hide inlay hints for constructors.
@@ -862,7 +862,7 @@ impl Config {
             parameter_hints: self.data.inlayHints_parameterHints,
             chaining_hints: self.data.inlayHints_chainingHints,
             closure_return_type_hints: self.data.inlayHints_closureReturnTypeHints,
-            lifetime_elision_hints: match self.data.inlayHints_lifetimeElisionHints {
+            lifetime_elision_hints: match self.data.inlayHints_lifetimeElisionHints_enable {
                 LifetimeElisionDef::Always => LifetimeElisionHints::Always,
                 LifetimeElisionDef::Never => LifetimeElisionHints::Never,
                 LifetimeElisionDef::SkipTrivial => LifetimeElisionHints::SkipTrivial,

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -383,7 +383,7 @@ Whether to show inlay type hints for return types of closures with blocks.
 --
 Whether to show inlay type hints for compiler inserted reborrows.
 --
-[[rust-analyzer.inlayHints.lifetimeElisionHints]]rust-analyzer.inlayHints.lifetimeElisionHints (default: `"never"`)::
+[[rust-analyzer.inlayHints.lifetimeElisionHints.enable]]rust-analyzer.inlayHints.lifetimeElisionHints.enable (default: `"never"`)::
 +
 --
 Whether to show inlay type hints for elided lifetimes in function signatures.

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -800,7 +800,7 @@
                     "default": false,
                     "type": "boolean"
                 },
-                "rust-analyzer.inlayHints.lifetimeElisionHints": {
+                "rust-analyzer.inlayHints.lifetimeElisionHints.enable": {
                     "markdownDescription": "Whether to show inlay type hints for elided lifetimes in function signatures.",
                     "default": "never",
                     "type": "string",


### PR DESCRIPTION
This is inconsistent with the other configuration keys unfortunately, but this is an issue of how we structured them here in general.

I feel like we'll have to do a proper pass over all the configs, check them for consistency and then write down some documentation of how our configs should be laid out, then apply fixes to the inconsistencies all at once which will entail breaking some user configurations unfortunately since we won't be able to do proper fallback handling for some of these.

Fixes https://github.com/rust-analyzer/rust-analyzer/issues/11778

bors r+