### PR TITLE
internal: move function unsafety determination out of the ItemTree

### DIFF
--- a/crates/hir/src/display.rs
+++ b/crates/hir/src/display.rs
@@ -26,16 +26,16 @@ impl HirDisplay for Function {
     fn hir_fmt(&self, f: &mut HirFormatter) -> Result<(), HirDisplayError> {
         let data = f.db.function_data(self.id);
         write_visibility(self.module(f.db).id, self.visibility(f.db), f)?;
-        if data.is_default() {
+        if data.has_default_kw() {
             f.write_str("default ")?;
         }
-        if data.is_const() {
+        if data.has_const_kw() {
             f.write_str("const ")?;
         }
-        if data.is_async() {
+        if data.has_async_kw() {
             f.write_str("async ")?;
         }
-        if data.is_unsafe() {
+        if self.is_unsafe_to_call(f.db) {
             f.write_str("unsafe ")?;
         }
         if let Some(abi) = &data.abi {
@@ -96,7 +96,7 @@ impl HirDisplay for Function {
         // `FunctionData::ret_type` will be `::core::future::Future<Output = ...>` for async fns.
         // Use ugly pattern match to strip the Future trait.
         // Better way?
-        let ret_type = if !data.is_async() {
+        let ret_type = if !data.has_async_kw() {
             &data.ret_type
         } else {
             match &*data.ret_type {

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1421,16 +1421,16 @@ impl Function {
             .collect()
     }
 
-    pub fn is_unsafe(self, db: &dyn HirDatabase) -> bool {
-        db.function_data(self.id).is_unsafe()
-    }
-
     pub fn is_const(self, db: &dyn HirDatabase) -> bool {
-        db.function_data(self.id).is_const()
+        db.function_data(self.id).has_const_kw()
     }
 
     pub fn is_async(self, db: &dyn HirDatabase) -> bool {
-        db.function_data(self.id).is_async()
+        db.function_data(self.id).has_async_kw()
+    }
+
+    pub fn is_unsafe_to_call(self, db: &dyn HirDatabase) -> bool {
+        hir_ty::is_fn_unsafe_to_call(db, self.id)
     }
 
     /// Whether this function declaration has a definition.

--- a/crates/hir_def/src/data.rs
+++ b/crates/hir_def/src/data.rs
@@ -110,20 +110,20 @@ impl FunctionData {
         self.flags.contains(FnFlags::HAS_SELF_PARAM)
     }
 
-    pub fn is_default(&self) -> bool {
-        self.flags.contains(FnFlags::IS_DEFAULT)
+    pub fn has_default_kw(&self) -> bool {
+        self.flags.contains(FnFlags::HAS_DEFAULT_KW)
     }
 
-    pub fn is_const(&self) -> bool {
-        self.flags.contains(FnFlags::IS_CONST)
+    pub fn has_const_kw(&self) -> bool {
+        self.flags.contains(FnFlags::HAS_CONST_KW)
     }
 
-    pub fn is_async(&self) -> bool {
-        self.flags.contains(FnFlags::IS_ASYNC)
+    pub fn has_async_kw(&self) -> bool {
+        self.flags.contains(FnFlags::HAS_ASYNC_KW)
     }
 
-    pub fn is_unsafe(&self) -> bool {
-        self.flags.contains(FnFlags::IS_UNSAFE)
+    pub fn has_unsafe_kw(&self) -> bool {
+        self.flags.contains(FnFlags::HAS_UNSAFE_KW)
     }
 
     pub fn is_varargs(&self) -> bool {

--- a/crates/hir_def/src/item_tree.rs
+++ b/crates/hir_def/src/item_tree.rs
@@ -606,10 +606,10 @@ bitflags::bitflags! {
     pub(crate) struct FnFlags: u8 {
         const HAS_SELF_PARAM = 1 << 0;
         const HAS_BODY = 1 << 1;
-        const IS_DEFAULT = 1 << 2;
-        const IS_CONST = 1 << 3;
-        const IS_ASYNC = 1 << 4;
-        const IS_UNSAFE = 1 << 5;
+        const HAS_DEFAULT_KW = 1 << 2;
+        const HAS_CONST_KW = 1 << 3;
+        const HAS_ASYNC_KW = 1 << 4;
+        const HAS_UNSAFE_KW = 1 << 5;
         const IS_VARARGS = 1 << 6;
     }
 }

--- a/crates/hir_def/src/item_tree/tests.rs
+++ b/crates/hir_def/src/item_tree/tests.rs
@@ -76,7 +76,6 @@ extern "C" {
                 pub(self) static EX_STATIC: u8 = _;
 
                 #[on_extern_fn]  // AttrId { ast_index: 0 }
-                // flags = 0x20
                 pub(self) fn ex_fn() -> ();
             }
         "##]],

--- a/crates/hir_ty/src/infer.rs
+++ b/crates/hir_ty/src/infer.rs
@@ -748,7 +748,7 @@ impl<'a> InferenceContext<'a> {
             self.infer_pat(*pat, &ty, BindingMode::default());
         }
         let error_ty = &TypeRef::Error;
-        let return_ty = if data.is_async() {
+        let return_ty = if data.has_async_kw() {
             data.async_ret_type.as_deref().unwrap_or(error_ty)
         } else {
             &*data.ret_type

--- a/crates/hir_ty/src/lib.rs
+++ b/crates/hir_ty/src/lib.rs
@@ -64,7 +64,7 @@ pub use mapping::{
     to_placeholder_idx,
 };
 pub use traits::TraitEnvironment;
-pub use utils::all_super_traits;
+pub use utils::{all_super_traits, is_fn_unsafe_to_call};
 pub use walk::TypeWalk;
 
 pub use chalk_ir::{

--- a/crates/ide/src/syntax_highlighting/highlight.rs
+++ b/crates/ide/src/syntax_highlighting/highlight.rs
@@ -362,7 +362,7 @@ fn highlight_def(sema: &Semantics<RootDatabase>, krate: hir::Crate, def: Definit
                 }
             }
 
-            if func.is_unsafe(db) {
+            if func.is_unsafe_to_call(db) {
                 h |= HlMod::Unsafe;
             }
             if func.is_async(db) {
@@ -508,7 +508,7 @@ fn highlight_method_call(
     let mut h = SymbolKind::Function.into();
     h |= HlMod::Associated;
 
-    if func.is_unsafe(sema.db) || sema.is_unsafe_method_call(method_call) {
+    if func.is_unsafe_to_call(sema.db) || sema.is_unsafe_method_call(method_call) {
         h |= HlMod::Unsafe;
     }
     if func.is_async(sema.db) {

--- a/crates/ide_completion/src/render/function.rs
+++ b/crates/ide_completion/src/render/function.rs
@@ -237,7 +237,7 @@ fn detail(db: &dyn HirDatabase, func: hir::Function) -> String {
     if func.is_async(db) {
         format_to!(detail, "async ");
     }
-    if func.is_unsafe(db) {
+    if func.is_unsafe_to_call(db) {
         format_to!(detail, "unsafe ");
     }
 


### PR DESCRIPTION
Resolves some FIXMEs.

I've also renamed some FnFlags to be more explicit about what they represent (presence of keywords, not necessarily presence of semantics)

bors r+