### PR TITLE
fix panic on GAT

### DIFF
--- a/crates/hir_ty/src/tests/regression.rs
+++ b/crates/hir_ty/src/tests/regression.rs
@@ -1471,7 +1471,7 @@ fn regression_11688_3() {
 }
 
 #[test]
-fn gat_crash() {
+fn gat_crash_1() {
     cov_mark::check!(ignore_gats);
     check_no_mismatches(
         r#"
@@ -1484,6 +1484,26 @@ trait Crash {
 
 fn test<T: Crash>() {
     T::new();
+}
+"#,
+    );
+}
+
+#[test]
+fn gat_crash_2() {
+    check_no_mismatches(
+        r#"
+pub struct InlineStorage {}
+
+pub struct InlineStorageHandle<T: ?Sized> {}
+
+pub unsafe trait Storage {
+    type Handle<T: ?Sized>;
+    fn create<T: ?Sized>() -> Self::Handle<T>;
+}
+
+unsafe impl Storage for InlineStorage {
+    type Handle<T: ?Sized> = InlineStorageHandle<T>;
 }
 "#,
     );


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

This is still a workaround on GAT panic, and didn't solve the full problem. But at least we won't panic now. False positive is better than panicking and letting VSCode constantly pop out the warning 🤣

This PR is simple -- only apply the https://github.com/rust-analyzer/rust-analyzer/pull/11878 fix on const generics. For normal GATs, just follow the previous approach.

This PR fixes https://github.com/rust-analyzer/rust-analyzer/issues/11939, I've added it as a test case.

This PR didn't fully fix / https://github.com/rust-analyzer/rust-analyzer/issues/11923. But at least it won't panic now -- will only give a type mismatch error.

Not sure if it fixes / https://github.com/rust-analyzer/rust-analyzer/issues/11921, I'll test it later.

cc @flodiebold for review, thanks!