### PR TITLE
complete pattern args based on type name

### DIFF
--- a/crates/ide_completion/src/render/function.rs
+++ b/crates/ide_completion/src/render/function.rs
@@ -141,7 +141,7 @@ pub(super) fn add_call_parens<'b>(
                                 Some(adt) => adt
                                     .name(ctx.db)
                                     .as_text()
-                                    .map(to_lower_snake_case)
+                                    .map(|s| to_lower_snake_case(s.as_str()))
                                     .unwrap_or("_".to_string()),
                             };
                             f(&format_args!("${{{}:{}}}", index + offset, name))

--- a/crates/ide_completion/src/render/function.rs
+++ b/crates/ide_completion/src/render/function.rs
@@ -137,10 +137,12 @@ pub(super) fn add_call_parens<'b>(
                         }
                         None => {
                             let name = match param.ty().as_adt() {
-                                Some(adt) => {
-                                    to_lower_snake_case(&adt.name(ctx.db).as_text().unwrap())
-                                }
                                 None => "_".to_string(),
+                                Some(adt) => adt
+                                    .name(ctx.db)
+                                    .as_text()
+                                    .map(to_lower_snake_case)
+                                    .unwrap_or("_".to_string()),
                             };
                             f(&format_args!("${{{}:{}}}", index + offset, name))
                         }

--- a/crates/ide_completion/src/render/function.rs
+++ b/crates/ide_completion/src/render/function.rs
@@ -142,7 +142,7 @@ pub(super) fn add_call_parens<'b>(
                                     .name(ctx.db)
                                     .as_text()
                                     .map(|s| to_lower_snake_case(s.as_str()))
-                                    .unwrap_or("_".to_string()),
+                                    .unwrap_or_else(|| "_".to_string()),
                             };
                             f(&format_args!("${{{}:{}}}", index + offset, name))
                         }

--- a/crates/ide_completion/src/render/function.rs
+++ b/crates/ide_completion/src/render/function.rs
@@ -3,7 +3,7 @@
 use hir::{db::HirDatabase, AsAssocItem, HirDisplay};
 use ide_db::{SnippetCap, SymbolKind};
 use itertools::Itertools;
-use stdx::format_to;
+use stdx::{format_to, to_lower_snake_case};
 use syntax::SmolStr;
 
 use crate::{
@@ -135,7 +135,15 @@ pub(super) fn add_call_parens<'b>(
                             let ref_ = ref_of_param(ctx, text, param.ty());
                             f(&format_args!("${{{}:{}{}}}", index + offset, ref_, text))
                         }
-                        None => f(&format_args!("${{{}:_}}", index + offset,)),
+                        None => {
+                            let name = match param.ty().as_adt() {
+                                Some(adt) => {
+                                    to_lower_snake_case(&adt.name(ctx.db).as_text().unwrap())
+                                }
+                                None => "_".to_string(),
+                            };
+                            f(&format_args!("${{{}:{}}}", index + offset, name))
+                        }
                     }
                 });
             match self_param {
@@ -515,6 +523,39 @@ fn take_mutably(mut x: &i32) {}
 
 fn main() {
     take_mutably(${1:x})$0
+}
+"#,
+        );
+    }
+
+    #[test]
+    fn complete_pattern_args_with_type_name_if_adt() {
+        check_edit(
+            "qux",
+            r#"
+struct Foo {
+    bar: i32
+}
+
+fn qux(Foo { bar }: Foo) {
+    println!("{}", bar);
+}
+
+fn main() {
+  qu$0
+}
+"#,
+            r#"
+struct Foo {
+    bar: i32
+}
+
+fn qux(Foo { bar }: Foo) {
+    println!("{}", bar);
+}
+
+fn main() {
+  qux(${1:foo})$0
 }
 "#,
         );


### PR DESCRIPTION
Addresses #11892 

Changes function argument completion to cover a case like this:
```rust
struct Foo { bar: i32 }

fn qux(Foo { bar }: Foo) {
  println!("{bar}");
}
```
When completing the function call for `qux`, instead of expanding to `qux(_)`, it will now expand to `qux(foo)` (based on the snake-cased version of the name of the ADT)

Non ADTs are unaffected
