### PR TITLE
Recover from missing type annotation

### DIFF
--- a/crates/hir_ty/src/tests/simple.rs
+++ b/crates/hir_ty/src/tests/simple.rs
@@ -2557,6 +2557,20 @@ fn f() {
 }
 
 #[test]
+fn infer_missing_type() {
+    check_types(
+        r#"
+struct S;
+
+fn f() {
+    let s: = S;
+      //^ S
+}
+    "#,
+    );
+}
+
+#[test]
 fn infer_type_alias_variant() {
     check_infer(
         r#"

--- a/crates/parser/src/grammar/types.rs
+++ b/crates/parser/src/grammar/types.rs
@@ -57,6 +57,12 @@ fn type_with_bounds_cond(p: &mut Parser, allow_bounds: bool) {
 pub(super) fn ascription(p: &mut Parser) {
     assert!(p.at(T![:]));
     p.bump(T![:]);
+    if p.at(T![=]) {
+        // recover from `let x: = expr;`, `const X: = expr;` and similars
+        // hopefully no type starts with `=`
+        p.error("missing type");
+        return;
+    }
     type_(p);
 }
 


### PR DESCRIPTION
We were missing the init expression in case of `let x: = 2`, which breaks type inference of that variable (previously x were `{unknown}`, now it is `i32`).
