### PR TITLE
fix: avoid returning `None` from `Span::join` to fix some proc macros

### DIFF
--- a/crates/proc_macro_srv/src/abis/abi_1_47/rustc_server.rs
+++ b/crates/proc_macro_srv/src/abis/abi_1_47/rustc_server.rs
@@ -662,8 +662,9 @@ impl server::Span for Rustc {
         // FIXME handle span
         LineColumn { line: 0, column: 0 }
     }
-    fn join(&mut self, _first: Self::Span, _second: Self::Span) -> Option<Self::Span> {
-        None
+    fn join(&mut self, first: Self::Span, _second: Self::Span) -> Option<Self::Span> {
+        // Just return the first span again, because some macros will unwrap the result.
+        Some(first)
     }
     fn resolved_at(&mut self, _span: Self::Span, _at: Self::Span) -> Self::Span {
         // FIXME handle span

--- a/crates/proc_macro_srv/src/abis/abi_1_54/rustc_server.rs
+++ b/crates/proc_macro_srv/src/abis/abi_1_54/rustc_server.rs
@@ -665,8 +665,9 @@ impl server::Span for Rustc {
         // FIXME handle span
         LineColumn { line: 0, column: 0 }
     }
-    fn join(&mut self, _first: Self::Span, _second: Self::Span) -> Option<Self::Span> {
-        None
+    fn join(&mut self, first: Self::Span, _second: Self::Span) -> Option<Self::Span> {
+        // Just return the first span again, because some macros will unwrap the result.
+        Some(first)
     }
     fn resolved_at(&mut self, _span: Self::Span, _at: Self::Span) -> Self::Span {
         // FIXME handle span

--- a/crates/proc_macro_srv/src/abis/abi_1_56/rustc_server.rs
+++ b/crates/proc_macro_srv/src/abis/abi_1_56/rustc_server.rs
@@ -677,8 +677,9 @@ impl server::Span for Rustc {
         // FIXME handle span
         LineColumn { line: 0, column: 0 }
     }
-    fn join(&mut self, _first: Self::Span, _second: Self::Span) -> Option<Self::Span> {
-        None
+    fn join(&mut self, first: Self::Span, _second: Self::Span) -> Option<Self::Span> {
+        // Just return the first span again, because some macros will unwrap the result.
+        Some(first)
     }
     fn resolved_at(&mut self, _span: Self::Span, _at: Self::Span) -> Self::Span {
         // FIXME handle span

--- a/crates/proc_macro_srv/src/abis/abi_1_57/rustc_server.rs
+++ b/crates/proc_macro_srv/src/abis/abi_1_57/rustc_server.rs
@@ -677,8 +677,9 @@ impl server::Span for Rustc {
         // FIXME handle span
         LineColumn { line: 0, column: 0 }
     }
-    fn join(&mut self, _first: Self::Span, _second: Self::Span) -> Option<Self::Span> {
-        None
+    fn join(&mut self, first: Self::Span, _second: Self::Span) -> Option<Self::Span> {
+        // Just return the first span again, because some macros will unwrap the result.
+        Some(first)
     }
     fn resolved_at(&mut self, _span: Self::Span, _at: Self::Span) -> Self::Span {
         // FIXME handle span

--- a/crates/proc_macro_srv/src/abis/abi_1_58/rustc_server.rs
+++ b/crates/proc_macro_srv/src/abis/abi_1_58/rustc_server.rs
@@ -681,8 +681,9 @@ impl server::Span for Rustc {
         // FIXME handle span
         LineColumn { line: 0, column: 0 }
     }
-    fn join(&mut self, _first: Self::Span, _second: Self::Span) -> Option<Self::Span> {
-        None
+    fn join(&mut self, first: Self::Span, _second: Self::Span) -> Option<Self::Span> {
+        // Just return the first span again, because some macros will unwrap the result.
+        Some(first)
     }
     fn resolved_at(&mut self, _span: Self::Span, _at: Self::Span) -> Self::Span {
         // FIXME handle span


### PR DESCRIPTION
Some proc macros, notably rocket, `.unwrap()` the result of `Span::join` (and correctly so, it should never be `None`). We don't have a proper implementation of that API, so we always returned `None`. This changes our stub impl to return the first span instead.

Does not fully fix rocket's macros, they need other stuff to work too.

bors r+