### PR TITLE
add test for postfix completion relevance

### DIFF
--- a/crates/ide_completion/src/completions/postfix.rs
+++ b/crates/ide_completion/src/completions/postfix.rs
@@ -243,8 +243,10 @@ fn build_postfix_snippet_builder<'ctx>(
                 CompletionItem::new(CompletionItemKind::Snippet, ctx.source_range(), label);
             item.detail(detail).snippet_edit(cap, edit);
             let postfix_match = if ctx.original_token.text() == label {
+                cov_mark::hit!(postfix_exact_match_is_high_priority);
                 Some(CompletionRelevancePostfixMatch::Exact)
             } else {
+                cov_mark::hit!(postfix_inexact_match_is_low_priority);
                 Some(CompletionRelevancePostfixMatch::NonExact)
             };
             let relevance = CompletionRelevance { postfix_match, ..Default::default() };

--- a/crates/ide_completion/src/render.rs
+++ b/crates/ide_completion/src/render.rs
@@ -1550,7 +1550,8 @@ fn foo() {
     }
 
     #[test]
-    fn postfix_completion_relevance() {
+    fn postfix_exact_match_is_high_priority() {
+        cov_mark::check!(postfix_exact_match_is_high_priority);
         check_relevance_for_kinds(
             r#"
 mod ops {
@@ -1582,6 +1583,35 @@ fn main() {
                 sn dbg []
                 sn dbgr []
                 sn call []
+            "#]],
+        );
+    }
+
+    #[test]
+    fn postfix_inexact_match_is_low_priority() {
+        cov_mark::check!(postfix_inexact_match_is_low_priority);
+        check_relevance_for_kinds(
+            r#"
+struct S;
+impl S {
+    fn f(&self) {}
+}
+fn main() {
+    S.$0
+}
+    "#,
+            &[CompletionItemKind::Snippet, CompletionItemKind::Method],
+            expect![[r#"
+                me f() []
+                sn ref []
+                sn refm []
+                sn match []
+                sn box []
+                sn dbg []
+                sn dbgr []
+                sn call []
+                sn let []
+                sn letm []
             "#]],
         );
     }


### PR DESCRIPTION
Follow up to #11857, add a test and cov-marks

bors r+
🤖