### PR TITLE
Fix: Select correct insert position for disabled group import

### DIFF
--- a/crates/ide_db/src/imports/insert_use/tests.rs
+++ b/crates/ide_db/src/imports/insert_use/tests.rs
@@ -86,7 +86,7 @@ use external_crate2::bar::A;",
 
 #[test]
 fn insert_not_group_empty() {
-    cov_mark::check!(insert_no_grouping_last2);
+    cov_mark::check!(insert_empty_file);
     check_with_config(
         "use external_crate2::bar::A",
         r"",
@@ -101,6 +101,44 @@ fn insert_not_group_empty() {
             skip_glob_imports: true,
         },
     );
+}
+
+#[test]
+fn insert_not_group_empty_module() {
+    cov_mark::check!(insert_empty_module);
+    check_with_config(
+        "foo::bar",
+        r"mod x {$0}",
+        r"mod x {
+    use foo::bar;
+}",
+        &InsertUseConfig {
+            granularity: ImportGranularity::Item,
+            enforce_granularity: true,
+            prefix_kind: PrefixKind::Plain,
+            group: false,
+            skip_glob_imports: true,
+        },
+    );
+}
+
+#[test]
+fn insert_no_group_after_inner_attr() {
+    cov_mark::check!(insert_empty_inner_attr);
+    check_with_config(
+        "foo::bar",
+        r"#![allow(unused_imports)]",
+        r"#![allow(unused_imports)]
+
+use foo::bar;",
+        &InsertUseConfig {
+            granularity: ImportGranularity::Item,
+            enforce_granularity: true,
+            prefix_kind: PrefixKind::Plain,
+            group: false,
+            skip_glob_imports: true,
+        },
+    )
 }
 
 #[test]
@@ -321,7 +359,7 @@ fn main() {}",
 
 #[test]
 fn insert_empty_file() {
-    cov_mark::check!(insert_group_empty_file);
+    cov_mark::check!(insert_empty_file);
     // empty files will get two trailing newlines
     // this is due to the test case insert_no_imports above
     check_crate(
@@ -335,7 +373,7 @@ fn insert_empty_file() {
 
 #[test]
 fn insert_empty_module() {
-    cov_mark::check!(insert_group_empty_module);
+    cov_mark::check!(insert_empty_module);
     check(
         "foo::bar",
         r"
@@ -352,7 +390,7 @@ mod x {
 
 #[test]
 fn insert_after_inner_attr() {
-    cov_mark::check!(insert_group_empty_inner_attr);
+    cov_mark::check!(insert_empty_inner_attr);
     check_crate(
         "foo::bar",
         r"#![allow(unused_imports)]",

--- a/crates/ide_db/src/imports/insert_use/tests.rs
+++ b/crates/ide_db/src/imports/insert_use/tests.rs
@@ -302,108 +302,99 @@ fn main() {}",
 
 #[test]
 fn insert_empty_file() {
-    {
-        // Default configuration
-        cov_mark::check!(insert_empty_file);
-        // empty files will get two trailing newlines
-        // this is due to the test case insert_no_imports above
-        check_crate(
-            "foo::bar",
-            "",
-            r"use foo::bar;
+    cov_mark::check_count!(insert_empty_file, 2);
+
+    // Default configuration
+    // empty files will get two trailing newlines
+    // this is due to the test case insert_no_imports above
+    check_crate(
+        "foo::bar",
+        "",
+        r"use foo::bar;
 
 ",
-        );
-    }
-    {
-        // "not group" configuration
-        cov_mark::check!(insert_empty_file);
-        check_with_config(
-            "use external_crate2::bar::A",
-            r"",
-            r"use external_crate2::bar::A;
+    );
+
+    // "not group" configuration
+    check_with_config(
+        "use external_crate2::bar::A",
+        r"",
+        r"use external_crate2::bar::A;
 
 ",
-            &InsertUseConfig {
-                granularity: ImportGranularity::Item,
-                enforce_granularity: true,
-                prefix_kind: PrefixKind::Plain,
-                group: false,
-                skip_glob_imports: true,
-            },
-        );
-    }
+        &InsertUseConfig {
+            granularity: ImportGranularity::Item,
+            enforce_granularity: true,
+            prefix_kind: PrefixKind::Plain,
+            group: false,
+            skip_glob_imports: true,
+        },
+    );
 }
 
 #[test]
 fn insert_empty_module() {
-    {
-        // Default configuration
-        cov_mark::check!(insert_empty_module);
-        check(
-            "foo::bar",
-            r"
+    cov_mark::check_count!(insert_empty_module, 2);
+
+    // Default configuration
+    check(
+        "foo::bar",
+        r"
 mod x {$0}
 ",
-            r"
+        r"
 mod x {
     use foo::bar;
 }
 ",
-            ImportGranularity::Item,
-        );
-    }
-    {
-        // "not group" configuration
-        cov_mark::check!(insert_empty_module);
-        check_with_config(
-            "foo::bar",
-            r"mod x {$0}",
-            r"mod x {
+        ImportGranularity::Item,
+    );
+
+    // "not group" configuration
+    check_with_config(
+        "foo::bar",
+        r"mod x {$0}",
+        r"mod x {
     use foo::bar;
 }",
-            &InsertUseConfig {
-                granularity: ImportGranularity::Item,
-                enforce_granularity: true,
-                prefix_kind: PrefixKind::Plain,
-                group: false,
-                skip_glob_imports: true,
-            },
-        );
-    }
+        &InsertUseConfig {
+            granularity: ImportGranularity::Item,
+            enforce_granularity: true,
+            prefix_kind: PrefixKind::Plain,
+            group: false,
+            skip_glob_imports: true,
+        },
+    );
 }
 
 #[test]
 fn insert_after_inner_attr() {
-    {
-        // Default configuration
-        cov_mark::check!(insert_empty_inner_attr);
-        check_crate(
-            "foo::bar",
-            r"#![allow(unused_imports)]",
-            r"#![allow(unused_imports)]
+    cov_mark::check_count!(insert_empty_inner_attr, 2);
+
+    // Default configuration
+    check_crate(
+        "foo::bar",
+        r"#![allow(unused_imports)]",
+        r"#![allow(unused_imports)]
 
 use foo::bar;",
-        );
-    }
-    {
-        // "not group" configuration
-        cov_mark::check!(insert_empty_inner_attr);
-        check_with_config(
-            "foo::bar",
-            r"#![allow(unused_imports)]",
-            r"#![allow(unused_imports)]
+    );
+
+    // "not group" configuration
+    check_with_config(
+        "foo::bar",
+        r"#![allow(unused_imports)]",
+        r"#![allow(unused_imports)]
 
 use foo::bar;",
-            &InsertUseConfig {
-                granularity: ImportGranularity::Item,
-                enforce_granularity: true,
-                prefix_kind: PrefixKind::Plain,
-                group: false,
-                skip_glob_imports: true,
-            },
-        );
-    }
+        &InsertUseConfig {
+            granularity: ImportGranularity::Item,
+            enforce_granularity: true,
+            prefix_kind: PrefixKind::Plain,
+            group: false,
+            skip_glob_imports: true,
+        },
+    );
 }
 
 #[test]

--- a/crates/ide_db/src/imports/insert_use/tests.rs
+++ b/crates/ide_db/src/imports/insert_use/tests.rs
@@ -85,63 +85,6 @@ use external_crate2::bar::A;",
 }
 
 #[test]
-fn insert_not_group_empty() {
-    cov_mark::check!(insert_empty_file);
-    check_with_config(
-        "use external_crate2::bar::A",
-        r"",
-        r"use external_crate2::bar::A;
-
-",
-        &InsertUseConfig {
-            granularity: ImportGranularity::Item,
-            enforce_granularity: true,
-            prefix_kind: PrefixKind::Plain,
-            group: false,
-            skip_glob_imports: true,
-        },
-    );
-}
-
-#[test]
-fn insert_not_group_empty_module() {
-    cov_mark::check!(insert_empty_module);
-    check_with_config(
-        "foo::bar",
-        r"mod x {$0}",
-        r"mod x {
-    use foo::bar;
-}",
-        &InsertUseConfig {
-            granularity: ImportGranularity::Item,
-            enforce_granularity: true,
-            prefix_kind: PrefixKind::Plain,
-            group: false,
-            skip_glob_imports: true,
-        },
-    );
-}
-
-#[test]
-fn insert_no_group_after_inner_attr() {
-    cov_mark::check!(insert_empty_inner_attr);
-    check_with_config(
-        "foo::bar",
-        r"#![allow(unused_imports)]",
-        r"#![allow(unused_imports)]
-
-use foo::bar;",
-        &InsertUseConfig {
-            granularity: ImportGranularity::Item,
-            enforce_granularity: true,
-            prefix_kind: PrefixKind::Plain,
-            group: false,
-            skip_glob_imports: true,
-        },
-    )
-}
-
-#[test]
 fn insert_existing() {
     check_crate("std::fs", "use std::fs;", "use std::fs;")
 }
@@ -359,45 +302,108 @@ fn main() {}",
 
 #[test]
 fn insert_empty_file() {
-    cov_mark::check!(insert_empty_file);
-    // empty files will get two trailing newlines
-    // this is due to the test case insert_no_imports above
-    check_crate(
-        "foo::bar",
-        "",
-        r"use foo::bar;
+    {
+        // Default configuration
+        cov_mark::check!(insert_empty_file);
+        // empty files will get two trailing newlines
+        // this is due to the test case insert_no_imports above
+        check_crate(
+            "foo::bar",
+            "",
+            r"use foo::bar;
 
 ",
-    )
+        );
+    }
+    {
+        // "not group" configuration
+        cov_mark::check!(insert_empty_file);
+        check_with_config(
+            "use external_crate2::bar::A",
+            r"",
+            r"use external_crate2::bar::A;
+
+",
+            &InsertUseConfig {
+                granularity: ImportGranularity::Item,
+                enforce_granularity: true,
+                prefix_kind: PrefixKind::Plain,
+                group: false,
+                skip_glob_imports: true,
+            },
+        );
+    }
 }
 
 #[test]
 fn insert_empty_module() {
-    cov_mark::check!(insert_empty_module);
-    check(
-        "foo::bar",
-        r"
+    {
+        // Default configuration
+        cov_mark::check!(insert_empty_module);
+        check(
+            "foo::bar",
+            r"
 mod x {$0}
 ",
-        r"
+            r"
 mod x {
     use foo::bar;
 }
 ",
-        ImportGranularity::Item,
-    )
+            ImportGranularity::Item,
+        );
+    }
+    {
+        // "not group" configuration
+        cov_mark::check!(insert_empty_module);
+        check_with_config(
+            "foo::bar",
+            r"mod x {$0}",
+            r"mod x {
+    use foo::bar;
+}",
+            &InsertUseConfig {
+                granularity: ImportGranularity::Item,
+                enforce_granularity: true,
+                prefix_kind: PrefixKind::Plain,
+                group: false,
+                skip_glob_imports: true,
+            },
+        );
+    }
 }
 
 #[test]
 fn insert_after_inner_attr() {
-    cov_mark::check!(insert_empty_inner_attr);
-    check_crate(
-        "foo::bar",
-        r"#![allow(unused_imports)]",
-        r"#![allow(unused_imports)]
+    {
+        // Default configuration
+        cov_mark::check!(insert_empty_inner_attr);
+        check_crate(
+            "foo::bar",
+            r"#![allow(unused_imports)]",
+            r"#![allow(unused_imports)]
 
 use foo::bar;",
-    )
+        );
+    }
+    {
+        // "not group" configuration
+        cov_mark::check!(insert_empty_inner_attr);
+        check_with_config(
+            "foo::bar",
+            r"#![allow(unused_imports)]",
+            r"#![allow(unused_imports)]
+
+use foo::bar;",
+            &InsertUseConfig {
+                granularity: ImportGranularity::Item,
+                enforce_granularity: true,
+                prefix_kind: PrefixKind::Plain,
+                group: false,
+                skip_glob_imports: true,
+            },
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
The logic for importing with and without `group_imports` differed
significantly when no previous group existed. This lead to the problem
of using the wrong position when importing inside a module (#11585) or
when inner attributes are involved.
The existing code for grouped imports is better and takes these things
into account.

This PR changes the flow to use the pre-existing code for adding a new
import group even for the non-grouped import settings.
Some coverage markers are updated and the `group` is removed, since they
are now invoked in both cases (grouping and no grouping).

Tests are updated and two tests (empty module and inner attribute) are
added.

Fixes #11585