### PR TITLE
Better error message on Flycheck Error message (from: unactionable error message if we are using `clippy` as the checker)

### DIFF
--- a/crates/flycheck/src/lib.rs
+++ b/crates/flycheck/src/lib.rs
@@ -329,7 +329,7 @@ impl CargoActor {
             Ok(output) if output.status.success() => Ok(()),
             Ok(output)  => {
                 Err(io::Error::new(io::ErrorKind::Other, format!(
-                    "Cargo watcher failed, the command produced no valid metadata (exit code: {:?})",
+                    "Cargo watcher failed, the command produced no valid metadata (exit code: {:?})\nMake sure to have `cargo clippy` installed.",
                     output.status
                 )))
             }

--- a/crates/flycheck/src/lib.rs
+++ b/crates/flycheck/src/lib.rs
@@ -2,7 +2,7 @@
 //! another compatible command (f.x. clippy) in a background thread and provide
 //! LSP diagnostics based on the output of the command.
 
-use std::{fmt, io, process::Command, time::Duration};
+use std::{fmt, io, process::Command, time::Duration, str::from_utf8};
 
 use crossbeam_channel::{never, select, unbounded, Receiver, Sender};
 use paths::AbsPathBuf;
@@ -329,8 +329,8 @@ impl CargoActor {
             Ok(output) if output.status.success() => Ok(()),
             Ok(output)  => {
                 Err(io::Error::new(io::ErrorKind::Other, format!(
-                    "Cargo watcher failed, the command produced no valid metadata (exit code: {:?})\nMake sure you have `cargo clippy` installed and updated.",
-                    output.status
+                    "Cargo watcher failed, the command produced no valid metadata (exit code: {:?})\nCargo's stderr output:\n{}",
+                    output.status, from_utf8(&output.stderr).unwrap_or("(Error: Could not fetch Cargo's stderr output)")
                 )))
             }
             Err(e) => Err(io::Error::new(e.kind(), format!("{:?}: {}", e, error))),

--- a/crates/flycheck/src/lib.rs
+++ b/crates/flycheck/src/lib.rs
@@ -2,7 +2,7 @@
 //! another compatible command (f.x. clippy) in a background thread and provide
 //! LSP diagnostics based on the output of the command.
 
-use std::{fmt, io, process::Command, time::Duration, str::from_utf8};
+use std::{fmt, io, process::Command, time::Duration};
 
 use crossbeam_channel::{never, select, unbounded, Receiver, Sender};
 use paths::AbsPathBuf;
@@ -330,7 +330,7 @@ impl CargoActor {
             Ok(output)  => {
                 Err(io::Error::new(io::ErrorKind::Other, format!(
                     "Cargo watcher failed, the command produced no valid metadata (exit code: {:?})\nCargo's stderr output:\n{}",
-                    output.status, from_utf8(&output.stderr).unwrap_or("(Error: Could not fetch Cargo's stderr output)")
+                    output.status, error
                 )))
             }
             Err(e) => Err(io::Error::new(e.kind(), format!("{:?}: {}", e, error))),

--- a/crates/flycheck/src/lib.rs
+++ b/crates/flycheck/src/lib.rs
@@ -329,7 +329,7 @@ impl CargoActor {
             Ok(output) if output.status.success() => Ok(()),
             Ok(output)  => {
                 Err(io::Error::new(io::ErrorKind::Other, format!(
-                    "Cargo watcher failed, the command produced no valid metadata (exit code: {:?})\nMake sure to have `cargo clippy` installed.",
+                    "Cargo watcher failed, the command produced no valid metadata (exit code: {:?})\nMake sure you have `cargo clippy` installed and updated.",
                     output.status
                 )))
             }


### PR DESCRIPTION
I have commented on this [S-unactionable issue](https://github.com/rust-analyzer/rust-analyzer/issues/6589) that the Flycheck error message should maybe provide a hint about what tool it actually runs. Searching on some places on the Internet I've found multiple people, including myself, losing copious amounts of time on the same issue. So I've decided to make this very small PR :-)

From an user experience standpoint, the current error message is unhelpful to the end user, because the end user does not know exactly what it needs to check/fix (outdated, broken, or missing `cargo clippy`). In my own case, `cargo clippy` was actually missing altogether (developing off `rust:1.59.0-bullseye` official Docker image).

Thanks in advance!


