### PR TITLE
Fix another const generic panic

### DIFF
--- a/crates/hir_ty/src/lower.rs
+++ b/crates/hir_ty/src/lower.rs
@@ -205,7 +205,7 @@ impl<'a> TyLoweringContext<'a> {
                     len,
                     self.type_param_mode,
                     || self.generics(),
-                    DebruijnIndex::INNERMOST,
+                    self.in_binders,
                 );
 
                 TyKind::Array(inner_ty, const_len).intern(Interner)
@@ -728,7 +728,7 @@ impl<'a> TyLoweringContext<'a> {
                             c,
                             self.type_param_mode,
                             || self.generics(),
-                            DebruijnIndex::INNERMOST,
+                            self.in_binders,
                         )
                     },
                 ) {

--- a/crates/hir_ty/src/tests/regression.rs
+++ b/crates/hir_ty/src/tests/regression.rs
@@ -1477,3 +1477,23 @@ fn regression_11688_2() {
         "#,
     );
 }
+
+#[test]
+fn regression_11688_3() {
+    check_types(
+        r#"
+        //- minicore: iterator
+        struct Ar<T, const N: u8>(T);
+        fn f<const LEN: usize, T, const BASE: u8>(
+            num_zeros: usize,
+        ) -> dyn Iterator<Item = [Ar<T, BASE>; LEN]> {
+            loop {}
+        }
+        fn dynamic_programming() {
+            for board in f::<9, u8, 7>(1) {
+              //^^^^^ [Ar<u8, 7>; 9]
+            }
+        }
+        "#,
+    );
+}


### PR DESCRIPTION
fix #11835

If I change `dyn` to `impl` in the test, it will infer the type as `IntoIterator::Item<impl Iterator<Item = [Ar<u8, 7>; 9]> + ?Sized>` instead of `[Ar<u8, 7>; 9]`. Maybe it needs some action?