### PR TITLE
Fix typo in the style documentation

### DIFF
--- a/docs/dev/style.md
+++ b/docs/dev/style.md
@@ -1036,7 +1036,7 @@ Having the result type specified up-front helps with understanding what the chai
 
 ## Helper Functions
 
-Avoid creating singe-use helper functions:
+Avoid creating single-use helper functions:
 
 ```rust
 // GOOD


### PR DESCRIPTION
Was going through the documentation itself and found this typo just waiting to be fixed