### PR TITLE
Type mismatch when last expression is noreturn asm

### DIFF
--- a/crates/hir_expand/src/builtin_fn_macro.rs
+++ b/crates/hir_expand/src/builtin_fn_macro.rs
@@ -295,7 +295,7 @@ fn asm_expand(
 
     let expanded = quote! {{
         ##literals
-        ()
+        loop {}
     }};
     ExpandResult::ok(expanded)
 }


### PR DESCRIPTION
When last expression in a function body is noreturn asm, then analyzer
complains about the type mismatch by highlighting entire body. This
fixes it by introducing loop {} in the expanded code.

Fixes: [#11820](https://github.com/rust-analyzer/rust-analyzer/issues/11820)