### PR TITLE
fix: Don't create `hir::Local`s from const path patterns

### DIFF
--- a/crates/ide_assists/src/handlers/inline_local_variable.rs
+++ b/crates/ide_assists/src/handlers/inline_local_variable.rs
@@ -938,4 +938,18 @@ fn f() {
 "#,
         );
     }
+
+    #[test]
+    fn test_inline_let_unit_struct() {
+        check_assist_not_applicable(
+            inline_local_variable,
+            r#"
+struct S;
+fn f() {
+    let S$0 = S;
+    S;
+}
+"#,
+        );
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/rust-analyzer/rust-analyzer/issues/11941