### PR TITLE
feat: disable experimental diagnostics by default

### DIFF
--- a/crates/rust-analyzer/src/config.rs
+++ b/crates/rust-analyzer/src/config.rs
@@ -176,7 +176,7 @@ config_data! {
         diagnostics_enable: bool                = "true",
         /// Whether to show experimental rust-analyzer diagnostics that might
         /// have more false positives than usual.
-        diagnostics_enableExperimental: bool    = "true",
+        diagnostics_enableExperimental: bool    = "false",
         /// List of rust-analyzer diagnostics to disable.
         diagnostics_disabled: FxHashSet<String> = "[]",
         /// Map of prefixes to be substituted when parsing diagnostic file paths.

--- a/docs/user/generated_config.adoc
+++ b/docs/user/generated_config.adoc
@@ -223,7 +223,7 @@ Enables completions of private items and fields that are defined in the current 
 --
 Whether to show native rust-analyzer diagnostics.
 --
-[[rust-analyzer.diagnostics.enableExperimental]]rust-analyzer.diagnostics.enableExperimental (default: `true`)::
+[[rust-analyzer.diagnostics.enableExperimental]]rust-analyzer.diagnostics.enableExperimental (default: `false`)::
 +
 --
 Whether to show experimental rust-analyzer diagnostics that might

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -645,7 +645,7 @@
                 },
                 "rust-analyzer.diagnostics.enableExperimental": {
                     "markdownDescription": "Whether to show experimental rust-analyzer diagnostics that might\nhave more false positives than usual.",
-                    "default": true,
+                    "default": false,
                     "type": "boolean"
                 },
                 "rust-analyzer.diagnostics.disabled": {


### PR DESCRIPTION
Now that we diagnose type mismatches, we have another diagnostic that can potentially produce false positives, so let's disable experimental diagnostics by default.