### PR TITLE
fix: Attempt to resolve paths in const arguments heuristically in IDE layer

### DIFF
--- a/crates/hir_def/src/item_tree/lower.rs
+++ b/crates/hir_def/src/item_tree/lower.rs
@@ -295,13 +295,13 @@ impl<'a> Ctx<'a> {
                         let mut pat = param.pat();
                         // FIXME: This really shouldn't be here, in fact FunctionData/ItemTree's function shouldn't know about
                         // pattern names at all
-                        let name = loop {
+                        let name = 'name: loop {
                             match pat {
                                 Some(ast::Pat::RefPat(ref_pat)) => pat = ref_pat.pat(),
                                 Some(ast::Pat::IdentPat(ident)) => {
-                                    break ident.name().map(|it| it.as_name())
+                                    break 'name ident.name().map(|it| it.as_name())
                                 }
-                                _ => break None,
+                                _ => break 'name None,
                             }
                         };
                         self.data().params.alloc(Param::Normal(name, ty))

--- a/crates/ide/src/syntax_highlighting/test_data/highlight_general.html
+++ b/crates/ide/src/syntax_highlighting/test_data/highlight_general.html
@@ -118,6 +118,7 @@ pre                 { color: #DCDCCC; background: #3F3F3F; font-size: 22px; padd
 <span class="brace">}</span>
 
 <span class="keyword">fn</span> <span class="function declaration">const_param</span><span class="angle">&lt;</span><span class="keyword">const</span> <span class="const_param declaration">FOO</span><span class="colon">:</span> <span class="builtin_type">usize</span><span class="angle">&gt;</span><span class="parenthesis">(</span><span class="parenthesis">)</span> <span class="operator">-&gt;</span> <span class="builtin_type">usize</span> <span class="brace">{</span>
+    <span class="function">const_param</span><span class="operator">::</span><span class="angle">&lt;</span><span class="brace">{</span> <span class="const_param">FOO</span> <span class="brace">}</span><span class="angle">&gt;</span><span class="parenthesis">(</span><span class="parenthesis">)</span><span class="semicolon">;</span>
     <span class="const_param">FOO</span>
 <span class="brace">}</span>
 

--- a/crates/ide/src/syntax_highlighting/tests.rs
+++ b/crates/ide/src/syntax_highlighting/tests.rs
@@ -172,6 +172,7 @@ fn never() -> ! {
 }
 
 fn const_param<const FOO: usize>() -> usize {
+    const_param::<{ FOO }>();
     FOO
 }
 


### PR DESCRIPTION
While we don't support const args in type inference yet, we can at least
make use of the fallback path resolution to resolve paths in const args
in the IDE layer to enable some features for them.

bors r+