### PR TITLE
fix: Fix panics with `#[cfg]`'d-out `self` parameter

### DIFF
--- a/crates/hir_def/src/data.rs
+++ b/crates/hir_def/src/data.rs
@@ -56,6 +56,15 @@ impl FunctionData {
         if is_varargs {
             flags.bits |= FnFlags::IS_VARARGS;
         }
+        if flags.bits & FnFlags::HAS_SELF_PARAM != 0 {
+            // If there's a self param in the syntax, but it is cfg'd out, remove the flag.
+            cov_mark::hit!(cfgd_out_self_param);
+            let param =
+                func.params.clone().next().expect("fn HAS_SELF_PARAM but no parameters allocated");
+            if !item_tree.attrs(db, krate, param.into()).is_cfg_enabled(cfg_options) {
+                flags.bits &= !FnFlags::HAS_SELF_PARAM;
+            }
+        }
 
         let legacy_const_generics_indices = item_tree
             .attrs(db, krate, ModItem::from(loc.id.value).into())

--- a/crates/hir_ty/src/tests/regression.rs
+++ b/crates/hir_ty/src/tests/regression.rs
@@ -1488,3 +1488,20 @@ fn test<T: Crash>() {
 "#,
     );
 }
+
+#[test]
+fn cfgd_out_self_param() {
+    cov_mark::check!(cfgd_out_self_param);
+    check_no_mismatches(
+        r#"
+struct S;
+impl S {
+    fn f(#[cfg(never)] &self) {}
+}
+
+fn f(s: S) {
+    s.f();
+}
+"#,
+    );
+}


### PR DESCRIPTION
bors r+