### PR TITLE
internal: remove `FnFlags::IS_IN_EXTERN_BLOCK`

### DIFF
--- a/crates/hir_def/src/data.rs
+++ b/crates/hir_def/src/data.rs
@@ -57,10 +57,6 @@ impl FunctionData {
             flags.bits |= FnFlags::IS_VARARGS;
         }
 
-        if matches!(loc.container, ItemContainerId::ExternBlockId(_)) {
-            flags.bits |= FnFlags::IS_IN_EXTERN_BLOCK;
-        }
-
         let legacy_const_generics_indices = item_tree
             .attrs(db, krate, ModItem::from(loc.id.value).into())
             .by_key("rustc_legacy_const_generics")
@@ -112,10 +108,6 @@ impl FunctionData {
 
     pub fn is_unsafe(&self) -> bool {
         self.flags.bits & FnFlags::IS_UNSAFE != 0
-    }
-
-    pub fn is_in_extern_block(&self) -> bool {
-        self.flags.bits & FnFlags::IS_IN_EXTERN_BLOCK != 0
     }
 
     pub fn is_varargs(&self) -> bool {

--- a/crates/hir_def/src/item_tree.rs
+++ b/crates/hir_def/src/item_tree.rs
@@ -612,9 +612,6 @@ impl FnFlags {
     pub(crate) const IS_CONST: u8 = 1 << 3;
     pub(crate) const IS_ASYNC: u8 = 1 << 4;
     pub(crate) const IS_UNSAFE: u8 = 1 << 5;
-    /// Whether the function is located in an `extern` block (*not* whether it is an
-    /// `extern "abi" fn`).
-    pub(crate) const IS_IN_EXTERN_BLOCK: u8 = 1 << 6;
     pub(crate) const IS_VARARGS: u8 = 1 << 7;
 }
 

--- a/crates/hir_ty/src/diagnostics/decl_check.rs
+++ b/crates/hir_ty/src/diagnostics/decl_check.rs
@@ -19,7 +19,8 @@ use hir_def::{
     adt::VariantData,
     expr::{Pat, PatId},
     src::HasSource,
-    AdtId, AttrDefId, ConstId, EnumId, FunctionId, Lookup, ModuleDefId, StaticId, StructId,
+    AdtId, AttrDefId, ConstId, EnumId, FunctionId, ItemContainerId, Lookup, ModuleDefId, StaticId,
+    StructId,
 };
 use hir_expand::{
     name::{AsName, Name},
@@ -198,7 +199,7 @@ impl<'a> DeclValidator<'a> {
 
     fn validate_func(&mut self, func: FunctionId) {
         let data = self.db.function_data(func);
-        if data.is_in_extern_block() {
+        if matches!(func.lookup(self.db.upcast()).container, ItemContainerId::ExternBlockId(_)) {
             cov_mark::hit!(extern_func_incorrect_case_ignored);
             return;
         }


### PR DESCRIPTION
This flag was determined purely based on the AST, which cannot work reliably since macros are allowed in `extern` blocks (in which case the function would not have an extern block parent in the AST).

bors r+