### PR TITLE
Consider types of const generics

### DIFF
--- a/crates/hir_ty/src/builder.rs
+++ b/crates/hir_ty/src/builder.rs
@@ -154,6 +154,10 @@ impl TyBuilder<()> {
         TyKind::Tuple(0, Substitution::empty(Interner)).intern(Interner)
     }
 
+    pub fn usize() -> Ty {
+        TyKind::Scalar(chalk_ir::Scalar::Uint(chalk_ir::UintTy::Usize)).intern(Interner)
+    }
+
     pub fn fn_ptr(sig: CallableSig) -> Ty {
         TyKind::Function(sig.to_fn_ptr()).intern(Interner)
     }

--- a/crates/hir_ty/src/infer/expr.rs
+++ b/crates/hir_ty/src/infer/expr.rs
@@ -1129,10 +1129,11 @@ impl<'a> InferenceContext<'a> {
                     arg,
                     self,
                     |this, type_ref| this.make_ty(type_ref),
-                    |this, c| {
+                    |this, c, ty| {
                         const_or_path_to_chalk(
                             this.db,
                             &this.resolver,
+                            ty,
                             c,
                             ParamLoweringMode::Placeholder,
                             || generics(this.db.upcast(), (&this.resolver).generic_def().unwrap()),

--- a/crates/ide_diagnostics/src/handlers/type_mismatch.rs
+++ b/crates/ide_diagnostics/src/handlers/type_mismatch.rs
@@ -317,6 +317,38 @@ fn div(x: i32, y: i32) -> Option<i32> {
     }
 
     #[test]
+    fn const_generic_type_mismatch() {
+        check_diagnostics(
+            r#"
+            pub struct Rate<const N: u32>;
+            fn f<const N: u64>() -> Rate<N> { // FIXME: add some error
+                loop {}
+            }
+            fn run(t: Rate<5>) {
+            }
+            fn main() {
+                run(f()) // FIXME: remove this error
+                  //^^^ error: expected Rate<5>, found Rate<_>
+            }
+"#,
+        );
+    }
+
+    #[test]
+    fn const_generic_unknown() {
+        check_diagnostics(
+            r#"
+            pub struct Rate<T, const NOM: u32, const DENOM: u32>(T);
+            fn run(t: Rate<u32, 1, 1>) {
+            }
+            fn main() {
+                run(Rate::<_, _, _>(5));
+            }
+"#,
+        );
+    }
+
+    #[test]
     fn test_wrap_return_type_option_tails() {
         check_fix(
             r#"


### PR DESCRIPTION
fix #11913 

We should emit type_mismatch in const generics, probably after #7434. Currently they will lead to a misleading, time of use type error (like the added test).
