### PR TITLE
internal: Show more project building errors to the user

### DIFF
--- a/crates/hir_expand/src/db.rs
+++ b/crates/hir_expand/src/db.rs
@@ -263,7 +263,7 @@ fn parse_macro_expansion(
                 .collect::<Vec<_>>()
                 .join("\n");
 
-        tracing::warn!(
+        tracing::debug!(
             "fail on macro_parse: (reason: {:?} macro_call: {:#}) parents: {}",
             err,
             node.value,

--- a/crates/rust-analyzer/src/main_loop.rs
+++ b/crates/rust-analyzer/src/main_loop.rs
@@ -190,7 +190,7 @@ impl GlobalState {
         // NOTE: don't count blocking select! call as a loop-turn time
         let _p = profile::span("GlobalState::handle_event");
 
-        tracing::info!("handle_event({:?})", event);
+        tracing::debug!("handle_event({:?})", event);
         let task_queue_len = self.task_pool.handle.len();
         if task_queue_len > 0 {
             tracing::info!("task queue len: {}", task_queue_len);


### PR DESCRIPTION
Something very fishy is going on with the `rustc_workspace` handling, which caused this bug to only manifest in the `std` library but not other library crate... So there is either a bug there or just the fact that we seem to add duplicate dependencies (I think this is what we are doing with this right?) might be tripping something up somewhere.

cc https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Frust-analyzer/topic/Rust-analyzer.20use.20inside.20stdlib

bors r+