### PR TITLE
Suggest infered type in auto complete

### DIFF
--- a/crates/hir_def/src/item_tree/lower.rs
+++ b/crates/hir_def/src/item_tree/lower.rs
@@ -302,9 +302,13 @@ impl<'a> Ctx<'a> {
         let end_param = self.next_param_idx();
         let params = IdxRange::new(start_param..end_param);
 
-        let ret_type = match func.ret_type().and_then(|rt| rt.ty()) {
-            Some(type_ref) => TypeRef::from_ast(&self.body_ctx, type_ref),
-            _ => TypeRef::unit(),
+        let ret_type = match func.ret_type() {
+            Some(rt) => match rt.ty() {
+                Some(type_ref) => TypeRef::from_ast(&self.body_ctx, type_ref),
+                None if rt.thin_arrow_token().is_some() => TypeRef::Error,
+                None => TypeRef::unit(),
+            },
+            None => TypeRef::unit(),
         };
 
         let (ret_type, async_ret_type) = if func.async_token().is_some() {

--- a/crates/ide_completion/src/completions.rs
+++ b/crates/ide_completion/src/completions.rs
@@ -21,12 +21,13 @@ pub(crate) mod vis;
 
 use std::iter;
 
-use hir::{db::HirDatabase, known, ScopeDef};
+use hir::{db::HirDatabase, known, HirDisplay, ScopeDef};
 use ide_db::SymbolKind;
 
 use crate::{
     context::Visible,
     item::Builder,
+    patterns::{ImmediateLocation, TypeAnnotation},
     render::{
         const_::render_const,
         function::{render_fn, render_method},
@@ -34,6 +35,7 @@ use crate::{
         macro_::render_macro,
         pattern::{render_struct_pat, render_variant_pat},
         render_field, render_resolution, render_resolution_simple, render_tuple_field,
+        render_type_inference,
         type_alias::{render_type_alias, render_type_alias_with_eq},
         union_literal::render_union_literal,
         RenderContext,
@@ -373,4 +375,20 @@ fn enum_variants_with_paths(
             }
         }
     }
+}
+
+pub(crate) fn inferred_type(acc: &mut Completions, ctx: &CompletionContext) -> Option<()> {
+    use TypeAnnotation::*;
+    let pat = match &ctx.completion_location {
+        Some(ImmediateLocation::TypeAnnotation(t)) => t,
+        _ => return None,
+    };
+    let x = match pat {
+        Let(pat) | FnParam(pat) => ctx.sema.type_of_pat(pat.as_ref()?),
+        Const(exp) | RetType(exp) => ctx.sema.type_of_expr(exp.as_ref()?),
+    }?
+    .adjusted();
+    let ty_string = x.display_source_code(ctx.db, ctx.module.into()).ok()?;
+    acc.add(render_type_inference(ty_string, ctx));
+    None
 }

--- a/crates/ide_completion/src/item.rs
+++ b/crates/ide_completion/src/item.rs
@@ -138,6 +138,8 @@ pub struct CompletionRelevance {
     pub is_private_editable: bool,
     /// Set for postfix snippet item completions
     pub postfix_match: Option<CompletionRelevancePostfixMatch>,
+    /// This is setted for type inference results
+    pub is_definite: bool,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -198,6 +200,7 @@ impl CompletionRelevance {
             is_op_method,
             is_private_editable,
             postfix_match,
+            is_definite,
         } = self;
 
         // lower rank private things
@@ -225,7 +228,9 @@ impl CompletionRelevance {
         if is_local {
             score += 1;
         }
-
+        if is_definite {
+            score += 10;
+        }
         score
     }
 
@@ -243,6 +248,7 @@ pub enum CompletionItemKind {
     SymbolKind(SymbolKind),
     Binding,
     BuiltinType,
+    InferredType,
     Keyword,
     Method,
     Snippet,
@@ -284,6 +290,7 @@ impl CompletionItemKind {
             },
             CompletionItemKind::Binding => "bn",
             CompletionItemKind::BuiltinType => "bt",
+            CompletionItemKind::InferredType => "it",
             CompletionItemKind::Keyword => "kw",
             CompletionItemKind::Method => "me",
             CompletionItemKind::Snippet => "sn",

--- a/crates/ide_completion/src/lib.rs
+++ b/crates/ide_completion/src/lib.rs
@@ -155,6 +155,7 @@ pub fn completions(
     completions::flyimport::import_on_the_fly(&mut acc, &ctx);
     completions::fn_param::complete_fn_param(&mut acc, &ctx);
     completions::format_string::format_string(&mut acc, &ctx);
+    completions::inferred_type(&mut acc, &ctx);
     completions::keyword::complete_expr_keyword(&mut acc, &ctx);
     completions::lifetime::complete_label(&mut acc, &ctx);
     completions::lifetime::complete_lifetime(&mut acc, &ctx);

--- a/crates/ide_completion/src/render.rs
+++ b/crates/ide_completion/src/render.rs
@@ -170,6 +170,13 @@ pub(crate) fn render_resolution_with_import(
     Some(render_resolution_(ctx, local_name, Some(import_edit), resolution))
 }
 
+pub(crate) fn render_type_inference(ty_string: String, ctx: &CompletionContext) -> CompletionItem {
+    let mut builder =
+        CompletionItem::new(CompletionItemKind::InferredType, ctx.source_range(), ty_string);
+    builder.set_relevance(CompletionRelevance { is_definite: true, ..Default::default() });
+    builder.build()
+}
+
 fn render_resolution_(
     ctx: RenderContext<'_>,
     local_name: hir::Name,
@@ -620,6 +627,7 @@ fn main() { let _: m::Spam = S$0 }
                             is_op_method: false,
                             is_private_editable: false,
                             postfix_match: None,
+                            is_definite: false,
                         },
                     },
                     CompletionItem {
@@ -641,6 +649,7 @@ fn main() { let _: m::Spam = S$0 }
                             is_op_method: false,
                             is_private_editable: false,
                             postfix_match: None,
+                            is_definite: false,
                         },
                     },
                 ]
@@ -728,6 +737,7 @@ fn foo() { A { the$0 } }
                             is_op_method: false,
                             is_private_editable: false,
                             postfix_match: None,
+                            is_definite: false,
                         },
                     },
                 ]

--- a/crates/ide_completion/src/tests/type_pos.rs
+++ b/crates/ide_completion/src/tests/type_pos.rs
@@ -90,6 +90,206 @@ fn x<'lt, T, const C: usize>() -> $0
 }
 
 #[test]
+fn inferred_type_const() {
+    check(
+        r#"
+struct Foo<T>(T);
+const FOO: $0 = Foo(2);
+"#,
+        expect![[r#"
+            it Foo<i32>
+            kw self
+            kw super
+            kw crate
+            tt Trait
+            en Enum
+            st Record
+            st Tuple
+            md module
+            st Foo<…>
+            st Unit
+            ma makro!(…) macro_rules! makro
+            un Union
+            bt u32
+        "#]],
+    );
+}
+
+#[test]
+fn inferred_type_closure_param() {
+    check(
+        r#"
+fn f1(f: fn(i32) -> i32) {}
+fn f2() {
+    f1(|x: $0);
+}
+"#,
+        expect![[r#"
+            it i32
+            kw self
+            kw super
+            kw crate
+            tt Trait
+            en Enum
+            st Record
+            st Tuple
+            md module
+            st Unit
+            ma makro!(…) macro_rules! makro
+            un Union
+            bt u32
+        "#]],
+    );
+}
+
+#[test]
+fn inferred_type_closure_return() {
+    check(
+        r#"
+fn f1(f: fn(u64) -> u64) {}
+fn f2() {
+    f1(|x| -> $0 {
+        x + 5
+    });
+}
+"#,
+        expect![[r#"
+            it u64
+            kw self
+            kw super
+            kw crate
+            tt Trait
+            en Enum
+            st Record
+            st Tuple
+            md module
+            st Unit
+            ma makro!(…) macro_rules! makro
+            un Union
+            bt u32
+        "#]],
+    );
+}
+
+#[test]
+fn inferred_type_fn_return() {
+    check(
+        r#"
+fn f2(x: u64) -> $0 {
+    x + 5
+}
+"#,
+        expect![[r#"
+            it u64
+            kw self
+            kw super
+            kw crate
+            tt Trait
+            en Enum
+            st Record
+            st Tuple
+            md module
+            st Unit
+            ma makro!(…) macro_rules! makro
+            un Union
+            bt u32
+        "#]],
+    );
+}
+
+#[test]
+fn inferred_type_fn_param() {
+    check(
+        r#"
+fn f1(x: i32) {}
+fn f2(x: $0) {
+    f1(x);
+}
+"#,
+        expect![[r#"
+            it i32
+            kw self
+            kw super
+            kw crate
+            tt Trait
+            en Enum
+            st Record
+            st Tuple
+            md module
+            st Unit
+            ma makro!(…) macro_rules! makro
+            un Union
+            bt u32
+        "#]],
+    );
+}
+
+#[test]
+fn inferred_type_not_in_the_scope() {
+    check(
+        r#"
+mod a {
+    pub struct Foo<T>(T);
+    pub fn x() -> Foo<Foo<i32>> {
+        Foo(Foo(2))
+    }
+}
+fn foo<'lt, T, const C: usize>() {
+    let local = ();
+    let foo: $0 = a::x();
+}
+"#,
+        expect![[r#"
+            it a::Foo<a::Foo<i32>>
+            kw self
+            kw super
+            kw crate
+            tp T
+            tt Trait
+            en Enum
+            st Record
+            st Tuple
+            md module
+            st Unit
+            ma makro!(…)           macro_rules! makro
+            un Union
+            md a
+            bt u32
+        "#]],
+    );
+}
+
+#[test]
+fn inferred_type_let() {
+    check(
+        r#"
+struct Foo<T>(T);
+fn foo<'lt, T, const C: usize>() {
+    let local = ();
+    let foo: $0 = Foo(2);
+}
+"#,
+        expect![[r#"
+            it Foo<i32>
+            kw self
+            kw super
+            kw crate
+            tp T
+            tt Trait
+            en Enum
+            st Record
+            st Tuple
+            md module
+            st Foo<…>
+            st Unit
+            ma makro!(…) macro_rules! makro
+            un Union
+            bt u32
+        "#]],
+    );
+}
+
+#[test]
 fn body_type_pos() {
     check(
         r#"

--- a/crates/rust-analyzer/src/to_proto.rs
+++ b/crates/rust-analyzer/src/to_proto.rs
@@ -107,6 +107,7 @@ pub(crate) fn completion_item_kind(
     match completion_item_kind {
         CompletionItemKind::Binding => lsp_types::CompletionItemKind::VARIABLE,
         CompletionItemKind::BuiltinType => lsp_types::CompletionItemKind::STRUCT,
+        CompletionItemKind::InferredType => lsp_types::CompletionItemKind::SNIPPET,
         CompletionItemKind::Keyword => lsp_types::CompletionItemKind::KEYWORD,
         CompletionItemKind::Method => lsp_types::CompletionItemKind::METHOD,
         CompletionItemKind::Snippet => lsp_types::CompletionItemKind::SNIPPET,


### PR DESCRIPTION
fix #11855

It doesn't work for return types and consts (so their tests are failing) because I can't find their body node in the original file. (Are these original and fake file documented somewhere?)

Also it currently needs to type first character of the type (or manual ctrl+space) to open the auto complete panel, is it possible to open it automatically on typing `:` and `->`?
