### PR TITLE
fix: Fix async block type inference using containing function return type

### DIFF
--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -364,7 +364,7 @@ pub(crate) struct InferenceContext<'a> {
     table: unify::InferenceTable<'a>,
     trait_env: Arc<TraitEnvironment>,
     result: InferenceResult,
-    /// The return type of the function being inferred, or the closure if we're
+    /// The return type of the function being inferred, the closure or async block if we're
     /// currently within one.
     ///
     /// We might consider using a nested inference context for checking


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/11804
Should fix https://github.com/rust-analyzer/rust-analyzer/issues/11798#issuecomment-1076880521