### PR TITLE
fix: Disable ref_match for qualified paths as well

### DIFF
--- a/crates/ide_completion/src/render.rs
+++ b/crates/ide_completion/src/render.rs
@@ -1468,6 +1468,43 @@ fn foo(f: Foo) { let _: &u32 = f.b$0 }
     }
 
     #[test]
+    fn qualified_path_ref() {
+        // disabled right now because it doesn't render correctly, #8058
+        check_kinds(
+            r#"
+struct S;
+
+struct T;
+impl T {
+    fn foo() -> S {}
+}
+
+fn bar(s: &S) {}
+
+fn main() {
+    bar(T::$0);
+}
+"#,
+            &[CompletionItemKind::SymbolKind(SymbolKind::Function)],
+            expect![[r#"
+                [
+                    CompletionItem {
+                        label: "foo()",
+                        source_range: 95..95,
+                        delete: 95..95,
+                        insert: "foo()$0",
+                        kind: SymbolKind(
+                            Function,
+                        ),
+                        lookup: "foo",
+                        detail: "fn() -> S",
+                    },
+                ]
+            "#]],
+        );
+    }
+
+    #[test]
     fn generic_enum() {
         check_relevance(
             r#"

--- a/crates/ide_completion/src/render/function.rs
+++ b/crates/ide_completion/src/render/function.rs
@@ -74,10 +74,10 @@ fn render(
     });
 
     if let Some(ref_match) = compute_ref_match(completion, &ret_type) {
-        // FIXME
-        // For now we don't properly calculate the edits for ref match
-        // completions on methods, so we've disabled them. See #8058.
-        if matches!(func_kind, FuncKind::Function) {
+        // FIXME For now we don't properly calculate the edits for ref match
+        // completions on methods or qualified paths, so we've disabled them.
+        // See #8058.
+        if matches!(func_kind, FuncKind::Function) && ctx.completion.path_qual().is_none() {
             item.ref_match(ref_match);
         }
     }


### PR DESCRIPTION
I.e. don't suggest `Foo::&foo()`.

CC #8058.