### PR TITLE
internal: Use bitflags for `FnFlags`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,7 @@ dependencies = [
  "anymap",
  "arrayvec",
  "base_db",
+ "bitflags",
  "cfg",
  "cov-mark",
  "dashmap",

--- a/crates/hir_def/Cargo.toml
+++ b/crates/hir_def/Cargo.toml
@@ -10,6 +10,7 @@ rust-version = "1.57"
 doctest = false
 
 [dependencies]
+bitflags = "1.3.2"
 cov-mark = "2.0.0-pre.1"
 dashmap = { version = "5.2.0", features = ["raw-api"] }
 lock_api = "0.4.6"

--- a/crates/hir_def/src/data.rs
+++ b/crates/hir_def/src/data.rs
@@ -54,9 +54,9 @@ impl FunctionData {
 
         let mut flags = func.flags;
         if is_varargs {
-            flags.bits |= FnFlags::IS_VARARGS;
+            flags |= FnFlags::IS_VARARGS;
         }
-        if flags.bits & FnFlags::HAS_SELF_PARAM != 0 {
+        if flags.contains(FnFlags::HAS_SELF_PARAM) {
             // If there's a self param in the syntax, but it is cfg'd out, remove the flag.
             let is_cfgd_out = match func.params.clone().next() {
                 Some(param) => {
@@ -69,7 +69,7 @@ impl FunctionData {
             };
             if is_cfgd_out {
                 cov_mark::hit!(cfgd_out_self_param);
-                flags.bits &= !FnFlags::HAS_SELF_PARAM;
+                flags.remove(FnFlags::HAS_SELF_PARAM);
             }
         }
 
@@ -101,33 +101,33 @@ impl FunctionData {
     }
 
     pub fn has_body(&self) -> bool {
-        self.flags.bits & FnFlags::HAS_BODY != 0
+        self.flags.contains(FnFlags::HAS_BODY)
     }
 
     /// True if the first param is `self`. This is relevant to decide whether this
     /// can be called as a method.
     pub fn has_self_param(&self) -> bool {
-        self.flags.bits & FnFlags::HAS_SELF_PARAM != 0
+        self.flags.contains(FnFlags::HAS_SELF_PARAM)
     }
 
     pub fn is_default(&self) -> bool {
-        self.flags.bits & FnFlags::IS_DEFAULT != 0
+        self.flags.contains(FnFlags::IS_DEFAULT)
     }
 
     pub fn is_const(&self) -> bool {
-        self.flags.bits & FnFlags::IS_CONST != 0
+        self.flags.contains(FnFlags::IS_CONST)
     }
 
     pub fn is_async(&self) -> bool {
-        self.flags.bits & FnFlags::IS_ASYNC != 0
+        self.flags.contains(FnFlags::IS_ASYNC)
     }
 
     pub fn is_unsafe(&self) -> bool {
-        self.flags.bits & FnFlags::IS_UNSAFE != 0
+        self.flags.contains(FnFlags::IS_UNSAFE)
     }
 
     pub fn is_varargs(&self) -> bool {
-        self.flags.bits & FnFlags::IS_VARARGS != 0
+        self.flags.contains(FnFlags::IS_VARARGS)
     }
 }
 

--- a/crates/hir_def/src/item_tree.rs
+++ b/crates/hir_def/src/item_tree.rs
@@ -601,18 +601,17 @@ pub enum Param {
     Varargs,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
-pub(crate) struct FnFlags {
-    pub(crate) bits: u8,
-}
-impl FnFlags {
-    pub(crate) const HAS_SELF_PARAM: u8 = 1 << 0;
-    pub(crate) const HAS_BODY: u8 = 1 << 1;
-    pub(crate) const IS_DEFAULT: u8 = 1 << 2;
-    pub(crate) const IS_CONST: u8 = 1 << 3;
-    pub(crate) const IS_ASYNC: u8 = 1 << 4;
-    pub(crate) const IS_UNSAFE: u8 = 1 << 5;
-    pub(crate) const IS_VARARGS: u8 = 1 << 7;
+bitflags::bitflags! {
+    #[derive(Default)]
+    pub(crate) struct FnFlags: u8 {
+        const HAS_SELF_PARAM = 1 << 0;
+        const HAS_BODY = 1 << 1;
+        const IS_DEFAULT = 1 << 2;
+        const IS_CONST = 1 << 3;
+        const IS_ASYNC = 1 << 4;
+        const IS_UNSAFE = 1 << 5;
+        const IS_VARARGS = 1 << 6;
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/crates/hir_def/src/item_tree/lower.rs
+++ b/crates/hir_def/src/item_tree/lower.rs
@@ -337,22 +337,22 @@ impl<'a> Ctx<'a> {
 
         let mut flags = FnFlags::default();
         if func.body().is_some() {
-            flags.bits |= FnFlags::HAS_BODY;
+            flags |= FnFlags::HAS_BODY;
         }
         if has_self_param {
-            flags.bits |= FnFlags::HAS_SELF_PARAM;
+            flags |= FnFlags::HAS_SELF_PARAM;
         }
         if func.default_token().is_some() {
-            flags.bits |= FnFlags::IS_DEFAULT;
+            flags |= FnFlags::IS_DEFAULT;
         }
         if func.const_token().is_some() {
-            flags.bits |= FnFlags::IS_CONST;
+            flags |= FnFlags::IS_CONST;
         }
         if func.async_token().is_some() {
-            flags.bits |= FnFlags::IS_ASYNC;
+            flags |= FnFlags::IS_ASYNC;
         }
         if func.unsafe_token().is_some() {
-            flags.bits |= FnFlags::IS_UNSAFE;
+            flags |= FnFlags::IS_UNSAFE;
         }
 
         let mut res = Function {
@@ -559,7 +559,7 @@ impl<'a> Ctx<'a> {
                             let func = &mut self.data().functions[func_id.index];
                             if is_intrinsic_fn_unsafe(&func.name) {
                                 // FIXME: this breaks in macros
-                                func.flags.bits |= FnFlags::IS_UNSAFE;
+                                func.flags |= FnFlags::IS_UNSAFE;
                             }
                             func_id.into()
                         }


### PR DESCRIPTION
Previously we didn't do this because it didn't pull its weight, but now we actually do some bitops

bors r+