### PR TITLE
docs(auto_import): change by_self -> self and by_crate -> crate

### DIFF
--- a/crates/ide_assists/src/handlers/auto_import.rs
+++ b/crates/ide_assists/src/handlers/auto_import.rs
@@ -54,9 +54,9 @@ use crate::{AssistContext, AssistId, AssistKind, Assists, GroupLabel};
 // The style of imports in the same crate is configurable through the `importPrefix` setting.
 // It has the following configurations:
 //
-// - `by_crate`: This setting will force paths to be always absolute, starting with the `crate`
+// - `crate`: This setting will force paths to be always absolute, starting with the `crate`
 //  prefix, unless the item is defined outside of the current crate.
-// - `by_self`: This setting will force paths that are relative to the current module to always
+// - `self`: This setting will force paths that are relative to the current module to always
 //  start with `self`. This will result in paths that always start with either `crate`, `self`,
 //  `super` or an extern crate identifier.
 // - `plain`: This setting does not impose any restrictions in imports.

--- a/docs/user/manual.adoc
+++ b/docs/user/manual.adoc
@@ -310,7 +310,7 @@ nvim_lsp.rust_analyzer.setup({
         ["rust-analyzer"] = {
             assist = {
                 importGranularity = "module",
-                importPrefix = "by_self",
+                importPrefix = "self",
             },
             cargo = {
                 loadOutDirsFromCheck = true


### PR DESCRIPTION


---

#### Commits _(oldest to newest)_

6b38c2d75 docs(auto_import): change by_self -> self and by_crate -> crate

Keep things consistent with the package.json , which uses `self` and
`crate` instead of `by_self` and `by_crate`. Both names are in fact
allowed as aliases, but we should be consistent so that people reading
the docs and using a schema do not see red squiggles.

<br/>