### PR TITLE
internal: Move mismatched arg count diagnostic to inference

### DIFF
--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1183,6 +1183,19 @@ impl DefWithBody {
                         .expect("break outside of loop in synthetic syntax");
                     acc.push(BreakOutsideOfLoop { expr }.into())
                 }
+                hir_ty::InferenceDiagnostic::MismatchedArgCount { call_expr, expected, found } => {
+                    match source_map.expr_syntax(*call_expr) {
+                        Ok(source_ptr) => acc.push(
+                            MismatchedArgCount {
+                                call_expr: source_ptr,
+                                expected: *expected,
+                                found: *found,
+                            }
+                            .into(),
+                        ),
+                        Err(SyntheticSyntax) => (),
+                    }
+                }
             }
         }
         for (expr, mismatch) in infer.expr_type_mismatches() {
@@ -1295,14 +1308,6 @@ impl DefWithBody {
                             }
                             .into(),
                         );
-                    }
-                }
-                BodyValidationDiagnostic::MismatchedArgCount { call_expr, expected, found } => {
-                    match source_map.expr_syntax(call_expr) {
-                        Ok(source_ptr) => acc.push(
-                            MismatchedArgCount { call_expr: source_ptr, expected, found }.into(),
-                        ),
-                        Err(SyntheticSyntax) => (),
                     }
                 }
                 BodyValidationDiagnostic::MissingMatchArms { match_expr } => {

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -143,6 +143,7 @@ pub(crate) type InferResult<T> = Result<InferOk<T>, TypeError>;
 pub enum InferenceDiagnostic {
     NoSuchField { expr: ExprId },
     BreakOutsideOfLoop { expr: ExprId },
+    MismatchedArgCount { call_expr: ExprId, expected: usize, found: usize },
 }
 
 /// A mismatch between an expected and an inferred type.

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -217,7 +217,6 @@ pub fn make_canonical<T: HasInterner<Interner = Interner>>(
 pub struct CallableSig {
     params_and_return: Arc<[Ty]>,
     is_varargs: bool,
-    legacy_const_generics_indices: Arc<[u32]>,
 }
 
 has_interner!(CallableSig);
@@ -228,11 +227,7 @@ pub type PolyFnSig = Binders<CallableSig>;
 impl CallableSig {
     pub fn from_params_and_return(mut params: Vec<Ty>, ret: Ty, is_varargs: bool) -> CallableSig {
         params.push(ret);
-        CallableSig {
-            params_and_return: params.into(),
-            is_varargs,
-            legacy_const_generics_indices: Arc::new([]),
-        }
+        CallableSig { params_and_return: params.into(), is_varargs }
     }
 
     pub fn from_fn_ptr(fn_ptr: &FnPointer) -> CallableSig {
@@ -249,12 +244,7 @@ impl CallableSig {
                 .map(|arg| arg.assert_ty_ref(Interner).clone())
                 .collect(),
             is_varargs: fn_ptr.sig.variadic,
-            legacy_const_generics_indices: Arc::new([]),
         }
-    }
-
-    pub fn set_legacy_const_generics_indices(&mut self, indices: &[u32]) {
-        self.legacy_const_generics_indices = indices.into();
     }
 
     pub fn to_fn_ptr(&self) -> FnPointer {
@@ -287,11 +277,7 @@ impl Fold<Interner> for CallableSig {
     ) -> Result<Self::Result, E> {
         let vec = self.params_and_return.to_vec();
         let folded = vec.fold_with(folder, outer_binder)?;
-        Ok(CallableSig {
-            params_and_return: folded.into(),
-            is_varargs: self.is_varargs,
-            legacy_const_generics_indices: self.legacy_const_generics_indices,
-        })
+        Ok(CallableSig { params_and_return: folded.into(), is_varargs: self.is_varargs })
     }
 }
 

--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -1364,10 +1364,7 @@ fn fn_sig_for_fn(db: &dyn HirDatabase, def: FunctionId) -> PolyFnSig {
         .with_type_param_mode(ParamLoweringMode::Variable);
     let ret = ctx_ret.lower_ty(&data.ret_type);
     let generics = generics(db.upcast(), def.into());
-    let mut sig = CallableSig::from_params_and_return(params, ret, data.is_varargs());
-    if !data.legacy_const_generics_indices.is_empty() {
-        sig.set_legacy_const_generics_indices(&data.legacy_const_generics_indices);
-    }
+    let sig = CallableSig::from_params_and_return(params, ret, data.is_varargs());
     make_binders(db, &generics, sig)
 }
 


### PR DESCRIPTION
This means we only need to handle legacy const generics in one place, and it fits there especially since there will be more diagnostics coming.