### PR TITLE
Ignore `Drop` and `Destruct` bounds for now

### DIFF
--- a/crates/hir_ty/src/tests/regression.rs
+++ b/crates/hir_ty/src/tests/regression.rs
@@ -1505,3 +1505,82 @@ fn f(s: S) {
 "#,
     );
 }
+
+#[test]
+fn rust_161_option_clone() {
+    check_types(
+        r#"
+//- minicore: option, drop
+
+fn test(o: &Option<i32>) {
+    o.my_clone();
+  //^^^^^^^^^^^^ Option<i32>
+}
+
+pub trait MyClone: Sized {
+    fn my_clone(&self) -> Self;
+}
+
+impl<T> const MyClone for Option<T>
+where
+    T: ~const MyClone + ~const Drop + ~const Destruct,
+{
+    fn my_clone(&self) -> Self {
+        match self {
+            Some(x) => Some(x.my_clone()),
+            None => None,
+        }
+    }
+}
+
+impl const MyClone for i32 {
+    fn my_clone(&self) -> Self {
+        *self
+    }
+}
+
+pub trait Destruct {}
+
+impl<T: ?Sized> const Destruct for T {}
+"#,
+    );
+}
+
+#[test]
+fn rust_162_option_clone() {
+    check_types(
+        r#"
+//- minicore: option, drop
+
+fn test(o: &Option<i32>) {
+    o.my_clone();
+  //^^^^^^^^^^^^ Option<i32>
+}
+
+pub trait MyClone: Sized {
+    fn my_clone(&self) -> Self;
+}
+
+impl<T> const MyClone for Option<T>
+where
+    T: ~const MyClone + ~const Destruct,
+{
+    fn my_clone(&self) -> Self {
+        match self {
+            Some(x) => Some(x.my_clone()),
+            None => None,
+        }
+    }
+}
+
+impl const MyClone for i32 {
+    fn my_clone(&self) -> Self {
+        *self
+    }
+}
+
+#[lang = "destruct"]
+pub trait Destruct {}
+"#,
+    );
+}


### PR DESCRIPTION
- `T: ~const Drop` has a special meaning in Rust 1.61 that we don't implement. (So ideally, we'd only ignore `~const Drop`, but this should be fine for now.)
- `Destruct` impls are built-in in 1.62 (current nightlies), so until the builtin impls are supported by Chalk, we ignore them as well. Since `Destruct` is implemented for everything in non-const contexts IIUC, this should also work fine.

Fixes #11932.