### PR TITLE
fix: Paper over GAT panic

### DIFF
--- a/crates/hir_ty/src/tests/regression.rs
+++ b/crates/hir_ty/src/tests/regression.rs
@@ -1497,3 +1497,22 @@ fn regression_11688_3() {
         "#,
     );
 }
+
+#[test]
+fn gat_crash() {
+    cov_mark::check!(ignore_gats);
+    check_no_mismatches(
+        r#"
+trait ATrait {}
+
+trait Crash {
+    type Member<const N: usize>: ATrait;
+    fn new<const N: usize>() -> Self::Member<N>;
+}
+
+fn test<T: Crash>() {
+    T::new();
+}
+"#,
+    );
+}

--- a/crates/hir_ty/src/utils.rs
+++ b/crates/hir_ty/src/utils.rs
@@ -175,6 +175,15 @@ pub(super) fn associated_type_by_name_including_super_traits(
 
 pub(crate) fn generics(db: &dyn DefDatabase, def: GenericDefId) -> Generics {
     let parent_generics = parent_generic_def(db, def).map(|def| Box::new(generics(db, def)));
+    if parent_generics.is_some() && matches!(def, GenericDefId::TypeAliasId(_)) {
+        // XXX: treat generic associated types as not existing to avoid crashes (#)
+        //
+        // Chalk expects the inner associated type's parameters to come
+        // *before*, not after the trait's generics as we've always done it.
+        // Adapting to this requires a larger refactoring
+        cov_mark::hit!(ignore_gats);
+        return Generics { def, params: Interned::new(Default::default()), parent_generics };
+    }
     Generics { def, params: db.generic_params(def), parent_generics }
 }
 


### PR DESCRIPTION
TIL that Chalk expects the arguments to a generic associated type to come *before* the ones for the parent trait, not *after* as we have been doing with all other nested generics. Fixing this requires a larger refactoring, so for now this just papers over the problem by completely ignoring parameters of associated types.

Fixes #11769.